### PR TITLE
Ignore `undefined is not an object (evaluating 'window.__pad.performLoop')` error

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -23,6 +23,9 @@ Sentry.init({
     : undefined,
   environment: onlineEnv ? SentryEnvHostnameMap[onlineEnv] : undefined,
   release: process.env.REACT_APP_GIT_SHA,
+  ignoreErrors: [
+    "undefined is not an object (evaluating 'window.__pad.performLoop')", // Only happens on Safari, but spams our servers. Doesn't break anything
+  ],
   integrations: [
     new SentryIntegrations.CaptureConsole({
       levels: ["error"],


### PR DESCRIPTION
For https://github.com/excalidraw/excalidraw/issues/1372