### PR TITLE
Async loading of TwitterPicker

### DIFF
--- a/src/components/ColorPicker.tsx
+++ b/src/components/ColorPicker.tsx
@@ -1,6 +1,11 @@
-import React from "react";
-import { TwitterPicker } from "react-color";
+import React, { lazy } from "react";
 import { Popover } from "./Popover";
+
+const TwitterPicker = lazy(() =>
+  import(
+    /* webpackPrefetch: true */ "react-color/lib/components/twitter/Twitter"
+  )
+);
 
 export function ColorPicker({
   color,
@@ -17,30 +22,32 @@ export function ColorPicker({
         style={color ? { backgroundColor: color } : undefined}
         onClick={() => setActive(!isActive)}
       />
-      {isActive ? (
-        <Popover onCloseRequest={() => setActive(false)}>
-          <TwitterPicker
-            colors={[
-              "#000000",
-              "#ABB8C3",
-              "#FFFFFF",
-              "#FF6900",
-              "#FCB900",
-              "#00D084",
-              "#8ED1FC",
-              "#0693E3",
-              "#EB144C",
-              "#F78DA7",
-              "#9900EF"
-            ]}
-            width="205px"
-            color={color || undefined}
-            onChange={changedColor => {
-              onChange(changedColor.hex);
-            }}
-          />
-        </Popover>
-      ) : null}
+      <React.Suspense fallback="">
+        {isActive ? (
+          <Popover onCloseRequest={() => setActive(false)}>
+            <TwitterPicker
+              colors={[
+                "#000000",
+                "#ABB8C3",
+                "#FFFFFF",
+                "#FF6900",
+                "#FCB900",
+                "#00D084",
+                "#8ED1FC",
+                "#0693E3",
+                "#EB144C",
+                "#F78DA7",
+                "#9900EF"
+              ]}
+              width="205px"
+              color={color || undefined}
+              onChange={changedColor => {
+                onChange(changedColor.hex);
+              }}
+            />
+          </Popover>
+        ) : null}
+      </React.Suspense>
       <input
         type="text"
         className="swatch-input"


### PR DESCRIPTION
Reduces initial bundle size by 25%

Before 
<img width="1280" alt="Screenshot 2020-01-07 at 23 06 58" src="https://user-images.githubusercontent.com/9278185/71917779-b509c200-31a2-11ea-8bca-2903e8075d10.png">

After
<img width="1280" alt="Screenshot 2020-01-07 at 23 08 27" src="https://user-images.githubusercontent.com/9278185/71917792-bd61fd00-31a2-11ea-94a8-7b7c8dfae84b.png">

