### PR TITLE
Disable escape when creating element

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -284,7 +284,7 @@ export class App extends React.Component<any, AppState> {
   };
 
   private onKeyDown = (event: KeyboardEvent) => {
-    if (event.key === KEYS.ESCAPE) {
+    if (event.key === KEYS.ESCAPE && !this.state.draggingElement) {
       elements = clearSelection(elements);
       this.forceUpdate();
       this.setState({ elementType: "selection" });


### PR DESCRIPTION
Problem:
- Select arrow
- Mouse down somewhere
- Mouse move somewhere to create an arrow
- Press escape
- Now you're in a weird situation where the shape is now "selection" but you're still dragging the arrow. If you mouse up, the arrow disappears

In order to solve this problem, we can avoid making escape do anything if you're currently dragging an element