### PR TITLE
Fix history - the 2nd installment

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -332,7 +332,7 @@ export class App extends React.Component<any, AppState> {
                       }
 
                       return elements;
-                    }, [] as any)
+                    }, [] as Mutable<typeof restoredState.elements>)
                     // add local elements that weren't deleted or on remote
                     .concat(...Object.values(localElementMap)),
                 );

--- a/src/element/index.ts
+++ b/src/element/index.ts
@@ -41,7 +41,7 @@ export function getSyncableElements(elements: readonly ExcalidrawElement[]) {
 }
 
 export function getElementMap(elements: readonly ExcalidrawElement[]) {
-  return getSyncableElements(elements).reduce(
+  return elements.reduce(
     (acc: { [key: string]: ExcalidrawElement }, element: ExcalidrawElement) => {
       acc[element.id] = element;
       return acc;

--- a/src/element/mutateElement.ts
+++ b/src/element/mutateElement.ts
@@ -53,8 +53,8 @@ export function newElementWith<TElement extends ExcalidrawElement>(
 ): TElement {
   return {
     ...element,
-    ...updates,
     version: element.version + 1,
     versionNonce: randomSeed(),
+    ...updates,
   };
 }

--- a/src/history.ts
+++ b/src/history.ts
@@ -32,9 +32,12 @@ export class SceneHistory {
               appState.multiElement && appState.multiElement.id === element.id
                 ? element.points.slice(0, -1)
                 : element.points,
+            // don't regenerate versionNonce else this will short-circuit our
+            //  bail-on-no-change logic in pushEntry()
+            versionNonce: element.versionNonce,
           });
         }
-        return newElementWith(element, {});
+        return newElementWith(element, { versionNonce: element.versionNonce });
       }),
     });
   }

--- a/src/history.ts
+++ b/src/history.ts
@@ -25,20 +25,41 @@ export class SceneHistory {
   ) {
     return JSON.stringify({
       appState: clearAppStatePropertiesForHistory(appState),
-      elements: elements.map(element => {
-        if (isLinearElement(element)) {
-          return newElementWith(element, {
-            points:
-              appState.multiElement && appState.multiElement.id === element.id
-                ? element.points.slice(0, -1)
-                : element.points,
-            // don't regenerate versionNonce else this will short-circuit our
-            //  bail-on-no-change logic in pushEntry()
-            versionNonce: element.versionNonce,
-          });
+      elements: elements.reduce((elements, element) => {
+        if (
+          isLinearElement(element) &&
+          appState.multiElement &&
+          appState.multiElement.id === element.id
+        ) {
+          // don't store multi-point arrow if still has only one point
+          if (
+            appState.multiElement &&
+            appState.multiElement.id === element.id &&
+            element.points.length < 2
+          ) {
+            return elements;
+          }
+
+          elements.push(
+            newElementWith(element, {
+              // don't store last point if not committed
+              points:
+                element.lastCommittedPoint !==
+                element.points[element.points.length - 1]
+                  ? element.points.slice(0, -1)
+                  : element.points,
+              // don't regenerate versionNonce else this will short-circuit our
+              //  bail-on-no-change logic in pushEntry()
+              versionNonce: element.versionNonce,
+            }),
+          );
+        } else {
+          elements.push(
+            newElementWith(element, { versionNonce: element.versionNonce }),
+          );
         }
-        return newElementWith(element, { versionNonce: element.versionNonce });
-      }),
+        return elements;
+      }, [] as Mutable<typeof elements>),
     });
   }
 


### PR DESCRIPTION
- previously, before pushing entry to history we were piping each element through `newElementWith()` which regenerates `versionNonce`. This resulted in every single change going through, effectively skipping the bail-on-no-change check, and thus we were adding changes to history e.g. just on clicking on an element.

     I've made it so that we don't update `versionNonce` on this occasion. Note that we're still incrementing `version` of each element. In this case it doesn't cause an immediate issue because when checking against the currently-stored-in-history elements, those already have `version` incremented from last push. WTBS, I think this is brittle and will result in some issue down the line. @petehunt was there a reason why you were doing this (both `version`, and `versionNonce`)?
- next, I fixed history handling multi-point arrows. Now we're storing them only from 2-point onwards, and also only removing uncommitted points.

Before merge, I can write tests for this, but don't have time ATM.