### PR TITLE
Update to browser-nativefs 0.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1936,21 +1936,6 @@
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.4.tgz",
       "integrity": "sha512-8+KAKzEvSUdeo+kmqnKrqgeE+LcA0tjYWFY7RPProVYwnqDjukzO+3b6dLD56rYX5TdWejnEOLJYOIeh4CXKuA=="
     },
-    "@types/lodash": {
-      "version": "4.14.149",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.149.tgz",
-      "integrity": "sha512-ijGqzZt/b7BfzcK9vTrS6MFljQRPn5BFWOx8oE0GYxribu6uV+aA9zZuXI1zc/etK9E8nrgdoF2+LgUw7+9tJQ==",
-      "dev": true
-    },
-    "@types/lodash.throttle": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@types/lodash.throttle/-/lodash.throttle-4.1.6.tgz",
-      "integrity": "sha512-/UIH96i/sIRYGC60NoY72jGkCJtFN5KVPhEMMMTjol65effe1gPn0tycJqV5tlSwMTzX8FqzB5yAj0rfGHTPNg==",
-      "dev": true,
-      "requires": {
-        "@types/lodash": "*"
-      }
-    },
     "@types/minimatch": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
@@ -3312,9 +3297,9 @@
       "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
     },
     "browser-nativefs": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/browser-nativefs/-/browser-nativefs-0.3.1.tgz",
-      "integrity": "sha512-dLcodrZMuyyJvNGJaLKuhPF3uAX/mU2+D3nwbzIc7a1RaNd2enpJhATbq6xZZWeYEvckNRg7KmqgiX+0Ht3zzA=="
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/browser-nativefs/-/browser-nativefs-0.4.0.tgz",
+      "integrity": "sha512-CiCwgd4Ir5OTC1IyVgyYJ5kJR7RDU/KLwgjrynoNNnKrBVwex3zRPKMmdAbcBXQJDbIQNnCyUQyvhbqH/9ERJA=="
     },
     "browser-process-hrtime": {
       "version": "0.1.3",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "not op_mini all"
   ],
   "dependencies": {
-    "browser-nativefs": "0.3.1",
+    "browser-nativefs": "0.4.0",
     "i18next-browser-languagedetector": "4.0.2",
     "nanoid": "2.1.11",
     "react": "16.13.0",


### PR DESCRIPTION
The enums of the Native File System API have changed ([details](https://github.com/WICG/native-file-system/issues/147)). Version 0.4.0 of [browser-nativefs](https://www.npmjs.com/package/browser-nativefs) deals with this. It's [ugly](https://github.com/GoogleChromeLabs/browser-nativefs/commit/a6ab5c3e93d1c22c38827dbf5aae14b607a38fad) since it involves nested `try {} catch (err) {}`, but will only be necessary until usage of Chrome 80 has died as the last browser to *not* support the new dash-separated enums. 