### PR TITLE
Set selection when unlocking

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -496,7 +496,12 @@ export class App extends React.Component<any, AppState> {
     return (
       <LockIcon
         checked={elementLocked}
-        onChange={() => this.setState({ elementLocked: !elementLocked })}
+        onChange={() => {
+          this.setState({
+            elementLocked: !elementLocked,
+            elementType: elementLocked ? "selection" : this.state.elementType,
+          });
+        }}
       />
     );
   }


### PR DESCRIPTION
A common workflow I have is to enable the lock, draw a bunch of things, unlock to be able to select stuff. However, after I unlock, the last shape is still enabled, so I end up drawing yet another of the same shape :(

This PR resets to selection instead!