### PR TITLE
Show shortcuts dialog when pressing `?`

### DIFF
--- a/src/appState.ts
+++ b/src/appState.ts
@@ -38,6 +38,7 @@ export function getDefaultAppState(): AppState {
     selectedElementIds: {},
     collaborators: new Map(),
     shouldCacheIgnoreZoom: false,
+    showShortcutsDialog: false,
   };
 }
 
@@ -54,6 +55,7 @@ export function clearAppStateForLocalStorage(appState: AppState) {
     isCollaborating,
     isLoading,
     errorMessage,
+    showShortcutsDialog,
     ...exportedState
   } = appState;
   return exportedState;

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -982,6 +982,12 @@ export class App extends React.Component<any, AppState> {
       return;
     }
 
+    if (event.key === KEYS.QUESTION_MARK) {
+      this.setState({
+        showShortcutsDialog: true,
+      });
+    }
+
     if (event.code === "KeyC" && event.altKey && event.shiftKey) {
       this.copyToClipboardAsPng();
       event.preventDefault();

--- a/src/components/LayerUI.tsx
+++ b/src/components/LayerUI.tsx
@@ -23,6 +23,7 @@ import { ZoomActions, SelectedShapeActions, ShapesSwitcher } from "./Actions";
 import { Section } from "./Section";
 import { RoomDialog } from "./RoomDialog";
 import { ErrorDialog } from "./ErrorDialog";
+import { ShortcutsDialog } from "./ShortcutsDialog";
 import { LoadingMessage } from "./LoadingMessage";
 
 interface LayerUIProps {
@@ -110,6 +111,11 @@ export const LayerUI = React.memo(
           <ErrorDialog
             message={appState.errorMessage}
             onClose={() => setAppState({ errorMessage: null })}
+          />
+        )}
+        {appState.showShortcutsDialog && (
+          <ShortcutsDialog
+            onClose={() => setAppState({ showShortcutsDialog: null })}
           />
         )}
         <FixedSideContainer side="top">

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -28,7 +28,14 @@ export function Modal(props: {
       aria-labelledby={props.labelledBy}
     >
       <div className="Modal__background" onClick={props.onCloseRequest}></div>
-      <div className="Modal__content" style={{ maxWidth: props.maxWidth }}>
+      <div
+        className="Modal__content"
+        style={{
+          maxWidth: props.maxWidth,
+          maxHeight: "100%",
+          overflowY: "scroll",
+        }}
+      >
         {props.children}
       </div>
     </div>,

--- a/src/components/ShortcutsDialog.tsx
+++ b/src/components/ShortcutsDialog.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { t } from "../i18n";
-
+import { isDarwin } from "../keys";
 import { Dialog } from "./Dialog";
 import { getShortcutKey } from "../utils";
 
@@ -179,11 +179,19 @@ export const ShortcutsDialog = ({ onClose }: { onClose?: () => void }) => {
             />
             <Shortcut
               title={t("labels.sendToBack")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+Alt+[", "")]}
+              shortcuts={[
+                isDarwin
+                  ? getShortcutKey("CtrlOrCmd+Alt+[", "")
+                  : getShortcutKey("CtrlOrCmd+Shift+[", ""),
+              ]}
             />
             <Shortcut
               title={t("labels.bringToFront")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+Alt+]", "")]}
+              shortcuts={[
+                isDarwin
+                  ? getShortcutKey("CtrlOrCmd+Alt+]", "")
+                  : getShortcutKey("CtrlOrCmd+Shift+]", ""),
+              ]}
             />
             <Shortcut
               title={t("labels.sendBackward")}

--- a/src/components/ShortcutsDialog.tsx
+++ b/src/components/ShortcutsDialog.tsx
@@ -2,8 +2,89 @@ import React from "react";
 import { t } from "../i18n";
 
 import { Dialog } from "./Dialog";
+import { getShortcutKey } from "../utils";
 
-export function ShortcutsDialog({ onClose }: { onClose?: () => void }) {
+const ShortcutIsland = (props: {
+  title: string;
+  children: React.ReactNode;
+}) => (
+  <div
+    style={{
+      width: "49%",
+      border: "1px solid #ced4da",
+      marginBottom: "16px",
+    }}
+    {...props}
+  >
+    <h3
+      style={{
+        margin: "0",
+        padding: "8px 4px",
+        backgroundColor: "#e9ecef",
+        textAlign: "center",
+      }}
+    >
+      {props.title}
+    </h3>
+    {props.children}
+  </div>
+);
+
+const Shortcut = (props: { title: string; shortcuts: string[] }) => (
+  <div
+    style={{
+      borderTop: "1px solid #ced4da",
+    }}
+    {...props}
+  >
+    <div
+      style={{
+        display: "flex",
+        justifyContent: "space-between",
+        margin: "0",
+        padding: "4px",
+        alignItems: "center",
+      }}
+    >
+      <div
+        style={{
+          flexBasis: 0,
+          flexGrow: 2,
+        }}
+      >
+        {props.title}
+      </div>
+      <div
+        style={{
+          display: "flex",
+          flexBasis: 0,
+          flexGrow: 1,
+          justifyContent: "center",
+        }}
+      >
+        {props.shortcuts.map((shortcut) => (
+          <ShortcutKey>{shortcut}</ShortcutKey>
+        ))}
+      </div>
+    </div>
+  </div>
+);
+
+const ShortcutKey = (props: { children: React.ReactNode }) => (
+  <span
+    style={{
+      border: "1px solid #ced4da",
+      padding: "2px 8px",
+      margin: "0 8px",
+      backgroundColor: "#e9ecef",
+      borderRadius: "2px",
+      fontSize: "0.9em",
+    }}
+    {...props}
+  />
+);
+
+export const ShortcutsDialog = ({ onClose }: { onClose?: () => void }) => {
   const handleClose = React.useCallback(() => {
     if (onClose) {
       onClose();
@@ -13,12 +94,94 @@ export function ShortcutsDialog({ onClose }: { onClose?: () => void }) {
   return (
     <>
       <Dialog
-        maxWidth={500}
+        maxWidth={800}
         onCloseRequest={handleClose}
-        title={t("errorDialog.title")}
+        title={t("shortcutsDialog.title")}
       >
-        <div>shortcuts</div>
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "row",
+            flexWrap: "wrap",
+            justifyContent: "space-between",
+          }}
+        >
+          <ShortcutIsland title={"Shapes"}>
+            <Shortcut title={t("toolBar.selection")} shortcuts={["S", "1"]} />
+            <Shortcut title={t("toolBar.rectangle")} shortcuts={["R", "2"]} />
+            <Shortcut title={t("toolBar.diamond")} shortcuts={["D", "3"]} />
+            <Shortcut title={t("toolBar.ellipse")} shortcuts={["E", "4"]} />
+            <Shortcut title={t("toolBar.arrow")} shortcuts={["A", "5"]} />
+            <Shortcut title={t("toolBar.line")} shortcuts={["L", "6"]} />
+            <Shortcut title={t("toolBar.text")} shortcuts={["T", "7"]} />
+            <Shortcut title={t("toolBar.lock")} shortcuts={["Q"]} />
+          </ShortcutIsland>
+          <ShortcutIsland title={"Editor"}>
+            <Shortcut
+              title={"Copy"}
+              shortcuts={[getShortcutKey("CtrlOrCmd+C", "")]}
+            />
+            <Shortcut
+              title={"Paste"}
+              shortcuts={[getShortcutKey("CtrlOrCmd+V", "")]}
+            />
+            <Shortcut
+              title={"Copy to clipboard as PNG"}
+              shortcuts={[getShortcutKey("Shift+Alt+C", "")]}
+            />
+            <Shortcut
+              title={"Copy styles"}
+              shortcuts={[getShortcutKey("CtrlOrCmd+Shift+C", "")]}
+            />
+            <Shortcut
+              title={"Paste styles"}
+              shortcuts={[getShortcutKey("CtrlOrCmd+Shift+V", "")]}
+            />
+            <Shortcut
+              title={"Delete"}
+              shortcuts={[getShortcutKey("Del", "")]}
+            />
+            <Shortcut
+              title={"Send to back"}
+              shortcuts={[getShortcutKey("CtrlOrCmd+Alt+[", "")]}
+            />
+            <Shortcut
+              title={"Bring to front"}
+              shortcuts={[getShortcutKey("CtrlOrCmd+Alt+]", "")]}
+            />
+            <Shortcut
+              title={"Send backwards"}
+              shortcuts={[getShortcutKey("CtrlOrCmd+[", "")]}
+            />
+            <Shortcut
+              title={"Bring forward"}
+              shortcuts={[getShortcutKey("CtrlOrCmd+]", "")]}
+            />
+            <Shortcut
+              title={"Duplicate selected element(s)"}
+              shortcuts={[getShortcutKey("CtrlOrCmd+D", "")]}
+            />
+          </ShortcutIsland>
+          <ShortcutIsland title={"View"}>
+            <Shortcut
+              title={"Zoom in"}
+              shortcuts={[getShortcutKey("CtrlOrCmd++", "")]}
+            />
+            <Shortcut
+              title={"Zoom out"}
+              shortcuts={[getShortcutKey("CtrlOrCmd+-", "")]}
+            />
+            <Shortcut
+              title={"Zoom reset"}
+              shortcuts={[getShortcutKey("CtrlOrCmd+0", "")]}
+            />
+            <Shortcut
+              title={"Toggle full screen"}
+              shortcuts={[getShortcutKey("F", "")]}
+            />
+          </ShortcutIsland>
+        </div>
       </Dialog>
     </>
   );
-}
+};

--- a/src/components/ShortcutsDialog.tsx
+++ b/src/components/ShortcutsDialog.tsx
@@ -42,7 +42,7 @@ const Shortcut = (props: { title: string; shortcuts: string[] }) => (
         display: "flex",
         justifyContent: "space-between",
         margin: "0",
-        padding: "4px",
+        padding: "2px 4px",
         alignItems: "center",
       }}
     >
@@ -50,6 +50,7 @@ const Shortcut = (props: { title: string; shortcuts: string[] }) => (
         style={{
           flexBasis: 0,
           flexGrow: 2,
+          lineHeight: 1.4,
         }}
       >
         {props.title}
@@ -82,6 +83,25 @@ const ShortcutKey = (props: { children: React.ReactNode }) => (
     }}
     {...props}
   />
+);
+
+const Footer = () => (
+  <div
+    style={{
+      display: "flex",
+      flexDirection: "row",
+      justifyContent: "space-between",
+      borderTop: "1px solid #ced4da",
+      marginTop: 8,
+      paddingTop: 16,
+    }}
+  >
+    <a href="https://blog.excalidraw.com">{t("shortcutsDialog.blog")}</a>
+    <a href="https://howto.excalidraw.com">{t("shortcutsDialog.howto")}</a>
+    <a href="https://github.com/excalidraw/excalidraw/issues">
+      {t("shortcutsDialog.github")}
+    </a>
+  </div>
 );
 
 export const ShortcutsDialog = ({ onClose }: { onClose?: () => void }) => {
@@ -177,6 +197,7 @@ export const ShortcutsDialog = ({ onClose }: { onClose?: () => void }) => {
             />
           </ShortcutIsland>
         </div>
+        <Footer />
       </Dialog>
     </>
   );

--- a/src/components/ShortcutsDialog.tsx
+++ b/src/components/ShortcutsDialog.tsx
@@ -19,7 +19,7 @@ const ShortcutIsland = (props: {
     <h3
       style={{
         margin: "0",
-        padding: "8px 4px",
+        padding: "4px",
         backgroundColor: "#e9ecef",
         textAlign: "center",
       }}
@@ -42,7 +42,7 @@ const Shortcut = (props: { title: string; shortcuts: string[] }) => (
         display: "flex",
         justifyContent: "space-between",
         margin: "0",
-        padding: "2px 4px",
+        padding: "4px",
         alignItems: "center",
       }}
     >
@@ -79,7 +79,7 @@ const ShortcutKey = (props: { children: React.ReactNode }) => (
       margin: "0 8px",
       backgroundColor: "#e9ecef",
       borderRadius: "2px",
-      fontSize: "0.9em",
+      fontSize: "0.8em",
     }}
     {...props}
   />

--- a/src/components/ShortcutsDialog.tsx
+++ b/src/components/ShortcutsDialog.tsx
@@ -106,7 +106,7 @@ export const ShortcutsDialog = ({ onClose }: { onClose?: () => void }) => {
             justifyContent: "space-between",
           }}
         >
-          <ShortcutIsland title={"Shapes"}>
+          <ShortcutIsland title={t("shortcutsDialog.shapes")}>
             <Shortcut title={t("toolBar.selection")} shortcuts={["S", "1"]} />
             <Shortcut title={t("toolBar.rectangle")} shortcuts={["R", "2"]} />
             <Shortcut title={t("toolBar.diamond")} shortcuts={["D", "3"]} />
@@ -116,68 +116,64 @@ export const ShortcutsDialog = ({ onClose }: { onClose?: () => void }) => {
             <Shortcut title={t("toolBar.text")} shortcuts={["T", "7"]} />
             <Shortcut title={t("toolBar.lock")} shortcuts={["Q"]} />
           </ShortcutIsland>
-          <ShortcutIsland title={"Editor"}>
+          <ShortcutIsland title={t("shortcutsDialog.editor")}>
             <Shortcut
-              title={"Copy"}
+              title={t("labels.copy")}
               shortcuts={[getShortcutKey("CtrlOrCmd+C", "")]}
             />
             <Shortcut
-              title={"Paste"}
+              title={t("labels.paste")}
               shortcuts={[getShortcutKey("CtrlOrCmd+V", "")]}
             />
             <Shortcut
-              title={"Copy to clipboard as PNG"}
+              title={t("labels.copyAsPng")}
               shortcuts={[getShortcutKey("Shift+Alt+C", "")]}
             />
             <Shortcut
-              title={"Copy styles"}
+              title={t("labels.copyStyles")}
               shortcuts={[getShortcutKey("CtrlOrCmd+Shift+C", "")]}
             />
             <Shortcut
-              title={"Paste styles"}
+              title={t("labels.pasteStyles")}
               shortcuts={[getShortcutKey("CtrlOrCmd+Shift+V", "")]}
             />
             <Shortcut
-              title={"Delete"}
+              title={t("labels.delete")}
               shortcuts={[getShortcutKey("Del", "")]}
             />
             <Shortcut
-              title={"Send to back"}
+              title={t("labels.sendToBack")}
               shortcuts={[getShortcutKey("CtrlOrCmd+Alt+[", "")]}
             />
             <Shortcut
-              title={"Bring to front"}
+              title={t("labels.bringToFront")}
               shortcuts={[getShortcutKey("CtrlOrCmd+Alt+]", "")]}
             />
             <Shortcut
-              title={"Send backwards"}
+              title={t("labels.sendBackward")}
               shortcuts={[getShortcutKey("CtrlOrCmd+[", "")]}
             />
             <Shortcut
-              title={"Bring forward"}
+              title={t("labels.bringForward")}
               shortcuts={[getShortcutKey("CtrlOrCmd+]", "")]}
             />
             <Shortcut
-              title={"Duplicate selected element(s)"}
+              title={t("labels.duplicateSelection")}
               shortcuts={[getShortcutKey("CtrlOrCmd+D", "")]}
             />
           </ShortcutIsland>
-          <ShortcutIsland title={"View"}>
+          <ShortcutIsland title={t("shortcutsDialog.view")}>
             <Shortcut
-              title={"Zoom in"}
+              title={t("buttons.zoomIn")}
               shortcuts={[getShortcutKey("CtrlOrCmd++", "")]}
             />
             <Shortcut
-              title={"Zoom out"}
+              title={t("buttons.zoomOut")}
               shortcuts={[getShortcutKey("CtrlOrCmd+-", "")]}
             />
             <Shortcut
-              title={"Zoom reset"}
+              title={t("buttons.resetZoom")}
               shortcuts={[getShortcutKey("CtrlOrCmd+0", "")]}
-            />
-            <Shortcut
-              title={"Toggle full screen"}
-              shortcuts={[getShortcutKey("F", "")]}
             />
           </ShortcutIsland>
         </div>

--- a/src/components/ShortcutsDialog.tsx
+++ b/src/components/ShortcutsDialog.tsx
@@ -96,9 +96,25 @@ const Footer = () => (
       paddingTop: 16,
     }}
   >
-    <a href="https://blog.excalidraw.com">{t("shortcutsDialog.blog")}</a>
-    <a href="https://howto.excalidraw.com">{t("shortcutsDialog.howto")}</a>
-    <a href="https://github.com/excalidraw/excalidraw/issues">
+    <a
+      href="https://blog.excalidraw.com"
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      {t("shortcutsDialog.blog")}
+    </a>
+    <a
+      href="https://howto.excalidraw.com"
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      {t("shortcutsDialog.howto")}
+    </a>
+    <a
+      href="https://github.com/excalidraw/excalidraw/issues"
+      target="_blank"
+      rel="noopener noreferrer"
+    >
       {t("shortcutsDialog.github")}
     </a>
   </div>

--- a/src/components/ShortcutsDialog.tsx
+++ b/src/components/ShortcutsDialog.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import { t } from "../i18n";
+
+import { Dialog } from "./Dialog";
+
+export function ShortcutsDialog({ onClose }: { onClose?: () => void }) {
+  const handleClose = React.useCallback(() => {
+    if (onClose) {
+      onClose();
+    }
+  }, [onClose]);
+
+  return (
+    <>
+      <Dialog
+        maxWidth={500}
+        onCloseRequest={handleClose}
+        title={t("errorDialog.title")}
+      >
+        <div>shortcuts</div>
+      </Dialog>
+    </>
+  );
+}

--- a/src/keys.ts
+++ b/src/keys.ts
@@ -12,6 +12,7 @@ export const KEYS = {
   CTRL_OR_CMD: isDarwin ? "metaKey" : "ctrlKey",
   TAB: "Tab",
   SPACE: " ",
+  QUESTION_MARK: "?",
 } as const;
 
 export type Key = keyof typeof KEYS;

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -132,6 +132,9 @@
     "title": "Keyboard shortcuts",
     "shapes": "Shapes",
     "editor": "Editor",
-    "view": "View"
+    "view": "View",
+    "blog": "Read the Blog",
+    "howto": "Check out the How To",
+    "github": "Found an issue? Submit"
   }
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -133,8 +133,8 @@
     "shapes": "Shapes",
     "editor": "Editor",
     "view": "View",
-    "blog": "Read the Blog",
-    "howto": "Check out the How To",
+    "blog": "Read our Blog",
+    "howto": "Follow our guides",
     "github": "Found an issue? Submit"
   }
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -133,7 +133,7 @@
     "shapes": "Shapes",
     "editor": "Editor",
     "view": "View",
-    "blog": "Read our Blog",
+    "blog": "Read our blog",
     "howto": "Follow our guides",
     "github": "Found an issue? Submit"
   }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -127,5 +127,8 @@
   },
   "errorDialog": {
     "title": "Error"
+  },
+  "shortcutsDialog": {
+    "title": "Keyboard shortcuts"
   }
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -129,6 +129,9 @@
     "title": "Error"
   },
   "shortcutsDialog": {
-    "title": "Keyboard shortcuts"
+    "title": "Keyboard shortcuts",
+    "shapes": "Shapes",
+    "editor": "Editor",
+    "view": "View"
   }
 }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -22,6 +22,16 @@ body {
   cursor: text;
 }
 
