### PR TITLE
Make gesture.pointers a Map instead of an array of pointers

### DIFF
--- a/src/gesture.ts
+++ b/src/gesture.ts
@@ -1,14 +1,15 @@
-import { Pointer } from "./types";
+import { PointerCoords } from "./types";
 import { normalizeScroll } from "./scene";
 
-export function getCenter(pointers: readonly Pointer[]) {
+export function getCenter(pointers: Map<number, PointerCoords>) {
+  const allCoords = Array.from(pointers.values());
   return {
-    x: normalizeScroll(sum(pointers, pointer => pointer.x) / pointers.length),
-    y: normalizeScroll(sum(pointers, pointer => pointer.y) / pointers.length),
+    x: normalizeScroll(sum(allCoords, coords => coords.x) / allCoords.length),
+    y: normalizeScroll(sum(allCoords, coords => coords.y) / allCoords.length),
   };
 }
 
-export function getDistance([a, b]: readonly Pointer[]) {
+export function getDistance([a, b]: readonly PointerCoords[]) {
   return Math.hypot(a.x - b.x, a.y - b.y);
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -36,14 +36,13 @@ export type AppState = {
   selectedElementIds: { [id: string]: boolean };
 };
 
-export type Pointer = Readonly<{
-  id: number;
+export type PointerCoords = Readonly<{
   x: number;
   y: number;
 }>;
 
 export type Gesture = {
-  pointers: Array<Pointer>;
+  pointers: Map<number, PointerCoords>;
   lastCenter: { x: number; y: number } | null;
   initialDistance: number | null;
   initialScale: number | null;


### PR DESCRIPTION
@lissitz debugged the selection issue here: https://github.com/excalidraw/excalidraw/issues/871#issuecomment-596258622. It jives with my sense of what the bug might be too.

Since it's a race condition it's hard to know if it's conclusively solved but I haven't been able to repro it since this patch.