### PR TITLE
Update copy and minor refactor (`duplicateSelection` => `duplicate`)

### DIFF
--- a/src/actions/actionDuplicate.tsx
+++ b/src/actions/actionDuplicate.tsx
@@ -9,8 +9,8 @@ import { clone } from "../components/icons";
 import { t } from "../i18n";
 import { getShortcutKey } from "../utils";
 
-export const actionDuplicateSelection = register({
-  name: "duplicateSelection",
+export const actionDuplicate = register({
+  name: "duplicate",
   perform: (elements, appState) => {
     return {
       appState,
@@ -32,16 +32,14 @@ export const actionDuplicateSelection = register({
       commitToHistory: true,
     };
   },
-  contextItemLabel: "labels.duplicateSelection",
+  contextItemLabel: "labels.duplicate",
   keyTest: (event) => event[KEYS.CTRL_OR_CMD] && event.key === "d",
   PanelComponent: ({ elements, appState, updateData }) => (
     <ToolButton
       type="button"
       icon={clone}
-      title={`${t("labels.duplicateSelection")} ${getShortcutKey(
-        "CtrlOrCmd+D",
-      )}`}
-      aria-label={t("labels.duplicateSelection")}
+      title={`${t("labels.duplicate")} ${getShortcutKey("CtrlOrCmd+D")}`}
+      aria-label={t("labels.duplicate")}
       onClick={() => updateData(null)}
       visible={isSomeElementSelected(elements, appState)}
     />

--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -6,7 +6,7 @@ export {
   actionSendToBack,
 } from "./actionZindex";
 export { actionSelectAll } from "./actionSelectAll";
-export { actionDuplicateSelection } from "./actionDuplicateSelection";
+export { actionDuplicate } from "./actionDuplicate";
 export {
   actionChangeStrokeColor,
   actionChangeBackgroundColor,

--- a/src/actions/types.ts
+++ b/src/actions/types.ts
@@ -41,7 +41,7 @@ export type ActionName =
   | "changeExportBackground"
   | "saveScene"
   | "loadScene"
-  | "duplicateSelection"
+  | "duplicate"
   | "deleteSelectedElements"
   | "changeViewBackgroundColor"
   | "clearCanvas"

--- a/src/components/Actions.tsx
+++ b/src/components/Actions.tsx
@@ -71,7 +71,7 @@ export function SelectedShapeActions({
         <fieldset>
           <legend>{t("labels.actions")}</legend>
           <div className="buttonList">
-            {renderAction("duplicateSelection")}
+            {renderAction("duplicate")}
             {renderAction("deleteSelectedElements")}
           </div>
         </fieldset>

--- a/src/components/MobileMenu.tsx
+++ b/src/components/MobileMenu.tsx
@@ -124,7 +124,7 @@ export function MobileMenu({
               {actionManager.renderAction("undo")}
               {actionManager.renderAction("redo")}
               {actionManager.renderAction(
-                appState.multiElement ? "finalize" : "duplicateSelection",
+                appState.multiElement ? "finalize" : "duplicate",
               )}
               {actionManager.renderAction("deleteSelectedElements")}
             </div>

--- a/src/components/ShortcutsDialog.tsx
+++ b/src/components/ShortcutsDialog.tsx
@@ -44,6 +44,7 @@ const Shortcut = (props: { title: string; shortcuts: string[] }) => (
         margin: "0",
         padding: "4px",
         alignItems: "center",
+        whiteSpace: "nowrap",
       }}
     >
       <div
@@ -75,7 +76,7 @@ const ShortcutKey = (props: { children: React.ReactNode }) => (
   <span
     style={{
       border: "1px solid #ced4da",
-      padding: "2px 8px",
+      padding: "2px 6px",
       margin: "0 4px",
       backgroundColor: "#e9ecef",
       borderRadius: "2px",
@@ -92,8 +93,8 @@ const Footer = () => (
       flexDirection: "row",
       justifyContent: "space-between",
       borderTop: "1px solid #ced4da",
-      marginTop: 8,
-      paddingTop: 16,
+      marginTop: 4,
+      paddingTop: 12,
     }}
   >
     <a
@@ -214,7 +215,7 @@ export const ShortcutsDialog = ({ onClose }: { onClose?: () => void }) => {
               shortcuts={[getShortcutKey("CtrlOrCmd+]", "")]}
             />
             <Shortcut
-              title={t("labels.duplicateSelection")}
+              title={t("labels.duplicate")}
               shortcuts={[getShortcutKey("CtrlOrCmd+D", "")]}
             />
           </ShortcutIsland>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -46,7 +46,7 @@
     "actions": "Actions",
     "language": "Language",
     "createRoom": "Share a live-collaboration session",
-    "duplicateSelection": "Duplicate selected elements"
+    "duplicate": "Duplicate"
   },
   "buttons": {
     "clearReset": "Reset the canvas",


### PR DESCRIPTION
I started with the copy, because it appears only on selected objects anyways and changed the variables for consistency. Nothing else is being duplicated so there is no confusion on what is being duplicated.