### PR TITLE
Make all operations on elements array immutable

### DIFF
--- a/src/element/resizeTest.ts
+++ b/src/element/resizeTest.ts
@@ -34,7 +34,7 @@ export function resizeTest(
 }
 
 export function getElementWithResizeHandler(
-  elements: ExcalidrawElement[],
+  elements: readonly ExcalidrawElement[],
   { x, y }: { x: number; y: number },
   { scrollX, scrollY }: SceneScroll
 ) {

--- a/src/history.ts
+++ b/src/history.ts
@@ -22,14 +22,15 @@ class SceneHistory {
     this.stateHistory.push(newEntry);
   }
 
-  restoreEntry(elements: ExcalidrawElement[], entry: string) {
-    const newElements = JSON.parse(entry);
-    elements.splice(0, elements.length);
-    newElements.forEach((newElement: ExcalidrawElement) => {
-      elements.push(newElement);
-    });
+  restoreEntry(entry: string) {
     // When restoring, we shouldn't add an history entry otherwise we'll be stuck with it and can't go back
     this.skipRecording();
+
+    try {
+      return JSON.parse(entry);
+    } catch {
+      return null;
+    }
   }
 
   clearRedoStack() {
@@ -40,9 +41,11 @@ class SceneHistory {
     const currentEntry = this.generateCurrentEntry(elements);
     const entryToRestore = this.redoStack.pop();
     if (entryToRestore !== undefined) {
-      this.restoreEntry(elements, entryToRestore);
       this.stateHistory.push(currentEntry);
+      return this.restoreEntry(entryToRestore);
     }
+
+    return null;
   }
 
   undoOnce(elements: ExcalidrawElement[]) {
@@ -54,9 +57,11 @@ class SceneHistory {
       entryToRestore = this.stateHistory.pop();
     }
     if (entryToRestore !== undefined) {
-      this.restoreEntry(elements, entryToRestore);
       this.redoStack.push(currentEntry);
+      return this.restoreEntry(entryToRestore);
     }
+
+    return null;
   }
 
   isRecording() {

--- a/src/history.ts
+++ b/src/history.ts
@@ -5,7 +5,7 @@ class SceneHistory {
   private stateHistory: string[] = [];
   private redoStack: string[] = [];
 
-  generateCurrentEntry(elements: ExcalidrawElement[]) {
+  generateCurrentEntry(elements: readonly ExcalidrawElement[]) {
     return JSON.stringify(
       elements.map(element => ({ ...element, isSelected: false }))
     );
@@ -37,7 +37,7 @@ class SceneHistory {
     this.redoStack.splice(0, this.redoStack.length);
   }
 
-  redoOnce(elements: ExcalidrawElement[]) {
+  redoOnce(elements: readonly ExcalidrawElement[]) {
     const currentEntry = this.generateCurrentEntry(elements);
     const entryToRestore = this.redoStack.pop();
     if (entryToRestore !== undefined) {
@@ -48,7 +48,7 @@ class SceneHistory {
     return null;
   }
 
-  undoOnce(elements: ExcalidrawElement[]) {
+  undoOnce(elements: readonly ExcalidrawElement[]) {
     const currentEntry = this.generateCurrentEntry(elements);
     let entryToRestore = this.stateHistory.pop();
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -214,10 +214,16 @@ export class App extends React.Component<{}, AppState> {
     } else if (event[META_KEY] && event.code === "KeyZ") {
       if (event.shiftKey) {
         // Redo action
-        history.redoOnce(elements);
+        const data = history.redoOnce(elements);
+        if (data !== null) {
+          elements = data;
+        }
       } else {
         // undo action
-        history.undoOnce(elements);
+        const data = history.undoOnce(elements);
+        if (data !== null) {
+          elements = data;
+        }
       }
       this.forceUpdate();
       event.preventDefault();

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -775,21 +775,21 @@ export class App extends React.Component<{}, AppState> {
                 document.documentElement.style.cursor = `${resizeHandle}-resize`;
                 isResizingElements = true;
               } else {
+                // clear selection if shift is not clicked
+                if (!e.shiftKey) {
+                  elements = clearSelection(elements);
+                }
                 const hitElement = getElementAtPosition(elements, x, y);
 
                 // If we click on something
                 if (hitElement) {
-                  if (hitElement.isSelected) {
-                    // If that element is already selected, do nothing,
-                    // we're likely going to drag it
-                  } else {
-                    // We unselect every other elements unless shift is pressed
-                    if (!e.shiftKey) {
-                      elements = clearSelection(elements);
-                    }
-                  }
+                  // deselect if item is selected
+                  // if shift is not clicked, this will always return true
+                  // otherwise, it will trigger selection based on current
+                  // state of the box
+                  hitElement.isSelected = !hitElement.isSelected;
+
                   // No matter what, we select it
-                  hitElement.isSelected = true;
                   // We duplicate the selected element if alt is pressed on Mouse down
                   if (e.altKey) {
                     elements = [
@@ -805,9 +805,6 @@ export class App extends React.Component<{}, AppState> {
                       }, [] as typeof elements)
                     ];
                   }
-                } else {
-                  // If we don't click on anything, let's remove all the selected elements
-                  elements = clearSelection(elements);
                 }
 
                 isDraggingElements = someElementIsSelected(elements);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -309,11 +309,12 @@ export class App extends React.Component<{}, AppState> {
   private changeProperty = (
     callback: (element: ExcalidrawElement) => ExcalidrawElement
   ) => {
-    elements = elements
-      .filter(el => el.isSelected)
-      .map(element => {
+    elements = elements.map(element => {
+      if (element.isSelected) {
         return callback(element);
-      });
+      }
+      return element;
+    });
 
     this.forceUpdate();
   };

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -157,7 +157,7 @@ export class App extends React.Component<{}, AppState> {
     if (isInputLike(event.target)) return;
 
     if (event.key === KEYS.ESCAPE) {
-      elements = clearSelection([...elements]);
+      elements = clearSelection(elements);
       this.forceUpdate();
       event.preventDefault();
     } else if (event.key === KEYS.BACKSPACE || event.key === KEYS.DELETE) {
@@ -416,7 +416,7 @@ export class App extends React.Component<{}, AppState> {
             activeTool={this.state.elementType}
             onToolChange={value => {
               this.setState({ elementType: value });
-              elements = clearSelection([...elements]);
+              elements = clearSelection(elements);
               document.documentElement.style.cursor =
                 value === "text" ? "text" : "crosshair";
               this.forceUpdate();
@@ -670,7 +670,7 @@ export class App extends React.Component<{}, AppState> {
             }
 
             if (!element.isSelected) {
-              elements = clearSelection([...elements]);
+              elements = clearSelection(elements);
               element.isSelected = true;
               this.forceUpdate();
             }
@@ -772,7 +772,7 @@ export class App extends React.Component<{}, AppState> {
                   } else {
                     // We unselect every other elements unless shift is pressed
                     if (!e.shiftKey) {
-                      elements = clearSelection([...elements]);
+                      elements = clearSelection(elements);
                     }
                   }
                   // No matter what, we select it
@@ -783,7 +783,9 @@ export class App extends React.Component<{}, AppState> {
                       ...elements,
                       ...elements.reduce((duplicates, element) => {
                         if (element.isSelected) {
-                          duplicates.push(duplicateElement(element));
+                          duplicates = duplicates.concat(
+                            duplicateElement(element)
+                          );
                           element.isSelected = false;
                         }
                         return duplicates;
@@ -792,7 +794,7 @@ export class App extends React.Component<{}, AppState> {
                   }
                 } else {
                   // If we don't click on anything, let's remove all the selected elements
-                  elements = clearSelection([...elements]);
+                  elements = clearSelection(elements);
                 }
 
                 isDraggingElements = someElementIsSelected(elements);
@@ -991,7 +993,7 @@ export class App extends React.Component<{}, AppState> {
                 : height;
 
               if (this.state.elementType === "selection") {
-                elements = setSelection([...elements], draggingElement);
+                elements = setSelection(elements, draggingElement);
               }
               // We don't want to save history when moving an element
               history.skipRecording();
@@ -1009,7 +1011,7 @@ export class App extends React.Component<{}, AppState> {
 
               // if no element is clicked, clear the selection and redraw
               if (draggingElement === null) {
-                elements = clearSelection([...elements]);
+                elements = clearSelection(elements);
                 this.forceUpdate();
                 return;
               }
@@ -1061,7 +1063,9 @@ export class App extends React.Component<{}, AppState> {
             let textY = e.clientY;
 
             if (elementAtPosition && isTextElement(elementAtPosition)) {
-              elements.splice(elements.indexOf(elementAtPosition), 1);
+              elements = elements.filter(
+                element => element !== elementAtPosition
+              );
               this.forceUpdate();
 
               Object.assign(element, elementAtPosition);
@@ -1165,7 +1169,7 @@ export class App extends React.Component<{}, AppState> {
       parsedElements.length > 0 &&
       parsedElements[0].type // need to implement a better check here...
     ) {
-      elements = clearSelection([...elements]);
+      elements = clearSelection(elements);
 
       if (x == null) x = 10 - this.state.scrollX;
       if (y == null) y = 10 - this.state.scrollY;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -775,8 +775,13 @@ export class App extends React.Component<{}, AppState> {
                 document.documentElement.style.cursor = `${resizeHandle}-resize`;
                 isResizingElements = true;
               } else {
+                const selected = getElementAtPosition(
+                  elements.filter(el => el.isSelected),
+                  x,
+                  y
+                );
                 // clear selection if shift is not clicked
-                if (!e.shiftKey) {
+                if (!selected && !e.shiftKey) {
                   elements = clearSelection(elements);
                 }
                 const hitElement = getElementAtPosition(elements, x, y);
@@ -787,7 +792,7 @@ export class App extends React.Component<{}, AppState> {
                   // if shift is not clicked, this will always return true
                   // otherwise, it will trigger selection based on current
                   // state of the box
-                  hitElement.isSelected = !hitElement.isSelected;
+                  hitElement.isSelected = true;
 
                   // No matter what, we select it
                   // We duplicate the selected element if alt is pressed on Mouse down

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1077,7 +1077,7 @@ export class App extends React.Component<{}, AppState> {
 
             if (elementAtPosition && isTextElement(elementAtPosition)) {
               elements = elements.filter(
-                element => element !== elementAtPosition
+                element => element.id !== elementAtPosition.id
               );
               this.forceUpdate();
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -106,10 +106,16 @@ export class App extends React.Component<{}, AppState> {
     document.addEventListener("keydown", this.onKeyDown, false);
     window.addEventListener("resize", this.onResize, false);
 
-    const appState = restoreFromLocalStorage(elements);
+    const { elements: newElements, appState } = restoreFromLocalStorage();
+
+    if (newElements) {
+      elements = newElements;
+    }
 
     if (appState) {
       this.setState(appState);
+    } else {
+      this.forceUpdate();
     }
   }
 
@@ -512,7 +518,10 @@ export class App extends React.Component<{}, AppState> {
             }
             onSaveScene={() => saveAsJSON(elements, this.state.name)}
             onLoadScene={() =>
-              loadFromJSON(elements).then(() => this.forceUpdate())
+              loadFromJSON().then(({ elements: newElements }) => {
+                elements = newElements;
+                this.forceUpdate();
+              })
             }
           />
         </div>

--- a/src/renderer/renderScene.ts
+++ b/src/renderer/renderScene.ts
@@ -14,7 +14,7 @@ import {
 import { renderElement } from "./renderElement";
 
 export function renderScene(
-  elements: ExcalidrawElement[],
+  elements: readonly ExcalidrawElement[],
   rc: RoughCanvas,
   canvas: HTMLCanvasElement,
   sceneState: SceneState,

--- a/src/scene/comparisons.ts
+++ b/src/scene/comparisons.ts
@@ -2,7 +2,7 @@ import { ExcalidrawElement } from "../element/types";
 import { hitTest } from "../element/collision";
 import { getElementAbsoluteCoords } from "../element";
 
-export const hasBackground = (elements: ExcalidrawElement[]) =>
+export const hasBackground = (elements: readonly ExcalidrawElement[]) =>
   elements.some(
     element =>
       element.isSelected &&
@@ -11,7 +11,7 @@ export const hasBackground = (elements: ExcalidrawElement[]) =>
         element.type === "diamond")
   );
 
-export const hasStroke = (elements: ExcalidrawElement[]) =>
+export const hasStroke = (elements: readonly ExcalidrawElement[]) =>
   elements.some(
     element =>
       element.isSelected &&
@@ -21,11 +21,11 @@ export const hasStroke = (elements: ExcalidrawElement[]) =>
         element.type === "arrow")
   );
 
-export const hasText = (elements: ExcalidrawElement[]) =>
+export const hasText = (elements: readonly ExcalidrawElement[]) =>
   elements.some(element => element.isSelected && element.type === "text");
 
 export function getElementAtPosition(
-  elements: ExcalidrawElement[],
+  elements: readonly ExcalidrawElement[],
   x: number,
   y: number
 ) {
@@ -42,7 +42,7 @@ export function getElementAtPosition(
 }
 
 export function getElementContainingPosition(
-  elements: ExcalidrawElement[],
+  elements: readonly ExcalidrawElement[],
   x: number,
   y: number
 ) {

--- a/src/scene/createScene.ts
+++ b/src/scene/createScene.ts
@@ -1,6 +1,6 @@
 import { ExcalidrawElement } from "../element/types";
 
 export const createScene = () => {
-  const elements = Array.of<ExcalidrawElement>();
+  const elements: readonly ExcalidrawElement[] = [];
   return { elements };
 };

--- a/src/scene/data.ts
+++ b/src/scene/data.ts
@@ -22,6 +22,11 @@ function saveFile(name: string, data: string) {
   link.remove();
 }
 
+interface DataState {
+  elements: ExcalidrawElement[];
+  appState: any;
+}
+
 export function saveAsJSON(elements: ExcalidrawElement[], name: string) {
   const serialized = JSON.stringify({
     version: 1,
@@ -35,7 +40,7 @@ export function saveAsJSON(elements: ExcalidrawElement[], name: string) {
   );
 }
 
-export function loadFromJSON(elements: ExcalidrawElement[]) {
+export function loadFromJSON() {
   const input = document.createElement("input");
   const reader = new FileReader();
   input.type = "file";
@@ -52,12 +57,17 @@ export function loadFromJSON(elements: ExcalidrawElement[]) {
 
   input.click();
 
-  return new Promise(resolve => {
+  return new Promise<DataState>(resolve => {
     reader.onloadend = () => {
       if (reader.readyState === FileReader.DONE) {
-        const data = JSON.parse(reader.result as string);
-        restore(elements, data.elements, null);
-        resolve();
+        let elements = [];
+        try {
+          const data = JSON.parse(reader.result as string);
+          elements = data.elements || [];
+        } catch (e) {
+          // Do nothing because elements array is already empty
+        }
+        resolve(restore(elements, null));
       }
     };
   });
@@ -130,43 +140,48 @@ export function exportAsPNG(
 }
 
 function restore(
-  elements: ExcalidrawElement[],
-  savedElements: string | ExcalidrawElement[] | null,
-  savedState: string | null
-) {
-  try {
-    if (savedElements) {
-      elements.splice(
-        0,
-        elements.length,
-        ...(typeof savedElements === "string"
-          ? JSON.parse(savedElements)
-          : savedElements)
-      );
-      elements.forEach((element: ExcalidrawElement) => {
-        element.id = element.id || nanoid();
-        element.fillStyle = element.fillStyle || "hachure";
-        element.strokeWidth = element.strokeWidth || 1;
-        element.roughness = element.roughness || 1;
-        element.opacity =
-          element.opacity === null || element.opacity === undefined
-            ? 100
-            : element.opacity;
-      });
-    }
-
-    return savedState ? JSON.parse(savedState) : null;
-  } catch (e) {
-    elements.splice(0, elements.length);
-    return null;
-  }
+  savedElements: ExcalidrawElement[],
+  savedState: any
+): DataState {
+  return {
+    elements: savedElements.map(element => ({
+      ...element,
+      id: element.id || nanoid(),
+      fillStyle: element.fillStyle || "hachure",
+      strokeWidth: element.strokeWidth || 1,
+      roughness: element.roughness || 1,
+      opacity:
+        element.opacity === null || element.opacity === undefined
+          ? 100
+          : element.opacity
+    })),
+    appState: savedState
+  };
 }
 
-export function restoreFromLocalStorage(elements: ExcalidrawElement[]) {
+export function restoreFromLocalStorage() {
   const savedElements = localStorage.getItem(LOCAL_STORAGE_KEY);
   const savedState = localStorage.getItem(LOCAL_STORAGE_KEY_STATE);
 
-  return restore(elements, savedElements, savedState);
+  let elements = [];
+  if (savedElements) {
+    try {
+      elements = JSON.parse(savedElements);
+    } catch (e) {
+      // Do nothing because elements array is already empty
+    }
+  }
+
+  let appState = null;
+  if (savedState) {
+    try {
+      appState = JSON.parse(savedState);
+    } catch (e) {
+      // Do nothing because appState is already null
+    }
+  }
+
+  return restore(elements, appState);
 }
 
 export function saveToLocalStorage(

--- a/src/scene/data.ts
+++ b/src/scene/data.ts
@@ -23,11 +23,14 @@ function saveFile(name: string, data: string) {
 }
 
 interface DataState {
-  elements: ExcalidrawElement[];
+  elements: readonly ExcalidrawElement[];
   appState: any;
 }
 
-export function saveAsJSON(elements: ExcalidrawElement[], name: string) {
+export function saveAsJSON(
+  elements: readonly ExcalidrawElement[],
+  name: string
+) {
   const serialized = JSON.stringify({
     version: 1,
     source: window.location.origin,
@@ -74,7 +77,7 @@ export function loadFromJSON() {
 }
 
 export function exportAsPNG(
-  elements: ExcalidrawElement[],
+  elements: readonly ExcalidrawElement[],
   canvas: HTMLCanvasElement,
   {
     exportBackground,
@@ -140,7 +143,7 @@ export function exportAsPNG(
 }
 
 function restore(
-  savedElements: ExcalidrawElement[],
+  savedElements: readonly ExcalidrawElement[],
   savedState: any
 ): DataState {
   return {
@@ -185,7 +188,7 @@ export function restoreFromLocalStorage() {
 }
 
 export function saveToLocalStorage(
-  elements: ExcalidrawElement[],
+  elements: readonly ExcalidrawElement[],
   state: AppState
 ) {
   localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(elements));

--- a/src/scene/scrollbars.ts
+++ b/src/scene/scrollbars.ts
@@ -7,7 +7,7 @@ export const SCROLLBAR_WIDTH = 6;
 export const SCROLLBAR_COLOR = "rgba(0,0,0,0.3)";
 
 export function getScrollBars(
-  elements: ExcalidrawElement[],
+  elements: readonly ExcalidrawElement[],
   canvasWidth: number,
   canvasHeight: number,
   scrollX: number,
@@ -76,7 +76,7 @@ export function getScrollBars(
 }
 
 export function isOverScrollBars(
-  elements: ExcalidrawElement[],
+  elements: readonly ExcalidrawElement[],
   x: number,
   y: number,
   canvasWidth: number,

--- a/src/scene/selection.ts
+++ b/src/scene/selection.ts
@@ -25,20 +25,20 @@ export function setSelection(
       selectionX2 >= elementX2 &&
       selectionY2 >= elementY2;
   });
+
+  return elements;
 }
 
 export function clearSelection(elements: ExcalidrawElement[]) {
   elements.forEach(element => {
     element.isSelected = false;
   });
+
+  return elements;
 }
 
 export function deleteSelectedElements(elements: ExcalidrawElement[]) {
-  for (let i = elements.length - 1; i >= 0; --i) {
-    if (elements[i].isSelected) {
-      elements.splice(i, 1);
-    }
-  }
+  return elements.filter(el => !el.isSelected);
 }
 
 export function getSelectedIndices(elements: ExcalidrawElement[]) {

--- a/src/scene/selection.ts
+++ b/src/scene/selection.ts
@@ -30,11 +30,13 @@ export function setSelection(
 }
 
 export function clearSelection(elements: readonly ExcalidrawElement[]) {
-  elements.forEach(element => {
+  const newElements = [...elements];
+
+  newElements.forEach(element => {
     element.isSelected = false;
   });
 
-  return elements;
+  return newElements;
 }
 
 export function deleteSelectedElements(elements: readonly ExcalidrawElement[]) {

--- a/src/scene/selection.ts
+++ b/src/scene/selection.ts
@@ -2,7 +2,7 @@ import { ExcalidrawElement } from "../element/types";
 import { getElementAbsoluteCoords } from "../element";
 
 export function setSelection(
-  elements: ExcalidrawElement[],
+  elements: readonly ExcalidrawElement[],
   selection: ExcalidrawElement
 ) {
   const [
@@ -29,7 +29,7 @@ export function setSelection(
   return elements;
 }
 
-export function clearSelection(elements: ExcalidrawElement[]) {
+export function clearSelection(elements: readonly ExcalidrawElement[]) {
   elements.forEach(element => {
     element.isSelected = false;
   });
@@ -37,11 +37,11 @@ export function clearSelection(elements: ExcalidrawElement[]) {
   return elements;
 }
 
-export function deleteSelectedElements(elements: ExcalidrawElement[]) {
+export function deleteSelectedElements(elements: readonly ExcalidrawElement[]) {
   return elements.filter(el => !el.isSelected);
 }
 
-export function getSelectedIndices(elements: ExcalidrawElement[]) {
+export function getSelectedIndices(elements: readonly ExcalidrawElement[]) {
   const selectedIndices: number[] = [];
   elements.forEach((element, index) => {
     if (element.isSelected) {
@@ -51,11 +51,11 @@ export function getSelectedIndices(elements: ExcalidrawElement[]) {
   return selectedIndices;
 }
 
-export const someElementIsSelected = (elements: ExcalidrawElement[]) =>
+export const someElementIsSelected = (elements: readonly ExcalidrawElement[]) =>
   elements.some(element => element.isSelected);
 
 export function getSelectedAttribute<T>(
-  elements: ExcalidrawElement[],
+  elements: readonly ExcalidrawElement[],
   getAttribute: (element: ExcalidrawElement) => T
 ): T | null {
   const attributes = Array.from(

--- a/src/zindex.ts
+++ b/src/zindex.ts
@@ -17,6 +17,8 @@ export function moveOneLeft<T>(elements: T[], indicesToMove: number[]) {
     }
     swap(elements, index - 1, index);
   });
+
+  return elements;
 }
 
 export function moveOneRight<T>(elements: T[], indicesToMove: number[]) {
@@ -35,6 +37,7 @@ export function moveOneRight<T>(elements: T[], indicesToMove: number[]) {
     }
     swap(elements, index + 1, index);
   });
+  return elements;
 }
 
 // Let's go through an example
@@ -112,6 +115,8 @@ export function moveAllLeft<T>(elements: T[], indicesToMove: number[]) {
   leftMostElements.forEach((element, i) => {
     elements[i] = element;
   });
+
+  return elements;
 }
 
 // Let's go through an example
@@ -190,4 +195,6 @@ export function moveAllRight<T>(elements: T[], indicesToMove: number[]) {
   rightMostElements.forEach((element, i) => {
     elements[elements.length - i - 1] = element;
   });
+
+  return elements;
 }


### PR DESCRIPTION
In this PR, I am making all the operations on elements array (not the actual elements within them) immutable. Now, all the functions return values instead of mutating the array directly. Some of the functions to mutate the array directly but currently, those functions accept a copy of the elements array instead of the actual array (`[...elements]`). Those functions are:

- clearSelection
- setSelection
- moveAllLeft / Right
- moveOneLeft / Right

We can also slowly make these functions immutable.

After this PR, I am planning on moving elements array into state as nothing is really dependent on it except for the App component.
