### PR TITLE
don't prevent select-element devTools action

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1048,6 +1048,11 @@ class App extends React.Component<any, AppState> {
   // Input handling
 
   private onKeyDown = withBatchedUpdates((event: KeyboardEvent) => {
+    // ensures we don't prevent devTools select-element feature
+    if (event[KEYS.CTRL_OR_CMD] && event.shiftKey && event.key === "C") {
+      return;
+    }
+
     if (
       (isWritableElement(event.target) && event.key !== KEYS.ESCAPE) ||
       // case: using arrows to move between buttons


### PR DESCRIPTION
Ensures that `Ctrl/Cmd+Shift+C` works when devTools is not focued. I do this so often that it's about time we fix this.