### PR TITLE
Fix group element removing

### DIFF
--- a/src/actions/actionDeleteSelected.tsx
+++ b/src/actions/actionDeleteSelected.tsx
@@ -1,4 +1,4 @@
-import { deleteSelectedElements, isSomeElementSelected } from "../scene";
+import { isSomeElementSelected } from "../scene";
 import { KEYS } from "../keys";
 import { ToolButton } from "../components/ToolButton";
 import React from "react";
@@ -6,14 +6,49 @@ import { trash } from "../components/icons";
 import { t } from "../i18n";
 import { register } from "./register";
 import { getNonDeletedElements } from "../element";
+import { ExcalidrawElement } from "../element/types";
+import { AppState } from "../types";
+import { newElementWith } from "../element/mutateElement";
+
+const deleteSelectedElements = (
+  elements: readonly ExcalidrawElement[],
+  appState: AppState,
+) => {
+  return {
+    elements: elements.map((el) => {
+      if (appState.selectedElementIds[el.id]) {
+        return newElementWith(el, { isDeleted: true });
+      }
+      return el;
+    }),
+    appState: {
+      ...appState,
+      selectedElementIds: {},
+    },
+  };
+};
 
 export const actionDeleteSelected = register({
   name: "deleteSelectedElements",
   perform: (elements, appState) => {
-    const {
+    let {
       elements: nextElements,
       appState: nextAppState,
     } = deleteSelectedElements(elements, appState);
+
+    if (appState.editingGroupId) {
+      const siblingElement = nextElements.find(
+        (element) =>
+          !element.isDeleted &&
+          element.groupIds.includes(appState.editingGroupId!),
+      );
+      if (siblingElement) {
+        nextAppState = {
+          ...nextAppState,
+          selectedElementIds: { [siblingElement.id]: true },
+        };
+      }
+    }
     return {
       elements: nextElements,
       appState: {

--- a/src/actions/actionDeleteSelected.tsx
+++ b/src/actions/actionDeleteSelected.tsx
@@ -9,6 +9,7 @@ import { getNonDeletedElements } from "../element";
 import { ExcalidrawElement } from "../element/types";
 import { AppState } from "../types";
 import { newElementWith } from "../element/mutateElement";
+import { getElementsInGroup } from "../groups";
 
 const deleteSelectedElements = (
   elements: readonly ExcalidrawElement[],
@@ -37,15 +38,14 @@ export const actionDeleteSelected = register({
     } = deleteSelectedElements(elements, appState);
 
     if (appState.editingGroupId) {
-      const siblingElement = nextElements.find(
-        (element) =>
-          !element.isDeleted &&
-          element.groupIds.includes(appState.editingGroupId!),
+      const siblingElements = getElementsInGroup(
+        getNonDeletedElements(nextElements),
+        appState.editingGroupId!,
       );
-      if (siblingElement) {
+      if (siblingElements.length) {
         nextAppState = {
           ...nextAppState,
-          selectedElementIds: { [siblingElement.id]: true },
+          selectedElementIds: { [siblingElements[0].id]: true },
         };
       }
     }

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -30,7 +30,6 @@ import {
   isNonDeletedElement,
 } from "../element";
 import {
-  deleteSelectedElements,
   getElementsWithinSelection,
   isOverScrollBars,
   getElementAtPosition,
@@ -124,7 +123,7 @@ import { invalidateShapeForElement } from "../renderer/renderElement";
 import { unstable_batchedUpdates } from "react-dom";
 import { SceneStateCallbackRemover } from "../scene/globalScene";
 import { isLinearElement } from "../element/typeChecks";
-import { actionFinalize } from "../actions";
+import { actionFinalize, actionDeleteSelected } from "../actions";
 import {
   restoreUsernameFromLocalStorage,
   saveUsernameToLocalStorage,
@@ -589,13 +588,7 @@ class App extends React.Component<any, AppState> {
       return;
     }
     this.copyAll();
-    const { elements: nextElements, appState } = deleteSelectedElements(
-      globalSceneState.getElementsIncludingDeleted(),
-      this.state,
-    );
-    globalSceneState.replaceAllElements(nextElements);
-    history.resumeRecording();
-    this.setState({ ...appState });
+    this.actionManager.executeAction(actionDeleteSelected);
     event.preventDefault();
   });
 

--- a/src/element/mutateElement.ts
+++ b/src/element/mutateElement.ts
@@ -34,7 +34,7 @@ export const mutateElement = <TElement extends Mutable<ExcalidrawElement>>(
       if (
         (element as any)[key] === value &&
         // if object, always update in case its deep prop was mutated
-        (typeof value !== "object" || value === null)
+        (typeof value !== "object" || value === null || key === "groupIds")
       ) {
         continue;
       }

--- a/src/element/newElement.ts
+++ b/src/element/newElement.ts
@@ -12,6 +12,7 @@ import { measureText, getFontString } from "../utils";
 import { randomInteger, randomId } from "../random";
 import { newElementWith } from "./mutateElement";
 import { getNewGroupIdsForDuplication } from "../groups";
+import { AppState } from "../types";
 
 type ElementConstructorOpts = {
   x: ExcalidrawGenericElement["x"];
@@ -169,7 +170,7 @@ export const deepCopyElement = (val: any, depth: number = 0) => {
  * @param overrides Any element properties to override
  */
 export const duplicateElement = <TElement extends Mutable<ExcalidrawElement>>(
-  editingGroupId: GroupId | null,
+  editingGroupId: AppState["editingGroupId"],
   groupIdMapForOperation: Map<GroupId, GroupId>,
   element: TElement,
   overrides?: Partial<TElement>,

--- a/src/element/types.ts
+++ b/src/element/types.ts
@@ -21,7 +21,7 @@ type _ExcalidrawElementBase = Readonly<{
   version: number;
   versionNonce: number;
   isDeleted: boolean;
-  groupIds: GroupId[];
+  groupIds: readonly GroupId[];
 }>;
 
 export type ExcalidrawSelectionElement = _ExcalidrawElementBase & {

--- a/src/groups.ts
+++ b/src/groups.ts
@@ -50,9 +50,7 @@ export function isSelectedViaGroup(
     .find((groupId) => appState.selectedGroupIds[groupId]);
 }
 
-export function getSelectedGroupIds(
-  appState: AppState,
-): ExcalidrawElement["groupIds"] {
+export function getSelectedGroupIds(appState: AppState): GroupId[] {
   return Object.entries(appState.selectedGroupIds)
     .filter(([groupId, isSelected]) => isSelected)
     .map(([groupId, isSelected]) => groupId);

--- a/src/groups.ts
+++ b/src/groups.ts
@@ -7,15 +7,31 @@ export function selectGroup(
   appState: AppState,
   elements: readonly NonDeleted<ExcalidrawElement>[],
 ): AppState {
+  const elementsInGroup = elements.filter((element) =>
+    element.groupIds.includes(groupId),
+  );
+
+  if (elementsInGroup.length < 2) {
+    if (
+      appState.selectedGroupIds[groupId] ||
+      appState.editingGroupId === groupId
+    ) {
+      return {
+        ...appState,
+        selectedGroupIds: { ...appState.selectedGroupIds, [groupId]: false },
+        editingGroupId: null,
+      };
+    }
+    return appState;
+  }
+
   return {
     ...appState,
     selectedGroupIds: { ...appState.selectedGroupIds, [groupId]: true },
     selectedElementIds: {
       ...appState.selectedElementIds,
       ...Object.fromEntries(
-        elements
-          .filter((element) => element.groupIds.includes(groupId))
-          .map((element) => [element.id, true]),
+        elementsInGroup.map((element) => [element.id, true]),
       ),
     },
   };

--- a/src/groups.ts
+++ b/src/groups.ts
@@ -34,7 +34,9 @@ export function isSelectedViaGroup(
     .find((groupId) => appState.selectedGroupIds[groupId]);
 }
 
-export function getSelectedGroupIds(appState: AppState): GroupId[] {
+export function getSelectedGroupIds(
+  appState: AppState,
+): ExcalidrawElement["groupIds"] {
   return Object.entries(appState.selectedGroupIds)
     .filter(([groupId, isSelected]) => isSelected)
     .map(([groupId, isSelected]) => groupId);
@@ -89,8 +91,8 @@ export function getSelectedGroupIdForElement(
 }
 
 export function getNewGroupIdsForDuplication(
-  groupIds: GroupId[],
-  editingGroupId: GroupId | null,
+  groupIds: ExcalidrawElement["groupIds"],
+  editingGroupId: AppState["editingGroupId"],
   mapper: (groupId: GroupId) => GroupId,
 ) {
   const copy = [...groupIds];
@@ -107,9 +109,9 @@ export function getNewGroupIdsForDuplication(
 }
 
 export function addToGroup(
-  prevGroupIds: GroupId[],
+  prevGroupIds: ExcalidrawElement["groupIds"],
   newGroupId: GroupId,
-  editingGroupId: GroupId | null,
+  editingGroupId: AppState["editingGroupId"],
 ) {
   // insert before the editingGroupId, or push to the end.
   const groupIds = [...prevGroupIds];
@@ -123,7 +125,7 @@ export function addToGroup(
 }
 
 export function removeFromSelectedGroups(
-  groupIds: GroupId[],
+  groupIds: ExcalidrawElement["groupIds"],
   selectedGroupIds: { [groupId: string]: boolean },
 ) {
   return groupIds.filter((groupId) => !selectedGroupIds[groupId]);

--- a/src/history.ts
+++ b/src/history.ts
@@ -22,6 +22,7 @@ const clearAppStatePropertiesForHistory = (appState: AppState) => {
   return {
     selectedElementIds: appState.selectedElementIds,
     viewBackgroundColor: appState.viewBackgroundColor,
+    editingGroupId: appState.editingGroupId,
     name: appState.name,
   };
 };

--- a/src/scene/index.ts
+++ b/src/scene/index.ts
@@ -1,6 +1,5 @@
 export { isOverScrollBars } from "./scrollbars";
 export {
-  deleteSelectedElements,
   isSomeElementSelected,
   getElementsWithinSelection,
   getCommonAttributeOfSelectedElements,

--- a/src/scene/selection.ts
+++ b/src/scene/selection.ts
@@ -4,7 +4,6 @@ import {
 } from "../element/types";
 import { getElementAbsoluteCoords, getElementBounds } from "../element";
 import { AppState } from "../types";
-import { newElementWith } from "../element/mutateElement";
 
 export const getElementsWithinSelection = (
   elements: readonly NonDeletedExcalidrawElement[],
@@ -29,24 +28,6 @@ export const getElementsWithinSelection = (
       selectionY2 >= elementY2
     );
   });
-};
-
-export const deleteSelectedElements = (
-  elements: readonly ExcalidrawElement[],
-  appState: AppState,
-) => {
-  return {
-    elements: elements.map((el) => {
-      if (appState.selectedElementIds[el.id]) {
-        return newElementWith(el, { isDeleted: true });
-      }
-      return el;
-    }),
-    appState: {
-      ...appState,
-      selectedElementIds: {},
-    },
-  };
 };
 
 export const isSomeElementSelected = (

--- a/src/tests/__snapshots__/regressionTests.test.tsx.snap
+++ b/src/tests/__snapshots__/regressionTests.test.tsx.snap
@@ -138,6 +138,7 @@ Object {
   "stateHistory": Array [
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Unbenannt-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -170,6 +171,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Unbenannt-201933152653",
         "selectedElementIds": Object {
           "id1": true,
@@ -223,6 +225,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Unbenannt-201933152653",
         "selectedElementIds": Object {
           "id2": true,
@@ -297,6 +300,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Unbenannt-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -490,6 +494,7 @@ Object {
   "stateHistory": Array [
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -522,6 +527,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -663,6 +669,7 @@ Object {
   "stateHistory": Array [
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -782,6 +789,7 @@ Object {
   "stateHistory": Array [
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -814,6 +822,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -846,6 +855,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -878,6 +888,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -910,6 +921,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -1030,6 +1042,7 @@ Object {
   "stateHistory": Array [
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -1062,6 +1075,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -1184,6 +1198,7 @@ Object {
   "stateHistory": Array [
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -1216,6 +1231,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -1249,6 +1265,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -1395,6 +1412,7 @@ Object {
   "stateHistory": Array [
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -1427,6 +1445,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id1": true,
@@ -1617,6 +1636,7 @@ Object {
   "stateHistory": Array [
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -1649,6 +1669,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id1": true,
@@ -1702,6 +1723,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id2": true,
@@ -1917,6 +1939,7 @@ Object {
   "stateHistory": Array [
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Unbenannt-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -1949,6 +1972,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Unbenannt-201933152653",
         "selectedElementIds": Object {
           "id1": true,
@@ -2002,6 +2026,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Unbenannt-201933152653",
         "selectedElementIds": Object {
           "id2": true,
@@ -2076,6 +2101,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Unbenannt-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -2482,6 +2508,7 @@ Object {
   "stateHistory": Array [
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {},
         "viewBackgroundColor": "#ffffff",
@@ -2490,6 +2517,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -2522,6 +2550,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id1": true,
@@ -2575,6 +2604,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id2": true,
@@ -2649,6 +2679,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id3": true,
@@ -2755,6 +2786,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id4": true,
@@ -2893,6 +2925,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id5": true,
@@ -3066,6 +3099,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id5": true,
@@ -3243,6 +3277,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id6": true,
@@ -3455,6 +3490,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id6": true,
@@ -3671,6 +3707,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id7": true,
@@ -4006,6 +4043,7 @@ Object {
   "stateHistory": Array [
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -4125,6 +4163,7 @@ Object {
   "stateHistory": Array [
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -4244,6 +4283,7 @@ Object {
   "stateHistory": Array [
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -4374,6 +4414,7 @@ Object {
   "stateHistory": Array [
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -4515,6 +4556,7 @@ Object {
   "stateHistory": Array [
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -4656,6 +4698,7 @@ Object {
   "stateHistory": Array [
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -4797,6 +4840,7 @@ Object {
   "stateHistory": Array [
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -4927,6 +4971,7 @@ Object {
   "stateHistory": Array [
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -5046,6 +5091,7 @@ Object {
   "stateHistory": Array [
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -5176,6 +5222,7 @@ Object {
   "stateHistory": Array [
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -5306,6 +5353,7 @@ Object {
   "stateHistory": Array [
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -5436,6 +5484,7 @@ Object {
   "stateHistory": Array [
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -5704,6 +5753,7 @@ Object {
   "stateHistory": Array [
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Unbenannt-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -5736,6 +5786,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Unbenannt-201933152653",
         "selectedElementIds": Object {
           "id1": true,
@@ -5789,6 +5840,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Unbenannt-201933152653",
         "selectedElementIds": Object {
           "id2": true,
@@ -5863,6 +5915,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Unbenannt-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -5946,6 +5999,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Unbenannt-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -6211,6 +6265,7 @@ Object {
   "stateHistory": Array [
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -6243,6 +6298,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id1": true,
@@ -6521,6 +6577,7 @@ Object {
   "stateHistory": Array [
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -6553,6 +6610,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -6586,6 +6644,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -6620,6 +6679,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -6655,6 +6715,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -6691,6 +6752,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -6728,6 +6790,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -6766,6 +6829,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -6805,6 +6869,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -6845,6 +6910,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -6886,6 +6952,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -6928,6 +6995,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -6971,6 +7039,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -7015,6 +7084,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -7060,6 +7130,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -7106,6 +7177,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -7153,6 +7225,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -7295,6 +7368,7 @@ Object {
   "stateHistory": Array [
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -7327,6 +7401,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -7360,6 +7435,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -7394,6 +7470,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -7429,6 +7506,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -7465,6 +7543,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -7502,6 +7581,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -7540,6 +7620,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -7671,6 +7752,7 @@ Object {
   "stateHistory": Array [
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -7703,6 +7785,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -7736,6 +7819,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -7770,6 +7854,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -7805,6 +7890,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -7841,6 +7927,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -7968,6 +8055,7 @@ Object {
   "stateHistory": Array [
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -8000,6 +8088,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -8033,6 +8122,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -8067,6 +8157,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -8190,6 +8281,7 @@ Object {
   "stateHistory": Array [
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -8222,6 +8314,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -8357,6 +8450,7 @@ Object {
   "stateHistory": Array [
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -8389,6 +8483,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -8422,6 +8517,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -8456,6 +8552,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -8491,6 +8588,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -8527,6 +8625,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -8564,6 +8663,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -8602,6 +8702,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -8641,6 +8742,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -8681,6 +8783,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -8722,6 +8825,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -8764,6 +8868,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -8807,6 +8912,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -8851,6 +8957,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -8896,6 +9003,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -8942,6 +9050,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -9089,6 +9198,7 @@ Object {
   "stateHistory": Array [
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -9121,6 +9231,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -9154,6 +9265,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -9188,6 +9300,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -9223,6 +9336,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -9259,6 +9373,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -9296,6 +9411,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -9334,6 +9450,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -9373,6 +9490,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -9413,6 +9531,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -9454,6 +9573,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -9496,6 +9616,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -9539,6 +9660,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -9583,6 +9705,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -9726,6 +9849,7 @@ Object {
   "stateHistory": Array [
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -9758,6 +9882,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -9791,6 +9916,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -9825,6 +9951,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -9860,6 +9987,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -9896,6 +10024,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -9933,6 +10062,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -9971,6 +10101,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -10010,6 +10141,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -10050,6 +10182,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -10091,6 +10224,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -10133,6 +10267,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -10272,6 +10407,7 @@ Object {
   "stateHistory": Array [
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -10304,6 +10440,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -10337,6 +10474,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -10371,6 +10509,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -10406,6 +10545,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -10442,6 +10582,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -10479,6 +10620,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -10517,6 +10659,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -10556,6 +10699,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -10596,6 +10740,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -10732,6 +10877,7 @@ Object {
   "stateHistory": Array [
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -10764,6 +10910,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -10797,6 +10944,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -10831,6 +10979,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -10866,6 +11015,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -10902,6 +11052,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -10939,6 +11090,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -10977,6 +11129,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -11016,6 +11169,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -11149,6 +11303,7 @@ Object {
   "stateHistory": Array [
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -11181,6 +11336,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -11214,6 +11370,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -11248,6 +11405,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -11283,6 +11441,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -11319,6 +11478,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -11356,6 +11516,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -11485,6 +11646,7 @@ Object {
   "stateHistory": Array [
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -11517,6 +11679,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -11550,6 +11713,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -11584,6 +11748,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -11619,6 +11784,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -11744,6 +11910,7 @@ Object {
   "stateHistory": Array [
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -11776,6 +11943,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -11809,6 +11977,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -11946,6 +12115,7 @@ Object {
   "stateHistory": Array [
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -11978,6 +12148,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -12011,6 +12182,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -12045,6 +12217,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -12080,6 +12253,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -12116,6 +12290,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -12153,6 +12328,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -12191,6 +12367,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -12230,6 +12407,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -12270,6 +12448,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -12311,6 +12490,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -12353,6 +12533,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -12396,6 +12577,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -12440,6 +12622,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -12485,6 +12668,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -12531,6 +12715,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -12578,6 +12763,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -12727,6 +12913,7 @@ Object {
   "stateHistory": Array [
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -12759,6 +12946,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -12792,6 +12980,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -12826,6 +13015,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -12861,6 +13051,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -12897,6 +13088,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -12934,6 +13126,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -12972,6 +13165,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -13011,6 +13205,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -13051,6 +13246,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -13092,6 +13288,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -13134,6 +13331,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -13177,6 +13375,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -13221,6 +13420,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -13266,6 +13466,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -13411,6 +13612,7 @@ Object {
   "stateHistory": Array [
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -13443,6 +13645,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -13476,6 +13679,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -13510,6 +13714,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -13545,6 +13750,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -13581,6 +13787,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -13618,6 +13825,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -13656,6 +13864,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -13695,6 +13904,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -13735,6 +13945,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -13776,6 +13987,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -13818,6 +14030,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -13861,6 +14074,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -14002,6 +14216,7 @@ Object {
   "stateHistory": Array [
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -14034,6 +14249,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -14067,6 +14283,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -14101,6 +14318,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -14136,6 +14354,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -14172,6 +14391,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -14209,6 +14429,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -14247,6 +14468,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -14286,6 +14508,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -14326,6 +14549,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -14367,6 +14591,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -14524,6 +14749,7 @@ Object {
   "stateHistory": Array [
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -14556,6 +14782,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id1": true,
@@ -14609,6 +14836,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -14869,6 +15097,7 @@ Object {
   "stateHistory": Array [
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Unbenannt-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -14901,6 +15130,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Unbenannt-201933152653",
         "selectedElementIds": Object {
           "id1": true,
@@ -14954,6 +15184,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Unbenannt-201933152653",
         "selectedElementIds": Object {
           "id2": true,
@@ -15028,6 +15259,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Unbenannt-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -15110,11 +15342,181 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": "id3",
         "name": "Unbenannt-201933152653",
         "selectedElementIds": Object {
           "id0": true,
           "id2": true,
           "id4": true,
+        },
+        "viewBackgroundColor": "#ffffff",
+      },
+      "elements": Array [
+        Object {
+          "angle": 0,
+          "backgroundColor": "transparent",
+          "fillStyle": "hachure",
+          "groupIds": Array [
+            "id3",
+          ],
+          "height": 10,
+          "id": "id0",
+          "isDeleted": false,
+          "opacity": 100,
+          "roughness": 1,
+          "seed": 337897,
+          "strokeColor": "#000000",
+          "strokeStyle": "solid",
+          "strokeWidth": 1,
+          "type": "rectangle",
+          "version": 3,
+          "versionNonce": 1150084233,
+          "width": 10,
+          "x": 10,
+          "y": 10,
+        },
+        Object {
+          "angle": 0,
+          "backgroundColor": "transparent",
+          "fillStyle": "hachure",
+          "groupIds": Array [
+            "id3",
+          ],
+          "height": 10,
+          "id": "id1",
+          "isDeleted": false,
+          "opacity": 100,
+          "roughness": 1,
+          "seed": 449462985,
+          "strokeColor": "#000000",
+          "strokeStyle": "solid",
+          "strokeWidth": 1,
+          "type": "rectangle",
+          "version": 3,
+          "versionNonce": 1116226695,
+          "width": 10,
+          "x": 30,
+          "y": 10,
+        },
+        Object {
+          "angle": 0,
+          "backgroundColor": "transparent",
+          "fillStyle": "hachure",
+          "groupIds": Array [
+            "id3",
+          ],
+          "height": 10,
+          "id": "id2",
+          "isDeleted": false,
+          "opacity": 100,
+          "roughness": 1,
+          "seed": 401146281,
+          "strokeColor": "#000000",
+          "strokeStyle": "solid",
+          "strokeWidth": 1,
+          "type": "rectangle",
+          "version": 3,
+          "versionNonce": 1014066025,
+          "width": 10,
+          "x": 50,
+          "y": 10,
+        },
+      ],
+    },
+    Object {
+      "appState": Object {
+        "editingGroupId": "id3",
+        "name": "Unbenannt-201933152653",
+        "selectedElementIds": Object {
+          "id0": true,
+          "id2": true,
+          "id4": true,
+        },
+        "viewBackgroundColor": "#ffffff",
+      },
+      "elements": Array [
+        Object {
+          "angle": 0,
+          "backgroundColor": "transparent",
+          "fillStyle": "hachure",
+          "groupIds": Array [
+            "id3",
+          ],
+          "height": 10,
+          "id": "id1",
+          "isDeleted": false,
+          "opacity": 100,
+          "roughness": 1,
+          "seed": 449462985,
+          "strokeColor": "#000000",
+          "strokeStyle": "solid",
+          "strokeWidth": 1,
+          "type": "rectangle",
+          "version": 3,
+          "versionNonce": 1116226695,
+          "width": 10,
+          "x": 30,
+          "y": 10,
+        },
+        Object {
+          "angle": 0,
+          "backgroundColor": "transparent",
+          "fillStyle": "hachure",
+          "groupIds": Array [
+            "id5",
+            "id3",
+          ],
+          "height": 10,
+          "id": "id0",
+          "isDeleted": false,
+          "opacity": 100,
+          "roughness": 1,
+          "seed": 337897,
+          "strokeColor": "#000000",
+          "strokeStyle": "solid",
+          "strokeWidth": 1,
+          "type": "rectangle",
+          "version": 4,
+          "versionNonce": 400692809,
+          "width": 10,
+          "x": 10,
+          "y": 10,
+        },
+        Object {
+          "angle": 0,
+          "backgroundColor": "transparent",
+          "fillStyle": "hachure",
+          "groupIds": Array [
+            "id5",
+            "id3",
+          ],
+          "height": 10,
+          "id": "id2",
+          "isDeleted": false,
+          "opacity": 100,
+          "roughness": 1,
+          "seed": 401146281,
+          "strokeColor": "#000000",
+          "strokeStyle": "solid",
+          "strokeWidth": 1,
+          "type": "rectangle",
+          "version": 4,
+          "versionNonce": 1604849351,
+          "width": 10,
+          "x": 50,
+          "y": 10,
+        },
+      ],
+    },
+    Object {
+      "appState": Object {
+        "editingGroupId": null,
+        "name": "Unbenannt-201933152653",
+        "selectedElementIds": Object {
+          "id0": true,
+          "id1": true,
+          "id2": true,
+          "id7": true,
         },
         "viewBackgroundColor": "#ffffff",
       },
@@ -15404,6 +15806,7 @@ Object {
   "redoStack": Array [
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id2": true,
@@ -15496,6 +15899,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id2": true,
@@ -15586,6 +15990,7 @@ Object {
   "stateHistory": Array [
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
@@ -15618,6 +16023,7 @@ Object {
     },
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id1": true,

--- a/src/tests/__snapshots__/regressionTests.test.tsx.snap
+++ b/src/tests/__snapshots__/regressionTests.test.tsx.snap
@@ -16138,6 +16138,7 @@ Object {
   "stateHistory": Array [
     Object {
       "appState": Object {
+        "editingGroupId": null,
         "name": "Unbenannt-201933152653",
         "selectedElementIds": Object {},
         "viewBackgroundColor": "#ffffff",

--- a/src/types.ts
+++ b/src/types.ts
@@ -71,8 +71,10 @@ export type AppState = {
   showShortcutsDialog: boolean;
   zenModeEnabled: boolean;
 
-  // groups
+  /** top-most selected groups (i.e. does not include nested groups) */
   selectedGroupIds: { [groupId: string]: boolean };
+  /** group being edited when you drill down to its constituent element
+    (e.g. when you double-click on a group's element) */
   editingGroupId: GroupId | null;
 };
 


### PR DESCRIPTION
Mainly, this fixes (in 2nd to last commit) the case where you edit a group and remove all except the last element in group. Afterwards, if you selected that element, it would show as a group, which it shouldn't.

We could either 1) automatically ungroup on removing penultimate element from group 2) ignore group selection for N=1 groups.

I went with (2) because if/when we later introduce layers, we don't want to remove groups when removing sibling elements. This is what Figma et al does. It also doesn't really hurt to retain the group, and just ignore it (it's also much simpler, and shows the group model we chose was the right call).

---

In the remaining commits, I do:

- Persist `editingGroupId` to history. This takes care of the case where you edit stuff within a group, and undo/redo. You want to remain in the editor (note: this doesn't work when undoing to initial change, i.e. the entering of the editor group).
- Select sibling elements when removing select element from a group (if sibling element exists).

    Note: I also made `cut` event reuse `actionDeleteSelected` action, and removed exported `deleteSelectedElements` helper because it was no longer used anywhere else (and shouldn't be). Best review the commit: https://github.com/excalidraw/excalidraw/pull/1676/commits/f96c96332e28bfec7869f1b7bb65ffad20a417ad
- Reuse types (so you can easily click-through to type definition, for docs).
- Ignore noop updates of `element.groupIds`. I made it immutable, so identity check is safe.
