### PR TITLE
Clean up `mutateElement`

### DIFF
--- a/src/actions/actionFinalize.tsx
+++ b/src/actions/actionFinalize.tsx
@@ -19,11 +19,11 @@ export const actionFinalize = register({
     if (appState.multiElement) {
       // pen and mouse have hover
       if (appState.lastPointerDownWith !== "touch") {
-        mutateElement(appState.multiElement, multiElement => {
-          multiElement.points = multiElement.points.slice(
+        mutateElement(appState.multiElement, {
+          points: appState.multiElement.points.slice(
             0,
-            multiElement.points.length - 1,
-          );
+            appState.multiElement.points.length - 1,
+          ),
         });
       }
       if (isInvisiblySmallElement(appState.multiElement)) {

--- a/src/actions/actionProperties.tsx
+++ b/src/actions/actionProperties.tsx
@@ -11,6 +11,7 @@ import { AppState } from "../../src/types";
 import { t } from "../i18n";
 import { DEFAULT_FONT } from "../appState";
 import { register } from "./register";
+import { newElementWith, newTextElementWith } from "../element/mutateElement";
 
 const changeProperty = (
   elements: readonly ExcalidrawElement[],
@@ -45,10 +46,11 @@ export const actionChangeStrokeColor = register({
   name: "changeStrokeColor",
   perform: (elements, appState, value) => {
     return {
-      elements: changeProperty(elements, appState, el => ({
-        ...el,
-        strokeColor: value,
-      })),
+      elements: changeProperty(elements, appState, el =>
+        newElementWith(el, {
+          strokeColor: value,
+        }),
+      ),
       appState: { ...appState, currentItemStrokeColor: value },
     };
   },
@@ -75,10 +77,11 @@ export const actionChangeBackgroundColor = register({
   name: "changeBackgroundColor",
   perform: (elements, appState, value) => {
     return {
-      elements: changeProperty(elements, appState, el => ({
-        ...el,
-        backgroundColor: value,
-      })),
+      elements: changeProperty(elements, appState, el =>
+        newElementWith(el, {
+          backgroundColor: value,
+        }),
+      ),
       appState: { ...appState, currentItemBackgroundColor: value },
     };
   },
@@ -105,10 +108,11 @@ export const actionChangeFillStyle = register({
   name: "changeFillStyle",
   perform: (elements, appState, value) => {
     return {
-      elements: changeProperty(elements, appState, el => ({
-        ...el,
-        fillStyle: value,
-      })),
+      elements: changeProperty(elements, appState, el =>
+        newElementWith(el, {
+          fillStyle: value,
+        }),
+      ),
       appState: { ...appState, currentItemFillStyle: value },
     };
   },
@@ -141,10 +145,11 @@ export const actionChangeStrokeWidth = register({
   name: "changeStrokeWidth",
   perform: (elements, appState, value) => {
     return {
-      elements: changeProperty(elements, appState, el => ({
-        ...el,
-        strokeWidth: value,
-      })),
+      elements: changeProperty(elements, appState, el =>
+        newElementWith(el, {
+          strokeWidth: value,
+        }),
+      ),
       appState: { ...appState, currentItemStrokeWidth: value },
     };
   },
@@ -175,10 +180,11 @@ export const actionChangeSloppiness = register({
   name: "changeSloppiness",
   perform: (elements, appState, value) => {
     return {
-      elements: changeProperty(elements, appState, el => ({
-        ...el,
-        roughness: value,
-      })),
+      elements: changeProperty(elements, appState, el =>
+        newElementWith(el, {
+          roughness: value,
+        }),
+      ),
       appState: { ...appState, currentItemRoughness: value },
     };
   },
@@ -209,10 +215,11 @@ export const actionChangeOpacity = register({
   name: "changeOpacity",
   perform: (elements, appState, value) => {
     return {
-      elements: changeProperty(elements, appState, el => ({
-        ...el,
-        opacity: value,
-      })),
+      elements: changeProperty(elements, appState, el =>
+        newElementWith(el, {
+          opacity: value,
+        }),
+      ),
       appState: { ...appState, currentItemOpacity: value },
     };
   },
@@ -259,10 +266,9 @@ export const actionChangeFontSize = register({
     return {
       elements: changeProperty(elements, appState, el => {
         if (isTextElement(el)) {
-          const element: ExcalidrawTextElement = {
-            ...el,
+          const element: ExcalidrawTextElement = newTextElementWith(el, {
             font: `${value}px ${el.font.split("px ")[1]}`,
-          };
+          });
           redrawTextBoundingBox(element);
           return element;
         }
@@ -307,10 +313,9 @@ export const actionChangeFontFamily = register({
     return {
       elements: changeProperty(elements, appState, el => {
         if (isTextElement(el)) {
-          const element: ExcalidrawTextElement = {
-            ...el,
+          const element: ExcalidrawTextElement = newTextElementWith(el, {
             font: `${el.font.split("px ")[0]}px ${value}`,
-          };
+          });
           redrawTextBoundingBox(element);
           return element;
         }

--- a/src/actions/actionStyles.ts
+++ b/src/actions/actionStyles.ts
@@ -6,7 +6,7 @@ import {
 import { KEYS } from "../keys";
 import { DEFAULT_FONT } from "../appState";
 import { register } from "./register";
-import { mutateTextElement } from "../element/mutateElement";
+import { mutateTextElement, newElementWith } from "../element/mutateElement";
 
 let copiedStyles: string = "{}";
 
@@ -35,20 +35,19 @@ export const actionPasteStyles = register({
     return {
       elements: elements.map(element => {
         if (appState.selectedElementIds[element.id]) {
-          const newElement = {
-            ...element,
+          const newElement = newElementWith(element, {
             backgroundColor: pastedElement?.backgroundColor,
             strokeWidth: pastedElement?.strokeWidth,
             strokeColor: pastedElement?.strokeColor,
             fillStyle: pastedElement?.fillStyle,
             opacity: pastedElement?.opacity,
             roughness: pastedElement?.roughness,
-          };
+          });
           if (isTextElement(newElement)) {
-            mutateTextElement(newElement, newElement => {
-              newElement.font = pastedElement?.font || DEFAULT_FONT;
-              redrawTextBoundingBox(newElement);
+            mutateTextElement(newElement, {
+              font: pastedElement?.font || DEFAULT_FONT,
             });
+            redrawTextBoundingBox(newElement);
           }
           return newElement;
         }

--- a/src/data/restore.ts
+++ b/src/data/restore.ts
@@ -48,6 +48,7 @@ export function restore(
 
       return {
         ...element,
+        version: element.id ? element.version + 1 : element.version || 0,
         id: element.id || nanoid(),
         fillStyle: element.fillStyle || "hachure",
         strokeWidth: element.strokeWidth || 1,

--- a/src/element/mutateElement.ts
+++ b/src/element/mutateElement.ts
@@ -1,26 +1,42 @@
-import {
-  MutableExcalidrawElement,
-  MutableExcalidrawTextElement,
-} from "./types";
+import { ExcalidrawElement, ExcalidrawTextElement } from "./types";
+
+type ElementUpdate<TElement extends ExcalidrawElement> = Omit<
+  Partial<TElement>,
+  "id" | "seed"
+>;
 
 // This function tracks updates of text elements for the purposes for collaboration.
 // The version is used to compare updates when more than one user is working in
 // the same drawing.
 export function mutateElement(
-  element: MutableExcalidrawElement,
-  callback: (mutatableElement: MutableExcalidrawElement) => void,
-): void {
-  element.version++;
-  callback(element);
+  element: ExcalidrawElement,
+  updates: ElementUpdate<ExcalidrawElement>,
+) {
+  Object.assign(element, updates);
+  (element as any).version++;
+}
+
+export function newElementWith(
+  element: ExcalidrawElement,
+  updates: ElementUpdate<ExcalidrawElement>,
+): ExcalidrawElement {
+  return { ...element, ...updates, version: element.version + 1 };
 }
 
 // This function tracks updates of text elements for the purposes for collaboration.
 // The version is used to compare updates when more than one user is working in
 // the same document.
 export function mutateTextElement(
-  element: MutableExcalidrawTextElement,
-  callback: (mutatableElement: MutableExcalidrawTextElement) => void,
+  element: ExcalidrawTextElement,
+  updates: ElementUpdate<ExcalidrawTextElement>,
 ): void {
-  element.version++;
-  callback(element);
+  Object.assign(element, updates);
+  (element as any).version++;
+}
+
+export function newTextElementWith(
+  element: ExcalidrawTextElement,
+  updates: ElementUpdate<ExcalidrawTextElement>,
+): ExcalidrawTextElement {
+  return { ...element, ...updates, version: element.version + 1 };
 }

--- a/src/element/sizeHelpers.ts
+++ b/src/element/sizeHelpers.ts
@@ -1,4 +1,4 @@
-import { ExcalidrawElement, MutableExcalidrawElement } from "./types";
+import { ExcalidrawElement } from "./types";
 import { invalidateShapeForElement } from "../renderer/renderElement";
 import { mutateElement } from "./mutateElement";
 
@@ -36,7 +36,7 @@ export function getPerfectElementSize(
 }
 
 export function resizePerfectLineForNWHandler(
-  element: MutableExcalidrawElement,
+  element: ExcalidrawElement,
   x: number,
   y: number,
 ) {
@@ -45,21 +45,28 @@ export function resizePerfectLineForNWHandler(
   const distanceToAnchorX = x - anchorX;
   const distanceToAnchorY = y - anchorY;
   if (Math.abs(distanceToAnchorX) < Math.abs(distanceToAnchorY) / 2) {
-    element.x = anchorX;
-    element.width = 0;
-    element.y = y;
-    element.height = -distanceToAnchorY;
+    mutateElement(element, {
+      x: anchorX,
+      width: 0,
+      y,
+      height: -distanceToAnchorY,
+    });
   } else if (Math.abs(distanceToAnchorY) < Math.abs(element.width) / 2) {
-    element.y = anchorY;
-    element.height = 0;
+    mutateElement(element, {
+      y: anchorY,
+      height: 0,
+    });
   } else {
-    element.x = x;
-    element.width = -distanceToAnchorX;
-    element.height =
+    const nextHeight =
       Math.sign(distanceToAnchorY) *
       Math.sign(distanceToAnchorX) *
       element.width;
-    element.y = anchorY - element.height;
+    mutateElement(element, {
+      x,
+      y: anchorY - nextHeight,
+      width: -distanceToAnchorX,
+      height: nextHeight,
+    });
   }
 }
 
@@ -79,16 +86,18 @@ export function normalizeDimensions(
   }
 
   if (element.width < 0) {
-    mutateElement(element, element => {
-      element.width = Math.abs(element.width);
-      element.x -= element.width;
+    const nextWidth = Math.abs(element.width);
+    mutateElement(element, {
+      width: nextWidth,
+      x: element.x - nextWidth,
     });
   }
 
   if (element.height < 0) {
-    mutateElement(element, element => {
-      element.height = Math.abs(element.height);
-      element.y -= element.height;
+    const nextHeight = Math.abs(element.height);
+    mutateElement(element, {
+      height: nextHeight,
+      y: element.y - nextHeight,
     });
   }
 

--- a/src/element/textElement.ts
+++ b/src/element/textElement.ts
@@ -1,11 +1,12 @@
 import { measureText } from "../utils";
-import { MutableExcalidrawTextElement } from "./types";
+import { ExcalidrawTextElement } from "./types";
+import { mutateTextElement } from "./mutateElement";
 
-export const redrawTextBoundingBox = (
-  element: MutableExcalidrawTextElement,
-) => {
+export const redrawTextBoundingBox = (element: ExcalidrawTextElement) => {
   const metrics = measureText(element.text, element.font);
-  element.width = metrics.width;
-  element.height = metrics.height;
-  element.baseline = metrics.baseline;
+  mutateTextElement(element, {
+    width: metrics.width,
+    height: metrics.height,
+    baseline: metrics.baseline,
+  });
 };

--- a/src/element/types.ts
+++ b/src/element/types.ts
@@ -6,17 +6,15 @@ import { newElement } from "./newElement";
  * between peers and contain no state local to the peer.
  */
 export type ExcalidrawElement = Readonly<ReturnType<typeof newElement>>;
-export type MutableExcalidrawElement = ReturnType<typeof newElement>;
 
-export type MutableExcalidrawTextElement = MutableExcalidrawElement & {
-  type: "text";
-  font: string;
-  text: string;
-  // for backward compatibility
-  actualBoundingBoxAscent?: number;
-  baseline: number;
-};
-
-export type ExcalidrawTextElement = Readonly<MutableExcalidrawTextElement>;
+export type ExcalidrawTextElement = ExcalidrawElement &
+  Readonly<{
+    type: "text";
+    font: string;
+    text: string;
+    // for backward compatibility
+    actualBoundingBoxAscent?: number;
+    baseline: number;
+  }>;
 
 export type PointerType = "mouse" | "pen" | "touch";

--- a/src/history.ts
+++ b/src/history.ts
@@ -1,6 +1,7 @@
 import { AppState } from "./types";
 import { ExcalidrawElement } from "./element/types";
 import { clearAppStatePropertiesForHistory } from "./appState";
+import { newElementWith } from "./element/mutateElement";
 
 type Result = {
   appState: AppState;
@@ -18,13 +19,14 @@ export class SceneHistory {
   ) {
     return JSON.stringify({
       appState: clearAppStatePropertiesForHistory(appState),
-      elements: elements.map(element => ({
-        ...element,
-        points:
-          appState.multiElement && appState.multiElement.id === element.id
-            ? element.points.slice(0, -1)
-            : element.points,
-      })),
+      elements: elements.map(element =>
+        newElementWith(element, {
+          points:
+            appState.multiElement && appState.multiElement.id === element.id
+              ? element.points.slice(0, -1)
+              : element.points,
+        }),
+      ),
     });
   }
 


### PR DESCRIPTION
I'm still not satisfied with how things are but this makes things a bit better :)

#898 merged in a few changes that I had made that I wasn't quite ready to commit to master :) There were two issues:
* `mutateElement` was a little awkward to use and allocated an extra closure which was wasteful (though probably didn't cause noticeable perf issues)
* We often clone elements and change their properties by doing `{...element, someProp: someValue}`. The issue with this is the `id` of the element will stay the same, but despite the element changing, `version` is not automatically updated. I added a new function to abstract away this pattern.

I do think we'd be better off at this point having ExcalidrawElement as a class, but I'm not 100% certain of it. Looking for feedback!

Test plan: 
* Updated and ran the test plan in #895
* Ran unit tests
* `git grep '\.\.\.el' src/`, make sure that every place where an element is spread the version number is updated appropriately (there was one case where we shouldn't do this, in `restore.ts`)