### PR TITLE
fix scrollToCenter when no elements supplied

### DIFF
--- a/src/element/bounds.ts
+++ b/src/element/bounds.ts
@@ -187,6 +187,10 @@ export function getArrowPoints(
 }
 
 export function getCommonBounds(elements: readonly ExcalidrawElement[]) {
+  if (!elements.length) {
+    return [0, 0, 0, 0];
+  }
+
   let minX = Infinity;
   let maxX = -Infinity;
   let minY = Infinity;

--- a/src/scene/scroll.ts
+++ b/src/scene/scroll.ts
@@ -9,6 +9,13 @@ export function normalizeScroll(pos: number) {
 export function calculateScrollCenter(
   elements: readonly ExcalidrawElement[],
 ): { scrollX: FlooredNumber; scrollY: FlooredNumber } {
+  if (!elements.length) {
+    return {
+      scrollX: normalizeScroll(0),
+      scrollY: normalizeScroll(0),
+    };
+  }
+
   const [x1, y1, x2, y2] = getCommonBounds(elements);
 
   const centerX = (x1 + x2) / 2;


### PR DESCRIPTION
test plan:

1. create empty-scene collab room
2. join in another tab
3. try to draw in the 2nd tab