### PR TITLE
Add npmrc to have pinned deps

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+save-exact=true


### PR DESCRIPTION
https://docs.npmjs.com/misc/config#save-exact

When installing new packages, it will save the exact version instead of rage (`^`)