### PR TITLE
Fix font preloading

### DIFF
--- a/public/fonts.css
+++ b/public/fonts.css
@@ -1,0 +1,13 @@
+/* http://www.eaglefonts.com/fg-virgil-ttf-131249.htm */
+@font-face {
+  font-family: "Virgil";
+  src: url("FG_Virgil.ttf");
+  font-display: swap;
+}
+
+/* https://github.com/microsoft/cascadia-code */
+@font-face {
+  font-family: "Cascadia";
+  src: url("Cascadia.ttf");
+  font-display: swap;
+}

--- a/public/index.html
+++ b/public/index.html
@@ -48,16 +48,17 @@
     <meta name="twitter:image" content="https://excalidraw.com/og-image.png" />
 
     <link rel="icon" href="%PUBLIC_URL%/logo.png" />
+    <link rel="stylesheet" href="%PUBLIC_URL%/fonts.css" />
     <link
       rel="preload"
-      href="/FG_Virgil.ttf"
+      href="%PUBLIC_URL%/FG_Virgil.ttf"
       as="font"
       type="font/ttf"
       crossorigin="anonymous"
     />
     <link
       rel="preload"
-      href="/Cascadia.ttf"
+      href="%PUBLIC_URL%/Cascadia.ttf"
       as="font"
       type="font/ttf"
       crossorigin="anonymous"

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,19 +1,5 @@
 @import "./theme.css";
 
-/* http://www.eaglefonts.com/fg-virgil-ttf-131249.htm */
-@font-face {
-  font-family: "Virgil";
-  src: url("/FG_Virgil.ttf");
-  font-display: swap;
-}
-
-/* https://github.com/microsoft/cascadia-code */
-@font-face {
-  font-family: "Cascadia";
-  src: url("/Cascadia.ttf");
-  font-display: swap;
-}
-
 body {
   margin: 0;
   font-family: Arial, Helvetica, sans-serif;


### PR DESCRIPTION
Thanks to this stack overflow answer ( https://stackoverflow.com/a/41678350/232122 ) I was able to fix the font preloading!

If we put fonts.css in the public/folder and include it with normal html, we can avoid going through the build pipeline!

Test Plan:
- Go to http://localhost:3000/?id=6309590945759232
- See that the font loads by default
- See that there's no warning in the console saying that we preload a font we don't use

Fixes #637