### PR TITLE
use position absolute to position fixed side container relative to its parent instead of viewport

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -111,7 +111,7 @@ import {
   CANVAS_ONLY_ACTIONS,
 } from "../constants";
 import {
-  INITAL_SCENE_UPDATE_TIMEOUT,
+  INITIAL_SCENE_UPDATE_TIMEOUT,
   TAP_TWICE_TIMEOUT,
   SYNC_FULL_SCENE_INTERVAL_MS,
 } from "../time_constants";
@@ -861,7 +861,7 @@ class App extends React.Component<any, AppState> {
       //  initial SCENE_UPDATE message
       const initializationTimer = setTimeout(
         initialize,
-        INITAL_SCENE_UPDATE_TIMEOUT,
+        INITIAL_SCENE_UPDATE_TIMEOUT,
       );
 
       const updateScene = (

--- a/src/components/FixedSideContainer.css
+++ b/src/components/FixedSideContainer.css
@@ -1,6 +1,6 @@
 .FixedSideContainer {
   --margin: 0.25rem;
-  position: fixed;
+  position: absolute;
   pointer-events: none;
 }
 

--- a/src/time_constants.ts
+++ b/src/time_constants.ts
@@ -1,4 +1,4 @@
 // time in milliseconds
 export const TAP_TWICE_TIMEOUT = 300;
-export const INITAL_SCENE_UPDATE_TIMEOUT = 5000;
+export const INITIAL_SCENE_UPDATE_TIMEOUT = 5000;
 export const SYNC_FULL_SCENE_INTERVAL_MS = 20000;


### PR DESCRIPTION
When rendered inside upstream App it will position relative to the parent instead of viewport.