### PR TITLE
Make the mouse location broadcast volatile

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -171,13 +171,14 @@ class Portal {
     data: SocketUpdateDataSource[keyof SocketUpdateDataSource] & {
       _brand: "socketUpdateData";
     },
+    volatile: boolean = false,
   ) {
     if (this.isOpen()) {
       const json = JSON.stringify(data);
       const encoded = new TextEncoder().encode(json);
       const encrypted = await encryptAESGEM(encoded, this.roomKey!);
       this.socket!.emit(
-        "server-broadcast",
+        volatile ? "server-volatile-broadcast" : "server-broadcast",
         this.roomID,
         encrypted.data,
         encrypted.iv,
@@ -993,6 +994,7 @@ export class App extends React.Component<any, AppState> {
       };
       return this.portal._broadcastSocketData(
         data as typeof data & { _brand: "socketUpdateData" },
+        true, // volatile
       );
     }
   };


### PR DESCRIPTION
Hoping that it will improve #1310 
I tried testing it with the browser throttled connection and it seemed to perform a bit better, though it's hard to tell if events actually get dropped. In any case, not a full solution to the problem.