### PR TITLE
docker build : install devDependencies so the build succeed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 FROM node:14-alpine AS build
 
-ENV NODE_ENV=production
 WORKDIR /usr/src/app
 
 COPY package.json package-lock.json ./
 RUN npm install
 
 COPY . .
+ENV NODE_ENV=production
 RUN npm run build:app
 
 FROM nginx:1.17-alpine


### PR DESCRIPTION
Declaring
`ENV NODE_ENV=production` before `npm install` will not install devDependencies and the build will fail with a TypeScript error, see issue #1593 
Move the declaration before `RUN npm run build:app` so the build succeed.