### PR TITLE
Revert "[RFC] Randomized names next to mouse pointers."

### DIFF
--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -43,7 +43,6 @@ export type SocketUpdateDataSource = {
     payload: {
       socketID: string;
       pointerCoords: { x: number; y: number };
-      username: string;
     };
   };
 };
@@ -359,94 +358,4 @@ export async function loadScene(id: string | null, privateKey?: string) {
     elements: data.elements,
     appState: data.appState && { ...data.appState },
   };
-}
-
-const ADJ = [
-  "aggressive",
-  "agreeable",
-  "ambitious",
-  "brave",
-  "calm",
-  "delightful",
-  "eager",
-  "faithful",
-  "gentle",
-  "happy",
-  "jolly",
-  "kind",
-  "lively",
-  "nice",
-  "obedient",
-  "polite",
-  "proud",
-  "silly",
-  "thankful",
-  "victorious",
-  "witty",
-  "wonderful",
-  "zealous",
-];
-
-const NOUN = [
-  "alligator",
-  "ant",
-  "bear",
-  "bee",
-  "bird",
-  "camel",
-  "cat",
-  "cheetah",
-  "chicken",
-  "chimpanzee",
-  "cow",
-  "crocodile",
-  "deer",
-  "dog",
-  "dolphin",
-  "duck",
-  "eagle",
-  "elephant",
-  "fish",
-  "fly",
-  "fox",
-  "frog",
-  "giraffe",
-  "goat",
-  "goldfish",
-  "hamster",
-  "hippopotamus",
-  "horse",
-  "kangaroo",
-  "kitten",
-  "lion",
-  "lobster",
-  "monkey",
-  "octopus",
-  "owl",
-  "panda",
-  "pig",
-  "puppy",
-  "rabbit",
-  "rat",
-  "scorpion",
-  "seal",
-  "shark",
-  "sheep",
-  "snail",
-  "snake",
-  "spider",
-  "squirrel",
-  "tiger",
-  "turtle",
-  "wolf",
-  "zebra",
-];
-
-export function createNameFromSocketId(socketId: string) {
-  const buf = new Buffer(socketId, "utf8");
-
-  return [
-    ADJ[buf.readUInt32LE(0) % ADJ.length],
-    NOUN[buf.readUInt32LE(4) % NOUN.length],
-  ].join(" ");
 }

--- a/src/renderer/renderScene.ts
+++ b/src/renderer/renderScene.ts
@@ -167,7 +167,6 @@ export function renderScene(
   // Paint remote pointers
   for (const clientId in sceneState.remotePointerViewportCoords) {
     let { x, y } = sceneState.remotePointerViewportCoords[clientId];
-    const username = sceneState.remotePointerUsernames[clientId];
 
     const width = 9;
     const height = 14;
@@ -201,30 +200,6 @@ export function renderScene(
     context.lineTo(x, y);
     context.fill();
     context.stroke();
-
-    if (!isOutOfBounds && username) {
-      const offsetX = x + width;
-      const offsetY = y + height;
-      const paddingHorizontal = 4;
-      const paddingVertical = 4;
-      const measure = context.measureText(username);
-      const measureHeight =
-        measure.actualBoundingBoxDescent + measure.actualBoundingBoxAscent;
-
-      context.fillRect(
-        offsetX,
-        offsetY,
-        measure.width + 2 * paddingHorizontal,
-        measureHeight + 2 * paddingVertical,
-      );
-      context.fillStyle = "white";
-      context.fillText(
-        username,
-        offsetX + paddingHorizontal,
-        offsetY + paddingVertical + measure.actualBoundingBoxAscent,
-      );
-    }
-
     context.strokeStyle = strokeStyle;
     context.fillStyle = fillStyle;
     context.globalAlpha = globalAlpha;

--- a/src/scene/export.ts
+++ b/src/scene/export.ts
@@ -50,7 +50,6 @@ export function exportToCanvas(
       scrollY: normalizeScroll(-minY + exportPadding),
       zoom: 1,
       remotePointerViewportCoords: {},
-      remotePointerUsernames: {},
     },
     {
       renderScrollbars: false,

--- a/src/scene/types.ts
+++ b/src/scene/types.ts
@@ -8,7 +8,6 @@ export type SceneState = {
   viewBackgroundColor: string | null;
   zoom: number;
   remotePointerViewportCoords: { [id: string]: { x: number; y: number } };
-  remotePointerUsernames: { [id: string]: string };
 };
 
 export type SceneScroll = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -36,10 +36,7 @@ export type AppState = {
   openMenu: "canvas" | "shape" | null;
   lastPointerDownWith: PointerType;
   selectedElementIds: { [id: string]: boolean };
-  collaborators: Map<
-    string,
-    { pointer?: { x: number; y: number }; username?: string }
-  >;
+  collaborators: Map<string, { pointer?: { x: number; y: number } }>;
 };
 
 export type PointerCoords = Readonly<{


### PR DESCRIPTION
Reverts excalidraw/excalidraw#971

Some of the words can be interpreted in a negative way: obedient, rat, cow, monkey...

Right now we don’t have a way to see what name we’ve been attributed nor actually change it.

I feel like I merged it too fast. Let’s build the view/edit flow and then merge it back in.

Reverting for now.