### PR TITLE
Fix flickering mouse tracking when using two touches on mobile

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -2576,6 +2576,8 @@ export class App extends React.Component<any, AppState> {
       return;
     }
     this.portal.socket &&
+      // do not broadcast when more than 1 pointer since that shows flickering on the other side
+      gesture.pointers.size < 2 &&
       this.broadcastMouseLocation({
         pointerCoords,
         button,


### PR DESCRIPTION
I think this should fix #903 

However, might want to test it with the deployed commit since not sure how to test this on local. I wasn't able to connect to the same collaboration session on my local server.
