### PR TITLE
Add ColorInput component

### DIFF
--- a/src/components/ColorPicker.css
+++ b/src/components/ColorPicker.css
@@ -78,7 +78,7 @@
   height: 30px;
   width: 30px;
   border-radius: 4px 0px 0px 4px;
-  color: #868e96;
+  color: #495057;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -91,7 +91,7 @@
 .color-picker-input {
   width: 100px;
   font-size: 14px;
-  color: #868e96;
+  color: #343a40;
   border: 0px;
   outline: none;
   height: 28px;

--- a/src/components/ColorPicker.css
+++ b/src/components/ColorPicker.css
@@ -7,6 +7,11 @@
   position: relative;
 }
 
+.color-picker-control-container {
+  display: flex;
+  align-items: center;
+}
+
 .color-picker-triangle-shadow {
   width: 0px;
   height: 0px;
@@ -33,13 +38,17 @@
   padding: 15px 9px 9px 15px;
 }
 
+.colors-gallery {
+  display: flex;
+  flex-wrap: wrap;
+}
+
 .color-picker-swatch {
+  position: relative;
   height: 30px;
   width: 30px;
   cursor: pointer;
-  position: relative;
   outline: none;
-  float: left;
   border-radius: 4px;
   margin: 0px 6px 6px 0px;
   box-sizing: border-box;
@@ -69,11 +78,14 @@
   height: 30px;
   width: 30px;
   border-radius: 4px 0px 0px 4px;
-  float: left;
   color: #868e96;
   display: flex;
   align-items: center;
   justify-content: center;
+}
+
+.color-input-container {
+  display: flex;
 }
 
 .color-picker-input {
@@ -92,9 +104,8 @@
 }
 
 .color-picker-label-swatch {
-  height: 24px;
-  width: 24px;
-  display: inline-block;
+  height: 30px;
+  width: 30px;
   margin-right: 4px;
   border: 1px solid #dee2e6;
 }

