### PR TITLE
Fix pasting styles on text elements

### DIFF
--- a/src/actions/actionStyles.ts
+++ b/src/actions/actionStyles.ts
@@ -43,7 +43,7 @@ export const actionPasteStyles: Action = {
             roughness: pastedElement?.roughness,
           };
           if (isTextElement(newElement)) {
-            newElement.font = pastedElement?.font;
+            newElement.font = pastedElement?.font || "20px Virgil";
             redrawTextBoundingBox(newElement);
           }
           return newElement;


### PR DESCRIPTION
Fixes: #814 second part(I missed it in the first PR #832 )

```
If it is a text elment or a multielement the app crashes. 
Otherwise, it pastes empty styles. Trying to change the background color of the element freezes the tab.
```