### PR TITLE
fix for duplicating elements

### DIFF
--- a/src/element/index.ts
+++ b/src/element/index.ts
@@ -1,4 +1,4 @@
-export { newElement } from "./newElement";
+export { newElement, duplicateElement } from "./newElement";
 export {
   getElementAbsoluteCoords,
   getDiamondPoints,

--- a/src/element/newElement.ts
+++ b/src/element/newElement.ts
@@ -32,3 +32,10 @@ export function newElement(
   };
   return element;
 }
+
+export function duplicateElement(element: ReturnType<typeof newElement>) {
+  const copy = { ...element };
+  copy.id = nanoid();
+  copy.seed = randomSeed();
+  return copy;
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,7 +4,13 @@ import rough from "roughjs/bin/wrappers/rough";
 
 import { moveOneLeft, moveAllLeft, moveOneRight, moveAllRight } from "./zindex";
 import { randomSeed } from "./random";
-import { newElement, resizeTest, isTextElement, textWysiwyg } from "./element";
+import {
+  newElement,
+  duplicateElement,
+  resizeTest,
+  isTextElement,
+  textWysiwyg
+} from "./element";
 import {
   clearSelection,
   getSelectedIndices,
@@ -44,7 +50,6 @@ import { PanelCanvas } from "./components/panels/PanelCanvas";
 
 const { elements } = createScene();
 const { history } = createHistory();
-
 const DEFAULT_PROJECT_NAME = `excalidraw-${getDateTime()}`;
 
 const CANVAS_WINDOW_OFFSET_LEFT = 250;
@@ -683,7 +688,7 @@ class App extends React.Component<{}, AppState> {
                     elements.push(
                       ...elements.reduce((duplicates, element) => {
                         if (element.isSelected) {
-                          duplicates.push({ ...element });
+                          duplicates.push(duplicateElement(element));
                           element.isSelected = false;
                         }
                         return duplicates;
@@ -1030,10 +1035,10 @@ class App extends React.Component<{}, AppState> {
       const dy = y - minY;
 
       parsedElements.forEach(parsedElement => {
-        parsedElement.x += dx;
-        parsedElement.y += dy;
-        parsedElement.seed = randomSeed();
-        elements.push(parsedElement);
+        const duplicate = duplicateElement(parsedElement);
+        duplicate.x += dx;
+        duplicate.y += dy;
+        elements.push(duplicate);
       });
       this.forceUpdate();
     }


### PR DESCRIPTION
Ok, making this PR a draft to ensure this one is done right :).

I've made a helper for duplicating elements. Technically, object spread won't be enough in case we add non-primitive members to elements in the future, so not sure about using that one.