### PR TITLE
Refactor ExcalidrawElement

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,5 +102,8 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/excalidraw/excalidraw.git"
+  },
+  "engines": {
+    "node": ">=12.0.0"
   }
 }

--- a/src/actions/actionDeleteSelected.tsx
+++ b/src/actions/actionDeleteSelected.tsx
@@ -10,22 +10,23 @@ export const actionDeleteSelected = register({
   name: "deleteSelectedElements",
   perform: (elements, appState) => {
     return {
-      elements: deleteSelectedElements(elements),
+      elements: deleteSelectedElements(elements, appState),
       appState: { ...appState, elementType: "selection", multiElement: null },
     };
   },
   contextItemLabel: "labels.delete",
   contextMenuOrder: 3,
-  commitToHistory: (_, elements) => isSomeElementSelected(elements),
+  commitToHistory: (appState, elements) =>
+    isSomeElementSelected(elements, appState),
   keyTest: event => event.key === KEYS.BACKSPACE || event.key === KEYS.DELETE,
-  PanelComponent: ({ elements, updateData }) => (
+  PanelComponent: ({ elements, appState, updateData }) => (
     <ToolButton
       type="button"
       icon={trash}
       title={t("labels.delete")}
       aria-label={t("labels.delete")}
       onClick={() => updateData(null)}
-      visible={isSomeElementSelected(elements)}
+      visible={isSomeElementSelected(elements, appState)}
     />
   ),
 });

--- a/src/actions/actionFinalize.tsx
+++ b/src/actions/actionFinalize.tsx
@@ -6,6 +6,7 @@ import { ToolButton } from "../components/ToolButton";
 import { done } from "../components/icons";
 import { t } from "../i18n";
 import { register } from "./register";
+import { invalidateShapeForElement } from "../renderer/renderElement";
 
 export const actionFinalize = register({
   name: "finalize",
@@ -25,7 +26,7 @@ export const actionFinalize = register({
       if (isInvisiblySmallElement(appState.multiElement)) {
         newElements = newElements.slice(0, -1);
       }
-      appState.multiElement.shape = null;
+      invalidateShapeForElement(appState.multiElement);
       if (!appState.elementLocked) {
         appState.selectedElementIds[appState.multiElement.id] = true;
       }

--- a/src/actions/actionFinalize.tsx
+++ b/src/actions/actionFinalize.tsx
@@ -1,5 +1,4 @@
 import { KEYS } from "../keys";
-import { clearSelection } from "../scene";
 import { isInvisiblySmallElement } from "../element";
 import { resetCursor } from "../utils";
 import React from "react";
@@ -11,7 +10,7 @@ import { register } from "./register";
 export const actionFinalize = register({
   name: "finalize",
   perform: (elements, appState) => {
-    let newElements = clearSelection(elements);
+    let newElements = elements;
     if (window.document.activeElement instanceof HTMLElement) {
       window.document.activeElement.blur();
     }
@@ -28,7 +27,7 @@ export const actionFinalize = register({
       }
       appState.multiElement.shape = null;
       if (!appState.elementLocked) {
-        appState.multiElement.isSelected = true;
+        appState.selectedElementIds[appState.multiElement.id] = true;
       }
     }
     if (!appState.elementLocked || !appState.multiElement) {
@@ -44,6 +43,7 @@ export const actionFinalize = register({
             : "selection",
         draggingElement: null,
         multiElement: null,
+        selectedElementIds: {},
       },
     };
   },

--- a/src/actions/actionProperties.tsx
+++ b/src/actions/actionProperties.tsx
@@ -14,10 +14,11 @@ import { register } from "./register";
 
 const changeProperty = (
   elements: readonly ExcalidrawElement[],
+  appState: AppState,
   callback: (element: ExcalidrawElement) => ExcalidrawElement,
 ) => {
   return elements.map(element => {
-    if (element.isSelected) {
+    if (appState.selectedElementIds[element.id]) {
       return callback(element);
     }
     return element;
@@ -25,15 +26,16 @@ const changeProperty = (
 };
 
 const getFormValue = function<T>(
-  editingElement: AppState["editingElement"],
   elements: readonly ExcalidrawElement[],
+  appState: AppState,
   getAttribute: (element: ExcalidrawElement) => T,
   defaultValue?: T,
 ): T | null {
+  const editingElement = appState.editingElement;
   return (
     (editingElement && getAttribute(editingElement)) ??
-    (isSomeElementSelected(elements)
-      ? getCommonAttributeOfSelectedElements(elements, getAttribute)
+    (isSomeElementSelected(elements, appState)
+      ? getCommonAttributeOfSelectedElements(elements, appState, getAttribute)
       : defaultValue) ??
     null
   );
@@ -43,7 +45,7 @@ export const actionChangeStrokeColor = register({
   name: "changeStrokeColor",
   perform: (elements, appState, value) => {
     return {
-      elements: changeProperty(elements, el => ({
+      elements: changeProperty(elements, appState, el => ({
         ...el,
         shape: null,
         strokeColor: value,
@@ -59,8 +61,8 @@ export const actionChangeStrokeColor = register({
         type="elementStroke"
         label={t("labels.stroke")}
         color={getFormValue(
-          appState.editingElement,
           elements,
+          appState,
           element => element.strokeColor,
           appState.currentItemStrokeColor,
         )}
@@ -74,7 +76,7 @@ export const actionChangeBackgroundColor = register({
   name: "changeBackgroundColor",
   perform: (elements, appState, value) => {
     return {
-      elements: changeProperty(elements, el => ({
+      elements: changeProperty(elements, appState, el => ({
         ...el,
         shape: null,
         backgroundColor: value,
@@ -90,8 +92,8 @@ export const actionChangeBackgroundColor = register({
         type="elementBackground"
         label={t("labels.background")}
         color={getFormValue(
-          appState.editingElement,
           elements,
+          appState,
           element => element.backgroundColor,
           appState.currentItemBackgroundColor,
         )}
@@ -105,7 +107,7 @@ export const actionChangeFillStyle = register({
   name: "changeFillStyle",
   perform: (elements, appState, value) => {
     return {
-      elements: changeProperty(elements, el => ({
+      elements: changeProperty(elements, appState, el => ({
         ...el,
         shape: null,
         fillStyle: value,
@@ -125,8 +127,8 @@ export const actionChangeFillStyle = register({
         ]}
         group="fill"
         value={getFormValue(
-          appState.editingElement,
           elements,
+          appState,
           element => element.fillStyle,
           appState.currentItemFillStyle,
         )}
@@ -142,7 +144,7 @@ export const actionChangeStrokeWidth = register({
   name: "changeStrokeWidth",
   perform: (elements, appState, value) => {
     return {
-      elements: changeProperty(elements, el => ({
+      elements: changeProperty(elements, appState, el => ({
         ...el,
         shape: null,
         strokeWidth: value,
@@ -162,8 +164,8 @@ export const actionChangeStrokeWidth = register({
           { value: 4, text: t("labels.extraBold") },
         ]}
         value={getFormValue(
-          appState.editingElement,
           elements,
+          appState,
           element => element.strokeWidth,
           appState.currentItemStrokeWidth,
         )}
@@ -177,7 +179,7 @@ export const actionChangeSloppiness = register({
   name: "changeSloppiness",
   perform: (elements, appState, value) => {
     return {
-      elements: changeProperty(elements, el => ({
+      elements: changeProperty(elements, appState, el => ({
         ...el,
         shape: null,
         roughness: value,
@@ -197,8 +199,8 @@ export const actionChangeSloppiness = register({
           { value: 2, text: t("labels.cartoonist") },
         ]}
         value={getFormValue(
-          appState.editingElement,
           elements,
+          appState,
           element => element.roughness,
           appState.currentItemRoughness,
         )}
@@ -212,7 +214,7 @@ export const actionChangeOpacity = register({
   name: "changeOpacity",
   perform: (elements, appState, value) => {
     return {
-      elements: changeProperty(elements, el => ({
+      elements: changeProperty(elements, appState, el => ({
         ...el,
         shape: null,
         opacity: value,
@@ -246,8 +248,8 @@ export const actionChangeOpacity = register({
         }}
         value={
           getFormValue(
-            appState.editingElement,
             elements,
+            appState,
             element => element.opacity,
             appState.currentItemOpacity,
           ) ?? undefined
@@ -261,7 +263,7 @@ export const actionChangeFontSize = register({
   name: "changeFontSize",
   perform: (elements, appState, value) => {
     return {
-      elements: changeProperty(elements, el => {
+      elements: changeProperty(elements, appState, el => {
         if (isTextElement(el)) {
           const element: ExcalidrawTextElement = {
             ...el,
@@ -295,8 +297,8 @@ export const actionChangeFontSize = register({
           { value: 36, text: t("labels.veryLarge") },
         ]}
         value={getFormValue(
-          appState.editingElement,
           elements,
+          appState,
           element => isTextElement(element) && +element.font.split("px ")[0],
           +(appState.currentItemFont || DEFAULT_FONT).split("px ")[0],
         )}
@@ -310,7 +312,7 @@ export const actionChangeFontFamily = register({
   name: "changeFontFamily",
   perform: (elements, appState, value) => {
     return {
-      elements: changeProperty(elements, el => {
+      elements: changeProperty(elements, appState, el => {
         if (isTextElement(el)) {
           const element: ExcalidrawTextElement = {
             ...el,
@@ -343,8 +345,8 @@ export const actionChangeFontFamily = register({
           { value: "Cascadia", text: t("labels.code") },
         ]}
         value={getFormValue(
-          appState.editingElement,
           elements,
+          appState,
           element => isTextElement(element) && element.font.split("px ")[1],
           (appState.currentItemFont || DEFAULT_FONT).split("px ")[1],
         )}

--- a/src/actions/actionProperties.tsx
+++ b/src/actions/actionProperties.tsx
@@ -47,7 +47,6 @@ export const actionChangeStrokeColor = register({
     return {
       elements: changeProperty(elements, appState, el => ({
         ...el,
-        shape: null,
         strokeColor: value,
       })),
       appState: { ...appState, currentItemStrokeColor: value },
@@ -78,7 +77,6 @@ export const actionChangeBackgroundColor = register({
     return {
       elements: changeProperty(elements, appState, el => ({
         ...el,
-        shape: null,
         backgroundColor: value,
       })),
       appState: { ...appState, currentItemBackgroundColor: value },
@@ -109,7 +107,6 @@ export const actionChangeFillStyle = register({
     return {
       elements: changeProperty(elements, appState, el => ({
         ...el,
-        shape: null,
         fillStyle: value,
       })),
       appState: { ...appState, currentItemFillStyle: value },
@@ -146,7 +143,6 @@ export const actionChangeStrokeWidth = register({
     return {
       elements: changeProperty(elements, appState, el => ({
         ...el,
-        shape: null,
         strokeWidth: value,
       })),
       appState: { ...appState, currentItemStrokeWidth: value },
@@ -181,7 +177,6 @@ export const actionChangeSloppiness = register({
     return {
       elements: changeProperty(elements, appState, el => ({
         ...el,
-        shape: null,
         roughness: value,
       })),
       appState: { ...appState, currentItemRoughness: value },
@@ -216,7 +211,6 @@ export const actionChangeOpacity = register({
     return {
       elements: changeProperty(elements, appState, el => ({
         ...el,
-        shape: null,
         opacity: value,
       })),
       appState: { ...appState, currentItemOpacity: value },
@@ -267,7 +261,6 @@ export const actionChangeFontSize = register({
         if (isTextElement(el)) {
           const element: ExcalidrawTextElement = {
             ...el,
-            shape: null,
             font: `${value}px ${el.font.split("px ")[1]}`,
           };
           redrawTextBoundingBox(element);
@@ -316,7 +309,6 @@ export const actionChangeFontFamily = register({
         if (isTextElement(el)) {
           const element: ExcalidrawTextElement = {
             ...el,
-            shape: null,
             font: `${el.font.split("px ")[0]}px ${value}`,
           };
           redrawTextBoundingBox(element);

--- a/src/actions/actionSelectAll.ts
+++ b/src/actions/actionSelectAll.ts
@@ -3,9 +3,14 @@ import { register } from "./register";
 
 export const actionSelectAll = register({
   name: "selectAll",
-  perform: elements => {
+  perform: (elements, appState) => {
     return {
-      elements: elements.map(elem => ({ ...elem, isSelected: true })),
+      appState: {
+        ...appState,
+        selectedElementIds: Object.fromEntries(
+          elements.map(element => [element.id, true]),
+        ),
+      },
     };
   },
   contextItemLabel: "labels.selectAll",

--- a/src/actions/actionStyles.ts
+++ b/src/actions/actionStyles.ts
@@ -35,7 +35,6 @@ export const actionPasteStyles = register({
         if (appState.selectedElementIds[element.id]) {
           const newElement = {
             ...element,
-            shape: null,
             backgroundColor: pastedElement?.backgroundColor,
             strokeWidth: pastedElement?.strokeWidth,
             strokeColor: pastedElement?.strokeColor,

--- a/src/actions/actionStyles.ts
+++ b/src/actions/actionStyles.ts
@@ -11,8 +11,8 @@ let copiedStyles: string = "{}";
 
 export const actionCopyStyles = register({
   name: "copyStyles",
-  perform: elements => {
-    const element = elements.find(el => el.isSelected);
+  perform: (elements, appState) => {
+    const element = elements.find(el => appState.selectedElementIds[el.id]);
     if (element) {
       copiedStyles = JSON.stringify(element);
     }
@@ -25,14 +25,14 @@ export const actionCopyStyles = register({
 
 export const actionPasteStyles = register({
   name: "pasteStyles",
-  perform: elements => {
+  perform: (elements, appState) => {
     const pastedElement = JSON.parse(copiedStyles);
     if (!isExcalidrawElement(pastedElement)) {
       return { elements };
     }
     return {
       elements: elements.map(element => {
-        if (element.isSelected) {
+        if (appState.selectedElementIds[element.id]) {
           const newElement = {
             ...element,
             shape: null,

--- a/src/actions/actionZindex.tsx
+++ b/src/actions/actionZindex.tsx
@@ -20,7 +20,10 @@ export const actionSendBackward = register({
   name: "sendBackward",
   perform: (elements, appState) => {
     return {
-      elements: moveOneLeft([...elements], getSelectedIndices(elements)),
+      elements: moveOneLeft(
+        [...elements],
+        getSelectedIndices(elements, appState),
+      ),
       appState,
     };
   },
@@ -44,7 +47,10 @@ export const actionBringForward = register({
   name: "bringForward",
   perform: (elements, appState) => {
     return {
-      elements: moveOneRight([...elements], getSelectedIndices(elements)),
+      elements: moveOneRight(
+        [...elements],
+        getSelectedIndices(elements, appState),
+      ),
       appState,
     };
   },
@@ -68,7 +74,10 @@ export const actionSendToBack = register({
   name: "sendToBack",
   perform: (elements, appState) => {
     return {
-      elements: moveAllLeft([...elements], getSelectedIndices(elements)),
+      elements: moveAllLeft(
+        [...elements],
+        getSelectedIndices(elements, appState),
+      ),
       appState,
     };
   },
@@ -91,7 +100,10 @@ export const actionBringToFront = register({
   name: "bringToFront",
   perform: (elements, appState) => {
     return {
-      elements: moveAllRight([...elements], getSelectedIndices(elements)),
+      elements: moveAllRight(
+        [...elements],
+        getSelectedIndices(elements, appState),
+      ),
       appState,
     };
   },

--- a/src/appState.ts
+++ b/src/appState.ts
@@ -32,6 +32,7 @@ export function getDefaultAppState(): AppState {
     zoom: 1,
     openMenu: null,
     lastPointerDownWith: "mouse",
+    selectedElementIds: {},
   };
 }
 

--- a/src/clipboard.ts
+++ b/src/clipboard.ts
@@ -1,5 +1,6 @@
 import { ExcalidrawElement } from "./element/types";
 import { getSelectedElements } from "./scene";
+import { AppState } from "./types";
 
 let CLIPBOARD = "";
 let PREFER_APP_CLIPBOARD = false;
@@ -18,9 +19,10 @@ export const probablySupportsClipboardBlob =
 
 export async function copyToAppClipboard(
   elements: readonly ExcalidrawElement[],
+  appState: AppState,
 ) {
   CLIPBOARD = JSON.stringify(
-    getSelectedElements(elements).map(({ shape, canvas, ...el }) => el),
+    getSelectedElements(elements, appState).map(({ shape, ...el }) => el),
   );
   try {
     // when copying to in-app clipboard, clear system clipboard so that if

--- a/src/clipboard.ts
+++ b/src/clipboard.ts
@@ -21,9 +21,7 @@ export async function copyToAppClipboard(
   elements: readonly ExcalidrawElement[],
   appState: AppState,
 ) {
-  CLIPBOARD = JSON.stringify(
-    getSelectedElements(elements, appState).map(({ shape, ...el }) => el),
-  );
+  CLIPBOARD = JSON.stringify(getSelectedElements(elements, appState));
   try {
     // when copying to in-app clipboard, clear system clipboard so that if
     //  system clip contains text on paste we know it was copied *after* user

--- a/src/components/Actions.tsx
+++ b/src/components/Actions.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { ExcalidrawElement } from "../element/types";
 import { ActionManager } from "../actions/manager";
-import { hasBackground, hasStroke, hasText, clearSelection } from "../scene";
+import { hasBackground, hasStroke, hasText } from "../scene";
 import { t } from "../i18n";
 import { SHAPES } from "../shapes";
 import { ToolButton } from "./ToolButton";
@@ -92,8 +92,11 @@ export function ShapesSwitcher({
             aria-label={capitalizeString(label)}
             aria-keyshortcuts={`${label[0]} ${index + 1}`}
             onChange={() => {
-              setAppState({ elementType: value, multiElement: null });
-              setElements(clearSelection(elements));
+              setAppState({
+                elementType: value,
+                multiElement: null,
+                selectedElementIds: {},
+              });
               document.documentElement.style.cursor =
                 value === "text" ? CURSOR_TYPE.TEXT : CURSOR_TYPE.CROSSHAIR;
               setAppState({});

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1402,14 +1402,17 @@ export class App extends React.Component<any, AppState> {
                     elements,
                     draggingElement,
                   );
-                  this.setState({
-                    selectedElementIds: Object.fromEntries(
-                      elementsWithinSelection.map(element => [
-                        element.id,
-                        true,
-                      ]),
-                    ),
-                  });
+                  this.setState(prevState => ({
+                    selectedElementIds: {
+                      ...prevState.selectedElementIds,
+                      ...Object.fromEntries(
+                        elementsWithinSelection.map(element => [
+                          element.id,
+                          true,
+                        ]),
+                      ),
+                    },
+                  }));
                 }
                 this.setState({});
               };

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -76,6 +76,7 @@ import {
 } from "../constants";
 import { LayerUI } from "./LayerUI";
 import { ScrollBars } from "../scene/types";
+import { invalidateShapeForElement } from "../renderer/renderElement";
 
 // -----------------------------------------------------------------------------
 // TEST HOOKS
@@ -295,7 +296,7 @@ export class App extends React.Component<any, AppState> {
   public state: AppState = getDefaultAppState();
 
   private onResize = () => {
-    elements = elements.map(el => ({ ...el, shape: null }));
+    elements.forEach(element => invalidateShapeForElement(element));
     this.setState({});
   };
 
@@ -931,7 +932,7 @@ export class App extends React.Component<any, AppState> {
                     },
                   }));
                   multiElement.points.push([x - rx, y - ry]);
-                  multiElement.shape = null;
+                  invalidateShapeForElement(multiElement);
                 } else {
                   this.setState(prevState => ({
                     selectedElementIds: {
@@ -940,7 +941,7 @@ export class App extends React.Component<any, AppState> {
                     },
                   }));
                   element.points.push([0, 0]);
-                  element.shape = null;
+                  invalidateShapeForElement(element);
                   elements = [...elements, element];
                   this.setState({
                     draggingElement: element,
@@ -1293,7 +1294,7 @@ export class App extends React.Component<any, AppState> {
                     );
                     el.x = element.x;
                     el.y = element.y;
-                    el.shape = null;
+                    invalidateShapeForElement(el);
 
                     lastX = x;
                     lastY = y;
@@ -1392,7 +1393,7 @@ export class App extends React.Component<any, AppState> {
                   draggingElement.height = height;
                 }
 
-                draggingElement.shape = null;
+                invalidateShapeForElement(draggingElement);
 
                 if (this.state.elementType === "selection") {
                   if (
@@ -1455,7 +1456,7 @@ export class App extends React.Component<any, AppState> {
                       x - draggingElement.x,
                       y - draggingElement.y,
                     ]);
-                    draggingElement.shape = null;
+                    invalidateShapeForElement(draggingElement);
                     this.setState({ multiElement: this.state.draggingElement });
                   } else if (draggingOccurred && !multiElement) {
                     if (!elementLocked) {
@@ -1767,7 +1768,7 @@ export class App extends React.Component<any, AppState> {
                 const pnt = points[points.length - 1];
                 pnt[0] = x - originX;
                 pnt[1] = y - originY;
-                multiElement.shape = null;
+                invalidateShapeForElement(multiElement);
                 this.setState({});
                 return;
               }

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -817,19 +817,11 @@ export class App extends React.Component<any, AppState> {
                     // We duplicate the selected element if alt is pressed on pointer down
                     if (event.altKey) {
                       elements = [
-                        ...elements.map(element => ({
-                          ...element,
-                          isSelected: false,
-                        })),
+                        ...elements,
                         ...getSelectedElements(elements, this.state).map(
                           element => {
                             const newElement = duplicateElement(element);
-                            this.setState(prevState => ({
-                              selectedElementIds: {
-                                ...prevState.selectedElementIds,
-                                [newElement.id]: true,
-                              },
-                            }));
+                            // TODO: focus the duplicated elements here, not the original ones?
                             return newElement;
                           },
                         ),

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -816,16 +816,19 @@ export class App extends React.Component<any, AppState> {
 
                     // We duplicate the selected element if alt is pressed on pointer down
                     if (event.altKey) {
-                      elements = [
-                        ...elements,
-                        ...getSelectedElements(elements, this.state).map(
-                          element => {
-                            const newElement = duplicateElement(element);
-                            // TODO: focus the duplicated elements here, not the original ones?
-                            return newElement;
-                          },
-                        ),
-                      ];
+                      // Move the currently selected elements to the top of the z index stack, and
+                      // put the duplicates where the selected elements used to be.
+                      const nextElements = [];
+                      const elementsToAppend = [];
+                      for (const element of elements) {
+                        if (this.state.selectedElementIds[element.id]) {
+                          nextElements.push(duplicateElement(element));
+                          elementsToAppend.push(element);
+                        } else {
+                          nextElements.push(element);
+                        }
+                      }
+                      elements = [...nextElements, ...elementsToAppend];
                     }
                   }
                 }

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1867,17 +1867,20 @@ export class App extends React.Component<any, AppState> {
     const dx = x - elementsCenterX;
     const dy = y - elementsCenterY;
 
-    elements = [
-      ...elements,
-      ...clipboardElements.map(clipboardElements => {
-        const duplicate = duplicateElement(clipboardElements);
-        duplicate.x += dx - minX;
-        duplicate.y += dy - minY;
-        return duplicate;
-      }),
-    ];
+    const newElements = clipboardElements.map(clipboardElements => {
+      const duplicate = duplicateElement(clipboardElements);
+      duplicate.x += dx - minX;
+      duplicate.y += dy - minY;
+      return duplicate;
+    });
+
+    elements = [...elements, ...newElements];
     history.resumeRecording();
-    this.setState({ selectedElementIds: {} });
+    this.setState({
+      selectedElementIds: Object.fromEntries(
+        newElements.map(element => [element.id, true]),
+      ),
+    });
   };
 
   private getTextWysiwygSnappedToCenterPosition(x: number, y: number) {

--- a/src/components/ExportDialog.tsx
+++ b/src/components/ExportDialog.tsx
@@ -48,7 +48,7 @@ function ExportModal({
   onExportToBackend: ExportCB;
   onCloseRequest: () => void;
 }) {
-  const someElementIsSelected = isSomeElementSelected(elements);
+  const someElementIsSelected = isSomeElementSelected(elements, appState);
   const [scale, setScale] = useState(defaultScale);
   const [exportSelected, setExportSelected] = useState(someElementIsSelected);
   const previewRef = useRef<HTMLDivElement>(null);
@@ -58,7 +58,7 @@ function ExportModal({
   const onlySelectedInput = useRef<HTMLInputElement>(null);
 
   const exportedElements = exportSelected
-    ? getSelectedElements(elements)
+    ? getSelectedElements(elements, appState)
     : elements;
 
   useEffect(() => {
@@ -67,7 +67,7 @@ function ExportModal({
 
   useEffect(() => {
     const previewNode = previewRef.current;
-    const canvas = exportToCanvas(exportedElements, {
+    const canvas = exportToCanvas(exportedElements, appState, {
       exportBackground,
       viewBackgroundColor,
       exportPadding,
@@ -78,6 +78,7 @@ function ExportModal({
       previewNode?.removeChild(canvas);
     };
   }, [
+    appState,
     exportedElements,
     exportBackground,
     exportPadding,

--- a/src/components/HintViewer.tsx
+++ b/src/components/HintViewer.tsx
@@ -4,15 +4,16 @@ import { ExcalidrawElement } from "../element/types";
 import { getSelectedElements } from "../scene";
 
 import "./HintViewer.css";
+import { AppState } from "../types";
 
 interface Hint {
-  elementType: string;
-  multiMode: boolean;
-  isResizing: boolean;
+  appState: AppState;
   elements: readonly ExcalidrawElement[];
 }
 
-const getHints = ({ elementType, multiMode, isResizing, elements }: Hint) => {
+const getHints = ({ appState, elements }: Hint) => {
+  const { elementType, isResizing } = appState;
+  const multiMode = appState.multiElement !== null;
   if (elementType === "arrow" || elementType === "line") {
     if (!multiMode) {
       return t("hints.linearElement");
@@ -21,7 +22,7 @@ const getHints = ({ elementType, multiMode, isResizing, elements }: Hint) => {
   }
 
   if (isResizing) {
-    const selectedElements = getSelectedElements(elements);
+    const selectedElements = getSelectedElements(elements, appState);
     if (
       selectedElements.length === 1 &&
       (selectedElements[0].type === "arrow" ||
@@ -36,16 +37,9 @@ const getHints = ({ elementType, multiMode, isResizing, elements }: Hint) => {
   return null;
 };
 
-export const HintViewer = ({
-  elementType,
-  multiMode,
-  isResizing,
-  elements,
-}: Hint) => {
+export const HintViewer = ({ appState, elements }: Hint) => {
   const hint = getHints({
-    elementType,
-    multiMode,
-    isResizing,
+    appState,
     elements,
   });
   if (!hint) {

--- a/src/components/LayerUI.tsx
+++ b/src/components/LayerUI.tsx
@@ -70,11 +70,11 @@ export const LayerUI = React.memo(
             if (canvas) {
               exportCanvas(
                 "backend",
-                exportedElements.map(element => ({
-                  ...element,
-                  isSelected: false,
-                })),
-                appState,
+                exportedElements,
+                {
+                  ...appState,
+                  selectedElementIds: {},
+                },
                 canvas,
                 appState,
               );

--- a/src/components/LayerUI.tsx
+++ b/src/components/LayerUI.tsx
@@ -50,7 +50,7 @@ export const LayerUI = React.memo(
         scale,
       ) => {
         if (canvas) {
-          exportCanvas(type, exportedElements, canvas, {
+          exportCanvas(type, exportedElements, appState, canvas, {
             exportBackground: appState.exportBackground,
             name: appState.name,
             viewBackgroundColor: appState.viewBackgroundColor,
@@ -74,6 +74,7 @@ export const LayerUI = React.memo(
                   ...element,
                   isSelected: false,
                 })),
+                appState,
                 canvas,
                 appState,
               );
@@ -95,12 +96,7 @@ export const LayerUI = React.memo(
     ) : (
       <>
         <FixedSideContainer side="top">
-          <HintViewer
-            elementType={appState.elementType}
-            multiMode={appState.multiElement !== null}
-            isResizing={appState.isResizing}
-            elements={elements}
-          />
+          <HintViewer appState={appState} elements={elements} />
           <div className="App-menu App-menu_top">
             <Stack.Col gap={4} align="end">
               <Section className="App-right-menu" heading="canvasActions">
@@ -123,10 +119,7 @@ export const LayerUI = React.memo(
                 >
                   <Island padding={4}>
                     <SelectedShapeActions
-                      targetElements={getTargetElement(
-                        appState.editingElement,
-                        elements,
-                      )}
+                      targetElements={getTargetElement(elements, appState)}
                       renderAction={actionManager.renderAction}
                       elementType={appState.elementType}
                     />

--- a/src/components/MobileMenu.tsx
+++ b/src/components/MobileMenu.tsx
@@ -58,10 +58,7 @@ export function MobileMenu({
         <Section className="App-mobile-menu" heading="selectedShapeActions">
           <div className="App-mobile-menu-scroller">
             <SelectedShapeActions
-              targetElements={getTargetElement(
-                appState.editingElement,
-                elements,
-              )}
+              targetElements={getTargetElement(elements, appState)}
               renderAction={actionManager.renderAction}
               elementType={appState.elementType}
             />
@@ -88,12 +85,7 @@ export function MobileMenu({
             </Stack.Col>
           )}
         </Section>
-        <HintViewer
-          elementType={appState.elementType}
-          multiMode={appState.multiElement !== null}
-          isResizing={appState.isResizing}
-          elements={elements}
-        />
+        <HintViewer appState={appState} elements={elements} />
       </FixedSideContainer>
       <footer className="App-toolbar">
         <div className="App-toolbar-content">

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -149,6 +149,7 @@ export async function importFromBackend(
 export async function exportCanvas(
   type: ExportType,
   elements: readonly ExcalidrawElement[],
+  appState: AppState,
   canvas: HTMLCanvasElement,
   {
     exportBackground,
@@ -181,7 +182,7 @@ export async function exportCanvas(
     return;
   }
 
-  const tempCanvas = exportToCanvas(elements, {
+  const tempCanvas = exportToCanvas(elements, appState, {
     exportBackground,
     viewBackgroundColor,
     exportPadding,

--- a/src/data/json.ts
+++ b/src/data/json.ts
@@ -14,7 +14,7 @@ export function serializeAsJSON(
       type: "excalidraw",
       version: 1,
       source: window.location.origin,
-      elements: elements.map(({ shape, ...el }) => el),
+      elements,
       appState: cleanAppStateForExport(appState),
     },
     null,

--- a/src/data/json.ts
+++ b/src/data/json.ts
@@ -14,7 +14,7 @@ export function serializeAsJSON(
       type: "excalidraw",
       version: 1,
       source: window.location.origin,
-      elements: elements.map(({ shape, canvas, isSelected, ...el }) => el),
+      elements: elements.map(({ shape, ...el }) => el),
       appState: cleanAppStateForExport(appState),
     },
     null,

--- a/src/data/localStorage.ts
+++ b/src/data/localStorage.ts
@@ -13,9 +13,7 @@ export function saveToLocalStorage(
   localStorage.setItem(
     LOCAL_STORAGE_KEY,
     JSON.stringify(
-      elements.map(
-        ({ shape, canvas, ...element }: ExcalidrawElement) => element,
-      ),
+      elements.map(({ shape, ...element }: ExcalidrawElement) => element),
     ),
   );
   localStorage.setItem(

--- a/src/data/localStorage.ts
+++ b/src/data/localStorage.ts
@@ -10,12 +10,7 @@ export function saveToLocalStorage(
   elements: readonly ExcalidrawElement[],
   appState: AppState,
 ) {
-  localStorage.setItem(
-    LOCAL_STORAGE_KEY,
-    JSON.stringify(
-      elements.map(({ shape, ...element }: ExcalidrawElement) => element),
-    ),
-  );
+  localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(elements));
   localStorage.setItem(
     LOCAL_STORAGE_KEY_STATE,
     JSON.stringify(clearAppStateForLocalStorage(appState)),
@@ -29,9 +24,7 @@ export function restoreFromLocalStorage() {
   let elements = [];
   if (savedElements) {
     try {
-      elements = JSON.parse(savedElements).map(
-        ({ shape, ...element }: ExcalidrawElement) => element,
-      );
+      elements = JSON.parse(savedElements);
     } catch {
       // Do nothing because elements array is already empty
     }

--- a/src/data/restore.ts
+++ b/src/data/restore.ts
@@ -58,9 +58,6 @@ export function restore(
             : element.opacity,
         points,
         shape: null,
-        canvas: null,
-        canvasOffsetX: element.canvasOffsetX || 0,
-        canvasOffsetY: element.canvasOffsetY || 0,
       };
     });
 

--- a/src/data/restore.ts
+++ b/src/data/restore.ts
@@ -57,7 +57,6 @@ export function restore(
             ? 100
             : element.opacity,
         points,
-        shape: null,
       };
     });
 

--- a/src/element/bounds.ts
+++ b/src/element/bounds.ts
@@ -2,6 +2,7 @@ import { ExcalidrawElement } from "./types";
 import { rotate } from "../math";
 import { Drawable } from "roughjs/bin/core";
 import { Point } from "roughjs/bin/geometry";
+import { getShapeForElement } from "../renderer/renderElement";
 
 // If the element is created from right to left, the width is going to be negative
 // This set of functions retrieves the absolute position of the 4 points.
@@ -33,7 +34,7 @@ export function getDiamondPoints(element: ExcalidrawElement) {
 }
 
 export function getLinearElementAbsoluteBounds(element: ExcalidrawElement) {
-  if (element.points.length < 2 || !element.shape) {
+  if (element.points.length < 2 || !getShapeForElement(element)) {
     const { minX, minY, maxX, maxY } = element.points.reduce(
       (limits, [x, y]) => {
         limits.minY = Math.min(limits.minY, y);
@@ -54,7 +55,7 @@ export function getLinearElementAbsoluteBounds(element: ExcalidrawElement) {
     ];
   }
 
-  const shape = element.shape as Drawable[];
+  const shape = getShapeForElement(element) as Drawable[];
 
   // first element is always the curve
   const ops = shape[0].sets[0].ops;
@@ -118,8 +119,7 @@ export function getLinearElementAbsoluteBounds(element: ExcalidrawElement) {
   ];
 }
 
-export function getArrowPoints(element: ExcalidrawElement) {
-  const shape = element.shape as Drawable[];
+export function getArrowPoints(element: ExcalidrawElement, shape: Drawable[]) {
   const ops = shape[0].sets[0].ops;
 
   const data = ops[ops.length - 1].data;

--- a/src/element/collision.ts
+++ b/src/element/collision.ts
@@ -9,13 +9,21 @@ import {
 } from "./bounds";
 import { Point } from "roughjs/bin/geometry";
 import { Drawable, OpSet } from "roughjs/bin/core";
+import { AppState } from "../types";
 
-function isElementDraggableFromInside(element: ExcalidrawElement): boolean {
-  return element.backgroundColor !== "transparent" || element.isSelected;
+function isElementDraggableFromInside(
+  element: ExcalidrawElement,
+  appState: AppState,
+): boolean {
+  return (
+    element.backgroundColor !== "transparent" ||
+    appState.selectedElementIds[element.id]
+  );
 }
 
 export function hitTest(
   element: ExcalidrawElement,
+  appState: AppState,
   x: number,
   y: number,
   zoom: number,
@@ -58,7 +66,7 @@ export function hitTest(
       ty /= t;
     });
 
-    if (isElementDraggableFromInside(element)) {
+    if (isElementDraggableFromInside(element, appState)) {
       return (
         a * tx - (px - lineThreshold) >= 0 && b * ty - (py - lineThreshold) >= 0
       );
@@ -67,7 +75,7 @@ export function hitTest(
   } else if (element.type === "rectangle") {
     const [x1, y1, x2, y2] = getElementAbsoluteCoords(element);
 
-    if (isElementDraggableFromInside(element)) {
+    if (isElementDraggableFromInside(element, appState)) {
       return (
         x > x1 - lineThreshold &&
         x < x2 + lineThreshold &&
@@ -99,7 +107,7 @@ export function hitTest(
       leftY,
     ] = getDiamondPoints(element);
 
-    if (isElementDraggableFromInside(element)) {
+    if (isElementDraggableFromInside(element, appState)) {
       // TODO: remove this when we normalize coordinates globally
       if (topY > bottomY) {
         [bottomY, topY] = [topY, bottomY];

--- a/src/element/collision.ts
+++ b/src/element/collision.ts
@@ -10,6 +10,7 @@ import {
 import { Point } from "roughjs/bin/geometry";
 import { Drawable, OpSet } from "roughjs/bin/core";
 import { AppState } from "../types";
+import { getShapeForElement } from "../renderer/renderElement";
 
 function isElementDraggableFromInside(
   element: ExcalidrawElement,
@@ -158,10 +159,10 @@ export function hitTest(
         lineThreshold
     );
   } else if (element.type === "arrow" || element.type === "line") {
-    if (!element.shape) {
+    if (!getShapeForElement(element)) {
       return false;
     }
-    const shape = element.shape as Drawable[];
+    const shape = getShapeForElement(element) as Drawable[];
 
     const [x1, y1, x2, y2] = getLinearElementAbsoluteBounds(element);
     if (x < x1 || y < y1 - 10 || x > x2 || y > y2 + 10) {

--- a/src/element/newElement.test.ts
+++ b/src/element/newElement.test.ts
@@ -54,8 +54,6 @@ it("clones arrow element", () => {
     ...element,
     id: copy.id,
     seed: copy.seed,
-    shape: undefined,
-    canvas: undefined,
   });
 });
 

--- a/src/element/newElement.ts
+++ b/src/element/newElement.ts
@@ -32,14 +32,9 @@ export function newElement(
     strokeWidth,
     roughness,
     opacity,
-    isSelected: false,
     seed: randomSeed(),
     shape: null as Drawable | Drawable[] | null,
     points: [] as Point[],
-    canvas: null as HTMLCanvasElement | null,
-    canvasZoom: 1, // The zoom level used to render the cached canvas
-    canvasOffsetX: 0,
-    canvasOffsetY: 0,
   };
   return element;
 }

--- a/src/element/newElement.ts
+++ b/src/element/newElement.ts
@@ -1,6 +1,5 @@
 import { randomSeed } from "roughjs/bin/math";
 import nanoid from "nanoid";
-import { Drawable } from "roughjs/bin/core";
 import { Point } from "roughjs/bin/geometry";
 
 import { ExcalidrawElement, ExcalidrawTextElement } from "../element/types";
@@ -33,7 +32,6 @@ export function newElement(
     roughness,
     opacity,
     seed: randomSeed(),
-    shape: null as Drawable | Drawable[] | null,
     points: [] as Point[],
   };
   return element;
@@ -47,7 +45,6 @@ export function newTextElement(
   const metrics = measureText(text, font);
   const textElement: ExcalidrawTextElement = {
     ...element,
-    shape: null,
     type: "text",
     text: text,
     font: font,

--- a/src/element/resizeTest.ts
+++ b/src/element/resizeTest.ts
@@ -1,17 +1,19 @@
 import { ExcalidrawElement, PointerType } from "./types";
 
 import { handlerRectangles } from "./handlerRectangles";
+import { AppState } from "../types";
 
 type HandlerRectanglesRet = keyof ReturnType<typeof handlerRectangles>;
 
 export function resizeTest(
   element: ExcalidrawElement,
+  appState: AppState,
   x: number,
   y: number,
   zoom: number,
   pointerType: PointerType,
 ): HandlerRectanglesRet | false {
-  if (!element.isSelected || element.type === "text") {
+  if (!appState.selectedElementIds[element.id] || element.type === "text") {
     return false;
   }
 
@@ -40,6 +42,7 @@ export function resizeTest(
 
 export function getElementWithResizeHandler(
   elements: readonly ExcalidrawElement[],
+  appState: AppState,
   { x, y }: { x: number; y: number },
   zoom: number,
   pointerType: PointerType,
@@ -48,7 +51,7 @@ export function getElementWithResizeHandler(
     if (result) {
       return result;
     }
-    const resizeHandle = resizeTest(element, x, y, zoom, pointerType);
+    const resizeHandle = resizeTest(element, appState, x, y, zoom, pointerType);
     return resizeHandle ? { element, resizeHandle } : null;
   }, null as { element: ExcalidrawElement; resizeHandle: ReturnType<typeof resizeTest> } | null);
 }

--- a/src/element/showSelectedShapeActions.ts
+++ b/src/element/showSelectedShapeActions.ts
@@ -8,6 +8,6 @@ export const showSelectedShapeActions = (
 ) =>
   Boolean(
     appState.editingElement ||
-      getSelectedElements(elements).length ||
+      getSelectedElements(elements, appState).length ||
       appState.elementType !== "selection",
   );

--- a/src/element/sizeHelpers.ts
+++ b/src/element/sizeHelpers.ts
@@ -1,4 +1,5 @@
 import { ExcalidrawElement } from "./types";
+import { invalidateShapeForElement } from "../renderer/renderElement";
 
 export function isInvisiblySmallElement(element: ExcalidrawElement): boolean {
   if (element.type === "arrow" || element.type === "line") {
@@ -86,7 +87,7 @@ export function normalizeDimensions(
     element.y -= element.height;
   }
 
-  element.shape = null;
+  invalidateShapeForElement(element);
 
   return true;
 }

--- a/src/element/types.ts
+++ b/src/element/types.ts
@@ -1,5 +1,10 @@
 import { newElement } from "./newElement";
 
+/**
+ * ExcalidrawElement should be JSON serializable and (eventually) contain
+ * no computed data. The list of all ExcalidrawElements should be shareable
+ * between peers and contain no state local to the peer.
+ */
 export type ExcalidrawElement = ReturnType<typeof newElement>;
 export type ExcalidrawTextElement = ExcalidrawElement & {
   type: "text";

--- a/src/history.ts
+++ b/src/history.ts
@@ -18,10 +18,8 @@ export class SceneHistory {
   ) {
     return JSON.stringify({
       appState: clearAppStatePropertiesForHistory(appState),
-      elements: elements.map(({ shape, ...element }) => ({
+      elements: elements.map(element => ({
         ...element,
-        shape: null,
-        canvas: null,
         points:
           appState.multiElement && appState.multiElement.id === element.id
             ? element.points.slice(0, -1)

--- a/src/history.ts
+++ b/src/history.ts
@@ -18,7 +18,7 @@ export class SceneHistory {
   ) {
     return JSON.stringify({
       appState: clearAppStatePropertiesForHistory(appState),
-      elements: elements.map(({ shape, canvas, ...element }) => ({
+      elements: elements.map(({ shape, ...element }) => ({
         ...element,
         shape: null,
         canvas: null,

--- a/src/index-node.ts
+++ b/src/index-node.ts
@@ -1,4 +1,5 @@
 import { exportToCanvas } from "./scene/export";
+import { getDefaultAppState } from "./appState";
 
 const { registerFont, createCanvas } = require("canvas");
 
@@ -60,6 +61,7 @@ registerFont("./public/FG_Virgil.ttf", { family: "Virgil" });
 registerFont("./public/Cascadia.ttf", { family: "Cascadia" });
 const canvas = exportToCanvas(
   elements as any,
+  getDefaultAppState(),
   {
     exportBackground: true,
     viewBackgroundColor: "#ffffff",

--- a/src/index-node.ts
+++ b/src/index-node.ts
@@ -17,7 +17,6 @@ const elements = [
     strokeWidth: 1,
     roughness: 1,
     opacity: 100,
-    isSelected: false,
     seed: 749612521,
   },
   {
@@ -33,7 +32,6 @@ const elements = [
     strokeWidth: 1,
     roughness: 1,
     opacity: 100,
-    isSelected: false,
     seed: 952056308,
   },
   {
@@ -49,7 +47,6 @@ const elements = [
     strokeWidth: 1,
     roughness: 1,
     opacity: 100,
-    isSelected: false,
     seed: 1683771448,
     text: "test",
     font: "20px Virgil",

--- a/src/renderer/renderScene.ts
+++ b/src/renderer/renderScene.ts
@@ -1,7 +1,7 @@
 import { RoughCanvas } from "roughjs/bin/canvas";
 import { RoughSVG } from "roughjs/bin/svg";
 
-import { FlooredNumber } from "../types";
+import { FlooredNumber, AppState } from "../types";
 import { ExcalidrawElement } from "../element/types";
 import { getElementAbsoluteCoords, handlerRectangles } from "../element";
 
@@ -19,6 +19,7 @@ import { renderElement, renderElementToSvg } from "./renderElement";
 
 export function renderScene(
   elements: readonly ExcalidrawElement[],
+  appState: AppState,
   selectionElement: ExcalidrawElement | null,
   rc: RoughCanvas,
   canvas: HTMLCanvasElement,
@@ -129,7 +130,7 @@ export function renderScene(
 
   // Pain selected elements
   if (renderSelection) {
-    const selectedElements = getSelectedElements(elements);
+    const selectedElements = getSelectedElements(elements, appState);
     const dashledLinePadding = 4 / sceneState.zoom;
 
     applyZoom(context);

--- a/src/scene/comparisons.ts
+++ b/src/scene/comparisons.ts
@@ -1,6 +1,7 @@
 import { ExcalidrawElement } from "../element/types";
 
 import { getElementAbsoluteCoords, hitTest } from "../element";
+import { AppState } from "../types";
 
 export const hasBackground = (type: string) =>
   type === "rectangle" || type === "ellipse" || type === "diamond";
@@ -16,6 +17,7 @@ export const hasText = (type: string) => type === "text";
 
 export function getElementAtPosition(
   elements: readonly ExcalidrawElement[],
+  appState: AppState,
   x: number,
   y: number,
   zoom: number,
@@ -23,7 +25,7 @@ export function getElementAtPosition(
   let hitElement = null;
   // We need to to hit testing from front (end of the array) to back (beginning of the array)
   for (let i = elements.length - 1; i >= 0; --i) {
-    if (hitTest(elements[i], x, y, zoom)) {
+    if (hitTest(elements[i], appState, x, y, zoom)) {
       hitElement = elements[i];
       break;
     }

--- a/src/scene/export.ts
+++ b/src/scene/export.ts
@@ -4,9 +4,11 @@ import { getCommonBounds } from "../element/bounds";
 import { renderScene, renderSceneToSvg } from "../renderer/renderScene";
 import { distance, SVG_NS } from "../utils";
 import { normalizeScroll } from "./scroll";
+import { AppState } from "../types";
 
 export function exportToCanvas(
   elements: readonly ExcalidrawElement[],
+  appState: AppState,
   {
     exportBackground,
     exportPadding = 10,
@@ -38,6 +40,7 @@ export function exportToCanvas(
 
   renderScene(
     elements,
+    appState,
     null,
     rough.canvas(tempCanvas),
     tempCanvas,

--- a/src/scene/index.ts
+++ b/src/scene/index.ts
@@ -1,6 +1,5 @@
 export { isOverScrollBars } from "./scrollbars";
 export {
-  clearSelection,
   getSelectedIndices,
   deleteSelectedElements,
   isSomeElementSelected,

--- a/src/scene/selection.ts
+++ b/src/scene/selection.ts
@@ -1,5 +1,6 @@
 import { ExcalidrawElement } from "../element/types";
 import { getElementAbsoluteCoords } from "../element";
+import { AppState } from "../types";
 
 export function getElementsWithinSelection(
   elements: readonly ExcalidrawElement[],
@@ -29,26 +30,20 @@ export function getElementsWithinSelection(
   });
 }
 
-export function clearSelection(elements: readonly ExcalidrawElement[]) {
-  let someWasSelected = false;
-  elements.forEach(element => {
-    if (element.isSelected) {
-      someWasSelected = true;
-      element.isSelected = false;
-    }
-  });
-
-  return someWasSelected ? elements.slice() : elements;
+export function deleteSelectedElements(
+  elements: readonly ExcalidrawElement[],
+  appState: AppState,
+) {
+  return elements.filter(el => !appState.selectedElementIds[el.id]);
 }
 
-export function deleteSelectedElements(elements: readonly ExcalidrawElement[]) {
-  return elements.filter(el => !el.isSelected);
-}
-
-export function getSelectedIndices(elements: readonly ExcalidrawElement[]) {
+export function getSelectedIndices(
+  elements: readonly ExcalidrawElement[],
+  appState: AppState,
+) {
   const selectedIndices: number[] = [];
   elements.forEach((element, index) => {
-    if (element.isSelected) {
+    if (appState.selectedElementIds[element.id]) {
       selectedIndices.push(index);
     }
   });
@@ -57,8 +52,9 @@ export function getSelectedIndices(elements: readonly ExcalidrawElement[]) {
 
 export function isSomeElementSelected(
   elements: readonly ExcalidrawElement[],
+  appState: AppState,
 ): boolean {
-  return elements.some(element => element.isSelected);
+  return elements.some(element => appState.selectedElementIds[element.id]);
 }
 
 /**
@@ -67,11 +63,14 @@ export function isSomeElementSelected(
  */
 export function getCommonAttributeOfSelectedElements<T>(
   elements: readonly ExcalidrawElement[],
+  appState: AppState,
   getAttribute: (element: ExcalidrawElement) => T,
 ): T | null {
   const attributes = Array.from(
     new Set(
-      getSelectedElements(elements).map(element => getAttribute(element)),
+      getSelectedElements(elements, appState).map(element =>
+        getAttribute(element),
+      ),
     ),
   );
   return attributes.length === 1 ? attributes[0] : null;
@@ -79,13 +78,16 @@ export function getCommonAttributeOfSelectedElements<T>(
 
 export function getSelectedElements(
   elements: readonly ExcalidrawElement[],
+  appState: AppState,
 ): readonly ExcalidrawElement[] {
-  return elements.filter(element => element.isSelected);
+  return elements.filter(element => appState.selectedElementIds[element.id]);
 }
 
 export function getTargetElement(
-  editingElement: ExcalidrawElement | null,
   elements: readonly ExcalidrawElement[],
+  appState: AppState,
 ) {
-  return editingElement ? [editingElement] : getSelectedElements(elements);
+  return appState.editingElement
+    ? [appState.editingElement]
+    : getSelectedElements(elements, appState);
 }

--- a/src/tests/move.test.tsx
+++ b/src/tests/move.test.tsx
@@ -31,7 +31,7 @@ describe("move element", () => {
       expect(renderScene).toHaveBeenCalledTimes(4);
       expect(h.appState.selectionElement).toBeNull();
       expect(h.elements.length).toEqual(1);
-      expect(h.elements[0].isSelected).toBeTruthy();
+      expect(h.appState.selectedElementIds[h.elements[0].id]).toBeTruthy();
       expect([h.elements[0].x, h.elements[0].y]).toEqual([30, 20]);
 
       renderScene.mockClear();
@@ -64,7 +64,7 @@ describe("duplicate element on move when ALT is clicked", () => {
       expect(renderScene).toHaveBeenCalledTimes(4);
       expect(h.appState.selectionElement).toBeNull();
       expect(h.elements.length).toEqual(1);
-      expect(h.elements[0].isSelected).toBeTruthy();
+      expect(h.appState.selectedElementIds[h.elements[0].id]).toBeTruthy();
       expect([h.elements[0].x, h.elements[0].y]).toEqual([30, 20]);
 
       renderScene.mockClear();
@@ -77,6 +77,7 @@ describe("duplicate element on move when ALT is clicked", () => {
     expect(renderScene).toHaveBeenCalledTimes(3);
     expect(h.appState.selectionElement).toBeNull();
     expect(h.elements.length).toEqual(2);
+
     // previous element should stay intact
     expect([h.elements[0].x, h.elements[0].y]).toEqual([30, 20]);
     expect([h.elements[1].x, h.elements[1].y]).toEqual([0, 40]);

--- a/src/tests/resize.test.tsx
+++ b/src/tests/resize.test.tsx
@@ -31,7 +31,7 @@ describe("resize element", () => {
       expect(renderScene).toHaveBeenCalledTimes(4);
       expect(h.appState.selectionElement).toBeNull();
       expect(h.elements.length).toEqual(1);
-      expect(h.elements[0].isSelected).toBeTruthy();
+      expect(h.appState.selectedElementIds[h.elements[0].id]).toBeTruthy();
       expect([h.elements[0].x, h.elements[0].y]).toEqual([30, 20]);
 
       expect([h.elements[0].width, h.elements[0].height]).toEqual([30, 50]);
@@ -72,7 +72,7 @@ describe("resize element with aspect ratio when SHIFT is clicked", () => {
       expect(renderScene).toHaveBeenCalledTimes(4);
       expect(h.appState.selectionElement).toBeNull();
       expect(h.elements.length).toEqual(1);
-      expect(h.elements[0].isSelected).toBeTruthy();
+      expect(h.appState.selectedElementIds[h.elements[0].id]).toBeTruthy();
       expect([h.elements[0].x, h.elements[0].y]).toEqual([30, 20]);
       expect([h.elements[0].x, h.elements[0].y]).toEqual([30, 20]);
       expect([h.elements[0].width, h.elements[0].height]).toEqual([30, 50]);

--- a/src/tests/selection.test.tsx
+++ b/src/tests/selection.test.tsx
@@ -97,7 +97,7 @@ describe("select single element on the scene", () => {
     expect(renderScene).toHaveBeenCalledTimes(7);
     expect(h.appState.selectionElement).toBeNull();
     expect(h.elements.length).toEqual(1);
-    expect(h.elements[0].isSelected).toBeTruthy();
+    expect(h.appState.selectedElementIds[h.elements[0].id]).toBeTruthy();
   });
 
   it("diamond", () => {
@@ -122,7 +122,7 @@ describe("select single element on the scene", () => {
     expect(renderScene).toHaveBeenCalledTimes(7);
     expect(h.appState.selectionElement).toBeNull();
     expect(h.elements.length).toEqual(1);
-    expect(h.elements[0].isSelected).toBeTruthy();
+    expect(h.appState.selectedElementIds[h.elements[0].id]).toBeTruthy();
   });
 
   it("ellipse", () => {
@@ -147,7 +147,7 @@ describe("select single element on the scene", () => {
     expect(renderScene).toHaveBeenCalledTimes(7);
     expect(h.appState.selectionElement).toBeNull();
     expect(h.elements.length).toEqual(1);
-    expect(h.elements[0].isSelected).toBeTruthy();
+    expect(h.appState.selectedElementIds[h.elements[0].id]).toBeTruthy();
   });
 
   it("arrow", () => {
@@ -172,7 +172,7 @@ describe("select single element on the scene", () => {
     expect(renderScene).toHaveBeenCalledTimes(7);
     expect(h.appState.selectionElement).toBeNull();
     expect(h.elements.length).toEqual(1);
-    expect(h.elements[0].isSelected).toBeTruthy();
+    expect(h.appState.selectedElementIds[h.elements[0].id]).toBeTruthy();
   });
 
   it("arrow", () => {
@@ -197,6 +197,6 @@ describe("select single element on the scene", () => {
     expect(renderScene).toHaveBeenCalledTimes(7);
     expect(h.appState.selectionElement).toBeNull();
     expect(h.elements.length).toEqual(1);
-    expect(h.elements[0].isSelected).toBeTruthy();
+    expect(h.appState.selectedElementIds[h.elements[0].id]).toBeTruthy();
   });
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,6 +33,7 @@ export type AppState = {
   zoom: number;
   openMenu: "canvas" | "shape" | null;
   lastPointerDownWith: PointerType;
+  selectedElementIds: { [id: string]: boolean };
 };
 
 export type Pointer = Readonly<{


### PR DESCRIPTION
I started trying to put the `ExcalidrawElement` array in Firebase to create a multiplayer whiteboard. It seems to be that the selection state should belong in `appState` not in `ExcalidrawElement`. I also took the opportunity to pull all the canvas stuff out of `ExcalidrawElement` and into a new interface.

Up next I want to pull `shape` out into as I did `canvas`, and add an `isDeleted` boolean to `ExcalidrawElement` rather than deleting out of the array. This will make it a lot easier to handle deletion in the shared whiteboard.