### PR TITLE
Add a doc with all the current shortcuts

### DIFF
--- a/docs/shortcuts.md
+++ b/docs/shortcuts.md
@@ -22,17 +22,17 @@
 
 ### Editor
 
-| Function       |   Mac    |   Other    |
-| -------------- | :------: | :--------: |
-| Copy           |   `⌘C`   | `Ctrl + C` |
-| Paste          |   `⌘V`   | `Ctrl + V` |
+| Function       |   Mac    |      Other       |
+| -------------- | :------: | :--------------: |
+| Copy           |   `⌘C`   |    `Ctrl + C`    |
+| Paste          |   `⌘V`   |    `Ctrl + V`    |
 | Copy styles    |
 | Paste styles   |
-| Delete         | `delete` |   `del`    |
-| Send to back   |
-| Bring to front |
-| Send backwards |
-| Bring forward  |
+| Delete         | `delete` |      `del`       |
+| Send to back   |  `⌥⌘[`   | `Alt + Ctrl + [` |
+| Bring to front |  `⌥⌘]`   | `Alt + Ctrl + ]` |
+| Send backwards |   `⌘[`   |    `Ctrl + [`    |
+| Bring forward  |   `⌘]`   |    `Ctrl + ]`    |
 
 ### View
 

--- a/docs/shortcuts.md
+++ b/docs/shortcuts.md
@@ -29,8 +29,8 @@
 | Copy styles    | ⌘⇧V  | `Shift + Ctrl + V` |
 | Paste styles   | ⌘⇧C  | `Shift + Ctrl + C` |
 | Delete         |  ⌫   |       `del`        |
-| Send to back   | ⌥⌘\[ |  `Alt + Ctrl + [`  |
-| Bring to front | ⌥⌘\] |  `Alt + Ctrl + ]`  |
+| Send to back   | ⌥⌘\[ | `Ctrl + Shift + [` |
+| Bring to front | ⌥⌘\] | `Ctrl + Shift + ]` |
 | Send backwards | ⌘\[  |     `Ctrl + [`     |
 | Bring forward  | ⌘\]  |     `Ctrl + ]`     |
 

--- a/docs/shortcuts.md
+++ b/docs/shortcuts.md
@@ -1,3 +1,12 @@
+### General
+
+| Function     | Mac | Other |
+| ------------ | :-: | :---: |
+| Load         |
+| Save         |
+| Export       |
+| Clear canvas |
+
 ### Shapes
 
 | Function  | Mac  | Other |

--- a/docs/shortcuts.md
+++ b/docs/shortcuts.md
@@ -22,22 +22,22 @@
 
 ### Editor
 
-| Function       |  Mac   |       Other        |
-| -------------- | :----: | :----------------: |
-| Copy           |   ⌘C   |     `Ctrl + C`     |
-| Paste          |   ⌘V   |     `Ctrl + V`     |
-| Copy styles    |  ⌘⇧V   | `Shift + Ctrl + V` |
-| Paste styles   |  ⌘⇧C   | `Shift + Ctrl + C` |
-| Delete         |   ⌫    |       `del`        |
-| Send to back   |  ⌥⌘\[  |  `Alt + Ctrl + [`  |
-| Bring to front |  ⌥⌘\]  |  `Alt + Ctrl + ]`  |
-| Send backwards |  ⌘\[   |     `Ctrl + [`     |
-| Bring forward  |  ⌘\]   |     `Ctrl + ]`     |
+| Function       | Mac  |       Other        |
+| -------------- | :--: | :----------------: |
+| Copy           |  ⌘C  |     `Ctrl + C`     |
+| Paste          |  ⌘V  |     `Ctrl + V`     |
+| Copy styles    | ⌘⇧V  | `Shift + Ctrl + V` |
+| Paste styles   | ⌘⇧C  | `Shift + Ctrl + C` |
+| Delete         |  ⌫   |       `del`        |
+| Send to back   | ⌥⌘\[ |  `Alt + Ctrl + [`  |
+| Bring to front | ⌥⌘\] |  `Alt + Ctrl + ]`  |
+| Send backwards | ⌘\[  |     `Ctrl + [`     |
+| Bring forward  | ⌘\]  |     `Ctrl + ]`     |
 
 ### View
 
-| Function   | Mac  |   Other    |
-| ---------- | :--: | :--------: |
-| Zoom in    | ⌘+ | `Ctrl + +` |
-| Zoom out   | ⌘- | `Ctrl + -` |
-| Zoom reset | ⌘0 | `Ctrl + 0` |
+| Function   | Mac |   Other    |
+| ---------- | :-: | :--------: |
+| Zoom in    | ⌘+  | `Ctrl + +` |
+| Zoom out   | ⌘-  | `Ctrl + -` |
+| Zoom reset | ⌘0  | `Ctrl + 0` |

--- a/docs/shortcuts.md
+++ b/docs/shortcuts.md
@@ -22,22 +22,22 @@
 
 ### Editor
 
