### PR TITLE
Modify action buttons visibility for desktop

### DIFF
--- a/src/components/Actions.tsx
+++ b/src/components/Actions.tsx
@@ -1,7 +1,8 @@
 import React from "react";
+import { AppState } from "../types";
 import { ExcalidrawElement } from "../element/types";
 import { ActionManager } from "../actions/manager";
-import { hasBackground, hasStroke, hasText } from "../scene";
+import { hasBackground, hasStroke, hasText, getTargetElement } from "../scene";
 import { t } from "../i18n";
 import { SHAPES } from "../shapes";
 import { ToolButton } from "./ToolButton";
@@ -11,14 +12,18 @@ import Stack from "./Stack";
 import useIsMobile from "../is-mobile";
 
 export function SelectedShapeActions({
-  targetElements,
+  appState,
+  elements,
   renderAction,
   elementType,
 }: {
-  targetElements: readonly ExcalidrawElement[];
+  appState: AppState;
+  elements: readonly ExcalidrawElement[];
   renderAction: ActionManager["renderAction"];
   elementType: ExcalidrawElement["type"];
 }) {
+  const targetElements = getTargetElement(elements, appState);
+  const isEditing = Boolean(appState.editingElement);
   const isMobile = useIsMobile();
 
   return (
@@ -62,7 +67,7 @@ export function SelectedShapeActions({
           {renderAction("bringForward")}
         </div>
       </fieldset>
-      {!isMobile && (
+      {!isMobile && !isEditing && targetElements.length > 0 && (
         <fieldset>
           <legend>{t("labels.actions")}</legend>
           <div className="buttonList">

--- a/src/components/LayerUI.tsx
+++ b/src/components/LayerUI.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { showSelectedShapeActions } from "../element";
-import { calculateScrollCenter, getTargetElement } from "../scene";
+import { calculateScrollCenter } from "../scene";
 import { exportCanvas } from "../data";
 
 import { AppState } from "../types";
@@ -137,7 +137,8 @@ export const LayerUI = React.memo(
                 >
                   <Island padding={4}>
                     <SelectedShapeActions
-                      targetElements={getTargetElement(elements, appState)}
+                      appState={appState}
+                      elements={elements}
                       renderAction={actionManager.renderAction}
                       elementType={appState.elementType}
                     />

--- a/src/components/MobileMenu.tsx
+++ b/src/components/MobileMenu.tsx
@@ -9,7 +9,7 @@ import { ExcalidrawElement } from "../element/types";
 import { FixedSideContainer } from "./FixedSideContainer";
 import { Island } from "./Island";
 import { HintViewer } from "./HintViewer";
-import { calculateScrollCenter, getTargetElement } from "../scene";
+import { calculateScrollCenter } from "../scene";
 import { SelectedShapeActions, ShapesSwitcher } from "./Actions";
 import { Section } from "./Section";
 import { RoomDialog } from "./RoomDialog";
@@ -110,7 +110,8 @@ export function MobileMenu({
             showSelectedShapeActions(appState, elements) ? (
             <Section className="App-mobile-menu" heading="selectedShapeActions">
               <SelectedShapeActions
-                targetElements={getTargetElement(elements, appState)}
+                appState={appState}
+                elements={elements}
                 renderAction={actionManager.renderAction}
                 elementType={appState.elementType}
               />


### PR DESCRIPTION
This work continues #1146 

The current action button is hidden by `visibility`, so it is still clickable and the tooltip is visible.
![invisible_action_buttons](https://user-images.githubusercontent.com/4126644/78174151-c3126a80-7493-11ea-91de-6ec6781fcbfc.gif)

To fix this, I modified the button to show after editing is complete. and also reflected [this suggestion](https://github.com/excalidraw/excalidraw/pull/1146#issuecomment-607097265).

![invisible_action_buttons_fixed](https://user-images.githubusercontent.com/4126644/78174723-adea0b80-7494-11ea-893a-8f209ef3774f.gif)

