### PR TITLE
Render shape action on tool selected

### DIFF
--- a/src/actions/actionProperties.tsx
+++ b/src/actions/actionProperties.tsx
@@ -35,7 +35,10 @@ export const actionChangeStrokeColor: Action = {
       <h5>Stroke</h5>
       <ColorPicker
         type="elementStroke"
-        color={getSelectedAttribute(elements, element => element.strokeColor)}
+        color={
+          getSelectedAttribute(elements, element => element.strokeColor) ||
+          appState.currentItemStrokeColor
+        }
         onChange={updateData}
       />
     </>
@@ -54,15 +57,15 @@ export const actionChangeBackgroundColor: Action = {
       appState: { ...appState, currentItemBackgroundColor: value }
     };
   },
-  PanelComponent: ({ elements, updateData }) => (
+  PanelComponent: ({ elements, appState, updateData }) => (
     <>
       <h5>Background</h5>
       <ColorPicker
         type="elementBackground"
-        color={getSelectedAttribute(
-          elements,
-          element => element.backgroundColor
-        )}
+        color={
+          getSelectedAttribute(elements, element => element.backgroundColor) ||
+          appState.currentItemBackgroundColor
+        }
         onChange={updateData}
       />
     </>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -341,8 +341,12 @@ export class App extends React.Component<{}, AppState> {
   };
 
   private renderSelectedShapeActions(elements: readonly ExcalidrawElement[]) {
+    const { elementType } = this.state;
     const selectedElements = elements.filter(el => el.isSelected);
-    if (selectedElements.length === 0) {
+    const hasSelectedElements = selectedElements.length > 0;
+    const isTextToolSelected = elementType === "text";
+    const isShapeToolSelected = elementType !== "selection";
+    if (!(hasSelectedElements || isShapeToolSelected || isTextToolSelected)) {
       return null;
     }
 
@@ -356,7 +360,8 @@ export class App extends React.Component<{}, AppState> {
             this.syncActionResult
           )}
 
-          {hasBackground(elements) && (
+          {(hasBackground(elements) ||
+            (isShapeToolSelected && !isTextToolSelected)) && (
             <>
               {this.actionManager.renderAction(
                 "changeBackgroundColor",
@@ -375,7 +380,8 @@ export class App extends React.Component<{}, AppState> {
             </>
           )}
 
-          {hasStroke(elements) && (
+          {(hasStroke(elements) ||
+            (isShapeToolSelected && !isTextToolSelected)) && (
             <>
               {this.actionManager.renderAction(
                 "changeStrokeWidth",
@@ -394,7 +400,7 @@ export class App extends React.Component<{}, AppState> {
             </>
           )}
 
-          {hasText(elements) && (
+          {(hasText(elements) || isTextToolSelected) && (
             <>
               {this.actionManager.renderAction(
                 "changeFontSize",


### PR DESCRIPTION
As proposed in https://github.com/excalidraw/excalidraw/issues/398, it'd be cool to render the shape actions panel right when a shape tool is selected

![IRSA](https://user-images.githubusercontent.com/23306911/72671762-6cc68b80-3a4f-11ea-864c-afb12aceda59.gif)