+a {
+  font-weight: 500;
+  text-decoration: none;
+  color: #1c7ed6; /* OC Blue 7 */
+
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
 canvas {
   touch-action: none;
   user-select: none;

--- a/src/tests/__snapshots__/regressionTests.test.tsx.snap
+++ b/src/tests/__snapshots__/regressionTests.test.tsx.snap
@@ -36,6 +36,7 @@ Object {
   },
   "selectionElement": null,
   "shouldCacheIgnoreZoom": false,
+  "showShortcutsDialog": false,
   "viewBackgroundColor": "#ffffff",
   "zoom": 1,
 }
@@ -222,6 +223,7 @@ Object {
   },
   "selectionElement": null,
   "shouldCacheIgnoreZoom": false,
+  "showShortcutsDialog": false,
   "viewBackgroundColor": "#ffffff",
   "zoom": 1,
 }
@@ -332,6 +334,7 @@ Object {
   },
   "selectionElement": null,
   "shouldCacheIgnoreZoom": false,
+  "showShortcutsDialog": false,
   "viewBackgroundColor": "#ffffff",
   "zoom": 1,
 }
@@ -583,6 +586,7 @@ Object {
   },
   "selectionElement": null,
   "shouldCacheIgnoreZoom": false,
+  "showShortcutsDialog": false,
   "viewBackgroundColor": "#ffffff",
   "zoom": 1,
 }
