### PR TITLE
Restore textAlign property

### DIFF
--- a/src/data/restore.ts
+++ b/src/data/restore.ts
@@ -57,7 +57,9 @@ export function restore(
         element.points = points;
       } else {
         if (isTextElement(element)) {
-          element.textAlign = DEFAULT_TEXT_ALIGN;
+          if (!element.textAlign) {
+            element.textAlign = DEFAULT_TEXT_ALIGN;
+          }
         }
 
         normalizeDimensions(element);


### PR DESCRIPTION
The `textAlign` property of text object was not read when reloading a scene or opening a saved file.