### PR TITLE
Alt should be labeled as Option on Mac

### DIFF
--- a/src/components/ShortcutsDialog.tsx
+++ b/src/components/ShortcutsDialog.tsx
@@ -245,7 +245,7 @@ export const ShortcutsDialog = ({ onClose }: { onClose?: () => void }) => {
               />
               <Shortcut
                 label={t("buttons.toggleZenMode")}
-                shortcuts={["Alt+Z"]}
+                shortcuts={[getShortcutKey("Alt+Z")]}
               />
             </ShortcutIsland>
           </Column>


### PR DESCRIPTION
As with the other shortcut keys in help modal, Alt should be labeled as Option on Mac.