@@ -730,6 +734,7 @@ Object {
   },
   "selectionElement": null,
   "shouldCacheIgnoreZoom": false,
+  "showShortcutsDialog": false,
   "viewBackgroundColor": "#ffffff",
   "zoom": 1,
 }
@@ -911,6 +916,7 @@ Object {
   },
   "selectionElement": null,
   "shouldCacheIgnoreZoom": false,
+  "showShortcutsDialog": false,
   "viewBackgroundColor": "#ffffff",
   "zoom": 1,
 }
@@ -1099,6 +1105,7 @@ Object {
   },
   "selectionElement": null,
   "shouldCacheIgnoreZoom": false,
+  "showShortcutsDialog": false,
   "viewBackgroundColor": "#ffffff",
   "zoom": 1,
 }
@@ -1378,6 +1385,7 @@ Object {
   "selectedElementIds": Object {},
   "selectionElement": null,
   "shouldCacheIgnoreZoom": false,
+  "showShortcutsDialog": false,
   "viewBackgroundColor": "#ffffff",
   "zoom": 1,
 }
@@ -1976,6 +1984,7 @@ Object {
   },
   "selectionElement": null,
   "shouldCacheIgnoreZoom": false,
+  "showShortcutsDialog": false,
   "viewBackgroundColor": "#ffffff",
   "zoom": 1,
 }
