### PR TITLE
prevent pasting svg copied from excalidraw

### DIFF
--- a/src/clipboard.ts
+++ b/src/clipboard.ts
@@ -1,6 +1,7 @@
 import { ExcalidrawElement } from "./element/types";
 import { getSelectedElements } from "./scene";
 import { AppState } from "./types";
+import { SVG_EXPORT_TAG } from "./scene/export";
 
 let CLIPBOARD = "";
 let PREFER_APP_CLIPBOARD = false;
@@ -39,6 +40,10 @@ export async function copyToAppClipboard(
 export function getAppClipboard(): {
   elements?: readonly ExcalidrawElement[];
 } {
+  if (!CLIPBOARD) {
+    return {};
+  }
+
   try {
     const clipboardElements = JSON.parse(CLIPBOARD);
 
@@ -68,7 +73,7 @@ export async function getClipboardContent(
       : probablySupportsClipboardReadText &&
         (await navigator.clipboard.readText());
 
-    if (text && !PREFER_APP_CLIPBOARD) {
+    if (text && !PREFER_APP_CLIPBOARD && !text.includes(SVG_EXPORT_TAG)) {
       return { text };
     }
   } catch (error) {
@@ -99,7 +104,7 @@ export async function copyCanvasToClipboardAsPng(canvas: HTMLCanvasElement) {
 
 export async function copyCanvasToClipboardAsSvg(svgroot: SVGSVGElement) {
   try {
-    await navigator.clipboard.writeText(svgroot.outerHTML);
+    await navigator.clipboard.writeText(`${svgroot.outerHTML}`);
   } catch (error) {
     console.error(error);
   }

--- a/src/clipboard.ts
+++ b/src/clipboard.ts
@@ -104,7 +104,7 @@ export async function copyCanvasToClipboardAsPng(canvas: HTMLCanvasElement) {
 
 export async function copyCanvasToClipboardAsSvg(svgroot: SVGSVGElement) {
   try {
-    await navigator.clipboard.writeText(`${svgroot.outerHTML}`);
+    await navigator.clipboard.writeText(svgroot.outerHTML);
   } catch (error) {
     console.error(error);
   }

--- a/src/scene/export.ts
+++ b/src/scene/export.ts
@@ -6,6 +6,8 @@ import { distance, SVG_NS } from "../utils";
 import { normalizeScroll } from "./scroll";
 import { AppState } from "../types";
 
+export const SVG_EXPORT_TAG = `<!-- svg-source:excalidraw -->`;
+
 export function exportToCanvas(
   elements: readonly ExcalidrawElement[],
   appState: AppState,
@@ -86,6 +88,7 @@ export function exportToSvg(
   svgRoot.setAttribute("viewBox", `0 0 ${width} ${height}`);
 
   svgRoot.innerHTML = `
+  ${SVG_EXPORT_TAG}
   <defs>
     <style>
       @font-face {


### PR DESCRIPTION
fixes https://github.com/excalidraw/excalidraw/issues/1252

- added excalidraw tag comment to export & clipboard (not sure if there's is normative `<svg>` attribute for this, but I didn't find it)