### PR TITLE
remove object.fromEntries

### DIFF
--- a/src/actions/actionSelectAll.ts
+++ b/src/actions/actionSelectAll.ts
@@ -7,9 +7,10 @@ export const actionSelectAll = register({
     return {
       appState: {
         ...appState,
-        selectedElementIds: Object.fromEntries(
-          elements.map(element => [element.id, true]),
-        ),
+        selectedElementIds: elements.reduce((map, element) => {
+          map[element.id] = true;
+          return map;
+        }, {} as any),
       },
     };
   },

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1872,9 +1872,10 @@ export class App extends React.Component<any, AppState> {
         this.setState(prevState => ({
           selectedElementIds: {
             ...prevState.selectedElementIds,
-            ...Object.fromEntries(
-              elementsWithinSelection.map(element => [element.id, true]),
-            ),
+            ...elementsWithinSelection.reduce((map, element) => {
+              map[element.id] = true;
+              return map;
+            }, {} as any),
           },
         }));
       }
@@ -2088,9 +2089,10 @@ export class App extends React.Component<any, AppState> {
     elements = [...elements, ...newElements];
     history.resumeRecording();
     this.setState({
-      selectedElementIds: Object.fromEntries(
-        newElements.map(element => [element.id, true]),
-      ),
+      selectedElementIds: newElements.reduce((map, element) => {
+        map[element.id] = true;
+        return map;
+      }, {} as any),
     });
   };
 

--- a/src/element/newElement.ts
+++ b/src/element/newElement.ts
@@ -98,7 +98,9 @@ function _duplicateElement(val: any, depth: number = 0) {
   return val;
 }
 
-export function duplicateElement(element: ReturnType<typeof newElement>) {
+export function duplicateElement(
+  element: ReturnType<typeof newElement>,
+): ReturnType<typeof newElement> {
   const copy = _duplicateElement(element);
   copy.id = nanoid();
   copy.seed = randomSeed();


### PR DESCRIPTION
fixes https://github.com/excalidraw/excalidraw/issues/931

This bug occurs in browsers we probably don't officially support, but `Object.fromEntries` is ES2020, so it's rather new. That said, replacing it with `Array#reduce` will arguably improve perf for little cost, so I say let's fix this.