### PR TITLE
Fix exported size when drawing to the left

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1382,9 +1382,9 @@ export class App extends React.Component<any, AppState> {
       elements = clearSelection(elements);
 
       let subCanvasX1 = Infinity;
-      let subCanvasX2 = 0;
+      let subCanvasX2 = -Infinity;
       let subCanvasY1 = Infinity;
-      let subCanvasY2 = 0;
+      let subCanvasY2 = -Infinity;
 
       const minX = Math.min(...parsedElements.map(element => element.x));
       const minY = Math.min(...parsedElements.map(element => element.y));

--- a/src/scene/getExportCanvasPreview.ts
+++ b/src/scene/getExportCanvasPreview.ts
@@ -29,9 +29,9 @@ export function getExportCanvasPreview(
 ) {
   // calculate smallest area to fit the contents in
   let subCanvasX1 = Infinity;
-  let subCanvasX2 = 0;
+  let subCanvasX2 = -Infinity;
   let subCanvasY1 = Infinity;
-  let subCanvasY2 = 0;
+  let subCanvasY2 = -Infinity;
 
   elements.forEach(element => {
     const [x1, y1, x2, y2] = getElementAbsoluteCoords(element);

--- a/src/scene/scrollbars.ts
+++ b/src/scene/scrollbars.ts
@@ -14,9 +14,9 @@ export function getScrollBars(
   scrollY: number,
 ) {
   let minX = Infinity;
-  let maxX = 0;
+  let maxX = -Infinity;
   let minY = Infinity;
-  let maxY = 0;
+  let maxY = -Infinity;
 
   elements.forEach(element => {
     const [x1, y1, x2, y2] = getElementAbsoluteCoords(element);


### PR DESCRIPTION
If you scroll and draw to the left of the origin, when you export the scene, there's a weird whitespace on the right. This is because we do the min() computation starting at 0 and not -Infinity

This also fixes pasted elements and scrollbars.