### PR TITLE
Bump roughjs and resolve breaking change in roughjs refactoring. (sorry)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14445,6 +14445,11 @@
       "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.1.tgz",
       "integrity": "sha512-BapA40NHICOS+USX9SN4tyhq+A2RrN/Ws5F0Z5aMHDp98Fl86lX8Oti8B7uN93L4Ifv4fHOEA+pQw87gmMO/lQ=="
     },
+    "path-data-parser": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/path-data-parser/-/path-data-parser-0.1.0.tgz",
+      "integrity": "sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w=="
+    },
     "path-dirname": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
@@ -14578,6 +14583,20 @@
       "integrity": "sha512-7Wjy+9E3WwLOEL30D+m8TSTF7qJJUJLONBnwQp0518siuMxUQUbgZwssaFX+QKlZkjHZcw/IpZCt/H0srrntSg==",
       "requires": {
         "ts-pnp": "^1.1.6"
+      }
+    },
+    "points-on-curve": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/points-on-curve/-/points-on-curve-0.2.0.tgz",
+      "integrity": "sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A=="
+    },
+    "points-on-path": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/points-on-path/-/points-on-path-0.2.0.tgz",
+      "integrity": "sha512-X+uusxIDk/DZBC1w6gYCThB9GiSI7wlatxPYmme4wmcWnHFGanxdFBtuZQj1YeYhxXESJ5/Ym/h7DWDMw4A9mA==",
+      "requires": {
+        "path-data-parser": "0.1.0",
+        "points-on-curve": "0.2.0"
       }
     },
     "portfinder": {
@@ -16550,9 +16569,14 @@
       }
     },
     "roughjs": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/roughjs/-/roughjs-4.1.4.tgz",
-      "integrity": "sha512-Mrx8r/NhTa9K+WuL2YfB5p40OAN/iRXXxmKUf/rxwgRh9Jrgz+dS2DOqnh0uMwzICJ2Rp0xTIFMgdqf0BCsmug=="
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/roughjs/-/roughjs-4.2.1.tgz",
+      "integrity": "sha512-OFUpA5smxcA6fE+uX4Nc6cvXMhYJ+/YscePoRyWpH36EJP/2GCtBi9VnhBFIO8lIfTtD0smLoWjVPFFKUMEfpA==",
+      "requires": {
+        "path-data-parser": "^0.1.0",
+        "points-on-curve": "^0.2.0",
+        "points-on-path": "^0.2.0"
+      }
     },
     "rsvp": {
       "version": "4.8.5",

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
   },
   "jest": {
     "transformIgnorePatterns": [
-      "node_modules/(?!(roughjs|browser-nativefs)/)"
+      "node_modules/(?!(roughjs|points-on-curve|path-data-parser|points-on-path|browser-nativefs)/)"
     ]
   },
   "private": true,

--- a/package.json
+++ b/package.json
@@ -25,11 +25,12 @@
     "i18next-browser-languagedetector": "4.1.1",
     "nanoid": "2.1.11",
     "open-color": "1.7.0",
+    "points-on-curve": "0.2.0",
     "pwacompat": "2.0.11",
     "react": "16.13.1",
     "react-dom": "16.13.1",
     "react-scripts": "3.4.1",
-    "roughjs": "4.1.4",
+    "roughjs": "4.2.1",
     "socket.io-client": "2.3.0"
   },
   "devDependencies": {

--- a/src/element/collision.ts
+++ b/src/element/collision.ts
@@ -4,7 +4,7 @@ import {
   rotate,
   isPointInPolygon,
 } from "../math";
-import { getPointsOnBezierCurves } from "roughjs/bin/geometry";
+import { pointsOnBezierCurves } from "points-on-curve";
 
 import { NonDeletedExcalidrawElement } from "./types";
 
@@ -266,7 +266,7 @@ const hitTestCurveInside = (
     }
   }
   if (points.length >= 4) {
-    const polygonPoints = getPointsOnBezierCurves(points as any, 50);
+    const polygonPoints = pointsOnBezierCurves(points as any, 10, 5);
     return isPointInPolygon(polygonPoints, x, y);
   }
   return false;


### PR DESCRIPTION
This came into light because of dependabot's PR for bumping roughjs version failed. https://github.com/excalidraw/excalidraw/pull/1458

I had refactored some of roughjs' geometry code into a separate npm package  (`points-on-curve`) without thinking of consequences. (This function was not documented and only used in excalidraw)

This PR bumps the version and uses the `points-on-curve` package which was refactored out of roughjs.