### PR TITLE
perf: Debounce cursor syncing

### DIFF
--- a/src/time_constants.ts
+++ b/src/time_constants.ts
@@ -2,3 +2,4 @@
 export const FONT_LOAD_THRESHOLD = 1000;
 export const TAP_TWICE_TIMEOUT = 300;
 export const INITAL_SCENE_UPDATE_TIMEOUT = 5000;
+export const CURSOR_SYNC_TIMEOUT = 30;


### PR DESCRIPTION
An improvement. as mentioned in https://github.com/excalidraw/excalidraw/issues/1523
We can come up with an acceptable timeout. 30ms is what I have tested with.