### PR TITLE
Apply scroll-back-to-content's z-index only for mobile

### DIFF
--- a/src/styles.scss
+++ b/src/styles.scss
@@ -374,7 +374,6 @@ button,
   bottom: 30px;
   transform: translateX(-50%);
   padding: 10px 20px;
-  z-index: -1;
 }
 
 @media #{$media-query} {
@@ -384,5 +383,6 @@ button,
   .scroll-back-to-content {
     bottom: 80px;
     bottom: calc(80px + var(--sab));
+    z-index: -1;
   }
 }


### PR DESCRIPTION
Fixes #1082 

'Scroll back to content' button is not visible only on the desktop. Changes have been made in [this work](https://github.com/excalidraw/excalidraw/pull/1002/files#diff-6a2256f44598ec970b4bd034962e011eR376). I modified the z-index because it should be applied only to mobile.