--- a/src/components/ColorPicker.tsx
+++ b/src/components/ColorPicker.tsx
@@ -80,6 +80,7 @@ function ColorInput({
         }}
         value={(innerValue || "").replace(/^#/, "")}
         onPaste={e => onChange(e.clipboardData.getData("text"))}
+        onBlur={() => setInnerValue(color)}
       />
     </div>
   );

--- a/src/components/ColorPicker.tsx
+++ b/src/components/ColorPicker.tsx
@@ -71,6 +71,7 @@ function ColorInput({
       <input
         spellCheck={false}
         className="color-picker-input"
+        aria-label="Hex color code"
         onChange={e => {
           const value = e.target.value;
           if (value.match(colorRegex)) {
@@ -102,6 +103,7 @@ export function ColorPicker({
       <div className="color-picker-control-container">
         <button
           className="color-picker-label-swatch"
+          aria-label="Change color"
           style={color ? { backgroundColor: color } : undefined}
           onClick={() => setActive(!isActive)}
         />

--- a/src/components/ColorPicker.tsx
+++ b/src/components/ColorPicker.tsx
@@ -15,53 +15,75 @@ const Picker = function({
   color: string | undefined;
   onChange: (color: string) => void;
 }) {
-  const [innerValue, setInnerValue] = React.useState(color);
-  React.useEffect(() => {
-    setInnerValue(color);
-  }, [color]);
   return (
     <div className="color-picker">
       <div className="color-picker-triangle-shadow"></div>
       <div className="color-picker-triangle"></div>
       <div className="color-picker-content">
-        {colors.map(color => (
-          <div
-            className="color-picker-swatch"
-            onClick={() => {
-              onChange(color);
-            }}
-            title={color}
-            tabIndex={0}
-            style={{ backgroundColor: color }}
-            key={color}
-          >
-            {color === "transparent" ? (
-              <div className="color-picker-transparent"></div>
-            ) : (
-              undefined
-            )}
-          </div>
-        ))}
-        <div className="color-picker-hash">#</div>
-        <div style={{ position: "relative" }}>
-          <input
-            spellCheck={false}
-            className="color-picker-input"
-            onChange={e => {
-              const value = e.target.value;
-              if (value.match(/^([0-9a-f]{3}|[0-9a-f]{6}|transparent)$/)) {
-                onChange(value === "transparent" ? "transparent" : "#" + value);
-              }
-              setInnerValue(value);
-            }}
-            value={(innerValue || "").replace(/^#/, "")}
-          />
+        <div className="colors-gallery">
+          {colors.map(color => (
+            <div
+              className="color-picker-swatch"
+              onClick={() => {
+                onChange(color);
+              }}
+              title={color}
+              tabIndex={0}
+              style={{ backgroundColor: color }}
+              key={color}
+            >
+              {color === "transparent" ? (
+                <div className="color-picker-transparent"></div>
+              ) : (
+                undefined
+              )}
+            </div>
+          ))}
         </div>
-        <div style={{ clear: "both" }}></div>
+        <ColorInput
+          color={color}
+          onChange={color => {
+            onChange(color);
+          }}
+        />
       </div>
     </div>
   );
 };
+
+function ColorInput({
+  color,
+  onChange
+}: {
+  color: string | undefined;
+  onChange: (color: string) => void;
+}) {
+  const colorRegex = /^([0-9a-f]{3}|[0-9a-f]{6}|[0-9a-f]{8}|transparent)$/;
+  const [innerValue, setInnerValue] = React.useState(color);
+
+  React.useEffect(() => {
+    setInnerValue(color);
+  }, [color]);
+
+  return (
+    <div className="color-input-container">
+      <div className="color-picker-hash">#</div>
+      <input
+        spellCheck={false}
+        className="color-picker-input"
+        onChange={e => {
+          const value = e.target.value;
+          if (value.match(colorRegex)) {
+            onChange(value === "transparent" ? "transparent" : "#" + value);
+          }
+          setInnerValue(value);
+        }}
+        value={(innerValue || "").replace(/^#/, "")}
+        onPaste={e => onChange(e.clipboardData.getData("text"))}
+      />
+    </div>
+  );
+}
 
 export function ColorPicker({
   type,
@@ -69,17 +91,26 @@ export function ColorPicker({
   onChange
 }: {
   type: "canvasBackground" | "elementBackground" | "elementStroke";
-  color: string | null;
+  color: string | undefined;
   onChange: (color: string) => void;
 }) {
   const [isActive, setActive] = React.useState(false);
+
   return (
     <div>
-      <button
-        className="color-picker-label-swatch"
-        style={color ? { backgroundColor: color } : undefined}
-        onClick={() => setActive(!isActive)}
-      />
+      <div className="color-picker-control-container">
+        <button
+          className="color-picker-label-swatch"
+          style={color ? { backgroundColor: color } : undefined}
+          onClick={() => setActive(!isActive)}
+        />
+        <ColorInput
+          color={color}
+          onChange={color => {
+            onChange(color);
+          }}
+        />
+      </div>
       <React.Suspense fallback="">
         {isActive ? (
           <Popover onCloseRequest={() => setActive(false)}>
@@ -93,13 +124,6 @@ export function ColorPicker({
           </Popover>
         ) : null}
       </React.Suspense>
-      <input
-        type="text"
-        className="color-picker-swatch-input"
-        value={color || ""}
-        onPaste={e => onChange(e.clipboardData.getData("text"))}
-        onChange={e => onChange(e.target.value)}
-      />
     </div>
   );
 }


### PR DESCRIPTION
Fixes #434, #418.

This PR refactors `Picker` and `ColorPicker` so that they share the same input field and logic to handle manual typing of hex color values.

1. External input uses the appearance from inner input:

**Before**:
![current UI](https://user-images.githubusercontent.com/10501948/72687673-ff623b80-3ade-11ea-80b9-5050485d3fa8.png)
**After**:
![UI with this PR](https://user-images.githubusercontent.com/10501948/72687678-0a1cd080-3adf-11ea-880f-58519da76a0a.png)

2. This keeps previous valid value while a new one is being typed and thus an invalid one is present:

![new hex color value being typed](https://user-images.githubusercontent.com/10501948/72687739-9f1fc980-3adf-11ea-8f19-e64cc8060071.gif)

3. Inner color picker now allows **#RRGGBBAA** format

