### PR TITLE
Change arabic language name

### DIFF
--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -23,7 +23,7 @@ export const languages = [
   { lng: "zh-CN", label: "简体中文", data: require("./locales/zh-CN.json") },
   {
     lng: "ar-SA",
-    label: "عربي",
+    label: "العربية",
     data: require("./locales/ar-SA.json"),
     rtl: true,
   },


### PR DESCRIPTION
As per #1183 I fixed the arabic language name by changing it from عربي to العربية as the existing one عربي is an adjective not the language name which is العربية.