### PR TITLE
Remove element shape object from local storage save

### DIFF
--- a/src/scene/data.ts
+++ b/src/scene/data.ts
@@ -187,7 +187,9 @@ export function restoreFromLocalStorage() {
   let elements = [];
   if (savedElements) {
     try {
-      elements = JSON.parse(savedElements);
+      elements = JSON.parse(savedElements).map(
+        ({ shape, ...element }: ExcalidrawElement) => element
+      );
     } catch (e) {
       // Do nothing because elements array is already empty
     }


### PR DESCRIPTION
This is a bug from shape generator optimization. The generator shapes were being saved into local storage which was causing any changes to the rendering etc to be saved. Now, it is removed.
