### PR TITLE
Trim trailing newlines

### DIFF
--- a/src/element/textWysiwyg.tsx
+++ b/src/element/textWysiwyg.tsx
@@ -1,6 +1,17 @@
 import { KEYS } from "../keys";
 import { selectNode } from "../utils";
 
+function trimText(text: string) {
+  // whitespace only → trim all because we'd end up inserting invisible element
+  if (!text.trim()) {
+    return "";
+  }
+  // replace trailing newlines (only) otherwise it messes up bounding box
+  //  calculation (there's also a bug on FF which inserts trailing newline
+  //  for multiline texts)
+  return text.replace(/^\n+|\n+$/g, "");
+}
+
 type TextWysiwygParams = {
   initText: string;
   x: number;
@@ -101,7 +112,7 @@ export function textWysiwyg({
 
   function handleSubmit() {
     if (editable.innerText) {
-      onSubmit(editable.innerText);
+      onSubmit(trimText(editable.innerText));
     } else {
       onCancel();
     }

--- a/src/element/textWysiwyg.tsx
+++ b/src/element/textWysiwyg.tsx
@@ -6,8 +6,8 @@ function trimText(text: string) {
   if (!text.trim()) {
     return "";
   }
-  // replace trailing newlines (only) otherwise it messes up bounding box
-  //  calculation (there's also a bug on FF which inserts trailing newline
+  // replace leading/trailing newlines (only) otherwise it messes up bounding
+  //  box calculation (there's also a bug in FF which inserts trailing newline
   //  for multiline texts)
   return text.replace(/^\n+|\n+$/g, "");
 }


### PR DESCRIPTION
- fix regression for https://github.com/excalidraw/excalidraw/pull/454 introduced in https://github.com/excalidraw/excalidraw/pull/947 (by trimming trailing newlines which have no usefulness and mess up bounding box `height` calculation, and they're also added on FF by default for multiline texts)
- also I'm trimming whitespace-only texts which would result in invisible text elements