### PR TITLE
Allow copy pasting inside of wysiwyg element

### DIFF
--- a/src/element/textWysiwyg.tsx
+++ b/src/element/textWysiwyg.tsx
@@ -73,14 +73,6 @@ export function textWysiwyg({
     }
   };
   editable.onblur = handleSubmit;
-  // override paste to disallow non-textual data, and replace newlines
-  editable.onpaste = ev => {
-    ev.preventDefault();
-    try {
-      const text = ev.clipboardData!.getData("text").replace(/\n+/g, " ");
-      editable.textContent = text;
-    } catch {}
-  };
 
   function stopEvent(ev: Event) {
     ev.stopPropagation();
@@ -98,7 +90,6 @@ export function textWysiwyg({
   function cleanup() {
     editable.onblur = null;
     editable.onkeydown = null;
-    editable.onpaste = null;
     window.removeEventListener("wheel", stopEvent, true);
     document.body.removeChild(editable);
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -31,6 +31,7 @@ export function isInputLike(
   | HTMLDivElement {
   return (
     (target instanceof HTMLElement && target.dataset.type === "wysiwyg") ||
+    target instanceof HTMLBRElement || // newline in wysiwyg
     target instanceof HTMLInputElement ||
     target instanceof HTMLTextAreaElement ||
     target instanceof HTMLSelectElement


### PR DESCRIPTION
We did some hackery to prevent copy pasting when we didn't support multilines. But we do now so we can remove it.

Interestingly, newlines are actually <br /> elements. So we need to tweak the isInputLike logic a bit

Fixed #396