### PR TITLE
move title to label

### DIFF
--- a/src/components/ToolButton.tsx
+++ b/src/components/ToolButton.tsx
@@ -50,12 +50,11 @@ export const ToolButton = React.forwardRef(function(
     );
 
   return (
-    <label className="ToolIcon">
+    <label className="ToolIcon" title={props.title}>
       <input
         className={`ToolIcon_type_radio ${sizeCn}`}
         type="radio"
         name={props.name}
-        title={props.title}
         aria-label={props["aria-label"]}
         aria-keyshortcuts={props["aria-keyshortcuts"]}
         id={props.id}


### PR DESCRIPTION
#534 broke tooltips of shape icons because it moved it to the `<input>` which is not full size of the `<label>`.

/cc @voluntadpear should we move the aria labels, too?

![image](https://user-images.githubusercontent.com/5153846/73140780-022fd400-407d-11ea-88c9-21f1f6c96642.png)