@@ -2086,6 +2095,7 @@ Object {
   },
   "selectionElement": null,
   "shouldCacheIgnoreZoom": false,
+  "showShortcutsDialog": false,
   "viewBackgroundColor": "#ffffff",
   "zoom": 1,
 }
@@ -2196,6 +2206,7 @@ Object {
   },
   "selectionElement": null,
   "shouldCacheIgnoreZoom": false,
+  "showShortcutsDialog": false,
   "viewBackgroundColor": "#ffffff",
   "zoom": 1,
 }
@@ -2306,6 +2317,7 @@ Object {
   },
   "selectionElement": null,
   "shouldCacheIgnoreZoom": false,
+  "showShortcutsDialog": false,
   "viewBackgroundColor": "#ffffff",
   "zoom": 1,
 }
@@ -2438,6 +2450,7 @@ Object {
   },
   "selectionElement": null,
   "shouldCacheIgnoreZoom": false,
+  "showShortcutsDialog": false,
   "viewBackgroundColor": "#ffffff",
   "zoom": 1,
 }
@@ -2570,6 +2583,7 @@ Object {
   },
   "selectionElement": null,
   "shouldCacheIgnoreZoom": false,
+  "showShortcutsDialog": false,
   "viewBackgroundColor": "#ffffff",
   "zoom": 1,
 }
