### PR TITLE
Use relative path for static files

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
       "prettier/prettier": "warn"
     }
   },
-  "homepage": "https://excalidraw.com",
+  "homepage": ".",
   "husky": {
     "hooks": {
       "pre-commit": "lint-staged"

--- a/public/index.html
+++ b/public/index.html
@@ -21,7 +21,7 @@
       name="description"
       content="Excalidraw is a whiteboard tool that lets you easily sketch diagrams that have a hand-drawn feel to them."
     />
-    <meta name="image" content="%PUBLIC_URL%/og-image.png" />
+    <meta name="image" content="og-image.png" />
 
     <!-- OpenGraph tags -->
     <meta property="og:url" content="https://excalidraw.com" />
@@ -32,11 +32,7 @@
       property="og:description"
       content="Excalidraw is a whiteboard tool that lets you easily sketch diagrams that have a hand-drawn feel to them."
     />
-    <meta
-      property="og:image"
-      name="twitter:image"
-      content="%PUBLIC_URL%/og-image.png"
-    />
+    <meta property="og:image" name="twitter:image" content="og-image.png" />
     <meta property="og:image:width" content="1280" />
     <meta property="og:image:height" content="669" />
 
@@ -52,77 +48,73 @@
       name="twitter:description"
       content="Excalidraw is a whiteboard tool that lets you easily sketch diagrams that have a hand-drawn feel to them."
     />
-    <meta name="twitter:image" content="%PUBLIC_URL%/og-image.png" />
+    <meta name="twitter:image" content="og-image.png" />
 
-    <link
-      rel="shortcut icon"
-      href="%PUBLIC_URL%/favicon.ico"
-      type="image/x-icon"
-    />
-    <link rel="stylesheet" href="%PUBLIC_URL%/fonts.css" />
+    <link rel="shortcut icon" href="favicon.ico" type="image/x-icon" />
+    <link rel="stylesheet" href="fonts.css" />
     <link
       rel="preload"
-      href="%PUBLIC_URL%/FG_Virgil.ttf"
+      href="FG_Virgil.ttf"
       as="font"
       type="font/ttf"
       crossorigin="anonymous"
     />
     <link
       rel="preload"
-      href="%PUBLIC_URL%/Cascadia.ttf"
+      href="Cascadia.ttf"
       as="font"
       type="font/ttf"
       crossorigin="anonymous"
     />
 
-    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+    <link rel="manifest" href="manifest.json" />
     <link
-      href="%PUBLIC_URL%/splashscreen_images/iphone5_splash.png"
+      href="splashscreen_images/iphone5_splash.png"
       media="(device-width: 320px) and (device-height: 568px) and (-webkit-device-pixel-ratio: 2)"
       rel="apple-touch-startup-image"
     />
     <link
-      href="%PUBLIC_URL%/splashscreen_images/iphone6_splash.png"
+      href="splashscreen_images/iphone6_splash.png"
       media="(device-width: 375px) and (device-height: 667px) and (-webkit-device-pixel-ratio: 2)"
       rel="apple-touch-startup-image"
     />
     <link
-      href="%PUBLIC_URL%/splashscreen_images/iphoneplus_splash.png"
+      href="splashscreen_images/iphoneplus_splash.png"
       media="(device-width: 621px) and (device-height: 1104px) and (-webkit-device-pixel-ratio: 3)"
       rel="apple-touch-startup-image"
     />
     <link
-      href="%PUBLIC_URL%/splashscreen_images/iphonex_splash.png"
+      href="splashscreen_images/iphonex_splash.png"
       media="(device-width: 375px) and (device-height: 812px) and (-webkit-device-pixel-ratio: 3)"
       rel="apple-touch-startup-image"
     />
     <link
-      href="%PUBLIC_URL%/splashscreen_images/iphonexr_splash.png"
+      href="splashscreen_images/iphonexr_splash.png"
       media="(device-width: 414px) and (device-height: 896px) and (-webkit-device-pixel-ratio: 2)"
       rel="apple-touch-startup-image"
     />
     <link
-      href="%PUBLIC_URL%/splashscreen_images/iphonexsmax_splash.png"
+      href="splashscreen_images/iphonexsmax_splash.png"
       media="(device-width: 414px) and (device-height: 896px) and (-webkit-device-pixel-ratio: 3)"
       rel="apple-touch-startup-image"
     />
     <link
-      href="%PUBLIC_URL%/splashscreen_images/ipad_splash.png"
+      href="splashscreen_images/ipad_splash.png"
       media="(device-width: 768px) and (device-height: 1024px) and (-webkit-device-pixel-ratio: 2)"
       rel="apple-touch-startup-image"
     />
     <link
-      href="%PUBLIC_URL%/splashscreen_images/ipadpro1_splash.png"
+      href="splashscreen_images/ipadpro1_splash.png"
       media="(device-width: 834px) and (device-height: 1112px) and (-webkit-device-pixel-ratio: 2)"
       rel="apple-touch-startup-image"
     />
     <link
-      href="%PUBLIC_URL%/splashscreen_images/ipadpro3_splash.png"
+      href="splashscreen_images/ipadpro3_splash.png"
       media="(device-width: 834px) and (device-height: 1194px) and (-webkit-device-pixel-ratio: 2)"
       rel="apple-touch-startup-image"
     />
     <link
-      href="%PUBLIC_URL%/splashscreen_images/ipadpro2_splash.png"
+      href="splashscreen_images/ipadpro2_splash.png"
       media="(device-width: 1024px) and (device-height: 1366px) and (-webkit-device-pixel-ratio: 2)"
       rel="apple-touch-startup-image"
     />


### PR DESCRIPTION
Related: https://github.com/excalidraw/excalidraw-desktop/pull/24

- [x] Don't load js from root  

  ```html
   <script src="/static/js/2.2a62696b.chunk.js"></script>
   <script src="/static/js/main.b098d13e.chunk.js"></script>
   ```

Does anyone know how to remove the leading slash?