### PR TITLE
ensure we reset draggingElement when tool locked

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1336,6 +1336,10 @@ export class App extends React.Component<any, AppState> {
                     draggingElement: null,
                     elementType: "selection",
                   });
+                } else {
+                  this.setState({
+                    draggingElement: null,
+                  });
                 }
 
                 history.resumeRecording();


### PR DESCRIPTION
Fixes issue where `state.draggingElement` wasn't reset when tools locked. This caused an issue where you couldn't `esc` to reset to `selection` after creating an element (among possible other bugs).

Steps to repro:

1. lock tools
2. create rectangle
3. press `esc`
4. tool is not reset to selection