### PR TITLE
Fix undo with line editing

### DIFF
--- a/src/element/linearElementEditor.ts
+++ b/src/element/linearElementEditor.ts
@@ -174,9 +174,7 @@ export class LinearElementEditor {
           ],
         });
       }
-      if (appState.editingLinearElement.lastUncommittedPoint !== null) {
-        history.resumeRecording();
-      }
+      history.resumeRecording();
       setState({
         editingLinearElement: {
           ...appState.editingLinearElement,


### PR DESCRIPTION
Undo line editing works as expected when I hold down the alt key and move the cursor.
However, if I hold down the alt key and clicking without moving the cursor, it will not work as expected.

It works as shown in the following image:

![200605_before](https://user-images.githubusercontent.com/31386431/83881810-2e223b00-a77c-11ea-808f-d56369ee06f1.gif)

I expect it to work like the image below.

![200605_after](https://user-images.githubusercontent.com/31386431/83881817-2febfe80-a77c-11ea-8afa-8f069523ccff.gif)

I suppose that if we call `createPointAt`, we also need to call `resumeRecording`.
