### PR TITLE
Clean up package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,8 +1,6 @@
 {
-  "name": "excalidraw",
-  "version": "1.0.0",
-  "lockfileVersion": 1,
   "requires": true,
+  "lockfileVersion": 1,
   "dependencies": {
     "@babel/code-frame": {
       "version": "7.8.3",

--- a/package.json
+++ b/package.json
@@ -37,10 +37,8 @@
     "rewire": "5.0.0",
     "typescript": "3.8.3"
   },
-  "jest": {
-    "transformIgnorePatterns": [
-      "node_modules/(?!(roughjs|browser-nativefs)/)"
-    ]
+  "engines": {
+    "node": ">=12.0.0"
   },
   "eslintConfig": {
     "extends": [
@@ -74,18 +72,22 @@
       "prettier/prettier": "warn"
     }
   },
-  "homepage": ".",
   "husky": {
     "hooks": {
       "pre-commit": "lint-staged"
     }
   },
+  "jest": {
+    "transformIgnorePatterns": [
+      "node_modules/(?!(roughjs|browser-nativefs)/)"
+    ]
+  },
   "private": true,
   "scripts": {
-    "build:app": "react-scripts build",
-    "build:zip": "node ./scripts/build-version.js",
     "build": "npm run build:app && npm run build:zip",
     "build-node": "node ./scripts/build-node.js",
+    "build:app": "react-scripts build",
+    "build:zip": "node ./scripts/build-version.js",
     "eject": "react-scripts eject",
     "fix": "npm run fix:other && npm run fix:code",
     "fix:code": "npm run test:code -- --fix",
@@ -94,12 +96,9 @@
     "start": "react-scripts start",
     "test": "npm run test:app",
     "test:app": "react-scripts test --env=jsdom --passWithNoTests",
-    "test:debug": "react-scripts --inspect-brk test --runInBand --no-cache",
     "test:code": "eslint --max-warnings=0 --ignore-path .gitignore --ext .js,.ts,.tsx .",
-    "test:typecheck": "tsc",
-    "test:other": "npm run prettier -- --list-different"
-  },
-  "engines": {
-    "node": ">=12.0.0"
+    "test:debug": "react-scripts --inspect-brk test --runInBand --no-cache",
+    "test:other": "npm run prettier -- --list-different",
+    "test:typecheck": "tsc"
   }
 }

--- a/package.json
+++ b/package.json
@@ -80,8 +80,7 @@
       "pre-commit": "lint-staged"
     }
   },
-  "main": "src/index.js",
-  "name": "excalidraw",
+  "private": true,
   "scripts": {
     "build:app": "react-scripts build",
     "build:zip": "node ./scripts/build-version.js",
@@ -99,12 +98,6 @@
     "test:code": "eslint --max-warnings=0 --ignore-path .gitignore --ext .js,.ts,.tsx .",
     "test:typecheck": "tsc",
     "test:other": "npm run prettier -- --list-different"
-  },
-  "version": "1.0.0",
-  "license": "MIT",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/excalidraw/excalidraw.git"
   },
   "engines": {
     "node": ">=12.0.0"


### PR DESCRIPTION
We don’t need `name`/`version`/etc if we don’t intend to publish to npm. Plus this ensures nobody accidentally `npm publish`es it.