### PR TITLE
improve error handling & map stack trace

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4761,6 +4761,14 @@
         "is-arrayish": "^0.2.1"
       }
     },
+    "error-stack-parser": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.0.6.tgz",
+      "integrity": "sha512-d51brTeqC+BHlwF0BhPtcYgF5nlzf9ZZ0ZIUQNZpc9ZB9qw5IJ2diTrBY9jlCJkTLITYPjmiX6OWCwH+fuyNgQ==",
+      "requires": {
+        "stackframe": "^1.1.1"
+      }
+    },
     "es-abstract": {
       "version": "1.17.4",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.4.tgz",
@@ -14120,10 +14128,49 @@
       "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
       "integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w=="
     },
+    "stack-generator": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/stack-generator/-/stack-generator-2.0.5.tgz",
+      "integrity": "sha512-/t1ebrbHkrLrDuNMdeAcsvynWgoH/i4o8EGGfX7dEYDoTXOYVAkEpFdtshlvabzc6JlJ8Kf9YdFEoz7JkzGN9Q==",
+      "requires": {
+        "stackframe": "^1.1.1"
+      }
+    },
     "stack-utils": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.2.tgz",
       "integrity": "sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA=="
+    },
+    "stackframe": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.1.1.tgz",
+      "integrity": "sha512-0PlYhdKh6AfFxRyK/v+6/k+/mMfyiEBbTM5L94D0ZytQnJ166wuwoTYLHFWGbs2dpA8Rgq763KGWmN1EQEYHRQ=="
+    },
+    "stacktrace-gps": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/stacktrace-gps/-/stacktrace-gps-3.0.4.tgz",
+      "integrity": "sha512-qIr8x41yZVSldqdqe6jciXEaSCKw1U8XTXpjDuy0ki/apyTn/r3w9hDAAQOhZdxvsC93H+WwwEu5cq5VemzYeg==",
+      "requires": {
+        "source-map": "0.5.6",
+        "stackframe": "^1.1.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.6",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
+        }
+      }
+    },
+    "stacktrace-js": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/stacktrace-js/-/stacktrace-js-2.0.2.tgz",
+      "integrity": "sha512-Je5vBeY4S1r/RnLydLl0TBTi3F2qdfWmYsGvtfZgEI+SCprPppaIhQf5nGcal4gI4cGpCV/duLcAzT1np6sQqg==",
+      "requires": {
+        "error-stack-parser": "^2.0.6",
+        "stack-generator": "^2.0.5",
+        "stacktrace-gps": "^3.0.4"
+      }
     },
     "static-extend": {
       "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "react": "16.12.0",
     "react-dom": "16.12.0",
     "react-scripts": "3.4.0",
-    "roughjs": "4.0.4"
+    "roughjs": "4.0.4",
+    "stacktrace-js": "2.0.2"
   },
   "description": "",
   "devDependencies": {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2321,13 +2321,15 @@ export class App extends React.Component<any, AppState> {
 
 const rootElement = document.getElementById("root");
 
-class TopErrorBoundary extends React.Component {
-  state: {
-    unresolvedError: Error | null;
-    hasError: boolean;
-    stack: string;
-    localStorage: string;
-  } = {
+interface TopErrorBoundaryState {
+  unresolvedError: Error | null;
+  hasError: boolean;
+  stack: string;
+  localStorage: string;
+}
+
+class TopErrorBoundary extends React.Component<any, TopErrorBoundaryState> {
+  state: TopErrorBoundaryState = {
     unresolvedError: null,
     hasError: false,
     stack: "",
@@ -2353,19 +2355,21 @@ class TopErrorBoundary extends React.Component {
   async componentDidUpdate() {
     if (this.state.unresolvedError !== null) {
       const StackTrace = await import("stacktrace-js");
-      let stack = "";
+      let stack = `${this.state.unresolvedError.message}:\n\n`;
       try {
-        stack = (await StackTrace.fromError(this.state.unresolvedError)).join(
+        stack += (await StackTrace.fromError(this.state.unresolvedError)).join(
           "\n",
         );
       } catch (err) {
         console.error(err);
-        stack = this.state.unresolvedError.stack || "";
+        stack += this.state.unresolvedError.stack || "";
       }
-      this.setState({
+      this.setState(state => ({
         unresolvedError: null,
-        stack,
-      });
+        stack: `${
+          state.stack ? `${state.stack}\n\n================\n\n${stack}` : stack
+        }`,
+      }));
     }
   }
 
@@ -2430,6 +2434,7 @@ class TopErrorBoundary extends React.Component {
                   <textarea
                     rows={10}
                     onPointerDown={this.selectTextArea}
+                    readOnly={true}
                     value={
                       this.state.unresolvedError
                         ? "Loading data. please wait..."
@@ -2440,6 +2445,7 @@ class TopErrorBoundary extends React.Component {
                   <textarea
                     rows={5}
                     onPointerDown={this.selectTextArea}
+                    readOnly={true}
                     value={this.state.localStorage}
                   />
                 </div>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2356,7 +2356,6 @@ class TopErrorBoundary extends React.Component<any, TopErrorBoundaryState> {
 
   async componentDidUpdate() {
     if (this.state.unresolvedError !== null) {
-      const StackTrace = await import("stacktrace-js");
       let stack = "";
       for (const error of this.state.unresolvedError) {
         if (stack) {
@@ -2364,6 +2363,7 @@ class TopErrorBoundary extends React.Component<any, TopErrorBoundaryState> {
         }
         stack += `${error.message}:\n\n`;
         try {
+          const StackTrace = await import("stacktrace-js");
           stack += (await StackTrace.fromError(error)).join("\n");
         } catch (err) {
           console.error(err);


### PR DESCRIPTION
fixes https://github.com/excalidraw/excalidraw/issues/498

- Improves the output of localStorage (gets rid of double escapes).
- Tries to map error stack trace using source maps (using https://github.com/stacktracejs/stacktrace.js). ~~No clue if this is going to work in production -- depends whether we deploy source maps. We'll see.~~ looks like it does on preview:

![image](https://user-images.githubusercontent.com/5153846/75096103-7ab28380-559c-11ea-9386-365fede077d1.png)

Repro:

1. load https://excalidraw-git-improveerrorhandling.vjeux.now.sh//?id=5142238724096000
2. click on the text element

