### PR TITLE
Refactor ResizeArrowFnType to resolve Codesandbox parsing error

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -21,7 +21,6 @@ import {
   getDrawingVersion,
   getSyncableElements,
   newLinearElement,
-  ResizeArrowFnType,
   resizeElements,
   getElementWithResizeHandler,
   canResizeMutlipleElements,
@@ -52,7 +51,11 @@ import {
 
 import { renderScene } from "../renderer";
 import { AppState, GestureEvent, Gesture } from "../types";
-import { ExcalidrawElement, ExcalidrawTextElement } from "../element/types";
+import {
+  ExcalidrawElement,
+  ExcalidrawTextElement,
+  ResizeArrowFnType,
+} from "../element/types";
 
 import { distance2d, isPathALoop } from "../math";
 

--- a/src/element/index.ts
+++ b/src/element/index.ts
@@ -29,7 +29,6 @@ export {
   getElementWithResizeHandler,
   getResizeHandlerFromCoords,
 } from "./resizeTest";
-export type { ResizeArrowFnType } from "./resizeElements";
 export { resizeElements, canResizeMutlipleElements } from "./resizeElements";
 export { isTextElement, isExcalidrawElement } from "./typeChecks";
 export { textWysiwyg } from "./textWysiwyg";

--- a/src/element/resizeElements.ts
+++ b/src/element/resizeElements.ts
@@ -3,11 +3,7 @@ import { SHIFT_LOCKING_ANGLE } from "../constants";
 import { getSelectedElements, globalSceneState } from "../scene";
 import { rescalePoints } from "../points";
 import { rotate, adjustXYWithRotation } from "../math";
-import {
-  ExcalidrawLinearElement,
-  NonDeletedExcalidrawElement,
-  NonDeleted,
-} from "./types";
+import { NonDeletedExcalidrawElement, ResizeArrowFnType } from "./types";
 import { getElementAbsoluteCoords, getCommonBounds } from "./bounds";
 import { isLinearElement } from "./typeChecks";
 import { mutateElement } from "./mutateElement";
@@ -19,16 +15,6 @@ import {
 } from "./resizeTest";
 
 type ResizeTestType = ReturnType<typeof resizeTest>;
-
-export type ResizeArrowFnType = (
-  element: NonDeleted<ExcalidrawLinearElement>,
-  pointIndex: number,
-  deltaX: number,
-  deltaY: number,
-  pointerX: number,
-  pointerY: number,
-  perfect: boolean,
-) => void;
 
 const arrowResizeOrigin: ResizeArrowFnType = (
   element,

--- a/src/element/types.ts
+++ b/src/element/types.ts
@@ -58,3 +58,13 @@ export type ExcalidrawLinearElement = _ExcalidrawElementBase &
 export type PointerType = "mouse" | "pen" | "touch";
 
 export type TextAlign = "left" | "center" | "right";
+
+export type ResizeArrowFnType = (
+  element: NonDeleted<ExcalidrawLinearElement>,
+  pointIndex: number,
+  deltaX: number,
+  deltaY: number,
+  pointerX: number,
+  pointerY: number,
+  perfect: boolean,
+) => void;


### PR DESCRIPTION
I'm not sure if it's only for me, but the following syntax is causing [codesandbox](https://codesandbox.io/s/github/excalidraw/excalidraw) parsing error. It seems to be an issue due to the syntax supported by typescript [v3.8.3](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-8.html#type-only-imports-exports). To solve this, the type was moved to the `element/types.ts` file according to the existing convention.
```ts
export type { ResizeArrowFnType } from "./resizeElements";
```

<img width="1620" alt="스크린샷 2020-04-09 오후 11 06 24" src="https://user-images.githubusercontent.com/4126644/78905621-41d15e00-7ab9-11ea-99c5-5d95f9f46f2a.png">
