### PR TITLE
Show move and resize cursors on hover

### DIFF
--- a/src/element/handlerRectangles.ts
+++ b/src/element/handlerRectangles.ts
@@ -1,11 +1,11 @@
-import { SceneState } from "../scene/types";
 import { ExcalidrawElement } from "./types";
+import { SceneScroll } from "../scene/types";
 
 type Sides = "n" | "s" | "w" | "e" | "nw" | "ne" | "sw" | "se";
 
 export function handlerRectangles(
   element: ExcalidrawElement,
-  sceneState: SceneState
+  { scrollX, scrollY }: SceneScroll
 ) {
   const elementX1 = element.x;
   const elementX2 = element.x + element.width;
@@ -21,15 +21,15 @@ export function handlerRectangles(
 
   if (Math.abs(elementX2 - elementX1) > minimumSize) {
     handlers["n"] = [
-      elementX1 + (elementX2 - elementX1) / 2 + sceneState.scrollX - 4,
-      elementY1 - margin + sceneState.scrollY + marginY,
+      elementX1 + (elementX2 - elementX1) / 2 + scrollX - 4,
+      elementY1 - margin + scrollY + marginY,
       8,
       8
     ];
 
     handlers["s"] = [
-      elementX1 + (elementX2 - elementX1) / 2 + sceneState.scrollX - 4,
-      elementY2 - margin + sceneState.scrollY - marginY,
+      elementX1 + (elementX2 - elementX1) / 2 + scrollX - 4,
+      elementY2 - margin + scrollY - marginY,
       8,
       8
     ];
@@ -37,41 +37,41 @@ export function handlerRectangles(
 
   if (Math.abs(elementY2 - elementY1) > minimumSize) {
     handlers["w"] = [
-      elementX1 - margin + sceneState.scrollX + marginX,
-      elementY1 + (elementY2 - elementY1) / 2 + sceneState.scrollY - 4,
+      elementX1 - margin + scrollX + marginX,
+      elementY1 + (elementY2 - elementY1) / 2 + scrollY - 4,
       8,
       8
     ];
 
     handlers["e"] = [
-      elementX2 - margin + sceneState.scrollX - marginX,
-      elementY1 + (elementY2 - elementY1) / 2 + sceneState.scrollY - 4,
+      elementX2 - margin + scrollX - marginX,
+      elementY1 + (elementY2 - elementY1) / 2 + scrollY - 4,
       8,
       8
     ];
   }
 
   handlers["nw"] = [
-    elementX1 - margin + sceneState.scrollX + marginX,
-    elementY1 - margin + sceneState.scrollY + marginY,
+    elementX1 - margin + scrollX + marginX,
+    elementY1 - margin + scrollY + marginY,
     8,
     8
   ]; // nw
   handlers["ne"] = [
-    elementX2 - margin + sceneState.scrollX - marginX,
-    elementY1 - margin + sceneState.scrollY + marginY,
+    elementX2 - margin + scrollX - marginX,
+    elementY1 - margin + scrollY + marginY,
     8,
     8
   ]; // ne
   handlers["sw"] = [
-    elementX1 - margin + sceneState.scrollX + marginX,
-    elementY2 - margin + sceneState.scrollY - marginY,
+    elementX1 - margin + scrollX + marginX,
+    elementY2 - margin + scrollY - marginY,
     8,
     8
   ]; // sw
   handlers["se"] = [
-    elementX2 - margin + sceneState.scrollX - marginX,
-    elementY2 - margin + sceneState.scrollY - marginY,
+    elementX2 - margin + scrollX - marginX,
+    elementY2 - margin + scrollY - marginY,
     8,
     8
   ]; // se

--- a/src/element/resizeTest.ts
+++ b/src/element/resizeTest.ts
@@ -1,7 +1,7 @@
 import { ExcalidrawElement } from "./types";
-import { SceneState } from "../scene/types";
 
 import { handlerRectangles } from "./handlerRectangles";
+import { SceneScroll } from "../scene/types";
 
 type HandlerRectanglesRet = keyof ReturnType<typeof handlerRectangles>;
 
@@ -9,20 +9,20 @@ export function resizeTest(
   element: ExcalidrawElement,
   x: number,
   y: number,
-  sceneState: SceneState
+  { scrollX, scrollY }: SceneScroll
 ): HandlerRectanglesRet | false {
   if (!element.isSelected || element.type === "text") return false;
 
-  const handlers = handlerRectangles(element, sceneState);
+  const handlers = handlerRectangles(element, { scrollX, scrollY });
 
   const filter = Object.keys(handlers).filter(key => {
     const handler = handlers[key as HandlerRectanglesRet]!;
 
     return (
-      x + sceneState.scrollX >= handler[0] &&
-      x + sceneState.scrollX <= handler[0] + handler[2] &&
-      y + sceneState.scrollY >= handler[1] &&
-      y + sceneState.scrollY <= handler[1] + handler[3]
+      x + scrollX >= handler[0] &&
+      x + scrollX <= handler[0] + handler[2] &&
+      y + scrollY >= handler[1] &&
+      y + scrollY <= handler[1] + handler[3]
     );
   });
 
@@ -31,4 +31,21 @@ export function resizeTest(
   }
 
   return false;
+}
+
+export function getElementWithResizeHandler(
+  elements: ExcalidrawElement[],
+  { x, y }: { x: number; y: number },
+  { scrollX, scrollY }: SceneScroll
+) {
+  return elements.reduce((result, element) => {
+    if (result) {
+      return result;
+    }
+    const resizeHandle = resizeTest(element, x, y, {
+      scrollX,
+      scrollY
+    });
+    return resizeHandle ? { element, resizeHandle } : null;
+  }, null as { element: ExcalidrawElement; resizeHandle: ReturnType<typeof resizeTest> } | null);
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -98,6 +98,15 @@ let lastCanvasHeight = -1;
 
 let lastMouseUp: ((e: any) => void) | null = null;
 
+export function viewportCoordsToSceneCoords(
+  { clientX, clientY }: { clientX: number; clientY: number },
+  { scrollX, scrollY }: { scrollX: number; scrollY: number }
+) {
+  const x = clientX - CANVAS_WINDOW_OFFSET_LEFT - scrollX;
+  const y = clientY - CANVAS_WINDOW_OFFSET_TOP - scrollY;
+  return { x, y };
+}
+
 export class App extends React.Component<{}, AppState> {
   canvas: HTMLCanvasElement | null = null;
   rc: RoughCanvas | null = null;
@@ -611,9 +620,8 @@ export class App extends React.Component<{}, AppState> {
               this.state.scrollY
             );
 
-            const x =
-              e.clientX - CANVAS_WINDOW_OFFSET_LEFT - this.state.scrollX;
-            const y = e.clientY - CANVAS_WINDOW_OFFSET_TOP - this.state.scrollY;
+            const { x, y } = viewportCoordsToSceneCoords(e, this.state);
+
             const element = newElement(
               this.state.elementType,
               x,
@@ -655,7 +663,7 @@ export class App extends React.Component<{}, AppState> {
                 // If we click on something
                 if (hitElement) {
                   if (hitElement.isSelected) {
-                    // If that element is not already selected, do nothing,
+                    // If that element is already selected, do nothing,
                     // we're likely going to drag it
                   } else {
                     // We unselect every other elements unless shift is pressed
@@ -932,9 +940,8 @@ export class App extends React.Component<{}, AppState> {
             this.forceUpdate();
           }}
           onDoubleClick={e => {
-            const x =
-              e.clientX - CANVAS_WINDOW_OFFSET_LEFT - this.state.scrollX;
-            const y = e.clientY - CANVAS_WINDOW_OFFSET_TOP - this.state.scrollY;
+            const { x, y } = viewportCoordsToSceneCoords(e, this.state);
+
             const elementAtPosition = getElementAtPosition(elements, x, y);
 
             const element = newElement(
@@ -1006,6 +1013,19 @@ export class App extends React.Component<{}, AppState> {
                 });
               }
             });
+          }}
+          onMouseMove={e => {
+            const hasDeselectedButton = Boolean(e.buttons);
+            if (hasDeselectedButton || this.state.elementType !== "selection") {
+              return;
+            }
+            const { x, y } = viewportCoordsToSceneCoords(e, this.state);
+            const hitElement = getElementAtPosition(elements, x, y);
+            if (hitElement) {
+              document.documentElement.style.cursor = `move`;
+            } else {
+              document.documentElement.style.cursor = ``;
+            }
           }}
         />
       </div>

--- a/src/scene/types.ts
+++ b/src/scene/types.ts
@@ -7,6 +7,11 @@ export type SceneState = {
   viewBackgroundColor: string | null;
 };
 
+export type SceneScroll = {
+  scrollX: number;
+  scrollY: number;
+};
+
 export interface Scene {
   elements: ExcalidrawTextElement[];
 }


### PR DESCRIPTION
Fixes #250 

Now, the cursor should change accordingly if the user hovers over the elements without having any mouse button depressed.

Additionally:

* Refactors the resizing test logic so that `resizeTest` is not invoked again after the selected element has been found.
* Adds a `viewportCoordsToSceneCoords` to replace the proper `x` and `y` coords calculation relative to the drawing canvas that was done in most event handlers.