@@ -2702,6 +2716,7 @@ Object {
   },
   "selectionElement": null,
   "shouldCacheIgnoreZoom": false,
+  "showShortcutsDialog": false,
   "viewBackgroundColor": "#ffffff",
   "zoom": 1,
 }
@@ -2812,6 +2827,7 @@ Object {
   },
   "selectionElement": null,
   "shouldCacheIgnoreZoom": false,
+  "showShortcutsDialog": false,
   "viewBackgroundColor": "#ffffff",
   "zoom": 1,
 }
@@ -2922,6 +2938,7 @@ Object {
   },
   "selectionElement": null,
   "shouldCacheIgnoreZoom": false,
+  "showShortcutsDialog": false,
   "viewBackgroundColor": "#ffffff",
   "zoom": 1,
 }
@@ -3054,6 +3071,7 @@ Object {
   },
   "selectionElement": null,
   "shouldCacheIgnoreZoom": false,
+  "showShortcutsDialog": false,
   "viewBackgroundColor": "#ffffff",
   "zoom": 1,
 }
@@ -3164,6 +3182,7 @@ Object {
   },
   "selectionElement": null,
   "shouldCacheIgnoreZoom": true,
+  "showShortcutsDialog": false,
   "viewBackgroundColor": "#ffffff",
   "zoom": 1,
 }
