### PR TITLE
Add keybindings for shapes

### DIFF
--- a/src/components/ToolButton.tsx
+++ b/src/components/ToolButton.tsx
@@ -13,6 +13,7 @@ type ToolButtonBaseProps = {
   name?: string;
   id?: string;
   size?: ToolIconSize;
+  keyBindingLabel?: string;
 };
 
 type ToolButtonProps =
@@ -63,7 +64,12 @@ export const ToolButton = React.forwardRef(function(
         checked={props.checked}
         ref={innerRef}
       />
-      <div className="ToolIcon__icon">{props.icon}</div>
+      <div className="ToolIcon__icon">
+        {props.icon}
+        {props.keyBindingLabel && (
+          <span className="ToolIcon__keybinding">{props.keyBindingLabel}</span>
+        )}
+      </div>
     </label>
   );
 });

--- a/src/components/ToolIcon.scss
+++ b/src/components/ToolIcon.scss
@@ -88,7 +88,7 @@
   position: absolute;
   bottom: 2px;
   right: 2px;
-  font-size: 0.1em;
+  font-size: 0.5em;
   color: #aaa;
   font-family: Arial, Helvetica, sans-serif;
 }

--- a/src/components/ToolIcon.scss
+++ b/src/components/ToolIcon.scss
@@ -87,8 +87,8 @@
 .ToolIcon__keybinding {
   position: absolute;
   bottom: 2px;
-  right: 2px;
+  right: 3px;
   font-size: 0.5em;
-  color: #aaa;
+  color: #adb5bd; // OC GRAY 5
   font-family: Arial, Helvetica, sans-serif;
 }

--- a/src/components/ToolIcon.scss
+++ b/src/components/ToolIcon.scss
@@ -83,3 +83,12 @@
     box-shadow: none;
   }
 }
+
+.ToolIcon__keybinding {
+  position: absolute;
+  bottom: 2px;
+  right: 2px;
+  font-size: 0.1em;
+  color: #aaa;
+  font-family: Arial, Helvetica, sans-serif;
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -377,7 +377,6 @@ export class App extends React.Component<any, AppState> {
     } else if (
       shapesShortcutKeys.includes(event.key.toLowerCase()) &&
       !event.ctrlKey &&
-      !event.shiftKey &&
       !event.altKey &&
       !event.metaKey &&
       this.state.draggingElement === null

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -558,6 +558,7 @@ export class App extends React.Component<any, AppState> {
               title={`${capitalizeString(label)} — ${
                 capitalizeString(value)[0]
               }, ${index + 1}`}
+              keyBindingLabel={`${index + 1}`}
               aria-label={capitalizeString(label)}
               aria-keyshortcuts={`${label[0]} ${index + 1}`}
               onChange={() => {


### PR DESCRIPTION
I'm not 100% sure about this one. I feel like it's going to help people be a lot more productive to display the key bindings at all time. But it also clutters the UI...

I tried putting both the letter and number but it looked really terrible. I feel like using the numbers is going to be more predictable anyway.

![ezgif-3-8f13f6b4b748](https://user-images.githubusercontent.com/197597/73586144-1fabd600-44a1-11ea-9a82-b88eeea8f837.gif)
