### PR TITLE
fix: Transparent backgrounds result in bleed

### DIFF
--- a/src/renderer/renderScene.ts
+++ b/src/renderer/renderScene.ts
@@ -36,6 +36,13 @@ export function renderScene(
 
   const fillStyle = context.fillStyle;
   if (typeof sceneState.viewBackgroundColor === "string") {
+    const hasTransparence =
+      sceneState.viewBackgroundColor === "transparent" ||
+      sceneState.viewBackgroundColor.length === 5 ||
+      sceneState.viewBackgroundColor.length === 9;
+    if (hasTransparence) {
+      context.clearRect(0, 0, canvas.width, canvas.height);
+    }
     context.fillStyle = sceneState.viewBackgroundColor;
     context.fillRect(0, 0, canvas.width, canvas.height);
   } else {


### PR DESCRIPTION
Fixes #457 . Covers the accepted input in src/components/ColorPicker.tsx and 4-digit rgba, but it will have to be revised if rgb/hsl/color names are accepted.