### PR TITLE
use deletedIds map to sync deletions

### DIFF
--- a/src/appState.ts
+++ b/src/appState.ts
@@ -34,6 +34,7 @@ export function getDefaultAppState(): AppState {
     openMenu: null,
     lastPointerDownWith: "mouse",
     selectedElementIds: {},
+    deletedIds: {},
     collaborators: new Map(),
   };
 }

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -309,8 +309,8 @@ export class App extends React.Component<any, AppState> {
                 )) {
                   if (
                     !localElementMap[id] ||
-                    // don't remove local element if we've local is newer than
-                    //  the one deleted on remote
+                    // don't remove local element if it's newer than the one
+                    //  deleted on remote
                     remoteDeletedEl.version >= localElementMap[id].version
                   ) {
                     deletedIds[id] = remoteDeletedEl;
@@ -410,7 +410,7 @@ export class App extends React.Component<any, AppState> {
     }
   };
 
-  // brands socketData to ensure we using the getSocketData() helper
+  // brands socketData to ensure we're using the getSocketData() helper
   private _getSocketData<T>(data: T): T & { _brand: "socketData" } {
     return data as typeof data & { _brand: "socketData" };
   }

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -30,6 +30,19 @@ export type EncryptedData = {
   iv: Uint8Array;
 };
 
+// internal, don't use
+export type SocketUpdateDataSource = {
+  SCENE_UPDATE: {
+    type: "SCENE_UPDATE";
+  };
+  MOUSE_LOCATION: {
+    type: "MOUSE_LOCATION";
+    payload: {
+      pointerCoords: { x: number; y: number };
+    };
+  };
+};
+
 export type SocketUpdateData =
   | {
       type: "SCENE_UPDATE";
@@ -42,9 +55,12 @@ export type SocketUpdateData =
       type: "MOUSE_LOCATION";
       payload: {
         socketID: string;
-        pointerCoords: { x: number; y: number };
+        pointerCoords: SocketUpdateDataSource["MOUSE_LOCATION"]["payload"]["pointerCoords"];
       };
-    }
+    };
+
+export type SocketUpdateDataIncoming =
+  | SocketUpdateData
   | {
       type: "INVALID_RESPONSE";
     };
@@ -137,7 +153,7 @@ export async function decryptAESGEM(
   data: ArrayBuffer,
   key: string,
   iv: Uint8Array,
-): Promise<SocketUpdateData> {
+): Promise<SocketUpdateDataIncoming> {
   try {
     const importedKey = await getImportedKey(key, "decrypt");
     const decrypted = await window.crypto.subtle.decrypt(

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -35,7 +35,7 @@ export type SocketUpdateData =
       type: "SCENE_UPDATE";
       payload: {
         elements: readonly ExcalidrawElement[];
-        appState: AppState | null;
+        appState: Pick<AppState, "viewBackgroundColor" | "name" | "deletedIds">;
       };
     }
   | {

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -30,8 +30,7 @@ export type EncryptedData = {
   iv: Uint8Array;
 };
 
-// internal, don't use
-export type SocketUpdateDataSource = {
+type _SocketUpdateDataSource = {
   SCENE_UPDATE: {
     type: "SCENE_UPDATE";
   };
@@ -43,7 +42,9 @@ export type SocketUpdateDataSource = {
   };
 };
 
-export type SocketUpdateData =
+export type SocketUpdateDataSource = _SocketUpdateDataSource[keyof _SocketUpdateDataSource];
+
+export type SocketUpdateDataIncoming =
   | {
       type: "SCENE_UPDATE";
       payload: {
@@ -55,12 +56,9 @@ export type SocketUpdateData =
       type: "MOUSE_LOCATION";
       payload: {
         socketID: string;
-        pointerCoords: SocketUpdateDataSource["MOUSE_LOCATION"]["payload"]["pointerCoords"];
+        pointerCoords: _SocketUpdateDataSource["MOUSE_LOCATION"]["payload"]["pointerCoords"];
       };
-    };
-
-export type SocketUpdateDataIncoming =
-  | SocketUpdateData
+    }
   | {
       type: "INVALID_RESPONSE";
     };

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -30,35 +30,25 @@ export type EncryptedData = {
   iv: Uint8Array;
 };
 
-type _SocketUpdateDataSource = {
+export type SocketUpdateDataSource = {
   SCENE_UPDATE: {
     type: "SCENE_UPDATE";
+    payload: {
+      elements: readonly ExcalidrawElement[];
+      appState: Pick<AppState, "viewBackgroundColor" | "name" | "deletedIds">;
+    };
   };
   MOUSE_LOCATION: {
     type: "MOUSE_LOCATION";
     payload: {
+      socketID: string;
       pointerCoords: { x: number; y: number };
     };
   };
 };
 
-export type SocketUpdateDataSource = _SocketUpdateDataSource[keyof _SocketUpdateDataSource];
-
 export type SocketUpdateDataIncoming =
-  | {
-      type: "SCENE_UPDATE";
-      payload: {
-        elements: readonly ExcalidrawElement[];
-        appState: Pick<AppState, "viewBackgroundColor" | "name" | "deletedIds">;
-      };
-    }
-  | {
-      type: "MOUSE_LOCATION";
-      payload: {
-        socketID: string;
-        pointerCoords: _SocketUpdateDataSource["MOUSE_LOCATION"]["payload"]["pointerCoords"];
-      };
-    }
+  | SocketUpdateDataSource[keyof SocketUpdateDataSource]
   | {
       type: "INVALID_RESPONSE";
     };

--- a/src/data/restore.ts
+++ b/src/data/restore.ts
@@ -52,7 +52,7 @@ export function restore(
 
       return {
         ...element,
-        version: element.id ? element.version + 1 : element.version || 0,
+        version: element.version || 0,
         id: element.id || nanoid(),
         fillStyle: element.fillStyle || "hachure",
         strokeWidth: element.strokeWidth || 1,

--- a/src/scene/selection.ts
+++ b/src/scene/selection.ts
@@ -34,11 +34,24 @@ export function deleteSelectedElements(
   elements: readonly ExcalidrawElement[],
   appState: AppState,
 ) {
+  const deletedIds: AppState["deletedIds"] = {};
   return {
-    elements: elements.filter(el => !appState.selectedElementIds[el.id]),
+    elements: elements.filter(el => {
+      if (appState.selectedElementIds[el.id]) {
+        deletedIds[el.id] = {
+          version: el.version,
+        };
+        return false;
+      }
+      return true;
+    }),
     appState: {
       ...appState,
       selectedElementIds: {},
+      deletedIds: {
+        ...appState.deletedIds,
+        ...deletedIds,
+      },
     },
   };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,6 +34,7 @@ export type AppState = {
   openMenu: "canvas" | "shape" | null;
   lastPointerDownWith: PointerType;
   selectedElementIds: { [id: string]: boolean };
+  deletedIds: { [id: string]: { version: ExcalidrawElement["version"] } };
   collaborators: Map<string, { pointer?: { x: number; y: number } }>;
 };
 


### PR DESCRIPTION
Moved to semi-tombstone architecture for syncing deletions: a map of deleted ids and version at time of deletion. Element is removed on local only if remote deletion has same or newer version than local version. For this reason I removed the `version` incrementing during restore, because that would break this (I also don't see why we did that to begin with).

Also, from now on we're syncing only selected props from `AppState` because we won't want to use any other. Currently I'm sending some props but not doing anything with them yet. Will do so later, and also refactor it a bit.

Don't merge yet. I'm not confident this is correct + I want to make some refactor.