### PR TITLE
add editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,9 +4,10 @@
 root = true
 
 [*]
-indent_style = space
+[*]
 charset = utf-8
-
-[*.{ts,tsx,js,json}]
-indent_size = 2
 end_of_line = lf
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+# http://EditorConfig.org
+
+# top-level EditorConfig file
+root = true
+
+[*]
+indent_style = space
+charset = utf-8
+
+[*.{ts,tsx,js,json}]
+indent_size = 2
+end_of_line = lf

--- a/.editorconfig
+++ b/.editorconfig
@@ -4,7 +4,6 @@
 root = true
 
 [*]
-[*]
 charset = utf-8
 end_of_line = lf
 indent_size = 2


### PR DESCRIPTION
This is purely for local editor convenience. `.editorconfig` is widely used for setting workspace settings.

My editor often doesn't infer tab size correctly, esp for new files. I guess I could use a `.vscoode/config.json`, but I thought this may help new contributors, too.

I've also added some other reasonable defaults.

