### PR TITLE
cancel text via doubleclick when in multiElement mode

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -777,6 +777,12 @@ export class App extends React.Component<any, AppState> {
   private handleCanvasDoubleClick = (
     event: React.MouseEvent<HTMLCanvasElement>,
   ) => {
+    // case: double-clicking with arrow/line tool selected would both create
+    //  text and enter multiElement mode
+    if (this.state.multiElement) {
+      return;
+    }
+
     resetCursor();
 
     const { x, y } = viewportCoordsToSceneCoords(


### PR DESCRIPTION
Partially helps with https://github.com/excalidraw/excalidraw/issues/740.

In the case of arrow/line, when you doubleclick with that shape selected it creates both, and the arrow/line ends up in some undefined state that throws.

This PR prevents creating text via doubleclick when in `multiElement` mode, which fixes this.

Test plan:

1. select `arrow` shape
2. double-click
3. create another arrow point
3. check console