### PR TITLE
Remove image type description when saving to png

### DIFF
--- a/src/scene/data.ts
+++ b/src/scene/data.ts
@@ -215,7 +215,6 @@ export async function exportCanvas(
       if (blob) {
         await fileSave(blob, {
           fileName: fileName,
-          description: "Excalidraw image",
         });
       }
     });


### PR DESCRIPTION
The description is the name of the file type in the dialog. This shouldn't be Excalidraw but the default one for a png.