### PR TITLE
Change the font family names

### DIFF
--- a/src/actions/actionProperties.tsx
+++ b/src/actions/actionProperties.tsx
@@ -246,9 +246,9 @@ export const actionChangeFontFamily: Action = {
       <h5>Font family</h5>
       <ButtonSelect
         options={[
-          { value: "Virgil", text: "Virgil" },
-          { value: "Helvetica", text: "Helvetica" },
-          { value: "Courier", text: "Courier" }
+          { value: "Virgil", text: "Hand-drawn" },
+          { value: "Helvetica", text: "Normal" },
+          { value: "Courier", text: "Code" }
         ]}
         value={getSelectedAttribute(
           elements,


### PR DESCRIPTION
- [x] Update the names in the UI

We have to change the logic to:
- [ ] Save these names in the JSON format and not their values
- [ ] Update UI to read the names and map the font used for each category
- [ ] Have a possible map from `labels` to `font names`

Because in the future we might change some fonts but not their meanings.