### PR TITLE
Zoom feature

### DIFF
--- a/src/actions/actionCanvas.tsx
+++ b/src/actions/actionCanvas.tsx
@@ -56,7 +56,7 @@ const ZOOM_STEP = 0.1;
 
 function getNormalizedZoom(zoom: number): number {
   const normalizedZoom = parseFloat(zoom.toFixed(2));
-  const clampedZoom = Math.max(0, Math.min(normalizedZoom, 2));
+  const clampedZoom = Math.max(0.1, Math.min(normalizedZoom, 2));
   return clampedZoom;
 }
 

--- a/src/actions/actionCanvas.tsx
+++ b/src/actions/actionCanvas.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { Action } from "./types";
 import { ColorPicker } from "../components/ColorPicker";
 import { getDefaultAppState } from "../appState";
-import { trash } from "../components/icons";
+import { trash, zoomIn, zoomOut } from "../components/icons";
 import { ToolButton } from "../components/ToolButton";
 import { t } from "../i18n";
 
@@ -47,6 +47,60 @@ export const actionClearCanvas: Action = {
           (window as any).handle = null;
           updateData(null);
         }
+      }}
+    />
+  ),
+};
+
+const ZOOM_STEP = 0.1;
+
+function getNormalizedZoom(zoom: number): number {
+  const normalizedZoom = parseFloat(zoom.toFixed(2));
+  const clampedZoom = Math.max(0, Math.min(normalizedZoom, 2));
+  return clampedZoom;
+}
+
+export const actionZoomIn: Action = {
+  name: "zoomIn",
+  perform: (elements, appState) => {
+    return {
+      appState: {
+        ...appState,
+        zoom: getNormalizedZoom(appState.zoom + ZOOM_STEP),
+      },
+    };
+  },
+  PanelComponent: ({ updateData }) => (
+    <ToolButton
+      type="button"
+      icon={zoomIn}
+      title={t("buttons.zoomIn")}
+      aria-label={t("buttons.zoomIn")}
+      onClick={() => {
+        updateData(null);
+      }}
+    />
+  ),
+};
+
+export const actionZoomOut: Action = {
+  name: "zoomOut",
+  perform: (elements, appState) => {
+    return {
+      appState: {
+        ...appState,
+        zoom: getNormalizedZoom(appState.zoom - ZOOM_STEP),
+      },
+    };
+  },
+  PanelComponent: ({ updateData }) => (
+    <ToolButton
+      type="button"
+      icon={zoomOut}
+      title={t("buttons.zoomOut")}
+      aria-label={t("buttons.zoomOut")}
+      onClick={() => {
+        updateData(null);
       }}
     />
   ),

--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -21,6 +21,8 @@ export {
 export {
   actionChangeViewBackgroundColor,
   actionClearCanvas,
+  actionZoomIn,
+  actionZoomOut,
 } from "./actionCanvas";
 
 export { actionFinalize } from "./actionFinalize";

--- a/src/appState.ts
+++ b/src/appState.ts
@@ -27,6 +27,7 @@ export function getDefaultAppState(): AppState {
     scrolledOutside: false,
     name: DEFAULT_PROJECT_NAME,
     isResizing: false,
+    zoom: 1,
   };
 }
 

--- a/src/components/icons.tsx
+++ b/src/components/icons.tsx
@@ -76,3 +76,21 @@ export const exportFile = (
     />
   </svg>
 );
+
+export const zoomIn = (
+  <svg aria-hidden="true" focusable="false" role="img" viewBox="0 0 448 512">
+    <path
+      fill="currentColor"
+      d="M416 208H272V64c0-17.67-14.33-32-32-32h-32c-17.67 0-32 14.33-32 32v144H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h144v144c0 17.67 14.33 32 32 32h32c17.67 0 32-14.33 32-32V304h144c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
+    />
+  </svg>
+);
+
+export const zoomOut = (
+  <svg aria-hidden="true" focusable="false" role="img" viewBox="0 0 448 512">
+    <path
+      fill="currentColor"
+      d="M416 208H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h384c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
+    />
+  </svg>
+);

--- a/src/element/index.ts
+++ b/src/element/index.ts
@@ -23,3 +23,4 @@ export {
   resizePerfectLineForNWHandler,
   normalizeDimensions,
 } from "./sizeHelpers";
+export { getScaledElement } from "./scale";

--- a/src/element/index.ts
+++ b/src/element/index.ts
@@ -24,3 +24,4 @@ export {
   normalizeDimensions,
 } from "./sizeHelpers";
 export { getScaledElement } from "./scale";
+export { getElementWithResizeHandler } from "./resizeTest";

--- a/src/element/scale.ts
+++ b/src/element/scale.ts
@@ -1,0 +1,53 @@
+import { isTextElement } from "./typeChecks";
+import { redrawTextBoundingBox } from "./textElement";
+import { ExcalidrawElement } from "./types";
+
+export function getScaledElement(
+  element: ExcalidrawElement,
+  scale: number,
+): ExcalidrawElement {
+  switch (element.type) {
+    case "selection": {
+      return element;
+    }
+    case "rectangle":
+    case "diamond":
+    case "ellipse":
+    case "line": {
+      const scaledElement = { ...element };
+      scaledElement.x *= scale;
+      scaledElement.y *= scale;
+      scaledElement.width *= scale;
+      scaledElement.height *= scale;
+      scaledElement.strokeWidth *= scale;
+      return scaledElement;
+    }
+    case "arrow": {
+      const scaledElement = { ...element };
+      scaledElement.x *= scale;
+      scaledElement.y *= scale;
+      scaledElement.width *= scale;
+      scaledElement.height *= scale;
+      scaledElement.strokeWidth *= scale;
+      scaledElement.points = scaledElement.points.map(([x, y]) => [
+        x * scale,
+        y * scale,
+      ]);
+      return scaledElement;
+    }
+    default: {
+      if (isTextElement(element)) {
+        const scaledElement = { ...element };
+        scaledElement.x *= scale;
+        scaledElement.y *= scale;
+        const fontSize = parseFloat(scaledElement.font);
+        scaledElement.font = `${fontSize * scale}px ${
+          scaledElement.font.split("px ")[1]
+        }`;
+        redrawTextBoundingBox(scaledElement);
+        return scaledElement;
+      }
+      throw new Error("Unimplemented type " + element.type);
+    }
+  }
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -17,17 +17,19 @@ import {
   getCursorForResizingElement,
   getPerfectElementSize,
   normalizeDimensions,
+  getElementWithResizeHandler,
+  getScaledElement,
 } from "./element";
 import {
+  getElementAtPosition,
+  getElementContainingPosition,
   clearSelection,
   deleteSelectedElements,
-  getElementsWithinSelection,
   isOverScrollBars,
   restoreFromLocalStorage,
   saveToLocalStorage,
-  getElementAtPosition,
+  getElementsWithinSelection,
   createScene,
-  getElementContainingPosition,
   hasBackground,
   hasStroke,
   hasText,
@@ -59,7 +61,6 @@ import { createHistory } from "./history";
 import ContextMenu from "./components/ContextMenu";
 
 import "./styles.scss";
-import { getElementWithResizeHandler } from "./element/resizeTest";
 import {
   ActionManager,
   actionDeleteSelected,
@@ -488,6 +489,93 @@ export class App extends React.Component<any, AppState> {
     }
   };
 
+  private getElementContainingPosition = (
+    elements: readonly ExcalidrawElement[],
+    x: number,
+    y: number,
+  ) => {
+    return getElementContainingPosition(
+      this.getElementsWithZoomScale(elements),
+      x,
+      y,
+    );
+  };
+
+  private getElementAtPosition = (
+    elements: readonly ExcalidrawElement[],
+    x: number,
+    y: number,
+  ) => {
+    return getElementAtPosition(this.getElementsWithZoomScale(elements), x, y);
+  };
+
+  private isOverScrollBars = (
+    elements: readonly ExcalidrawElement[],
+    x: number,
+    y: number,
+    canvasWidth: number,
+    canvasHeight: number,
+    scrollX: number,
+    scrollY: number,
+  ) => {
+    return isOverScrollBars(
+      this.getElementsWithZoomScale(elements),
+      x,
+      y,
+      canvasWidth,
+      canvasHeight,
+      scrollX,
+      scrollY,
+    );
+  };
+
+  private getElementsWithinSelection = (
+    elements: readonly ExcalidrawElement[],
+    selection: ExcalidrawElement,
+  ) => {
+    return getElementsWithinSelection(
+      this.getElementsWithZoomScale(elements),
+      selection,
+    );
+  };
+
+  private getCommonBounds = (elements: readonly ExcalidrawElement[]) => {
+    return getCommonBounds(this.getElementsWithZoomScale(elements));
+  };
+
+  private getElementsWithZoomScale = (
+    elements: readonly ExcalidrawElement[],
+  ): ExcalidrawElement[] => {
+    return elements.map(element => getScaledElement(element, this.state.zoom));
+  };
+
+  private setIsSelectedOnElement = (
+    element: ExcalidrawElement,
+    isSelected: boolean,
+  ) => {
+    elements = elements.map(someElement => {
+      if (someElement.id === element.id) {
+        someElement.isSelected = isSelected;
+      }
+      return someElement;
+    });
+  };
+
+  private selectElement = (element: ExcalidrawElement | null) => {
+    if (element === null) {
+      return;
+    }
+    element.isSelected = true;
+    this.setIsSelectedOnElement(element, true);
+  };
+  private deselectElement = (element: ExcalidrawElement | null) => {
+    if (element === null) {
+      return;
+    }
+    element.isSelected = false;
+    this.setIsSelectedOnElement(element, false);
+  };
+
   private renderSelectedShapeActions(elements: readonly ExcalidrawElement[]) {
     const { elementType, editingElement } = this.state;
     const targetElements = editingElement
@@ -807,6 +895,9 @@ export class App extends React.Component<any, AppState> {
                 this.canvas.addEventListener("wheel", this.handleWheel, {
                   passive: false,
                 });
+                this.canvas
+                  .getContext("2d")
+                  ?.setTransform(canvasScale, 0, 0, canvasScale, 0, 0);
               } else {
                 this.canvas?.removeEventListener("wheel", this.handleWheel);
               }
@@ -816,7 +907,7 @@ export class App extends React.Component<any, AppState> {
 
               const { x, y } = viewportCoordsToSceneCoords(e, this.state);
 
-              const element = getElementAtPosition(elements, x, y);
+              const element = this.getElementAtPosition(elements, x, y);
               if (!element) {
                 ContextMenu.push({
                   options: [
@@ -839,7 +930,7 @@ export class App extends React.Component<any, AppState> {
 
               if (!element.isSelected) {
                 elements = clearSelection(elements);
-                element.isSelected = true;
+                this.selectElement(element);
                 this.setState({});
               }
 
@@ -934,7 +1025,7 @@ export class App extends React.Component<any, AppState> {
               const {
                 isOverHorizontalScrollBar,
                 isOverVerticalScrollBar,
-              } = isOverScrollBars(
+              } = this.isOverScrollBars(
                 elements,
                 e.clientX - CANVAS_WINDOW_OFFSET_LEFT,
                 e.clientY - CANVAS_WINDOW_OFFSET_TOP,
@@ -992,7 +1083,7 @@ export class App extends React.Component<any, AppState> {
                   );
                   isResizingElements = true;
                 } else {
-                  hitElement = getElementAtPosition(elements, x, y);
+                  hitElement = this.getElementAtPosition(elements, x, y);
                   // clear selection if shift is not clicked
                   if (!hitElement?.isSelected && !e.shiftKey) {
                     elements = clearSelection(elements);
@@ -1005,7 +1096,7 @@ export class App extends React.Component<any, AppState> {
                     // otherwise, it will trigger selection based on current
                     // state of the box
                     if (!hitElement.isSelected) {
-                      hitElement.isSelected = true;
+                      this.selectElement(hitElement);
                       elementIsAddedToSelection = true;
                     }
 
@@ -1094,11 +1185,11 @@ export class App extends React.Component<any, AppState> {
                 if (this.state.multiElement) {
                   const { multiElement } = this.state;
                   const { x: rx, y: ry } = multiElement;
-                  multiElement.isSelected = true;
+                  this.selectElement(multiElement);
                   multiElement.points.push([x - rx, y - ry]);
                   multiElement.shape = null;
                 } else {
-                  element.isSelected = false;
+                  this.deselectElement(element);
                   element.points.push([0, 0]);
                   element.shape = null;
                   elements = [...elements, element];
@@ -1537,13 +1628,11 @@ export class App extends React.Component<any, AppState> {
                   if (!e.shiftKey) {
                     elements = clearSelection(elements);
                   }
-                  const elementsWithinSelection = getElementsWithinSelection(
+                  const elementsWithinSelection = this.getElementsWithinSelection(
                     elements,
                     draggingElement,
                   );
-                  elementsWithinSelection.forEach(element => {
-                    element.isSelected = true;
-                  });
+                  elementsWithinSelection.forEach(this.selectElement);
                 }
                 // We don't want to save history when moving an element
                 history.skipRecording();
@@ -1579,7 +1668,7 @@ export class App extends React.Component<any, AppState> {
                     draggingElement.shape = null;
                     this.setState({ multiElement: this.state.draggingElement });
                   } else if (draggingOccurred && !multiElement) {
-                    this.state.draggingElement!.isSelected = true;
+                    this.selectElement(this.state.draggingElement);
                     this.setState({
                       draggingElement: null,
                       elementType: "selection",
@@ -1628,10 +1717,10 @@ export class App extends React.Component<any, AppState> {
                   !elementIsAddedToSelection
                 ) {
                   if (e.shiftKey) {
-                    hitElement.isSelected = false;
+                    this.deselectElement(hitElement);
                   } else {
                     elements = clearSelection(elements);
-                    hitElement.isSelected = true;
+                    this.selectElement(hitElement);
                   }
                 }
 
@@ -1645,7 +1734,7 @@ export class App extends React.Component<any, AppState> {
                 if (elementType === "selection") {
                   elements = elements.slice(0, -1);
                 } else if (!elementLocked) {
-                  draggingElement.isSelected = true;
+                  this.selectElement(draggingElement);
                 }
 
                 if (!elementLocked) {
@@ -1680,7 +1769,11 @@ export class App extends React.Component<any, AppState> {
             onDoubleClick={e => {
               const { x, y } = viewportCoordsToSceneCoords(e, this.state);
 
-              const elementAtPosition = getElementAtPosition(elements, x, y);
+              const elementAtPosition = this.getElementAtPosition(
+                elements,
+                x,
+                y,
+              );
 
               const element =
                 elementAtPosition && isTextElement(elementAtPosition)
@@ -1816,7 +1909,7 @@ export class App extends React.Component<any, AppState> {
                   return;
                 }
               }
-              const hitElement = getElementAtPosition(elements, x, y);
+              const hitElement = this.getElementAtPosition(elements, x, y);
               document.documentElement.style.cursor = hitElement ? "move" : "";
             }}
             onDrop={e => {
@@ -1898,7 +1991,7 @@ export class App extends React.Component<any, AppState> {
   ) => {
     elements = clearSelection(elements);
 
-    const [minX, minY, maxX, maxY] = getCommonBounds(clipboardElements);
+    const [minX, minY, maxX, maxY] = this.getCommonBounds(clipboardElements);
 
     const elementsCenterX = distance(minX, maxX) / 2;
     const elementsCenterY = distance(minY, maxY) / 2;
@@ -1924,7 +2017,11 @@ export class App extends React.Component<any, AppState> {
   };
 
   private getTextWysiwygSnappedToCenterPosition(x: number, y: number) {
-    const elementClickedInside = getElementContainingPosition(elements, x, y);
+    const elementClickedInside = this.getElementContainingPosition(
+      elements,
+      x,
+      y,
+    );
     if (elementClickedInside) {
       const elementCenterX =
         elementClickedInside.x + elementClickedInside.width / 2;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -44,6 +44,7 @@ import {
 import { renderScene } from "./renderer";
 import { AppState } from "./types";
 import { ExcalidrawElement } from "./element/types";
+import { SceneScroll } from "./scene/types";
 
 import {
   isInputLike,
@@ -541,6 +542,18 @@ export class App extends React.Component<any, AppState> {
 
   private getCommonBounds = (elements: readonly ExcalidrawElement[]) => {
     return getCommonBounds(this.getElementsWithZoomScale(elements));
+  };
+
+  private getElementWithResizeHandler = (
+    elements: readonly ExcalidrawElement[],
+    { x, y }: { x: number; y: number },
+    { scrollX, scrollY }: SceneScroll,
+  ) => {
+    return getElementWithResizeHandler(
+      this.getElementsWithZoomScale(elements),
+      { x, y },
+      { scrollX, scrollY },
+    );
   };
 
   private getElementsWithZoomScale = (
@@ -1067,7 +1080,7 @@ export class App extends React.Component<any, AppState> {
               let hitElement: ExcalidrawElement | null = null;
               let elementIsAddedToSelection = false;
               if (this.state.elementType === "selection") {
-                const resizeElement = getElementWithResizeHandler(
+                const resizeElement = this.getElementWithResizeHandler(
                   elements,
                   { x, y },
                   this.state,
@@ -1897,7 +1910,7 @@ export class App extends React.Component<any, AppState> {
               const selectedElements = elements.filter(e => e.isSelected)
                 .length;
               if (selectedElements === 1) {
-                const resizeElement = getElementWithResizeHandler(
+                const resizeElement = this.getElementWithResizeHandler(
                   elements,
                   { x, y },
                   this.state,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -545,7 +545,7 @@ export class App extends React.Component<any, AppState> {
 
   private getElementsWithZoomScale = (
     elements: readonly ExcalidrawElement[],
-  ): ExcalidrawElement[] => {
+  ): readonly ExcalidrawElement[] => {
     return elements.map(element => getScaledElement(element, this.state.zoom));
   };
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1968,7 +1968,7 @@ export class App extends React.Component<any, AppState> {
         scrollX: this.state.scrollX,
         scrollY: this.state.scrollY,
         viewBackgroundColor: this.state.viewBackgroundColor,
-        zoom: 1,
+        zoom: this.state.zoom,
       },
     );
     const scrolledOutside = !atLeastOneVisibleElement && elements.length > 0;

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -53,7 +53,9 @@
     "close": "Close",
     "selectLanguage": "Select Language",
     "previouslyLoadedScenes": "Previously loaded scenes",
-    "scrollBackToContent": "Scroll back to content"
+    "scrollBackToContent": "Scroll back to content",
+    "zoomIn": "Zoom in",
+    "zoomOut": "Zoom out"
   },
   "alerts": {
     "clearReset": "This will clear the whole canvas. Are you sure?",

--- a/src/renderer/renderScene.ts
+++ b/src/renderer/renderScene.ts
@@ -98,7 +98,7 @@ export function renderScene(
     const selectedElements = scaledElements.filter(
       element => element.isSelected,
     );
-    const margin = 8;
+    const margin = 4;
 
     selectedElements.forEach(element => {
       const [
@@ -112,8 +112,8 @@ export function renderScene(
       context.strokeRect(
         elementX1 - margin + sceneState.scrollX,
         elementY1 - margin + sceneState.scrollY,
-        elementX2 - elementX1 + margin,
-        elementY2 - elementY1 + margin,
+        elementX2 - elementX1 + margin * 2,
+        elementY2 - elementY1 + margin * 2,
       );
       context.setLineDash(lineDash);
     });

--- a/src/renderer/renderScene.ts
+++ b/src/renderer/renderScene.ts
@@ -219,8 +219,11 @@ function getScaledElement(
   switch (element.type) {
     case "selection": {
       const scaledElement = { ...element };
+      scaledElement.x *= scale;
+      scaledElement.y *= scale;
       scaledElement.width *= scale;
       scaledElement.height *= scale;
+      scaledElement.strokeWidth *= scale;
       return scaledElement;
     }
     case "rectangle":
@@ -228,6 +231,8 @@ function getScaledElement(
     case "ellipse":
     case "line": {
       const scaledElement = { ...element };
+      scaledElement.x *= scale;
+      scaledElement.y *= scale;
       scaledElement.width *= scale;
       scaledElement.height *= scale;
       scaledElement.strokeWidth *= scale;
@@ -235,14 +240,22 @@ function getScaledElement(
     }
     case "arrow": {
       const scaledElement = { ...element };
+      scaledElement.x *= scale;
+      scaledElement.y *= scale;
       scaledElement.width *= scale;
       scaledElement.height *= scale;
       scaledElement.strokeWidth *= scale;
+      scaledElement.points = scaledElement.points.map(([x, y]) => [
+        x * scale,
+        y * scale,
+      ]);
       return scaledElement;
     }
     default: {
       if (isTextElement(element)) {
         const scaledElement = { ...element };
+        scaledElement.x *= scale;
+        scaledElement.y *= scale;
         const fontSize = parseFloat(scaledElement.font);
         scaledElement.font = `${fontSize * scale}px ${
           scaledElement.font.split("px ")[1]

--- a/src/renderer/renderScene.ts
+++ b/src/renderer/renderScene.ts
@@ -5,7 +5,7 @@ import { ExcalidrawElement } from "../element/types";
 import {
   getElementAbsoluteCoords,
   handlerRectangles,
-  isTextElement,
+  getScaledElement,
 } from "../element";
 
 import { roundRect } from "./roundRect";
@@ -158,6 +158,16 @@ export function renderScene(
     context.fillStyle = fillStyle;
   }
 
+  // Reset context transform matrix
+  context.setTransform(
+    window.devicePixelRatio,
+    0,
+    0,
+    window.devicePixelRatio,
+    0,
+    0,
+  );
+
   return visibleElements.length > 0;
 }
 
@@ -210,59 +220,4 @@ export function renderSceneToSvg(
       element.y + offsetY,
     );
   });
-}
-
-function getScaledElement(
-  element: ExcalidrawElement,
-  scale: number,
-): ExcalidrawElement {
-  switch (element.type) {
-    case "selection": {
-      const scaledElement = { ...element };
-      scaledElement.x *= scale;
-      scaledElement.y *= scale;
-      scaledElement.width *= scale;
-      scaledElement.height *= scale;
-      scaledElement.strokeWidth *= scale;
-      return scaledElement;
-    }
-    case "rectangle":
-    case "diamond":
-    case "ellipse":
-    case "line": {
-      const scaledElement = { ...element };
-      scaledElement.x *= scale;
-      scaledElement.y *= scale;
-      scaledElement.width *= scale;
-      scaledElement.height *= scale;
-      scaledElement.strokeWidth *= scale;
-      return scaledElement;
-    }
-    case "arrow": {
-      const scaledElement = { ...element };
-      scaledElement.x *= scale;
-      scaledElement.y *= scale;
-      scaledElement.width *= scale;
-      scaledElement.height *= scale;
-      scaledElement.strokeWidth *= scale;
-      scaledElement.points = scaledElement.points.map(([x, y]) => [
-        x * scale,
-        y * scale,
-      ]);
-      return scaledElement;
-    }
-    default: {
-      if (isTextElement(element)) {
-        const scaledElement = { ...element };
-        scaledElement.x *= scale;
-        scaledElement.y *= scale;
-        const fontSize = parseFloat(scaledElement.font);
-        scaledElement.font = `${fontSize * scale}px ${
-          scaledElement.font.split("px ")[1]
-        }`;
-        return scaledElement;
-      }
-      throw new Error("Unimplemented type " + element.type);
-    }
-  }
 }

--- a/src/renderer/renderScene.ts
+++ b/src/renderer/renderScene.ts
@@ -35,7 +35,7 @@ export function renderScene(
     renderScrollbars?: boolean;
     renderSelection?: boolean;
   } = {},
-) {
+): boolean {
   if (!canvas) {
     return false;
   }

--- a/src/scene/export.ts
+++ b/src/scene/export.ts
@@ -43,6 +43,7 @@ export function exportToCanvas(
       viewBackgroundColor: exportBackground ? viewBackgroundColor : null,
       scrollX: 0,
       scrollY: 0,
+      zoom: 1,
     },
     {
       offsetX: -minX + exportPadding,

--- a/src/scene/types.ts
+++ b/src/scene/types.ts
@@ -5,6 +5,7 @@ export type SceneState = {
   scrollY: number;
   // null indicates transparent bg
   viewBackgroundColor: string | null;
+  zoom: number;
 };
 
 export type SceneScroll = {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -138,6 +138,28 @@ button,
   justify-self: flex-end;
 }
 
+.App-menu_bottom {
+  position: fixed;
+  bottom: 0;
+
+  grid-template-columns: 1fr auto 1fr;
+  align-items: flex-start;
+  cursor: default;
+  pointer-events: none !important;
+}
+
+.App-menu_bottom > * {
+  pointer-events: all;
+}
+
+.App-menu_bottom > *:first-child {
+  justify-self: flex-start;
+}
+
+.App-menu_bottom > *:last-child {
+  justify-self: flex-end;
+}
+
 .App-menu_left {
   grid-template-rows: 1fr auto 1fr;
   height: 100%;

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,4 +26,5 @@ export type AppState = {
   name: string;
   selectedId?: string;
   isResizing: boolean;
+  zoom: number;
 };


### PR DESCRIPTION
Covers https://github.com/excalidraw/excalidraw/issues/13.

There are quite a bit of things to discuss I feel.

I chose an approach where the base `elements` values are not touched, and every time you want to do something regarding how they finally render on the canvas, we apply some scaling factor on them. I played around scaling the whole canvas using `scale`, but I could see a lot of growing complexity around it because we have too many other functions relying on the elements sizing outside of the `renderScene` functions (hovers, selection, drag, etc.). 

I can understand this is a huge decision to take, so I commented everything inline below.

In any case, I think the result is quite good 😁 

---

As pointed out in the comments below, there are some still some issues to fix. Let's first agree on the direction we want to take for this feature and I will make sure to close every issue before merging.

Known issues:

- [x] Scaling handlers are not working when not 100% zoom.
- [ ] Mouse movements should be mapped to canvas coordinates taking into consideration zoom scaling.
- [ ] Arrow hit testing.
- [ ] Zoom buttons are overlapping the list of the recent imported canvas ids.
