### PR TITLE
Adjust type of data URI when saving

### DIFF
--- a/src/scene/data.ts
+++ b/src/scene/data.ts
@@ -96,7 +96,7 @@ export async function saveAsJSON(
   } else {
     saveFile(
       name,
-      "data:text/plain;charset=utf-8," + encodeURIComponent(serialized)
+      "data:application/json;charset=utf-8," + encodeURIComponent(serialized)
     );
   }
 }


### PR DESCRIPTION
Previously the type used for the data URI when saving was text/plain. On iPad Safari, this caused the file to automatically have a .txt extension added (so files ended up with names like "drawing-xyz.json.txt"). This meant that the files couldn't be loaded by the tool, which expects only files with a .json extension.

Now, the type used is application/json, which means that the files get reliably saved with the correct extension and can be successfully loaded by the tool later.