### PR TITLE
Fix performance regression (#977)

### DIFF
--- a/src/components/Popover.tsx
+++ b/src/components/Popover.tsx
@@ -1,5 +1,6 @@
 import React, { useLayoutEffect, useRef, useEffect } from "react";
 import "./Popover.css";
+import { unstable_batchedUpdates } from "react-dom";
 
 type Props = {
   top?: number;
@@ -39,7 +40,7 @@ export function Popover({
     if (onCloseRequest) {
       const handler = (e: Event) => {
         if (!popoverRef.current?.contains(e.target as Node)) {
-          onCloseRequest();
+          unstable_batchedUpdates(() => onCloseRequest());
         }
       };
       document.addEventListener("pointerdown", handler, false);

--- a/src/element/mutateElement.ts
+++ b/src/element/mutateElement.ts
@@ -10,7 +10,8 @@ type ElementUpdate<TElement extends ExcalidrawElement> = Omit<
 
 // This function tracks updates of text elements for the purposes for collaboration.
 // The version is used to compare updates when more than one user is working in
-// the same drawing.
+// the same drawing. Note: this will trigger the component to update. Make sure you
+// are calling it either from a React event handler or within unstable_batchedUpdates().
 export function mutateElement<TElement extends ExcalidrawElement>(
   element: TElement,
   updates: ElementUpdate<TElement>,


### PR DESCRIPTION
I made the faulty assumption that we always called `mutateElement()` from within a React event handler (which is wrapped in `batchedUpdates()`). This isn't true -- we add and remove regular listeners from the `window` also. I wrapped all the event handlers in `unstable_batchedUpdates()` which fixed the performance issue.