### PR TITLE
fix: use full url for og:image

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -8,6 +8,7 @@
       content="width=device-width, initial-scale=1, shrink-to-fit=no"
     />
     <meta name="theme-color" content="#000000" />
+    <!-- General tags -->
     <meta
       name="description"
       content="Excalidraw is a whiteboard tool that lets you easily sketch diagrams that have a hand-drawn feel to them."
@@ -32,9 +33,17 @@
     <meta property="og:image:height" content="669" />
 
     <!-- Twitter Card tags -->
-    <!-- <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:site" content="@Vjeux" />
-    <meta name="twitter:creator" content="@Vjeux" /> -->
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:creator" content="@Vjeux" />
+    <meta name="twitter:title" content="Excalidraw" />
+    <meta
+      name="twitter:description"
+      content="Excalidraw is a whiteboard tool that lets you easily sketch diagrams that have a hand-drawn feel to them."
+    />
+    <meta
+      name="twitter:image"
+      content="https://www.excalidraw.com/og-image.png"
+    />
 
     <link rel="icon" href="%PUBLIC_URL%/logo.png" />
     <link

--- a/public/index.html
+++ b/public/index.html
@@ -12,7 +12,7 @@
       name="description"
       content="Excalidraw is a whiteboard tool that lets you easily sketch diagrams that have a hand-drawn feel to them."
     />
-    <meta name="image" content="%PUBLIC_URL%/og-image.png" />
+    <meta name="image" content="https://www.excalidraw.com/og-image.png" />
 
     <!-- OpenGraph tags -->
     <meta property="og:url" content="https://www.excalidraw.com/" />

--- a/public/index.html
+++ b/public/index.html
@@ -26,15 +26,15 @@
     <meta
       property="og:image"
       name="twitter:image"
-      content="%PUBLIC_URL%/og-image.png"
+      content="https://www.excalidraw.com/og-image.pngg"
     />
     <meta property="og:image:width" content="1280" />
     <meta property="og:image:height" content="669" />
 
     <!-- Twitter Card tags -->
-    <meta name="twitter:card" content="summary_large_image" />
+    <!-- <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:site" content="@Vjeux" />
-    <meta name="twitter:creator" content="@Vjeux" />
+    <meta name="twitter:creator" content="@Vjeux" /> -->
 
     <link rel="icon" href="%PUBLIC_URL%/logo.png" />
     <link

--- a/public/index.html
+++ b/public/index.html
@@ -31,6 +31,11 @@
     <meta property="og:image:width" content="1280" />
     <meta property="og:image:height" content="669" />
 
+    <!-- Twitter Card tags -->
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:site" content="@Vjeux" />
+    <meta name="twitter:creator" content="@Vjeux" />
+
     <link rel="icon" href="%PUBLIC_URL%/logo.png" />
     <link
       rel="preload"

--- a/public/index.html
+++ b/public/index.html
@@ -34,7 +34,6 @@
 
     <!-- Twitter Card tags -->
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:creator" content="@Vjeux" />
     <meta name="twitter:title" content="Excalidraw" />
     <meta
       name="twitter:description"


### PR DESCRIPTION
We thought #400 would resolve #379 but unfortunately, the `og:image` doesn't seem to be working as @Fausto95 noted. 

I believe this is because we were using a relative path to the image, instead of an absolute path (which makes sense I guess). 

We'll test this using the deploy preview link to make sure. 