### PR TITLE
change copy/paste styles shortcuts

### DIFF
--- a/src/actions/actionStyles.ts
+++ b/src/actions/actionStyles.ts
@@ -27,7 +27,7 @@ export const actionCopyStyles = register({
   },
   contextItemLabel: "labels.copyStyles",
   keyTest: (event) =>
-    event[KEYS.CTRL_OR_CMD] && event.shiftKey && event.key === "C",
+    event[KEYS.CTRL_OR_CMD] && event.altKey && event.key === "c",
   contextMenuOrder: 0,
 });
 
@@ -67,6 +67,6 @@ export const actionPasteStyles = register({
   },
   contextItemLabel: "labels.pasteStyles",
   keyTest: (event) =>
-    event[KEYS.CTRL_OR_CMD] && event.shiftKey && event.key === "V",
+    event[KEYS.CTRL_OR_CMD] && event.altKey && event.key === "v",
   contextMenuOrder: 1,
 });

--- a/src/actions/actionStyles.ts
+++ b/src/actions/actionStyles.ts
@@ -27,7 +27,9 @@ export const actionCopyStyles = register({
   },
   contextItemLabel: "labels.copyStyles",
   keyTest: (event) =>
-    event[KEYS.CTRL_OR_CMD] && event.altKey && event.key === "c",
+    event[KEYS.CTRL_OR_CMD] &&
+    event.altKey &&
+    event.keyCode === KEYS.C_KEY_CODE,
   contextMenuOrder: 0,
 });
 
@@ -67,6 +69,8 @@ export const actionPasteStyles = register({
   },
   contextItemLabel: "labels.pasteStyles",
   keyTest: (event) =>
-    event[KEYS.CTRL_OR_CMD] && event.altKey && event.key === "v",
+    event[KEYS.CTRL_OR_CMD] &&
+    event.altKey &&
+    event.keyCode === KEYS.V_KEY_CODE,
   contextMenuOrder: 1,
 });

--- a/src/components/ShortcutsDialog.tsx
+++ b/src/components/ShortcutsDialog.tsx
@@ -287,11 +287,11 @@ export const ShortcutsDialog = ({ onClose }: { onClose?: () => void }) => {
               />
               <Shortcut
                 label={t("labels.copyStyles")}
-                shortcuts={[getShortcutKey("CtrlOrCmd+Shift+C")]}
+                shortcuts={[getShortcutKey("CtrlOrCmd+Alt+C")]}
               />
               <Shortcut
                 label={t("labels.pasteStyles")}
-                shortcuts={[getShortcutKey("CtrlOrCmd+Shift+V")]}
+                shortcuts={[getShortcutKey("CtrlOrCmd+Alt+V")]}
               />
               <Shortcut
                 label={t("labels.delete")}

--- a/src/keys.ts
+++ b/src/keys.ts
@@ -18,6 +18,8 @@ export const KEYS = {
   Z_KEY_CODE: 90,
   GRID_KEY_CODE: 222,
   G_KEY_CODE: 71,
+  C_KEY_CODE: 67,
+  V_KEY_CODE: 86,
 } as const;
 
 export type Key = keyof typeof KEYS;


### PR DESCRIPTION
fix https://github.com/excalidraw/excalidraw/issues/1688

Moved to `Cmd/Ctrl+Opt/Alt+C/V` for copy/paste styles, because previous shortcuts collided with browser default.

overrides Mac's "inspect element", but that shortcut is only an alias for cross-platform `Cmd+Shift+C`, and Figma uses this also, so it should be fine.