### PR TITLE
Align ToolButton Label in RTL mode

### DIFF
--- a/src/components/ToolButton.tsx
+++ b/src/components/ToolButton.tsx
@@ -2,6 +2,8 @@ import "./ToolIcon.scss";
 
 import React from "react";
 
+import { getLanguage } from "../i18n";
+
 type ToolIconSize = "s" | "m";
 
 type ToolButtonBaseProps = {
@@ -34,6 +36,7 @@ type ToolButtonProps =
     });
 
 const DEFAULT_SIZE: ToolIconSize = "m";
+const isRTL = getLanguage().rtl;
 
 export const ToolButton = React.forwardRef(function (
   props: ToolButtonProps,
@@ -42,7 +45,6 @@ export const ToolButton = React.forwardRef(function (
   const innerRef = React.useRef(null);
   React.useImperativeHandle(ref, () => innerRef.current);
   const sizeCn = `ToolIcon_size_${props.size || DEFAULT_SIZE}`;
-
   if (props.type === "button") {
     return (
       <button
@@ -63,7 +65,9 @@ export const ToolButton = React.forwardRef(function (
           {props.icon || props.label}
         </div>
         {props.showAriaLabel && (
-          <div className="ToolIcon__label">{props["aria-label"]}</div>
+          <div className={`ToolIcon__label ${isRTL && "rtl"}`}>
+            {props["aria-label"]}
+          </div>
         )}
         {props.children}
       </button>

--- a/src/components/ToolButton.tsx
+++ b/src/components/ToolButton.tsx
@@ -2,8 +2,6 @@ import "./ToolIcon.scss";
 
 import React from "react";
 
-import { getLanguage } from "../i18n";
-
 type ToolIconSize = "s" | "m";
 
 type ToolButtonBaseProps = {
@@ -36,7 +34,6 @@ type ToolButtonProps =
     });
 
 const DEFAULT_SIZE: ToolIconSize = "m";
-const isRTL = getLanguage().rtl;
 
 export const ToolButton = React.forwardRef(function (
   props: ToolButtonProps,
@@ -45,6 +42,7 @@ export const ToolButton = React.forwardRef(function (
   const innerRef = React.useRef(null);
   React.useImperativeHandle(ref, () => innerRef.current);
   const sizeCn = `ToolIcon_size_${props.size || DEFAULT_SIZE}`;
+
   if (props.type === "button") {
     return (
       <button
@@ -65,9 +63,7 @@ export const ToolButton = React.forwardRef(function (
           {props.icon || props.label}
         </div>
         {props.showAriaLabel && (
-          <div className={`ToolIcon__label${isRTL ? " rtl" : ""}`}>
-            {props["aria-label"]}
-          </div>
+          <div className="ToolIcon__label">{props["aria-label"]}</div>
         )}
         {props.children}
       </button>

--- a/src/components/ToolButton.tsx
+++ b/src/components/ToolButton.tsx
@@ -65,7 +65,7 @@ export const ToolButton = React.forwardRef(function (
           {props.icon || props.label}
         </div>
         {props.showAriaLabel && (
-          <div className={`ToolIcon__label ${isRTL && "rtl"}`}>
+          <div className={`ToolIcon__label${isRTL ? " rtl" : ""}`}>
             {props["aria-label"]}
           </div>
         )}

--- a/src/components/ToolIcon.scss
+++ b/src/components/ToolIcon.scss
@@ -33,6 +33,10 @@
 
   & + .ToolIcon__label {
     margin-left: 0;
+    &.rtl {
+      margin-right: 0;
+      margin-left: 0.8em;
+    }
   }
 }
 

--- a/src/components/ToolIcon.scss
+++ b/src/components/ToolIcon.scss
@@ -32,11 +32,7 @@
   }
 
   & + .ToolIcon__label {
-    margin-left: 0;
-    &.rtl {
-      margin-right: 0;
-      margin-left: 0.8em;
-    }
+    margin-inline-start: 0;
   }
 }
 


### PR DESCRIPTION
As per #1183 this fixes the alignment of the ToolButton Label in RTL mode as mentioned per this screenshot:
<img width="556" alt="Screen Shot 2020-04-03 at 1 24 27 PM" src="https://user-images.githubusercontent.com/5364177/78361714-c2232b00-75b0-11ea-98e0-9df57970f0e9.png">

