### PR TITLE
Remove CSP

### DIFF
--- a/now.json
+++ b/now.json
@@ -18,10 +18,6 @@
         {
           "key": "Referrer-Policy",
           "value": "origin"
-        },
-        {
-          "key": "Content-Security-Policy",
-          "value": "default-src https: data: 'unsafe-inline'; connect-src https://*.excalidraw.com https://*.excalidraw.now.sh wss://excalidraw-socket.herokuapp.com https://excalidraw-socket.herokuapp.com https://sentry.io;"
         }
       ]
     }

--- a/public/index.html
+++ b/public/index.html
@@ -64,10 +64,6 @@
     />
     <!-- OG tags require absolute url for images -->
     <meta name="twitter:image" content="https://excalidraw.com/og-image.png" />
-    <meta
-      http-equiv="Content-Security-Policy"
-      content="block-all-mixed-content; child-src 'self' https://codesandbox.io https://*.csb.app; worker-src 'self'; connect-src 'self' https: wss: http: ws:; default-src 'self'; font-src 'self' data: https: filesystem:; img-src 'self' data: https:; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.googletagmanager.com https://www.google-analytics.com https://codesandbox.io https://*.csb.app https://cdnjs.cloudflare.com; style-src 'self' 'unsafe-inline' https:;"
-    />
     <link rel="shortcut icon" href="favicon.ico" type="image/x-icon" />
     <link
       href="https://excalidraw-socket.herokuapp.com/socket.io"


### PR DESCRIPTION
After internal discussion, we decided to remove CSP directives for now, as it was still causing issues.

We can try to introduce it again when we're more mature, and when there's an actual use case (attack vector) we want to guard against. Right now it's only causing issues when we develop new features.

/cc @lipis @Shriram-Balaji 