@@ -3232,6 +3251,7 @@ Object {
   },
   "selectionElement": null,
   "shouldCacheIgnoreZoom": false,
+  "showShortcutsDialog": false,
   "viewBackgroundColor": "#ffffff",
   "zoom": 1,
 }
@@ -3909,6 +3929,7 @@ Object {
   },
   "selectionElement": null,
   "shouldCacheIgnoreZoom": false,
+  "showShortcutsDialog": false,
   "viewBackgroundColor": "#ffffff",
   "zoom": 1,
 }
@@ -4269,6 +4290,7 @@ Object {
   },
   "selectionElement": null,
   "shouldCacheIgnoreZoom": false,
+  "showShortcutsDialog": false,
   "viewBackgroundColor": "#ffffff",
   "zoom": 1,
 }
@@ -4557,6 +4579,7 @@ Object {
   },
   "selectionElement": null,
   "shouldCacheIgnoreZoom": false,
+  "showShortcutsDialog": false,
   "viewBackgroundColor": "#ffffff",
   "zoom": 1,
 }
@@ -4773,6 +4796,7 @@ Object {
   },
   "selectionElement": null,
   "shouldCacheIgnoreZoom": false,
+  "showShortcutsDialog": false,
   "viewBackgroundColor": "#ffffff",
   "zoom": 1,
 }