-| Function       |   Mac    |       Other        |
-| -------------- | :------: | :----------------: |
-| Copy           |   `⌘C`   |     `Ctrl + C`     |
-| Paste          |   `⌘V`   |     `Ctrl + V`     |
-| Copy styles    |  `⌘⇧V`   | `Shift + Ctrl + V` |
-| Paste styles   |  `⌘⇧C`   | `Shift + Ctrl + C` |
-| Delete         | `delete` |       `del`        |
-| Send to back   |  `⌥⌘[`   |  `Alt + Ctrl + [`  |
-| Bring to front |  `⌥⌘]`   |  `Alt + Ctrl + ]`  |
-| Send backwards |   `⌘[`   |     `Ctrl + [`     |
-| Bring forward  |   `⌘]`   |     `Ctrl + ]`     |
+| Function       |  Mac   |       Other        |
+| -------------- | :----: | :----------------: |
+| Copy           |   ⌘C   |     `Ctrl + C`     |
+| Paste          |   ⌘V   |     `Ctrl + V`     |
+| Copy styles    |  ⌘⇧V   | `Shift + Ctrl + V` |
+| Paste styles   |  ⌘⇧C   | `Shift + Ctrl + C` |
+| Delete         |   ⌫    |       `del`        |
+| Send to back   |  ⌥⌘\[  |  `Alt + Ctrl + [`  |
+| Bring to front |  ⌥⌘\]  |  `Alt + Ctrl + ]`  |
+| Send backwards |  ⌘\[   |     `Ctrl + [`     |
+| Bring forward  |  ⌘\]   |     `Ctrl + ]`     |
 
 ### View
 
 | Function   | Mac  |   Other    |
 | ---------- | :--: | :--------: |
-| Zoom in    | `⌘+` | `Ctrl + +` |
-| Zoom out   | `⌘-` | `Ctrl + -` |
-| Zoom reset | `⌘0` | `Ctrl + 0` |
+| Zoom in    | ⌘+ | `Ctrl + +` |
+| Zoom out   | ⌘- | `Ctrl + -` |
+| Zoom reset | ⌘0 | `Ctrl + 0` |

--- a/docs/shortcuts.md
+++ b/docs/shortcuts.md
@@ -22,17 +22,17 @@
 
 ### Editor
 
-| Function       |   Mac    |      Other       |
-| -------------- | :------: | :--------------: |
-| Copy           |   `⌘C`   |    `Ctrl + C`    |
-| Paste          |   `⌘V`   |    `Ctrl + V`    |
-| Copy styles    |
-| Paste styles   |
-| Delete         | `delete` |      `del`       |
-| Send to back   |  `⌥⌘[`   | `Alt + Ctrl + [` |
-| Bring to front |  `⌥⌘]`   | `Alt + Ctrl + ]` |
-| Send backwards |   `⌘[`   |    `Ctrl + [`    |
-| Bring forward  |   `⌘]`   |    `Ctrl + ]`    |
+| Function       |   Mac    |       Other        |
+| -------------- | :------: | :----------------: |
+| Copy           |   `⌘C`   |     `Ctrl + C`     |
+| Paste          |   `⌘V`   |     `Ctrl + V`     |
+| Copy styles    |  `⌘⇧V`   | `Shift + Ctrl + V` |
+| Paste styles   |  `⌘⇧C`   | `Shift + Ctrl + C` |
+| Delete         | `delete` |       `del`        |
+| Send to back   |  `⌥⌘[`   |  `Alt + Ctrl + [`  |
+| Bring to front |  `⌥⌘]`   |  `Alt + Ctrl + ]`  |
+| Send backwards |   `⌘[`   |     `Ctrl + [`     |
+| Bring forward  |   `⌘]`   |     `Ctrl + ]`     |
 
 ### View
 

--- a/docs/shortcuts.md
+++ b/docs/shortcuts.md
@@ -9,26 +9,26 @@
 
 ### Shapes
 
-| Function  | Mac  | Other |
-| --------- | :--: | :---: |
-| Selection | S, 1 | S, 1  |
-| Rectangle | R, 2 | R, 2  |
-| Diamond   | D, 3 | D, 3  |
-| Ellipse   | E, 4 | E, 4  |
-| Arrow     | A, 5 | A, 5  |
-| Line      | L, 6 | L, 6  |
-| Text      | T, 7 | T, 7  |
-| Lock      |      |       |
+| Function  |    Mac     |   Other    |
+| --------- | :--------: | :--------: |
+| Selection | `S` or `1` | `S` or `1` |
+| Rectangle | `R` or `2` | `R` or `2` |
+| Diamond   | `D` or `3` | `D` or `3` |
+| Ellipse   | `E` or `4` | `E` or `4` |
+| Arrow     | `A` or `5` | `A` or `5` |
+| Line      | `L` or `6` | `L` or `6` |
+| Text      | `T` or `7` | `T` or `7` |
+| Lock      |            |            |
 
 ### Editor
 
