### PR TITLE
Add AppState to export json to fix various import bugs

### DIFF
--- a/src/actions/actionExport.tsx
+++ b/src/actions/actionExport.tsx
@@ -40,7 +40,7 @@ export const actionChangeExportBackground: Action = {
 export const actionSaveScene: Action = {
   name: "saveScene",
   perform: (elements, appState, value) => {
-    saveAsJSON(elements, appState.name);
+    saveAsJSON(elements, appState);
     return {};
   },
   PanelComponent: ({ updateData }) => (
@@ -56,8 +56,12 @@ export const actionSaveScene: Action = {
 
 export const actionLoadScene: Action = {
   name: "loadScene",
-  perform: (elements, appState, loadedElements) => {
-    return { elements: loadedElements };
+  perform: (
+    elements,
+    appState,
+    { elements: loadedElements, appState: loadedAppState }
+  ) => {
+    return { elements: loadedElements, appState: loadedAppState };
   },
   PanelComponent: ({ updateData }) => (
     <ToolIcon
@@ -66,8 +70,8 @@ export const actionLoadScene: Action = {
       title="Load"
       aria-label="Load"
       onClick={() => {
-        loadFromJSON().then(({ elements }) => {
-          updateData(elements);
+        loadFromJSON().then(({ elements, appState }) => {
+          updateData({ elements: elements, appState: appState });
         });
       }}
     />

--- a/src/scene/data.ts
+++ b/src/scene/data.ts
@@ -3,6 +3,7 @@ import rough from "roughjs/bin/rough";
 import { ExcalidrawElement } from "../element/types";
 
 import { getElementAbsoluteCoords } from "../element";
+import { getDefaultAppState } from "../appState";
 
 import { renderScene } from "../renderer";
 import { AppState } from "../types";
@@ -25,21 +26,22 @@ function saveFile(name: string, data: string) {
 
 interface DataState {
   elements: readonly ExcalidrawElement[];
-  appState: any;
+  appState: AppState;
 }
 
 export function saveAsJSON(
   elements: readonly ExcalidrawElement[],
-  name: string
+  appState: AppState
 ) {
   const serialized = JSON.stringify({
     version: 1,
     source: window.location.origin,
-    elements: elements.map(({ shape, ...el }) => el)
+    elements: elements.map(({ shape, ...el }) => el),
+    appState: appState
   });
 
   saveFile(
-    `${name}.json`,
+    `${appState.name}.json`,
     "data:text/plain;charset=utf-8," + encodeURIComponent(serialized)
   );
 }
@@ -64,14 +66,17 @@ export function loadFromJSON() {
   return new Promise<DataState>(resolve => {
     reader.onloadend = () => {
       if (reader.readyState === FileReader.DONE) {
+        const defaultAppState = getDefaultAppState();
         let elements = [];
+        let appState = defaultAppState;
         try {
           const data = JSON.parse(reader.result as string);
           elements = data.elements || [];
+          appState = data.appState || defaultAppState;
         } catch (e) {
           // Do nothing because elements array is already empty
         }
-        resolve(restore(elements, null));
+        resolve(restore(elements, appState));
       }
     };
   });
@@ -215,7 +220,7 @@ export function exportCanvas(
 
 function restore(
   savedElements: readonly ExcalidrawElement[],
-  savedState: any
+  savedState: AppState
 ): DataState {
   return {
     elements: savedElements.map(element => ({

--- a/src/scene/data.ts
+++ b/src/scene/data.ts
@@ -72,7 +72,7 @@ export function loadFromJSON() {
         try {
           const data = JSON.parse(reader.result as string);
           elements = data.elements || [];
-          appState = data.appState || defaultAppState;
+          appState = { ...defaultAppState, ...data.appState };
         } catch (e) {
           // Do nothing because elements array is already empty
         }


### PR DESCRIPTION
Adds AppState to the json created when clicking "Save as...". This fixes a few bugs:

  * #306 - Now the scroll position will be the same as it was when the user saved the file. This is how we treat loading from local storage, so we should be treating loading from a file the same way.
  * #357 - By adding the AppState to the exported json, we also keep the background color, which previously was not stored in the file, so all drawings that were imported would have a blank background

Before:
![ezgif com-video-to-gif (4)](https://user-images.githubusercontent.com/16962017/72234577-b9b3e900-359b-11ea-8453-1fa58d4caaa0.gif)

After:
![ezgif com-video-to-gif (6)](https://user-images.githubusercontent.com/16962017/72234722-5c6c6780-359c-11ea-9ced-9dd200d861b2.gif)




