### PR TITLE
filter out selection elements on restore

### DIFF
--- a/src/data/restore.ts
+++ b/src/data/restore.ts
@@ -13,7 +13,9 @@ export function restore(
   opts?: { scrollToContent: boolean },
 ): DataState {
   const elements = savedElements
-    .filter(el => !isInvisiblySmallElement(el))
+    .filter(el => {
+      return el.type !== "selection" && !isInvisiblySmallElement(el);
+    })
     .map(element => {
       let points: Point[] = [];
       if (element.type === "arrow") {

--- a/src/data/restore.ts
+++ b/src/data/restore.ts
@@ -14,6 +14,8 @@ export function restore(
 ): DataState {
   const elements = savedElements
     .filter(el => {
+      // filtering out selection, which is legacy, no longer kept in elements,
+      //  and causing issues if retained
       return el.type !== "selection" && !isInvisiblySmallElement(el);
     })
     .map(element => {


### PR DESCRIPTION
fixes https://github.com/excalidraw/excalidraw/issues/900

~~before merge, I'll quickly check whether we want to also remove it from `appState` where we stored selection for a while IIRC.~~ nvm, we still do that :).