### PR TITLE
Bump browser-nativefs version to v0.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2750,9 +2750,9 @@
       "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
     },
     "browser-nativefs": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/browser-nativefs/-/browser-nativefs-0.1.1.tgz",
-      "integrity": "sha512-FHt/+3LutToaybxSRxt7Tpm+pU7FuHlT4b8xPjBFETTDirvYtf0q3FXXvdYrxtbW8AUX9xobqLHu/NLRQP24jA=="
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/browser-nativefs/-/browser-nativefs-0.2.0.tgz",
+      "integrity": "sha512-TKStaoiZCw6ZP4SaX40UuLeZm65WzzO+FEr/qv/k8pyVIi9z2dDLib/WTBfkQDOsTYauAdGgJu7Xtvhn5gXzlA=="
     },
     "browser-process-hrtime": {
       "version": "0.1.3",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "not op_mini all"
   ],
   "dependencies": {
-    "browser-nativefs": "0.1.1",
+    "browser-nativefs": "0.2.0",
     "i18next": "19.0.3",
     "i18next-browser-languagedetector": "4.0.1",
     "i18next-xhr-backend": "3.2.2",


### PR DESCRIPTION
In reply to https://github.com/tomayac/browser-nativefs/issues/2.