### PR TITLE
Show confirmation dialog before the user closes a collaborative session

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -522,6 +522,8 @@ export class App extends React.Component<any, AppState> {
     }
     const scene = await loadScene(null);
     this.syncActionResult(scene);
+
+    window.addEventListener("beforeunload", this.beforeUnload);
   }
 
   public componentWillUnmount() {
@@ -554,6 +556,7 @@ export class App extends React.Component<any, AppState> {
       false,
     );
     document.removeEventListener("gestureend", this.onGestureEnd as any, false);
+    window.removeEventListener("beforeunload", this.beforeUnload);
   }
 
   public state: AppState = getDefaultAppState();
@@ -2178,6 +2181,17 @@ export class App extends React.Component<any, AppState> {
       scrollX: normalizeScroll(scrollX - deltaX / zoom),
       scrollY: normalizeScroll(scrollY - deltaY / zoom),
     }));
+  };
+
+  private beforeUnload = (event: BeforeUnloadEvent) => {
+    if (
+      this.state.isCollaborating &&
+      hasNonDeletedElements(globalSceneState.getAllElements())
+    ) {
+      event.preventDefault();
+      // NOTE: modern browsers no longer allow showing a custom message here
+      event.returnValue = "";
+    }
   };
 
   private addElementsFromPaste = (


### PR DESCRIPTION
After accidentally closing a multiplayer session, my natural reaction is to just reopen the page. However, if I was the last or only user in the session, the reopened page will be empty. The reopened page overwrites my local history so https://excalidraw.com/ is empty too.

![ezgif-1-8ddf273c636f](https://user-images.githubusercontent.com/2268452/76696314-2e141280-6647-11ea-9ccc-e12dae6eb881.gif)

I know there's already a "if all of you disconnect, you will loose the data" warning when I start a multiplayer session, but... the warning doesn't stop me from fat-fingering the close button. So I think it'd be useful to show a confirmation before the user closes or refreshes the page.

NOTE: ideally this prompt is only shown when there has been changes since the last save/export, but I can't seem to find a clean way to do this (marking the app state as "dirty"). But I think this could still be a good start?

Test Plan:
<img width="532" alt="Screen Shot 2020-03-14 at 10 36 58 PM" src="https://user-images.githubusercontent.com/2268452/76696354-b85c7680-6647-11ea-8edf-e8ef45baf8cd.png">
<img width="832" alt="Screen Shot 2020-03-14 at 10 36 39 PM" src="https://user-images.githubusercontent.com/2268452/76696355-ba263a00-6647-11ea-81dd-6e16e955e32b.png">
<img width="532" alt="Screen Shot 2020-03-14 at 10 36 15 PM" src="https://user-images.githubusercontent.com/2268452/76696356-bb576700-6647-11ea-9eca-9e5c04c2c152.png">
