### PR TITLE
Add a Shortcut for Toggling Shape Lock

### DIFF
--- a/docs/shortcuts.md
+++ b/docs/shortcuts.md
@@ -18,7 +18,7 @@
 | Arrow     | `A` or `5` | `A` or `5` |
 | Line      | `L` or `6` | `L` or `6` |
 | Text      | `T` or `7` | `T` or `7` |
-| Lock      |            |            |
+| Lock      |    `Q`     |    `Q`     |
 
 ### Editor
 

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -638,13 +638,16 @@ export class App extends React.Component<any, AppState> {
       );
       event.preventDefault();
     } else if (
-      shapesShortcutKeys.includes(event.key.toLowerCase()) &&
       !event.ctrlKey &&
       !event.altKey &&
       !event.metaKey &&
       this.state.draggingElement === null
     ) {
-      this.selectShapeTool(shape);
+      if (shapesShortcutKeys.includes(event.key.toLowerCase())) {
+        this.selectShapeTool(shape);
+      } else if (event.code === "KeyQ") {
+        this.toggleLock();
+      }
     } else if (event.key === KEYS.SPACE && gesture.pointers.size === 0) {
       isHoldingSpace = true;
       document.documentElement.style.cursor = CURSOR_TYPE.GRABBING;
@@ -789,6 +792,15 @@ export class App extends React.Component<any, AppState> {
     this.destroySocketClient();
   };
 
+  toggleLock = () => {
+    this.setState(prevState => ({
+      elementLocked: !prevState.elementLocked,
+      elementType: prevState.elementLocked
+        ? "selection"
+        : prevState.elementType,
+    }));
+  };
+
   private setElements = (elements: readonly ExcalidrawElement[]) => {
     globalSceneState.replaceAllElements(elements);
   };
@@ -814,6 +826,7 @@ export class App extends React.Component<any, AppState> {
           language={getLanguage()}
           onRoomCreate={this.createRoom}
           onRoomDestroy={this.destroyRoom}
+          onToggleLock={this.toggleLock}
         />
         <main>
           <canvas

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -645,7 +645,7 @@ export class App extends React.Component<any, AppState> {
     ) {
       if (shapesShortcutKeys.includes(event.key.toLowerCase())) {
         this.selectShapeTool(shape);
-      } else if (event.code === "KeyQ") {
+      } else if (event.key === "q") {
         this.toggleLock();
       }
     } else if (event.key === KEYS.SPACE && gesture.pointers.size === 0) {

--- a/src/components/LayerUI.tsx
+++ b/src/components/LayerUI.tsx
@@ -33,6 +33,7 @@ interface LayerUIProps {
   setElements: (elements: readonly ExcalidrawElement[]) => void;
   onRoomCreate: () => void;
   onRoomDestroy: () => void;
+  onToggleLock: () => void;
 }
 
 export const LayerUI = React.memo(
@@ -46,6 +47,7 @@ export const LayerUI = React.memo(
     setElements,
     onRoomCreate,
     onRoomDestroy,
+    onToggleLock,
   }: LayerUIProps) => {
     const isMobile = useIsMobile();
 
@@ -157,14 +159,7 @@ export const LayerUI = React.memo(
                     </Island>
                     <LockIcon
                       checked={appState.elementLocked}
-                      onChange={() => {
-                        setAppState({
-                          elementLocked: !appState.elementLocked,
-                          elementType: appState.elementLocked
-                            ? "selection"
-                            : appState.elementType,
-                        });
-                      }}
+                      onChange={onToggleLock}
                       title={t("toolBar.lock")}
                       isButton={isMobile}
                     />

--- a/src/components/LockIcon.tsx
+++ b/src/components/LockIcon.tsx
@@ -1,6 +1,7 @@
 import "./ToolIcon.scss";
 
 import React from "react";
+import { getShortcutKey } from "../utils";
 
 type LockIconSize = "s" | "m";
 
@@ -48,7 +49,7 @@ export function LockIcon(props: LockIconProps) {
       className={`ToolIcon ToolIcon__lock ${
         props.isButton ? "ToolIcon_type_button" : "ToolIcon_type_floating"
       } ${sizeCn}`}
-      title={props.title}
+      title={`${props.title} ${getShortcutKey("Q")}`}
     >
       <input
         className="ToolIcon_type_checkbox"


### PR DESCRIPTION
Resolves #997 

I think there might be a mistake in accidentally closing the window by pressing `⌘ + Q` while working. To prevent this, ``` ` ```(backquote/backtick) or other keys may be a better option. Please give me feedback.

![shortcut_lock_demo](https://user-images.githubusercontent.com/4126644/76986677-507a9880-6985-11ea-9939-fbe790d182d1.gif)
