### PR TITLE
change cartoonist roughness

### DIFF
--- a/src/actions/actionProperties.tsx
+++ b/src/actions/actionProperties.tsx
@@ -182,7 +182,7 @@ export const actionChangeSloppiness: Action = {
         options={[
           { value: 0, text: t("labels.architect") },
           { value: 1, text: t("labels.artist") },
-          { value: 3, text: t("labels.cartoonist") },
+          { value: 2, text: t("labels.cartoonist") },
         ]}
         value={getFormValue(
           appState.editingElement,


### PR DESCRIPTION
The cartoonist roughness is IMO too sloppy (it goes from `0` → `1` → `3`). I think it's often unusable for anything useful. I propose changing it to `2`.

Come to think of it, I should have first created an issue for this. Feel free to close if you think it's not a good idea.

![image](https://user-images.githubusercontent.com/5153846/73140293-aca4f880-4077-11ea-9931-a24e1cdfd76a.png)

![image](https://user-images.githubusercontent.com/5153846/73140294-af9fe900-4077-11ea-979b-e39ced027eec.png)
