### PR TITLE
add support for clearing canvas

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -773,6 +773,18 @@ class App extends React.Component<{}, AppState> {
     this.forceUpdate();
   };
 
+  private clearCanvas = () => {
+    if (window.confirm("This will clear the whole canvas. Are you sure?")) {
+      elements = [];
+      this.setState({
+        viewBackgroundColor: "#ffffff",
+        scrollX: 0,
+        scrollY: 0
+      });
+      this.forceUpdate();
+    }
+  };
+
   private moveAllLeft = () => {
     moveAllLeft(elements, getSelectedIndices());
     this.forceUpdate();
@@ -889,6 +901,15 @@ class App extends React.Component<{}, AppState> {
               />
               Shape Background
             </label>
+          </div>
+          <h4>Canvas</h4>
+          <div className="panelColumn">
+            <button
+              onClick={this.clearCanvas}
+              title="Clear the canvas & reset background color"
+            >
+              Clear canvas
+            </button>
           </div>
           <h4>Export</h4>
           <div className="panelColumn">

--- a/src/styles.css
+++ b/src/styles.css
@@ -78,3 +78,7 @@ button {
 
   padding: 5px;
 }
+
+button:disabled {
+  cursor: not-allowed;
+}


### PR DESCRIPTION
Right now, since we auto-save to localStorage, there's no way to easily start a new canvas. This PR adds support for clearing it.

Technically, one could select all elements and hit `delete`, but suppose the elements are all over the place (some out of visible area), or there's a bug like the one that didn't clear selections.

![image](https://user-images.githubusercontent.com/5153846/71765238-4e5e7d00-2ef2-11ea-82e4-c1ceef2131a7.png)
