### PR TITLE
Add rule banning literal text in JSX

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,14 @@
         }
       ],
       "prefer-template": "warn",
-      "prettier/prettier": "warn"
+      "prettier/prettier": "warn",
+      "no-restricted-syntax": [
+        "warn",
+        {
+          "selector": "JSXText[value=/\\w/]",
+          "message": "Use 't(...)' instead of literal text in JSX"
+        }
+      ]
     }
   },
   "homepage": ".",

--- a/src/components/LoadingMessage.tsx
+++ b/src/components/LoadingMessage.tsx
@@ -4,7 +4,7 @@ export const LoadingMessage = () => {
   // !! KEEP THIS IN SYNC WITH index.html !!
   return (
     <div className="LoadingMessage">
-      <span>Loading scene...</span>
+      <span>{"Loading scene..."}</span>
     </div>
   );
 };


### PR DESCRIPTION
This helps prompt people to use `t()` instead. You can work around the rule bu wrapping the text in `{""}`.