### PR TITLE
Improve color suggestions

### DIFF
--- a/src/components/ColorPicker.tsx
+++ b/src/components/ColorPicker.tsx
@@ -8,9 +8,11 @@ const TwitterPicker = lazy(() =>
 );
 
 export function ColorPicker({
+  type,
   color,
   onChange
 }: {
+  type: "canvasBackground" | "elementBackground" | "elementStroke";
   color: string | null;
   onChange: (color: string) => void;
 }) {
@@ -26,19 +28,7 @@ export function ColorPicker({
         {isActive ? (
           <Popover onCloseRequest={() => setActive(false)}>
             <TwitterPicker
-              colors={[
-                "#000000",
-                "#ABB8C3",
-                "#FFFFFF",
-                "#FF6900",
-                "#FCB900",
-                "#00D084",
-                "#8ED1FC",
-                "#0693E3",
-                "#EB144C",
-                "#F78DA7",
-                "#9900EF"
-              ]}
+              colors={colors[type]}
               width="205px"
               color={color || undefined}
               onChange={changedColor => {
@@ -58,3 +48,42 @@ export function ColorPicker({
     </div>
   );
 }
+
+const colors = {
+  canvasBackground: [
+    "#DEE6EF",
+    "#FCEAD8",
+    "#F9E0E0",
+    "#E6F1F1",
+    "#E0EDDF",
+    "#FBF5DD",
+    "#F0E6ED",
+    "#FFEDEF",
+    "#EDE5E1",
+    "#F2F0EF"
+  ],
+  elementBackground: [
+    "#4E79A7",
+    "#F28E2C",
+    "#E15759",
+    "#76B7B2",
+    "#59A14F",
+    "#EDC949",
+    "#AF7AA1",
+    "#FF9DA7",
+    "#9C755F",
+    "#BAB0AB"
+  ],
+  elementStroke: [
+    "#324E6B",
+    "#9B5B1D",
+    "#903839",
+    "#4C7572",
+    "#396733",
+    "#AD9336",
+    "#805976",
+    "#BA737A",
+    "#725646",
+    "#88817D"
+  ]
+};

--- a/src/components/ColorPicker.tsx
+++ b/src/components/ColorPicker.tsx
@@ -60,7 +60,8 @@ const colors = {
     "#F0E6ED",
     "#FFEDEF",
     "#EDE5E1",
-    "#F2F0EF"
+    "#F2F0EF",
+    "#FFFFFF"
   ],
   elementBackground: [
     "#4E79A7",
@@ -84,6 +85,7 @@ const colors = {
     "#805976",
     "#BA737A",
     "#725646",
-    "#88817D"
+    "#88817D",
+    "#000000"
   ]
 };

--- a/src/components/ColorPicker.tsx
+++ b/src/components/ColorPicker.tsx
@@ -73,7 +73,8 @@ const colors = {
     "#AF7AA1",
     "#FF9DA7",
     "#9C755F",
-    "#BAB0AB"
+    "#BAB0AB",
+    "#FFFFFF"
   ],
   elementStroke: [
     "#324E6B",

--- a/src/components/SidePanel.tsx
+++ b/src/components/SidePanel.tsx
@@ -71,6 +71,7 @@ export const SidePanel: React.FC<SidePanelProps> = ({
 
         <PanelColor
           title="Stroke Color"
+          colorType="elementStroke"
           onColorChange={(color: string) => {
             changeProperty(element => ({
               ...element,
@@ -88,6 +89,7 @@ export const SidePanel: React.FC<SidePanelProps> = ({
           <>
             <PanelColor
               title="Background Color"
+              colorType="elementBackground"
               onColorChange={(color: string) => {
                 changeProperty(element => ({
                   ...element,

--- a/src/components/panels/PanelCanvas.tsx
+++ b/src/components/panels/PanelCanvas.tsx
@@ -18,6 +18,7 @@ export const PanelCanvas: React.FC<PanelCanvasProps> = ({
     <Panel title="Canvas">
       <h5>Canvas Background Color</h5>
       <ColorPicker
+        type="canvasBackground"
         color={viewBackgroundColor}
         onChange={color => onViewBackgroundColorChange(color)}
       />

--- a/src/components/panels/PanelColor.tsx
+++ b/src/components/panels/PanelColor.tsx
@@ -3,12 +3,14 @@ import { ColorPicker } from "../ColorPicker";
 
 interface PanelColorProps {
   title: string;
+  colorType: "canvasBackground" | "elementBackground" | "elementStroke";
   colorValue: string | null;
   onColorChange: (value: string) => void;
 }
 
 export const PanelColor: React.FC<PanelColorProps> = ({
   title,
+  colorType,
   onColorChange,
   colorValue
 }) => {
@@ -16,6 +18,7 @@ export const PanelColor: React.FC<PanelColorProps> = ({
     <>
       <h5>{title}</h5>
       <ColorPicker
+        type={colorType}
         color={colorValue}
         onChange={color => onColorChange(color)}
       />


### PR DESCRIPTION
Covers https://github.com/excalidraw/excalidraw/issues/262.

Thinking about the comment by @vjeux about using different color palettes for each type of color in the app, I thought it would make great sense to use one same palette with different levels of lightness to reinforce their role.

So I took the `schemeTableau10` color palette from [d3 palettes](https://github.com/d3/d3-scale-chromatic#api-reference) as @pshihn suggested and modified it based on lightness to have light pastel-like colors for the canvas background (so we easily add on top with contrast), saturated and clean colors for the elements background (so they catch eyes as they are the main elements) and dark colors for strokes (so they highlight elements more effectively).

Canvas background:

<img width="246" alt="Screenshot 2020-01-10 at 23 02 47" src="https://user-images.githubusercontent.com/10673347/72189564-6a37b680-33fd-11ea-82f4-f3c06bf5f0e9.png">

Element background:

<img width="246" alt="Screenshot 2020-01-10 at 23 03 12" src="https://user-images.githubusercontent.com/10673347/72189562-6a37b680-33fd-11ea-8c3f-bfb2ed36de80.png">

Element stroke:

<img width="246" alt="Screenshot 2020-01-10 at 23 02 56" src="https://user-images.githubusercontent.com/10673347/72189563-6a37b680-33fd-11ea-878d-b1cbebe7fefd.png">

I have played a bit around, I feel like I can almost select any color on top of any other and it will look pretty decent. That said, I'm definitely open for suggestions or any ideas you might have. Colors are pretty hard and subjective 😄 

Regarding the code, I did it in the more straightforward way. An object with array of colors as values that we select based on a `type` property that is an enum. Let me know if you want to reorganize it in some other way 👍 