### PR TITLE
edit text when clicked on with text tool

### DIFF
--- a/src/components/Actions.tsx
+++ b/src/components/Actions.tsx
@@ -6,8 +6,7 @@ import { hasBackground, hasStroke, hasText, getTargetElement } from "../scene";
 import { t } from "../i18n";
 import { SHAPES } from "../shapes";
 import { ToolButton } from "./ToolButton";
-import { capitalizeString, getShortcutKey } from "../utils";
-import { CURSOR_TYPE } from "../constants";
+import { capitalizeString, getShortcutKey, setCursorForShape } from "../utils";
 import Stack from "./Stack";
 import useIsMobile from "../is-mobile";
 
@@ -115,8 +114,7 @@ export function ShapesSwitcher({
                 multiElement: null,
                 selectedElementIds: {},
               });
-              document.documentElement.style.cursor =
-                value === "text" ? CURSOR_TYPE.TEXT : CURSOR_TYPE.CROSSHAIR;
+              setCursorForShape(value);
               setAppState({});
             }}
           ></ToolButton>

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -67,6 +67,7 @@ import {
   resetCursor,
   viewportCoordsToSceneCoords,
   sceneCoordsToViewportCoords,
+  setCursorForShape,
 } from "../utils";
 import { KEYS, isArrowKey } from "../keys";
 
@@ -143,15 +144,6 @@ const gesture: Gesture = {
   initialDistance: null,
   initialScale: null,
 };
-
-function setCursorForShape(shape: string) {
-  if (shape === "selection") {
-    resetCursor();
-  } else {
-    document.documentElement.style.cursor =
-      shape === "text" ? CURSOR_TYPE.TEXT : CURSOR_TYPE.CROSSHAIR;
-  }
-}
 
 export class App extends React.Component<any, AppState> {
   canvas: HTMLCanvasElement | null = null;
@@ -1108,10 +1100,7 @@ export class App extends React.Component<any, AppState> {
       if (this.state.elementType === "selection") {
         resetCursor();
       } else {
-        document.documentElement.style.cursor =
-          this.state.elementType === "text"
-            ? CURSOR_TYPE.TEXT
-            : CURSOR_TYPE.CROSSHAIR;
+        setCursorForShape(this.state.elementType);
         this.setState({ selectedElementIds: {} });
       }
       isHoldingSpace = false;
@@ -1482,7 +1471,11 @@ export class App extends React.Component<any, AppState> {
     }
 
     const hasDeselectedButton = Boolean(event.buttons);
-    if (hasDeselectedButton || this.state.elementType !== "selection") {
+    if (
+      hasDeselectedButton ||
+      (this.state.elementType !== "selection" &&
+        this.state.elementType !== "text")
+    ) {
       return;
     }
 
@@ -1512,8 +1505,14 @@ export class App extends React.Component<any, AppState> {
       y,
       this.state.zoom,
     );
-    document.documentElement.style.cursor =
-      hitElement && !isOverScrollBar ? "move" : "";
+    if (this.state.elementType === "text") {
+      document.documentElement.style.cursor = isTextElement(hitElement)
+        ? CURSOR_TYPE.TEXT
+        : CURSOR_TYPE.CROSSHAIR;
+    } else {
+      document.documentElement.style.cursor =
+        hitElement && !isOverScrollBar ? "move" : "";
+    }
   };
 
   private handleCanvasPointerDown = (
@@ -1789,47 +1788,25 @@ export class App extends React.Component<any, AppState> {
         return;
       }
 
-      const snappedToCenterPosition = event.altKey
-        ? null
-        : this.getTextWysiwygSnappedToCenterPosition(
-            x,
-            y,
-            this.state,
-            this.canvas,
-            window.devicePixelRatio,
-          );
+      const { x, y } = viewportCoordsToSceneCoords(
+        event,
+        this.state,
+        this.canvas,
+        window.devicePixelRatio,
+      );
 
-      const element = newTextElement({
-        x: snappedToCenterPosition?.elementCenterX ?? x,
-        y: snappedToCenterPosition?.elementCenterY ?? y,
-        strokeColor: this.state.currentItemStrokeColor,
-        backgroundColor: this.state.currentItemBackgroundColor,
-        fillStyle: this.state.currentItemFillStyle,
-        strokeWidth: this.state.currentItemStrokeWidth,
-        roughness: this.state.currentItemRoughness,
-        opacity: this.state.currentItemOpacity,
-        text: "",
-        font: this.state.currentItemFont,
+      this.startTextEditing({
+        x: x,
+        y: y,
+        clientX: event.clientX,
+        clientY: event.clientY,
+        centerIfPossible: !event.altKey,
       });
 
-      globalSceneState.replaceAllElements([
-        ...globalSceneState.getAllElements(),
-        element,
-      ]);
-
-      this.handleTextWysiwyg(element, {
-        x: snappedToCenterPosition?.wysiwygX ?? event.clientX,
-        y: snappedToCenterPosition?.wysiwygY ?? event.clientY,
-      });
       resetCursor();
       if (!this.state.elementLocked) {
         this.setState({
-          editingElement: element,
           elementType: "selection",
-        });
-      } else {
-        this.setState({
-          editingElement: element,
         });
       }
       return;

--- a/src/element/typeChecks.ts
+++ b/src/element/typeChecks.ts
@@ -5,9 +5,9 @@ import {
 } from "./types";
 
 export function isTextElement(
-  element: ExcalidrawElement,
+  element: ExcalidrawElement | null,
 ): element is ExcalidrawTextElement {
-  return element.type === "text";
+  return element != null && element.type === "text";
 }
 
 export function isLinearElement(

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,6 @@
 import { FlooredNumber } from "./types";
 import { getZoomOrigin } from "./scene";
+import { CURSOR_TYPE } from "./constants";
 
 export const SVG_NS = "http://www.w3.org/2000/svg";
 
@@ -142,6 +143,14 @@ export function distance2d(x1: number, y1: number, x2: number, y2: number) {
 
 export function resetCursor() {
   document.documentElement.style.cursor = "";
+}
+
+export function setCursorForShape(shape: string) {
+  if (shape === "selection") {
+    resetCursor();
+  } else {
+    document.documentElement.style.cursor = CURSOR_TYPE.CROSSHAIR;
+  }
 }
 
 export const isFullScreen = () =>


### PR DESCRIPTION
fixes https://github.com/excalidraw/excalidraw/issues/992

1. edit existing text when clicked on with text tool
2. changed default cursor for text tool from `text` to `crosshair`, so that when you hover over text it's distinguished. This aligns it with Figma et al.

Surprisingly, side effect of (1) is simplifying/DRY-ing the code which is a bonus.