### PR TITLE
Optimize undo history

### DIFF
--- a/src/element/newElement.ts
+++ b/src/element/newElement.ts
@@ -114,7 +114,7 @@ export const newLinearElement = (
 //  (doesn't clone Date, RegExp, Map, Set, Typed arrays etc.)
 //
 // Adapted from https://github.com/lukeed/klona
-const _duplicateElement = (val: any, depth: number = 0) => {
+export const deepCopyElement = (val: any, depth: number = 0) => {
   if (val == null || typeof val !== "object") {
     return val;
   }
@@ -130,7 +130,7 @@ const _duplicateElement = (val: any, depth: number = 0) => {
         if (depth === 0 && (key === "shape" || key === "canvas")) {
           continue;
         }
-        tmp[key] = _duplicateElement(val[key], depth + 1);
+        tmp[key] = deepCopyElement(val[key], depth + 1);
       }
     }
     return tmp;
@@ -140,7 +140,7 @@ const _duplicateElement = (val: any, depth: number = 0) => {
     let k = val.length;
     const arr = new Array(k);
     while (k--) {
-      arr[k] = _duplicateElement(val[k], depth + 1);
+      arr[k] = deepCopyElement(val[k], depth + 1);
     }
     return arr;
   }
@@ -152,7 +152,7 @@ export const duplicateElement = <TElement extends Mutable<ExcalidrawElement>>(
   element: TElement,
   overrides?: Partial<TElement>,
 ): TElement => {
-  let copy: TElement = _duplicateElement(element);
+  let copy: TElement = deepCopyElement(element);
   copy.id = randomId();
   copy.seed = randomInteger();
   if (overrides) {

--- a/src/history.ts
+++ b/src/history.ts
@@ -75,7 +75,9 @@ export class SceneHistory {
           versions.set(element.version, new Map());
         }
         const nonces = versions.get(element.version)!;
-        nonces.set(element.versionNonce, deepCopyElement(element));
+        if (!nonces.has(element.versionNonce)) {
+          nonces.set(element.versionNonce, deepCopyElement(element));
+        }
         return {
           id: element.id,
           version: element.version,

--- a/src/history.ts
+++ b/src/history.ts
@@ -63,12 +63,11 @@ export class SceneHistory {
     return {
       appState,
       elements: elements.map((element) => {
-        // We should be able to avoid deep copying the element if it's already in the cache,
-        // however, there is some hidden mutation somewhere that causes tests to break.
-
         const { id, version, versionNonce } = element;
         const entryId = `${id}:${version}:${versionNonce}`;
-        this.elementCache.set(entryId, deepCopyElement(element));
+        if (!this.elementCache.has(entryId)) {
+          this.elementCache.set(entryId, deepCopyElement(element));
+        }
         return {
           id: element.id,
           version: element.version,
@@ -94,6 +93,7 @@ export class SceneHistory {
     this.stateHistory.length = 0;
     this.redoStack.length = 0;
     this.lastEntry = null;
+    this.elementCache.clear();
   }
 
   private generateEntry = (


### PR DESCRIPTION
Rather than serialize/deserialize all the elements, instead only store the elements that have changed.

Tested by making changes in a large scene and manually inspecting the history object.

I also took a look at the staged version of this PR vs production excalidraw.com. When I load up a 2mb scene, force GC, drag an element 10 times, and force GC again, the production version uses 28mb of RAM, and this diff drops it down to 17mb.

When you take a look at the memory usage after loading and rendering the scene the difference is much more pronounced: the production version stores 14mb of history, and this version stores only 3.

Fixes #1258
Probably fixes #1246 and #1357