### PR TITLE
move footer into layerUI & refactor ActionManager

### DIFF
--- a/src/actions/types.ts
+++ b/src/actions/types.ts
@@ -3,8 +3,8 @@ import { ExcalidrawElement } from "../element/types";
 import { AppState } from "../types";
 
 export type ActionResult = {
-  elements?: readonly ExcalidrawElement[];
-  appState?: AppState;
+  elements?: readonly ExcalidrawElement[] | null;
+  appState?: AppState | null;
 };
 
 type ActionFn = (
@@ -13,7 +13,7 @@ type ActionFn = (
   formData: any,
 ) => ActionResult;
 
-export type UpdaterFn = (res: ActionResult) => void;
+export type UpdaterFn = (res: ActionResult, commitToHistory?: boolean) => void;
 export type ActionFilterFn = (action: Action) => void;
 
 export interface Action {
@@ -43,7 +43,7 @@ export interface ActionsManagerInterface {
     [keyProp: string]: Action;
   };
   registerAction: (action: Action) => void;
-  handleKeyDown: (event: KeyboardEvent) => ActionResult | null;
+  handleKeyDown: (event: KeyboardEvent) => boolean;
   getContextMenuItems: (
     actionFilter: ActionFilterFn,
   ) => { label: string; action: () => void }[];

--- a/src/appState.ts
+++ b/src/appState.ts
@@ -1,6 +1,5 @@
 import { AppState } from "./types";
 import { getDateTime } from "./utils";
-import { getLanguage } from "./i18n";
 
 const DEFAULT_PROJECT_NAME = `excalidraw-${getDateTime()}`;
 
@@ -29,7 +28,6 @@ export function getDefaultAppState(): AppState {
     name: DEFAULT_PROJECT_NAME,
     isResizing: false,
     selectionElement: null,
-    lng: getLanguage(),
   };
 }
 

--- a/src/scene/index.ts
+++ b/src/scene/index.ts
@@ -18,6 +18,7 @@ export {
   importFromBackend,
   addToLoadedScenes,
   loadedScenes,
+  loadScene,
   calculateScrollCenter,
 } from "./data";
 export {

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,5 +28,4 @@ export type AppState = {
   name: string;
   selectedId?: string;
   isResizing: boolean;
-  lng: string;
 };


### PR DESCRIPTION
A refactor and some tweaks:

- Move `footer` to `<LayerUI>`.
- Scrap `state.lng` (from https://github.com/excalidraw/excalidraw/pull/726) in favor of passing it as a prop to `LayerUI` because we weren't using `state.lng` anywhere so it seemed weird to introduce it just to fix a stale state issue.
- Moved history resuming from ActionManager up to `updater` passed from upstream (`asyncActionResult`), which is now passed `commitToHistory: boolean` (defaults to `true`). This is in preparation for making ActionManager usable across the app as a way to sync state.
- Made `loadScene` readonly and factored out.
- Few other tweaks and refactor.

Make sure to review without whitespace changes:

![image](https://user-images.githubusercontent.com/5153846/74052737-c67cfe80-49da-11ea-947e-893383e29f2e.png)