-| Function       |  Mac   |  Other   |
-| -------------- | :----: | :------: |
-| Copy           |   ⌘C   | Ctrl + C |
-| Paste          |   ⌘V   | Ctrl + V |
+| Function       |   Mac    |   Other    |
+| -------------- | :------: | :--------: |
+| Copy           |   `⌘C`   | `Ctrl + C` |
+| Paste          |   `⌘V`   | `Ctrl + V` |
 | Copy styles    |
 | Paste styles   |
-| Delete         | delete |   del    |
+| Delete         | `delete` |   `del`    |
 | Send to back   |
 | Bring to front |
 | Send backwards |
@@ -36,8 +36,8 @@
 
 ### View
 
-| Function   | Mac |  Other   |
-| ---------- | :-: | :------: |
-| Zoom in    | ⌘+  | Ctrl + + |
-| Zoom out   | ⌘-  | Ctrl + - |
-| Zoom reset | ⌘0  | Ctrl + 0 |
+| Function   | Mac  |   Other    |
+| ---------- | :--: | :--------: |
+| Zoom in    | `⌘+` | `Ctrl + +` |
+| Zoom out   | `⌘-` | `Ctrl + -` |
+| Zoom reset | `⌘0` | `Ctrl + 0` |

--- a/docs/shortcuts.md
+++ b/docs/shortcuts.md
@@ -26,8 +26,8 @@
 | -------------- | :--: | :----------------: |
 | Copy           |  ⌘C  |     `Ctrl + C`     |
 | Paste          |  ⌘V  |     `Ctrl + V`     |
-| Copy styles    | ⌘⇧V  | `Ctrl + Shift + V` |
-| Paste styles   | ⌘⇧C  | `Ctrl + Shift + C` |
+| Copy styles    | ⇧⌘V  | `Ctrl + Shift + V` |
+| Paste styles   | ⇧⌘C  | `Ctrl + Shift + C` |
 | Delete         |  ⌫   |       `Del`        |
 | Send to back   | ⌥⌘\[ | `Ctrl + Shift + [` |
 | Bring to front | ⌥⌘\] | `Ctrl + Shift + ]` |

--- a/docs/shortcuts.md
+++ b/docs/shortcuts.md
@@ -28,7 +28,7 @@
 | Paste          |  ⌘V  |     `Ctrl + V`     |
 | Copy styles    | ⌘⇧V  | `Ctrl + Shift + V` |
 | Paste styles   | ⌘⇧C  | `Ctrl + Shift + C` |
-| Delete         |  ⌫   |       `del`        |
+| Delete         |  ⌫   |       `Del`        |
 | Send to back   | ⌥⌘\[ | `Ctrl + Shift + [` |
 | Bring to front | ⌥⌘\] | `Ctrl + Shift + ]` |
 | Send backwards | ⌘\[  |     `Ctrl + [`     |

--- a/docs/shortcuts.md
+++ b/docs/shortcuts.md
@@ -1,0 +1,34 @@
+### Shapes
+
+| Function  | Mac  | Other |
+| --------- | :--: | :---: |
+| Selection | S, 1 | S, 1  |
+| Rectangle | R, 2 | R, 2  |
+| Diamond   | D, 3 | D, 3  |
+| Ellipse   | E, 4 | E, 4  |
+| Arrow     | A, 5 | A, 5  |
+| Line      | L, 6 | L, 6  |
+| Text      | T, 7 | T, 7  |
+| Lock      |      |       |
+
+### Editor
+
+| Function       |  Mac   |  Other   |
+| -------------- | :----: | :------: |
+| Copy           |   ⌘C   | Ctrl + C |
+| Paste          |   ⌘V   | Ctrl + V |
+| Copy styles    |
+| Paste styles   |
+| Delete         | delete |   del    |
+| Send to back   |
+| Bring to front |
+| Send backwards |
+| Bring forward  |
+
+### View
+
+| Function   | Mac |  Other   |
+| ---------- | :-: | :------: |
+| Zoom in    | ⌘+  | Ctrl + + |
+| Zoom out   | ⌘-  | Ctrl + - |
+| Zoom reset | ⌘0  | Ctrl + 0 |

--- a/docs/shortcuts.md
+++ b/docs/shortcuts.md
@@ -26,8 +26,8 @@
 | -------------- | :--: | :----------------: |
 | Copy           |  ⌘C  |     `Ctrl + C`     |
 | Paste          |  ⌘V  |     `Ctrl + V`     |
-| Copy styles    | ⌘⇧V  | `Shift + Ctrl + V` |
-| Paste styles   | ⌘⇧C  | `Shift + Ctrl + C` |
+| Copy styles    | ⌘⇧V  | `Ctrl + Shift + V` |
+| Paste styles   | ⌘⇧C  | `Ctrl + Shift + C` |
 | Delete         |  ⌫   |       `del`        |
 | Send to back   | ⌥⌘\[ | `Ctrl + Shift + [` |
 | Bring to front | ⌥⌘\] | `Ctrl + Shift + ]` |


### PR DESCRIPTION
Let's keep track of this document that could be later used as a base for #408 or possible documentation page somewhere like excalidraw.com/docs/shortcuts


Preview: https://github.com/excalidraw/excalidraw/blob/shortcutdocs/docs/shortcuts.md