### PR TITLE
Fix codesandbox

### DIFF
--- a/src/actions/actionProperties.tsx
+++ b/src/actions/actionProperties.tsx
@@ -7,7 +7,7 @@ import { PanelColor } from "../components/panels/PanelColor";
 import { isTextElement, redrawTextBoundingBox } from "../element";
 
 const changeProperty = (
-  elements: readonly ExcalidrawElement[],
+  elements: ExcalidrawElement[],
   callback: (element: ExcalidrawElement) => ExcalidrawElement
 ) => {
   return elements.map(element => {

--- a/src/actions/manager.tsx
+++ b/src/actions/manager.tsx
@@ -22,7 +22,7 @@ export class ActionManager implements ActionsManagerInterface {
 
   handleKeyDown(
     event: KeyboardEvent,
-    elements: readonly ExcalidrawElement[],
+    elements: ExcalidrawElement[],
     appState: AppState
   ) {
     const data = Object.values(this.actions)
@@ -38,7 +38,7 @@ export class ActionManager implements ActionsManagerInterface {
   }
 
   getContextMenuItems(
-    elements: readonly ExcalidrawElement[],
+    elements: ExcalidrawElement[],
     appState: AppState,
     updater: UpdaterFn
   ) {
@@ -64,7 +64,7 @@ export class ActionManager implements ActionsManagerInterface {
 
   renderAction(
     name: string,
-    elements: readonly ExcalidrawElement[],
+    elements: ExcalidrawElement[],
     appState: AppState,
     updater: UpdaterFn
   ) {

--- a/src/components/SidePanel.tsx
+++ b/src/components/SidePanel.tsx
@@ -19,7 +19,7 @@ import { UpdaterFn } from "../actions/types";
 
 interface SidePanelProps {
   actionManager: ActionManager;
-  elements: readonly ExcalidrawElement[];
+  elements: ExcalidrawElement[];
   syncActionResult: UpdaterFn;
   appState: AppState;
   onToolChange: (elementType: string) => void;

--- a/src/components/panels/PanelCanvas.tsx
+++ b/src/components/panels/PanelCanvas.tsx
@@ -8,7 +8,7 @@ import { UpdaterFn } from "../../actions/types";
 
 interface PanelCanvasProps {
   actionManager: ActionManager;
-  elements: readonly ExcalidrawElement[];
+  elements: ExcalidrawElement[];
   appState: AppState;
   syncActionResult: UpdaterFn;
 }

--- a/src/components/panels/PanelExport.tsx
+++ b/src/components/panels/PanelExport.tsx
@@ -10,7 +10,7 @@ import { UpdaterFn } from "../../actions/types";
 
 interface PanelExportProps {
   actionManager: ActionManager;
-  elements: readonly ExcalidrawElement[];
+  elements: ExcalidrawElement[];
   appState: AppState;
   syncActionResult: UpdaterFn;
   onExportCanvas: (type: ExportType) => void;
@@ -22,7 +22,7 @@ const ClipboardIcon = () => (
     <path
       fill="currentColor"
       d="M384 112v352c0 26.51-21.49 48-48 48H48c-26.51 0-48-21.49-48-48V112c0-26.51 21.49-48 48-48h80c0-35.29 28.71-64 64-64s64 28.71 64 64h80c26.51 0 48 21.49 48 48zM192 40c-13.255 0-24 10.745-24 24s10.745 24 24 24 24-10.745 24-24-10.745-24-24-24m96 114v-20a6 6 0 0 0-6-6H102a6 6 0 0 0-6 6v20a6 6 0 0 0 6 6h180a6 6 0 0 0 6-6z"
-    ></path>
+    />
   </svg>
 );
 

--- a/src/components/panels/PanelSelection.tsx
+++ b/src/components/panels/PanelSelection.tsx
@@ -6,7 +6,7 @@ import { UpdaterFn } from "../../actions/types";
 
 interface PanelSelectionProps {
   actionManager: ActionManager;
-  elements: readonly ExcalidrawElement[];
+  elements: ExcalidrawElement[];
   appState: AppState;
   syncActionResult: UpdaterFn;
 }

--- a/src/element/resizeTest.ts
+++ b/src/element/resizeTest.ts
@@ -34,18 +34,24 @@ export function resizeTest(
 }
 
 export function getElementWithResizeHandler(
-  elements: readonly ExcalidrawElement[],
+  elements: ExcalidrawElement[],
   { x, y }: { x: number; y: number },
   { scrollX, scrollY }: SceneScroll
 ) {
-  return elements.reduce((result, element) => {
-    if (result) {
-      return result;
-    }
-    const resizeHandle = resizeTest(element, x, y, {
-      scrollX,
-      scrollY
-    });
-    return resizeHandle ? { element, resizeHandle } : null;
-  }, null as { element: ExcalidrawElement; resizeHandle: ReturnType<typeof resizeTest> } | null);
+  return elements.reduce(
+    (result, element) => {
+      if (result) {
+        return result;
+      }
+      const resizeHandle = resizeTest(element, x, y, {
+        scrollX,
+        scrollY
+      });
+      return resizeHandle ? { element, resizeHandle } : null;
+    },
+    null as {
+      element: ExcalidrawElement;
+      resizeHandle: ReturnType<typeof resizeTest>;
+    } | null
+  );
 }

--- a/src/history.ts
+++ b/src/history.ts
@@ -5,7 +5,7 @@ class SceneHistory {
   private stateHistory: string[] = [];
   private redoStack: string[] = [];
 
-  generateCurrentEntry(elements: readonly ExcalidrawElement[]) {
+  generateCurrentEntry(elements: ExcalidrawElement[]) {
     return JSON.stringify(
       elements.map(element => ({ ...element, isSelected: false }))
     );
@@ -37,7 +37,7 @@ class SceneHistory {
     this.redoStack.splice(0, this.redoStack.length);
   }
 
-  redoOnce(elements: readonly ExcalidrawElement[]) {
+  redoOnce(elements: ExcalidrawElement[]) {
     const currentEntry = this.generateCurrentEntry(elements);
     const entryToRestore = this.redoStack.pop();
     if (entryToRestore !== undefined) {
@@ -48,7 +48,7 @@ class SceneHistory {
     return null;
   }
 
-  undoOnce(elements: readonly ExcalidrawElement[]) {
+  undoOnce(elements: ExcalidrawElement[]) {
     const currentEntry = this.generateCurrentEntry(elements);
     let entryToRestore = this.stateHistory.pop();
 

--- a/src/renderer/renderScene.ts
+++ b/src/renderer/renderScene.ts
@@ -14,7 +14,7 @@ import {
 import { renderElement } from "./renderElement";
 
 export function renderScene(
-  elements: readonly ExcalidrawElement[],
+  elements: ExcalidrawElement[],
   rc: RoughCanvas,
   canvas: HTMLCanvasElement,
   sceneState: SceneState,

--- a/src/scene/comparisons.ts
+++ b/src/scene/comparisons.ts
@@ -2,7 +2,7 @@ import { ExcalidrawElement } from "../element/types";
 import { hitTest } from "../element/collision";
 import { getElementAbsoluteCoords } from "../element";
 
-export const hasBackground = (elements: readonly ExcalidrawElement[]) =>
+export const hasBackground = (elements: ExcalidrawElement[]) =>
   elements.some(
     element =>
       element.isSelected &&
@@ -11,7 +11,7 @@ export const hasBackground = (elements: readonly ExcalidrawElement[]) =>
         element.type === "diamond")
   );
 
-export const hasStroke = (elements: readonly ExcalidrawElement[]) =>
+export const hasStroke = (elements: ExcalidrawElement[]) =>
   elements.some(
     element =>
       element.isSelected &&
@@ -21,11 +21,11 @@ export const hasStroke = (elements: readonly ExcalidrawElement[]) =>
         element.type === "arrow")
   );
 
-export const hasText = (elements: readonly ExcalidrawElement[]) =>
+export const hasText = (elements: ExcalidrawElement[]) =>
   elements.some(element => element.isSelected && element.type === "text");
 
 export function getElementAtPosition(
-  elements: readonly ExcalidrawElement[],
+  elements: ExcalidrawElement[],
   x: number,
   y: number
 ) {
@@ -42,7 +42,7 @@ export function getElementAtPosition(
 }
 
 export function getElementContainingPosition(
-  elements: readonly ExcalidrawElement[],
+  elements: ExcalidrawElement[],
   x: number,
   y: number
 ) {

--- a/src/scene/createScene.ts
+++ b/src/scene/createScene.ts
@@ -1,6 +1,6 @@
 import { ExcalidrawElement } from "../element/types";
 
 export const createScene = () => {
-  const elements: readonly ExcalidrawElement[] = [];
+  const elements: ExcalidrawElement[] = [];
   return { elements };
 };

--- a/src/scene/data.ts
+++ b/src/scene/data.ts
@@ -24,14 +24,11 @@ function saveFile(name: string, data: string) {
 }
 
 interface DataState {
-  elements: readonly ExcalidrawElement[];
+  elements: ExcalidrawElement[];
   appState: any;
 }
 
-export function saveAsJSON(
-  elements: readonly ExcalidrawElement[],
-  name: string
-) {
+export function saveAsJSON(elements: ExcalidrawElement[], name: string) {
   const serialized = JSON.stringify({
     version: 1,
     source: window.location.origin,
@@ -79,7 +76,7 @@ export function loadFromJSON() {
 
 export function exportCanvas(
   type: ExportType,
-  elements: readonly ExcalidrawElement[],
+  elements: ExcalidrawElement[],
   canvas: HTMLCanvasElement,
   {
     exportBackground,
@@ -161,7 +158,7 @@ export function exportCanvas(
 }
 
 function restore(
-  savedElements: readonly ExcalidrawElement[],
+  savedElements: ExcalidrawElement[],
   savedState: any
 ): DataState {
   return {
@@ -206,7 +203,7 @@ export function restoreFromLocalStorage() {
 }
 
 export function saveToLocalStorage(
-  elements: readonly ExcalidrawElement[],
+  elements: ExcalidrawElement[],
   state: AppState
 ) {
   localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(elements));

--- a/src/scene/scrollbars.ts
+++ b/src/scene/scrollbars.ts
@@ -7,7 +7,7 @@ export const SCROLLBAR_WIDTH = 6;
 export const SCROLLBAR_COLOR = "rgba(0,0,0,0.3)";
 
 export function getScrollBars(
-  elements: readonly ExcalidrawElement[],
+  elements: ExcalidrawElement[],
   canvasWidth: number,
   canvasHeight: number,
   scrollX: number,
@@ -76,7 +76,7 @@ export function getScrollBars(
 }
 
 export function isOverScrollBars(
-  elements: readonly ExcalidrawElement[],
+  elements: ExcalidrawElement[],
   x: number,
   y: number,
   canvasWidth: number,

--- a/src/scene/selection.ts
+++ b/src/scene/selection.ts
@@ -2,7 +2,7 @@ import { ExcalidrawElement } from "../element/types";
 import { getElementAbsoluteCoords } from "../element";
 
 export function setSelection(
-  elements: readonly ExcalidrawElement[],
+  elements: ExcalidrawElement[],
   selection: ExcalidrawElement
 ) {
   const [
@@ -29,7 +29,7 @@ export function setSelection(
   return elements;
 }
 
-export function clearSelection(elements: readonly ExcalidrawElement[]) {
+export function clearSelection(elements: ExcalidrawElement[]) {
   const newElements = [...elements];
 
   newElements.forEach(element => {
@@ -39,11 +39,11 @@ export function clearSelection(elements: readonly ExcalidrawElement[]) {
   return newElements;
 }
 
-export function deleteSelectedElements(elements: readonly ExcalidrawElement[]) {
+export function deleteSelectedElements(elements: ExcalidrawElement[]) {
   return elements.filter(el => !el.isSelected);
 }
 
-export function getSelectedIndices(elements: readonly ExcalidrawElement[]) {
+export function getSelectedIndices(elements: ExcalidrawElement[]) {
   const selectedIndices: number[] = [];
   elements.forEach((element, index) => {
     if (element.isSelected) {
@@ -53,11 +53,11 @@ export function getSelectedIndices(elements: readonly ExcalidrawElement[]) {
   return selectedIndices;
 }
 
-export const someElementIsSelected = (elements: readonly ExcalidrawElement[]) =>
+export const someElementIsSelected = (elements: ExcalidrawElement[]) =>
   elements.some(element => element.isSelected);
 
 export function getSelectedAttribute<T>(
-  elements: readonly ExcalidrawElement[],
+  elements: ExcalidrawElement[],
   getAttribute: (element: ExcalidrawElement) => T
 ): T | null {
   const attributes = Array.from(


### PR DESCRIPTION
Unfortunately codesandbox chokes on `readonly`. Let's remove it for now so that we can keep using codesandbox. If they fix it, we can put it back.

Fixes #303