### PR TITLE
z-index button fixes

### DIFF
--- a/src/actions/actionZindex.tsx
+++ b/src/actions/actionZindex.tsx
@@ -12,58 +12,37 @@ import { t } from "../i18n";
 
 const ICONS = {
   bringForward: (
-    <svg
-      viewBox="0 0 24 24"
-      xmlns="http://www.w3.org/2000/svg"
-      fillRule="evenodd"
-      clipRule="evenodd"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
+    <svg viewBox="0 0 24 24">
+      <path
+        d="M22 9.556C22 8.696 21.303 8 20.444 8H16v8H8v4.444C8 21.304 8.697 22 9.556 22h10.888c.86 0 1.556-.697 1.556-1.556V9.556z"
+        stroke="#000"
+        strokeWidth="2"
+      />
       <path
         d="M16 3.556C16 2.696 15.303 2 14.444 2H3.556C2.696 2 2 2.697 2 3.556v10.888C2 15.304 2.697 16 3.556 16h10.888c.86 0 1.556-.697 1.556-1.556V3.556z"
         fill="none"
         stroke="#000"
-        strokeWidth="1.9988945999999999"
-      />
-      <path
-        d="M22 9.556C22 8.696 21.303 8 20.444 8H16v8H8v4.444C8 21.304 8.697 22 9.556 22h10.888c.86 0 1.556-.697 1.556-1.556V9.556z"
-        stroke="#000"
-        strokeWidth="1.9988945999999999"
+        strokeWidth="2"
       />
     </svg>
   ),
   sendBackward: (
-    <svg
-      viewBox="0 0 24 24"
-      xmlns="http://www.w3.org/2000/svg"
-      fillRule="evenodd"
-      clipRule="evenodd"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
+    <svg viewBox="0 0 24 24">
       <path
         d="M16 3.556C16 2.696 15.303 2 14.444 2H3.556C2.696 2 2 2.697 2 3.556v10.888C2 15.304 2.697 16 3.556 16h10.888c.86 0 1.556-.697 1.556-1.556V3.556z"
         fill="none"
         stroke="#000"
-        strokeWidth="1.9988945999999999"
+        strokeWidth="2"
       />
       <path
         d="M22 9.556C22 8.696 21.303 8 20.444 8H9.556C8.696 8 8 8.697 8 9.556v10.888C8 21.304 8.697 22 9.556 22h10.888c.86 0 1.556-.697 1.556-1.556V9.556z"
         stroke="#000"
-        strokeWidth="1.9988945999999999"
+        strokeWidth="2"
       />
     </svg>
   ),
   bringToFront: (
-    <svg
-      viewBox="0 0 24 24"
-      xmlns="http://www.w3.org/2000/svg"
-      fillRule="evenodd"
-      clipRule="evenodd"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
+    <svg viewBox="0 0 24 24">
       <path
         d="M13 21a1 1 0 001 1h7a1 1 0 001-1v-7a1 1 0 00-1-1h-3v5h-5v3zM11 3a1 1 0 00-1-1H3a1 1 0 00-1 1v7a1 1 0 001 1h3V6h5V3z"
         stroke="#000"
@@ -73,24 +52,17 @@ const ICONS = {
         d="M18 7.333C18 6.597 17.403 6 16.667 6H7.333C6.597 6 6 6.597 6 7.333v9.334C6 17.403 6.597 18 7.333 18h9.334c.736 0 1.333-.597 1.333-1.333V7.333z"
         fill="none"
         stroke="#000"
-        strokeWidth="2.00001"
+        strokeWidth="2"
       />
     </svg>
   ),
   sendToBack: (
-    <svg
-      viewBox="0 0 24 24"
-      xmlns="http://www.w3.org/2000/svg"
-      fillRule="evenodd"
-      clipRule="evenodd"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
+    <svg viewBox="0 0 24 24" strokeLinecap="round" strokeLinejoin="round">
       <path
         d="M18 7.333C18 6.597 17.403 6 16.667 6H7.333C6.597 6 6 6.597 6 7.333v9.334C6 17.403 6.597 18 7.333 18h9.334c.736 0 1.333-.597 1.333-1.333V7.333z"
         fill="none"
         stroke="#000"
-        strokeWidth="2.00001"
+        strokeWidth="2"
       />
       <path
         d="M11 3a1 1 0 00-1-1H3a1 1 0 00-1 1v7a1 1 0 001 1h8V3zM22 14a1 1 0 00-1-1h-7a1 1 0 00-1 1v7a1 1 0 001 1h8v-8z"

--- a/src/actions/actionZindex.tsx
+++ b/src/actions/actionZindex.tsx
@@ -10,6 +10,8 @@ import { getSelectedIndices } from "../scene";
 import { KEYS } from "../keys";
 import { t } from "../i18n";
 
+const ACTIVE_ELEM_COLOR = "#ffa94d"; // OC ORANGE 4
+
 const ICONS = {
   bringForward: (
     <svg viewBox="0 0 24 24">
@@ -20,8 +22,8 @@ const ICONS = {
       />
       <path
         d="M16 3.556C16 2.696 15.303 2 14.444 2H3.556C2.696 2 2 2.697 2 3.556v10.888C2 15.304 2.697 16 3.556 16h10.888c.86 0 1.556-.697 1.556-1.556V3.556z"
-        fill="none"
-        stroke="#000"
+        fill={ACTIVE_ELEM_COLOR}
+        stroke={ACTIVE_ELEM_COLOR}
         strokeWidth="2"
       />
     </svg>
@@ -30,8 +32,8 @@ const ICONS = {
     <svg viewBox="0 0 24 24">
       <path
         d="M16 3.556C16 2.696 15.303 2 14.444 2H3.556C2.696 2 2 2.697 2 3.556v10.888C2 15.304 2.697 16 3.556 16h10.888c.86 0 1.556-.697 1.556-1.556V3.556z"
-        fill="none"
-        stroke="#000"
+        fill={ACTIVE_ELEM_COLOR}
+        stroke={ACTIVE_ELEM_COLOR}
         strokeWidth="2"
       />
       <path
@@ -50,8 +52,8 @@ const ICONS = {
       />
       <path
         d="M18 7.333C18 6.597 17.403 6 16.667 6H7.333C6.597 6 6 6.597 6 7.333v9.334C6 17.403 6.597 18 7.333 18h9.334c.736 0 1.333-.597 1.333-1.333V7.333z"
-        fill="none"
-        stroke="#000"
+        fill={ACTIVE_ELEM_COLOR}
+        stroke={ACTIVE_ELEM_COLOR}
         strokeWidth="2"
       />
     </svg>
@@ -60,8 +62,8 @@ const ICONS = {
     <svg viewBox="0 0 24 24" strokeLinecap="round" strokeLinejoin="round">
       <path
         d="M18 7.333C18 6.597 17.403 6 16.667 6H7.333C6.597 6 6 6.597 6 7.333v9.334C6 17.403 6.597 18 7.333 18h9.334c.736 0 1.333-.597 1.333-1.333V7.333z"
-        fill="none"
-        stroke="#000"
+        fill={ACTIVE_ELEM_COLOR}
+        stroke={ACTIVE_ELEM_COLOR}
         strokeWidth="2"
       />
       <path

--- a/src/actions/actionZindex.tsx
+++ b/src/actions/actionZindex.tsx
@@ -15,21 +15,21 @@ const ICONS = {
     <svg
       viewBox="0 0 24 24"
       xmlns="http://www.w3.org/2000/svg"
-      fill-rule="evenodd"
-      clip-rule="evenodd"
-      stroke-linecap="round"
-      stroke-linejoin="round"
+      fillRule="evenodd"
+      clipRule="evenodd"
+      strokeLinecap="round"
+      strokeLinejoin="round"
     >
       <path
         d="M16 3.556C16 2.696 15.303 2 14.444 2H3.556C2.696 2 2 2.697 2 3.556v10.888C2 15.304 2.697 16 3.556 16h10.888c.86 0 1.556-.697 1.556-1.556V3.556z"
         fill="none"
         stroke="#000"
-        stroke-width="1.9988945999999999"
+        strokeWidth="1.9988945999999999"
       />
       <path
         d="M22 9.556C22 8.696 21.303 8 20.444 8H16v8H8v4.444C8 21.304 8.697 22 9.556 22h10.888c.86 0 1.556-.697 1.556-1.556V9.556z"
         stroke="#000"
-        stroke-width="1.9988945999999999"
+        strokeWidth="1.9988945999999999"
       />
     </svg>
   ),
@@ -37,21 +37,21 @@ const ICONS = {
     <svg
       viewBox="0 0 24 24"
       xmlns="http://www.w3.org/2000/svg"
-      fill-rule="evenodd"
-      clip-rule="evenodd"
-      stroke-linecap="round"
-      stroke-linejoin="round"
+      fillRule="evenodd"
+      clipRule="evenodd"
+      strokeLinecap="round"
+      strokeLinejoin="round"
     >
       <path
         d="M16 3.556C16 2.696 15.303 2 14.444 2H3.556C2.696 2 2 2.697 2 3.556v10.888C2 15.304 2.697 16 3.556 16h10.888c.86 0 1.556-.697 1.556-1.556V3.556z"
         fill="none"
         stroke="#000"
-        stroke-width="1.9988945999999999"
+        strokeWidth="1.9988945999999999"
       />
       <path
         d="M22 9.556C22 8.696 21.303 8 20.444 8H9.556C8.696 8 8 8.697 8 9.556v10.888C8 21.304 8.697 22 9.556 22h10.888c.86 0 1.556-.697 1.556-1.556V9.556z"
         stroke="#000"
-        stroke-width="1.9988945999999999"
+        strokeWidth="1.9988945999999999"
       />
     </svg>
   ),
@@ -59,21 +59,21 @@ const ICONS = {
     <svg
       viewBox="0 0 24 24"
       xmlns="http://www.w3.org/2000/svg"
-      fill-rule="evenodd"
-      clip-rule="evenodd"
-      stroke-linecap="round"
-      stroke-linejoin="round"
+      fillRule="evenodd"
+      clipRule="evenodd"
+      strokeLinecap="round"
+      strokeLinejoin="round"
     >
       <path
         d="M13 21a1 1 0 001 1h7a1 1 0 001-1v-7a1 1 0 00-1-1h-3v5h-5v3zM11 3a1 1 0 00-1-1H3a1 1 0 00-1 1v7a1 1 0 001 1h3V6h5V3z"
         stroke="#000"
-        stroke-width="2"
+        strokeWidth="2"
       />
       <path
         d="M18 7.333C18 6.597 17.403 6 16.667 6H7.333C6.597 6 6 6.597 6 7.333v9.334C6 17.403 6.597 18 7.333 18h9.334c.736 0 1.333-.597 1.333-1.333V7.333z"
         fill="none"
         stroke="#000"
-        stroke-width="2.00001"
+        strokeWidth="2.00001"
       />
     </svg>
   ),
@@ -81,21 +81,21 @@ const ICONS = {
     <svg
       viewBox="0 0 24 24"
       xmlns="http://www.w3.org/2000/svg"
-      fill-rule="evenodd"
-      clip-rule="evenodd"
-      stroke-linecap="round"
-      stroke-linejoin="round"
+      fillRule="evenodd"
+      clipRule="evenodd"
+      strokeLinecap="round"
+      strokeLinejoin="round"
     >
       <path
         d="M18 7.333C18 6.597 17.403 6 16.667 6H7.333C6.597 6 6 6.597 6 7.333v9.334C6 17.403 6.597 18 7.333 18h9.334c.736 0 1.333-.597 1.333-1.333V7.333z"
         fill="none"
         stroke="#000"
-        stroke-width="2.00001"
+        strokeWidth="2.00001"
       />
       <path
         d="M11 3a1 1 0 00-1-1H3a1 1 0 00-1 1v7a1 1 0 001 1h8V3zM22 14a1 1 0 00-1-1h-7a1 1 0 00-1 1v7a1 1 0 001 1h8v-8z"
         stroke="#000"
-        stroke-width="2"
+        strokeWidth="2"
       />
     </svg>
   ),

--- a/src/components/ToolIcon.scss
+++ b/src/components/ToolIcon.scss
@@ -60,6 +60,9 @@
   &:focus + .ToolIcon__icon {
     box-shadow: 0 0 0 2px #a5d8ff;
   }
+  &:active + .ToolIcon__icon {
+    background-color: #adb5bd;
+  }
 }
 
 .ToolIcon.ToolIcon__lock {

--- a/src/components/ToolIcon.scss
+++ b/src/components/ToolIcon.scss
@@ -94,4 +94,5 @@
   font-size: 0.5em;
   color: #adb5bd; // OC GRAY 5
   font-family: Arial, Helvetica, sans-serif;
+  user-select: none;
 }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -100,7 +100,7 @@ button,
   }
 
   &:active {
-    background-color: #ced4da;
+    background-color: #adb5bd;
   }
 
   &:disabled {
@@ -113,6 +113,9 @@ button,
   background-color: #ced4da;
   &:hover {
     background-color: #ced4da;
+  }
+  &:active {
+    background-color: #adb5bd;
   }
 }
 

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -250,8 +250,16 @@ button,
 }
 
 .zIndexButton {
-  width: 26px;
   margin: 0 5px;
+  padding: 5px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+
+  svg {
+    width: 18px;
+    height: 18px;
+  }
 }
 
 .scroll-back-to-content {


### PR DESCRIPTION
1. fix svg jsx attributes, and remove unnecessary ones
2. center & make active elem orange so it's obvious which is which
    
    before:
    
    ![image](https://user-images.githubusercontent.com/5153846/74103971-c272ed00-4b50-11ea-8a02-0a82d5bcf675.png)
    
    after: 
    
    ![image](https://user-images.githubusercontent.com/5153846/74105039-b429ce80-4b5a-11ea-803e-8903dc19e3a4.png)


