### PR TITLE
Add cursor pointer style to hidden radio buttons

### DIFF
--- a/src/components/ToolIcon.scss
+++ b/src/components/ToolIcon.scss
@@ -55,6 +55,7 @@
 .ToolIcon_type_checkbox {
   position: absolute;
   opacity: 0;
+  pointer-events: none;
 
   &:hover + .ToolIcon__icon {
     background-color: #e9ecef;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -81,6 +81,7 @@ canvas {
     input[type="radio"] {
       opacity: 0;
       position: absolute;
+      cursor: pointer;
     }
   }
 

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -81,7 +81,7 @@ canvas {
     input[type="radio"] {
       opacity: 0;
       position: absolute;
-      cursor: pointer;
+      pointer-events: none;
     }
   }
 


### PR DESCRIPTION
When hovering buttons with hidden radio buttons inside, there's a small part(the hidden radio button) where mouse returns to normal when it should be pointer.

This PR adds `cursor: pointer;` style to radio buttons so the mouse stays consistent.