### PR TITLE
fix wysiwyg event cleanup

### DIFF
--- a/src/element/textWysiwyg.tsx
+++ b/src/element/textWysiwyg.tsx
@@ -139,6 +139,12 @@ export function textWysiwyg({
   }
 
   function cleanup() {
+    // remove events to ensure they don't late-fire
+    editable.onblur = null;
+    editable.onpaste = null;
+    editable.oninput = null;
+    editable.onkeydown = null;
+
     window.removeEventListener("wheel", stopEvent, true);
     document.body.removeChild(editable);
   }


### PR DESCRIPTION
fixes https://github.com/excalidraw/excalidraw/issues/1247

I messed up when I removed those handler removals, because it turns out they weren't there for memory leak problems :)