### PR TITLE
Fix URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ## Try it now
 
-Go to https://excalidraw.com to start sketching
+Go to https://www.excalidraw.com to start sketching
 
 ## Testimonials
 


### PR DESCRIPTION
Looks like excalidraw.com is an SSL error, but www.excalidraw.com
works great.  It's possible the github pages config could be changed
to make both work, but this seemed easier to fix.