### PR TITLE
Respect initial aspect ratio while resizing with shift pressed

### DIFF
--- a/src/appState.ts
+++ b/src/appState.ts
@@ -11,6 +11,8 @@ export function getDefaultAppState(): AppState {
     resizingElement: null,
     multiElement: null,
     editingElement: null,
+    aspectRatioElement: null,
+    rollbackShiftElement: null,
     elementType: "selection",
     elementLocked: false,
     exportBackground: true,

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,6 +16,8 @@ export type AppState = {
   resizingElement: ExcalidrawElement | null;
   multiElement: ExcalidrawLinearElement | null;
   selectionElement: ExcalidrawElement | null;
+  aspectRatioElement: ExcalidrawElement | null;
+  rollbackShiftElement: ExcalidrawElement | null;
   // element being edited, but not necessarily added to elements array yet
   //  (e.g. text element when typing into the input)
   editingElement: ExcalidrawElement | null;


### PR DESCRIPTION
Part of https://github.com/excalidraw/excalidraw/issues/690.

Missing:

- [ ] Adjust `rollbackShiftElement` while resizing in aspect ratio mode so when you release the key the changes are applied to it.
- [ ] All handlers should respect aspect ratio.
- [ ] Aspect ratio while creating ? (maybe another PR ?).