### PR TITLE
Update shortcut display for enter on Mac

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -163,7 +163,7 @@ export const getShortcutKey = (shortcut: string): string => {
       .replace("Ctrl+", "⌃")
       .replace("Shift+", "⇧")
       .replace("Del", "⌫")
-      .replace("Enter", "Return")}`;
+      .replace(/Enter|Return/, "↩")}`;
   }
   return `${shortcut.replace("CtrlOrCmd", "Ctrl")}`;
 };


### PR DESCRIPTION
<img width="388" alt="Screenshot_2020-04-10 10 02 47" src="https://user-images.githubusercontent.com/25517624/78996365-74f40b80-7b12-11ea-8ee4-177a76a29cc3.png">
