### PR TITLE
Lock drag direction using `Shift`

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -2996,7 +2996,25 @@ class App extends React.Component<ExcalidrawProps, AppState> {
             pointerCoords.y - pointerDownState.drag.offset.y,
             this.state.gridSize,
           );
-          dragSelectedElements(selectedElements, dragX, dragY, this.scene);
+
+          const [dragDistanceX, dragDistanceY] = [
+            Math.abs(pointerCoords.x - pointerDownState.origin.x),
+            Math.abs(pointerCoords.y - pointerDownState.origin.y),
+          ];
+
+          // We only drag in one direction if shift is pressed
+          const lockDirection = event.shiftKey;
+
+          dragSelectedElements(
+            selectedElements,
+            pointerDownState.resize.originalElements,
+            dragX,
+            dragY,
+            this.scene,
+            lockDirection,
+            dragDistanceX,
+            dragDistanceY,
+          );
           this.maybeSuggestBindingForAll(selectedElements);
 
           // We duplicate the selected element if alt is pressed on pointer move

--- a/src/element/dragElements.ts
+++ b/src/element/dragElements.ts
@@ -5,10 +5,11 @@ import { mutateElement } from "./mutateElement";
 import { getPerfectElementSize } from "./sizeHelpers";
 import Scene from "../scene/Scene";
 import { NonDeletedExcalidrawElement } from "./types";
