### PR TITLE
fix(data): removes unnecessary await

### DIFF
--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -113,7 +113,7 @@ export async function generateCollaborationLink() {
   return `${window.location.origin}${window.location.pathname}#room=${id},${key}`;
 }
 
-function getImportedKey(key: string, usage: string): PromiseLike<CryptoKey> {
+async function getImportedKey(key: string, usage: string): Promise<CryptoKey> {
   return window.crypto.subtle.importKey(
     "jwk",
     {

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -113,7 +113,7 @@ export async function generateCollaborationLink() {
   return `${window.location.origin}${window.location.pathname}#room=${id},${key}`;
 }
 
-function getImportedKey(key: string, usage: string): Promise<CryptoKey> {
+function getImportedKey(key: string, usage: string): PromiseLike<CryptoKey> {
   return window.crypto.subtle.importKey(
     "jwk",
     {

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -113,7 +113,7 @@ export async function generateCollaborationLink() {
   return `${window.location.origin}${window.location.pathname}#room=${id},${key}`;
 }
 
-async function getImportedKey(key: string, usage: string): Promise<CryptoKey> {
+function getImportedKey(key: string, usage: string) {
   return window.crypto.subtle.importKey(
     "jwk",
     {

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -113,8 +113,8 @@ export async function generateCollaborationLink() {
   return `${window.location.origin}${window.location.pathname}#room=${id},${key}`;
 }
 
-async function getImportedKey(key: string, usage: string): Promise<CryptoKey> {
-  return await window.crypto.subtle.importKey(
+function getImportedKey(key: string, usage: string): Promise<CryptoKey> {
+  return window.crypto.subtle.importKey(
     "jwk",
     {
       alg: "A128GCM",


### PR DESCRIPTION
`crypto.subtle.importKey` returns a promise, so there's no need to `await`

edit: tsc complained, the WebCrypto interface currently returns `PromiseLike`... it looks like the issue was recently resolved (see: https://github.com/microsoft/TSJS-lib-generator/pull/193) but hasn't made it into typescript release yet (see: https://github.com/microsoft/TSJS-lib-generator/pull/843)

in lieu of changing the return type to `PromiseLike` i'll revert it to async function so it's wrapped in a vanilla promise, once these PRs land in ts, can remove async wrapper

this PR will reduce `getImportedKey` from 3 to 2 promises