### PR TITLE
Only insert text on double click when selection is enabled

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1695,6 +1695,10 @@ class App extends React.Component<ExcalidrawProps, AppState> {
     if (this.state.multiElement) {
       return;
     }
+    // we should only be able to double click when mode is selection
+    if (this.state.elementType !== "selection") {
+      return;
+    }
 
     const selectedElements = getSelectedElements(
       globalSceneState.getElements(),


### PR DESCRIPTION
This was an oversight to enable it for all the shapes. I don't believe that we want to be able to insert text on double click when drawing a rectangle for example. And it's definitely a broken experience when doing so for free draw.

Fixes part of #1935