### PR TITLE
Stop using getTransform

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -2215,6 +2215,7 @@ export class App extends React.Component<any, AppState> {
       elements,
       this.state,
       this.state.selectionElement,
+      window.devicePixelRatio,
       this.rc!,
       this.canvas!,
       {

--- a/src/renderer/renderElement.ts
+++ b/src/renderer/renderElement.ts
@@ -303,6 +303,10 @@ export function renderElement(
       context.fillStyle = "rgba(0, 0, 255, 0.10)";
       context.fillRect(0, 0, element.width, element.height);
       context.fillStyle = fillStyle;
+      context.translate(
+        -element.x - sceneState.scrollX,
+        -element.y - sceneState.scrollY,
+      );
       break;
     }
     case "rectangle":

--- a/src/scene/export.ts
+++ b/src/scene/export.ts
@@ -42,6 +42,7 @@ export function exportToCanvas(
     elements,
     appState,
     null,
+    scale,
     rough.canvas(tempCanvas),
     tempCanvas,
     {

--- a/src/scene/index.ts
+++ b/src/scene/index.ts
@@ -17,4 +17,4 @@ export {
   hasText,
 } from "./comparisons";
 export { createScene } from "./createScene";
-export { getZoomOrigin, getZoomTranslation, getNormalizedZoom } from "./zoom";
+export { getZoomOrigin, getNormalizedZoom } from "./zoom";

--- a/src/scene/zoom.ts
+++ b/src/scene/zoom.ts
@@ -16,19 +16,6 @@ export function getZoomOrigin(canvas: HTMLCanvasElement | null) {
   };
 }
 
-export function getZoomTranslation(canvas: HTMLCanvasElement, zoom: number) {
-  const diffMiddleOfTheCanvas = {
-    x: (canvas.width / 2) * (zoom - 1),
-    y: (canvas.height / 2) * (zoom - 1),
-  };
-
-  // Due to JavaScript float precision, we fix to fix decimals count to have symmetric zoom
-  return {
-    x: parseFloat(diffMiddleOfTheCanvas.x.toFixed(8)),
-    y: parseFloat(diffMiddleOfTheCanvas.y.toFixed(8)),
-  };
-}
-
 export function getNormalizedZoom(zoom: number): number {
   const normalizedZoom = parseFloat(zoom.toFixed(2));
   const clampedZoom = Math.max(0.1, Math.min(normalizedZoom, 2));


### PR DESCRIPTION
Fixes #861

The original motivation behind this is to make it work with Firefox. But it also helped make the code more intentional.

Test Plan:
- Create one square, select it, zoom in repeatedly, make sure that it zooms centered in the screen and everything looks good
- Scroll at various zoom levels, things look good
- Export a small scene at 1x and 3x, make sure the background is properly set and look good