### PR TITLE
cache nonDeleted elements

### DIFF
--- a/src/scene/globalScene.ts
+++ b/src/scene/globalScene.ts
@@ -13,6 +13,7 @@ export interface SceneStateCallbackRemover {
 }
 
 class GlobalScene {
+  private nonDeletedElements: readonly NonDeletedExcalidrawElement[] = [];
   private callbacks: Set<SceneStateCallback> = new Set();
 
   constructor(private _elements: readonly ExcalidrawElement[] = []) {}
@@ -22,11 +23,12 @@ class GlobalScene {
   }
 
   getElements(): readonly NonDeletedExcalidrawElement[] {
-    return getNonDeletedElements(this._elements);
+    return this.nonDeletedElements;
   }
 
   replaceAllElements(nextElements: readonly ExcalidrawElement[]) {
     this._elements = nextElements;
+    this.nonDeletedElements = getNonDeletedElements(this._elements);
     this.informMutation();
   }
 


### PR DESCRIPTION
This PR caches nonDeleted elements on each replacement so that `globalSceneState.getElements()` 1) doesn't renew array reference unnecessarily (used in `LayerUI` memoization), and 2) makes it `O(1)` instead of `O(n)` operation.

This kinda hinges on the fact that we call `replaceAllElements()` when we delete them, which we seem to be doing now.

This gets us back to 60FPS for regular scenes (for a subset of operations).

Here's element dragging on the 256 scene:

Before:

![image](https://user-images.githubusercontent.com/5153846/82667811-d7274c80-9c38-11ea-9acc-40fda9c0cf9f.png)

After:

![image](https://user-images.githubusercontent.com/5153846/82667800-d2629880-9c38-11ea-97d3-f2994e417464.png)
