### PR TITLE
Better resize cursors on rotated elements

### DIFF
--- a/src/element/resizeTest.ts
+++ b/src/element/resizeTest.ts
@@ -109,7 +109,7 @@ const RESIZE_CURSORS = ["ns", "nesw", "ew", "nwse"];
 const rotateResizeCursor = (cursor: string, angle: number) => {
   const index = RESIZE_CURSORS.indexOf(cursor);
   if (index >= 0) {
-    const a = Math.floor((angle + Math.PI / 8) / (Math.PI / 4));
+    const a = Math.round(angle / (Math.PI / 4));
     cursor = RESIZE_CURSORS[(index + a) % RESIZE_CURSORS.length];
   }
   return cursor;

--- a/src/element/resizeTest.ts
+++ b/src/element/resizeTest.ts
@@ -105,6 +105,16 @@ export function getResizeHandlerFromCoords(
   return (found || false) as HandlerRectanglesRet;
 }
 
+const RESIZE_CURSORS = ["ns", "nesw", "ew", "nwse"];
+const rotateResizeCursor = (cursor: string, angle: number) => {
+  const index = RESIZE_CURSORS.indexOf(cursor);
+  if (index >= 0) {
+    const a = Math.floor((angle + Math.PI / 8) / (Math.PI / 4));
+    cursor = RESIZE_CURSORS[(index + a) % RESIZE_CURSORS.length];
+  }
+  return cursor;
+};
+
 /*
  * Returns bi-directional cursor for the element being resized
  */
@@ -143,8 +153,11 @@ export function getCursorForResizingElement(resizingElement: {
       }
       break;
     case "rotation":
-      cursor = "ew";
-      break;
+      return "grab";
+  }
+
+  if (cursor && element) {
+    cursor = rotateResizeCursor(cursor, element.angle);
   }
 
   return cursor ? `${cursor}-resize` : "";


### PR DESCRIPTION
This is something I gave up in #1099, because creating arbitrary cursors is not trivial.
However, rotating existing cursors is not hard, and this is it.

![exdraw30](https://user-images.githubusercontent.com/490574/79936308-0dcf4300-8492-11ea-87d5-05b95eba4134.gif)

We might want a custom cursor for rotation, though.