### PR TITLE
fix: Preview image is being stretched when the proportions are wrong

### DIFF
--- a/src/scene/getExportCanvasPreview.ts
+++ b/src/scene/getExportCanvasPreview.ts
@@ -21,8 +21,6 @@ export function getExportCanvasPreview(
     height
   ) {
     const tempCanvas = document.createElement("canvas");
-    tempCanvas.style.width = width + "px";
-    tempCanvas.style.height = height + "px";
     tempCanvas.width = width * scale;
     tempCanvas.height = height * scale;
     return tempCanvas;


### PR DESCRIPTION
Fixes #490. Preserves the ratio of the preview image when width / height reaches max-width/max-height.