### PR TITLE
ensure duplicateElement does deep copy of points

### DIFF
--- a/src/element/newElement.ts
+++ b/src/element/newElement.ts
@@ -63,7 +63,10 @@ export function newTextElement(
 }
 
 export function duplicateElement(element: ReturnType<typeof newElement>) {
-  const copy = { ...element };
+  const copy = {
+    ...element,
+    points: JSON.parse(JSON.stringify(element.points)),
+  };
   delete copy.shape;
   copy.id = nanoid();
   copy.seed = randomSeed();


### PR DESCRIPTION
fixes #739

I wanted to go for `JSON.parse(JSON.stringify(element))` altogether, to guard against future regressions, but it could cause regressions on other fronts (e.g. when we expected some functions to be kept). We should migrate to a structured cloning algorithm, later.