### PR TITLE
tweak blurry bg for legibility & remove from modals

### DIFF
--- a/src/components/Island.css
+++ b/src/components/Island.css
@@ -1,7 +1,7 @@
 .Island {
   --padding: 0;
   background-color: var(--bg-color-island);
-  backdrop-filter: saturate(180%) blur(20px);
+  backdrop-filter: saturate(100%) blur(10px);
   box-shadow: var(--shadow-island);
   border-radius: var(--border-radius-m);
   padding: calc(var(--padding) * var(--space-factor));

--- a/src/components/Modal.scss
+++ b/src/components/Modal.scss
@@ -35,6 +35,10 @@
   animation: Modal__content_fade-in 0.1s ease-out 0.05s forwards;
   position: relative;
 
+  // for modals, reset blurry bg
+  background: #fff;
+  backdrop-filter: none;
+
   @media #{$media-query} {
     max-width: 100%;
   }

--- a/src/css/theme.scss
+++ b/src/css/theme.scss
@@ -2,7 +2,7 @@
   --text-color-primary: #343a40;
   --bg-color-main: #fff;
   --shadow-island: 0 1px 5px rgba(0, 0, 0, 0.15);
-  --bg-color-island: rgba(255, 255, 255, 0.7);
+  --bg-color-island: rgba(255, 255, 255, 0.9);
   --border-radius-m: 4px;
   --space-factor: 0.25rem;
 }


### PR DESCRIPTION
Removed transparency from modals, and tweaked menus for better legibility.

menu before:

![image](https://user-images.githubusercontent.com/5153846/79378983-784a2580-7f5e-11ea-8768-5b20fe974b9a.png)

menu after:

![image](https://user-images.githubusercontent.com/5153846/79379021-84ce7e00-7f5e-11ea-8418-03928b8c1a65.png)
