### PR TITLE
fix bg color picker rendered behind shape menu

### DIFF
--- a/src/components/Island.css
+++ b/src/components/Island.css
@@ -5,4 +5,5 @@
   box-shadow: var(--shadow-island);
   border-radius: var(--border-radius-m);
   padding: calc(var(--padding) * var(--space-factor));
+  position: relative;
 }

--- a/src/components/Island.tsx
+++ b/src/components/Island.tsx
@@ -6,13 +6,14 @@ type IslandProps = {
   children: React.ReactNode;
   padding?: number;
   className?: string;
+  style?: object;
 };
 
 export const Island = React.forwardRef<HTMLDivElement, IslandProps>(
-  ({ children, padding, className }, ref) => (
+  ({ children, padding, className, style }, ref) => (
     <div
       className={`${className ?? ""} Island`}
-      style={{ "--padding": padding } as React.CSSProperties}
+      style={{ "--padding": padding, ...style } as React.CSSProperties}
       ref={ref}
     >
       {children}

--- a/src/components/LayerUI.tsx
+++ b/src/components/LayerUI.tsx
@@ -125,7 +125,7 @@ export const LayerUI = React.memo(
           <div className="App-menu App-menu_top">
             <Stack.Col gap={4}>
               <Section heading="canvasActions">
-                <Island padding={4}>
+                <Island padding={4} style={{ zIndex: 1 }}>
                   <Stack.Col gap={4}>
                     <Stack.Row gap={1} justifyContent={"space-between"}>
                       {actionManager.renderAction("loadScene")}

--- a/src/components/LayerUI.tsx
+++ b/src/components/LayerUI.tsx
@@ -125,6 +125,8 @@ export const LayerUI = React.memo(
           <div className="App-menu App-menu_top">
             <Stack.Col gap={4}>
               <Section heading="canvasActions">
+                {/* the zIndex ensures this menu has higher stacking order,
+                     see https://github.com/excalidraw/excalidraw/pull/1445 */}
                 <Island padding={4} style={{ zIndex: 1 }}>
                   <Stack.Col gap={4}>
                     <Stack.Row gap={1} justifyContent={"space-between"}>


### PR DESCRIPTION
fixes https://github.com/excalidraw/excalidraw/issues/1444

Since the `backdrop-filter` on `.Island` introduced in https://github.com/excalidraw/excalidraw/issues/1444 creates a local stacking context, the nested color picker is stacked relative to the `.Island`. And since shape actions menu is rendered 2nd in the DOM, it has higher local stacking order.

This PR makes the 1st menu have higher stacking order by first making all `.Island` elements positioned so that `z-index` takes effect, and second making the 1st menu have higher `z-index` value than the shape menu.