### PR TITLE
createWriter is now createWritable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3544,9 +3544,9 @@
       "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
     },
     "browser-nativefs": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/browser-nativefs/-/browser-nativefs-0.4.0.tgz",
-      "integrity": "sha512-CiCwgd4Ir5OTC1IyVgyYJ5kJR7RDU/KLwgjrynoNNnKrBVwex3zRPKMmdAbcBXQJDbIQNnCyUQyvhbqH/9ERJA=="
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/browser-nativefs/-/browser-nativefs-0.5.0.tgz",
+      "integrity": "sha512-X7IMjKSk/llmXkSZBOecvCdPT8V+aeT+O9i313ocNAqnyKLt/vY+xxDPqsNxLf31sZKsm/IZeSc8sD8DOoTeYA=="
     },
     "browser-process-hrtime": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@sentry/browser": "5.15.4",
     "@sentry/integrations": "5.15.4",
-    "browser-nativefs": "0.4.0",
+    "browser-nativefs": "0.5.0",
     "i18next-browser-languagedetector": "4.0.2",
     "nanoid": "2.1.11",
     "react": "16.13.1",


### PR DESCRIPTION
Updated with browser-nativefs v0.5.0.

https://wicg.github.io/native-file-system/#ref-for-dom-filesystemfilehandle-createwritable①:~:text=In%20the%20Origin%20Trial%20as%20available%20in%20Chrome%2082%2C%20createWritable%20replaces%20the%20createWriter%20method.
