### PR TITLE
History improvements

### DIFF
--- a/src/history.ts
+++ b/src/history.ts
@@ -22,7 +22,11 @@ class SceneHistory {
       // If the last entry is the same as this one, ignore it
       return;
     }
+
     this.stateHistory.push(newEntry);
+
+    // As a new entry was pushed, we invalidate the redo stack
+    this.clearRedoStack();
   }
 
   restoreEntry(entry: string) {

--- a/src/history.ts
+++ b/src/history.ts
@@ -41,6 +41,10 @@ class SceneHistory {
   }
 
   redoOnce() {
+    if (this.redoStack.length === 0) {
+      return null;
+    }
+
     const entryToRestore = this.redoStack.pop();
 
     if (entryToRestore !== undefined) {

--- a/src/history.ts
+++ b/src/history.ts
@@ -30,9 +30,6 @@ class SceneHistory {
   }
 
   restoreEntry(entry: string) {
-    // When restoring, we shouldn't add an history entry otherwise we'll be stuck with it and can't go back
-    this.skipRecording();
-
     try {
       return JSON.parse(entry);
     } catch {

--- a/src/history.ts
+++ b/src/history.ts
@@ -40,11 +40,11 @@ class SceneHistory {
     this.redoStack.splice(0, this.redoStack.length);
   }
 
-  redoOnce(elements: readonly ExcalidrawElement[]) {
-    const currentEntry = this.generateCurrentEntry(elements);
+  redoOnce() {
     const entryToRestore = this.redoStack.pop();
+
     if (entryToRestore !== undefined) {
-      this.stateHistory.push(currentEntry);
+      this.stateHistory.push(entryToRestore);
       return this.restoreEntry(entryToRestore);
     }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1026,7 +1026,6 @@ export class App extends React.Component<{}, AppState> {
     this.saveDebounced();
     if (history.isRecording()) {
       history.pushEntry(history.generateCurrentEntry(elements));
-      history.clearRedoStack();
     }
   }
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -291,7 +291,7 @@ export class App extends React.Component<{}, AppState> {
     } else if (event[META_KEY] && event.code === "KeyZ") {
       if (event.shiftKey) {
         // Redo action
-        const data = history.redoOnce(elements);
+        const data = history.redoOnce();
         if (data !== null) {
           elements = data;
         }


### PR DESCRIPTION
Following up https://github.com/excalidraw/excalidraw/issues/307.

Covers:

- Simplify `redoOnce` function to match `undoOnce` shape.
- Move `clearRedoStack` call to `pushEntry` (we might be erasing the redo stack when we haven't created any new entry in the history if the generated current entry is equal to last history entry).
- Remove `skipRecording` call from `restoreEntry` because we already make sure to don't loop by checking that the history entry we want to push is not equal to the last one. If we want to optimize the number of calls to `pushEntry` in `componentDidUpdate`, we should do it via external mechanism (same way we only call `pushEntry` if `isRecording`). The history itself should not be aware of this recording thing. 

cc @vjeux as he was in the context 👍 