### PR TITLE
Ignore enter `keydown` events that are part of composition

### DIFF
--- a/src/element/textWysiwyg.tsx
+++ b/src/element/textWysiwyg.tsx
@@ -55,6 +55,9 @@ export function textWysiwyg({
     }
     if (ev.key === KEYS.ENTER) {
       ev.preventDefault();
+      if (ev.isComposing || ev.keyCode === 229) {
+        return;
+      }
       handleSubmit();
     }
   };


### PR DESCRIPTION
When we are inputting Japanese(and probably Chinese, Korean, and more...), need to input Enter key for committing IME conversion. But now, when we input Enter key, `textWysiwyg` always submit and blurs. So I modified to ignore Enter `keydown` events that are part of composition.

ref: https://developer.mozilla.org/en-US/docs/Web/API/Document/keydown_event

***
@vjeux and contributors, thank you for developing such a great tool!