### PR TITLE
Only load PWACompat when we really need it

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -13,7 +13,10 @@ import "./css/styles.scss";
 // On Apple mobile devices add the proprietary app icon and splashscreen markup.
 // No one should have to do this manually, and eventually this annoyance will
 // go away once https://bugs.webkit.org/show_bug.cgi?id=183937 is fixed.
-if (/\b(iPad|iPhone|iPod)\b/.test(navigator.userAgent)) {
+if (
+  /\b(iPad|iPhone|iPod)\b/.test(navigator.userAgent) &&
+  !matchMedia("(display-mode: standalone)").matches
+) {
   import("pwacompat");
 }
 


### PR DESCRIPTION
It does nothing once the app is installed, so don't load it.