### PR TITLE
Add Security Headers

### DIFF
--- a/now.json
+++ b/now.json
@@ -21,7 +21,7 @@
         },
         {
           "key": "Content-Security-Policy",
-          "value": "default-src https: data: 'unsafe-inline'"
+          "value": "default-src https:; script-src 'unsafe-inline'; img-src data:"
         }
       ]
     }

--- a/now.json
+++ b/now.json
@@ -21,7 +21,7 @@
         },
         {
           "key": "Content-Security-Policy",
-          "value": "default-src https: data: 'unsafe-inline'; connect-src wss://excalidraw-socket.herokuapp.com"
+          "value": "default-src https: data: 'unsafe-inline'; connect-src wss://excalidraw-socket.herokuapp.com, https://excalidraw-socket.herokuapp.com/"
         }
       ]
     }

--- a/now.json
+++ b/now.json
@@ -4,6 +4,10 @@
       "source": "/(.*)",
       "headers": [
         {
+          "key": "Access-Control-Allow-Origin",
+          "value": "*"
+        },
+        {
           "key": "X-Content-Type-Options",
           "value": "nosniff"
         },

--- a/now.json
+++ b/now.json
@@ -21,7 +21,7 @@
         },
         {
           "key": "Content-Security-Policy",
-          "value": "default-src https:; script-src 'unsafe-inline'; img-src data:"
+          "value": "default-src https: data: 'unsafe-inline'"
         }
       ]
     }

--- a/now.json
+++ b/now.json
@@ -8,6 +8,10 @@
           "value": "nosniff"
         },
         {
+          "key": "Feature-Policy",
+          "value": "*"
+        },
+        {
           "key": "Referrer-Policy",
           "value": "origin"
         }

--- a/now.json
+++ b/now.json
@@ -21,7 +21,7 @@
         },
         {
           "key": "Content-Security-Policy",
-          "value": "default-src https:; script-src: unsafe-inline"
+          "value": "default-src https:; script-src unsafe-inline"
         }
       ]
     }

--- a/now.json
+++ b/now.json
@@ -21,7 +21,7 @@
         },
         {
           "key": "Content-Security-Policy",
-          "value": "default-src https: "
+          "value": "default-src https:; script-src: unsafe-inline"
         }
       ]
     }

--- a/now.json
+++ b/now.json
@@ -21,7 +21,7 @@
         },
         {
           "key": "Content-Security-Policy",
-          "value": "default-src https:; script-src unsafe-inline"
+          "value": "default-src https: 'unsafe-inline'"
         }
       ]
     }

--- a/now.json
+++ b/now.json
@@ -21,7 +21,7 @@
         },
         {
           "key": "Content-Security-Policy",
-          "value": "default-src https: data: 'unsafe-inline'; connect-src wss://excalidraw-socket.herokuapp.com, https://excalidraw-socket.herokuapp.com"
+          "value": "default-src https: data: 'unsafe-inline'; connect-src wss://excalidraw-socket.herokuapp.com https://excalidraw-socket.herokuapp.com"
         }
       ]
     }

--- a/now.json
+++ b/now.json
@@ -1,4 +1,19 @@
 {
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "X-Content-Type-Options",
+          "value": "nosniff"
+        },
+        {
+          "key": "X-Frame-Options",
+          "value": "SAMEORIGIN"
+        }
+      ]
+    }
+  ],
   "redirects": [
     {
       "source": "/([^.]+)",

--- a/now.json
+++ b/now.json
@@ -6,6 +6,10 @@
         {
           "key": "X-Content-Type-Options",
           "value": "nosniff"
+        },
+        {
+          "key": "Referrer-Policy",
+          "value": "origin"
         }
       ]
     }

--- a/now.json
+++ b/now.json
@@ -21,7 +21,7 @@
         },
         {
           "key": "Content-Security-Policy",
-          "value": "default-src https: data: 'unsafe-inline'"
+          "value": "default-src https: data: 'unsafe-inline'; connect-src wss://excalidraw-socket.herokuapp.com"
         }
       ]
     }

--- a/now.json
+++ b/now.json
@@ -21,7 +21,7 @@
         },
         {
           "key": "Content-Security-Policy",
-          "value": "default-src https: 'unsafe-inline'"
+          "value": "default-src https: data: 'unsafe-inline'"
         }
       ]
     }

--- a/now.json
+++ b/now.json
@@ -18,6 +18,10 @@
         {
           "key": "Referrer-Policy",
           "value": "origin"
+        },
+        {
+          "key": "Content-Security-Policy",
+          "value": "default-src https: "
         }
       ]
     }

--- a/now.json
+++ b/now.json
@@ -21,7 +21,7 @@
         },
         {
           "key": "Content-Security-Policy",
-          "value": "default-src https: data: 'unsafe-inline'; connect-src wss://excalidraw-socket.herokuapp.com https://excalidraw-socket.herokuapp.com"
+          "value": "default-src https: data: 'unsafe-inline'; connect-src https://*.excalidraw.com wss://excalidraw-socket.herokuapp.com https://excalidraw-socket.herokuapp.com"
         }
       ]
     }

--- a/now.json
+++ b/now.json
@@ -21,7 +21,7 @@
         },
         {
           "key": "Content-Security-Policy",
-          "value": "default-src https: data: 'unsafe-inline'; connect-src wss://excalidraw-socket.herokuapp.com, https://excalidraw-socket.herokuapp.com/"
+          "value": "default-src https: data: 'unsafe-inline'; connect-src wss://excalidraw-socket.herokuapp.com, https://excalidraw-socket.herokuapp.com"
         }
       ]
     }

--- a/now.json
+++ b/now.json
@@ -6,10 +6,6 @@
         {
           "key": "X-Content-Type-Options",
           "value": "nosniff"
-        },
-        {
-          "key": "X-Frame-Options",
-          "value": "SAMEORIGIN"
         }
       ]
     }

--- a/public/index.html
+++ b/public/index.html
@@ -7,10 +7,11 @@
       name="viewport"
       content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover, shrink-to-fit=no"
     />
+    <meta name="referrer" content="origin" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
 
     <meta name="theme-color" content="#000000" />
-    <!-- prettier-ignore -->
+
     <meta
       http-equiv="origin-trial"
       content="AsyySICOnLFPHhAi+SdB6g3Cr28MuSeq3a+2k3UOUKu+ikmEjAqYHAK3HSLx4keUd1BLYUPWPYAe6F9hyuO3JwUAAABceyJvcmlnaW4iOiJodHRwczovL3d3dy5leGNhbGlkcmF3LmNvbTo0NDMiLCJmZWF0dXJlIjoiTmF0aXZlRmlsZVN5c3RlbSIsImV4cGlyeSI6MTU4OTE4MzIxMH0="


### PR DESCRIPTION
Fixes #1192

### Requirements:

- We should allow websites to embed Excalidraw in an `iFrame`

### Preview

- [**Preview**](https://excalidraw-git-headers.excalidraw.now.sh)

### Test, Read
- [Test Before](https://securityheaders.com/?q=https%3A%2F%2Fexcalidraw.com%2F&followRedirects=on): **D**
- [Test After](https://securityheaders.com/?q=https%3A%2F%2Fexcalidraw-git-headers.excalidraw.now.sh&followRedirects=on): **A**
- https://www.cspisawesome.com

### At least the following ones

- [x] X-Content-Type-Options
- [ ] ~~X-Frame-Options~~: Conflicts with requirements
- [x] Strict-Transport-Security
- [x] Content-Security-Policy
- [x] Referrer-Policy
- [x] Feature-Policy
- [x] Make sure collaboration works
- [x] Make sure share/load file works