### PR TITLE
use width,height from current appstate when initializing scene

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -316,6 +316,8 @@ class App extends React.Component<ExcalidrawProps, AppState> {
               editingElement || actionResult.appState?.editingElement || null,
             isCollaborating: state.isCollaborating,
             collaborators: state.collaborators,
+            width: state.width,
+            height: state.height,
           }),
           () => {
             if (actionResult.syncHistory) {

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -316,8 +316,6 @@ class App extends React.Component<ExcalidrawProps, AppState> {
               editingElement || actionResult.appState?.editingElement || null,
             isCollaborating: state.isCollaborating,
             collaborators: state.collaborators,
-            width: state.width,
-            height: state.height,
           }),
           () => {
             if (actionResult.syncHistory) {

--- a/src/data/localStorage.ts
+++ b/src/data/localStorage.ts
@@ -80,6 +80,8 @@ export const restoreFromLocalStorage = () => {
       // If we're retrieving from local storage, we should not be collaborating
       appState.isCollaborating = false;
       appState.collaborators = new Map();
+      delete appState.width;
+      delete appState.height;
     } catch {
       // Do nothing because appState is already null
     }


### PR DESCRIPTION
After merging https://github.com/excalidraw/excalidraw/commit/9351b2821c1d6a96f384d7fb2d92a006b9fc056e
the height/width if changed when you open excalidraw, takes the older height/width until resized instead of the current one since it's saved in local storage.