### PR TITLE
Remove support for some older browsers that probably didn’t work anyway

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,16 +1,23 @@
 {
-  "browserslist": [
-    ">0.2%",
-    "not dead",
-    "not ie <= 11",
-    "not op_mini all",
-    "not safari < 12",
-    "not kaios <= 2.5",
-    "not edge < 79",
-    "not chrome < 70",
-    "not and_uc < 13",
-    "not samsung < 10"
-  ],
+  "browserslist": {
+    "production": [
+      ">0.2%",
+      "not dead",
+      "not ie <= 11",
+      "not op_mini all",
+      "not safari < 12",
+      "not kaios <= 2.5",
+      "not edge < 79",
+      "not chrome < 70",
+      "not and_uc < 13",
+      "not samsung < 10"
+    ],
+    "development": [
+      "last 1 chrome version",
+      "last 1 firefox version",
+      "last 1 safari version"
+    ]
+  },
   "dependencies": {
     "browser-nativefs": "0.4.0",
     "i18next-browser-languagedetector": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,13 @@
     ">0.2%",
     "not dead",
     "not ie <= 11",
-    "not op_mini all"
+    "not op_mini all",
+    "not safari < 12",
+    "not kaios <= 2.5",
+    "not edge < 79",
+    "not chrome < 70",
+    "not and_uc < 13",
+    "not samsung < 10"
   ],
   "dependencies": {
     "browser-nativefs": "0.4.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es6",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,


### PR DESCRIPTION
- Safari < 12 don’t support `.flat()`, which we use.
- KaiOS doesn’t support async functions, and runs on a lot of feature phones which I hope we don’t target.
- Trident-based Edge (12–18) don’t support `.flat()`.
- Chrome < 70 doesn’t support Grid or `.flat()`
- Samsung Internet < 10 and UC Browser < 13 don’t support `.flat()`.

Note: to get the build script to take the new values, you have to `rm -rf node_modules/.cache`.

It also adds a smaller set of supported browsers for dev mode. I’m happy to revert this if someone on the team is deving on an older browser.