### PR TITLE
Remove no longer needed Native File System API v1 origin trial token

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -13,12 +13,6 @@
 
     <meta name="theme-color" content="#000" />
 
-    <!-- Origin Trial token for the Native File System API v1 https://developers.chrome.com/origintrials/#/view_trial/3868592079911256065 (Chrome 78–81) -->
-    <meta
-      http-equiv="origin-trial"
-      content="AoGjY+6r8OQZ5c0AXpK+bbca0pJdCTSHWFqSFNulxiW4OwFBB63kHdDHNo433GeuEOir8IvSovR0LOZLfPnEDAUAAABceyJvcmlnaW4iOiJodHRwczovL3d3dy5leGNhbGlkcmF3LmNvbTo0NDMiLCJmZWF0dXJlIjoiTmF0aXZlRmlsZVN5c3RlbSIsImV4cGlyeSI6MTU4OTMyNzk5OX0="
-    />
-
     <!-- Origin Trial token for the Native File System API v2 https://developers.chrome.com/origintrials/#/view_trial/4019462667428167681 (Chrome 83–85) -->
     <meta
       http-equiv="origin-trial"


### PR DESCRIPTION
The origin trial ran out on May 13.