@@ -4933,6 +4957,7 @@ Object {
   },
   "selectionElement": null,
   "shouldCacheIgnoreZoom": false,
+  "showShortcutsDialog": false,
   "viewBackgroundColor": "#ffffff",
   "zoom": 1,
 }
@@ -5581,6 +5606,7 @@ Object {
   },
   "selectionElement": null,
   "shouldCacheIgnoreZoom": false,
+  "showShortcutsDialog": false,
   "viewBackgroundColor": "#ffffff",
   "zoom": 1,
 }
@@ -6157,6 +6183,7 @@ Object {
   },
   "selectionElement": null,
   "shouldCacheIgnoreZoom": false,
+  "showShortcutsDialog": false,
   "viewBackgroundColor": "#ffffff",
   "zoom": 1,
 }
@@ -6661,6 +6688,7 @@ Object {
   },
   "selectionElement": null,
   "shouldCacheIgnoreZoom": false,
+  "showShortcutsDialog": false,
   "viewBackgroundColor": "#ffffff",
   "zoom": 1,
 }
@@ -7094,6 +7122,7 @@ Object {
   },
   "selectionElement": null,
   "shouldCacheIgnoreZoom": false,
+  "showShortcutsDialog": false,
   "viewBackgroundColor": "#ffffff",
   "zoom": 1,
 }
@@ -7490,6 +7519,7 @@ Object {
   },
   "selectionElement": null,
   "shouldCacheIgnoreZoom": false,
+  "showShortcutsDialog": false,
   "viewBackgroundColor": "#ffffff",
   "zoom": 1,
 }
@@ -7814,6 +7844,7 @@ Object {
   },
   "selectionElement": null,
   "shouldCacheIgnoreZoom": false,
+  "showShortcutsDialog": false,
   "viewBackgroundColor": "#ffffff",
   "zoom": 1,
 }
@@ -8066,6 +8097,7 @@ Object {
   },
   "selectionElement": null,
   "shouldCacheIgnoreZoom": false,
+  "showShortcutsDialog": false,
   "viewBackgroundColor": "#ffffff",
   "zoom": 1,
 }
@@ -8262,6 +8294,7 @@ Object {
   },
   "selectionElement": null,
   "shouldCacheIgnoreZoom": false,
