### PR TITLE
Fix display of some emoji on Windows

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -70,6 +70,8 @@ export const FONT_FAMILY = {
   3: "Cascadia",
 } as const;
 
+export const WINDOWS_EMOJI_FALLBACK_FONT = "Segoe UI Emoji";
+
 export const DEFAULT_FONT_SIZE = 20;
 export const DEFAULT_FONT_FAMILY: FontFamily = 1;
 export const DEFAULT_TEXT_ALIGN = "left";

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,10 @@
 import { FlooredNumber } from "./types";
 import { getZoomOrigin } from "./scene";
-import { CURSOR_TYPE, FONT_FAMILY } from "./constants";
+import {
+  CURSOR_TYPE,
+  FONT_FAMILY,
+  WINDOWS_EMOJI_FALLBACK_FONT,
+} from "./constants";
 import { FontFamily, FontString } from "./element/types";
 
 export const SVG_NS = "http://www.w3.org/2000/svg";
@@ -66,7 +70,7 @@ export const getFontFamilyString = ({
 }: {
   fontFamily: FontFamily;
 }) => {
-  return FONT_FAMILY[fontFamily];
+  return [FONT_FAMILY[fontFamily], WINDOWS_EMOJI_FALLBACK_FONT].join(",");
 };
 
 /** returns fontSize+fontFamily string for assignment to DOM elements */

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -70,7 +70,7 @@ export const getFontFamilyString = ({
 }: {
   fontFamily: FontFamily;
 }) => {
-  return [FONT_FAMILY[fontFamily], WINDOWS_EMOJI_FALLBACK_FONT].join(",");
+  return `${FONT_FAMILY[fontFamily]}, ${WINDOWS_EMOJI_FALLBACK_FONT}`;
 };
 
 /** returns fontSize+fontFamily string for assignment to DOM elements */


### PR DESCRIPTION
#### Problem 

In many Windows browsers (Chrome, Firefox, Edge), certain older emoji (pre-2012) render in monochrome using the Segoe UI Symbols font. Newer emoji are rendered in the Segoe UI Emoji font. 

![image](https://user-images.githubusercontent.com/2136620/87851649-08e82700-c8fb-11ea-96f4-a516f45f46f3.png)

#### Solution 

If the css `fontFamily` string for an element includes `Segoe UI Emoji` as a final fallback, all emoji are rendered correctly. 

This PR appends the fallback font in the `getFontFamilyString` utility function. So for example if the user's selected font is `Cascadia`, the result will be `Cascadia,Segoe UI Emoji`. 

![image](https://user-images.githubusercontent.com/2136620/87851648-0685cd00-c8fb-11ea-9bd5-ecc4ffc736f9.png)
