### PR TITLE
Make left panel height flexible to avoid overflow

### DIFF
--- a/src/components/Island.tsx
+++ b/src/components/Island.tsx
@@ -2,12 +2,16 @@ import "./Island.css";
 
 import React from "react";
 
-type IslandProps = { children: React.ReactNode; padding?: number };
+type IslandProps = {
+  children: React.ReactNode;
+  padding?: number;
+  className?: string;
+};
 
 export const Island = React.forwardRef<HTMLDivElement, IslandProps>(
-  ({ children, padding }, ref) => (
+  ({ children, padding, className }, ref) => (
     <div
-      className="Island"
+      className={`${className ?? ""} Island`}
       style={{ "--padding": padding } as React.CSSProperties}
       ref={ref}
     >

--- a/src/components/LayerUI.tsx
+++ b/src/components/LayerUI.tsx
@@ -136,11 +136,8 @@ export const LayerUI = React.memo(
                 </Island>
               </Section>
               {showSelectedShapeActions(appState, elements) && (
-                <Section
-                  className="App-menu__left"
-                  heading="selectedShapeActions"
-                >
-                  <Island padding={4}>
+                <Section heading="selectedShapeActions">
+                  <Island className="App-menu__left" padding={4}>
                     <SelectedShapeActions
                       appState={appState}
                       elements={elements}

--- a/src/components/LayerUI.tsx
+++ b/src/components/LayerUI.tsx
@@ -137,7 +137,7 @@ export const LayerUI = React.memo(
               </Section>
               {showSelectedShapeActions(appState, elements) && (
                 <Section
-                  className="App-right-menu"
+                  className="App-menu__left--scrollable"
                   heading="selectedShapeActions"
                 >
                   <Island padding={4}>

--- a/src/components/LayerUI.tsx
+++ b/src/components/LayerUI.tsx
@@ -116,7 +116,7 @@ export const LayerUI = React.memo(
           <HintViewer appState={appState} elements={elements} />
           <div className="App-menu App-menu_top">
             <Stack.Col gap={4}>
-              <Section className="App-right-menu" heading="canvasActions">
+              <Section heading="canvasActions">
                 <Island padding={4}>
                   <Stack.Col gap={4}>
                     <Stack.Row gap={1} justifyContent={"space-between"}>

--- a/src/components/LayerUI.tsx
+++ b/src/components/LayerUI.tsx
@@ -137,7 +137,7 @@ export const LayerUI = React.memo(
               </Section>
               {showSelectedShapeActions(appState, elements) && (
                 <Section
-                  className="App-menu__left--scrollable"
+                  className="App-menu__left"
                   heading="selectedShapeActions"
                 >
                   <Island padding={4}>

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -268,8 +268,7 @@ button,
 
 .App-menu__left {
   overflow-y: auto;
-  max-height: calc(100vh - 204px);
-  box-shadow: var(--shadow-island);
+  max-height: calc(100vh - 236px);
 }
 
 .ErrorSplash {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -228,6 +228,9 @@ button,
 
 .App-menu_top > *:first-child {
   justify-self: flex-start;
+  overflow-y: scroll;
+  max-height: calc(100vh - 60px);
+  padding: 5px;
 }
 
 .App-menu_top > *:last-child {
@@ -236,12 +239,13 @@ button,
 
 .App-menu_bottom {
   position: fixed;
-  bottom: 0;
+  bottom: var(--margin);
   grid-template-columns: 1fr auto 1fr;
   grid-gap: 4px;
   align-items: flex-start;
   cursor: default;
   pointer-events: none !important;
+  padding: 5px;
 }
 
 .App-menu_bottom > * {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -228,9 +228,6 @@ button,
 
 .App-menu_top > *:first-child {
   justify-self: flex-start;
-  overflow-y: scroll;
-  max-height: calc(100vh - 60px);
-  padding: 5px;
 }
 
 .App-menu_top > *:last-child {
@@ -239,13 +236,12 @@ button,
 
 .App-menu_bottom {
   position: fixed;
-  bottom: var(--margin);
+  bottom: 0;
   grid-template-columns: 1fr auto 1fr;
   grid-gap: 4px;
   align-items: flex-start;
   cursor: default;
   pointer-events: none !important;
-  padding: 5px;
 }
 
 .App-menu_bottom > * {
@@ -268,6 +264,12 @@ button,
 .App-menu_right {
   grid-template-rows: 1fr;
   height: 100%;
+}
+
+.App-menu__left--scrollable {
+  overflow-y: scroll;
+  max-height: calc(100vh - 204px);
+  box-shadow: var(--shadow-island);
 }
 
 .ErrorSplash {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -266,7 +266,7 @@ button,
   height: 100%;
 }
 
-.App-menu__left--scrollable {
+.App-menu__left {
   overflow-y: auto;
   max-height: calc(100vh - 204px);
   box-shadow: var(--shadow-island);

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -267,7 +267,7 @@ button,
 }
 
 .App-menu__left--scrollable {
-  overflow-y: scroll;
+  overflow-y: auto;
   max-height: calc(100vh - 204px);
   box-shadow: var(--shadow-island);
 }


### PR DESCRIPTION
Fixes #1127 

### Changes
- Modify markup to move the zoom button to left menus
- Add some styles for left center menu
- Remove unused menu related classes

![panel_overflow_final](https://user-images.githubusercontent.com/4126644/78262270-4935bc00-753b-11ea-9062-c931eab5fe66.gif)



