### PR TITLE
make text committing cross-platform

### DIFF
--- a/src/element/textWysiwyg.tsx
+++ b/src/element/textWysiwyg.tsx
@@ -109,7 +109,7 @@ export function textWysiwyg({
       ev.preventDefault();
       handleSubmit();
     }
-    if (ev.key === KEYS.ENTER && (ev.shiftKey || ev.metaKey)) {
+    if (ev.key === KEYS.ENTER && (ev.shiftKey || ev[KEYS.CTRL_OR_CMD])) {
       ev.preventDefault();
       if (ev.isComposing || ev.keyCode === 229) {
         return;


### PR DESCRIPTION
fix https://github.com/excalidraw/excalidraw/pull/1185 not using `ctrl` for windows.

Before merging this, we should also decide whether we want to keep `shift+enter` to enter newline despite the default for that being `enter` without shift. /cc @vjeux 