### PR TITLE
Room dialog: Change 'Name' to 'Your name'

### DIFF
--- a/src/components/RoomDialog.tsx
+++ b/src/components/RoomDialog.tsx
@@ -80,7 +80,7 @@ function RoomModal({
           </div>
           <div className="RoomDialog-usernameContainer">
             <label className="RoomDialog-usernameLabel" htmlFor="username">
-              {t("labels.name")}
+              {t("labels.yourName")}
             </label>
             <input
               id="username"

--- a/src/locales/ar-SA.json
+++ b/src/locales/ar-SA.json
@@ -54,6 +54,7 @@
     "duplicateSelection": "",
     "untitled": "",
     "name": "",
+    "yourName": "",
     "madeWithExcalidraw": ""
   },
   "buttons": {

--- a/src/locales/bg-BG.json
+++ b/src/locales/bg-BG.json
@@ -54,6 +54,7 @@
     "duplicateSelection": "Дублирай",
     "untitled": "Неозаглавено",
     "name": "Име",
+    "yourName": "Име",
     "madeWithExcalidraw": ""
   },
   "buttons": {

--- a/src/locales/de-DE.json
+++ b/src/locales/de-DE.json
@@ -54,6 +54,7 @@
     "duplicateSelection": "Duplizieren",
     "untitled": "Unbenannt",
     "name": "Name",
+    "yourName": "Name",
     "madeWithExcalidraw": "Made with Excalidraw"
   },
   "buttons": {

--- a/src/locales/el-GR.json
+++ b/src/locales/el-GR.json
@@ -54,6 +54,7 @@
     "duplicateSelection": "Δημιουργία αντιγράφου",
     "untitled": "Χωρίς τίτλο",
     "name": "Όνομα",
+    "yourName": "Όνομα",
     "madeWithExcalidraw": "Φτιαγμένο με Excalidraw"
   },
   "buttons": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -53,7 +53,7 @@
     "createRoom": "Share a live-collaboration session",
     "duplicateSelection": "Duplicate",
     "untitled": "Untitled",
-    "name": "Name",
+    "yourName": "Your name",
     "madeWithExcalidraw": "Made with Excalidraw"
   },
   "buttons": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -53,6 +53,7 @@
     "createRoom": "Share a live-collaboration session",
     "duplicateSelection": "Duplicate",
     "untitled": "Untitled",
+    "name": "Name",
     "yourName": "Your name",
     "madeWithExcalidraw": "Made with Excalidraw"
   },

--- a/src/locales/es-ES.json
+++ b/src/locales/es-ES.json
@@ -54,6 +54,7 @@
     "duplicateSelection": "Duplicar",
     "untitled": "Sin título",
     "name": "Nombre",
