### PR TITLE
Implementing grouping between multiple elements

### DIFF
--- a/src/actions/actionCanvas.tsx
+++ b/src/actions/actionCanvas.tsx
@@ -8,7 +8,7 @@ import { t } from "../i18n";
 
 export const actionChangeViewBackgroundColor: Action = {
   name: "changeViewBackgroundColor",
-  perform: (_, appState, value) => {
+  perform: (elements, groups, appState, value) => {
     return { appState: { ...appState, viewBackgroundColor: value } };
   },
   PanelComponent: ({ appState, updateData }) => {

--- a/src/actions/actionDeleteSelected.tsx
+++ b/src/actions/actionDeleteSelected.tsx
@@ -4,7 +4,7 @@ import { KEYS } from "../keys";
 
 export const actionDeleteSelected: Action = {
   name: "deleteSelectedElements",
-  perform: (elements, appState) => {
+  perform: (elements, _, appState) => {
     return {
       elements: deleteSelectedElements(elements),
       appState: { ...appState, elementType: "selection", multiElement: null },

--- a/src/actions/actionExport.tsx
+++ b/src/actions/actionExport.tsx
@@ -8,7 +8,7 @@ import { t } from "../i18n";
 
 export const actionChangeProjectName: Action = {
   name: "changeProjectName",
-  perform: (elements, appState, value) => {
+  perform: (elements, _, appState, value) => {
     return { appState: { ...appState, name: value } };
   },
   PanelComponent: ({ appState, updateData }) => (
@@ -22,7 +22,7 @@ export const actionChangeProjectName: Action = {
 
 export const actionChangeExportBackground: Action = {
   name: "changeExportBackground",
-  perform: (elements, appState, value) => {
+  perform: (elements, _, appState, value) => {
     return { appState: { ...appState, exportBackground: value } };
   },
   PanelComponent: ({ appState, updateData }) => (
@@ -41,8 +41,8 @@ export const actionChangeExportBackground: Action = {
 
 export const actionSaveScene: Action = {
   name: "saveScene",
-  perform: (elements, appState, value) => {
-    saveAsJSON(elements, appState).catch(err => console.error(err));
+  perform: (elements, groups, appState, value) => {
+    saveAsJSON(elements, groups, appState).catch(err => console.error(err));
     return {};
   },
   PanelComponent: ({ updateData }) => (
@@ -60,6 +60,7 @@ export const actionLoadScene: Action = {
   name: "loadScene",
   perform: (
     elements,
+    groups,
     appState,
     { elements: loadedElements, appState: loadedAppState },
   ) => {

--- a/src/actions/actionFinalize.tsx
+++ b/src/actions/actionFinalize.tsx
@@ -5,7 +5,7 @@ import { isInvisiblySmallElement } from "../element";
 
 export const actionFinalize: Action = {
   name: "finalize",
-  perform: (elements, appState) => {
+  perform: (elements, _, appState) => {
     let newElements = clearSelection(elements);
     if (window.document.activeElement instanceof HTMLElement) {
       window.document.activeElement.blur();

--- a/src/actions/actionGrouping.ts
+++ b/src/actions/actionGrouping.ts
@@ -1,0 +1,70 @@
+import { Action } from "./types";
+import { KEYS } from "../keys";
+import { ExcalidrawGroupElement } from "../element/types";
+import { newGroupElement } from "../element/newElement";
+
+export const actionGroupElements: Action = {
+  name: "groupElements",
+  perform: (elements, groups) => {
+    const result = Array.from(groups);
+    const selected: ExcalidrawGroupElement = newGroupElement();
+    elements
+      .filter(el => el.isSelected)
+      .forEach(el => {
+        const index = result.findIndex(group => group.children.find(id => id === el.id));
+        if (index !== -1) {
+          result[index].children.forEach(e => selected.children.push(e));
+          result.splice(index, 1);
+        } else {
+          selected.children.push(el.id);
+        }
+      });
+    if (selected.children.length > 1) {
+      result.push(selected);
+    }
+
+    return {
+      elements: elements,
+      groups: Array.from(new Set(result))
+    };
+  },
+  contextItemLabel: "labels.groupElements",
+  keyTest: event => event[KEYS.META] && event.key === "g",
+  contextMenuOrder: 0,
+};
+
+export const actionUngroupElements: Action = {
+  name: "ungroupElements",
+  perform: (elements, groups) => {
+    const result = Array.from(groups);
+    const selectedElements = elements.filter(el => el.isSelected);
+    const groupIndex = result.findIndex(group => {
+      for (const i in selectedElements) {
+        const element = selectedElements[i];
+        if (!group.children.find(id => id === element.id)) {
+          return false;
+        }
+      }
+      return true;
+    });
+    if (groupIndex !== -1) {
+      const group = result[groupIndex];
+      selectedElements.forEach(el => {
+        const index = group.children.indexOf(el.id);
+        if (index) {
+          group.children.splice(index, 1);
+        }
+      });
+      if (group.children.length < 2) {
+        result.splice(groupIndex, 1);
+      }
+    }
+    return {
+      elements: elements,
+      groups: Array.from(new Set(result)),
+    };
+  },
+  contextItemLabel: "labels.ungroupElements",
+  keyTest: event => event[KEYS.META] && event.shiftKey && event.key === "G",
+  contextMenuOrder: 0,
+};

--- a/src/actions/actionProperties.tsx
+++ b/src/actions/actionProperties.tsx
@@ -37,7 +37,7 @@ const getFormValue = function<T>(
 
 export const actionChangeStrokeColor: Action = {
   name: "changeStrokeColor",
-  perform: (elements, appState, value) => {
+  perform: (elements, _, appState, value) => {
     return {
       elements: changeProperty(elements, el => ({
         ...el,
@@ -68,7 +68,7 @@ export const actionChangeStrokeColor: Action = {
 
 export const actionChangeBackgroundColor: Action = {
   name: "changeBackgroundColor",
-  perform: (elements, appState, value) => {
+  perform: (elements, _, appState, value) => {
     return {
       elements: changeProperty(elements, el => ({
         ...el,
@@ -99,7 +99,7 @@ export const actionChangeBackgroundColor: Action = {
 
 export const actionChangeFillStyle: Action = {
   name: "changeFillStyle",
-  perform: (elements, appState, value) => {
+  perform: (elements, _, appState, value) => {
     return {
       elements: changeProperty(elements, el => ({
         ...el,
@@ -136,7 +136,7 @@ export const actionChangeFillStyle: Action = {
 
 export const actionChangeStrokeWidth: Action = {
   name: "changeStrokeWidth",
-  perform: (elements, appState, value) => {
+  perform: (elements, _, appState, value) => {
     return {
       elements: changeProperty(elements, el => ({
         ...el,
@@ -171,7 +171,7 @@ export const actionChangeStrokeWidth: Action = {
 
 export const actionChangeSloppiness: Action = {
   name: "changeSloppiness",
-  perform: (elements, appState, value) => {
+  perform: (elements, _, appState, value) => {
     return {
       elements: changeProperty(elements, el => ({
         ...el,
@@ -206,7 +206,7 @@ export const actionChangeSloppiness: Action = {
 
 export const actionChangeOpacity: Action = {
   name: "changeOpacity",
-  perform: (elements, appState, value) => {
+  perform: (elements, _, appState, value) => {
     return {
       elements: changeProperty(elements, el => ({
         ...el,
@@ -255,7 +255,7 @@ export const actionChangeOpacity: Action = {
 
 export const actionChangeFontSize: Action = {
   name: "changeFontSize",
-  perform: (elements, appState, value) => {
+  perform: (elements, _, appState, value) => {
     return {
       elements: changeProperty(elements, el => {
         if (isTextElement(el)) {
@@ -304,7 +304,7 @@ export const actionChangeFontSize: Action = {
 
 export const actionChangeFontFamily: Action = {
   name: "changeFontFamily",
-  perform: (elements, appState, value) => {
+  perform: (elements, _, appState, value) => {
     return {
       elements: changeProperty(elements, el => {
         if (isTextElement(el)) {

--- a/src/actions/actionZindex.tsx
+++ b/src/actions/actionZindex.tsx
@@ -10,7 +10,7 @@ import { KEYS } from "../keys";
 
 export const actionSendBackward: Action = {
   name: "sendBackward",
-  perform: (elements, appState) => {
+  perform: (elements, _, appState) => {
     return {
       elements: moveOneLeft([...elements], getSelectedIndices(elements)),
       appState,
@@ -24,7 +24,7 @@ export const actionSendBackward: Action = {
 
 export const actionBringForward: Action = {
   name: "bringForward",
-  perform: (elements, appState) => {
+  perform: (elements, _, appState) => {
     return {
       elements: moveOneRight([...elements], getSelectedIndices(elements)),
       appState,
@@ -38,7 +38,7 @@ export const actionBringForward: Action = {
 
 export const actionSendToBack: Action = {
   name: "sendToBack",
-  perform: (elements, appState) => {
+  perform: (elements, _, appState) => {
     return {
       elements: moveAllLeft([...elements], getSelectedIndices(elements)),
       appState,
@@ -51,7 +51,7 @@ export const actionSendToBack: Action = {
 
 export const actionBringToFront: Action = {
   name: "bringToFront",
-  perform: (elements, appState) => {
+  perform: (elements, _, appState) => {
     return {
       elements: moveAllRight([...elements], getSelectedIndices(elements)),
       appState,

--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -33,3 +33,5 @@ export {
 } from "./actionExport";
 
 export { actionCopyStyles, actionPasteStyles } from "./actionStyles";
+
+export { actionGroupElements, actionUngroupElements } from "./actionGrouping";

--- a/src/actions/manager.tsx
+++ b/src/actions/manager.tsx
@@ -5,7 +5,7 @@ import {
   UpdaterFn,
   ActionFilterFn,
 } from "./types";
-import { ExcalidrawElement } from "../element/types";
+import { ExcalidrawElement, ExcalidrawGroupElement } from "../element/types";
 import { AppState } from "../types";
 import { t } from "../i18n";
 
@@ -20,16 +20,20 @@ export class ActionManager implements ActionsManagerInterface {
 
   getElements: () => readonly ExcalidrawElement[];
 
+  getGroups: () => readonly ExcalidrawGroupElement[];
+
   constructor(
     updater: UpdaterFn,
     resumeHistoryRecording: () => void,
     getAppState: () => AppState,
     getElements: () => readonly ExcalidrawElement[],
+    getGroups: () => readonly ExcalidrawGroupElement[],
   ) {
     this.updater = updater;
     this.resumeHistoryRecording = resumeHistoryRecording;
     this.getAppState = getAppState;
     this.getElements = getElements;
+    this.getGroups = getGroups;
   }
 
   registerAction(action: Action) {
@@ -56,7 +60,7 @@ export class ActionManager implements ActionsManagerInterface {
     ) {
       this.resumeHistoryRecording();
     }
-    return data[0].perform(this.getElements(), this.getAppState(), null);
+    return data[0].perform(this.getElements(), this.getGroups(), this.getAppState(), null);
   }
 
   getContextMenuItems(actionFilter: ActionFilterFn = action => action) {
@@ -78,7 +82,7 @@ export class ActionManager implements ActionsManagerInterface {
             this.resumeHistoryRecording();
           }
           this.updater(
-            action.perform(this.getElements(), this.getAppState(), null),
+            action.perform(this.getElements(), this.getGroups(), this.getAppState(), null),
           );
         },
       }));
@@ -97,7 +101,7 @@ export class ActionManager implements ActionsManagerInterface {
           this.resumeHistoryRecording();
         }
         this.updater(
-          action.perform(this.getElements(), this.getAppState(), formState),
+          action.perform(this.getElements(), this.getGroups(), this.getAppState(), formState),
         );
       };
 

--- a/src/actions/types.ts
+++ b/src/actions/types.ts
@@ -1,14 +1,16 @@
 import React from "react";
-import { ExcalidrawElement } from "../element/types";
+import { ExcalidrawElement, ExcalidrawGroupElement } from "../element/types";
 import { AppState } from "../types";
 
 export type ActionResult = {
   elements?: readonly ExcalidrawElement[];
+  groups?: readonly ExcalidrawGroupElement[];
   appState?: AppState;
 };
 
 type ActionFn = (
   elements: readonly ExcalidrawElement[],
+  groups: readonly ExcalidrawGroupElement[],
   appState: AppState,
   formData: any,
 ) => ActionResult;

--- a/src/components/ExportDialog.tsx
+++ b/src/components/ExportDialog.tsx
@@ -6,7 +6,7 @@ import { Modal } from "./Modal";
 import { ToolButton } from "./ToolButton";
 import { clipboard, exportFile, link } from "./icons";
 import { Island } from "./Island";
-import { ExcalidrawElement } from "../element/types";
+import { ExcalidrawElement, ExcalidrawGroupElement } from "../element/types";
 import { AppState } from "../types";
 import { exportToCanvas } from "../scene/export";
 import { ActionsManagerInterface } from "../actions/types";
@@ -27,6 +27,7 @@ type ExportCB = (
 
 function ExportModal({
   elements,
+  groups,
   appState,
   exportPadding = 10,
   actionManager,
@@ -38,6 +39,7 @@ function ExportModal({
 }: {
   appState: AppState;
   elements: readonly ExcalidrawElement[];
+  groups: readonly ExcalidrawGroupElement[];
   exportPadding?: number;
   actionManager: ActionsManagerInterface;
   onExportToPng: ExportCB;
@@ -65,7 +67,7 @@ function ExportModal({
 
   useEffect(() => {
     const previewNode = previewRef.current;
-    const canvas = exportToCanvas(exportedElements, {
+    const canvas = exportToCanvas(exportedElements, groups, {
       exportBackground,
       viewBackgroundColor,
       exportPadding,
@@ -200,6 +202,7 @@ function ExportModal({
 
 export function ExportDialog({
   elements,
+  groups,
   appState,
   exportPadding = 10,
   actionManager,
@@ -210,6 +213,7 @@ export function ExportDialog({
 }: {
   appState: AppState;
   elements: readonly ExcalidrawElement[];
+  groups: readonly ExcalidrawGroupElement[];
   exportPadding?: number;
   actionManager: ActionsManagerInterface;
   onExportToPng: ExportCB;
@@ -243,6 +247,7 @@ export function ExportDialog({
         >
           <ExportModal
             elements={elements}
+            groups={groups}
             appState={appState}
             exportPadding={exportPadding}
             actionManager={actionManager}

--- a/src/element/newElement.ts
+++ b/src/element/newElement.ts
@@ -3,7 +3,11 @@ import nanoid from "nanoid";
 import { Drawable } from "roughjs/bin/core";
 import { Point } from "roughjs/bin/geometry";
 
-import { ExcalidrawElement, ExcalidrawTextElement } from "../element/types";
+import {
+  ExcalidrawElement,
+  ExcalidrawTextElement,
+  ExcalidrawGroupElement,
+} from "../element/types";
 import { measureText } from "../utils";
 
 export function newElement(
@@ -60,6 +64,16 @@ export function newTextElement(
   };
 
   return textElement;
+}
+
+export function newGroupElement(
+  children: ExcalidrawElement[] = [],
+) {
+  const group: ExcalidrawGroupElement = {
+    type: "group",
+    children: children.map(e => e.id),
+  };
+  return group;
 }
 
 export function duplicateElement(element: ReturnType<typeof newElement>) {

--- a/src/element/types.ts
+++ b/src/element/types.ts
@@ -9,3 +9,7 @@ export type ExcalidrawTextElement = ExcalidrawElement & {
   actualBoundingBoxAscent?: number;
   baseline: number;
 };
+export type ExcalidrawGroupElement = {
+  type: "group";
+  children: string[];
+}

--- a/src/index-node.ts
+++ b/src/index-node.ts
@@ -1,4 +1,6 @@
 import { exportToCanvas } from "./scene/export";
+import { newGroupElement } from "./element/newElement";
+import { ExcalidrawGroupElement } from "./element/types";
 
 const { registerFont, createCanvas } = require("canvas");
 
@@ -60,6 +62,7 @@ registerFont("./public/FG_Virgil.ttf", { family: "Virgil" });
 registerFont("./public/Cascadia.ttf", { family: "Cascadia" });
 const canvas = exportToCanvas(
   elements as any,
+  [],
   {
     exportBackground: true,
     viewBackgroundColor: "#ffffff",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1,5 +1,7 @@
 {
   "labels": {
+    "groupElements": "Group Elements",
+    "ungroupElements": "Ungroup Elements",
     "paste": "Paste",
     "selectAll": "Select All",
     "copy": "Copy",

--- a/src/scene/createScene.ts
+++ b/src/scene/createScene.ts
@@ -1,6 +1,7 @@
-import { ExcalidrawElement } from "../element/types";
+import { ExcalidrawElement, ExcalidrawGroupElement } from "../element/types";
 
 export const createScene = () => {
   const elements: readonly ExcalidrawElement[] = [];
-  return { elements };
+  const groups: readonly ExcalidrawGroupElement[] = [];
+  return { elements, groups };
 };

--- a/src/scene/export.ts
+++ b/src/scene/export.ts
@@ -1,11 +1,12 @@
 import rough from "roughjs/bin/rough";
-import { ExcalidrawElement } from "../element/types";
+import { ExcalidrawElement, ExcalidrawGroupElement } from "../element/types";
 import { getCommonBounds } from "../element/bounds";
 import { renderScene, renderSceneToSvg } from "../renderer/renderScene";
 import { distance, SVG_NS } from "../utils";
 
 export function exportToCanvas(
   elements: readonly ExcalidrawElement[],
+  groups: readonly ExcalidrawGroupElement[],
   {
     exportBackground,
     exportPadding = 10,
@@ -38,6 +39,7 @@ export function exportToCanvas(
   renderScene(
     elements,
     null,
+    groups,
     rough.canvas(tempCanvas),
     tempCanvas,
     {


### PR DESCRIPTION
This PR addresses issue #173 .
The logic behind grouping is that you can move elements as one module, without having to select them every time. 

#### Grouping `Cmd + G`
* When grouping two or more elements that aren't in a group, then they form a group.
* When grouping two or more elements that are already in a group, then their groups get merged.
![Grouping](https://i.imgur.com/SgLwuO1.gif)

#### Ungrouping `Cmd + Shift + G`
* When ungrouping all elements, they stop behaving as a group.
* When ungrouping some but not all elements, they get removed from the group but the group still exists.
In order to ungroup the selected elements, they all have to be in the same group. Otherwise, the operation fails (should that be changed?). 
![Ungrouping](https://i.imgur.com/qcn1Qav.gif)

All the groups are stored as an array of sets internally, which can be useful if we want to visualize every group in a future layer panel.