### PR TITLE
Fix alt-duplicate

### DIFF
--- a/src/element/newElement.ts
+++ b/src/element/newElement.ts
@@ -37,6 +37,7 @@ export function newElement(
 
 export function duplicateElement(element: ReturnType<typeof newElement>) {
   const copy = { ...element };
+  delete copy.shape;
   copy.id = nanoid();
   copy.seed = randomSeed();
   return copy;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -520,20 +520,20 @@ export class App extends React.Component<{}, AppState> {
                     elementIsAddedToSelection = true;
                   }
 
-                  // No matter what, we select it
                   // We duplicate the selected element if alt is pressed on Mouse down
                   if (e.altKey) {
                     elements = [
-                      ...elements,
-                      ...elements.reduce((duplicates, element) => {
-                        if (element.isSelected) {
-                          duplicates = duplicates.concat(
-                            duplicateElement(element)
-                          );
-                          element.isSelected = false;
-                        }
-                        return duplicates;
-                      }, [] as typeof elements)
+                      ...elements.map(element => ({
+                        ...element,
+                        isSelected: false
+                      })),
+                      ...elements
+                        .filter(element => element.isSelected)
+                        .map(element => {
+                          const newElement = duplicateElement(element);
+                          newElement.isSelected = true;
+                          return newElement;
+                        })
                     ];
                   }
                 }


### PR DESCRIPTION
We need to unselect all the previous elements and select all the new ones. Also made sure that the shape is regenerated when the element is duplicated

![ezgif-6-48d6f23d6327](https://user-images.githubusercontent.com/197597/72213746-4d58bd00-34a9-11ea-9321-c874931b6722.gif)
