### PR TITLE
Add loading state

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -130,6 +130,25 @@
       media="(device-width: 1024px) and (device-height: 1366px) and (-webkit-device-pixel-ratio: 2)"
       rel="apple-touch-startup-image"
     />
+    <style>
+      .LoadingMessage {
+        position: fixed;
+        top: 0;
+        right: 0;
+        bottom: 0;
+        left: 0;
+        z-index: 999;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        pointer-events: none;
+      }
+      .LoadingMessage span {
+        background-color: rgba(255, 255, 255, 0.8);
+        padding: 0.8em 1.2em;
+        font-size: 1.3em;
+      }
+    </style>
     <script
       async
       src="https://www.googletagmanager.com/gtag/js?id=UA-387204-13"
@@ -151,7 +170,11 @@
     <header>
       <h1 class="visually-hidden">Excalidraw</h1>
     </header>
-    <div id="root"></div>
+    <div id="root">
+      <div class="LoadingMessage">
+        <span>Loading scene...</span>
+      </div>
+    </div>
     <aside>
       <!-- https://github.com/tholman/github-corners -->
       <svg

--- a/public/index.html
+++ b/public/index.html
@@ -145,6 +145,7 @@
       }
       .LoadingMessage span {
         background-color: rgba(255, 255, 255, 0.8);
+        border-radius: 5px;
         padding: 0.8em 1.2em;
         font-size: 1.3em;
       }

