### PR TITLE
Make tools shortcuts case insensitive

### DIFF
--- a/src/shapes.tsx
+++ b/src/shapes.tsx
@@ -83,7 +83,9 @@ export const shapesShortcutKeys = SHAPES.map((shape, index) => [
 export function findShapeByKey(key: string) {
   return (
     SHAPES.find((shape, index) => {
-      return shape.value[0] === key || key === (index + 1).toString();
+      return (
+        shape.value[0] === key.toLowerCase() || key === (index + 1).toString()
+      );
     })?.value || "selection"
   );
 }


### PR DESCRIPTION
FIxes issue #1532
For ease of understanding I'll use an example

The user wants to use the text tool and uses the keyboard to select it:
Before to select the text tool **t** would work but **T** wouldn't work
Now using **t** or **T** will select the text tool