### PR TITLE
Use Ctrl instead of Cmd for keyboard shortcuts on Windows

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -55,6 +55,10 @@ const KEYS = {
   BACKSPACE: "Backspace"
 };
 
+const META_KEY = /Mac|iPod|iPhone|iPad/.test(window.navigator.platform)
+  ? "metaKey"
+  : "ctrlKey";
+
 function isArrowKey(keyCode: string) {
   return (
     keyCode === KEYS.ARROW_LEFT ||
@@ -165,7 +169,7 @@ class App extends React.Component<{}, AppState> {
 
       // Send backward: Cmd-Shift-Alt-B
     } else if (
-      event.metaKey &&
+      event[META_KEY] &&
       event.shiftKey &&
       event.altKey &&
       event.code === "KeyB"
@@ -174,13 +178,13 @@ class App extends React.Component<{}, AppState> {
       event.preventDefault();
 
       // Send to back: Cmd-Shift-B
-    } else if (event.metaKey && event.shiftKey && event.code === "KeyB") {
+    } else if (event[META_KEY] && event.shiftKey && event.code === "KeyB") {
       this.moveAllLeft();
       event.preventDefault();
 
       // Bring forward: Cmd-Shift-Alt-F
     } else if (
-      event.metaKey &&
+      event[META_KEY] &&
       event.shiftKey &&
       event.altKey &&
       event.code === "KeyF"
@@ -189,12 +193,12 @@ class App extends React.Component<{}, AppState> {
       event.preventDefault();
 
       // Bring to front: Cmd-Shift-F
-    } else if (event.metaKey && event.shiftKey && event.code === "KeyF") {
+    } else if (event[META_KEY] && event.shiftKey && event.code === "KeyF") {
       this.moveAllRight();
       event.preventDefault();
 
       // Select all: Cmd-A
-    } else if (event.metaKey && event.code === "KeyA") {
+    } else if (event[META_KEY] && event.code === "KeyA") {
       elements.forEach(element => {
         element.isSelected = true;
       });
@@ -202,7 +206,7 @@ class App extends React.Component<{}, AppState> {
       event.preventDefault();
     } else if (shapesShortcutKeys.includes(event.key.toLowerCase())) {
       this.setState({ elementType: findShapeByKey(event.key) });
-    } else if (event.metaKey && event.code === "KeyZ") {
+    } else if (event[META_KEY] && event.code === "KeyZ") {
       if (event.shiftKey) {
         // Redo action
         history.redoOnce(elements);


### PR DESCRIPTION
As mentioned in https://github.com/excalidraw/excalidraw/pull/141#issuecomment-570899194, the `⌘ Cmd` keyboard shortcuts don't work on Windows/Linux/others. We can use the `Ctrl` key for these devices.