### PR TITLE
fix accessing nonexisting config property during appState clearing

### DIFF
--- a/src/appState.ts
+++ b/src/appState.ts
@@ -139,7 +139,13 @@ const _clearAppStateForStorage = <ExportType extends "export" | "browser">(
   }[keyof typeof APP_STATE_STORAGE_CONF];
   const stateForExport = {} as { [K in ExportableKeys]?: typeof appState[K] };
   for (const key of Object.keys(appState) as (keyof typeof appState)[]) {
-    if (APP_STATE_STORAGE_CONF[key][exportType]) {
+    const propConfig = APP_STATE_STORAGE_CONF[key];
+    if (!propConfig) {
+      console.error(
+        `_clearAppStateForStorage: appState key "${key}" config doesn't exist for "${exportType}" export type`,
+      );
+    }
+    if (propConfig?.[exportType]) {
       // @ts-ignore see https://github.com/microsoft/TypeScript/issues/31445
       stateForExport[key] = appState[key];
     }


### PR DESCRIPTION
We're [getting errors](https://sentry.io/organizations/excalidraw/issues/1778894364/?environment=production&project=5179260&query=is%3Aunresolved) (me included) while clearing appState for storage. Happened to me several times during init load. Not sure how/why (it'd make sense for old schemas, but I'm on latest so it shouldn't be happening), so I added an extra log so we can diagnose.