### PR TITLE
load from localStorage only if not in multiplayer

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -332,6 +332,7 @@ export class App extends React.Component<any, AppState> {
       false,
     );
     document.addEventListener("gestureend", this.onGestureEnd as any, false);
+    window.addEventListener("beforeunload", this.beforeUnload);
 
     const searchParams = new URLSearchParams(window.location.search);
     const id = searchParams.get("id");
@@ -351,16 +352,14 @@ export class App extends React.Component<any, AppState> {
       return;
     }
 
-    const scene = await loadScene(null);
-    this.syncActionResult(scene);
-
     const roomMatch = getCollaborationLinkData(window.location.href);
     if (roomMatch) {
       this.initializeSocketClient();
       return;
     }
 
-    window.addEventListener("beforeunload", this.beforeUnload);
+    const scene = await loadScene(null);
+    this.syncActionResult(scene);
   }
 
   public componentWillUnmount() {


### PR DESCRIPTION
reverts https://github.com/excalidraw/excalidraw/pull/1036 to fix https://github.com/excalidraw/excalidraw/issues/1072

We can decide later what we want to do. For now I think this should be merged asap because it has the tendency to leak user's private scene to remote rooms.

Explanation: https://github.com/excalidraw/excalidraw/issues/1072#issuecomment-603364309