### PR TITLE
Deselect all elements when inserting text with double click

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1028,6 +1028,9 @@ export class App extends React.Component<any, AppState> {
       });
     };
 
+    // deselect all other elements when inserting text
+    this.setState({ selectedElementIds: {} });
+
     textWysiwyg({
       initText: element.text,
       x: textX,


### PR DESCRIPTION
Hey Excalidraw! This is a really awesome tool first of all and thanks for making this great!

Totally new-comer here but think I got a fix for https://github.com/excalidraw/excalidraw/issues/994.

From my understanding, double clicking to insert text node into canvas should de-select all the elements that are currently selected. So re-initializing the `selectedElementIds` seemed to be a no brainer.

But since I'm new to this land, I could be totally wrong (very likely)! Appreciate it in advance if anyone catches something that I'd missed.

Other than that, here's the test screenshot I used:

![Mar-17-2020 21-48-20](https://user-images.githubusercontent.com/13282699/76926252-28ae0680-6899-11ea-92f4-8ac280c314a4.gif)

Forgot to screenshot the case where it's a background filled rectangle but it works with that, too.


