### PR TITLE
"Select All" only appears when clicking outside of a shape via action…

### DIFF
--- a/src/actions/manager.tsx
+++ b/src/actions/manager.tsx
@@ -1,5 +1,10 @@
 import React from "react";
-import { Action, ActionsManagerInterface, UpdaterFn } from "./types";
+import {
+  Action,
+  ActionsManagerInterface,
+  UpdaterFn,
+  ActionFilterFn
+} from "./types";
 import { ExcalidrawElement } from "../element/types";
 import { AppState } from "../types";
 
@@ -40,9 +45,11 @@ export class ActionManager implements ActionsManagerInterface {
   getContextMenuItems(
     elements: readonly ExcalidrawElement[],
     appState: AppState,
-    updater: UpdaterFn
+    updater: UpdaterFn,
+    actionFilter: ActionFilterFn = action => action
   ) {
     return Object.values(this.actions)
+      .filter(actionFilter)
       .filter(action => "contextItemLabel" in action)
       .sort(
         (a, b) =>

--- a/src/actions/types.ts
+++ b/src/actions/types.ts
@@ -14,6 +14,7 @@ type ActionFn = (
 ) => ActionResult;
 
 export type UpdaterFn = (res: ActionResult) => void;
+export type ActionFilterFn = (action: Action) => void;
 
 export interface Action {
   name: string;
@@ -46,7 +47,8 @@ export interface ActionsManagerInterface {
   getContextMenuItems: (
     elements: readonly ExcalidrawElement[],
     appState: AppState,
-    updater: UpdaterFn
+    updater: UpdaterFn,
+    actionFilter: ActionFilterFn
   ) => { label: string; action: () => void }[];
   renderAction: (
     name: string,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -64,7 +64,7 @@ import {
   actionPasteStyles
 } from "./actions";
 import { SidePanel } from "./components/SidePanel";
-import { ActionResult } from "./actions/types";
+import { Action, ActionResult } from "./actions/types";
 
 let { elements } = createScene();
 const { history } = createHistory();
@@ -123,6 +123,7 @@ export class App extends React.Component<{}, AppState> {
   rc: RoughCanvas | null = null;
 
   actionManager: ActionManager = new ActionManager();
+  canvasOnlyActions: Array<Action>;
   constructor(props: any) {
     super(props);
     this.actionManager.registerAction(actionDeleteSelected);
@@ -151,6 +152,8 @@ export class App extends React.Component<{}, AppState> {
 
     this.actionManager.registerAction(actionCopyStyles);
     this.actionManager.registerAction(actionPasteStyles);
+
+    this.canvasOnlyActions = [actionSelectAll];
   }
 
   private syncActionResult = (res: ActionResult) => {
@@ -396,7 +399,13 @@ export class App extends React.Component<{}, AppState> {
                   navigator.clipboard && {
                     label: "Paste",
                     action: () => this.pasteFromClipboard()
-                  }
+                  },
+                  ...this.actionManager.getContextMenuItems(
+                    elements,
+                    this.state,
+                    this.syncActionResult,
+                    action => this.canvasOnlyActions.includes(action)
+                  )
                 ],
                 top: e.clientY,
                 left: e.clientX
@@ -423,7 +432,8 @@ export class App extends React.Component<{}, AppState> {
                 ...this.actionManager.getContextMenuItems(
                   elements,
                   this.state,
-                  this.syncActionResult
+                  this.syncActionResult,
+                  action => !this.canvasOnlyActions.includes(action)
                 )
               ],
               top: e.clientY,


### PR DESCRIPTION
…Filter

Fixes https://github.com/excalidraw/excalidraw/issues/318

Added a new parameter when getting context items that accepts a consumer defined filter function. The main app now keeps track of what actions apply only when clicking on the canvas, so more can be added if needed. 

Let me know what you think!