+  "showShortcutsDialog": false,
   "viewBackgroundColor": "#ffffff",
   "zoom": 1,
 }
@@ -8946,6 +8979,7 @@ Object {
   },
   "selectionElement": null,
   "shouldCacheIgnoreZoom": false,
+  "showShortcutsDialog": false,
   "viewBackgroundColor": "#ffffff",
   "zoom": 1,
 }
@@ -9558,6 +9592,7 @@ Object {
   },
   "selectionElement": null,
   "shouldCacheIgnoreZoom": false,
+  "showShortcutsDialog": false,
   "viewBackgroundColor": "#ffffff",
   "zoom": 1,
 }
@@ -10098,6 +10133,7 @@ Object {
   },
   "selectionElement": null,
   "shouldCacheIgnoreZoom": false,
+  "showShortcutsDialog": false,
   "viewBackgroundColor": "#ffffff",
   "zoom": 1,
 }
@@ -10562,6 +10598,7 @@ Object {
   },
   "selectionElement": null,
   "shouldCacheIgnoreZoom": false,
+  "showShortcutsDialog": false,
   "viewBackgroundColor": "#ffffff",
   "zoom": 1,
 }
@@ -10800,6 +10837,7 @@ Object {
   "selectedElementIds": Object {},
   "selectionElement": null,
   "shouldCacheIgnoreZoom": false,
+  "showShortcutsDialog": false,
   "viewBackgroundColor": "#ffffff",
   "zoom": 1,
 }
@@ -10852,6 +10890,7 @@ Object {
   },
   "selectionElement": null,
   "shouldCacheIgnoreZoom": true,
+  "showShortcutsDialog": false,
   "viewBackgroundColor": "#ffffff",
   "zoom": 1,
 }
@@ -10904,6 +10943,7 @@ Object {
   },
   "selectionElement": null,
   "shouldCacheIgnoreZoom": false,
+  "showShortcutsDialog": false,
   "viewBackgroundColor": "#ffffff",
   "zoom": 1,
 }
@@ -11184,6 +11224,7 @@ Object {
   "selectedElementIds": Object {},
   "selectionElement": null,
   "shouldCacheIgnoreZoom": false,
+  "showShortcutsDialog": false,
   "viewBackgroundColor": "#ffffff",
   "zoom": 1,
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -45,6 +45,7 @@ export type AppState = {
   selectedElementIds: { [id: string]: boolean };
   collaborators: Map<string, { pointer?: { x: number; y: number } }>;
   shouldCacheIgnoreZoom: boolean;
+  showShortcutsDialog: boolean;
 };
 
 export type PointerCoords = Readonly<{

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -144,16 +144,17 @@ export function resetCursor() {
   document.documentElement.style.cursor = "";
 }
 
-export const getShortcutKey = (shortcut: string): string => {
+export const getShortcutKey = (shortcut: string, prefix = " — "): string => {
   const isMac = /Mac|iPod|iPhone|iPad/.test(window.navigator.platform);
   if (isMac) {
-    return ` — ${shortcut
+    return `${prefix}${shortcut
       .replace("CtrlOrCmd+", "⌘")
       .replace("Alt+", "⌥")
       .replace("Ctrl+", "⌃")
-      .replace("Shift+", "⇧")}`;
+      .replace("Shift+", "⇧")
+      .replace("Del", "⌫")}`;
   }
-  return ` — ${shortcut.replace("CtrlOrCmd", "Ctrl")}`;
+  return `${prefix}${shortcut.replace("CtrlOrCmd", "Ctrl")}`;
 };
 export function viewportCoordsToSceneCoords(
   { clientX, clientY }: { clientX: number; clientY: number },


### PR DESCRIPTION
### [Preview](https://excalidraw-git-shortcuts-hint.excalidraw.now.sh)

- [x] Use labels from `en.json`
- [x] More shortcuts? Am I missing anything?
- [x] Test on Mac
- [x] Test on Windows
- [x] Test on Linux 
- [x] Footer with links to blog, howto, github
- [x] Scroll if the window height is too small
- [ ] ~~Add a button next to the language select with `?`~~ Next PR