### PR TITLE
persist pointerDown event

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1577,6 +1577,8 @@ class App extends React.Component<any, AppState> {
   private handleCanvasPointerDown = (
     event: React.PointerEvent<HTMLCanvasElement>,
   ) => {
+    event.persist();
+
     if (lastPointerUp !== null) {
       // Unfortunately, sometimes we don't get a pointerup after a pointerdown,
       // this can happen when a contextual menu or alert is triggered. In order to avoid


### PR DESCRIPTION
fixes case when wheel-dragging, and the callback accesses the event asynchronously.

![image](https://user-images.githubusercontent.com/5153846/79214808-47c59700-7e4b-11ea-83a0-e6ad2f834e62.png)

https://reactjs.org/docs/events.html#event-pooling