### PR TITLE
Restore missing env vars in Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,3 +5,4 @@
 !package-lock.json
 !package.json
 !tsconfig.json
+!.env


### PR DESCRIPTION
As I began working on the Docker image, I realised that the environment variables defined in https://github.com/excalidraw/excalidraw/blob/8621ddb/.env were being ignored. This fixes a regression introduced in #1848.

## Before

![image](https://user-images.githubusercontent.com/2852660/87504967-a1fb1180-c65f-11ea-85bc-acb0a2a49c8a.png)


## After

![image](https://user-images.githubusercontent.com/2852660/87504752-3add5d00-c65f-11ea-9212-a0563494a5cd.png)
