### PR TITLE
disallow shape selection during creation

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -298,8 +298,7 @@ export class App extends React.Component<{}, AppState> {
       !event.shiftKey &&
       !event.altKey &&
       !event.metaKey &&
-      (this.state.draggingElement === null ||
-        this.state.elementType !== "selection")
+      this.state.draggingElement === null
     ) {
       this.setState({ elementType: findShapeByKey(event.key) });
     } else if (event[META_KEY] && event.code === "KeyZ") {


### PR DESCRIPTION
Followup to #447 - disallowing shape selection (via hotkey) even during element creation.

/cc @sosukesuzuki is there a reason why you included this line:

https://github.com/sosukesuzuki/excalidraw/blob/3efa673fe80128f88b620b98af251fd1ff33e940/src/index.tsx#L302