### PR TITLE
prevent commit on eslint warnings & fix lint

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
       "git add"
     ],
     "*.{js,ts,tsx}": [
-      "eslint"
+      "eslint --max-warnings 0"
     ]
   }
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,7 +3,6 @@ import ReactDOM from "react-dom";
 import rough from "roughjs/bin/wrappers/rough";
 
 import { moveOneLeft, moveAllLeft, moveOneRight, moveAllRight } from "./zindex";
-import { randomSeed } from "./random";
 import {
   newElement,
   duplicateElement,


### PR DESCRIPTION
Made pre-commit hook to fail on eslint warnings. WTBS, we still lint and prettify only staged lines, which means it won't catch stuff like "unused variables" --- shouldn't we move to lint & prettify whole codebase?