### PR TITLE
Suppresses unnecessary fill-rule attribute in SVG

### DIFF
--- a/src/renderer/renderElement.ts
+++ b/src/renderer/renderElement.ts
@@ -426,7 +426,11 @@ export function renderElementToSvg(
             offsetY || 0
           }) rotate(${degree} ${cx} ${cy})`,
         );
-        if (element.type === "line") {
+        if (
+          element.type === "line" &&
+          isPathALoop(element.points) &&
+          element.backgroundColor !== "transparent"
+        ) {
           node.setAttribute("fill-rule", "evenodd");
         }
         group.appendChild(node);


### PR DESCRIPTION
https://github.com/excalidraw/excalidraw/pull/1396#discussion_r407142052

When exporting the SVG contains a line element, all line elements had `fill-rule` attribute.
But this is useless, so fixed it to only set it when necessary.