### PR TITLE
Meta key drawing

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -293,10 +293,9 @@ export class App extends React.Component<{}, AppState> {
       event.preventDefault();
     } else if (
       shapesShortcutKeys.includes(event.key.toLowerCase()) &&
-      !event.ctrlKey &&
+      !event[META_KEY] &&
       !event.shiftKey &&
-      !event.altKey &&
-      !event.metaKey
+      !event.altKey
     ) {
       this.setState({ elementType: findShapeByKey(event.key) });
     } else if (event[META_KEY] && event.code === "KeyZ") {
@@ -440,7 +439,9 @@ export class App extends React.Component<{}, AppState> {
             icon={icon}
             checked={this.state.elementType === value}
             name="editor-current-shape"
-            title={`${capitalizeString(value)} — ${capitalizeString(value)[0]}, ${index + 1}`}
+            title={`${capitalizeString(value)} — ${
+              capitalizeString(value)[0]
+            }, ${index + 1}`}
             onChange={() => {
               this.setState({ elementType: value });
               elements = clearSelection(elements);
@@ -1018,10 +1019,13 @@ export class App extends React.Component<{}, AppState> {
                 draggingElement.isSelected = true;
               }
 
-              this.setState({
-                draggingElement: null,
-                elementType: "selection"
-              });
+              if (!e[META_KEY]) {
+                // Doesn't reset selection when the user holds cmd or ctrl
+                this.setState({
+                  draggingElement: null,
+                  elementType: "selection"
+                });
+              }
 
               history.resumeRecording();
               this.forceUpdate();

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -439,9 +439,9 @@ export class App extends React.Component<{}, AppState> {
             icon={icon}
             checked={this.state.elementType === value}
             name="editor-current-shape"
-            title={`${capitalizeString(value)} — ${
+            title={`${capitalizeString(value)} — ${index + 1}, ${
               capitalizeString(value)[0]
-            }, ${index + 1}`}
+            }`}
             onChange={() => {
               this.setState({ elementType: value });
               elements = clearSelection(elements);


### PR DESCRIPTION
Hello.

When I wanted to draw 5 rectangles, I found it very tedious to have to reselect the rectangle after every draw. 

Example: ![2020-01-15 22 25 38](https://user-images.githubusercontent.com/2955483/72499796-b4e37500-37e7-11ea-963e-8504db975851.gif)

I added a check for `metakey` to conditionally reset the selection. It makes a major difference!

Example: 
![2020-01-15 22 29 14](https://user-images.githubusercontent.com/2955483/72499851-da707e80-37e7-11ea-9bfd-d4b7edff7ffd.gif)

I also changed the order as requested in my [previous PR](https://github.com/excalidraw/excalidraw/pull/380)


