### PR TITLE
Add titles to shape buttons with key shortcuts

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -886,6 +886,11 @@ const SHAPES = [
 
 const shapesShortcutKeys = SHAPES.map(shape => shape.value[0]);
 
+
+function capitalize(str: string) {
+  return str.charAt(0).toUpperCase() + str.slice(1);
+}
+
 function findElementByKey(key: string) {
   const defaultElement = "selection";
   return SHAPES.reduce((element, shape) => {
@@ -1126,7 +1131,7 @@ class App extends React.Component<{}, AppState> {
           <h4>Shapes</h4>
           <div className="panelTools">
             {SHAPES.map(({ value, icon }) => (
-              <label key={value} className="tool">
+              <label key={value} className="tool" title={`${capitalize(value)} - ${capitalize(value)[0]}`}>
                 <input
                   type="radio"
                   checked={this.state.elementType === value}


### PR DESCRIPTION
Added quick and dirty tooltips using `title` attributes with shape keyboard shortcuts.

![Kapture 2020-01-05 at 10 45 01](https://user-images.githubusercontent.com/4060187/71784465-9c35bc80-2fa8-11ea-9e66-0b4036856450.gif)
