### PR TITLE
Remap delete action to 'D' key

### DIFF
--- a/src/actions/actionDeleteSelected.tsx
+++ b/src/actions/actionDeleteSelected.tsx
@@ -29,7 +29,10 @@ export const actionDeleteSelected = register({
   },
   contextItemLabel: "labels.delete",
   contextMenuOrder: 3,
-  keyTest: (event) => event.key === KEYS.BACKSPACE || event.key === KEYS.DELETE,
+  keyTest: (event) =>
+    event.key === KEYS.BACKSPACE ||
+    event.key === KEYS.DELETE ||
+    event.key.toLowerCase() === "d",
   PanelComponent: ({ elements, appState, updateData }) => (
     <ToolButton
       type="button"

--- a/src/components/ShortcutsDialog.tsx
+++ b/src/components/ShortcutsDialog.tsx
@@ -180,7 +180,7 @@ export const ShortcutsDialog = ({ onClose }: { onClose?: () => void }) => {
             <ShortcutIsland caption={t("shortcutsDialog.shapes")}>
               <Shortcut label={t("toolBar.selection")} shortcuts={["S", "1"]} />
               <Shortcut label={t("toolBar.rectangle")} shortcuts={["R", "2"]} />
-              <Shortcut label={t("toolBar.diamond")} shortcuts={["D", "3"]} />
+              <Shortcut label={t("toolBar.diamond")} shortcuts={["G", "3"]} />
               <Shortcut label={t("toolBar.ellipse")} shortcuts={["E", "4"]} />
               <Shortcut label={t("toolBar.arrow")} shortcuts={["A", "5"]} />
               <Shortcut label={t("toolBar.line")} shortcuts={["L", "6"]} />
@@ -277,7 +277,7 @@ export const ShortcutsDialog = ({ onClose }: { onClose?: () => void }) => {
               />
               <Shortcut
                 label={t("labels.delete")}
-                shortcuts={[getShortcutKey("Del")]}
+                shortcuts={[getShortcutKey("D"), getShortcutKey("Del")]}
               />
               <Shortcut
                 label={t("labels.sendToBack")}

--- a/src/shapes.tsx
+++ b/src/shapes.tsx
@@ -31,7 +31,7 @@ export const SHAPES = [
       </svg>
     ),
     value: "diamond",
-    key: "d",
+    key: "g",
   },
   {
     icon: (

--- a/src/tests/__snapshots__/regressionTests.test.tsx.snap
+++ b/src/tests/__snapshots__/regressionTests.test.tsx.snap
@@ -3412,6 +3412,127 @@ exports[`regression tests hotkey e selects ellipse tool: [end of test] number of
 
 exports[`regression tests hotkey e selects ellipse tool: [end of test] number of renders 1`] = `6`;
 
+exports[`regression tests hotkey g selects diamond tool: [end of test] appState 1`] = `
+Object {
+  "collaborators": Map {},
+  "currentItemBackgroundColor": "transparent",
+  "currentItemFillStyle": "hachure",
+  "currentItemFont": "20px Virgil",
+  "currentItemOpacity": 100,
+  "currentItemRoughness": 1,
+  "currentItemStrokeColor": "#000000",
+  "currentItemStrokeWidth": 1,
+  "currentItemTextAlign": "left",
+  "cursorButton": "up",
+  "cursorX": 0,
+  "cursorY": 0,
+  "draggingElement": null,
+  "editingElement": null,
+  "elementLocked": false,
+  "elementType": "selection",
+  "errorMessage": null,
+  "exportBackground": true,
+  "isCollaborating": false,
+  "isLoading": false,
+  "isResizing": false,
+  "isRotating": false,
+  "lastPointerDownWith": "mouse",
+  "multiElement": null,
+  "name": "Untitled-201933152653",
+  "openMenu": null,
+  "resizingElement": null,
+  "scrollX": 0,
+  "scrollY": 0,
+  "scrolledOutside": false,
+  "selectedElementIds": Object {
+    "id0": true,
+  },
+  "selectionElement": null,
+  "shouldAddWatermark": false,
+  "shouldCacheIgnoreZoom": false,
+  "showShortcutsDialog": false,
+  "username": "",
+  "viewBackgroundColor": "#ffffff",
+  "zenModeEnabled": false,
+  "zoom": 1,
+}
+`;
+
+exports[`regression tests hotkey g selects diamond tool: [end of test] element 0 1`] = `
+Object {
+  "angle": 0,
+  "backgroundColor": "transparent",
+  "fillStyle": "hachure",
+  "height": 10,
+  "id": "id0",
+  "isDeleted": false,
+  "opacity": 100,
+  "roughness": 1,
+  "seed": 337897,
+  "strokeColor": "#000000",
+  "strokeWidth": 1,
+  "type": "diamond",
+  "version": 2,
+  "versionNonce": 1278240551,
+  "width": 10,
+  "x": 10,
+  "y": 10,
+}
+`;
+
+exports[`regression tests hotkey g selects diamond tool: [end of test] history 1`] = `
+Object {
+  "recording": false,
+  "redoStack": Array [],
+  "stateHistory": Array [
+    Object {
+      "appState": Object {
+        "currentItemBackgroundColor": "transparent",
+        "currentItemFillStyle": "hachure",
+        "currentItemFont": "20px Virgil",
+        "currentItemOpacity": 100,
+        "currentItemRoughness": 1,
+        "currentItemStrokeColor": "#000000",
+        "currentItemStrokeWidth": 1,
+        "currentItemTextAlign": "left",
+        "exportBackground": true,
+        "name": "Untitled-201933152653",
+        "selectedElementIds": Object {
+          "id0": true,
+        },
+        "shouldAddWatermark": false,
+        "viewBackgroundColor": "#ffffff",
+      },
+      "elements": Array [
+        Object {
+          "angle": 0,
+          "backgroundColor": "transparent",
+          "fillStyle": "hachure",
+          "height": 10,
+          "id": "id0",
+          "isDeleted": false,
+          "opacity": 100,
+          "roughness": 1,
+          "seed": 337897,
+          "strokeColor": "#000000",
+          "strokeWidth": 1,
+          "type": "diamond",
+          "version": 3,
+          "versionNonce": 1278240551,
+          "width": 10,
+          "x": 10,
+          "y": 10,
+        },
+      ],
+    },
+  ],
+}
+`;
+
+exports[`regression tests hotkey g selects diamond tool: [end of test] number of elements 1`] = `1`;
+
+exports[`regression tests hotkey g selects diamond tool: [end of test] number of renders 1`] = `6`;
+
 exports[`regression tests hotkey l selects line tool: [end of test] appState 1`] = `
 Object {
   "collaborators": Map {},

--- a/src/tests/regressionTests.test.tsx
+++ b/src/tests/regressionTests.test.tsx
@@ -291,7 +291,7 @@ describe("regression tests", () => {
 
   for (const [keys, shape] of [
     ["2r", "rectangle"],
-    ["3d", "diamond"],
+    ["3g", "diamond"],
     ["4e", "ellipse"],
     ["5a", "arrow"],
     ["6l", "line"],


### PR DESCRIPTION
Hey team, I'm using Excalidraw extensively in the last couple of months and it's great! I'm amazed by performance boost it provides for diagram manipulations.

I noticed that some inconvenience when using editor with touchpad or mouse. Hotkey layout for some actions are out of reach for left hand. For example "Delete - backspace", "Send Front - cmd+]" or "Curved Line - L". 

Maybe it would be more convenient if all actions are actually located in reach of left hand (see picture). For example, map deletion on "D" and remap diamond shape to "G".

https://ibb.co/tHmXy4n
https://ibb.co/3RCkvDc
https://ibb.co/WHFZvhP