### PR TITLE
feat(duplicate_element): duplicate element by alt dragging

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -671,7 +671,7 @@ class App extends React.Component<{}, AppState> {
                     if (!e.shiftKey) {
                       clearSelection(elements);
                     }
-                    // No matter what, we select it
+                    // We duplicate the selected element if alt is pressed on Mouse down
                     if (e.altKey) {
                       const element = newElement(
                         hitElement.type,
@@ -689,6 +689,7 @@ class App extends React.Component<{}, AppState> {
 
                       elements.push(element);
                     }
+                    // No matter what, we select it
                     hitElement.isSelected = true;
                   }
                 } else {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -671,26 +671,26 @@ class App extends React.Component<{}, AppState> {
                     if (!e.shiftKey) {
                       clearSelection(elements);
                     }
-                    // We duplicate the selected element if alt is pressed on Mouse down
-                    if (e.altKey) {
-                      const element = newElement(
-                        hitElement.type,
-                        hitElement.x,
-                        hitElement.y,
-                        hitElement.strokeColor,
-                        hitElement.backgroundColor,
-                        hitElement.fillStyle,
-                        hitElement.strokeWidth,
-                        hitElement.roughness,
-                        hitElement.opacity,
-                        hitElement.width,
-                        hitElement.height
-                      );
+                  }
+                  // No matter what, we select it
+                  hitElement.isSelected = true;
+                  // We duplicate the selected element if alt is pressed on Mouse down
+                  if (e.altKey) {
+                    const element = newElement(
+                      hitElement.type,
+                      hitElement.x,
+                      hitElement.y,
+                      hitElement.strokeColor,
+                      hitElement.backgroundColor,
+                      hitElement.fillStyle,
+                      hitElement.strokeWidth,
+                      hitElement.roughness,
+                      hitElement.opacity,
+                      hitElement.width,
+                      hitElement.height
+                    );
 
-                      elements.push(element);
-                    }
-                    // No matter what, we select it
-                    hitElement.isSelected = true;
+                    elements.push(element);
                   }
                 } else {
                   // If we don't click on anything, let's remove all the selected elements

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -672,6 +672,23 @@ class App extends React.Component<{}, AppState> {
                       clearSelection(elements);
                     }
                     // No matter what, we select it
+                    if (e.altKey) {
+                      const element = newElement(
+                        hitElement.type,
+                        hitElement.x,
+                        hitElement.y,
+                        hitElement.strokeColor,
+                        hitElement.backgroundColor,
+                        hitElement.fillStyle,
+                        hitElement.strokeWidth,
+                        hitElement.roughness,
+                        hitElement.opacity,
+                        hitElement.width,
+                        hitElement.height
+                      );
+
+                      elements.push(element);
+                    }
                     hitElement.isSelected = true;
                   }
                 } else {


### PR DESCRIPTION
Issue #165 

By pressing the alt key while clicking an element it duplicates it.
Here is how it behaves:
![duplicate](https://user-images.githubusercontent.com/15782436/71984269-cdbcbb00-3228-11ea-9762-a9d488053452.gif)

