### PR TITLE
Add option for self-hosting via Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+*
+!public/
+!src/
+!.npmrc
+!package-lock.json
+!package.json
+!tsconfig.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM node:14-alpine AS build
+
+ENV NODE_ENV=production
+WORKDIR /usr/src/app
+
+COPY package.json package-lock.json ./
+RUN npm install
+
+COPY . .
+RUN npm run build:app
+
+FROM nginx:1.17-alpine
+
+COPY --from=build /usr/src/app/build /usr/share/nginx/html
+
+HEALTHCHECK CMD wget -q -O /dev/null http://localhost || exit 1

--- a/README.md
+++ b/README.md
@@ -48,6 +48,25 @@ git clone https://github.com/excalidraw/excalidraw.git
 | `npm run test:update` | Update test snapshots             |
 | `npm run test:code`   | Test for formatting with Prettier |
 
+### Docker Installation
+
+A production-ready version for deploying to e.g. Kubernetes or OpenShift can be built using Docker.
+
+#### Docker Compose
+
+```sh
+docker-compose up --build -d
+```
+
+#### Native Docker
+
+```sh
+docker build -t excalidraw/excalidraw .
+docker run --rm -dit --name excalidraw -p 5000:80 excalidraw/excalidraw:latest
+```
+
+After building the image and running the container, open <http://localhost:5000> to see the application.
+
 ## Contributing
 
 Pull requests are welcome. For major changes, please [open an issue](https://github.com/excalidraw/excalidraw/issues/new) first to discuss what you would like to change.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: "3"
+
+services:
+  excalidraw:
+    build: .
+    container_name: excalidraw
+    ports:
+      - "5000:80"
+    restart: on-failure

--- a/package.json
+++ b/package.json
@@ -31,16 +31,18 @@
     "react-dom": "16.13.1",
     "react-scripts": "3.4.1",
     "roughjs": "4.2.3",
-    "socket.io-client": "2.3.0"
-  },
-  "devDependencies": {
-    "@testing-library/jest-dom": "5.5.0",
-    "@testing-library/react": "10.0.3",
+    "socket.io-client": "2.3.0",
+    "node-sass": "4.14.0",
+    "typescript": "3.8.3",
     "@types/jest": "25.2.1",
     "@types/nanoid": "2.1.0",
     "@types/react": "16.9.34",
     "@types/react-dom": "16.9.6",
     "@types/socket.io-client": "1.4.32",
+    "@testing-library/jest-dom": "5.5.0",
+    "@testing-library/react": "10.0.3"
+  },
+  "devDependencies": {
     "asar": "3.0.3",
     "eslint": "6.8.0",
     "eslint-config-prettier": "6.11.0",
@@ -48,11 +50,9 @@
     "husky": "4.2.5",
     "jest-canvas-mock": "2.2.0",
     "lint-staged": "10.1.7",
-    "node-sass": "4.14.0",
     "pepjs": "0.5.2",
     "prettier": "2.0.5",
-    "rewire": "5.0.0",
-    "typescript": "3.8.3"
+    "rewire": "5.0.0"
   },
   "engines": {
     "node": ">=12.0.0"


### PR DESCRIPTION
Hi,

I've been searching for a good whiteboard tool and Excalidraw looks very prominent for that.

I would, however, like to self-host this so in this PR I added necessary files to build a Docker image and test it locally. The resulting image is as small as **23.3 MB** 🎉 

If this satisfies the needs, this also fixes #1078 

Eventually, it might be wise to add a new Github Action for pushing this image to Docker Hub using e.g. this [official action](https://github.com/docker/build-push-action).

To get up and running, I've added instructions into README. Let me know if you require more information.