### PR TITLE
fix decoding imported data from backend

### DIFF
--- a/src/scene/data.ts
+++ b/src/scene/data.ts
@@ -252,8 +252,7 @@ export async function importFromBackend(
         buffer,
       );
       // We need to convert the decrypted array buffer to a string
-      const string = String.fromCharCode.apply(
-        null,
+      const string = new window.TextDecoder("utf-8").decode(
         new Uint8Array(decrypted) as any,
       );
       data = JSON.parse(string);


### PR DESCRIPTION
fixes https://github.com/excalidraw/excalidraw/issues/721

Backward compat should be free because the TextEncoder we're currently using for encoding is by default already in `utf8`.