### PR TITLE
Improve pasting

### DIFF
--- a/src/element/textWysiwyg.tsx
+++ b/src/element/textWysiwyg.tsx
@@ -63,25 +63,18 @@ export function textWysiwyg({
       }
       selection.deleteFromDocument();
 
-      const lines = ev
-        .clipboardData!.getData("text")
-        .replace(/\r\n?/g, "\n")
-        .split("\n");
+      const text = ev.clipboardData!.getData("text").replace(/\r\n?/g, "\n");
 
-      lines.reduce((node: Range | Text | HTMLBRElement, line, idx) => {
-        const textNode = document.createTextNode(line);
-        if (node instanceof Range) {
-          node.insertNode(textNode);
-        } else {
-          node.parentNode!.insertBefore(textNode, node.nextSibling);
-        }
-        if (typeof lines[idx + 1] === "string") {
-          const newlineNode = document.createElement("br");
-          textNode.parentNode!.insertBefore(newlineNode, textNode.nextSibling);
-          return newlineNode;
-        }
-        return textNode;
-      }, selection.getRangeAt(0));
+      const span = document.createElement("span");
+      span.innerText = text;
+      const range = selection.getRangeAt(0);
+      range.insertNode(span);
+
+      // deselect
+      window.getSelection()!.removeAllRanges();
+      range.setStart(span, span.childNodes.length);
+      range.setEnd(span, span.childNodes.length);
+      selection.addRange(range);
 
       ev.preventDefault();
     } catch (err) {

--- a/src/element/textWysiwyg.tsx
+++ b/src/element/textWysiwyg.tsx
@@ -53,6 +53,7 @@ export function textWysiwyg({
     outline: "1px solid transparent",
     whiteSpace: "nowrap",
     minHeight: "1em",
+    backfaceVisibility: "hidden",
   });
 
   editable.onpaste = ev => {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -101,11 +101,7 @@ import { t, languages, setLanguage, getLanguage } from "./i18n";
 import { StoredScenesList } from "./components/StoredScenesList";
 import { HintViewer } from "./components/HintViewer";
 
-import {
-  getAppClipboard,
-  copyToAppClipboard,
-  parseClipboardEvent,
-} from "./clipboard";
+import { copyToAppClipboard, getClipboardContent } from "./clipboard";
 
 let { elements } = createScene();
 const { history } = createHistory();
@@ -475,48 +471,6 @@ export class App extends React.Component<any, AppState> {
     copyToAppClipboard(elements);
     e.preventDefault();
   };
-  private onPaste = (e: ClipboardEvent) => {
-    // #686
-    const target = document.activeElement;
-    const elementUnderCursor = document.elementFromPoint(cursorX, cursorY);
-    if (
-      elementUnderCursor instanceof HTMLCanvasElement &&
-      !isWritableElement(target)
-    ) {
-      const data = parseClipboardEvent(e);
-      if (data.elements) {
-        this.addElementsFromPaste(data.elements);
-      } else if (data.text) {
-        const { x, y } = viewportCoordsToSceneCoords(
-          { clientX: cursorX, clientY: cursorY },
-          this.state,
-        );
-
-        const element = newTextElement(
-          newElement(
-            "text",
-            x,
-            y,
-            this.state.currentItemStrokeColor,
-            this.state.currentItemBackgroundColor,
-            this.state.currentItemFillStyle,
-            this.state.currentItemStrokeWidth,
-            this.state.currentItemRoughness,
-            this.state.currentItemOpacity,
-          ),
-          data.text,
-          this.state.currentItemFont,
-        );
-
-        element.isSelected = true;
-
-        elements = [...clearSelection(elements), element];
-        history.resumeRecording();
-      }
-      this.selectShapeTool("selection");
-      e.preventDefault();
-    }
-  };
 
   private onUnload = () => {
     isHoldingSpace = false;
@@ -552,7 +506,7 @@ export class App extends React.Component<any, AppState> {
 
   public async componentDidMount() {
     document.addEventListener("copy", this.onCopy);
-    document.addEventListener("paste", this.onPaste);
+    document.addEventListener("paste", this.pasteFromClipboard);
     document.addEventListener("cut", this.onCut);
 
     document.addEventListener("keydown", this.onKeyDown, false);
@@ -584,7 +538,7 @@ export class App extends React.Component<any, AppState> {
 
   public componentWillUnmount() {
     document.removeEventListener("copy", this.onCopy);
-    document.removeEventListener("paste", this.onPaste);
+    document.removeEventListener("paste", this.pasteFromClipboard);
     document.removeEventListener("cut", this.onCut);
 
     document.removeEventListener("keydown", this.onKeyDown, false);
@@ -715,10 +669,49 @@ export class App extends React.Component<any, AppState> {
     copyToAppClipboard(elements);
   };
 
-  private pasteFromClipboard = () => {
-    const data = getAppClipboard();
-    if (data.elements) {
-      this.addElementsFromPaste(data.elements);
+  private pasteFromClipboard = async (e: ClipboardEvent | null) => {
+    // #686
+    const target = document.activeElement;
+    const elementUnderCursor = document.elementFromPoint(cursorX, cursorY);
+    if (
+      // if no ClipboardEvent supplied, assume we're pasting via contextMenu
+      //  thus these checks don't make sense
+      !e ||
+      (elementUnderCursor instanceof HTMLCanvasElement &&
+        !isWritableElement(target))
+    ) {
+      const data = await getClipboardContent(e);
+      if (data.elements) {
+        this.addElementsFromPaste(data.elements);
+      } else if (data.text) {
+        const { x, y } = viewportCoordsToSceneCoords(
+          { clientX: cursorX, clientY: cursorY },
+          this.state,
+        );
+
+        const element = newTextElement(
+          newElement(
+            "text",
+            x,
+            y,
+            this.state.currentItemStrokeColor,
+            this.state.currentItemBackgroundColor,
+            this.state.currentItemFillStyle,
+            this.state.currentItemStrokeWidth,
+            this.state.currentItemRoughness,
+            this.state.currentItemOpacity,
+          ),
+          data.text,
+          this.state.currentItemFont,
+        );
+
+        element.isSelected = true;
+
+        elements = [...clearSelection(elements), element];
+        history.resumeRecording();
+      }
+      this.selectShapeTool("selection");
+      e?.preventDefault();
     }
   };
 
@@ -807,7 +800,7 @@ export class App extends React.Component<any, AppState> {
                   options: [
                     navigator.clipboard && {
                       label: t("labels.paste"),
-                      action: () => this.pasteFromClipboard(),
+                      action: () => this.pasteFromClipboard(null),
                     },
                     ...this.actionManager.getContextMenuItems(action =>
                       this.canvasOnlyActions.includes(action),
@@ -833,7 +826,7 @@ export class App extends React.Component<any, AppState> {
                   },
                   navigator.clipboard && {
                     label: t("labels.paste"),
-                    action: () => this.pasteFromClipboard(),
+                    action: () => this.pasteFromClipboard(null),
                   },
                   ...this.actionManager.getContextMenuItems(
                     action => !this.canvasOnlyActions.includes(action),

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -46,6 +46,7 @@ import { ExcalidrawElement } from "./element/types";
 import {
   isWritableElement,
   isInputLike,
+  isToolIcon,
   debounce,
   capitalizeString,
   distance,
@@ -511,8 +512,8 @@ export class App extends React.Component<any, AppState> {
 
         elements = [...clearSelection(elements), element];
         history.resumeRecording();
-        this.setState({});
       }
+      this.selectShapeTool("selection");
       e.preventDefault();
     }
   };
@@ -657,14 +658,7 @@ export class App extends React.Component<any, AppState> {
       !event.metaKey &&
       this.state.draggingElement === null
     ) {
-      if (!isHoldingSpace) {
-        setCursorForShape(shape);
-      }
-      if (document.activeElement instanceof HTMLElement) {
-        document.activeElement.blur();
-      }
-      elements = clearSelection(elements);
-      this.setState({ elementType: shape });
+      this.selectShapeTool(shape);
       // Undo action
     } else if (event[KEYS.META] && /z/i.test(event.key)) {
       event.preventDefault();
@@ -727,6 +721,19 @@ export class App extends React.Component<any, AppState> {
       this.addElementsFromPaste(data.elements);
     }
   };
+
+  private selectShapeTool(elementType: AppState["elementType"]) {
+    if (!isHoldingSpace) {
+      setCursorForShape(elementType);
+    }
+    if (isToolIcon(document.activeElement)) {
+      document.activeElement.blur();
+    }
+    if (elementType !== "selection") {
+      elements = clearSelection(elements);
+    }
+    this.setState({ elementType });
+  }
 
   setAppState = (obj: any) => {
     this.setState(obj);

--- a/src/shapes.tsx
+++ b/src/shapes.tsx
@@ -65,7 +65,7 @@ export const SHAPES = [
     ),
     value: "text",
   },
-];
+] as const;
 
 export const shapesShortcutKeys = SHAPES.map((shape, index) => [
   shape.value[0],
@@ -73,12 +73,9 @@ export const shapesShortcutKeys = SHAPES.map((shape, index) => [
 ]).flat(1);
 
 export function findShapeByKey(key: string) {
-  const defaultElement = "selection";
-  return SHAPES.reduce((element, shape, index) => {
-    if (shape.value[0] !== key && key !== (index + 1).toString()) {
-      return element;
-    }
-
-    return shape.value;
-  }, defaultElement);
+  return (
+    SHAPES.find((shape, index) => {
+      return shape.value[0] !== key || key === (index + 1).toString();
+    })?.value || "selection"
+  );
 }

--- a/src/shapes.tsx
+++ b/src/shapes.tsx
@@ -75,7 +75,7 @@ export const shapesShortcutKeys = SHAPES.map((shape, index) => [
 export function findShapeByKey(key: string) {
   return (
     SHAPES.find((shape, index) => {
-      return shape.value[0] !== key || key === (index + 1).toString();
+      return shape.value[0] === key || key === (index + 1).toString();
     })?.value || "selection"
   );
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 import { ExcalidrawElement } from "./element/types";
+import { SHAPES } from "./shapes";
 
 export type AppState = {
   draggingElement: ExcalidrawElement | null;
@@ -8,7 +9,7 @@ export type AppState = {
   // element being edited, but not necessarily added to elements array yet
   //  (e.g. text element when typing into the input)
   editingElement: ExcalidrawElement | null;
-  elementType: string;
+  elementType: typeof SHAPES[number]["value"];
   elementLocked: boolean;
   exportBackground: boolean;
   currentItemStrokeColor: string;


### PR DESCRIPTION
Fixes 3 issues:

- Reset to `selection` tool on paste (fixes https://github.com/excalidraw/excalidraw/issues/712).
- Ensure pasting via contextMenu and via event (`cmd+v`) is aligned. Fixes the case where pasting. via hotkey would paste text from the clipboard, but via contextMenu would paste element.

    In order to implement this I had to use `navigator.clipboard.readText` again, which means no support for non-chromium browsers, and it'll ask for permissions again (but unlike old clipboard implem, it will work).
- Ensure pasting into wysiwyg editor allows for plaintext only. Which means I had to revert https://github.com/excalidraw/excalidraw/pull/651/files and reimplement `onpaste`.

    before:
    ![excalidraw_plaintext_paste_before](https://user-images.githubusercontent.com/5153846/73974288-6035a480-4924-11ea-9cab-85bfa704361a.gif)

    after:
    ![excalidraw_plaintext_paste_after](https://user-images.githubusercontent.com/5153846/73974287-5f9d0e00-4924-11ea-9ece-41ef2dc9bf00.gif)

