### PR TITLE
alt+drag should duplicate all selected elems

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -680,21 +680,15 @@ class App extends React.Component<{}, AppState> {
                   hitElement.isSelected = true;
                   // We duplicate the selected element if alt is pressed on Mouse down
                   if (e.altKey) {
-                    const element = newElement(
-                      hitElement.type,
-                      hitElement.x,
-                      hitElement.y,
-                      hitElement.strokeColor,
-                      hitElement.backgroundColor,
-                      hitElement.fillStyle,
-                      hitElement.strokeWidth,
-                      hitElement.roughness,
-                      hitElement.opacity,
-                      hitElement.width,
-                      hitElement.height
+                    elements.push(
+                      ...elements.reduce((duplicates, element) => {
+                        if (element.isSelected) {
+                          duplicates.push({ ...element });
+                          element.isSelected = false;
+                        }
+                        return duplicates;
+                      }, [] as typeof elements)
                     );
-
-                    elements.push(element);
                   }
                 } else {
                   // If we don't click on anything, let's remove all the selected elements


### PR DESCRIPTION
additional fix for #255

![excalidraw_alt_drag_duplicate_many](https://user-images.githubusercontent.com/5153846/71997160-b936ed80-323d-11ea-9788-00f5db26511d.gif)
