### PR TITLE
PoC: Expose wysiwyg element to manipulate from outside

### DIFF
--- a/src/actions/actionProperties.tsx
+++ b/src/actions/actionProperties.tsx
@@ -27,7 +27,10 @@ const changeProperty = (
   callback: (element: ExcalidrawElement) => ExcalidrawElement,
 ) => {
   return elements.map((element) => {
-    if (appState.selectedElementIds[element.id]) {
+    if (
+      appState.selectedElementIds[element.id] ||
+      element.id === appState.editingElement?.id
+    ) {
       return callback(element);
     }
     return element;
@@ -276,6 +279,7 @@ export const actionChangeOpacity = register({
 export const actionChangeFontSize = register({
   name: "changeFontSize",
   perform: (elements, appState, value) => {
+    // let editingElement;
     return {
       elements: changeProperty(elements, appState, (el) => {
         if (isTextElement(el)) {
@@ -290,19 +294,6 @@ export const actionChangeFontSize = register({
       }),
       appState: {
         ...appState,
-        editingElement: appState.editingElement
-          ? {
-              ...(appState.editingElement as ExcalidrawTextElement),
-              isDeleted: false,
-              font: `${value}px ${
-                appState
-                  ? (
-                      appState.editingElement as ExcalidrawTextElement
-                    ).font.split("px ")[1]
-                  : ""
-              }`,
-            }
-          : null,
         currentItemFont: `${value}px ${
           appState.currentItemFont.split("px ")[1]
         }`,

--- a/src/actions/actionProperties.tsx
+++ b/src/actions/actionProperties.tsx
@@ -279,7 +279,6 @@ export const actionChangeOpacity = register({
 export const actionChangeFontSize = register({
   name: "changeFontSize",
   perform: (elements, appState, value) => {
-    // let editingElement;
     return {
       elements: changeProperty(elements, appState, (el) => {
         if (isTextElement(el)) {

--- a/src/actions/actionProperties.tsx
+++ b/src/actions/actionProperties.tsx
@@ -290,6 +290,19 @@ export const actionChangeFontSize = register({
       }),
       appState: {
         ...appState,
+        editingElement: appState.editingElement
+          ? {
+              ...(appState.editingElement as ExcalidrawTextElement),
+              isDeleted: false,
+              font: `${value}px ${
+                appState
+                  ? (
+                      appState.editingElement as ExcalidrawTextElement
+                    ).font.split("px ")[1]
+                  : ""
+              }`,
+            }
+          : null,
         currentItemFont: `${value}px ${
           appState.currentItemFont.split("px ")[1]
         }`,

--- a/src/appState.ts
+++ b/src/appState.ts
@@ -7,6 +7,7 @@ export const DEFAULT_TEXT_ALIGN = "left";
 
 export function getDefaultAppState(): AppState {
   return {
+    wysiwygElement: null,
     isLoading: false,
     errorMessage: null,
     draggingElement: null,

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -25,6 +25,7 @@ import {
   getElementWithResizeHandler,
   canResizeMutlipleElements,
   getResizeHandlerFromCoords,
+  isNonDeletedElement,
 } from "../element";
 import {
   deleteSelectedElements,
@@ -269,19 +270,31 @@ export class App extends React.Component<any, AppState> {
     if (this.unmounted) {
       return;
     }
+
+    let editingElement: AppState["editingElement"] | null = null;
     if (res.elements) {
+      res.elements.forEach((element) => {
+        if (
+          this.state.editingElement?.id === element.id &&
+          this.state.editingElement !== element &&
+          isNonDeletedElement(element)
+        ) {
+          editingElement = element;
+        }
+      });
       globalSceneState.replaceAllElements(res.elements);
       if (res.commitToHistory) {
         history.resumeRecording();
       }
     }
 
-    if (res.appState) {
+    if (res.appState || editingElement) {
       if (res.commitToHistory) {
         history.resumeRecording();
       }
       this.setState((state) => ({
         ...res.appState,
+        editingElement: editingElement || state.editingElement,
         isCollaborating: state.isCollaborating,
         collaborators: state.collaborators,
       }));

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1210,7 +1210,7 @@ export class App extends React.Component<any, AppState> {
       ]);
     };
 
-    const updateElement = (text: string, font: string) => {
+    const updateElement = (text: string) => {
       globalSceneState.replaceAllElements([
         ...globalSceneState.getElementsIncludingDeleted().map((_element) => {
           if (_element.id === element.id) {
@@ -1219,7 +1219,6 @@ export class App extends React.Component<any, AppState> {
               x: element.x,
               y: element.y,
               text,
-              font,
             });
           }
           return _element;
@@ -1237,15 +1236,15 @@ export class App extends React.Component<any, AppState> {
       angle: element.angle,
       textAlign: element.textAlign,
       zoom: this.state.zoom,
-      onChange: withBatchedUpdates((event) => {
-        if (event) {
-          updateElement(event.text, event.font);
+      onChange: withBatchedUpdates((text) => {
+        if (text) {
+          updateElement(text);
         } else {
           deleteElement();
         }
       }),
-      onSubmit: withBatchedUpdates((event) => {
-        updateElement(event.text, event.font);
+      onSubmit: withBatchedUpdates((text) => {
+        updateElement(text);
         this.setState((prevState) => ({
           wysiwygElement: null,
           selectedElementIds: {
@@ -1272,7 +1271,7 @@ export class App extends React.Component<any, AppState> {
 
     // do an initial update to re-initialize element position since we were
     //  modifying element's x/y for sake of editor (case: syncing to remote)
-    updateElement(element.text, element.font);
+    updateElement(element.text);
   }
 
   private startTextEditing = ({

--- a/src/element/index.ts
+++ b/src/element/index.ts
@@ -1,4 +1,8 @@
-import { ExcalidrawElement, NonDeletedExcalidrawElement } from "./types";
+import {
+  ExcalidrawElement,
+  NonDeletedExcalidrawElement,
+  NonDeleted,
+} from "./types";
 import { isInvisiblySmallElement } from "./sizeHelpers";
 
 export {
@@ -67,4 +71,10 @@ export function getNonDeletedElements(elements: readonly ExcalidrawElement[]) {
     elements.filter((element) => !element.isDeleted) as
     readonly NonDeletedExcalidrawElement[]
   );
+}
+
+export function isNonDeletedElement<T extends ExcalidrawElement>(
+  element: T,
+): element is NonDeleted<T> {
+  return !element.isDeleted;
 }

--- a/src/element/textWysiwyg.tsx
+++ b/src/element/textWysiwyg.tsx
@@ -22,8 +22,8 @@ type TextWysiwygParams = {
   zoom: number;
   angle: number;
   textAlign: string;
-  onChange?: (text: string) => void;
-  onSubmit: (text: string) => void;
+  onChange?: (event: { text: string; font: string }) => void;
+  onSubmit: (event: { text: string; font: string }) => void;
   onCancel: () => void;
 };
 
@@ -102,7 +102,10 @@ export function textWysiwyg({
 
   if (onChange) {
     editable.oninput = () => {
-      onChange(trimText(editable.innerText));
+      onChange({
+        text: trimText(editable.innerText),
+        font: editable.style.font,
+      });
     };
   }
 
@@ -120,7 +123,7 @@ export function textWysiwyg({
       event.stopPropagation();
     }
   };
-  editable.onblur = handleSubmit;
+  // editable.onblur = handleSubmit;
 
   function stopEvent(event: Event) {
     event.stopPropagation();
@@ -128,7 +131,10 @@ export function textWysiwyg({
 
   function handleSubmit() {
     if (editable.innerText) {
-      onSubmit(trimText(editable.innerText));
+      onSubmit({
+        text: trimText(editable.innerText),
+        font: editable.style.font,
+      });
     } else {
       onCancel();
     }
@@ -143,11 +149,22 @@ export function textWysiwyg({
     editable.onkeydown = null;
 
     window.removeEventListener("wheel", stopEvent, true);
-    document.body.removeChild(editable);
+    try {
+      document.body.removeChild(editable);
+    } catch (e) {
+      // TODO: figure why this is happening
+    }
   }
 
   window.addEventListener("wheel", stopEvent, true);
   document.body.appendChild(editable);
   editable.focus();
   selectNode(editable);
+
+  return {
+    submit: handleSubmit,
+    changeStyle: (style: any) => {
+      Object.assign(editable.style, style);
+    },
+  };
 }

--- a/src/element/textWysiwyg.tsx
+++ b/src/element/textWysiwyg.tsx
@@ -147,6 +147,7 @@ export function textWysiwyg({
       document.body.removeChild(editable);
     } catch (e) {
       // TODO: figure why this is happening
+      console.error("failed to remove element");
     }
   }
 

--- a/src/element/textWysiwyg.tsx
+++ b/src/element/textWysiwyg.tsx
@@ -1,5 +1,6 @@
 import { KEYS } from "../keys";
 import { selectNode } from "../utils";
+import { WysiwigElement } from "./types";
 
 function trimText(text: string) {
   // whitespace only → trim all because we'd end up inserting invisible element
@@ -40,7 +41,7 @@ export function textWysiwyg({
   textAlign,
   onSubmit,
   onCancel,
-}: TextWysiwygParams) {
+}: TextWysiwygParams): WysiwigElement {
   const editable = document.createElement("div");
   try {
     editable.contentEditable = "plaintext-only";

--- a/src/element/textWysiwyg.tsx
+++ b/src/element/textWysiwyg.tsx
@@ -22,8 +22,8 @@ type TextWysiwygParams = {
   zoom: number;
   angle: number;
   textAlign: string;
-  onChange?: (event: { text: string; font: string }) => void;
-  onSubmit: (event: { text: string; font: string }) => void;
+  onChange?: (text: string) => void;
+  onSubmit: (text: string) => void;
   onCancel: () => void;
 };
 
@@ -102,10 +102,7 @@ export function textWysiwyg({
 
   if (onChange) {
     editable.oninput = () => {
-      onChange({
-        text: trimText(editable.innerText),
-        font: editable.style.font,
-      });
+      onChange(trimText(editable.innerText));
     };
   }
 
@@ -131,10 +128,7 @@ export function textWysiwyg({
 
   function handleSubmit() {
     if (editable.innerText) {
-      onSubmit({
-        text: trimText(editable.innerText),
-        font: editable.style.font,
-      });
+      onSubmit(trimText(editable.innerText));
     } else {
       onCancel();
     }

--- a/src/element/textWysiwyg.tsx
+++ b/src/element/textWysiwyg.tsx
@@ -165,6 +165,7 @@ export function textWysiwyg({
     submit: handleSubmit,
     changeStyle: (style: any) => {
       Object.assign(editable.style, style);
+      editable.focus();
     },
   };
 }

--- a/src/element/textWysiwyg.tsx
+++ b/src/element/textWysiwyg.tsx
@@ -143,12 +143,7 @@ export function textWysiwyg({
     editable.onkeydown = null;
 
     window.removeEventListener("wheel", stopEvent, true);
-    try {
-      document.body.removeChild(editable);
-    } catch (e) {
-      // TODO: figure why this is happening
-      console.error("failed to remove element");
-    }
+    document.body.removeChild(editable);
   }
 
   window.addEventListener("wheel", stopEvent, true);

--- a/src/element/textWysiwyg.tsx
+++ b/src/element/textWysiwyg.tsx
@@ -120,7 +120,6 @@ export function textWysiwyg({
       event.stopPropagation();
     }
   };
-  // editable.onblur = handleSubmit;
 
   function stopEvent(event: Event) {
     event.stopPropagation();
@@ -137,7 +136,6 @@ export function textWysiwyg({
 
   function cleanup() {
     // remove events to ensure they don't late-fire
-    editable.onblur = null;
     editable.onpaste = null;
     editable.oninput = null;
     editable.onkeydown = null;

--- a/src/element/types.ts
+++ b/src/element/types.ts
@@ -68,3 +68,8 @@ export type ResizeArrowFnType = (
   pointerY: number,
   perfect: boolean,
 ) => void;
+
+export type WysiwigElement = {
+  submit: () => void;
+  changeStyle: (style: Record<string, any>) => void;
+};

--- a/src/renderer/renderScene.ts
+++ b/src/renderer/renderScene.ts
@@ -5,6 +5,7 @@ import { FlooredNumber, AppState } from "../types";
 import {
   ExcalidrawElement,
   NonDeletedExcalidrawElement,
+  ExcalidrawTextElement,
 } from "../element/types";
 import {
   getElementAbsoluteCoords,
@@ -100,6 +101,14 @@ export function renderScene(
 ) {
   if (!canvas) {
     return { atLeastOneVisibleElement: false };
+  }
+
+  if (appState.wysiwygElement && appState.wysiwygElement.changeStyle) {
+    appState.wysiwygElement.changeStyle({
+      font: appState.editingElement
+        ? (appState.editingElement as ExcalidrawTextElement).font
+        : "",
+    });
   }
 
   const context = canvas.getContext("2d")!;

--- a/src/renderer/renderScene.ts
+++ b/src/renderer/renderScene.ts
@@ -104,11 +104,14 @@ export function renderScene(
   }
 
   if (appState.wysiwygElement && appState.wysiwygElement.changeStyle) {
-    appState.wysiwygElement.changeStyle({
-      font: appState.editingElement
-        ? (appState.editingElement as ExcalidrawTextElement).font
-        : "",
-    });
+    if (appState.editingElement) {
+      appState.wysiwygElement.changeStyle({
+        font: (appState.editingElement as ExcalidrawTextElement).font,
+        textAlign: (appState.editingElement as ExcalidrawTextElement).textAlign,
+        color: (appState.editingElement as ExcalidrawTextElement).strokeColor,
+        opacity: (appState.editingElement as ExcalidrawTextElement).opacity,
+      });
+    }
   }
 
   const context = canvas.getContext("2d")!;

--- a/src/renderer/renderScene.ts
+++ b/src/renderer/renderScene.ts
@@ -103,15 +103,17 @@ export function renderScene(
     return { atLeastOneVisibleElement: false };
   }
 
-  if (appState.wysiwygElement && appState.wysiwygElement.changeStyle) {
-    if (isTextElement(appState.editingElement)) {
-      appState.wysiwygElement.changeStyle({
-        font: appState.editingElement.font,
-        textAlign: appState.editingElement.textAlign,
-        color: appState.editingElement.strokeColor,
-        opacity: appState.editingElement.opacity,
-      });
-    }
+  if (
+    appState.wysiwygElement &&
+    appState.wysiwygElement.changeStyle &&
+    isTextElement(appState.editingElement)
+  ) {
+    appState.wysiwygElement.changeStyle({
+      font: appState.editingElement.font,
+      textAlign: appState.editingElement.textAlign,
+      color: appState.editingElement.strokeColor,
+      opacity: appState.editingElement.opacity,
+    });
   }
 
   const context = canvas.getContext("2d")!;

--- a/src/renderer/renderScene.ts
+++ b/src/renderer/renderScene.ts
@@ -104,8 +104,7 @@ export function renderScene(
   }
 
   if (
-    appState.wysiwygElement &&
-    appState.wysiwygElement.changeStyle &&
+    appState.wysiwygElement?.changeStyle &&
     isTextElement(appState.editingElement)
   ) {
     appState.wysiwygElement.changeStyle({

--- a/src/renderer/renderScene.ts
+++ b/src/renderer/renderScene.ts
@@ -5,7 +5,6 @@ import { FlooredNumber, AppState } from "../types";
 import {
   ExcalidrawElement,
   NonDeletedExcalidrawElement,
-  ExcalidrawTextElement,
 } from "../element/types";
 import {
   getElementAbsoluteCoords,
@@ -107,10 +106,10 @@ export function renderScene(
   if (appState.wysiwygElement && appState.wysiwygElement.changeStyle) {
     if (isTextElement(appState.editingElement)) {
       appState.wysiwygElement.changeStyle({
-        font: (appState.editingElement as ExcalidrawTextElement).font,
-        textAlign: (appState.editingElement as ExcalidrawTextElement).textAlign,
-        color: (appState.editingElement as ExcalidrawTextElement).strokeColor,
-        opacity: (appState.editingElement as ExcalidrawTextElement).opacity,
+        font: appState.editingElement.font,
+        textAlign: appState.editingElement.textAlign,
+        color: appState.editingElement.strokeColor,
+        opacity: appState.editingElement.opacity,
       });
     }
   }

--- a/src/renderer/renderScene.ts
+++ b/src/renderer/renderScene.ts
@@ -14,6 +14,7 @@ import {
   handlerRectangles,
   getCommonBounds,
   canResizeMutlipleElements,
+  isTextElement,
 } from "../element";
 
 import { roundRect } from "./roundRect";
@@ -104,7 +105,7 @@ export function renderScene(
   }
 
   if (appState.wysiwygElement && appState.wysiwygElement.changeStyle) {
-    if (appState.editingElement) {
+    if (isTextElement(appState.editingElement)) {
       appState.wysiwygElement.changeStyle({
         font: (appState.editingElement as ExcalidrawTextElement).font,
         textAlign: (appState.editingElement as ExcalidrawTextElement).textAlign,

--- a/src/tests/__snapshots__/regressionTests.test.tsx.snap
+++ b/src/tests/__snapshots__/regressionTests.test.tsx.snap
@@ -41,6 +41,7 @@ Object {
   "showShortcutsDialog": false,
   "username": "",
   "viewBackgroundColor": "#ffffff",
+  "wysiwygElement": null,
   "zoom": 1,
 }
 `;
@@ -240,6 +241,7 @@ Object {
   "showShortcutsDialog": false,
   "username": "",
   "viewBackgroundColor": "#ffffff",
+  "wysiwygElement": null,
   "zoom": 1,
 }
 `;
@@ -358,6 +360,7 @@ Object {
   "showShortcutsDialog": false,
   "username": "",
   "viewBackgroundColor": "#ffffff",
+  "wysiwygElement": null,
   "zoom": 1,
 }
 `;
@@ -633,6 +636,7 @@ Object {
   "showShortcutsDialog": false,
   "username": "",
   "viewBackgroundColor": "#ffffff",
+  "wysiwygElement": null,
   "zoom": 1,
 }
 `;
@@ -793,6 +797,7 @@ Object {
   "showShortcutsDialog": false,
   "username": "",
   "viewBackgroundColor": "#ffffff",
+  "wysiwygElement": null,
   "zoom": 1,
 }
 `;
@@ -993,6 +998,7 @@ Object {
   "showShortcutsDialog": false,
   "username": "",
   "viewBackgroundColor": "#ffffff",
+  "wysiwygElement": null,
   "zoom": 1,
 }
 `;
@@ -1252,6 +1258,7 @@ Object {
   "showShortcutsDialog": false,
   "username": "",
   "viewBackgroundColor": "#ffffff",
+  "wysiwygElement": null,
   "zoom": 1,
 }
 `;
@@ -1603,7 +1610,32 @@ Object {
   "cursorX": 0,
   "cursorY": 0,
   "draggingElement": null,
-  "editingElement": null,
+  "editingElement": Object {
+    "angle": 0,
+    "backgroundColor": "transparent",
+    "fillStyle": "hachure",
+    "height": 0,
+    "id": "id6",
+    "isDeleted": false,
+    "lastCommittedPoint": null,
+    "opacity": 100,
+    "points": Array [
+      Array [
+        0,
+        0,
+      ],
+    ],
+    "roughness": 1,
+    "seed": 845789479,
+    "strokeColor": "#000000",
+    "strokeWidth": 1,
+    "type": "line",
+    "version": 6,
+    "versionNonce": 745419401,
+    "width": 0,
+    "x": 30,
+    "y": 30,
+  },
   "elementLocked": false,
   "elementType": "selection",
   "errorMessage": null,
@@ -1626,6 +1658,7 @@ Object {
   "showShortcutsDialog": false,
   "username": "",
   "viewBackgroundColor": "#ffffff",
+  "wysiwygElement": null,
   "zoom": 1,
 }
 `;
@@ -2250,6 +2283,7 @@ Object {
   "showShortcutsDialog": false,
   "username": "",
   "viewBackgroundColor": "#ffffff",
+  "wysiwygElement": null,
   "zoom": 1,
 }
 `;
@@ -2368,6 +2402,7 @@ Object {
   "showShortcutsDialog": false,
   "username": "",
   "viewBackgroundColor": "#ffffff",
+  "wysiwygElement": null,
   "zoom": 1,
 }
 `;
@@ -2486,6 +2521,7 @@ Object {
   "showShortcutsDialog": false,
   "username": "",
   "viewBackgroundColor": "#ffffff",
+  "wysiwygElement": null,
   "zoom": 1,
 }
 `;
@@ -2604,6 +2640,7 @@ Object {
   "showShortcutsDialog": false,
   "username": "",
   "viewBackgroundColor": "#ffffff",
+  "wysiwygElement": null,
   "zoom": 1,
 }
 `;
@@ -2744,6 +2781,7 @@ Object {
   "showShortcutsDialog": false,
   "username": "",
   "viewBackgroundColor": "#ffffff",
+  "wysiwygElement": null,
   "zoom": 1,
 }
 `;
@@ -2884,6 +2922,7 @@ Object {
   "showShortcutsDialog": false,
   "username": "",
   "viewBackgroundColor": "#ffffff",
+  "wysiwygElement": null,
   "zoom": 1,
 }
 `;
@@ -3024,6 +3063,7 @@ Object {
   "showShortcutsDialog": false,
   "username": "",
   "viewBackgroundColor": "#ffffff",
+  "wysiwygElement": null,
   "zoom": 1,
 }
 `;
@@ -3142,6 +3182,7 @@ Object {
   "showShortcutsDialog": false,
   "username": "",
   "viewBackgroundColor": "#ffffff",
+  "wysiwygElement": null,
   "zoom": 1,
 }
 `;
@@ -3260,6 +3301,7 @@ Object {
   "showShortcutsDialog": false,
   "username": "",
   "viewBackgroundColor": "#ffffff",
+  "wysiwygElement": null,
   "zoom": 1,
 }
 `;
@@ -3400,6 +3442,7 @@ Object {
   "showShortcutsDialog": false,
   "username": "",
   "viewBackgroundColor": "#ffffff",
+  "wysiwygElement": null,
   "zoom": 1,
 }
 `;
@@ -3518,6 +3561,7 @@ Object {
   "showShortcutsDialog": false,
   "username": "",
   "viewBackgroundColor": "#ffffff",
+  "wysiwygElement": null,
   "zoom": 1,
 }
 `;
@@ -3590,6 +3634,7 @@ Object {
   "showShortcutsDialog": false,
   "username": "",
   "viewBackgroundColor": "#ffffff",
+  "wysiwygElement": null,
   "zoom": 1,
 }
 `;
@@ -4475,6 +4520,7 @@ Object {
   "showShortcutsDialog": false,
   "username": "",
   "viewBackgroundColor": "#ffffff",
+  "wysiwygElement": null,
   "zoom": 1,
 }
 `;
@@ -4899,6 +4945,7 @@ Object {
   "showShortcutsDialog": false,
   "username": "",
   "viewBackgroundColor": "#ffffff",
+  "wysiwygElement": null,
   "zoom": 1,
 }
 `;
@@ -5230,6 +5277,7 @@ Object {
   "showShortcutsDialog": false,
   "username": "",
   "viewBackgroundColor": "#ffffff",
+  "wysiwygElement": null,
   "zoom": 1,
 }
 `;
@@ -5472,6 +5520,7 @@ Object {
   "showShortcutsDialog": false,
   "username": "",
   "viewBackgroundColor": "#ffffff",
+  "wysiwygElement": null,
   "zoom": 1,
 }
 `;
@@ -5645,6 +5694,7 @@ Object {
   "showShortcutsDialog": false,
   "username": "",
   "viewBackgroundColor": "#ffffff",
+  "wysiwygElement": null,
   "zoom": 1,
 }
 `;
@@ -6481,6 +6531,7 @@ Object {
   "showShortcutsDialog": false,
   "username": "",
   "viewBackgroundColor": "#ffffff",
+  "wysiwygElement": null,
   "zoom": 1,
 }
 `;
@@ -7208,6 +7259,7 @@ Object {
   "showShortcutsDialog": false,
   "username": "",
   "viewBackgroundColor": "#ffffff",
+  "wysiwygElement": null,
   "zoom": 1,
 }
 `;
@@ -7830,6 +7882,7 @@ Object {
   "showShortcutsDialog": false,
   "username": "",
   "viewBackgroundColor": "#ffffff",
+  "wysiwygElement": null,
   "zoom": 1,
 }
 `;
@@ -8352,6 +8405,7 @@ Object {
   "showShortcutsDialog": false,
   "username": "",
   "viewBackgroundColor": "#ffffff",
+  "wysiwygElement": null,
   "zoom": 1,
 }
 `;
@@ -8824,6 +8878,7 @@ Object {
   "showShortcutsDialog": false,
   "username": "",
   "viewBackgroundColor": "#ffffff",
+  "wysiwygElement": null,
   "zoom": 1,
 }
 `;
@@ -9201,6 +9256,7 @@ Object {
   "showShortcutsDialog": false,
   "username": "",
   "viewBackgroundColor": "#ffffff",
+  "wysiwygElement": null,
   "zoom": 1,
 }
 `;
@@ -9487,6 +9543,7 @@ Object {
   "showShortcutsDialog": false,
   "username": "",
   "viewBackgroundColor": "#ffffff",
+  "wysiwygElement": null,
   "zoom": 1,
 }
 `;
@@ -9702,6 +9759,7 @@ Object {
   "showShortcutsDialog": false,
   "username": "",
   "viewBackgroundColor": "#ffffff",
+  "wysiwygElement": null,
   "zoom": 1,
 }
 `;
@@ -10594,6 +10652,7 @@ Object {
   "showShortcutsDialog": false,
   "username": "",
   "viewBackgroundColor": "#ffffff",
+  "wysiwygElement": null,
   "zoom": 1,
 }
 `;
@@ -11375,6 +11434,7 @@ Object {
   "showShortcutsDialog": false,
   "username": "",
   "viewBackgroundColor": "#ffffff",
+  "wysiwygElement": null,
   "zoom": 1,
 }
 `;
@@ -12049,6 +12109,7 @@ Object {
   "showShortcutsDialog": false,
   "username": "",
   "viewBackgroundColor": "#ffffff",
+  "wysiwygElement": null,
   "zoom": 1,
 }
 `;
@@ -12616,6 +12677,7 @@ Object {
   "showShortcutsDialog": false,
   "username": "",
   "viewBackgroundColor": "#ffffff",
+  "wysiwygElement": null,
   "zoom": 1,
 }
 `;
@@ -12994,6 +13056,7 @@ Object {
   "showShortcutsDialog": false,
   "username": "",
   "viewBackgroundColor": "#ffffff",
+  "wysiwygElement": null,
   "zoom": 1,
 }
 `;
@@ -13050,6 +13113,7 @@ Object {
   "showShortcutsDialog": false,
   "username": "",
   "viewBackgroundColor": "#ffffff",
+  "wysiwygElement": null,
   "zoom": 1,
 }
 `;
@@ -13106,6 +13170,7 @@ Object {
   "showShortcutsDialog": false,
   "username": "",
   "viewBackgroundColor": "#ffffff",
+  "wysiwygElement": null,
   "zoom": 1,
 }
 `;
@@ -13402,6 +13467,7 @@ Object {
   "showShortcutsDialog": false,
   "username": "",
   "viewBackgroundColor": "#ffffff",
+  "wysiwygElement": null,
   "zoom": 1,
 }
 `;

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,7 @@ import {
   NonDeletedExcalidrawElement,
   NonDeleted,
   TextAlign,
+  WysiwigElement,
 } from "./element/types";
 import { SHAPES } from "./shapes";
 import { Point as RoughPoint } from "roughjs/bin/geometry";
@@ -12,7 +13,7 @@ export type FlooredNumber = number & { _brand: "FlooredNumber" };
 export type Point = Readonly<RoughPoint>;
 
 export type AppState = {
-  wysiwygElement: any | null;
+  wysiwygElement: WysiwigElement | null;
   isLoading: boolean;
   errorMessage: string | null;
   draggingElement: NonDeletedExcalidrawElement | null;

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,7 @@ export type FlooredNumber = number & { _brand: "FlooredNumber" };
 export type Point = Readonly<RoughPoint>;
 
 export type AppState = {
+  wysiwygElement: any | null;
   isLoading: boolean;
   errorMessage: string | null;
   draggingElement: NonDeletedExcalidrawElement | null;


### PR DESCRIPTION
Re: #1325 , the `blur` handler on the editable is causing the active editing element to become a normal element, whenever a click happens outside that element, including the choosing of a style on the toolbox.

This PR is a PoC, to expose the wysiwyg element so we can finalize it on demand, thus allowing us to do in-place style changes while it is still on editing mode.

I can see how this could potentially pave the way for tackling https://github.com/excalidraw/excalidraw/pull/1213 and https://github.com/excalidraw/excalidraw/issues/1126. Let me know if I'm wrong on this.