### PR TITLE
pan canvas on wheel button drag

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -627,6 +627,32 @@ export class App extends React.Component<{}, AppState> {
               // being in a weird state, we clean up on the next mousedown
               lastMouseUp(e);
             }
+
+            // pan canvas on wheel button drag
+            if (e.button === 1) {
+              let { clientX: lastX, clientY: lastY } = e;
+              const onMouseMove = (e: MouseEvent) => {
+                document.documentElement.style.cursor = `grabbing`;
+                let deltaX = lastX - e.clientX;
+                let deltaY = lastY - e.clientY;
+                lastX = e.clientX;
+                lastY = e.clientY;
+                this.setState(state => ({
+                  scrollX: state.scrollX - deltaX,
+                  scrollY: state.scrollY - deltaY
+                }));
+              };
+              const onMouseUp = (lastMouseUp = (e: MouseEvent) => {
+                lastMouseUp = null;
+                resetCursor();
+                window.removeEventListener("mousemove", onMouseMove);
+                window.removeEventListener("mouseup", onMouseUp);
+              });
+              window.addEventListener("mousemove", onMouseMove);
+              window.addEventListener("mouseup", onMouseUp);
+              return;
+            }
+
             // only handle left mouse button
             if (e.button !== 0) return;
             // fixes mousemove causing selection of UI texts #32

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -648,7 +648,9 @@ export class App extends React.Component<{}, AppState> {
                 window.removeEventListener("mousemove", onMouseMove);
                 window.removeEventListener("mouseup", onMouseUp);
               });
-              window.addEventListener("mousemove", onMouseMove);
+              window.addEventListener("mousemove", onMouseMove, {
+                passive: true
+              });
               window.addEventListener("mouseup", onMouseUp);
               return;
             }


### PR DESCRIPTION
Implemented canvas panning on wheel button drag, since there's currently no way for non-touchpad users to pan horizontally.

This has potential (well, actual) bad performance on more complex scenes. Unfortunately, I have no idea how to improve that (debounce/throttle wouldn't help here), apart from actually improving render performance. Or, is it possible to translate canvas without fully rerendering it?

WTBS, performance-wise, this shouldn't be different from what we're currently doing on scrolling via high-resolution mouse wheel, or touchpad.

Made the `mousemove` event `passive`, whatever good it's gonna do here. Possibly none?

![excalidraw_pan](https://user-images.githubusercontent.com/5153846/72466926-2a484900-37da-11ea-8e6c-398c7f30e007.gif)
