### PR TITLE
Only show correct settings

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -381,17 +381,10 @@ export class App extends React.Component<any, AppState> {
   private renderSelectedShapeActions(elements: readonly ExcalidrawElement[]) {
     const { t } = this.props;
     const { elementType, editingElement } = this.state;
-    const selectedElements = elements.filter(el => el.isSelected);
-    const hasSelectedElements = selectedElements.length > 0;
-    const isTextToolSelected = elementType === "text";
-    const isShapeToolSelected = elementType !== "selection";
-    const isEditingText = editingElement && editingElement.type === "text";
-    if (
-      !hasSelectedElements &&
-      !isShapeToolSelected &&
-      !isTextToolSelected &&
-      !isEditingText
-    ) {
+    const targetElements = editingElement
+      ? [editingElement]
+      : elements.filter(el => el.isSelected);
+    if (!targetElements.length && elementType === "selection") {
       return null;
     }
 
@@ -405,9 +398,8 @@ export class App extends React.Component<any, AppState> {
             this.syncActionResult,
             t,
           )}
-          {(hasSelectedElements
-            ? selectedElements.some(element => hasBackground(element.type))
-            : hasBackground(elementType)) && (
+          {(hasBackground(elementType) ||
+            targetElements.some(element => hasBackground(element.type))) && (
             <>
               {this.actionManager.renderAction(
                 "changeBackgroundColor",
@@ -427,9 +419,8 @@ export class App extends React.Component<any, AppState> {
             </>
           )}
 
-          {(hasSelectedElements
-            ? selectedElements.some(element => hasStroke(element.type))
-            : hasStroke(elementType)) && (
+          {(hasStroke(elementType) ||
+            targetElements.some(element => hasStroke(element.type))) && (
             <>
               {this.actionManager.renderAction(
                 "changeStrokeWidth",
@@ -449,9 +440,8 @@ export class App extends React.Component<any, AppState> {
             </>
           )}
 
-          {(hasSelectedElements
-            ? selectedElements.some(element => hasText(element.type))
-            : hasText(elementType)) && (
+          {(hasText(elementType) ||
+            targetElements.some(element => hasText(element.type))) && (
             <>
               {this.actionManager.renderAction(
                 "changeFontSize",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -405,9 +405,9 @@ export class App extends React.Component<any, AppState> {
             this.syncActionResult,
             t,
           )}
-
-          {(hasBackground(elements) ||
-            (isShapeToolSelected && !isTextToolSelected)) && (
+          {(hasSelectedElements
+            ? selectedElements.some(element => hasBackground(element.type))
+            : hasBackground(elementType)) && (
             <>
               {this.actionManager.renderAction(
                 "changeBackgroundColor",
@@ -424,12 +424,12 @@ export class App extends React.Component<any, AppState> {
                 this.syncActionResult,
                 t,
               )}
-              <hr />
             </>
           )}
 
-          {(hasStroke(elements) ||
-            (isShapeToolSelected && !isTextToolSelected)) && (
+          {(hasSelectedElements
+            ? selectedElements.some(element => hasStroke(element.type))
+            : hasStroke(elementType)) && (
             <>
               {this.actionManager.renderAction(
                 "changeStrokeWidth",
@@ -446,11 +446,12 @@ export class App extends React.Component<any, AppState> {
                 this.syncActionResult,
                 t,
               )}
-              <hr />
             </>
           )}
 
-          {(hasText(elements) || isTextToolSelected || isEditingText) && (
+          {(hasSelectedElements
+            ? selectedElements.some(element => hasText(element.type))
+            : hasText(elementType)) && (
             <>
               {this.actionManager.renderAction(
                 "changeFontSize",
@@ -467,7 +468,6 @@ export class App extends React.Component<any, AppState> {
                 this.syncActionResult,
                 t,
               )}
-              <hr />
             </>
           )}
 

--- a/src/scene/comparisons.ts
+++ b/src/scene/comparisons.ts
@@ -2,28 +2,17 @@ import { ExcalidrawElement } from "../element/types";
 import { hitTest } from "../element/collision";
 import { getElementAbsoluteCoords } from "../element";
 
-export const hasBackground = (elements: readonly ExcalidrawElement[]) =>
-  elements.some(
-    element =>
-      element.isSelected &&
-      (element.type === "rectangle" ||
-        element.type === "ellipse" ||
-        element.type === "diamond"),
-  );
+export const hasBackground = (type: string) =>
+  type === "rectangle" || type === "ellipse" || type === "diamond";
 
-export const hasStroke = (elements: readonly ExcalidrawElement[]) =>
-  elements.some(
-    element =>
-      element.isSelected &&
-      (element.type === "rectangle" ||
-        element.type === "ellipse" ||
-        element.type === "diamond" ||
-        element.type === "arrow" ||
-        element.type === "line"),
-  );
+export const hasStroke = (type: string) =>
+  type === "rectangle" ||
+  type === "ellipse" ||
+  type === "diamond" ||
+  type === "arrow" ||
+  type === "line";
 
-export const hasText = (elements: readonly ExcalidrawElement[]) =>
-  elements.some(element => element.isSelected && element.type === "text");
+export const hasText = (type: string) => type === "text";
 
 export function getElementAtPosition(
   elements: readonly ExcalidrawElement[],


### PR DESCRIPTION
The logic to display which settings when nothing was selected was incorrect. This PR ensures that they are in sync.

I also removed all the `<hr />` which after the redesigned just looked like weird empty spaces