### PR TITLE
prompt when loading external scene before overriding local one

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -344,10 +344,12 @@ class App extends React.Component<any, AppState> {
       /^#json=([0-9]+),([a-zA-Z0-9_-]+)$/,
     );
 
-    let isCollaborationScene = getCollaborationLinkData(window.location.href);
     let scene = await loadScene(null);
 
-    if (id || jsonMatch || isCollaborationScene) {
+    let isCollaborationScene = !!getCollaborationLinkData(window.location.href);
+    const isExternalScene = !!(id || jsonMatch || isCollaborationScene);
+
+    if (isExternalScene) {
       if (
         !scene.elements.length ||
         window.confirm(t("alerts.loadSceneOverridePrompt"))
@@ -362,7 +364,7 @@ class App extends React.Component<any, AppState> {
           window.history.replaceState({}, "Excalidraw", window.location.origin);
         }
       } else {
-        isCollaborationScene = null;
+        isCollaborationScene = false;
         window.history.replaceState({}, "Excalidraw", window.location.origin);
       }
     }

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -367,17 +367,11 @@ class App extends React.Component<any, AppState> {
       }
     }
 
-    if (scene && !isCollaborationScene) {
-      this.syncActionResult(scene);
-    }
-
-    if (this.state.isLoading) {
-      this.setState({ isLoading: false });
-    }
-
-    // run this last else the `isLoading` would be overriden
     if (isCollaborationScene) {
       this.initializeSocketClient({ showLoadingState: true });
+    } else if (scene) {
+      this.syncActionResult(scene);
+      this.setState({ isLoading: false });
     }
   };
 

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -352,9 +352,7 @@ class App extends React.Component<any, AppState> {
       if (id || jsonMatch) {
         if (
           !scene.elements.length ||
-          window.confirm(
-            "Loading external scene will override your local content. Do you wish to continue?",
-          )
+          window.confirm(t("alerts.loadSceneOverridePrompt"))
         ) {
           // Backwards compatibility with legacy url format
           if (id) {

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -367,11 +367,14 @@ class App extends React.Component<any, AppState> {
       }
     }
 
+    if (this.state.isLoading) {
+      this.setState({ isLoading: false });
+    }
+
     if (isCollaborationScene) {
       this.initializeSocketClient({ showLoadingState: true });
     } else if (scene) {
       this.syncActionResult(scene);
-      this.setState({ isLoading: false });
     }
   };
 

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -348,13 +348,22 @@ class App extends React.Component<any, AppState> {
 
     if (!isCollaborationScene) {
       let scene: ResolutionType<typeof loadScene> | undefined;
-      // Backwards compatibility with legacy url format
-      if (id) {
-        scene = await loadScene(id);
-      } else if (jsonMatch) {
-        scene = await loadScene(jsonMatch[1], jsonMatch[2]);
-      } else {
-        scene = await loadScene(null);
+      scene = await loadScene(null);
+      if (id || jsonMatch) {
+        if (
+          !scene.elements.length ||
+          window.confirm(
+            "Loading external scene will override your local content. Do you wish to continue?",
+          )
+        ) {
+          // Backwards compatibility with legacy url format
+          if (id) {
+            scene = await loadScene(id);
+          } else if (jsonMatch) {
+            scene = await loadScene(jsonMatch[1], jsonMatch[2]);
+          }
+        }
+        window.history.replaceState({}, "Excalidraw", window.location.origin);
       }
       if (scene) {
         this.syncActionResult(scene);

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -77,3 +77,5 @@ export const DEFAULT_VERTICAL_ALIGN = "top";
 export const CANVAS_ONLY_ACTIONS = ["selectAll"];
 
 export const GRID_SIZE = 20; // TODO make it configurable?
+
+export const LOCAL_STORAGE_KEY_COLLAB_FORCE_FLAG = "collabLinkForceLoadFlag";

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -367,7 +367,6 @@ export const loadScene = async (id: string | null, privateKey?: string) => {
     // the private key is used to decrypt the content from the server, take
     // extra care not to leak it
     data = await importFromBackend(id, privateKey);
-    window.history.replaceState({}, "Excalidraw", window.location.origin);
   } else {
     data = restoreFromLocalStorage();
   }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -102,7 +102,8 @@
     "cannotExportEmptyCanvas": "Cannot export empty canvas.",
     "couldNotCopyToClipboard": "Couldn't copy to clipboard. Try using Chrome browser.",
     "decryptFailed": "Couldn't decrypt data.",
-    "uploadedSecurly": "The upload has been secured with end-to-end encryption, which means that Excalidraw server and third parties can't read the content."
+    "uploadedSecurly": "The upload has been secured with end-to-end encryption, which means that Excalidraw server and third parties can't read the content.",
+    "loadSceneOverridePrompt": "Loading external scene will override your local content. Do you wish to continue?"
   },
   "toolBar": {
     "selection": "Selection",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -103,7 +103,7 @@
     "couldNotCopyToClipboard": "Couldn't copy to clipboard. Try using Chrome browser.",
     "decryptFailed": "Couldn't decrypt data.",
     "uploadedSecurly": "The upload has been secured with end-to-end encryption, which means that Excalidraw server and third parties can't read the content.",
-    "loadSceneOverridePrompt": "Loading external drawing will replace your local content. Do you wish to continue?"
+    "loadSceneOverridePrompt": "Loading external drawing will replace your existing content. Do you wish to continue?"
   },
   "toolBar": {
     "selection": "Selection",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -103,7 +103,7 @@
     "couldNotCopyToClipboard": "Couldn't copy to clipboard. Try using Chrome browser.",
     "decryptFailed": "Couldn't decrypt data.",
     "uploadedSecurly": "The upload has been secured with end-to-end encryption, which means that Excalidraw server and third parties can't read the content.",
-    "loadSceneOverridePrompt": "Loading external scene will override your local content. Do you wish to continue?"
+    "loadSceneOverridePrompt": "Loading external drawing will replace your local content. Do you wish to continue?"
   },
   "toolBar": {
     "selection": "Selection",


### PR DESCRIPTION
fixes https://github.com/excalidraw/excalidraw/issues/1861

- prompts only if local scene contains elements (appState overriding is low-profile, so let's limit the prompting when not absolutely necessary)

Suboptimal behavior:

- reloading page during collab will prompt for confirmation, too
- ditto for loading identical collab link