+    "yourName": "Nombre",
     "madeWithExcalidraw": ""
   },
   "buttons": {

--- a/src/locales/fi-FI.json
+++ b/src/locales/fi-FI.json
@@ -54,6 +54,7 @@
     "duplicateSelection": "Monista",
     "untitled": "Nimetön",
     "name": "Nimi",
+    "yourName": "Nimi",
     "madeWithExcalidraw": "Tehty Excalidrawilla"
   },
   "buttons": {

--- a/src/locales/fr-FR.json
+++ b/src/locales/fr-FR.json
@@ -54,6 +54,7 @@
     "duplicateSelection": "Dupliquer",
     "untitled": "Sans titre",
     "name": "Nom",
+    "yourName": "Nom",
     "madeWithExcalidraw": "Fabriqué avec Excalidraw"
   },
   "buttons": {

--- a/src/locales/he-IL.json
+++ b/src/locales/he-IL.json
@@ -54,6 +54,7 @@
     "duplicateSelection": "שכפל",
     "untitled": "ללא כותרת",
     "name": "שם",
+    "yourName": "שם",
     "madeWithExcalidraw": "נוצר באמצעות Excalidraw"
   },
   "buttons": {

--- a/src/locales/hi-IN.json
+++ b/src/locales/hi-IN.json
@@ -54,6 +54,7 @@
     "duplicateSelection": "",
     "untitled": "",
     "name": "",
+    "yourName": "",
     "madeWithExcalidraw": ""
   },
   "buttons": {

--- a/src/locales/hu-HU.json
+++ b/src/locales/hu-HU.json
@@ -54,6 +54,7 @@
     "duplicateSelection": "",
     "untitled": "",
     "name": "",
+    "yourName": "",
     "madeWithExcalidraw": ""
   },
   "buttons": {

--- a/src/locales/id-ID.json
+++ b/src/locales/id-ID.json
@@ -54,6 +54,7 @@
     "duplicateSelection": "Duplikat",
     "untitled": "Tanpa judul",
     "name": "Nama",
+    "yourName": "Nama",
     "madeWithExcalidraw": ""
   },
   "buttons": {

--- a/src/locales/it-IT.json
+++ b/src/locales/it-IT.json
@@ -54,6 +54,7 @@
     "duplicateSelection": "Duplica",
     "untitled": "Senza titolo",
     "name": "Nome",
+    "yourName": "Nome",
     "madeWithExcalidraw": "Creato con Excalidraw"
   },
   "buttons": {

--- a/src/locales/ja-JP.json
+++ b/src/locales/ja-JP.json
@@ -54,6 +54,7 @@
     "duplicateSelection": "複製",
     "untitled": "Untitled",
     "name": "名前",
+    "yourName": "名前",
     "madeWithExcalidraw": "Excalidrawで作成"
   },
   "buttons": {

--- a/src/locales/ko-KR.json
+++ b/src/locales/ko-KR.json
@@ -54,6 +54,7 @@
     "duplicateSelection": "복제",
     "untitled": "제목 없음",
     "name": "",
+    "yourName": "",
     "madeWithExcalidraw": ""
   },
   "buttons": {

--- a/src/locales/nl-NL.json
+++ b/src/locales/nl-NL.json
@@ -54,6 +54,7 @@
     "duplicateSelection": "Dupliceer",
     "untitled": "Naamloos",
     "name": "Naam",
+    "yourName": "Naam",
     "madeWithExcalidraw": "Gemaakt met Excalidraw"
   },
   "buttons": {

--- a/src/locales/no-NO.json
+++ b/src/locales/no-NO.json
@@ -54,6 +54,7 @@
     "duplicateSelection": "Dupliser",
     "untitled": "Uten navn",
     "name": "Navn",
+    "yourName": "Navn",
     "madeWithExcalidraw": "Laget med Excalidraw"
   },
   "buttons": {

--- a/src/locales/pl-PL.json
+++ b/src/locales/pl-PL.json
@@ -54,6 +54,7 @@
     "duplicateSelection": "Powiel",
     "untitled": "Bez tytułu",
     "name": "Nazwa",
+    "yourName": "Nazwa",
     "madeWithExcalidraw": "Zrobione w Excalidraw"
   },
   "buttons": {

--- a/src/locales/pt-PT.json
+++ b/src/locales/pt-PT.json
@@ -54,6 +54,7 @@
     "duplicateSelection": "Duplicar",
     "untitled": "Sem título",
     "name": "Nome",
+    "yourName": "Nome",
     "madeWithExcalidraw": "Feito com Excalidraw"
   },
   "buttons": {

--- a/src/locales/ru-RU.json
+++ b/src/locales/ru-RU.json
@@ -54,6 +54,7 @@
     "duplicateSelection": "Дубликат",
     "untitled": "",
     "name": "Имя",
+    "yourName": "Имя",
     "madeWithExcalidraw": ""
   },
   "buttons": {

--- a/src/locales/tr-TR.json
+++ b/src/locales/tr-TR.json
@@ -54,6 +54,7 @@
     "duplicateSelection": "Kopyala",
     "untitled": "Başlıksız",
     "name": "",
+    "yourName": "",
     "madeWithExcalidraw": ""
   },
   "buttons": {

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -54,6 +54,7 @@
     "duplicateSelection": "复制所有已选择的元素",
     "untitled": "无标题",
     "name": "名字",
+    "yourName": "名字",
     "madeWithExcalidraw": ""
   },
   "buttons": {

--- a/src/locales/zh-TW.json
+++ b/src/locales/zh-TW.json
@@ -54,6 +54,7 @@
     "duplicateSelection": "",
     "untitled": "",
     "name": "",
+    "yourName": "",
     "madeWithExcalidraw": ""
   },
   "buttons": {


### PR DESCRIPTION
Small wording change. I was confused by the room dialog, thinking 'Name' was asking me to assign a label to the live collaboration session. 

<img width=250 src=https://user-images.githubusercontent.com/2136620/81471936-172c0f80-91f5-11ea-97f5-2e7eb0069888.png />

Changing the label to 'Your name' eliminates that ambiguity. 

<img width=250 src=https://user-images.githubusercontent.com/2136620/81471986-6ffba800-91f5-11ea-839d-d39ebe0fbc79.png />

I added a new label `labels.yourName`, and set it to 'Your name' in English. For the rest of the languages I duplicated the existing `labels.name`, so that it falls back on the existing localized text rather than reverting to English. Let me know if there's a better approach. 
