### PR TITLE
rewrite wysiwyg property updating

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -62,10 +62,10 @@
     />
     <!-- OG tags require absolute url for images -->
     <meta name="twitter:image" content="https://excalidraw.com/og-image.png" />
-    <!-- <meta
+    <meta
       http-equiv="Content-Security-Policy"
       content="block-all-mixed-content; child-src 'none'; connect-src https: wss:; default-src 'self'; font-src 'self' data: https: filesystem:; img-src 'self' data: https:; script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://www.google-analytics.com; style-src 'self' 'unsafe-inline' https:;"
-    /> -->
+    />
     <link rel="shortcut icon" href="favicon.ico" type="image/x-icon" />
     <link rel="stylesheet" href="fonts.css" />
     <link

--- a/public/index.html
+++ b/public/index.html
@@ -62,10 +62,10 @@
     />
     <!-- OG tags require absolute url for images -->
     <meta name="twitter:image" content="https://excalidraw.com/og-image.png" />
-    <meta
+    <!-- <meta
       http-equiv="Content-Security-Policy"
       content="block-all-mixed-content; child-src 'none'; connect-src https: wss:; default-src 'self'; font-src 'self' data: https: filesystem:; img-src 'self' data: https:; script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://www.google-analytics.com; style-src 'self' 'unsafe-inline' https:;"
-    />
+    /> -->
     <link rel="shortcut icon" href="favicon.ico" type="image/x-icon" />
     <link rel="stylesheet" href="fonts.css" />
     <link

--- a/src/appState.ts
+++ b/src/appState.ts
@@ -8,7 +8,6 @@ export const DEFAULT_TEXT_ALIGN = "left";
 
 export function getDefaultAppState(): AppState {
   return {
-    wysiwygElement: null,
     isLoading: false,
     errorMessage: null,
     draggingElement: null,

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1245,7 +1245,8 @@ export class App extends React.Component<any, AppState> {
       ]);
     };
 
