### PR TITLE
fix: replace Draftsman with Architect

### DIFF
--- a/src/actions/actionProperties.tsx
+++ b/src/actions/actionProperties.tsx
@@ -141,7 +141,7 @@ export const actionChangeSloppiness: Action = {
       <h5>Sloppiness</h5>
       <ButtonSelect
         options={[
-          { value: 0, text: "Draftsman" },
+          { value: 0, text: "Architect" },
           { value: 1, text: "Artist" },
           { value: 3, text: "Cartoonist" }
         ]}


### PR DESCRIPTION
This changes the label "Draftsman" with "Architect" to be more inclusive. 

Suggestion via Twitter:
<blockquote class="twitter-tweet"><p lang="en" dir="ltr">hi! I&#39;m not savvy enough to submit a PR myself — so instead you get a tweet! <br><br>It would be really great to change the label for &#39;Sloppiness&#39; from Craftsman to Craftsperson. Craftsman is unnecessarily exclusionary language! <a href="https://t.co/Raz2EykNzt">pic.twitter.com/Raz2EykNzt</a></p>&mdash; Jason Crabtree (@jasontcrabtree) <a href="https://twitter.com/jasontcrabtree/status/1218186980275650560?ref_src=twsrc%5Etfw">January 17, 2020</a></blockquote>

## Screenshot
![image](https://user-images.githubusercontent.com/3806031/72630029-b9ef1400-390e-11ea-8e2a-97f32de076be.png)
