### PR TITLE
Fix value when multiple elements are selected

### DIFF
--- a/src/actions/actionProperties.tsx
+++ b/src/actions/actionProperties.tsx
@@ -27,8 +27,9 @@ const getFormValue = function<T>(
 ): T | null {
   return (
     (editingElement && getAttribute(editingElement)) ??
-    getCommonAttributeOfSelectedElements(elements, getAttribute) ??
-    defaultValue ??
+    (elements.some(element => element.isSelected)
+      ? getCommonAttributeOfSelectedElements(elements, getAttribute)
+      : defaultValue) ??
     null
   );
 };


### PR DESCRIPTION
If you have two elements selected that have a different value (eg: a green line and a red line), the value of the color picker should be undefined, not the default value.