### PR TITLE
Update shield's tooltip

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -156,6 +156,6 @@
     "zoomToFit": "Zoom to fit all elements"
   },
   "encrypted": {
-    "tooltip": "Your drawings are end-to-end encrypted so Excalidraw's servers will never see them.\nClick the icon to learn more..."
+    "tooltip": "Your drawings are end-to-end encrypted so Excalidraw's servers will never see them."
   }
 }


### PR DESCRIPTION
I think it's pretty obvious that it's clickable since we are changing the pointer. 

I don't like it when have to point the obvious, especially with `click here`, etc..