### PR TITLE
Fix adding incorrect dragging element when handleCanvasPointerDown

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1558,7 +1558,7 @@ export class App extends React.Component<any, AppState> {
       if (element.type === "selection") {
         this.setState({
           selectionElement: element,
-          draggingElement: element,
+          draggingElement: hitElement ? hitElement : element,
         });
       } else {
         globalSceneState.replaceAllElements([


### PR DESCRIPTION
Fix for https://github.com/excalidraw/excalidraw/issues/927

The issue is, in the `handleCanvasPointerDown` event handler, we're always setting the `state.draggingElement` to a newly instantiated element:

https://github.com/excalidraw/excalidraw/blob/master/src/components/App.tsx#L1614-L1630

And later it gets added to the selected elements unconditionally

https://github.com/excalidraw/excalidraw/blob/master/src/components/App.tsx#L2152

The fix I'm proposing is that in the pointer down event handler, and if we have a `hitElement`, we're gonna set the `draggingElement` to the `hitElement` (which makes sense) instead of creating a new one. So that later when we set the `selectedElement`, the draggingElement already exists in the selected element and we don't mistakenly create a new "selected element."

## Test

See how `state.selectedElementIds` changes:

Before

Every time you start drag, there's one more selected element added to the state.

![before_real](https://user-images.githubusercontent.com/13282699/77134669-460fdb80-6a25-11ea-8211-7d8645fcb9ea.gif)

After

The selected elements stay correct.

![after_real](https://user-images.githubusercontent.com/13282699/77134677-4b6d2600-6a25-11ea-9769-5728442104de.gif)

---

Thought the fix made sense to me but I'm likely to misunderstand it though. Open to discussion :)