--- a/src/appState.ts
+++ b/src/appState.ts
@@ -5,6 +5,7 @@ export const DEFAULT_FONT = "20px Virgil";
 
 export function getDefaultAppState(): AppState {
   return {
+    isLoading: false,
     draggingElement: null,
     resizingElement: null,
     multiElement: null,
@@ -47,6 +48,7 @@ export function clearAppStateForLocalStorage(appState: AppState) {
     isResizing,
     collaborators,
     isCollaborating,
+    isLoading,
     ...exportedState
   } = appState;
   return exportedState;

--- a/src/components/LayerUI.tsx
+++ b/src/components/LayerUI.tsx
@@ -22,6 +22,7 @@ import { MobileMenu } from "./MobileMenu";
 import { ZoomActions, SelectedShapeActions, ShapesSwitcher } from "./Actions";
 import { Section } from "./Section";
 import { RoomDialog } from "./RoomDialog";
+import { LoadingMessage } from "./LoadingMessage";
 
 interface LayerUIProps {
   actionManager: ActionManager;
@@ -105,6 +106,7 @@ export const LayerUI = React.memo(
       />
     ) : (
       <>
+        {appState.isLoading && <LoadingMessage />}
         <FixedSideContainer side="top">
           <HintViewer appState={appState} elements={elements} />
           <div className="App-menu App-menu_top">

--- a/src/components/LoadingMessage.tsx
+++ b/src/components/LoadingMessage.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 
 export const LoadingMessage = () => {
+  // !! KEEP THIS IN SYNC WITH index.html !!
   return (
-    // !! KEEP THIS IN SYNC WITH index.html !!
     <div className="LoadingMessage">
       <span>Loading scene...</span>
     </div>

--- a/src/components/LoadingMessage.tsx
+++ b/src/components/LoadingMessage.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+
+export const LoadingMessage = () => {
+  return (
+    // !! KEEP THIS IN SYNC WITH index.html !!
+    <div className="LoadingMessage">
+      <span>Loading scene...</span>
+    </div>
+  );
+};

--- a/src/components/MobileMenu.tsx
+++ b/src/components/MobileMenu.tsx
@@ -15,6 +15,7 @@ import { Section } from "./Section";
 import { RoomDialog } from "./RoomDialog";
 import { SCROLLBAR_WIDTH, SCROLLBAR_MARGIN } from "../scene/scrollbars";
 import { LockIcon } from "./LockIcon";
+import { LoadingMessage } from "./LoadingMessage";
 
 type MobileMenuProps = {
   appState: AppState;
@@ -41,6 +42,7 @@ export function MobileMenu({
 }: MobileMenuProps) {
   return (
     <>
+      {appState.isLoading && <LoadingMessage />}
       <FixedSideContainer side="top">
         <Section heading="shapes">
           {(heading) => (

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -9,3 +9,9 @@ interface Clipboard extends EventTarget {
 type Mutable<T> = {
   -readonly [P in keyof T]: T[P];
 };
+
+type ResolutionType<T extends (...args: any) => any> = T extends (
+  ...args: any
+) => Promise<infer R>
+  ? R
+  : any;

--- a/src/tests/__snapshots__/regressionTests.test.tsx.snap
+++ b/src/tests/__snapshots__/regressionTests.test.tsx.snap
@@ -18,6 +18,7 @@ Object {
   "elementType": "selection",
   "exportBackground": true,
   "isCollaborating": false,
+  "isLoading": false,
   "isResizing": false,
   "lastPointerDownWith": "mouse",
   "multiElement": null,
@@ -176,7 +177,7 @@ Object {
 
 exports[`regression tests alt-drag duplicates an element: [end of test] number of elements 1`] = `2`;
 
-exports[`regression tests alt-drag duplicates an element: [end of test] number of renders 1`] = `8`;
+exports[`regression tests alt-drag duplicates an element: [end of test] number of renders 1`] = `9`;
 
 exports[`regression tests arrow keys: [end of test] appState 1`] = `
 Object {
@@ -196,6 +197,7 @@ Object {
   "elementType": "selection",
   "exportBackground": true,
   "isCollaborating": false,
+  "isLoading": false,
   "isResizing": false,
   "lastPointerDownWith": "mouse",
   "multiElement": null,
@@ -280,7 +282,7 @@ Object {
 
 exports[`regression tests arrow keys: [end of test] number of elements 1`] = `1`;
 
-exports[`regression tests arrow keys: [end of test] number of renders 1`] = `11`;
+exports[`regression tests arrow keys: [end of test] number of renders 1`] = `12`;
 
 exports[`regression tests change the properties of a shape: [end of test] appState 1`] = `
 Object {
@@ -300,6 +302,7 @@ Object {
   "elementType": "selection",
   "exportBackground": true,
   "isCollaborating": false,
+  "isLoading": false,
   "isResizing": false,
   "lastPointerDownWith": "mouse",
   "multiElement": null,
@@ -520,7 +523,7 @@ Object {
 
 exports[`regression tests change the properties of a shape: [end of test] number of elements 1`] = `1`;
 
-exports[`regression tests change the properties of a shape: [end of test] number of renders 1`] = `9`;
+exports[`regression tests change the properties of a shape: [end of test] number of renders 1`] = `10`;
 
 exports[`regression tests click on an element and drag it: [dragged] appState 1`] = `
 Object {
@@ -540,6 +543,7 @@ Object {
   "elementType": "selection",
   "exportBackground": true,
   "isCollaborating": false,
+  "isLoading": false,
   "isResizing": false,
   "lastPointerDownWith": "mouse",
   "multiElement": null,
@@ -659,7 +663,7 @@ Object {
 
 exports[`regression tests click on an element and drag it: [dragged] number of elements 1`] = `1`;
 
-exports[`regression tests click on an element and drag it: [dragged] number of renders 1`] = `8`;
+exports[`regression tests click on an element and drag it: [dragged] number of renders 1`] = `9`;
 
 exports[`regression tests click on an element and drag it: [end of test] appState 1`] = `
 Object {
@@ -679,6 +683,7 @@ Object {
   "elementType": "selection",
   "exportBackground": true,
   "isCollaborating": false,
+  "isLoading": false,
   "isResizing": false,
   "lastPointerDownWith": "mouse",
   "multiElement": null,
@@ -833,7 +838,7 @@ Object {
 
 exports[`regression tests click on an element and drag it: [end of test] number of elements 1`] = `1`;
 
-exports[`regression tests click on an element and drag it: [end of test] number of renders 1`] = `11`;
+exports[`regression tests click on an element and drag it: [end of test] number of renders 1`] = `12`;
 
 exports[`regression tests click to select a shape: [end of test] appState 1`] = `
 Object {
@@ -853,6 +858,7 @@ Object {
   "elementType": "selection",
   "exportBackground": true,
   "isCollaborating": false,
+  "isLoading": false,
   "isResizing": false,
   "lastPointerDownWith": "mouse",
   "multiElement": null,
@@ -1011,7 +1017,7 @@ Object {
 
 exports[`regression tests click to select a shape: [end of test] number of elements 1`] = `2`;
 
-exports[`regression tests click to select a shape: [end of test] number of renders 1`] = `11`;
+exports[`regression tests click to select a shape: [end of test] number of renders 1`] = `12`;
 
 exports[`regression tests click-drag to select a group: [end of test] appState 1`] = `
 Object {
@@ -1031,6 +1037,7 @@ Object {
   "elementType": "selection",
   "exportBackground": true,
   "isCollaborating": false,
+  "isLoading": false,
   "isResizing": false,
   "lastPointerDownWith": "mouse",
   "multiElement": null,
@@ -1281,7 +1288,7 @@ Object {
 
 exports[`regression tests click-drag to select a group: [end of test] number of elements 1`] = `3`;
 
-exports[`regression tests click-drag to select a group: [end of test] number of renders 1`] = `16`;
+exports[`regression tests click-drag to select a group: [end of test] number of renders 1`] = `17`;
 
 exports[`regression tests draw every type of shape: [end of test] appState 1`] = `
 Object {
@@ -1301,6 +1308,7 @@ Object {
   "elementType": "selection",
   "exportBackground": true,
   "isCollaborating": false,
+  "isLoading": false,
   "isResizing": false,
   "lastPointerDownWith": "mouse",
   "multiElement": null,
@@ -1853,7 +1861,7 @@ Object {
 
 exports[`regression tests draw every type of shape: [end of test] number of elements 1`] = `5`;
 
-exports[`regression tests draw every type of shape: [end of test] number of renders 1`] = `33`;
+exports[`regression tests draw every type of shape: [end of test] number of renders 1`] = `34`;
 
 exports[`regression tests hotkey 2 selects rectangle tool: [end of test] appState 1`] = `
 Object {
@@ -1873,6 +1881,7 @@ Object {
   "elementType": "selection",
   "exportBackground": true,
   "isCollaborating": false,
+  "isLoading": false,
   "isResizing": false,
   "lastPointerDownWith": "mouse",
   "multiElement": null,
@@ -1957,7 +1966,7 @@ Object {
 
 exports[`regression tests hotkey 2 selects rectangle tool: [end of test] number of elements 1`] = `1`;
 
-exports[`regression tests hotkey 2 selects rectangle tool: [end of test] number of renders 1`] = `5`;
+exports[`regression tests hotkey 2 selects rectangle tool: [end of test] number of renders 1`] = `6`;
 
 exports[`regression tests hotkey 3 selects diamond tool: [end of test] appState 1`] = `
 Object {
@@ -1977,6 +1986,7 @@ Object {
   "elementType": "selection",
   "exportBackground": true,
   "isCollaborating": false,
+  "isLoading": false,
   "isResizing": false,
   "lastPointerDownWith": "mouse",
   "multiElement": null,
@@ -2061,7 +2071,7 @@ Object {
 
 exports[`regression tests hotkey 3 selects diamond tool: [end of test] number of elements 1`] = `1`;
 
-exports[`regression tests hotkey 3 selects diamond tool: [end of test] number of renders 1`] = `5`;
+exports[`regression tests hotkey 3 selects diamond tool: [end of test] number of renders 1`] = `6`;
 
 exports[`regression tests hotkey 4 selects ellipse tool: [end of test] appState 1`] = `
 Object {
@@ -2081,6 +2091,7 @@ Object {
   "elementType": "selection",
   "exportBackground": true,
   "isCollaborating": false,
+  "isLoading": false,
   "isResizing": false,
   "lastPointerDownWith": "mouse",
   "multiElement": null,
@@ -2165,7 +2176,7 @@ Object {
 
 exports[`regression tests hotkey 4 selects ellipse tool: [end of test] number of elements 1`] = `1`;
 
-exports[`regression tests hotkey 4 selects ellipse tool: [end of test] number of renders 1`] = `5`;
+exports[`regression tests hotkey 4 selects ellipse tool: [end of test] number of renders 1`] = `6`;
 
 exports[`regression tests hotkey 5 selects arrow tool: [end of test] appState 1`] = `
 Object {
@@ -2185,6 +2196,7 @@ Object {
   "elementType": "selection",
   "exportBackground": true,
   "isCollaborating": false,
+  "isLoading": false,
   "isResizing": false,
   "lastPointerDownWith": "mouse",
   "multiElement": null,
@@ -2291,7 +2303,7 @@ Object {
 
 exports[`regression tests hotkey 5 selects arrow tool: [end of test] number of elements 1`] = `1`;
 
-exports[`regression tests hotkey 5 selects arrow tool: [end of test] number of renders 1`] = `5`;
+exports[`regression tests hotkey 5 selects arrow tool: [end of test] number of renders 1`] = `6`;
 
 exports[`regression tests hotkey 6 selects line tool: [end of test] appState 1`] = `
 Object {
@@ -2311,6 +2323,7 @@ Object {
   "elementType": "selection",
   "exportBackground": true,
   "isCollaborating": false,
+  "isLoading": false,
   "isResizing": false,
   "lastPointerDownWith": "mouse",
   "multiElement": null,
@@ -2417,7 +2430,7 @@ Object {
 
 exports[`regression tests hotkey 6 selects line tool: [end of test] number of elements 1`] = `1`;
 
-exports[`regression tests hotkey 6 selects line tool: [end of test] number of renders 1`] = `5`;
+exports[`regression tests hotkey 6 selects line tool: [end of test] number of renders 1`] = `6`;
 
 exports[`regression tests hotkey a selects arrow tool: [end of test] appState 1`] = `
 Object {
@@ -2437,6 +2450,7 @@ Object {
   "elementType": "selection",
   "exportBackground": true,
   "isCollaborating": false,
+  "isLoading": false,
   "isResizing": false,
   "lastPointerDownWith": "mouse",
   "multiElement": null,
@@ -2543,7 +2557,7 @@ Object {
 
 exports[`regression tests hotkey a selects arrow tool: [end of test] number of elements 1`] = `1`;
 
-exports[`regression tests hotkey a selects arrow tool: [end of test] number of renders 1`] = `5`;
+exports[`regression tests hotkey a selects arrow tool: [end of test] number of renders 1`] = `6`;
 
 exports[`regression tests hotkey d selects diamond tool: [end of test] appState 1`] = `
 Object {
@@ -2563,6 +2577,7 @@ Object {
   "elementType": "selection",
   "exportBackground": true,
   "isCollaborating": false,
+  "isLoading": false,
   "isResizing": false,
   "lastPointerDownWith": "mouse",
   "multiElement": null,
@@ -2647,7 +2662,7 @@ Object {
 
 exports[`regression tests hotkey d selects diamond tool: [end of test] number of elements 1`] = `1`;
 
-exports[`regression tests hotkey d selects diamond tool: [end of test] number of renders 1`] = `5`;
+exports[`regression tests hotkey d selects diamond tool: [end of test] number of renders 1`] = `6`;
 
 exports[`regression tests hotkey e selects ellipse tool: [end of test] appState 1`] = `
 Object {
@@ -2667,6 +2682,7 @@ Object {
   "elementType": "selection",
   "exportBackground": true,
   "isCollaborating": false,
+  "isLoading": false,
   "isResizing": false,
   "lastPointerDownWith": "mouse",
   "multiElement": null,
@@ -2751,7 +2767,7 @@ Object {
 
 exports[`regression tests hotkey e selects ellipse tool: [end of test] number of elements 1`] = `1`;
 
-exports[`regression tests hotkey e selects ellipse tool: [end of test] number of renders 1`] = `5`;
+exports[`regression tests hotkey e selects ellipse tool: [end of test] number of renders 1`] = `6`;
 
 exports[`regression tests hotkey l selects line tool: [end of test] appState 1`] = `
 Object {
@@ -2771,6 +2787,7 @@ Object {
   "elementType": "selection",
   "exportBackground": true,
   "isCollaborating": false,
+  "isLoading": false,
   "isResizing": false,
   "lastPointerDownWith": "mouse",
   "multiElement": null,
@@ -2877,7 +2894,7 @@ Object {
 
 exports[`regression tests hotkey l selects line tool: [end of test] number of elements 1`] = `1`;
 
-exports[`regression tests hotkey l selects line tool: [end of test] number of renders 1`] = `5`;
+exports[`regression tests hotkey l selects line tool: [end of test] number of renders 1`] = `6`;
 
 exports[`regression tests hotkey r selects rectangle tool: [end of test] appState 1`] = `
 Object {
@@ -2897,6 +2914,7 @@ Object {
   "elementType": "selection",
   "exportBackground": true,
   "isCollaborating": false,
+  "isLoading": false,
   "isResizing": false,
   "lastPointerDownWith": "mouse",
   "multiElement": null,
@@ -2981,7 +2999,7 @@ Object {
 
 exports[`regression tests hotkey r selects rectangle tool: [end of test] number of elements 1`] = `1`;
 
-exports[`regression tests hotkey r selects rectangle tool: [end of test] number of renders 1`] = `5`;
+exports[`regression tests hotkey r selects rectangle tool: [end of test] number of renders 1`] = `6`;
 
 exports[`regression tests pinch-to-zoom works: [end of test] appState 1`] = `
 Object {
@@ -3001,6 +3019,7 @@ Object {
   "elementType": "selection",
   "exportBackground": true,
   "isCollaborating": false,
+  "isLoading": false,
   "isResizing": false,
   "lastPointerDownWith": "touch",
   "multiElement": null,
@@ -3029,7 +3048,7 @@ Object {
 
 exports[`regression tests pinch-to-zoom works: [end of test] number of elements 1`] = `0`;
 
-exports[`regression tests pinch-to-zoom works: [end of test] number of renders 1`] = `7`;
+exports[`regression tests pinch-to-zoom works: [end of test] number of renders 1`] = `8`;
 
 exports[`regression tests resize an element, trying every resize handle: [end of test] appState 1`] = `
 Object {
@@ -3049,6 +3068,7 @@ Object {
   "elementType": "selection",
   "exportBackground": true,
   "isCollaborating": false,
+  "isLoading": false,
   "isResizing": false,
   "lastPointerDownWith": "mouse",
   "multiElement": null,
@@ -3693,7 +3713,7 @@ Object {
 
 exports[`regression tests resize an element, trying every resize handle: [end of test] number of elements 1`] = `1`;
 
-exports[`regression tests resize an element, trying every resize handle: [end of test] number of renders 1`] = `53`;
+exports[`regression tests resize an element, trying every resize handle: [end of test] number of renders 1`] = `54`;
 
 exports[`regression tests resize an element, trying every resize handle: [resize handle ne (+5, +5)] appState 1`] = `
 Object {
@@ -3713,6 +3733,7 @@ Object {
   "elementType": "selection",
   "exportBackground": true,
   "isCollaborating": false,
+  "isLoading": false,
   "isResizing": false,
   "lastPointerDownWith": "mouse",
   "multiElement": null,
@@ -4042,7 +4063,7 @@ Object {
 
 exports[`regression tests resize an element, trying every resize handle: [resize handle ne (+5, +5)] number of elements 1`] = `1`;
 
-exports[`regression tests resize an element, trying every resize handle: [resize handle ne (+5, +5)] number of renders 1`] = `26`;
+exports[`regression tests resize an element, trying every resize handle: [resize handle ne (+5, +5)] number of renders 1`] = `27`;
 
 exports[`regression tests resize an element, trying every resize handle: [resize handle ne (-5, -5)] appState 1`] = `
 Object {
@@ -4062,6 +4083,7 @@ Object {
   "elementType": "selection",
   "exportBackground": true,
   "isCollaborating": false,
+  "isLoading": false,
   "isResizing": false,
   "lastPointerDownWith": "mouse",
   "multiElement": null,
@@ -4321,7 +4343,7 @@ Object {
 
 exports[`regression tests resize an element, trying every resize handle: [resize handle ne (-5, -5)] number of elements 1`] = `1`;
 
-exports[`regression tests resize an element, trying every resize handle: [resize handle ne (-5, -5)] number of renders 1`] = `20`;
+exports[`regression tests resize an element, trying every resize handle: [resize handle ne (-5, -5)] number of renders 1`] = `21`;
 
 exports[`regression tests resize an element, trying every resize handle: [resize handle nw (+5, +5)] appState 1`] = `
 Object {
@@ -4341,6 +4363,7 @@ Object {
   "elementType": "selection",
   "exportBackground": true,
   "isCollaborating": false,
+  "isLoading": false,
   "isResizing": false,
   "lastPointerDownWith": "mouse",
   "multiElement": null,
@@ -4530,7 +4553,7 @@ Object {
 
 exports[`regression tests resize an element, trying every resize handle: [resize handle nw (+5, +5)] number of elements 1`] = `1`;
 
-exports[`regression tests resize an element, trying every resize handle: [resize handle nw (+5, +5)] number of renders 1`] = `14`;
+exports[`regression tests resize an element, trying every resize handle: [resize handle nw (+5, +5)] number of renders 1`] = `15`;
 
 exports[`regression tests resize an element, trying every resize handle: [resize handle nw (-5, -5)] appState 1`] = `
 Object {
@@ -4550,6 +4573,7 @@ Object {
   "elementType": "selection",
   "exportBackground": true,
   "isCollaborating": false,
+  "isLoading": false,
   "isResizing": false,
   "lastPointerDownWith": "mouse",
   "multiElement": null,
@@ -4669,7 +4693,7 @@ Object {
 
 exports[`regression tests resize an element, trying every resize handle: [resize handle nw (-5, -5)] number of elements 1`] = `1`;
 
-exports[`regression tests resize an element, trying every resize handle: [resize handle nw (-5, -5)] number of renders 1`] = `8`;
+exports[`regression tests resize an element, trying every resize handle: [resize handle nw (-5, -5)] number of renders 1`] = `9`;
 
 exports[`regression tests resize an element, trying every resize handle: [resize handle se (+5, +5)] appState 1`] = `
 Object {
@@ -4689,6 +4713,7 @@ Object {
   "elementType": "selection",
   "exportBackground": true,
   "isCollaborating": false,
+  "isLoading": false,
   "isResizing": false,
   "lastPointerDownWith": "mouse",
   "multiElement": null,
@@ -5298,7 +5323,7 @@ Object {
 
 exports[`regression tests resize an element, trying every resize handle: [resize handle se (+5, +5)] number of elements 1`] = `1`;
 
-exports[`regression tests resize an element, trying every resize handle: [resize handle se (+5, +5)] number of renders 1`] = `50`;
+exports[`regression tests resize an element, trying every resize handle: [resize handle se (+5, +5)] number of renders 1`] = `51`;
 
 exports[`regression tests resize an element, trying every resize handle: [resize handle se (-5, -5)] appState 1`] = `
 Object {
@@ -5318,6 +5343,7 @@ Object {
   "elementType": "selection",
   "exportBackground": true,
   "isCollaborating": false,
+  "isLoading": false,
   "isResizing": false,
   "lastPointerDownWith": "mouse",
   "multiElement": null,
@@ -5857,7 +5883,7 @@ Object {
 
 exports[`regression tests resize an element, trying every resize handle: [resize handle se (-5, -5)] number of elements 1`] = `1`;
 
-exports[`regression tests resize an element, trying every resize handle: [resize handle se (-5, -5)] number of renders 1`] = `44`;
+exports[`regression tests resize an element, trying every resize handle: [resize handle se (-5, -5)] number of renders 1`] = `45`;
 
 exports[`regression tests resize an element, trying every resize handle: [resize handle sw (+5, +5)] appState 1`] = `
 Object {
@@ -5877,6 +5903,7 @@ Object {
   "elementType": "selection",
   "exportBackground": true,
   "isCollaborating": false,
+  "isLoading": false,
   "isResizing": false,
   "lastPointerDownWith": "mouse",
   "multiElement": null,
@@ -6346,7 +6373,7 @@ Object {
 
 exports[`regression tests resize an element, trying every resize handle: [resize handle sw (+5, +5)] number of elements 1`] = `1`;
 
-exports[`regression tests resize an element, trying every resize handle: [resize handle sw (+5, +5)] number of renders 1`] = `38`;
+exports[`regression tests resize an element, trying every resize handle: [resize handle sw (+5, +5)] number of renders 1`] = `39`;
 
 exports[`regression tests resize an element, trying every resize handle: [resize handle sw (-5, -5)] appState 1`] = `
 Object {
@@ -6366,6 +6393,7 @@ Object {
   "elementType": "selection",
   "exportBackground": true,
   "isCollaborating": false,
+  "isLoading": false,
   "isResizing": false,
   "lastPointerDownWith": "mouse",
   "multiElement": null,
@@ -6765,7 +6793,7 @@ Object {
 
 exports[`regression tests resize an element, trying every resize handle: [resize handle sw (-5, -5)] number of elements 1`] = `1`;
 
-exports[`regression tests resize an element, trying every resize handle: [resize handle sw (-5, -5)] number of renders 1`] = `32`;
+exports[`regression tests resize an element, trying every resize handle: [resize handle sw (-5, -5)] number of renders 1`] = `33`;
 
 exports[`regression tests resize an element, trying every resize handle: [unresize handle ne (+5, +5)] appState 1`] = `
 Object {
@@ -6785,6 +6813,7 @@ Object {
   "elementType": "selection",
   "exportBackground": true,
   "isCollaborating": false,
+  "isLoading": false,
   "isResizing": false,
   "lastPointerDownWith": "mouse",
   "multiElement": null,
@@ -7149,7 +7178,7 @@ Object {
 
 exports[`regression tests resize an element, trying every resize handle: [unresize handle ne (+5, +5)] number of elements 1`] = `1`;
 
-exports[`regression tests resize an element, trying every resize handle: [unresize handle ne (+5, +5)] number of renders 1`] = `29`;
+exports[`regression tests resize an element, trying every resize handle: [unresize handle ne (+5, +5)] number of renders 1`] = `30`;
 
 exports[`regression tests resize an element, trying every resize handle: [unresize handle ne (-5, -5)] appState 1`] = `
 Object {
@@ -7169,6 +7198,7 @@ Object {
   "elementType": "selection",
   "exportBackground": true,
   "isCollaborating": false,
+  "isLoading": false,
   "isResizing": false,
   "lastPointerDownWith": "mouse",
   "multiElement": null,
@@ -7463,7 +7493,7 @@ Object {
 
 exports[`regression tests resize an element, trying every resize handle: [unresize handle ne (-5, -5)] number of elements 1`] = `1`;
 
-exports[`regression tests resize an element, trying every resize handle: [unresize handle ne (-5, -5)] number of renders 1`] = `23`;
+exports[`regression tests resize an element, trying every resize handle: [unresize handle ne (-5, -5)] number of renders 1`] = `24`;
 
 exports[`regression tests resize an element, trying every resize handle: [unresize handle nw (+5, +5)] appState 1`] = `
 Object {
@@ -7483,6 +7513,7 @@ Object {
   "elementType": "selection",
   "exportBackground": true,
   "isCollaborating": false,
+  "isLoading": false,
   "isResizing": false,
   "lastPointerDownWith": "mouse",
   "multiElement": null,
@@ -7707,7 +7738,7 @@ Object {
 
 exports[`regression tests resize an element, trying every resize handle: [unresize handle nw (+5, +5)] number of elements 1`] = `1`;
 
-exports[`regression tests resize an element, trying every resize handle: [unresize handle nw (+5, +5)] number of renders 1`] = `17`;
+exports[`regression tests resize an element, trying every resize handle: [unresize handle nw (+5, +5)] number of renders 1`] = `18`;
 
 exports[`regression tests resize an element, trying every resize handle: [unresize handle nw (-5, -5)] appState 1`] = `
 Object {
@@ -7727,6 +7758,7 @@ Object {
   "elementType": "selection",
   "exportBackground": true,
   "isCollaborating": false,
+  "isLoading": false,
   "isResizing": false,
   "lastPointerDownWith": "mouse",
   "multiElement": null,
@@ -7881,7 +7913,7 @@ Object {
 
 exports[`regression tests resize an element, trying every resize handle: [unresize handle nw (-5, -5)] number of elements 1`] = `1`;
 
-exports[`regression tests resize an element, trying every resize handle: [unresize handle nw (-5, -5)] number of renders 1`] = `11`;
+exports[`regression tests resize an element, trying every resize handle: [unresize handle nw (-5, -5)] number of renders 1`] = `12`;
 
 exports[`regression tests resize an element, trying every resize handle: [unresize handle se (+5, +5)] appState 1`] = `
 Object {
@@ -7901,6 +7933,7 @@ Object {
   "elementType": "selection",
   "exportBackground": true,
   "isCollaborating": false,
+  "isLoading": false,
   "isResizing": false,
   "lastPointerDownWith": "mouse",
   "multiElement": null,
@@ -8545,7 +8578,7 @@ Object {
 
 exports[`regression tests resize an element, trying every resize handle: [unresize handle se (+5, +5)] number of elements 1`] = `1`;
 
-exports[`regression tests resize an element, trying every resize handle: [unresize handle se (+5, +5)] number of renders 1`] = `53`;
+exports[`regression tests resize an element, trying every resize handle: [unresize handle se (+5, +5)] number of renders 1`] = `54`;
 
 exports[`regression tests resize an element, trying every resize handle: [unresize handle se (-5, -5)] appState 1`] = `
 Object {
@@ -8565,6 +8598,7 @@ Object {
   "elementType": "selection",
   "exportBackground": true,
   "isCollaborating": false,
+  "isLoading": false,
   "isResizing": false,
   "lastPointerDownWith": "mouse",
   "multiElement": null,
@@ -9139,7 +9173,7 @@ Object {
 
 exports[`regression tests resize an element, trying every resize handle: [unresize handle se (-5, -5)] number of elements 1`] = `1`;
 
-exports[`regression tests resize an element, trying every resize handle: [unresize handle se (-5, -5)] number of renders 1`] = `47`;
+exports[`regression tests resize an element, trying every resize handle: [unresize handle se (-5, -5)] number of renders 1`] = `48`;
 
 exports[`regression tests resize an element, trying every resize handle: [unresize handle sw (+5, +5)] appState 1`] = `
 Object {
@@ -9159,6 +9193,7 @@ Object {
   "elementType": "selection",
   "exportBackground": true,
   "isCollaborating": false,
+  "isLoading": false,
   "isResizing": false,
   "lastPointerDownWith": "mouse",
   "multiElement": null,
@@ -9663,7 +9698,7 @@ Object {
 
 exports[`regression tests resize an element, trying every resize handle: [unresize handle sw (+5, +5)] number of elements 1`] = `1`;
 
-exports[`regression tests resize an element, trying every resize handle: [unresize handle sw (+5, +5)] number of renders 1`] = `41`;
+exports[`regression tests resize an element, trying every resize handle: [unresize handle sw (+5, +5)] number of renders 1`] = `42`;
 
 exports[`regression tests resize an element, trying every resize handle: [unresize handle sw (-5, -5)] appState 1`] = `
 Object {
@@ -9683,6 +9718,7 @@ Object {
   "elementType": "selection",
   "exportBackground": true,
   "isCollaborating": false,
+  "isLoading": false,
   "isResizing": false,
   "lastPointerDownWith": "mouse",
   "multiElement": null,
@@ -10117,7 +10153,7 @@ Object {
 
 exports[`regression tests resize an element, trying every resize handle: [unresize handle sw (-5, -5)] number of elements 1`] = `1`;
 
-exports[`regression tests resize an element, trying every resize handle: [unresize handle sw (-5, -5)] number of renders 1`] = `35`;
+exports[`regression tests resize an element, trying every resize handle: [unresize handle sw (-5, -5)] number of renders 1`] = `36`;
 
 exports[`regression tests shift-click to select a group, then drag: [end of test] appState 1`] = `
 Object {
@@ -10137,6 +10173,7 @@ Object {
   "elementType": "selection",
   "exportBackground": true,
   "isCollaborating": false,
+  "isLoading": false,
   "isResizing": false,
   "lastPointerDownWith": "mouse",
   "multiElement": null,
@@ -10350,7 +10387,7 @@ Object {
 
 exports[`regression tests shift-click to select a group, then drag: [end of test] number of elements 1`] = `2`;
 
-exports[`regression tests shift-click to select a group, then drag: [end of test] number of renders 1`] = `16`;
+exports[`regression tests shift-click to select a group, then drag: [end of test] number of renders 1`] = `17`;
 
 exports[`regression tests spacebar + drag scrolls the canvas: [end of test] appState 1`] = `
 Object {
@@ -10370,6 +10407,7 @@ Object {
   "elementType": "selection",
   "exportBackground": true,
   "isCollaborating": false,
+  "isLoading": false,
   "isResizing": false,
   "lastPointerDownWith": "mouse",
   "multiElement": null,
@@ -10396,7 +10434,7 @@ Object {
 
 exports[`regression tests spacebar + drag scrolls the canvas: [end of test] number of elements 1`] = `0`;
 
-exports[`regression tests spacebar + drag scrolls the canvas: [end of test] number of renders 1`] = `3`;
+exports[`regression tests spacebar + drag scrolls the canvas: [end of test] number of renders 1`] = `4`;
 
 exports[`regression tests two-finger scroll works: [end of test] appState 1`] = `
 Object {
@@ -10416,6 +10454,7 @@ Object {
   "elementType": "selection",
   "exportBackground": true,
   "isCollaborating": false,
+  "isLoading": false,
   "isResizing": false,
   "lastPointerDownWith": "mouse",
   "multiElement": null,
@@ -10444,7 +10483,7 @@ Object {
 
 exports[`regression tests two-finger scroll works: [end of test] number of elements 1`] = `0`;
 
-exports[`regression tests two-finger scroll works: [end of test] number of renders 1`] = `9`;
+exports[`regression tests two-finger scroll works: [end of test] number of renders 1`] = `10`;
 
 exports[`regression tests undo/redo drawing an element: [end of test] appState 1`] = `
 Object {
@@ -10464,6 +10503,7 @@ Object {
   "elementType": "selection",
   "exportBackground": true,
   "isCollaborating": false,
+  "isLoading": false,
   "isResizing": false,
   "lastPointerDownWith": "mouse",
   "multiElement": null,
@@ -10713,7 +10753,7 @@ Object {
 
 exports[`regression tests undo/redo drawing an element: [end of test] number of elements 1`] = `3`;
 
-exports[`regression tests undo/redo drawing an element: [end of test] number of renders 1`] = `16`;
+exports[`regression tests undo/redo drawing an element: [end of test] number of renders 1`] = `17`;
 
 exports[`regression tests zoom hotkeys: [end of test] appState 1`] = `
 Object {
@@ -10733,6 +10773,7 @@ Object {
   "elementType": "selection",
   "exportBackground": true,
   "isCollaborating": false,
+  "isLoading": false,
   "isResizing": false,
   "lastPointerDownWith": "mouse",
   "multiElement": null,
@@ -10759,4 +10800,4 @@ Object {
 
 exports[`regression tests zoom hotkeys: [end of test] number of elements 1`] = `0`;
 
-exports[`regression tests zoom hotkeys: [end of test] number of renders 1`] = `3`;
+exports[`regression tests zoom hotkeys: [end of test] number of renders 1`] = `4`;

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,6 +10,7 @@ export type FlooredNumber = number & { _brand: "FlooredNumber" };
 export type Point = Readonly<RoughPoint>;
 
 export type AppState = {
+  isLoading: boolean;
   draggingElement: ExcalidrawElement | null;
   resizingElement: ExcalidrawElement | null;
   multiElement: ExcalidrawLinearElement | null;


### PR DESCRIPTION
Added loading state to the app, useful for 3 main cases:

1. During initial app load so that users with slow connection (or when Netlify is slow) know something is happening.
2. When loading hefty scenes, or importing them.
3. When initializing a collaboration session.

![excalidraw_loading_state_import](https://user-images.githubusercontent.com/5153846/77188312-1371eb80-6ad6-11ea-86d5-385cd4108c14.gif)
