### PR TITLE
sync remote selection

### DIFF
--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -49,6 +49,7 @@ export type SocketUpdateDataSource = {
     payload: {
       socketID: string;
       pointerCoords: { x: number; y: number };
+      selectedElementIds: AppState["selectedElementIds"];
     };
   };
 };

--- a/src/renderer/renderScene.ts
+++ b/src/renderer/renderScene.ts
@@ -151,9 +151,6 @@ export function renderScene(
     context.translate(sceneState.scrollX, sceneState.scrollY);
 
     const selections = elements.reduce((acc, element) => {
-      if (element.isDeleted) {
-        return acc;
-      }
       const selectionColors = [];
       // local user
       if (appState.selectedElementIds[element.id]) {
@@ -222,13 +219,16 @@ export function renderScene(
     });
     context.translate(-sceneState.scrollX, -sceneState.scrollY);
 
-    const selectedElements = getSelectedElements(elements, appState);
+    const locallySelectedElements = getSelectedElements(elements, appState);
 
     // Paint resize handlers
-    if (selectedElements.length === 1) {
+    if (locallySelectedElements.length === 1) {
       context.translate(sceneState.scrollX, sceneState.scrollY);
       context.fillStyle = "#fff";
-      const handlers = handlerRectangles(selectedElements[0], sceneState.zoom);
+      const handlers = handlerRectangles(
+        locallySelectedElements[0],
+        sceneState.zoom,
+      );
       Object.keys(handlers).forEach((key) => {
         const handler = handlers[key as HandlerRectanglesRet];
         if (handler !== undefined) {
@@ -242,7 +242,7 @@ export function renderScene(
               handler[2],
               handler[3],
             );
-          } else if (selectedElements[0].type !== "text") {
+          } else if (locallySelectedElements[0].type !== "text") {
             strokeRectWithRotation(
               context,
               handler[0],
@@ -251,7 +251,7 @@ export function renderScene(
               handler[3],
               handler[0] + handler[2] / 2,
               handler[1] + handler[3] / 2,
-              selectedElements[0].angle,
+              locallySelectedElements[0].angle,
               true, // fill before stroke
             );
           }

--- a/src/renderer/renderScene.ts
+++ b/src/renderer/renderScene.ts
@@ -151,6 +151,9 @@ export function renderScene(
     context.translate(sceneState.scrollX, sceneState.scrollY);
 
     const selections = elements.reduce((acc, element) => {
+      if (element.isDeleted) {
+        return acc;
+      }
       const selectionColors = [];
       // local user
       if (appState.selectedElementIds[element.id]) {

--- a/src/scene/export.ts
+++ b/src/scene/export.ts
@@ -50,6 +50,7 @@ export function exportToCanvas(
       scrollY: normalizeScroll(-minY + exportPadding),
       zoom: 1,
       remotePointerViewportCoords: {},
+      remoteSelectedElementIds: {},
       shouldCacheIgnoreZoom: false,
     },
     {

--- a/src/scene/types.ts
+++ b/src/scene/types.ts
@@ -9,6 +9,7 @@ export type SceneState = {
   zoom: number;
   shouldCacheIgnoreZoom: boolean;
   remotePointerViewportCoords: { [id: string]: { x: number; y: number } };
+  remoteSelectedElementIds: { [elementId: string]: string[] };
 };
 
 export type SceneScroll = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -43,7 +43,16 @@ export type AppState = {
   openMenu: "canvas" | "shape" | null;
   lastPointerDownWith: PointerType;
   selectedElementIds: { [id: string]: boolean };
-  collaborators: Map<string, { pointer?: { x: number; y: number } }>;
+  collaborators: Map<
+    string,
+    {
+      pointer?: {
+        x: number;
+        y: number;
+      };
+      selectedElementIds?: AppState["selectedElementIds"];
+    }
+  >;
   shouldCacheIgnoreZoom: boolean;
 };
 


### PR DESCRIPTION
Fixes https://github.com/excalidraw/excalidraw/issues/1109

First take. Will refactor tomorrow.

(The stroke rendering courtesy of @vjeux)

![excalidraw_sync_selection](https://user-images.githubusercontent.com/5153846/78404867-98452500-75ff-11ea-8335-180dbaaaad05.gif)

Related: I think we should use a subset of bright colors for remote users. I often get gray/dark-blue/purple remote color which is hardly distinguishable from local color (black).