### PR TITLE
Change key label to its actual key, not index.

### DIFF
--- a/src/components/Actions.tsx
+++ b/src/components/Actions.tsx
@@ -106,7 +106,7 @@ export const ShapesSwitcher = ({
           checked={elementType === value}
           name="editor-current-shape"
           title={`${capitalizeString(label)} — ${shortcut}`}
-          keyBindingLabel={`${index + 1}`}
+          keyBindingLabel={capitalizeString(key)}
           aria-label={capitalizeString(label)}
           aria-keyshortcuts={`${key} ${index + 1}`}
           data-testid={value}


### PR DESCRIPTION
The display shortcut key idea is great, but using letter instead of number is more idiomatic / natural for user.