### PR TITLE
Fix history saving for resizing/dragging element

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1051,6 +1051,8 @@ export class App extends React.Component<{}, AppState> {
                 draggingElement: null,
                 elementType: "selection"
               });
+
+              history.resumeRecording();
               this.forceUpdate();
             };
 
@@ -1280,7 +1282,6 @@ export class App extends React.Component<{}, AppState> {
       history.pushEntry(history.generateCurrentEntry(elements));
       history.clearRedoStack();
     }
-    history.resumeRecording();
   }
 }
 


### PR DESCRIPTION
Fix for #290 

Moving `history.resumeRecording();` to `onMouseUp` from `componentDidUpdate`. 

`skipRecording` is called in `onMouseDown` and `onMouseMove`. However, component is being updated a number of times which causes componentDidUpdate to call `resumeRecording` before being skipped again.
