### PR TITLE
fix: start dragging grouped elements

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -2139,6 +2139,17 @@ class App extends React.Component<any, AppState> {
               x,
               y,
             );
+          } else if (hitElement.groupIds.length) {
+            const allElements = globalSceneState.getElements();
+            dragOffsetXY = getDragOffsetXY(
+              allElements.filter((element) =>
+                element.groupIds.some((groupId) =>
+                  hitElement?.groupIds.includes(groupId),
+                ),
+              ),
+              x,
+              y,
+            );
           } else {
             dragOffsetXY = getDragOffsetXY([hitElement], x, y);
           }

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -2355,6 +2355,10 @@ class App extends React.Component<any, AppState> {
     let selectedElementWasDuplicated = false;
 
     const onPointerMove = withBatchedUpdates((event: PointerEvent) => {
+      // We need to initialize dragOffsetXY only after we've updated
+      // `state.selectedElementIds` on pointerDown. Doing it here in pointerMove
+      // event handler should hopefully ensure we're already working with
+      // the updated state.
       if (dragOffsetXY === null) {
         dragOffsetXY = getDragOffsetXY(
           getSelectedElements(globalSceneState.getElements(), this.state),

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -2046,7 +2046,7 @@ class App extends React.Component<any, AppState> {
     let resizeArrowDirection: "origin" | "end" = "origin";
     let isResizingElements = false;
     let draggingOccurred = false;
-    let dragOffsetXY: [number, number] = [0, 0];
+    let dragOffsetXY: [number, number] | null = null;
     let hitElement: ExcalidrawElement | null = null;
     let hitElementWasAddedToSelection = false;
 
@@ -2129,31 +2129,6 @@ class App extends React.Component<any, AppState> {
         hitElement =
           hitElement ||
           getElementAtPosition(elements, this.state, x, y, this.state.zoom);
-
-        if (hitElement && isNonDeletedElement(hitElement)) {
-          if (this.state.selectedElementIds[hitElement.id]) {
-            dragOffsetXY = getDragOffsetXY(selectedElements, x, y);
-          } else if (event.shiftKey) {
-            dragOffsetXY = getDragOffsetXY(
-              [...selectedElements, hitElement],
-              x,
-              y,
-            );
-          } else if (hitElement.groupIds.length) {
-            const allElements = globalSceneState.getElements();
-            dragOffsetXY = getDragOffsetXY(
-              allElements.filter((element) =>
-                element.groupIds.some((groupId) =>
-                  hitElement?.groupIds.includes(groupId),
-                ),
-              ),
-              x,
-              y,
-            );
-          } else {
-            dragOffsetXY = getDragOffsetXY([hitElement], x, y);
-          }
-        }
 
         // clear selection if shift is not clicked
         if (
@@ -2380,6 +2355,14 @@ class App extends React.Component<any, AppState> {
     let selectedElementWasDuplicated = false;
 
     const onPointerMove = withBatchedUpdates((event: PointerEvent) => {
+      if (dragOffsetXY === null) {
+        dragOffsetXY = getDragOffsetXY(
+          getSelectedElements(globalSceneState.getElements(), this.state),
+          originX,
+          originY,
+        );
+      }
+
       const target = event.target;
       if (!(target instanceof HTMLElement)) {
         return;


### PR DESCRIPTION
close #1816 

This is exactly what I concerned in https://github.com/excalidraw/excalidraw/pull/1788#discussion_r443167541 but wasn't sure the specific case to fail.

This PR should fix the case reported. Note the code is not very ideal, and it feels like we do duplicated things. Glad if someone could take a look to refactor. cc @petehunt 