### PR TITLE
Support http: ws: for self in connect-src csp

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -64,7 +64,7 @@
     <meta name="twitter:image" content="https://excalidraw.com/og-image.png" />
     <meta
       http-equiv="Content-Security-Policy"
-      content="block-all-mixed-content; child-src 'none'; connect-src https: wss:; default-src 'self'; font-src 'self' data: https: filesystem:; img-src 'self' data: https:; script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://www.google-analytics.com; style-src 'self' 'unsafe-inline' https:;"
+      content="block-all-mixed-content; child-src 'none'; connect-src 'self' https: wss: http: ws:; default-src 'self'; font-src 'self' data: https: filesystem:; img-src 'self' data: https:; script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://www.google-analytics.com; style-src 'self' 'unsafe-inline' https:;"
     />
     <link rel="shortcut icon" href="favicon.ico" type="image/x-icon" />
     <link rel="stylesheet" href="fonts.css" />


### PR DESCRIPTION
Fixes https://github.com/excalidraw/excalidraw/issues/1385 and https://github.com/excalidraw/excalidraw/issues/1386

@dwelle I think this should fix the issue. It looks like the connect-src implementation isn't as consistent across browsers. Would it be possible for us to check this on Safari also, before this PR is merged. I run a linux system and cannot test that out currently. But I can confirm that it works alright on Firefox, Chromium, Brave on Linux.