-    const wysiwygElement = textWysiwyg({
+    textWysiwyg({
+      id: element.id,
       x,
       y,
       initText: element.text,
@@ -1265,7 +1266,6 @@ export class App extends React.Component<any, AppState> {
       onSubmit: withBatchedUpdates((text) => {
         updateElement(text);
         this.setState((prevState) => ({
-          wysiwygElement: null,
           selectedElementIds: {
             ...prevState.selectedElementIds,
             [element.id]: true,
@@ -1286,7 +1286,7 @@ export class App extends React.Component<any, AppState> {
       }),
     });
     // deselect all other elements when inserting text
-    this.setState({ selectedElementIds: {}, wysiwygElement });
+    this.setState({ selectedElementIds: {} });
 
     // do an initial update to re-initialize element position since we were
     //  modifying element's x/y for sake of editor (case: syncing to remote)
@@ -1596,9 +1596,6 @@ export class App extends React.Component<any, AppState> {
   private handleCanvasPointerDown = (
     event: React.PointerEvent<HTMLCanvasElement>,
   ) => {
-    if (this.state.wysiwygElement && this.state.wysiwygElement.submit) {
-      this.state.wysiwygElement.submit();
-    }
     if (lastPointerUp !== null) {
       // Unfortunately, sometimes we don't get a pointerup after a pointerdown,
       // this can happen when a contextual menu or alert is triggered. In order to avoid

--- a/src/components/LayerUI.tsx
+++ b/src/components/LayerUI.tsx
@@ -26,6 +26,7 @@ import { ErrorDialog } from "./ErrorDialog";
 import { ShortcutsDialog } from "./ShortcutsDialog";
 import { LoadingMessage } from "./LoadingMessage";
 import { GitHubCorner } from "./GitHubCorner";
+import { CLASSES } from "../constants";
 
 interface LayerUIProps {
   actionManager: ActionManager;
@@ -146,7 +147,7 @@ export const LayerUI = React.memo(
               </Section>
               {showSelectedShapeActions(appState, elements) && (
                 <Section heading="selectedShapeActions">
-                  <Island className="App-menu__left" padding={4}>
+                  <Island className={CLASSES.SHAPE_ACTIONS_MENU} padding={4}>
                     <SelectedShapeActions
                       appState={appState}
                       elements={elements}

--- a/src/components/LayerUI.tsx
+++ b/src/components/LayerUI.tsx
@@ -146,10 +146,7 @@ export const LayerUI = React.memo(
               </Section>
               {showSelectedShapeActions(appState, elements) && (
                 <Section heading="selectedShapeActions">
-                  <Island
-                    className="App-menu__left ShapeActions__desktop"
-                    padding={4}
-                  >
+                  <Island className="App-menu__left" padding={4}>
                     <SelectedShapeActions
                       appState={appState}
                       elements={elements}

--- a/src/components/LayerUI.tsx
+++ b/src/components/LayerUI.tsx
@@ -146,7 +146,10 @@ export const LayerUI = React.memo(
               </Section>
               {showSelectedShapeActions(appState, elements) && (
                 <Section heading="selectedShapeActions">
-                  <Island className="App-menu__left" padding={4}>
+                  <Island
+                    className="App-menu__left ShapeActions__desktop"
+                    padding={4}
+                  >
                     <SelectedShapeActions
                       appState={appState}
                       elements={elements}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -53,3 +53,7 @@ export const BROADCAST = {
   SERVER_VOLATILE: "server-volatile-broadcast",
   SERVER: "server-broadcast",
 };
+
+export const CLASSES = {
+  SHAPE_ACTIONS_MENU: "App-menu__left",
+};

--- a/src/element/textWysiwyg.tsx
+++ b/src/element/textWysiwyg.tsx
@@ -139,6 +139,10 @@ export function textWysiwyg({
   }
 
   function cleanup() {
+    if (isDestroyed) {
+      return;
+    }
+    isDestroyed = true;
     // remove events to ensure they don't late-fire
     editable.onblur = null;
     editable.onpaste = null;
@@ -196,6 +200,8 @@ export function textWysiwyg({
     }
     editable.focus();
   });
+
+  let isDestroyed = false;
 
   editable.onblur = handleSubmit;
   window.addEventListener("pointerdown", onPointerDown);

--- a/src/element/textWysiwyg.tsx
+++ b/src/element/textWysiwyg.tsx
@@ -1,6 +1,7 @@
 import { KEYS } from "../keys";
-import { selectNode } from "../utils";
-import { WysiwigElement } from "./types";
+import { selectNode, isWritableElement } from "../utils";
+import { globalSceneState } from "../scene";
+import { isTextElement } from "./typeChecks";
 
 function trimText(text: string) {
   // whitespace only → trim all because we'd end up inserting invisible element
@@ -14,6 +15,7 @@ function trimText(text: string) {
 }
 
 type TextWysiwygParams = {
+  id: string;
   initText: string;
   x: number;
   y: number;
@@ -29,6 +31,7 @@ type TextWysiwygParams = {
 };
 
 export function textWysiwyg({
+  id,
   initText,
   x,
   y,
@@ -41,7 +44,7 @@ export function textWysiwyg({
   textAlign,
   onSubmit,
   onCancel,
-}: TextWysiwygParams): WysiwigElement {
+}: TextWysiwygParams) {
   const editable = document.createElement("div");
   try {
     editable.contentEditable = "plaintext-only";
@@ -137,24 +140,67 @@ export function textWysiwyg({
 
   function cleanup() {
     // remove events to ensure they don't late-fire
+    editable.onblur = null;
     editable.onpaste = null;
     editable.oninput = null;
     editable.onkeydown = null;
 
     window.removeEventListener("wheel", stopEvent, true);
+    window.removeEventListener("pointerdown", onPointerDown);
+    window.removeEventListener("pointerup", rebindBlur);
+    window.removeEventListener("blur", handleSubmit);
+
+    unbindUpdate();
+
     document.body.removeChild(editable);
   }
 
+  const rebindBlur = () => {
+    window.removeEventListener("pointerup", rebindBlur);
+    editable.onblur = handleSubmit;
+    // case: clicking on the same property → no change → no update.
+    // Deferred because clicking on a UI button steals focus in next frame,
+    //  which would in turn blur wysiwyg again and confirm it
+    setTimeout(() => {
+      editable.focus();
+    });
+  };
+
+  // prevent blur when changing properties from the menu
+  const onPointerDown = (event: MouseEvent) => {
+    if (
+      event.target instanceof HTMLElement &&
+      event.target.closest(".ShapeActions__desktop") &&
+      !isWritableElement(event.target)
+    ) {
+      editable.onblur = null;
+      window.addEventListener("pointerup", rebindBlur);
+      // handle edge-case where pointerup doesn't fire e.g. due to user
+      //  alt-tabbing away
+      window.addEventListener("blur", handleSubmit);
+    }
+  };
+
+  // handle updates of textElement properties of editing element
+  const unbindUpdate = globalSceneState.addCallback(() => {
+    const editingElement = globalSceneState
+      .getElementsIncludingDeleted()
+      .find((element) => element.id === id);
+    if (editingElement && isTextElement(editingElement)) {
+      Object.assign(editable.style, {
+        font: editingElement.font,
+        textAlign: editingElement.textAlign,
+        color: editingElement.strokeColor,
+        opacity: editingElement.opacity,
+      });
+    }
+    editable.focus();
+  });
+
+  editable.onblur = handleSubmit;
+  window.addEventListener("pointerdown", onPointerDown);
   window.addEventListener("wheel", stopEvent, true);
   document.body.appendChild(editable);
   editable.focus();
   selectNode(editable);
-
-  return {
-    submit: handleSubmit,
-    changeStyle: (style: any) => {
-      Object.assign(editable.style, style);
-      editable.focus();
-    },
-  };
 }

--- a/src/element/textWysiwyg.tsx
+++ b/src/element/textWysiwyg.tsx
@@ -157,11 +157,11 @@ export function textWysiwyg({
 
   const rebindBlur = () => {
     window.removeEventListener("pointerup", rebindBlur);
-    editable.onblur = handleSubmit;
-    // case: clicking on the same property → no change → no update.
-    // Deferred because clicking on a UI button steals focus in next frame,
-    //  which would in turn blur wysiwyg again and confirm it
+    // deferred to guard against focus traps on various UIs that steal focus
+    //  upon pointerUp
     setTimeout(() => {
+      editable.onblur = handleSubmit;
+      // case: clicking on the same property → no change → no update → no focus
       editable.focus();
     });
   };

--- a/src/element/textWysiwyg.tsx
+++ b/src/element/textWysiwyg.tsx
@@ -170,7 +170,7 @@ export function textWysiwyg({
   const onPointerDown = (event: MouseEvent) => {
     if (
       event.target instanceof HTMLElement &&
-      event.target.closest(".ShapeActions__desktop") &&
+      event.target.closest(".App-menu__left") &&
       !isWritableElement(event.target)
     ) {
       editable.onblur = null;

--- a/src/element/textWysiwyg.tsx
+++ b/src/element/textWysiwyg.tsx
@@ -195,7 +195,7 @@ export function textWysiwyg({
         font: editingElement.font,
         textAlign: editingElement.textAlign,
         color: editingElement.strokeColor,
-        opacity: editingElement.opacity,
+        opacity: editingElement.opacity / 100,
       });
     }
     editable.focus();

--- a/src/element/textWysiwyg.tsx
+++ b/src/element/textWysiwyg.tsx
@@ -2,6 +2,7 @@ import { KEYS } from "../keys";
 import { selectNode, isWritableElement } from "../utils";
 import { globalSceneState } from "../scene";
 import { isTextElement } from "./typeChecks";
+import { CLASSES } from "../constants";
 
 function trimText(text: string) {
   // whitespace only → trim all because we'd end up inserting invisible element
@@ -174,7 +175,7 @@ export function textWysiwyg({
   const onPointerDown = (event: MouseEvent) => {
     if (
       event.target instanceof HTMLElement &&
-      event.target.closest(".App-menu__left") &&
+      event.target.closest(CLASSES.SHAPE_ACTIONS_MENU) &&
       !isWritableElement(event.target)
     ) {
       editable.onblur = null;

--- a/src/element/types.ts
+++ b/src/element/types.ts
@@ -68,8 +68,3 @@ export type ResizeArrowFnType = (
   pointerY: number,
   perfect: boolean,
 ) => void;
-
-export type WysiwigElement = {
-  submit: () => void;
-  changeStyle: (style: Record<string, any>) => void;
-};

--- a/src/renderer/renderScene.ts
+++ b/src/renderer/renderScene.ts
@@ -14,7 +14,6 @@ import {
   handlerRectangles,
   getCommonBounds,
   canResizeMutlipleElements,
-  isTextElement,
 } from "../element";
 
 import { roundRect } from "./roundRect";
@@ -102,18 +101,6 @@ export function renderScene(
 ) {
   if (!canvas) {
     return { atLeastOneVisibleElement: false };
-  }
-
-  if (
-    appState.wysiwygElement?.changeStyle &&
-    isTextElement(appState.editingElement)
-  ) {
-    appState.wysiwygElement.changeStyle({
-      font: appState.editingElement.font,
-      textAlign: appState.editingElement.textAlign,
-      color: appState.editingElement.strokeColor,
-      opacity: appState.editingElement.opacity,
-    });
   }
 
   const context = canvas.getContext("2d")!;

--- a/src/tests/__snapshots__/regressionTests.test.tsx.snap
+++ b/src/tests/__snapshots__/regressionTests.test.tsx.snap
@@ -41,7 +41,6 @@ Object {
   "showShortcutsDialog": false,
   "username": "",
   "viewBackgroundColor": "#ffffff",
-  "wysiwygElement": null,
   "zoom": 1,
 }
 `;
@@ -241,7 +240,6 @@ Object {
   "showShortcutsDialog": false,
   "username": "",
   "viewBackgroundColor": "#ffffff",
-  "wysiwygElement": null,
   "zoom": 1,
 }
 `;
@@ -360,7 +358,6 @@ Object {
   "showShortcutsDialog": false,
   "username": "",
   "viewBackgroundColor": "#ffffff",
-  "wysiwygElement": null,
   "zoom": 1,
 }
 `;
@@ -636,7 +633,6 @@ Object {
   "showShortcutsDialog": false,
   "username": "",
   "viewBackgroundColor": "#ffffff",
-  "wysiwygElement": null,
   "zoom": 1,
 }
 `;
@@ -797,7 +793,6 @@ Object {
   "showShortcutsDialog": false,
   "username": "",
   "viewBackgroundColor": "#ffffff",
-  "wysiwygElement": null,
   "zoom": 1,
 }
 `;
@@ -998,7 +993,6 @@ Object {
   "showShortcutsDialog": false,
   "username": "",
   "viewBackgroundColor": "#ffffff",
-  "wysiwygElement": null,
   "zoom": 1,
 }
 `;
@@ -1258,7 +1252,6 @@ Object {
   "showShortcutsDialog": false,
   "username": "",
   "viewBackgroundColor": "#ffffff",
-  "wysiwygElement": null,
   "zoom": 1,
 }
 `;
@@ -1658,7 +1651,6 @@ Object {
   "showShortcutsDialog": false,
   "username": "",
   "viewBackgroundColor": "#ffffff",
-  "wysiwygElement": null,
   "zoom": 1,
 }
 `;
@@ -2283,7 +2275,6 @@ Object {
   "showShortcutsDialog": false,
   "username": "",
   "viewBackgroundColor": "#ffffff",
-  "wysiwygElement": null,
   "zoom": 1,
 }
 `;
@@ -2402,7 +2393,6 @@ Object {
   "showShortcutsDialog": false,
   "username": "",
   "viewBackgroundColor": "#ffffff",
-  "wysiwygElement": null,
   "zoom": 1,
 }
 `;
@@ -2521,7 +2511,6 @@ Object {
   "showShortcutsDialog": false,
   "username": "",
   "viewBackgroundColor": "#ffffff",
-  "wysiwygElement": null,
   "zoom": 1,
 }
 `;
@@ -2640,7 +2629,6 @@ Object {
   "showShortcutsDialog": false,
   "username": "",
   "viewBackgroundColor": "#ffffff",
-  "wysiwygElement": null,
   "zoom": 1,
 }
 `;
@@ -2781,7 +2769,6 @@ Object {
   "showShortcutsDialog": false,
   "username": "",
   "viewBackgroundColor": "#ffffff",
-  "wysiwygElement": null,
   "zoom": 1,
 }
 `;
@@ -2922,7 +2909,6 @@ Object {
   "showShortcutsDialog": false,
   "username": "",
   "viewBackgroundColor": "#ffffff",
-  "wysiwygElement": null,
   "zoom": 1,
 }
 `;
@@ -3063,7 +3049,6 @@ Object {
   "showShortcutsDialog": false,
   "username": "",
   "viewBackgroundColor": "#ffffff",
-  "wysiwygElement": null,
   "zoom": 1,
 }
 `;
@@ -3182,7 +3167,6 @@ Object {
   "showShortcutsDialog": false,
   "username": "",
   "viewBackgroundColor": "#ffffff",
-  "wysiwygElement": null,
   "zoom": 1,
 }
 `;
@@ -3301,7 +3285,6 @@ Object {
   "showShortcutsDialog": false,
   "username": "",
   "viewBackgroundColor": "#ffffff",
-  "wysiwygElement": null,
   "zoom": 1,
 }
 `;
@@ -3442,7 +3425,6 @@ Object {
   "showShortcutsDialog": false,
   "username": "",
   "viewBackgroundColor": "#ffffff",
-  "wysiwygElement": null,
   "zoom": 1,
 }
 `;
@@ -3561,7 +3543,6 @@ Object {
   "showShortcutsDialog": false,
   "username": "",
   "viewBackgroundColor": "#ffffff",
-  "wysiwygElement": null,
   "zoom": 1,
 }
 `;
@@ -3634,7 +3615,6 @@ Object {
   "showShortcutsDialog": false,
   "username": "",
   "viewBackgroundColor": "#ffffff",
-  "wysiwygElement": null,
   "zoom": 1,
 }
 `;
@@ -4520,7 +4500,6 @@ Object {
   "showShortcutsDialog": false,
   "username": "",
   "viewBackgroundColor": "#ffffff",
-  "wysiwygElement": null,
   "zoom": 1,
 }
 `;
@@ -4945,7 +4924,6 @@ Object {
   "showShortcutsDialog": false,
   "username": "",
   "viewBackgroundColor": "#ffffff",
-  "wysiwygElement": null,
   "zoom": 1,
 }
 `;
@@ -5277,7 +5255,6 @@ Object {
   "showShortcutsDialog": false,
   "username": "",
   "viewBackgroundColor": "#ffffff",
-  "wysiwygElement": null,
   "zoom": 1,
 }
 `;
@@ -5520,7 +5497,6 @@ Object {
   "showShortcutsDialog": false,
   "username": "",
   "viewBackgroundColor": "#ffffff",
-  "wysiwygElement": null,
   "zoom": 1,
 }
 `;
@@ -5694,7 +5670,6 @@ Object {
   "showShortcutsDialog": false,
   "username": "",
   "viewBackgroundColor": "#ffffff",
-  "wysiwygElement": null,
   "zoom": 1,
 }
 `;
@@ -6531,7 +6506,6 @@ Object {
   "showShortcutsDialog": false,
   "username": "",
   "viewBackgroundColor": "#ffffff",
-  "wysiwygElement": null,
   "zoom": 1,
 }
 `;
@@ -7259,7 +7233,6 @@ Object {
   "showShortcutsDialog": false,
   "username": "",
   "viewBackgroundColor": "#ffffff",
-  "wysiwygElement": null,
   "zoom": 1,
 }
 `;
@@ -7882,7 +7855,6 @@ Object {
   "showShortcutsDialog": false,
   "username": "",
   "viewBackgroundColor": "#ffffff",
-  "wysiwygElement": null,
   "zoom": 1,
 }
 `;
@@ -8405,7 +8377,6 @@ Object {
   "showShortcutsDialog": false,
   "username": "",
   "viewBackgroundColor": "#ffffff",
-  "wysiwygElement": null,
   "zoom": 1,
 }
 `;
@@ -8878,7 +8849,6 @@ Object {
   "showShortcutsDialog": false,
   "username": "",
   "viewBackgroundColor": "#ffffff",
-  "wysiwygElement": null,
   "zoom": 1,
 }
 `;
@@ -9256,7 +9226,6 @@ Object {
   "showShortcutsDialog": false,
   "username": "",
   "viewBackgroundColor": "#ffffff",
-  "wysiwygElement": null,
   "zoom": 1,
 }
 `;
@@ -9543,7 +9512,6 @@ Object {
   "showShortcutsDialog": false,
   "username": "",
   "viewBackgroundColor": "#ffffff",
-  "wysiwygElement": null,
   "zoom": 1,
 }
 `;
@@ -9759,7 +9727,6 @@ Object {
   "showShortcutsDialog": false,
   "username": "",
   "viewBackgroundColor": "#ffffff",
-  "wysiwygElement": null,
   "zoom": 1,
 }
 `;
@@ -10652,7 +10619,6 @@ Object {
   "showShortcutsDialog": false,
   "username": "",
   "viewBackgroundColor": "#ffffff",
-  "wysiwygElement": null,
   "zoom": 1,
 }
 `;
@@ -11434,7 +11400,6 @@ Object {
   "showShortcutsDialog": false,
   "username": "",
   "viewBackgroundColor": "#ffffff",
-  "wysiwygElement": null,
   "zoom": 1,
 }
 `;
@@ -12109,7 +12074,6 @@ Object {
   "showShortcutsDialog": false,
   "username": "",
   "viewBackgroundColor": "#ffffff",
-  "wysiwygElement": null,
   "zoom": 1,
 }
 `;
@@ -12677,7 +12641,6 @@ Object {
   "showShortcutsDialog": false,
   "username": "",
   "viewBackgroundColor": "#ffffff",
-  "wysiwygElement": null,
   "zoom": 1,
 }
 `;
@@ -13056,7 +13019,6 @@ Object {
   "showShortcutsDialog": false,
   "username": "",
   "viewBackgroundColor": "#ffffff",
-  "wysiwygElement": null,
   "zoom": 1,
 }
 `;
@@ -13113,7 +13075,6 @@ Object {
   "showShortcutsDialog": false,
   "username": "",
   "viewBackgroundColor": "#ffffff",
-  "wysiwygElement": null,
   "zoom": 1,
 }
 `;
@@ -13170,7 +13131,6 @@ Object {
   "showShortcutsDialog": false,
   "username": "",
   "viewBackgroundColor": "#ffffff",
-  "wysiwygElement": null,
   "zoom": 1,
 }
 `;
@@ -13467,7 +13427,6 @@ Object {
   "showShortcutsDialog": false,
   "username": "",
   "viewBackgroundColor": "#ffffff",
-  "wysiwygElement": null,
   "zoom": 1,
 }
 `;

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,7 +4,6 @@ import {
   NonDeletedExcalidrawElement,
   NonDeleted,
   TextAlign,
-  WysiwigElement,
 } from "./element/types";
 import { SHAPES } from "./shapes";
 import { Point as RoughPoint } from "roughjs/bin/geometry";
@@ -13,7 +12,6 @@ export type FlooredNumber = number & { _brand: "FlooredNumber" };
 export type Point = Readonly<RoughPoint>;
 
 export type AppState = {
-  wysiwygElement: WysiwigElement | null;
   isLoading: boolean;
   errorMessage: string | null;
   draggingElement: NonDeletedExcalidrawElement | null;


### PR DESCRIPTION
So, at first I started making a few fixes which then turned into a full rewrite :smile:.

First, I wanted to fix problems with previous solution that discarded wysiwyg's `blur` event altogether. Problem with finalizing wysiwyg on explicit `pointerDown` on canvas is that we don't finalize when e.g. changing tools (which we should), or zooming in/out (which resulted in visual bugs) and who knows what else.

So instead I used a different workaround: when clicking inside the menu, temporarily remove the `blur` event, and re-enable it on `pointerup` (plus some logic on top to handle edge-cases).

I've also fixed a case when you click on the same property which doesn't result in update, so on previous solution the wysiwyg wasn't focused.

Another bug this PR fixes is trying to type into color inputs, which previously resulted in wysiwyg stealing focus again.

And on top, I enabled this only for desktop shape menu, because previously it resulted in some very weird stuff going on when you tried to edit wysiwyg props on mobile (there I'd argue it should blur & confirm on trying to open mobile menu).

Second, I wanted to simplify the wysiwyg updating. I realized we have a global element mutation event we can subscribe to, so I used that. For now, I'm updating the wysiwyg on every mutation update, which is a bit inefficient but it doesn't matter for now.

Both of the above changes resulted in not having to expose any wysiwyg API outside, and not needing any extra `appState` properties either.

This way all logic related to `wysiwyg` is encapsulated in the module, which I think is a good thing.

Now, I'm not sure if this is 100% working solution, so try to break it and let me know.