### PR TITLE
Properly center the shape switcher

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -152,34 +152,5 @@
       <h1 class="visually-hidden">Excalidraw</h1>
     </header>
     <div id="root"></div>
-    <aside>
-      <!-- https://github.com/tholman/github-corners -->
-      <svg
-        xmlns="http://www.w3.org/2000/svg"
-        width="40"
-        height="40"
-        viewBox="0 0 250 250"
-        style="position: absolute; top: 0; right: 0"
-      >
-        <a
-          href="https://github.com/excalidraw/excalidraw"
-          target="_blank"
-          aria-label="GitHub repository"
-        >
-          <path d="M0 0l115 115h15l12 27 108 108V0z" fill="#6c6c6c" />
-          <path
-            class="octo-arm"
-            d="M128 109c-15-9-9-19-9-19 3-7 2-11 2-11-1-7 3-2 3-2 4 5 2 11 2 11-3 10 5 15 9 16"
-            style="transform-origin: 130px 106px"
-            fill="#fff"
-          />
-          <path
-            class="octo-body"
-            d="M115 115s4 2 5 0l14-14c3-2 6-3 8-3-8-11-15-24 2-41 5-5 10-7 16-7 1-2 3-7 12-11 0 0 5 3 7 16 4 2 8 5 12 9s7 8 9 12c14 3 17 7 17 7-4 8-9 11-11 11 0 6-2 11-7 16-16 16-30 10-41 2 0 3-1 7-5 11l-12 11c-1 1 1 5 1 5z"
-            fill="#fff"
-          />
-        </a>
-      </svg>
-    </aside>
   </body>
 </html>

--- a/src/components/GitHubCorner.tsx
+++ b/src/components/GitHubCorner.tsx
@@ -4,7 +4,6 @@ import React from "react";
 
 export default () => (
   <svg
-    xmlns="http://www.w3.org/2000/svg"
     width="40"
     height="40"
     viewBox="0 0 250 250"
@@ -19,16 +18,15 @@ export default () => (
       target="_blank"
       rel="noopener noreferrer"
       aria-label="GitHub repository"
+      style={{ cursor: "pointer" }}
     >
       <path d="M0 0l115 115h15l12 27 108 108V0z" fill="#6c6c6c" />
       <path
-        className="octo-arm"
         d="M128 109c-15-9-9-19-9-19 3-7 2-11 2-11-1-7 3-2 3-2 4 5 2 11 2 11-3 10 5 15 9 16"
         transform-origin="130px 106px"
         fill="#fff"
       />
       <path
-        className="octo-body"
         d="M115 115s4 2 5 0l14-14c3-2 6-3 8-3-8-11-15-24 2-41 5-5 10-7 16-7 1-2 3-7 12-11 0 0 5 3 7 16 4 2 8 5 12 9s7 8 9 12c14 3 17 7 17 7-4 8-9 11-11 11 0 6-2 11-7 16-16 16-30 10-41 2 0 3-1 7-5 11l-12 11c-1 1 1 5 1 5z"
         fill="#fff"
       />

--- a/src/components/GitHubCorner.tsx
+++ b/src/components/GitHubCorner.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+
+// https://github.com/tholman/github-corners
+
+export default () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="40"
+    height="40"
+    viewBox="0 0 250 250"
+    style={{
+      position: "relative",
+      left: "var(--margin)",
+      bottom: "var(--margin)",
+    }}
+  >
+    <a
+      href="https://github.com/excalidraw/excalidraw"
+      target="_blank"
+      rel="noopener noreferrer"
+      aria-label="GitHub repository"
+    >
+      <path d="M0 0l115 115h15l12 27 108 108V0z" fill="#6c6c6c" />
+      <path
+        className="octo-arm"
+        d="M128 109c-15-9-9-19-9-19 3-7 2-11 2-11-1-7 3-2 3-2 4 5 2 11 2 11-3 10 5 15 9 16"
+        transform-origin="130px 106px"
+        fill="#fff"
+      />
+      <path
+        className="octo-body"
+        d="M115 115s4 2 5 0l14-14c3-2 6-3 8-3-8-11-15-24 2-41 5-5 10-7 16-7 1-2 3-7 12-11 0 0 5 3 7 16 4 2 8 5 12 9s7 8 9 12c14 3 17 7 17 7-4 8-9 11-11 11 0 6-2 11-7 16-16 16-30 10-41 2 0 3-1 7-5 11l-12 11c-1 1 1 5 1 5z"
+        fill="#fff"
+      />
+    </a>
+  </svg>
+);

--- a/src/components/LayerUI.tsx
+++ b/src/components/LayerUI.tsx
@@ -129,7 +129,7 @@ export const LayerUI = React.memo(
             </Stack.Col>
             <Section heading="shapes">
               {heading => (
-                <Stack.Col gap={4} align="start">
+                <Stack.Col gap={4} align="center">
                   <Stack.Row gap={1}>
                     <Island padding={1}>
                       {heading}

--- a/src/components/LayerUI.tsx
+++ b/src/components/LayerUI.tsx
@@ -21,6 +21,7 @@ import { ExportType } from "../scene/types";
 import { MobileMenu } from "./MobileMenu";
 import { ZoomActions, SelectedShapeActions, ShapesSwitcher } from "./Actions";
 import { Section } from "./Section";
+import GitHubCorner from "./GitHubCorner";
 
 interface LayerUIProps {
   actionManager: ActionManager;
@@ -159,7 +160,7 @@ export const LayerUI = React.memo(
                 </Stack.Col>
               )}
             </Section>
-            <div />
+            <GitHubCorner />
           </div>
           <div className="App-menu App-menu_bottom">
             <Stack.Col gap={2}>

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -189,7 +189,7 @@ button,
 }
 
 .App-menu_top {
-  grid-template-columns: auto 1fr;
+  grid-template-columns: auto 1fr auto;
   align-items: flex-start;
   cursor: default;
   pointer-events: none !important;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -189,7 +189,7 @@ button,
 }
 
 .App-menu_top {
-  grid-template-columns: 1fr auto 1fr;
+  grid-template-columns: auto 1fr;
   align-items: flex-start;
   cursor: default;
   pointer-events: none !important;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -364,9 +364,6 @@ button,
 }
 
 @media (max-width: 600px), (max-height: 500px) and (max-width: 1000px) {
-  aside {
-    display: none;
-  }
   .scroll-back-to-content {
     bottom: 80px;
     bottom: calc(80px + env(safe-area-inset-bottom));


### PR DESCRIPTION
Fixes #896. I can also change this to ignore the 🔒 button for the purposes of alignment.