### PR TITLE
Disable shortcuts for shapes while dragging the selection

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -297,7 +297,9 @@ export class App extends React.Component<{}, AppState> {
       !event.ctrlKey &&
       !event.shiftKey &&
       !event.altKey &&
-      !event.metaKey
+      !event.metaKey &&
+      (this.state.draggingElement === null ||
+        this.state.elementType !== "selection")
     ) {
       this.setState({ elementType: findShapeByKey(event.key) });
     } else if (event[META_KEY] && event.code === "KeyZ") {


### PR DESCRIPTION
Fixes #429

I have one question. We can use shortcuts for choosing a shape(e.g. `R` key for rectangle) while dragging a shape. Is it intentional?
![838e5d88bd3bdac6d33a9a1bccc1b3e7](https://user-images.githubusercontent.com/14838850/72670021-ccd32700-3a7b-11ea-9d1e-67d392eb6a89.gif)
