### PR TITLE
reload scene on hashchange

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -397,6 +397,10 @@ class App extends React.Component<ExcalidrawProps, AppState> {
       /^#json=([0-9]+),([a-zA-Z0-9_-]+)$/,
     );
 
+    if (!this.state.isLoading) {
+      this.setState({ isLoading: true });
+    }
+
     let scene = await loadScene(null);
 
     let isCollaborationScene = !!getCollaborationLinkData(window.location.href);
@@ -484,7 +488,6 @@ class App extends React.Component<ExcalidrawProps, AppState> {
 
   private onHashChange = (event: HashChangeEvent) => {
     if (window.location.hash.length > 1) {
-      this.setState({ isLoading: true });
       this.initializeScene();
     }
   };

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -482,6 +482,13 @@ class App extends React.Component<ExcalidrawProps, AppState> {
     this.setState({});
   });
 
+  private onHashChange = (event: HashChangeEvent) => {
+    if (window.location.hash.length > 1) {
+      this.setState({ isLoading: true });
+      this.initializeScene();
+    }
+  };
+
   private removeEventListeners() {
     document.removeEventListener(EVENT.COPY, this.onCopy);
     document.removeEventListener(EVENT.PASTE, this.pasteFromClipboard);
@@ -499,6 +506,7 @@ class App extends React.Component<ExcalidrawProps, AppState> {
     window.removeEventListener(EVENT.BLUR, this.onBlur, false);
     window.removeEventListener(EVENT.DRAG_OVER, this.disableEvent, false);
     window.removeEventListener(EVENT.DROP, this.disableEvent, false);
+    window.removeEventListener(EVENT.HASHCHANGE, this.onHashChange, false);
 
     document.removeEventListener(
       EVENT.GESTURE_START,
@@ -534,6 +542,7 @@ class App extends React.Component<ExcalidrawProps, AppState> {
     window.addEventListener(EVENT.BLUR, this.onBlur, false);
     window.addEventListener(EVENT.DRAG_OVER, this.disableEvent, false);
     window.addEventListener(EVENT.DROP, this.disableEvent, false);
+    window.addEventListener(EVENT.HASHCHANGE, this.onHashChange, false);
 
     // rerender text elements on font load to fix #637 && #1553
     document.fonts?.addEventListener?.("loadingdone", this.onFontLoaded);

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -46,6 +46,7 @@ export enum EVENT {
   WHEEL = "wheel",
   TOUCH_START = "touchstart",
   TOUCH_END = "touchend",
+  HASHCHANGE = "hashchange",
 }
 
 export const ENV = {


### PR DESCRIPTION
It's annoying that when you paste a scene link to url bar it doesn't reload until 2nd confirm (at least on Win Chrome). This PR fixes that by listening on `hashchange`.