### PR TITLE
Fix arrow scale

### DIFF
--- a/src/element/newElement.ts
+++ b/src/element/newElement.ts
@@ -32,6 +32,8 @@ export function newElement(
     strokeWidth,
     roughness,
     opacity,
+    scaleX: 1.0,
+    scaleY: 1.0,
     isSelected: false,
     seed: randomSeed(),
     shape: null as Drawable | Drawable[] | null,

--- a/src/element/newElement.ts
+++ b/src/element/newElement.ts
@@ -34,6 +34,8 @@ export function newElement(
     opacity,
     scaleX: 1.0,
     scaleY: 1.0,
+    scaleOriginX: 0,
+    scaleOriginY: 0,
     isSelected: false,
     seed: randomSeed(),
     shape: null as Drawable | Drawable[] | null,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1366,7 +1366,14 @@ export class App extends React.Component<any, AppState> {
                             element,
                           );
 
-                          // TODO: Set bottom most point as origin for scale
+                          element.scaleOriginY = element.points.reduce(
+                            (prev, curr) => {
+                              return Math.max(prev, curr[1]);
+                            },
+                            -Infinity,
+                          );
+                          element.scaleOriginX = 0;
+
                           if (element.scaleY < 0) {
                             element.scaleY += (y - y1) / y2;
                           } else {
@@ -1385,7 +1392,14 @@ export class App extends React.Component<any, AppState> {
                             element,
                           );
 
-                          // TODO: Set right most point as origin for scale
+                          element.scaleOriginX = element.points.reduce(
+                            (prev, curr) => {
+                              return Math.max(prev, curr[0]);
+                            },
+                            -Infinity,
+                          );
+                          element.scaleOriginY = 0;
+
                           if (element.scaleX < 0) {
                             element.scaleX += (x - x1) / x2;
                           } else {
@@ -1402,7 +1416,14 @@ export class App extends React.Component<any, AppState> {
                             element,
                           );
 
-                          // TODO: Set top most point as origin for scale
+                          element.scaleOriginY = element.points.reduce(
+                            (prev, curr) => {
+                              return Math.min(prev, curr[1]);
+                            },
+                            +Infinity,
+                          );
+                          element.scaleOriginX = 0;
+
                           if (element.scaleY < 0) {
                             element.scaleY += (y - y1) / y2;
                           } else {
@@ -1419,7 +1440,14 @@ export class App extends React.Component<any, AppState> {
                             element,
                           );
 
-                          // TODO: Set left most point as origin for scale
+                          element.scaleOriginX = element.points.reduce(
+                            (prev, curr) => {
+                              return Math.min(prev, curr[0]);
+                            },
+                            +Infinity,
+                          );
+                          element.scaleOriginY = 0;
+
                           if (element.scaleX < 0) {
                             element.scaleX += (x - x1) / x2;
                           } else {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -17,6 +17,7 @@ import {
   getCursorForResizingElement,
   getPerfectElementSize,
   normalizeDimensions,
+  getLinearElementAbsoluteBounds,
 } from "./element";
 import {
   clearSelection,
@@ -1358,67 +1359,74 @@ export class App extends React.Component<any, AppState> {
                         }
                         break;
                       case "n": {
-                        element.height -= deltaY;
                         element.y += deltaY;
 
                         if (element.points.length > 0) {
-                          const len = element.points.length;
-
-                          const points = [...element.points].sort(
-                            (a, b) => a[1] - b[1],
+                          const [, y1, , y2] = getLinearElementAbsoluteBounds(
+                            element,
                           );
 
-                          for (let i = 1; i < points.length; ++i) {
-                            const pnt = points[i];
-                            pnt[1] -= deltaY / (len - i);
+                          // TODO: Set bottom most point as origin for scale
+                          if (element.scaleY < 0) {
+                            element.scaleY += (y - y1) / y2;
+                          } else {
+                            element.scaleY += (y - y2) / y2;
                           }
+                        } else {
+                          element.height -= deltaY;
                         }
                         break;
                       }
                       case "w": {
-                        element.width -= deltaX;
                         element.x += deltaX;
 
                         if (element.points.length > 0) {
-                          const len = element.points.length;
-                          const points = [...element.points].sort(
-                            (a, b) => a[0] - b[0],
+                          const [x1, , x2, ,] = getLinearElementAbsoluteBounds(
+                            element,
                           );
 
-                          for (let i = 0; i < points.length; ++i) {
-                            const pnt = points[i];
-                            pnt[0] -= deltaX / (len - i);
+                          // TODO: Set right most point as origin for scale
+                          if (element.scaleX < 0) {
+                            element.scaleX += (x - x1) / x2;
+                          } else {
+                            element.scaleX += (x - x2) / x2;
                           }
+                        } else {
+                          element.width -= deltaX;
                         }
                         break;
                       }
                       case "s": {
-                        element.height += deltaY;
                         if (element.points.length > 0) {
-                          const len = element.points.length;
-                          const points = [...element.points].sort(
-                            (a, b) => a[1] - b[1],
+                          const [, y1, , y2] = getLinearElementAbsoluteBounds(
+                            element,
                           );
 
-                          for (let i = 1; i < points.length; ++i) {
-                            const pnt = points[i];
-                            pnt[1] += deltaY / (len - i);
+                          // TODO: Set top most point as origin for scale
+                          if (element.scaleY < 0) {
+                            element.scaleY += (y - y1) / y2;
+                          } else {
+                            element.scaleY += (y - y2) / y2;
                           }
+                        } else {
+                          element.height += deltaY;
                         }
                         break;
                       }
                       case "e": {
-                        element.width += deltaX;
                         if (element.points.length > 0) {
-                          const len = element.points.length;
-                          const points = [...element.points].sort(
-                            (a, b) => a[0] - b[0],
+                          const [x1, , x2, ,] = getLinearElementAbsoluteBounds(
+                            element,
                           );
 
-                          for (let i = 1; i < points.length; ++i) {
-                            const pnt = points[i];
-                            pnt[0] += deltaX / (len - i);
+                          // TODO: Set left most point as origin for scale
+                          if (element.scaleX < 0) {
+                            element.scaleX += (x - x1) / x2;
+                          } else {
+                            element.scaleX += (x - x2) / x2;
                           }
+                        } else {
+                          element.width += deltaX;
                         }
                         break;
                       }

--- a/src/renderer/renderElement.ts
+++ b/src/renderer/renderElement.ts
@@ -104,8 +104,8 @@ function generateElement(
         element.shape = [
           generator.curve(
             points.map(pnt => [
-              pnt[0] * element.scaleX,
-              pnt[1] * element.scaleY,
+              (pnt[0] - element.scaleOriginX) * element.scaleX,
+              (pnt[1] - element.scaleOriginY) * element.scaleY,
             ]),
             options,
           ),

--- a/src/renderer/renderElement.ts
+++ b/src/renderer/renderElement.ts
@@ -101,7 +101,15 @@ function generateElement(
 
         // curve is always the first element
         // this simplifies finding the curve for an element
-        element.shape = [generator.curve(points, options)];
+        element.shape = [
+          generator.curve(
+            points.map(pnt => [
+              pnt[0] * element.scaleX,
+              pnt[1] * element.scaleY,
+            ]),
+            options,
+          ),
+        ];
 
         // add lines only in arrow
         if (element.type === "arrow") {


### PR DESCRIPTION
I am currently experimenting with fixing the scale for arrows and I have gotten some promising results. Things to fix:

- [ ] Set scale origin to pin a single bound when scaling the arrow.
- [ ] (maybe) normalize arrow points to have the left most point at (0,0) instead of the first point being at (0,0)
- [ ] Fix resizing West and North
- [ ] Test edge cases such as scale factor being too big

**Question: Should we store the scale parameters in scene data or local storage? What if we "commit" scale changes on mouse up or during export / saving to local storage? The downside to doing this is that we will lose the original shape.**