### PR TITLE
Tweak context menu style

### DIFF
--- a/src/components/ContextMenu.css
+++ b/src/components/ContextMenu.css
@@ -5,6 +5,10 @@
   padding: 0;
   list-style: none;
   user-select: none;
+  margin: -4px 0 0 1px;
+  padding: 4px 0;
+  background-color: #f2f2f2;
+  border: 1px solid #bcbcbc;
 }
 
 .context-menu__option {
@@ -17,18 +21,16 @@
   margin: 0;
   text-align: left;
   border-radius: 0;
+  padding-left: 20px;
+  background-color: #f2f2f2;
+  border: none;
+}
+
+.context-menu-option:hover {
+  color: white;
+  background-color: #4e95f5;
 }
 
 .context-menu-option:focus {
   z-index: 1;
-}
-
-.context-menu__option:first-child .context-menu-option {
-  border-top-left-radius: 4px;
-  border-top-right-radius: 4px;
-}
-
-.context-menu__option:last-child .context-menu-option {
-  border-bottom-left-radius: 4px;
-  border-bottom-right-radius: 4px;
 }


### PR DESCRIPTION
- Move the context menu right next to the mouse so it's not so far away. But 1px out so that nothing is selected until you move your mouse
- Change the colors to be closer to the macos one. Unfortunately, macos has a 0.5px border that I'm not able to reproduce without some annoying hacks, 1px it'll be.

![ezgif-6-573462013b16](https://user-images.githubusercontent.com/197597/72212096-4622b680-348b-11ea-909e-775aa49c67db.gif)

Fixes #269