### PR TITLE
Remove superfluous meta tag

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -12,7 +12,7 @@
     <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-touch-fullscreen" content="yes" />
 
-    <meta name="theme-color" content="#000000" />
+    <meta name="theme-color" content="#fff" />
 
     <meta
       http-equiv="origin-trial"
@@ -50,8 +50,6 @@
     <meta property="og:image:height" content="669" />
     <meta property="og:image:alt" content="Excalidraw logo with byline." />
 
-    <!-- Chrome -->
-    <meta name="theme-color" content="#FFFF" />
     <!-- Safari -->
     <meta name="apple-mobile-web-app-status-bar-style" content="default" />
 


### PR DESCRIPTION
The `meta[name="theme-color"]` was declared twice, with contradictory values (black, white). This PR removes one of them and sets the theme color to white.