### PR TITLE
Ignore enter `keydown` events that are part of composition

### DIFF
--- a/src/components/ProjectName.tsx
+++ b/src/components/ProjectName.tsx
@@ -25,6 +25,9 @@ export class ProjectName extends Component<Props> {
   private handleKeyDown = (e: React.KeyboardEvent<HTMLElement>) => {
     if (e.key === "Enter") {
       e.preventDefault();
+      if (e.nativeEvent.isComposing || e.keyCode === 229) {
+        return;
+      }
       e.currentTarget.blur();
     }
   };


### PR DESCRIPTION
Fixes the text area as #446 for non-latin letters
<img width="844" alt="スクリーンショット 2020-02-17 17 27 46" src="https://user-images.githubusercontent.com/14838850/74636485-6bea5c00-51ab-11ea-8925-8b883dd54a31.png">
