### PR TITLE
Add page landmarks

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -81,35 +81,38 @@
     <noscript>
       You need to enable JavaScript to run this app.
     </noscript>
-    <h1 class="visually-hidden">Excalidraw</h1>
+    <header>
+      <h1 class="visually-hidden">Excalidraw</h1>
+    </header>
     <div id="root"></div>
-
-    <!-- https://github.com/tholman/github-corners -->
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      width="40"
-      height="40"
-      viewBox="0 0 250 250"
-      style="position: absolute; top: 0; right: 0"
-    >
-      <a
-        href="https://github.com/excalidraw/excalidraw"
-        target="_blank"
-        aria-label="GitHub repository"
+    <aside>
+      <!-- https://github.com/tholman/github-corners -->
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="40"
+        height="40"
+        viewBox="0 0 250 250"
+        style="position: absolute; top: 0; right: 0"
       >
-        <path d="M0 0l115 115h15l12 27 108 108V0z" fill="#6c6c6c" />
-        <path
-          class="octo-arm"
-          d="M128 109c-15-9-9-19-9-19 3-7 2-11 2-11-1-7 3-2 3-2 4 5 2 11 2 11-3 10 5 15 9 16"
-          style="transform-origin: 130px 106px"
-          fill="#fff"
-        />
-        <path
-          class="octo-body"
-          d="M115 115s4 2 5 0l14-14c3-2 6-3 8-3-8-11-15-24 2-41 5-5 10-7 16-7 1-2 3-7 12-11 0 0 5 3 7 16 4 2 8 5 12 9s7 8 9 12c14 3 17 7 17 7-4 8-9 11-11 11 0 6-2 11-7 16-16 16-30 10-41 2 0 3-1 7-5 11l-12 11c-1 1 1 5 1 5z"
-          fill="#fff"
-        />
-      </a>
-    </svg>
+        <a
+          href="https://github.com/excalidraw/excalidraw"
+          target="_blank"
+          aria-label="GitHub repository"
+        >
+          <path d="M0 0l115 115h15l12 27 108 108V0z" fill="#6c6c6c" />
+          <path
+            class="octo-arm"
+            d="M128 109c-15-9-9-19-9-19 3-7 2-11 2-11-1-7 3-2 3-2 4 5 2 11 2 11-3 10 5 15 9 16"
+            style="transform-origin: 130px 106px"
+            fill="#fff"
+          />
+          <path
+            class="octo-body"
+            d="M115 115s4 2 5 0l14-14c3-2 6-3 8-3-8-11-15-24 2-41 5-5 10-7 16-7 1-2 3-7 12-11 0 0 5 3 7 16 4 2 8 5 12 9s7 8 9 12c14 3 17 7 17 7-4 8-9 11-11 11 0 6-2 11-7 16-16 16-30 10-41 2 0 3-1 7-5 11l-12 11c-1 1 1 5 1 5z"
+            fill="#fff"
+          />
+        </a>
+      </svg>
+    </aside>
   </body>
 </html>

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -38,7 +38,8 @@
     "cartoonist": "Cartoonist",
     "fileTitle": "File title",
     "colorPicker": "Color picker",
-    "canvasBackground": "Canvas background"
+    "canvasBackground": "Canvas background",
+    "drawingCanvas": "Drawing Canvas"
   },
   "buttons": {
     "clearReset": "Clear the canvas & reset background color",
@@ -48,7 +49,8 @@
     "save": "Save",
     "load": "Load",
     "getShareableLink": "Get shareable link",
-    "close": "Close"
+    "close": "Close",
+    "selectLanguage": "Select Language"
   },
   "alerts": {
     "clearReset": "This will clear the whole canvas. Are you sure?",
@@ -67,5 +69,10 @@
     "line": "Line",
     "text": "Text",
     "lock": "Keep selected tool active after drawing"
+  },
+  "headings": {
+    "canvasActions": "Canvas actions",
+    "selectedShapeActions": "Selected shape actions",
+    "shapes": "Shapes"
   }
 }

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -38,7 +38,8 @@
     "cartoonist": "Caricatura",
     "fileTitle": "Título del archivo",
     "colorPicker": "Selector de color",
-    "canvasBackground": "Fondo del lienzo"
+    "canvasBackground": "Fondo del lienzo",
+    "drawingCanvas": "Lienzo de dibujo"
   },
   "buttons": {
     "clearReset": "Limpiar lienzo y reiniciar el color de fondo",
@@ -49,7 +50,8 @@
     "load": "Cargar",
     "getShareableLink": "Obtener enlace para compartir",
     "showExportDialog": "Mostrar diálogo para exportar",
-    "close": "Cerrar"
+    "close": "Cerrar",
+    "selectLanguage": "Select Language"
   },
   "alerts": {
     "clearReset": "Esto limpiará todo el lienzo. Estás seguro?",
@@ -66,6 +68,12 @@
     "ellipse": "Elipse",
     "arrow": "Flecha",
     "line": "Línea",
-    "text": "Texto"
+    "text": "Texto",
+    "lock": "Mantener la herramienta seleccionada activa después de dibujar"
+  },
+  "headings": {
+    "canvasActions": "Acciones del lienzo",
+    "selectedShapeActions": "Acciones de la forma seleccionada",
+    "shapes": "Formas"
   }
 }

--- a/src/components/LanguageList.tsx
+++ b/src/components/LanguageList.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { useTranslation } from "react-i18next";
 
 export function LanguageList<T>({
   onClick,
@@ -9,12 +10,15 @@ export function LanguageList<T>({
   onClick: (value: string) => void;
   currentLanguage: string;
 }) {
+  const { t } = useTranslation();
+
   return (
     <React.Fragment>
       <select
         className="language-select"
         onChange={({ target }) => onClick(target.value)}
         value={currentLanguage}
+        aria-label={t("buttons.selectLanguage")}
       >
         {languages.map(language => (
           <option key={language.lng} value={language.lng}>

--- a/src/components/LockIcon.tsx
+++ b/src/components/LockIcon.tsx
@@ -51,6 +51,7 @@ export function LockIcon(props: LockIconProps) {
         id={props.id}
         onChange={props.onChange}
         checked={props.checked}
+        aria-label={props.title}
       />
       <div className="ToolIcon__icon">
         {props.checked ? ICONS.CHECKED : ICONS.UNCHECKED}


### PR DESCRIPTION
This PR uses HTML semantic elements to set the landmarks of the page.

This is helpful for assistive technologies to determine the different regions of content. In our case it's useful for jumping between the different islands that we use to group the form controls.

**Note:** The diff looks large because the `<canvas>` is now wrapped in a `<main>` element and I included [fallback text](http://pauljadam.com/demos/canvas.html) to describe it. No logic change was made in this PR.