### PR TITLE
Cleanup saved json file

### DIFF
--- a/src/scene/data.ts
+++ b/src/scene/data.ts
@@ -27,14 +27,20 @@ interface DataState {
 
 export function serializeAsJSON(
   elements: readonly ExcalidrawElement[],
-  appState?: AppState,
+  appState: AppState,
 ): string {
-  return JSON.stringify({
-    version: 1,
-    source: window.location.origin,
-    elements: elements.map(({ shape, ...el }) => el),
-    appState: appState || getDefaultAppState(),
-  });
+  return JSON.stringify(
+    {
+      type: "excalidraw",
+      version: 1,
+      appState: {
+        viewBackgroundColor: appState.viewBackgroundColor,
+      },
+      elements: elements.map(({ shape, isSelected, ...el }) => el),
+    },
+    null,
+    2,
+  );
 }
 
 function calculateScroll(


### PR DESCRIPTION
It turns out the only thing we need to save in the appState is the background color. All the rest is transient data.

I added `"type": "excalidraw"` at the beginning to explain where it was.

I removed `"source": "http://localhost:3000/"`. I don't think we want to leak on which webpage it was saved from.

I removed `isSelected` from the json

I added indentation so it's easier to read the content. I'm not 100% sure on this one, but I figure filesize doesn't matter too much those days. And if we want to shrink it, there are more effective ways than json.