### PR TITLE
Use system fonts where possible.

### DIFF
--- a/src/styles.scss
+++ b/src/styles.scss
@@ -10,7 +10,8 @@
 
 body {
   margin: 0;
-  --ui-font: Arial, Helvetica, sans-serif;
+  --ui-font: BlinkMacSystemFont, -apple-system, Segoe UI, Roboto, Helvetica,
+    Arial, sans-serif;
   font-family: var(--ui-font);
   color: var(--text-color-primary);
   -webkit-text-size-adjust: 100%;


### PR DESCRIPTION
Also put Arial after Helvetica. I hate Arial.

Apparently there’s `system-ui` which was supposed to make this much simpler but if you use Windows 7 with an East Asian language the system font for Latin letters is truly awful.