### PR TITLE
feat: resize multiple elements including two-point lines

### DIFF
--- a/src/element/bounds.ts
+++ b/src/element/bounds.ts
@@ -111,6 +111,7 @@ const getLinearElementAbsoluteCoords = (
   element: ExcalidrawLinearElement,
 ): [number, number, number, number] => {
   if (element.points.length < 2 || !getShapeForElement(element)) {
+    // XXX this is just a poor estimate and not very useful
     const { minX, minY, maxX, maxY } = element.points.reduce(
       (limits, [x, y]) => {
         limits.minY = Math.min(limits.minY, y);
@@ -216,6 +217,7 @@ const getLinearElementRotatedBounds = (
   cy: number,
 ): [number, number, number, number] => {
   if (element.points.length < 2 || !getShapeForElement(element)) {
+    // XXX this is just a poor estimate and not very useful
     const { minX, minY, maxX, maxY } = element.points.reduce(
       (limits, [x, y]) => {
         [x, y] = rotate(element.x + x, element.y + y, cx, cy, element.angle);
@@ -308,7 +310,7 @@ export const getResizedElementAbsoluteCoords = (
   nextWidth: number,
   nextHeight: number,
 ): [number, number, number, number] => {
-  if (!isLinearElement(element) || element.points.length <= 2) {
+  if (!isLinearElement(element)) {
     return [
       element.x,
       element.y,

--- a/src/element/resizeElements.ts
+++ b/src/element/resizeElements.ts
@@ -407,7 +407,7 @@ export const canResizeMutlipleElements = (
   return elements.every(
     (element) =>
       ["rectangle", "diamond", "ellipse"].includes(element.type) ||
-      (isLinearElement(element) && element.points.length > 2),
+      isLinearElement(element),
   );
 };
 

--- a/src/points.ts
+++ b/src/points.ts
@@ -23,16 +23,22 @@ export function rescalePoints(
 
   let nextMinDimension = Infinity;
 
-  const scaledPoints = prevPoints.map((prevPoint) =>
-    prevPoint.map((value, currentDimension) => {
-      if (currentDimension !== dimension) {
-        return value;
-      }
-      const scaledValue = value * dimensionScaleFactor;
-      nextMinDimension = Math.min(scaledValue, nextMinDimension);
-      return scaledValue;
-    }),
+  const scaledPoints = prevPoints.map(
+    (prevPoint) =>
+      prevPoint.map((value, currentDimension) => {
+        if (currentDimension !== dimension) {
+          return value;
+        }
+        const scaledValue = value * dimensionScaleFactor;
+        nextMinDimension = Math.min(scaledValue, nextMinDimension);
+        return scaledValue;
+      }) as [number, number],
   );
+
+  if (scaledPoints.length === 2) {
+    // we don't tranlate two-point lines
+    return scaledPoints;
+  }
 
   const translation = prevMinDimension - nextMinDimension;
 

--- a/src/points.ts
+++ b/src/points.ts
@@ -18,7 +18,8 @@ export function rescalePoints(
   const prevMinDimension = Math.min(...prevDimValues);
   const prevDimensionSize = prevMaxDimension - prevMinDimension;
 
-  const dimensionScaleFactor = nextDimensionSize / prevDimensionSize;
+  const dimensionScaleFactor =
+    prevDimensionSize === 0 ? 1 : nextDimensionSize / prevDimensionSize;
 
   let nextMinDimension = Infinity;
 


### PR DESCRIPTION
For part of #1218. This was tricky regardless of the small diff. Even with two-point lines, element.width/height are different from the absolute coords.

![exdraw42](https://user-images.githubusercontent.com/490574/82133403-9c7f7780-9826-11ea-9a35-cddd6071b3f3.gif)