+import { PointerDownState } from "../components/App";
 
 export const dragSelectedElements = (
+  pointerDownState: PointerDownState,
   selectedElements: NonDeletedExcalidrawElement[],
-  originalElements: readonly NonDeletedExcalidrawElement[],
   pointerX: number,
   pointerY: number,
   scene: Scene,
@@ -18,14 +19,22 @@ export const dragSelectedElements = (
 ) => {
   const [x1, y1] = getCommonBounds(selectedElements);
   const offset = { x: pointerX - x1, y: pointerY - y1 };
-  selectedElements.forEach((element, i) => {
-    const original = originalElements[i];
-    const lockX = lockDirection && distanceX < distanceY;
-    const lockY = lockDirection && distanceX > distanceY;
+  selectedElements.forEach((element) => {
+    let x, y;
+    if (lockDirection) {
+      const lockX = lockDirection && distanceX < distanceY;
+      const lockY = lockDirection && distanceX > distanceY;
+      const original = pointerDownState.originalElements.get(element.id);
+      x = lockX && original ? original.x : element.x + offset.x;
+      y = lockY && original ? original.y : element.y + offset.y;
+    } else {
+      x = element.x + offset.x;
+      y = element.y + offset.y;
+    }
 
     mutateElement(element, {
-      x: lockX ? original.x : element.x + offset.x,
-      y: lockY ? original.y : element.y + offset.y,
+      x,
+      y,
     });
 
     updateBoundElements(element, {

--- a/src/element/dragElements.ts
+++ b/src/element/dragElements.ts
@@ -8,18 +8,29 @@ import { NonDeletedExcalidrawElement } from "./types";
 
 export const dragSelectedElements = (
   selectedElements: NonDeletedExcalidrawElement[],
+  originalElements: readonly NonDeletedExcalidrawElement[],
   pointerX: number,
   pointerY: number,
   scene: Scene,
+  lockDirection: boolean = false,
+  distanceX: number = 0,
+  distanceY: number = 0,
 ) => {
   const [x1, y1] = getCommonBounds(selectedElements);
   const offset = { x: pointerX - x1, y: pointerY - y1 };
-  selectedElements.forEach((element) => {
+  selectedElements.forEach((element, i) => {
+    const original = originalElements[i];
+    const lockX = lockDirection && distanceX < distanceY;
+    const lockY = lockDirection && distanceX > distanceY;
+
     mutateElement(element, {
-      x: element.x + offset.x,
-      y: element.y + offset.y,
+      x: lockX ? original.x : element.x + offset.x,
+      y: lockY ? original.y : element.y + offset.y,
     });
-    updateBoundElements(element, { simultaneouslyUpdated: selectedElements });
+
+    updateBoundElements(element, {
+      simultaneouslyUpdated: selectedElements,
+    });
   });
 };
 

--- a/src/element/resizeElements.ts
+++ b/src/element/resizeElements.ts
@@ -26,6 +26,7 @@ import {
   TransformHandleType,
   MaybeTransformHandleType,
 } from "./transformHandles";
+import { PointerDownState } from "../components/App";
 
 const normalizeAngle = (angle: number): number => {
   if (angle >= 2 * Math.PI) {
@@ -36,6 +37,7 @@ const normalizeAngle = (angle: number): number => {
 
 // Returns true when transform (resizing/rotation) happened
 export const transformElements = (
+  pointerDownState: PointerDownState,
   transformHandleType: MaybeTransformHandleType,
   setTransformHandle: (nextTransformHandle: MaybeTransformHandleType) => void,
   selectedElements: readonly NonDeletedExcalidrawElement[],
@@ -47,7 +49,6 @@ export const transformElements = (
   pointerY: number,
   centerX: number,
   centerY: number,
-  originalElements: readonly NonDeletedExcalidrawElement[],
 ) => {
   if (selectedElements.length === 1) {
     const [element] = selectedElements;
@@ -119,13 +120,13 @@ export const transformElements = (
   } else if (selectedElements.length > 1) {
     if (transformHandleType === "rotation") {
       rotateMultipleElements(
+        pointerDownState,
         selectedElements,
         pointerX,
         pointerY,
         isRotateWithDiscreteAngle,
         centerX,
         centerY,
-        originalElements,
       );
       return true;
     } else if (
@@ -618,13 +619,13 @@ const resizeMultipleElements = (
 };
 
 const rotateMultipleElements = (
+  pointerDownState: PointerDownState,
   elements: readonly NonDeletedExcalidrawElement[],
   pointerX: number,
   pointerY: number,
   isRotateWithDiscreteAngle: boolean,
   centerX: number,
   centerY: number,
-  originalElements: readonly NonDeletedExcalidrawElement[],
 ) => {
   let centerAngle =
     (5 * Math.PI) / 2 + Math.atan2(pointerY - centerY, pointerX - centerX);
@@ -636,17 +637,19 @@ const rotateMultipleElements = (
     const [x1, y1, x2, y2] = getElementAbsoluteCoords(element);
     const cx = (x1 + x2) / 2;
     const cy = (y1 + y2) / 2;
+    const origAngle =
+      pointerDownState.originalElements.get(element.id)?.angle ?? element.angle;
     const [rotatedCX, rotatedCY] = rotate(
       cx,
       cy,
       centerX,
       centerY,
-      centerAngle + originalElements[index].angle - element.angle,
+      centerAngle + origAngle - element.angle,
     );
     mutateElement(element, {
       x: element.x + (rotatedCX - cx),
       y: element.y + (rotatedCY - cy),
-      angle: normalizeAngle(centerAngle + originalElements[index].angle),
+      angle: normalizeAngle(centerAngle + origAngle),
     });
   });
 };

--- a/src/tests/__snapshots__/resize.test.tsx.snap
+++ b/src/tests/__snapshots__/resize.test.tsx.snap
@@ -25,29 +25,3 @@ Object {
   "y": 47,
 }
 `;
-
-exports[`resize element with aspect ratio when SHIFT is clicked rectangle 1`] = `
-Object {
-  "angle": 0,
-  "backgroundColor": "transparent",
-  "boundElementIds": null,
-  "fillStyle": "hachure",
-  "groupIds": Array [],
-  "height": 50,
-  "id": "id0",
-  "isDeleted": false,
-  "opacity": 100,
-  "roughness": 1,
-  "seed": 337897,
-  "strokeColor": "#000000",
-  "strokeSharpness": "sharp",
-  "strokeStyle": "solid",
-  "strokeWidth": 1,
-  "type": "rectangle",
-  "version": 3,
-  "versionNonce": 401146281,
-  "width": 30,
-  "x": 29,
-  "y": 47,
-}
-`;

--- a/src/tests/resize.test.tsx
+++ b/src/tests/resize.test.tsx
@@ -4,6 +4,10 @@ import { render, fireEvent } from "./test-utils";
 import App from "../components/App";
 import * as Renderer from "../renderer/renderScene";
 import { reseed } from "../random";
+import { UI, Pointer, Keyboard } from "./helpers/ui";
+import { getTransformHandles } from "../element/transformHandles";
+
+const mouse = new Pointer("mouse");
 
 // Unmount ReactDOM from root
 ReactDOM.unmountComponentAtNode(document.getElementById("root")!);
@@ -62,43 +66,25 @@ describe("resize element", () => {
 
 describe("resize element with aspect ratio when SHIFT is clicked", () => {
   it("rectangle", () => {
-    const { getByToolName, container } = render(<App />);
-    const canvas = container.querySelector("canvas")!;
+    render(<App />);
 
-    {
-      // create element
-      const tool = getByToolName("rectangle");
-      fireEvent.click(tool);
-      fireEvent.pointerDown(canvas, { clientX: 30, clientY: 20 });
-      fireEvent.pointerMove(canvas, { clientX: 60, clientY: 70 });
-      fireEvent.pointerUp(canvas);
+    const rectangle = UI.createElement("rectangle", {
+      x: 0,
+      width: 30,
+      height: 50,
+    });
 
-      expect(renderScene).toHaveBeenCalledTimes(5);
-      expect(h.state.selectionElement).toBeNull();
-      expect(h.elements.length).toEqual(1);
-      expect(h.state.selectedElementIds[h.elements[0].id]).toBeTruthy();
-      expect([h.elements[0].x, h.elements[0].y]).toEqual([30, 20]);
-      expect([h.elements[0].x, h.elements[0].y]).toEqual([30, 20]);
-      expect([h.elements[0].width, h.elements[0].height]).toEqual([30, 50]);
+    mouse.select(rectangle);
 
-      renderScene.mockClear();
-    }
-
-    // select the element first
-    fireEvent.pointerDown(canvas, { clientX: 50, clientY: 20 });
-    fireEvent.pointerUp(canvas);
-
-    // select a handler rectangle (top-left)
-    fireEvent.pointerDown(canvas, { clientX: 21, clientY: 13 });
-    fireEvent.pointerMove(canvas, { clientX: 20, clientY: 40, shiftKey: true });
-    fireEvent.pointerUp(canvas);
-
-    expect(renderScene).toHaveBeenCalledTimes(5);
-    expect(h.state.selectionElement).toBeNull();
-    expect(h.elements.length).toEqual(1);
-    expect([h.elements[0].x, h.elements[0].y]).toEqual([29, 47]);
-    expect([h.elements[0].width, h.elements[0].height]).toEqual([30, 50]);
-
-    h.elements.forEach((element) => expect(element).toMatchSnapshot());
+    const se = getTransformHandles(rectangle, h.state.zoom, "mouse").se!;
+    const clientX = se[0] + se[2] / 2;
+    const clientY = se[1] + se[3] / 2;
+    Keyboard.withModifierKeys({ shift: true }, () => {
+      mouse.reset();
+      mouse.down(clientX, clientY);
+      mouse.move(1, 1);
+      mouse.up();
+    });
+    expect([h.elements[0].width, h.elements[0].height]).toEqual([51, 51]);
   });
 });


### PR DESCRIPTION
This feature allows you to lock the direction you are moving/dragging a selection in, as inspired by @Andarius #1844 
![screenshot-oy71MNUh](https://user-images.githubusercontent.com/6642554/86299195-de5e5480-bbff-11ea-89de-97256a4c49ec.gif)

Implemented as follows:
- Original coordinates are saved when starting dragging
- If `shift` is pressed (can also happen after a while) it will see if you are moving more into the x or y direction
- It then does not modify the opposing property

This is my first contribution to Excalidraw (actually my first OSS contrib ever 😊 ) as I wanted to support in any way. Help and feedback is welcome.

Closes #1844