### PR TITLE
Fix wysiwyg text overflow

### DIFF
--- a/src/element/textWysiwyg.tsx
+++ b/src/element/textWysiwyg.tsx
@@ -39,7 +39,7 @@ export function textWysiwyg({
 
   Object.assign(editable.style, {
     color: strokeColor,
-    position: "absolute",
+    position: "fixed",
     opacity: opacity / 100,
     top: y + "px",
     left: x + "px",


### PR DESCRIPTION
By using position: fixed like the rest of the UI components, it will no longer make the body change size and have bad side effects like scrolling.

Fixes #365