### PR TITLE
End to end encryption description

### DIFF
--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -2,7 +2,6 @@
   "alerts": {
     "cannotExportEmptyCanvas": "Leere Zeichenfläche kann nicht exportiert werden.",
     "clearReset": "Dies wird die ganze Zeichenfläche löschen. Bist du dir sicher?",
-    "copiedToClipboard": "In Zwischenablage kopiert: {{url}}",
     "couldNotCopyToClipboard": "Konnte nicht in die Zwischenablage kopieren. Versuch es mit dem Chrome Browser.",
     "couldNotCreateShareableLink": "Konnte keinen teilbaren Link erstellen.",
     "importBackendFailed": "Import vom Server ist fehlgeschlagen."

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -61,7 +61,7 @@
     "importBackendFailed": "Importing from backend failed.",
     "cannotExportEmptyCanvas": "Cannot export empty canvas.",
     "couldNotCopyToClipboard": "Couldn't copy to clipboard. Try using Chrome browser.",
-    "copiedToClipboard": "Copied to clipboard: {{url}}"
+    "uploadedSecurly": "The upload has been secured with end-to-end encryption, which means that excalidraw server and third parties can't read the content."
   },
   "toolBar": {
     "selection": "Selection",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -61,7 +61,7 @@
     "importBackendFailed": "Importing from backend failed.",
     "cannotExportEmptyCanvas": "Cannot export empty canvas.",
     "couldNotCopyToClipboard": "Couldn't copy to clipboard. Try using Chrome browser.",
-    "uploadedSecurly": "The upload has been secured with end-to-end encryption, which means that excalidraw server and third parties can't read the content."
+    "uploadedSecurly": "The upload has been secured with end-to-end encryption, which means that Excalidraw server and third parties can't read the content."
   },
   "toolBar": {
     "selection": "Selection",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -60,8 +60,7 @@
     "couldNotCreateShareableLink": "No se pudo crear un enlace para compartir.",
     "importBackendFailed": "La importación falló.",
     "cannotExportEmptyCanvas": "No se puede exportar un lienzo vació",
-    "couldNotCopyToClipboard": "No se ha podido copiar al portapapeles, intente usar Chrome como navegador.",
-    "copiedToClipboard": "Copiado en el portapapeles: {{url}}"
+    "couldNotCopyToClipboard": "No se ha podido copiar al portapapeles, intente usar Chrome como navegador."
   },
   "toolBar": {
     "selection": "Selección",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -54,8 +54,7 @@
     "couldNotCreateShareableLink": "Impossible de créer un lien de partage.",
     "importBackendFailed": "L'import depuis le backend a échoué.",
     "cannotExportEmptyCanvas": "Impossible d'exporter un canvas vide.",
-    "couldNotCopyToClipboard": "Impossible de copier dans le presse-papier. Essayez d'utiliser le navigateur Chrome.",
-    "copiedToClipboard": "Copié dans le presse-papier: {{url}}"
+    "couldNotCopyToClipboard": "Impossible de copier dans le presse-papier. Essayez d'utiliser le navigateur Chrome."
   },
   "toolBar": {
     "selection": "Sélection",

--- a/src/locales/nb-no.json
+++ b/src/locales/nb-no.json
@@ -60,8 +60,7 @@
     "couldNotCreateShareableLink": "Kunne ikke lage delbar lenke.",
     "importBackendFailed": "Importering av backend feilet.",
     "cannotExportEmptyCanvas": "Kan ikke eksportere et tomt lerret.",
-    "couldNotCopyToClipboard": "Kunne ikke kopiere til utklippstavlen. Prøv med nettleseren Chrome.",
-    "copiedToClipboard": "Kopierte til utklippstavlen: {{url}}"
+    "couldNotCopyToClipboard": "Kunne ikke kopiere til utklippstavlen. Prøv med nettleseren Chrome."
   },
   "toolBar": {
     "selection": "Velg",

--- a/src/locales/pl.json
+++ b/src/locales/pl.json
@@ -60,8 +60,7 @@
     "couldNotCreateShareableLink": "Wystąpił błąd przy generowaniu linka do udostępniania.",
     "importBackendFailed": "Wystąpił błąd podczas importowania pliku.",
     "cannotExportEmptyCanvas": "Najpierw musisz coś narysować, aby zapisać dokument.",
-    "couldNotCopyToClipboard": "Błąd podczas kopiowania. Spróbuj użyć Google Chrome.",
-    "copiedToClipboard": "Skopiowano link: {{url}}"
+    "couldNotCopyToClipboard": "Błąd podczas kopiowania. Spróbuj użyć Google Chrome."
   },
   "toolBar": {
     "selection": "Zaznaczenie",

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -54,8 +54,7 @@
     "couldNotCreateShareableLink": "Não foi possível criar um link de partilha.",
     "importBackendFailed": "O carregamento no servidor falhou.",
     "cannotExportEmptyCanvas": "Não é possível exportar um canvas vazío.",
-    "couldNotCopyToClipboard": "Não foi possível copiar no clipboard. Experimente no navegador Chrome.",
-    "copiedToClipboard": "Copiado no clipboard: {{url}}"
+    "couldNotCopyToClipboard": "Não foi possível copiar no clipboard. Experimente no navegador Chrome."
   },
   "toolBar": {
     "selection": "Seleção",

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -59,8 +59,7 @@
     "couldNotCreateShareableLink": "Не удалось создать общедоступную ссылку.",
     "importBackendFailed": "Не удалось импортировать из бэкэнда.",
     "cannotExportEmptyCanvas": "Не может экспортировать пустой холст.",
-    "couldNotCopyToClipboard": "Не удалось скопировать в буфер обмена. Попробуйте использовать веб-браузер Chrome.",
-    "copiedToClipboard": "Скопировано в буфер обмена: {{url}}"
+    "couldNotCopyToClipboard": "Не удалось скопировать в буфер обмена. Попробуйте использовать веб-браузер Chrome."
   },
   "toolBar": {
     "selection": "Выделение области",

--- a/src/scene/data.ts
+++ b/src/scene/data.ts
@@ -15,10 +15,7 @@ import { getCommonBounds, normalizeDimensions } from "../element";
 
 import { Point } from "roughjs/bin/geometry";
 import { t } from "../i18n";
-import {
-  copyTextToSystemClipboard,
-  copyCanvasToClipboardAsPng,
-} from "../clipboard";
+import { copyCanvasToClipboardAsPng } from "../clipboard";
 
 const LOCAL_STORAGE_KEY = "excalidraw";
 const LOCAL_STORAGE_SCENE_PREVIOUS_KEY = "excalidraw-previos-scenes";
@@ -191,12 +188,7 @@ export async function exportToBackend(
       url.hash = `json=${json.id},${exportedKey.k!}`;
       const urlString = url.toString();
 
-      try {
-        await copyTextToSystemClipboard(urlString);
-        window.alert(t("alerts.copiedToClipboard", { url: urlString }));
-      } catch (err) {
-        // TODO: link will be displayed for user to copy manually in later PR
-      }
+      window.prompt(t("alerts.uploadedSecurly"), urlString);
     } else {
       window.alert(t("alerts.couldNotCreateShareableLink"));
     }


### PR DESCRIPTION
This PR updates the url upload description to mention that it is end to end encrypted. I used a very similar message as whatsapp so that it is familar to people.

I also removed the automatic copying and turned the alert into prompt. This should be less awkward than the current implementation.

![image](https://user-images.githubusercontent.com/197597/74078597-4a39e980-49e1-11ea-9f36-c1c6a31199cc.png)
