### PR TITLE
Fix typing into color picker popup text field

### DIFF
--- a/src/components/ColorPicker.tsx
+++ b/src/components/ColorPicker.tsx
@@ -4,6 +4,7 @@ import { Popover } from "./Popover";
 import "./ColorPicker.css";
 import { KEYS } from "../keys";
 import { t } from "../i18n";
+import { isWritableElement } from "../utils";
 
 // This is a narrow reimplementation of the awesome react-color Twitter component
 // https://github.com/casesandberg/react-color/blob/master/src/components/twitter/Twitter.js
@@ -84,7 +85,10 @@ const Picker = function({
         (gallery!.current!.children![nextIndex] as any).focus();
       }
       e.preventDefault();
-    } else if (keyBindings.includes(e.key.toLowerCase())) {
+    } else if (
+      keyBindings.includes(e.key.toLowerCase()) &&
+      !isWritableElement(e.target)
+    ) {
       const index = keyBindings.indexOf(e.key.toLowerCase());
       (gallery!.current!.children![index] as any).focus();
       e.preventDefault();
@@ -200,9 +204,6 @@ const ColorInput = React.forwardRef(
           onPaste={e => onChange(e.clipboardData.getData("text"))}
           onBlur={() => setInnerValue(color)}
           ref={inputRef}
-          onKeyDown={e => {
-            e.stopPropagation();
-          }}
           onFocus={e => {
             e.target.select();
           }}

--- a/src/components/ColorPicker.tsx
+++ b/src/components/ColorPicker.tsx
@@ -200,6 +200,12 @@ const ColorInput = React.forwardRef(
           onPaste={e => onChange(e.clipboardData.getData("text"))}
           onBlur={() => setInnerValue(color)}
           ref={inputRef}
+          onKeyDown={e => {
+            e.stopPropagation();
+          }}
+          onFocus={e => {
+            e.target.select();
+          }}
         />
       </div>
     );

--- a/src/components/ColorPicker.tsx
+++ b/src/components/ColorPicker.tsx
@@ -40,8 +40,8 @@ const Picker = function({
     // focus on first input
     if (activeItem.current) {
       activeItem.current.focus();
-    } else if (firstItem.current) {
-      firstItem.current.focus();
+    } else if (colorInput.current) {
+      colorInput.current.focus();
     }
   }, []);
 


### PR DESCRIPTION
Fixes #688 

This PR fixes typing into a color picker popup text field that causes color selection via a hotkey. Also, another change I made,  text in the text field is selected/highlighted on the first click. This might be something that needs to be discussed because people might have different preferences. In my opinion, selecting all text makes deleting/removing easier.

Action: selecting  color picker, clicking on the color text field and  typing `"d"`

Before:

![captured (1)](https://user-images.githubusercontent.com/26898520/73732836-e945b380-474b-11ea-8919-8d7df93fcbfd.gif)

After:

![captured (2)](https://user-images.githubusercontent.com/26898520/73733127-712bbd80-474c-11ea-8220-7a17301063bd.gif)

