### PR TITLE
Normalize dimensions

### DIFF
--- a/src/element/index.ts
+++ b/src/element/index.ts
@@ -8,7 +8,11 @@ export {
 
 export { handlerRectangles } from "./handlerRectangles";
 export { hitTest } from "./collision";
-export { resizeTest, getCursorForResizingElement } from "./resizeTest";
+export {
+  resizeTest,
+  getCursorForResizingElement,
+  normalizeResizeHandle,
+} from "./resizeTest";
 export { isTextElement } from "./typeChecks";
 export { textWysiwyg } from "./textWysiwyg";
 export { redrawTextBoundingBox } from "./textElement";
@@ -16,4 +20,5 @@ export {
   getPerfectElementSize,
   isInvisiblySmallElement,
   resizePerfectLineForNWHandler,
+  normalizeDimensions,
 } from "./sizeHelpers";

--- a/src/element/resizeTest.ts
+++ b/src/element/resizeTest.ts
@@ -91,3 +91,61 @@ export function getCursorForResizingElement(resizingElement: {
 
   return cursor ? `${cursor}-resize` : "";
 }
+
+export function normalizeResizeHandle(
+  element: ExcalidrawElement,
+  resizeHandle: HandlerRectanglesRet,
+): HandlerRectanglesRet {
+  if (
+    (element.width >= 0 && element.height >= 0) ||
+    element.type === "line" ||
+    element.type === "arrow"
+  ) {
+    return resizeHandle;
+  }
+
+  if (element.width < 0 && element.height < 0) {
+    switch (resizeHandle) {
+      case "nw":
+        return "se";
+      case "ne":
+        return "sw";
+      case "se":
+        return "nw";
+      case "sw":
+        return "ne";
+    }
+  } else if (element.width < 0) {
+    switch (resizeHandle) {
+      case "nw":
+        return "ne";
+      case "ne":
+        return "nw";
+      case "se":
+        return "sw";
+      case "sw":
+        return "se";
+      case "e":
+        return "w";
+      case "w":
+        return "e";
+    }
+  } else {
+    switch (resizeHandle) {
+      case "nw":
+        return "sw";
+      case "ne":
+        return "se";
+      case "se":
+        return "ne";
+      case "sw":
+        return "nw";
+      case "n":
+        return "s";
+      case "s":
+        return "n";
+    }
+  }
+
+  return resizeHandle;
+}

--- a/src/element/sizeHelpers.ts
+++ b/src/element/sizeHelpers.ts
@@ -57,3 +57,33 @@ export function resizePerfectLineForNWHandler(
     element.y = anchorY - element.height;
   }
 }
+
+/**
+ * @returns {boolean} whether element was normalized
+ */
+export function normalizeDimensions(
+  element: ExcalidrawElement | null,
+): element is ExcalidrawElement {
+  if (
+    !element ||
+    (element.width >= 0 && element.height >= 0) ||
+    element.type === "line" ||
+    element.type === "arrow"
+  ) {
+    return false;
+  }
+
+  if (element.width < 0) {
+    element.width = Math.abs(element.width);
+    element.x -= element.width;
+  }
+
+  if (element.height < 0) {
+    element.height = Math.abs(element.height);
+    element.y -= element.height;
+  }
+
+  element.shape = null;
+
+  return true;
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -9,6 +9,7 @@ import {
   newTextElement,
   duplicateElement,
   resizeTest,
+  normalizeResizeHandle,
   isInvisiblySmallElement,
   isTextElement,
   textWysiwyg,
@@ -16,6 +17,7 @@ import {
   getCursorForResizingElement,
   getPerfectElementSize,
   resizePerfectLineForNWHandler,
+  normalizeDimensions,
 } from "./element";
 import {
   clearSelection,
@@ -38,7 +40,7 @@ import { renderScene } from "./renderer";
 import { AppState } from "./types";
 import { ExcalidrawElement } from "./element/types";
 
-import { isInputLike, debounce, capitalizeString } from "./utils";
+import { isInputLike, debounce, capitalizeString, distance } from "./utils";
 import { KEYS, isArrowKey } from "./keys";
 
 import { findShapeByKey, shapesShortcutKeys, SHAPES } from "./shapes";
@@ -776,6 +778,9 @@ export class App extends React.Component<any, AppState> {
 
             const { x, y } = viewportCoordsToSceneCoords(e, this.state);
 
+            const originX = x;
+            const originY = y;
+
             let element = newElement(
               this.state.elementType,
               x,
@@ -937,6 +942,10 @@ export class App extends React.Component<any, AppState> {
                 return;
               }
 
+              const isLinear =
+                this.state.elementType === "line" ||
+                this.state.elementType === "arrow";
+
               if (isResizingElements && this.state.resizingElement) {
                 const el = this.state.resizingElement;
                 const selectedElements = elements.filter(el => el.isSelected);
@@ -951,10 +960,7 @@ export class App extends React.Component<any, AppState> {
                       element.x += deltaX;
 
                       if (e.shiftKey) {
-                        if (
-                          element.type === "arrow" ||
-                          element.type === "line"
-                        ) {
+                        if (isLinear) {
                           resizePerfectLineForNWHandler(element, x, y);
                         } else {
                           element.y += element.height - element.width;
@@ -986,10 +992,7 @@ export class App extends React.Component<any, AppState> {
                       break;
                     case "se":
                       if (e.shiftKey) {
-                        if (
-                          element.type === "arrow" ||
-                          element.type === "line"
-                        ) {
+                        if (isLinear) {
                           const { width, height } = getPerfectElementSize(
                             element.type,
                             x - element.x,
@@ -1021,6 +1024,11 @@ export class App extends React.Component<any, AppState> {
                       element.width += deltaX;
                       break;
                   }
+
+                  if (resizeHandle) {
+                    resizeHandle = normalizeResizeHandle(element, resizeHandle);
+                  }
+                  normalizeDimensions(element);
 
                   document.documentElement.style.cursor = getCursorForResizingElement(
                     { element, resizeHandle },
@@ -1064,33 +1072,31 @@ export class App extends React.Component<any, AppState> {
               const draggingElement = this.state.draggingElement;
               if (!draggingElement) return;
 
-              let width =
-                e.clientX -
-                CANVAS_WINDOW_OFFSET_LEFT -
-                draggingElement.x -
-                this.state.scrollX;
-              let height =
-                e.clientY -
-                CANVAS_WINDOW_OFFSET_TOP -
-                draggingElement.y -
-                this.state.scrollY;
+              const { x, y } = viewportCoordsToSceneCoords(e, this.state);
+
+              let width = distance(originX, x);
+              let height = distance(originY, y);
+
+              if (isLinear && x < originX) width = -width;
+              if (isLinear && y < originY) height = -height;
 
               if (e.shiftKey) {
-                let {
-                  width: newWidth,
-                  height: newHeight,
-                } = getPerfectElementSize(
+                ({ width, height } = getPerfectElementSize(
                   this.state.elementType,
                   width,
-                  height,
-                );
-                draggingElement.width = newWidth;
-                draggingElement.height = newHeight;
-              } else {
-                draggingElement.width = width;
-                draggingElement.height = height;
+                  !isLinear && y < originY ? -height : height,
+                ));
+
+                if (!isLinear && height < 0) height = -height;
               }
 
+              if (!isLinear) {
+                draggingElement.x = x < originX ? originX - width : originX;
+                draggingElement.y = y < originY ? originY - height : originY;
+              }
+
+              draggingElement.width = width;
+              draggingElement.height = height;
               draggingElement.shape = null;
 
               if (this.state.elementType === "selection") {
@@ -1134,6 +1140,10 @@ export class App extends React.Component<any, AppState> {
                 });
                 this.forceUpdate();
                 return;
+              }
+
+              if (normalizeDimensions(draggingElement)) {
+                this.forceUpdate();
               }
 
               if (resizingElement && isInvisiblySmallElement(resizingElement)) {
@@ -1348,10 +1358,6 @@ export class App extends React.Component<any, AppState> {
 
       const minX = Math.min(...parsedElements.map(element => element.x));
       const minY = Math.min(...parsedElements.map(element => element.y));
-
-      const distance = (x: number, y: number) => {
-        return Math.abs(x > y ? x - y : y - x);
-      };
 
       parsedElements.forEach(parsedElement => {
         const [x1, y1, x2, y2] = getElementAbsoluteCoords(parsedElement);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -942,10 +942,6 @@ export class App extends React.Component<any, AppState> {
                 return;
               }
 
-              const isLinear =
-                this.state.elementType === "line" ||
-                this.state.elementType === "arrow";
-
               if (isResizingElements && this.state.resizingElement) {
                 const el = this.state.resizingElement;
                 const selectedElements = elements.filter(el => el.isSelected);
@@ -954,6 +950,8 @@ export class App extends React.Component<any, AppState> {
                   const deltaX = x - lastX;
                   const deltaY = y - lastY;
                   const element = selectedElements[0];
+                  const isLinear =
+                    element.type === "line" || element.type === "arrow";
                   switch (resizeHandle) {
                     case "nw":
                       element.width -= deltaX;
@@ -1076,6 +1074,10 @@ export class App extends React.Component<any, AppState> {
 
               let width = distance(originX, x);
               let height = distance(originY, y);
+
+              const isLinear =
+                this.state.elementType === "line" ||
+                this.state.elementType === "arrow";
 
               if (isLinear && x < originX) width = -width;
               if (isLinear && y < originY) height = -height;

--- a/src/scene/getExportCanvasPreview.ts
+++ b/src/scene/getExportCanvasPreview.ts
@@ -2,6 +2,7 @@ import rough from "roughjs/bin/rough";
 import { ExcalidrawElement } from "../element/types";
 import { getElementAbsoluteCoords } from "../element/bounds";
 import { renderScene } from "../renderer/renderScene";
+import { distance } from "../utils";
 
 export function getExportCanvasPreview(
   elements: readonly ExcalidrawElement[],
@@ -39,10 +40,6 @@ export function getExportCanvasPreview(
     subCanvasX2 = Math.max(subCanvasX2, x2);
     subCanvasY2 = Math.max(subCanvasY2, y2);
   });
-
-  function distance(x: number, y: number) {
-    return Math.abs(x > y ? x - y : y - x);
-  }
 
   const width = distance(subCanvasX1, subCanvasX2) + exportPadding * 2;
   const height = distance(subCanvasY1, subCanvasY2) + exportPadding * 2;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -86,3 +86,7 @@ export function removeSelection() {
     selection.removeAllRanges();
   }
 }
+
+export function distance(x: number, y: number) {
+  return Math.abs(x > y ? x - y : y - x);
+}


### PR DESCRIPTION
fixes #505

I decided to do another take on normalizing dimensions, because fixing #505 without it would be a pain. On top of it, I still believe that not-normalizing will result (and already has) in lots of lost time, and hacks on top of hacks. Without it, we need to account for negative dimensions (`width`/`height`), handles reported e.g. as `w` when in reality user holds `e` etc.

This PR doesn't yet normalize `arrow` & `line` elem. It works without it, but we should normalize every element. Will fix tomorrow or in another PR.

Note: while functioning, I'm not sure if it doesn't break unrelated things. Also, tomorrow I plan to refactor the codebase to remove the hacks which are no longer necessary.

(I haven't in fact checked #342, so not sure what I'm doing differently, and what I haven't thought of. Will check tomorrow, too.)

:warning: 2nd commit adds dimensions to the left panel for debugging. The commit must be removed before merge. But it can technically be tightened up and reused for #517 (but as of now it's not styled, and has terrible perf).

In the GIF below notice that `width`/`height` dimensions are no longer ever negative.

![excalidraw_normalize_dimensions](https://user-images.githubusercontent.com/5153846/73006372-d73e4980-3e0a-11ea-8e1f-0567181048d3.gif)
