### PR TITLE
Fix a bug where clipboard object doesn't exist in Safari

### DIFF
--- a/src/components/panels/PanelExport.tsx
+++ b/src/components/panels/PanelExport.tsx
@@ -27,6 +27,7 @@ const ClipboardIcon = () => (
 
 const probablySupportsClipboard =
   "toBlob" in HTMLCanvasElement.prototype &&
+  "clipboard" in navigator &&
   "write" in navigator.clipboard &&
   "ClipboardItem" in window;
 


### PR DESCRIPTION
For some reason `navigator.clipboard` object is `undefined` in Safari; so, `"write" in navigator.clipboard` throws error. I have added another check to see if `navigator.clipboard` object exists.

EDIT: It is not supported in [Safari](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/clipboard)