### PR TITLE
Fix fill of looping lines in exported SVG

### DIFF
--- a/src/renderer/renderElement.ts
+++ b/src/renderer/renderElement.ts
@@ -426,6 +426,9 @@ export function renderElementToSvg(
             offsetY || 0
           }) rotate(${degree} ${cx} ${cy})`,
         );
+        if (element.type === "line") {
+          node.setAttribute("fill-rule", "evenodd");
+        }
         group.appendChild(node);
       });
       svgRoot.appendChild(group);


### PR DESCRIPTION
Fill of looping lines is not worked expectedly in exported SVG file.

On canvas:
<img src="https://user-images.githubusercontent.com/31386431/79058658-ba980c00-7cab-11ea-8d67-635dbd49bb6d.png" width=200>

Exported SVG:
<img src="https://user-images.githubusercontent.com/31386431/79058660-c08ded00-7cab-11ea-88d0-439464a4e736.png" width=200>

In accordance with #1315, apply the evenodd rule to SVG fills as well.
(This will need to be fixed If we want to merge changes like #1341.)

And the following is the behavior after fix:

On canvas:
<img src="https://user-images.githubusercontent.com/31386431/79058699-37c38100-7cac-11ea-83eb-eee84aa9a927.png" width=500>

Exported SVG:
<img src="https://user-images.githubusercontent.com/31386431/79058728-7e18e000-7cac-11ea-8ac1-24cac89eb590.png" width=500>




