### PR TITLE
Fix typo in "Opacity"

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -15,7 +15,7 @@
     "fill": "Fill",
     "strokeWidth": "Stroke Width",
     "sloppiness": "Sloppiness",
-    "oppacity": "Opacity",
+    "opacity": "Opacity",
     "fontSize": "Font Size",
     "fontFamily": "Font Family",
     "onlySelected": "Only selected",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -15,7 +15,7 @@
     "fill": "Fill",
     "strokeWidth": "Stroke Width",
     "sloppiness": "Sloppiness",
-    "oppacity": "Oppacity",
+    "oppacity": "Opacity",
     "fontSize": "Font Size",
     "fontFamily": "Font Family",
     "onlySelected": "Only selected",

--- a/src/actions/actionProperties.tsx
+++ b/src/actions/actionProperties.tsx
@@ -199,7 +199,7 @@ export const actionChangeOpacity: Action = {
   },
   PanelComponent: ({ elements, appState, updateData, t }) => (
     <>
-      <h5>{t("labels.oppacity")}</h5>
+      <h5>{t("labels.opacity")}</h5>
       <input
         type="range"
         min="0"


### PR DESCRIPTION
https://en.wikipedia.org/wiki/Opacity_(optics)

I left the variable/key as-is, it's not visible to users anyway.