### PR TITLE
fallback if TextMeasure.actualBoundingBox* unavailable

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1335,15 +1335,17 @@ class App extends React.Component<{}, AppState> {
               if (text === null) {
                 return;
               }
+              const fontSize = 20;
               element.text = text;
-              element.font = "20px Virgil";
+              element.font = `${fontSize}px Virgil`;
               const font = context.font;
               context.font = element.font;
-              const {
-                actualBoundingBoxAscent,
-                actualBoundingBoxDescent,
-                width
-              } = context.measureText(element.text);
+              const textMeasure = context.measureText(element.text);
+              const width = textMeasure.width;
+              const actualBoundingBoxAscent =
+                textMeasure.actualBoundingBoxAscent || fontSize;
+              const actualBoundingBoxDescent =
+                textMeasure.actualBoundingBoxDescent || 0;
               element.actualBoundingBoxAscent = actualBoundingBoxAscent;
               context.font = font;
               const height = actualBoundingBoxAscent + actualBoundingBoxDescent;


### PR DESCRIPTION
fixes #153 

`actualBoundingBoxAscent` and -descent are only supported by Chrome and Safari.

https://developer.mozilla.org/en-US/docs/Web/API/TextMetrics

This falls back to simply using the font size, which is probably not as precise but seems to work fine. The value is hardcoded like the font size (a few lines above). If someone adds support for changing the font-size, this will have to be applied to this measure as well.