### PR TITLE
do not select deleted elements

### DIFF
--- a/src/actions/actionSelectAll.ts
+++ b/src/actions/actionSelectAll.ts
@@ -8,7 +8,9 @@ export const actionSelectAll = register({
       appState: {
         ...appState,
         selectedElementIds: elements.reduce((map, element) => {
-          map[element.id] = true;
+          if (!element.isDeleted) {
+            map[element.id] = true;
+          }
           return map;
         }, {} as any),
       },


### PR DESCRIPTION
While I was developing #1193, I found a weird behavior.
It was because selectAll selects deleted elements.
Unless it is intentional, this should fix it.
(Otherwise, I can do a workaround.)