### PR TITLE
Make selection handle resolution independent

### DIFF
--- a/src/renderer/renderScene.ts
+++ b/src/renderer/renderScene.ts
@@ -155,12 +155,15 @@ export function renderScene(
 
       const initialLineDash = context.getLineDash();
       context.setLineDash([8 / sceneState.zoom, 4 / sceneState.zoom]);
+      const lineWidth = context.lineWidth;
+      context.lineWidth = 1 / sceneState.zoom;
       context.strokeRect(
         elementX1 - dashledLinePadding,
         elementY1 - dashledLinePadding,
         elementWidth + dashledLinePadding * 2,
         elementHeight + dashledLinePadding * 2,
       );
+      context.lineWidth = lineWidth;
       context.setLineDash(initialLineDash);
     });
     resetZoom(context);
@@ -174,8 +177,11 @@ export function renderScene(
       Object.values(handlers)
         .filter(handler => handler !== undefined)
         .forEach(handler => {
+          const lineWidth = context.lineWidth;
+          context.lineWidth = 1 / sceneState.zoom;
           context.fillRect(handler[0], handler[1], handler[2], handler[3]);
           context.strokeRect(handler[0], handler[1], handler[2], handler[3]);
+          context.lineWidth = lineWidth;
         });
       resetZoom(context);
     }


### PR DESCRIPTION
They shouldn't really change when zooming in or out.

Before:
![ezgif-3-aa54ad3b7a69](https://user-images.githubusercontent.com/197597/76690288-d00e0d80-65fb-11ea-8c2c-a79365507c49.gif)


After:
![ezgif-3-fd7f57616ef8](https://user-images.githubusercontent.com/197597/76690276-c08ec480-65fb-11ea-8907-9f1bae82812b.gif)

