### PR TITLE
use commitToHistory prop for handling draw history

### DIFF
--- a/src/actions/actionFinalize.tsx
+++ b/src/actions/actionFinalize.tsx
@@ -89,7 +89,7 @@ export const actionFinalize = register({
               }
             : appState.selectedElementIds,
       },
-      commitToHistory: false,
+      commitToHistory: appState.elementType === "draw",
     };
   },
   keyTest: (event, appState) =>

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -2340,7 +2340,6 @@ class App extends React.Component<any, AppState> {
 
       if (draggingElement?.type === "draw") {
         this.actionManager.executeAction(actionFinalize);
-        history.resumeRecording();
         return;
       }
       if (isLinearElement(draggingElement)) {


### PR DESCRIPTION
https://github.com/excalidraw/excalidraw/pull/1594 was merged a bit too fast. While correct, we should use `commitToHistory` prop in actions.

/cc @kbariotis @lusingander 