### PR TITLE
fix incorrect font rendered on late load

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -114,7 +114,6 @@ import {
   ENV,
 } from "../constants";
 import {
-  FONT_LOAD_THRESHOLD,
   INITAL_SCENE_UPDATE_TIMEOUT,
   TAP_TWICE_TIMEOUT,
 } from "../time_constants";
@@ -298,6 +297,15 @@ class App extends React.Component<any, AppState> {
     event.preventDefault();
   };
 
+  private onFontLoaded = () => {
+    globalSceneState.getElementsIncludingDeleted().forEach((element) => {
+      if (isTextElement(element)) {
+        invalidateShapeForElement(element);
+      }
+    });
+    this.onSceneUpdated();
+  };
+
   private initializeScene = async () => {
     const searchParams = new URLSearchParams(window.location.search);
     const id = searchParams.get("id");
@@ -320,23 +328,6 @@ class App extends React.Component<any, AppState> {
       if (scene) {
         this.syncActionResult(scene);
       }
-    }
-
-    // rerender text elements on font load to fix #637
-    try {
-      await Promise.race([
-        document.fonts?.ready?.then(() => {
-          globalSceneState.getElementsIncludingDeleted().forEach((element) => {
-            if (isTextElement(element)) {
-              invalidateShapeForElement(element);
-            }
-          });
-        }),
-        // if fonts don't load in 1s for whatever reason, don't block the UI
-        new Promise((resolve) => setTimeout(resolve, FONT_LOAD_THRESHOLD)),
-      ]);
-    } catch (error) {
-      console.error(error);
     }
 
     if (this.state.isLoading) {
@@ -396,6 +387,9 @@ class App extends React.Component<any, AppState> {
     window.addEventListener(EVENT.BLUR, this.onBlur, false);
     window.addEventListener(EVENT.DRAG_OVER, this.disableEvent, false);
     window.addEventListener(EVENT.DROP, this.disableEvent, false);
+
+    // rerender text elements on font load to fix #637 && #1553
+    document.fonts?.addEventListener?.("loadingdone", this.onFontLoaded);
 
     // Safari-only desktop pinch zoom
     document.addEventListener(

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,6 +1,10 @@
 interface Document {
   fonts?: {
     ready?: Promise<void>;
+    addEventListener?<K extends "loading" | "loadingdone" | "loadingerror">(
+      type: K,
+      listener: (this: Document, ev: Event) => any,
+    ): void;
   };
 }
 

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,8 +1,8 @@
 interface Document {
   fonts?: {
     ready?: Promise<void>;
-    addEventListener?<K extends "loading" | "loadingdone" | "loadingerror">(
-      type: K,
+    addEventListener?(
+      type: "loading" | "loadingdone" | "loadingerror",
       listener: (this: Document, ev: Event) => any,
     ): void;
   };

--- a/src/time_constants.ts
+++ b/src/time_constants.ts
@@ -1,4 +1,3 @@
 // time in milliseconds
-export const FONT_LOAD_THRESHOLD = 1000;
 export const TAP_TWICE_TIMEOUT = 300;
 export const INITAL_SCENE_UPDATE_TIMEOUT = 5000;


### PR DESCRIPTION
fixes https://github.com/excalidraw/excalidraw/issues/1553

It seems, at least in FF, that fonts are being (re)loaded on init when we join remote scene. Instead of waiting on font load twice (once in init after component mount, and once after we initialize remote scene), or potentially more (in the future), I've added a listener for font loading which should fix all the cases.

I removed the initial wait for font load in compo mount to simplify things. This will likely result in initial FOUT for non-remote scenes, but IMO it's not drastic.