### PR TITLE
Optimize ShortcutsDialog style

### DIFF
--- a/src/components/Island.css
+++ b/src/components/Island.css
@@ -1,5 +1,6 @@
 .Island {
   --padding: 0;
+  word-break: keep-all;
   background-color: var(--bg-color-main);
   box-shadow: var(--shadow-island);
   border-radius: var(--border-radius-m);

--- a/src/components/Island.css
+++ b/src/components/Island.css
@@ -1,6 +1,5 @@
 .Island {
   --padding: 0;
-  word-break: keep-all;
   background-color: var(--bg-color-main);
   box-shadow: var(--shadow-island);
   border-radius: var(--border-radius-m);

--- a/src/components/ShortcutsDialog.tsx
+++ b/src/components/ShortcutsDialog.tsx
@@ -86,6 +86,7 @@ Shortcut.defaultProps = {
 const ShortcutKey = (props: { children: React.ReactNode }) => (
   <span
     style={{
+      wordBreak: "keep-all",
       border: "1px solid #ced4da",
       padding: "2px 8px",
       margin: "0 4px",

--- a/src/components/ShortcutsDialog.tsx
+++ b/src/components/ShortcutsDialog.tsx
@@ -13,6 +13,7 @@ const ShortcutIsland = (props: {
       width: "49%",
       border: "1px solid #ced4da",
       marginBottom: "16px",
+      height: "-webkit-fill-available",
     }}
   >
     <h3


### PR DESCRIPTION
1. Fix Chinese display unnecessary line breaks.
2. Keep all row heights consistent.

Before:
![image](https://user-images.githubusercontent.com/33168165/78857454-06ed0d00-7a5c-11ea-840d-5a39e0b8f6d1.png)
After:
![image](https://user-images.githubusercontent.com/33168165/78857485-1704ec80-7a5c-11ea-8207-239ddb2f030f.png)

