### PR TITLE
Fix unexpected behavior of resizing a line with multiple points

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -2055,7 +2055,9 @@ export class App extends React.Component<any, AppState> {
                 mutateElement(element, {
                   width,
                   height,
-                  ...adjustXYWithRotation("nw", element, deltaX, dY, angle),
+                  ...(isLinearElement(element) && (width < 0 || height < 0)
+                    ? element
+                    : adjustXYWithRotation("nw", element, deltaX, dY, angle)),
                   ...(isLinearElement(element) && width >= 0 && height >= 0
                     ? {
                         points: rescalePoints(
@@ -2086,7 +2088,9 @@ export class App extends React.Component<any, AppState> {
                 mutateElement(element, {
                   width,
                   height,
-                  ...adjustXYWithRotation("ne", element, deltaX, dY, angle),
+                  ...(isLinearElement(element) && (width < 0 || height < 0)
+                    ? element
+                    : adjustXYWithRotation("ne", element, deltaX, dY, angle)),
                   ...(isLinearElement(element) && width >= 0 && height >= 0
                     ? {
                         points: rescalePoints(
@@ -2117,7 +2121,9 @@ export class App extends React.Component<any, AppState> {
                 mutateElement(element, {
                   width,
                   height,
-                  ...adjustXYWithRotation("sw", element, deltaX, dY, angle),
+                  ...(isLinearElement(element) && (width < 0 || height < 0)
+                    ? element
+                    : adjustXYWithRotation("sw", element, deltaX, dY, angle)),
                   ...(isLinearElement(element) && width >= 0 && height >= 0
                     ? {
                         points: rescalePoints(
@@ -2148,7 +2154,9 @@ export class App extends React.Component<any, AppState> {
                 mutateElement(element, {
                   width,
                   height,
-                  ...adjustXYWithRotation("se", element, deltaX, dY, angle),
+                  ...(isLinearElement(element) && (width < 0 || height < 0)
+                    ? element
+                    : adjustXYWithRotation("se", element, deltaX, dY, angle)),
                   ...(isLinearElement(element) && width >= 0 && height >= 0
                     ? {
                         points: rescalePoints(

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -2056,7 +2056,7 @@ export class App extends React.Component<any, AppState> {
                   width,
                   height,
                   ...(isLinearElement(element) && (width < 0 || height < 0)
-                    ? element
+                    ? { x: element.x, y: element.y }
                     : adjustXYWithRotation("nw", element, deltaX, dY, angle)),
                   ...(isLinearElement(element) && width >= 0 && height >= 0
                     ? {
@@ -2089,7 +2089,7 @@ export class App extends React.Component<any, AppState> {
                   width,
                   height,
                   ...(isLinearElement(element) && (width < 0 || height < 0)
-                    ? element
+                    ? { x: element.x, y: element.y }
                     : adjustXYWithRotation("ne", element, deltaX, dY, angle)),
                   ...(isLinearElement(element) && width >= 0 && height >= 0
                     ? {
@@ -2122,7 +2122,7 @@ export class App extends React.Component<any, AppState> {
                   width,
                   height,
                   ...(isLinearElement(element) && (width < 0 || height < 0)
-                    ? element
+                    ? { x: element.x, y: element.y }
                     : adjustXYWithRotation("sw", element, deltaX, dY, angle)),
                   ...(isLinearElement(element) && width >= 0 && height >= 0
                     ? {
@@ -2155,7 +2155,7 @@ export class App extends React.Component<any, AppState> {
                   width,
                   height,
                   ...(isLinearElement(element) && (width < 0 || height < 0)
-                    ? element
+                    ? { x: element.x, y: element.y }
                     : adjustXYWithRotation("se", element, deltaX, dY, angle)),
                   ...(isLinearElement(element) && width >= 0 && height >= 0
                     ? {

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -2036,139 +2036,183 @@ export class App extends React.Component<any, AppState> {
           // reverse rotate delta
           const [deltaX, deltaY] = rotate(x - lastX, y - lastY, 0, 0, -angle);
           switch (resizeHandle) {
-            case "nw":
-              if (isLinearElement(element) && element.points.length === 2) {
-                const [, p1] = element.points;
+            case "nw": {
+              const width = element.width - deltaX;
+              const height = event.shiftKey ? width : element.height - deltaY;
+              const dY = element.height - height;
+              if (isLinearElement(element)) {
+                if (element.points.length === 2) {
+                  const [, p1] = element.points;
 
-                if (!resizeArrowFn) {
-                  if (p1[0] < 0 || p1[1] < 0) {
-                    resizeArrowFn = arrowResizeEnd;
-                  } else {
-                    resizeArrowFn = arrowResizeOrigin;
+                  if (!resizeArrowFn) {
+                    if (p1[0] < 0 || p1[1] < 0) {
+                      resizeArrowFn = arrowResizeEnd;
+                    } else {
+                      resizeArrowFn = arrowResizeOrigin;
+                    }
                   }
+                  resizeArrowFn(
+                    element,
+                    1,
+                    deltaX,
+                    deltaY,
+                    x,
+                    y,
+                    event.shiftKey,
+                  );
+                } else if (width >= 0 && height >= 0) {
+                  mutateElement(element, {
+                    width,
+                    height,
+                    ...adjustXYWithRotation("nw", element, deltaX, dY, angle),
+                    points: rescalePoints(
+                      0,
+                      width,
+                      rescalePoints(1, height, element.points),
+                    ),
+                  });
                 }
-                resizeArrowFn(element, 1, deltaX, deltaY, x, y, event.shiftKey);
               } else {
-                const width = element.width - deltaX;
-                const height = event.shiftKey ? width : element.height - deltaY;
-                const dY = element.height - height;
                 mutateElement(element, {
                   width,
                   height,
-                  ...(isLinearElement(element) && (width < 0 || height < 0)
-                    ? { x: element.x, y: element.y }
-                    : adjustXYWithRotation("nw", element, deltaX, dY, angle)),
-                  ...(isLinearElement(element) && width >= 0 && height >= 0
-                    ? {
-                        points: rescalePoints(
-                          0,
-                          width,
-                          rescalePoints(1, height, element.points),
-                        ),
-                      }
-                    : {}),
+                  ...adjustXYWithRotation("nw", element, deltaX, dY, angle),
                 });
               }
               break;
-            case "ne":
-              if (isLinearElement(element) && element.points.length === 2) {
-                const [, p1] = element.points;
-                if (!resizeArrowFn) {
-                  if (p1[0] >= 0) {
-                    resizeArrowFn = arrowResizeEnd;
-                  } else {
-                    resizeArrowFn = arrowResizeOrigin;
+            }
+            case "ne": {
+              const width = element.width + deltaX;
+              const height = event.shiftKey ? width : element.height - deltaY;
+              const dY = element.height - height;
+              if (isLinearElement(element)) {
+                if (element.points.length === 2) {
+                  const [, p1] = element.points;
+                  if (!resizeArrowFn) {
+                    if (p1[0] >= 0) {
+                      resizeArrowFn = arrowResizeEnd;
+                    } else {
+                      resizeArrowFn = arrowResizeOrigin;
+                    }
                   }
+                  resizeArrowFn(
+                    element,
+                    1,
+                    deltaX,
+                    deltaY,
+                    x,
+                    y,
+                    event.shiftKey,
+                  );
+                } else if (width >= 0 && height >= 0) {
+                  mutateElement(element, {
+                    width,
+                    height,
+                    ...adjustXYWithRotation("ne", element, deltaX, dY, angle),
+                    points: rescalePoints(
+                      0,
+                      width,
+                      rescalePoints(1, height, element.points),
+                    ),
+                  });
                 }
-                resizeArrowFn(element, 1, deltaX, deltaY, x, y, event.shiftKey);
               } else {
-                const width = element.width + deltaX;
-                const height = event.shiftKey ? width : element.height - deltaY;
-                const dY = element.height - height;
                 mutateElement(element, {
                   width,
                   height,
-                  ...(isLinearElement(element) && (width < 0 || height < 0)
-                    ? { x: element.x, y: element.y }
-                    : adjustXYWithRotation("ne", element, deltaX, dY, angle)),
-                  ...(isLinearElement(element) && width >= 0 && height >= 0
-                    ? {
-                        points: rescalePoints(
-                          0,
-                          width,
-                          rescalePoints(1, height, element.points),
-                        ),
-                      }
-                    : {}),
+                  ...adjustXYWithRotation("ne", element, deltaX, dY, angle),
                 });
               }
               break;
-            case "sw":
-              if (isLinearElement(element) && element.points.length === 2) {
-                const [, p1] = element.points;
-                if (!resizeArrowFn) {
-                  if (p1[0] <= 0) {
-                    resizeArrowFn = arrowResizeEnd;
-                  } else {
-                    resizeArrowFn = arrowResizeOrigin;
+            }
+            case "sw": {
+              const width = element.width - deltaX;
+              const height = event.shiftKey ? width : element.height + deltaY;
+              const dY = height - element.height;
+              if (isLinearElement(element)) {
+                if (element.points.length === 2) {
+                  const [, p1] = element.points;
+                  if (!resizeArrowFn) {
+                    if (p1[0] <= 0) {
+                      resizeArrowFn = arrowResizeEnd;
+                    } else {
+                      resizeArrowFn = arrowResizeOrigin;
+                    }
                   }
+                  resizeArrowFn(
+                    element,
+                    1,
+                    deltaX,
+                    deltaY,
+                    x,
+                    y,
+                    event.shiftKey,
+                  );
+                } else if (width >= 0 && height >= 0) {
+                  mutateElement(element, {
+                    width,
+                    height,
+                    ...adjustXYWithRotation("sw", element, deltaX, dY, angle),
+                    points: rescalePoints(
+                      0,
+                      width,
+                      rescalePoints(1, height, element.points),
+                    ),
+                  });
                 }
-                resizeArrowFn(element, 1, deltaX, deltaY, x, y, event.shiftKey);
               } else {
-                const width = element.width - deltaX;
-                const height = event.shiftKey ? width : element.height + deltaY;
-                const dY = height - element.height;
                 mutateElement(element, {
                   width,
                   height,
-                  ...(isLinearElement(element) && (width < 0 || height < 0)
-                    ? { x: element.x, y: element.y }
-                    : adjustXYWithRotation("sw", element, deltaX, dY, angle)),
-                  ...(isLinearElement(element) && width >= 0 && height >= 0
-                    ? {
-                        points: rescalePoints(
-                          0,
-                          width,
-                          rescalePoints(1, height, element.points),
-                        ),
-                      }
-                    : {}),
+                  ...adjustXYWithRotation("sw", element, deltaX, dY, angle),
                 });
               }
               break;
-            case "se":
-              if (isLinearElement(element) && element.points.length === 2) {
-                const [, p1] = element.points;
-                if (!resizeArrowFn) {
-                  if (p1[0] > 0 || p1[1] > 0) {
-                    resizeArrowFn = arrowResizeEnd;
-                  } else {
-                    resizeArrowFn = arrowResizeOrigin;
+            }
+            case "se": {
+              const width = element.width + deltaX;
+              const height = event.shiftKey ? width : element.height + deltaY;
+              const dY = height - element.height;
+              if (isLinearElement(element)) {
+                if (element.points.length === 2) {
+                  const [, p1] = element.points;
+                  if (!resizeArrowFn) {
+                    if (p1[0] > 0 || p1[1] > 0) {
+                      resizeArrowFn = arrowResizeEnd;
+                    } else {
+                      resizeArrowFn = arrowResizeOrigin;
+                    }
                   }
+                  resizeArrowFn(
+                    element,
+                    1,
+                    deltaX,
+                    deltaY,
+                    x,
+                    y,
+                    event.shiftKey,
+                  );
+                } else if (width >= 0 && height >= 0) {
+                  mutateElement(element, {
+                    width,
+                    height,
+                    ...adjustXYWithRotation("se", element, deltaX, dY, angle),
+                    points: rescalePoints(
+                      0,
+                      width,
+                      rescalePoints(1, height, element.points),
+                    ),
+                  });
                 }
-                resizeArrowFn(element, 1, deltaX, deltaY, x, y, event.shiftKey);
               } else {
-                const width = element.width + deltaX;
-                const height = event.shiftKey ? width : element.height + deltaY;
-                const dY = height - element.height;
                 mutateElement(element, {
                   width,
                   height,
-                  ...(isLinearElement(element) && (width < 0 || height < 0)
-                    ? { x: element.x, y: element.y }
-                    : adjustXYWithRotation("se", element, deltaX, dY, angle)),
-                  ...(isLinearElement(element) && width >= 0 && height >= 0
-                    ? {
-                        points: rescalePoints(
-                          0,
-                          width,
-                          rescalePoints(1, height, element.points),
-                        ),
-                      }
-                    : {}),
+                  ...adjustXYWithRotation("se", element, deltaX, dY, angle),
                 });
               }
               break;
+            }
             case "n": {
               const height = element.height - deltaY;
 


### PR DESCRIPTION
If grab a corner point (excluding the lower right) and resize a line (or arrow) object with multiple points, the object moves as shown in the following image.

<img src="https://user-images.githubusercontent.com/31386431/78419279-3cba7c00-767f-11ea-9665-e2f1ef2ba477.gif" width=300>

This seems to be an unexpected behavior.

So I fixed it so that the behavior is the same as the original bottom right point (no inversion and no further change in size).
