### PR TITLE
rewrite picker color handling

### DIFF
--- a/src/renderer/renderScene.ts
+++ b/src/renderer/renderScene.ts
@@ -114,8 +114,9 @@ export function renderScene(
   if (typeof sceneState.viewBackgroundColor === "string") {
     const hasTransparence =
       sceneState.viewBackgroundColor === "transparent" ||
-      sceneState.viewBackgroundColor.length === 5 ||
-      sceneState.viewBackgroundColor.length === 9;
+      sceneState.viewBackgroundColor.length === 5 || // #RGBA
+      sceneState.viewBackgroundColor.length === 9 || // #RRGGBBA
+      /(hsla|rgba)\(/.test(sceneState.viewBackgroundColor);
     if (hasTransparence) {
       context.clearRect(0, 0, normalizedCanvasWidth, normalizedCanvasHeight);
     }


### PR DESCRIPTION
Fixes:

- inability to input HEX colors without `#` (fixes https://github.com/excalidraw/excalidraw/issues/1485)
- in many cases, colors being normalized to HEX while you're typing

Adds:

- keep colors in the form user typed them
- ability to use rgba/hsla