### PR TITLE
Disable Sentry inside Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,12 +17,10 @@ COPY . .
 FROM node:14-alpine AS build
 
 ARG NODE_ENV=production
-ARG REACT_APP_INCLUDE_GTAG=false
 
 WORKDIR /opt/node_app
 COPY --from=deps /opt/node_app .
-RUN ls
-RUN npm run build:app
+RUN npm run build:app:docker
 
 FROM nginx:1.17-alpine
 

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "build": "npm run build:app && npm run build:zip",
     "build-node": "node ./scripts/build-node.js",
     "build:app": "REACT_APP_INCLUDE_GTAG=true REACT_APP_GIT_SHA=$NOW_GITHUB_COMMIT_SHA react-scripts build",
+    "build:app:docker": "REACT_APP_INCLUDE_GTAG=false REACT_APP_DISABLE_SENTRY=true react-scripts build",
     "build:zip": "node ./scripts/build-version.js",
     "eject": "react-scripts eject",
     "fix": "npm run fix:other && npm run fix:code",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -27,12 +27,14 @@ const SentryEnvHostnameMap: { [key: string]: string } = {
   "now.sh": "staging",
 };
 
-const onlineEnv = Object.keys(SentryEnvHostnameMap).find(
-  (item) => window.location.hostname.indexOf(item) >= 0,
-);
+// Disable Sentry locally or inside the Docker to avoid noise/respect privacy
+const onlineEnv =
+  process.env.REACT_APP_DISABLE_SENTRY !== "true" &&
+  Object.keys(SentryEnvHostnameMap).find(
+    (item) => window.location.hostname.indexOf(item) >= 0,
+  );
 
 Sentry.init({
-  // Disable Sentry locally to avoid noise
   dsn: onlineEnv
     ? "https://7bfc596a5bf945eda6b660d3015a5460@sentry.io/5179260"
     : undefined,


### PR DESCRIPTION
Disables Sentry inside the Docker container (also disables Gtag as previously an env var was being overridden).

https://github.com/excalidraw/excalidraw/issues/1768