### PR TITLE
Reset to selection after creating a text

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -568,6 +568,7 @@ export class App extends React.Component<{}, AppState> {
                   });
                 }
               });
+              this.setState({ elementType: "selection" });
               return;
             }
 


### PR DESCRIPTION
Fixes #252

Test plan:
- Click on text icon
- Click anywhere to start entering text
- Add a letter
- Make sure the cursor is selection and not text
- Click anywhere else, make sure it completes the text and not create a new one