### PR TITLE
fix resize hints not showing due to LayerUI bailing on updates

### DIFF
--- a/src/components/LayerUI.tsx
+++ b/src/components/LayerUI.tsx
@@ -547,16 +547,7 @@ const LayerUI = ({
 
 const areEqual = (prev: LayerUIProps, next: LayerUIProps) => {
   const getNecessaryObj = (appState: AppState): Partial<AppState> => {
-    const {
-      draggingElement,
-      resizingElement,
-      multiElement,
-      editingElement,
-      isResizing,
-      cursorX,
-      cursorY,
-      ...ret
-    } = appState;
+    const { cursorX, cursorY, ...ret } = appState;
     return ret;
   };
   const prevAppState = getNecessaryObj(prev.appState);


### PR DESCRIPTION
Not sure when it regressed, but since we are disregarding `isResizing` when comparing states in LayerUI memo resolver, it resulted in the hint not being shown.

I've also removed discarding other props that we either consider in HintViewer, or may do in the near future. Not sure why those props were being ignored ITFP since they shouldn't result in degrading the performance much.