### PR TITLE
Fix cmd-a drawing arrows

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -232,7 +232,7 @@ export class App extends React.Component<{}, AppState> {
     const data = this.actionManager.handleKeyDown(event, elements, this.state);
     this.syncActionResult(data);
 
-    if (data.elements !== undefined && data.appState !== undefined) {
+    if (data.elements !== undefined || data.appState !== undefined) {
       return;
     }
 


### PR DESCRIPTION
We need to quit if we have either elements OR appState, not both.

Test plan:
- Cmd-a
- Observe that it selects elements
- Observe that it doesn't enable arrow creation

Fixes #319