### PR TITLE
Eslint tweaks

### DIFF
--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -7,7 +7,7 @@ const cli = new CLIEngine({});
 module.exports = {
   "*.{js,ts,tsx}": files => {
     return (
-      "eslint --fix " + files.filter(file => !cli.isPathIgnored(file)).join(" ")
+      "eslint --max-warnings=0 --fix " + files.filter(file => !cli.isPathIgnored(file)).join(" ")
     );
   },
   "*.{css,scss,json,md,html,yml}": ["prettier --write"],

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
           ]
         }
       ],
+      "no-else-return": "warn",
       "no-useless-return": "warn",
       "prefer-const": [
         "warn",

--- a/package.json
+++ b/package.json
@@ -39,9 +39,9 @@
       "prettier"
     ],
     "rules": {
-      "curly": "error",
+      "curly": "warn",
       "no-console": [
-        "error",
+        "warn",
         {
           "allow": [
             "warn",
@@ -50,16 +50,15 @@
           ]
         }
       ],
-      "no-else-return": "error",
-      "no-useless-return": "error",
+      "no-useless-return": "warn",
       "prefer-const": [
-        "error",
+        "warn",
         {
           "destructuring": "all"
         }
       ],
-      "prefer-template": "error",
-      "prettier/prettier": "error"
+      "prefer-template": "warn",
+      "prettier/prettier": "warn"
     }
   },
   "homepage": "https://excalidraw.com",

--- a/src/clipboard.ts
+++ b/src/clipboard.ts
@@ -62,9 +62,8 @@ export function parseClipboardEvent(
     const text = e.clipboardData?.getData("text/plain").trim();
     if (text && !PREFER_APP_CLIPBOARD) {
       return { text };
-    } else {
-      return getAppClipboard();
     }
+    return getAppClipboard();
   } catch (e) {}
 
   return {};

--- a/src/clipboard.ts
+++ b/src/clipboard.ts
@@ -62,7 +62,6 @@ export function parseClipboardEvent(
     const text = e.clipboardData?.getData("text/plain").trim();
     if (text && !PREFER_APP_CLIPBOARD) {
       return { text };
-      // eslint-disable-next-line no-else-return
     } else {
       return getAppClipboard();
     }


### PR DESCRIPTION
- ~Remove `no-else-return` (was unnecessarily strict rule that needed manual refactors).~
- Make eslint styleguide rules from `error` → `warn` so that you can distinguish between syntax/type errors when writing code.
- Reintroduce `max-warnings=0` due to the above (not sure why it was removed in #626).