### PR TITLE
Tune down z-index for the color-picker-hash div

### DIFF
--- a/src/components/ColorPicker.scss
+++ b/src/components/ColorPicker.scss
@@ -99,7 +99,6 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  z-index: 1;
   position: relative;
 }
 .color-input-container:focus-within .color-picker-hash {


### PR DESCRIPTION
Here's a fix for the issue #1675 . It was a small change for a z-index. The colour picker hash div does not conflict with any other elements and should be on the base.
 
**Screenshots**

![Screenshot 2020-06-05 at 1 08 13 AM](https://user-images.githubusercontent.com/23500643/83802844-1b9af980-a6c9-11ea-9877-3185fa0e70cc.png)
_Issue_

![Screenshot 2020-06-05 at 1 08 21 AM](https://user-images.githubusercontent.com/23500643/83802851-1dfd5380-a6c9-11ea-9d15-18901625eb6f.png)
_Fix_

