### PR TITLE
Fixed ellipse hit test if sizes are negative

### DIFF
--- a/src/element/collision.ts
+++ b/src/element/collision.ts
@@ -27,8 +27,8 @@ export function hitTest(
     let tx = 0.707;
     let ty = 0.707;
 
-    const a = element.width / 2;
-    const b = element.height / 2;
+    const a = Math.abs(element.width) / 2;
+    const b = Math.abs(element.height) / 2;
 
     [0, 1, 2, 3].forEach(x => {
       const xx = a * tx;


### PR DESCRIPTION
Ellipse hit test function is not working properly if width or height of ellipse is negative