### PR TITLE
change selection/line/draw shortcut defaults

### DIFF
--- a/src/components/Actions.tsx
+++ b/src/components/Actions.tsx
@@ -104,9 +104,11 @@ export const ShapesSwitcher = ({
   <>
     {SHAPES.map(({ value, icon, key }, index) => {
       const label = t(`toolBar.${value}`);
-      const shortcut = `${capitalizeString(
-        typeof key === "string" ? key : key[0],
-      )} ${t("shortcutsDialog.or")} ${index + 1}`;
+      const letter = typeof key === "string" ? key : key[0];
+      const letterShortcut = /[a-z]/.test(letter) ? letter : `Shift+${letter}`;
+      const shortcut = `${capitalizeString(letterShortcut)} ${t(
+        "shortcutsDialog.or",
+      )} ${index + 1}`;
       return (
         <ToolButton
           className="Shape"

--- a/src/components/Actions.tsx
+++ b/src/components/Actions.tsx
@@ -104,9 +104,9 @@ export const ShapesSwitcher = ({
   <>
     {SHAPES.map(({ value, icon, key }, index) => {
       const label = t(`toolBar.${value}`);
-      const shortcut = `${capitalizeString(key)} ${t("shortcutsDialog.or")} ${
-        index + 1
-      }`;
+      const shortcut = `${capitalizeString(
+        typeof key === "string" ? key : key[0],
+      )} ${t("shortcutsDialog.or")} ${index + 1}`;
       return (
         <ToolButton
           className="Shape"

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -85,7 +85,7 @@ import {
   getRotateWithDiscreteAngleKey,
 } from "../keys";
 
-import { findShapeByKey, shapesShortcutKeys } from "../shapes";
+import { findShapeByKey } from "../shapes";
 import { createHistory, SceneHistory } from "../history";
 
 import ContextMenu from "./ContextMenu";
@@ -1379,8 +1379,6 @@ class App extends React.Component<ExcalidrawProps, AppState> {
       this.setState({ isLibraryOpen: !this.state.isLibraryOpen });
     }
 
-    const shape = findShapeByKey(event.key);
-
     if (isArrowKey(event.key)) {
       const step =
         (this.state.gridSize &&
@@ -1444,15 +1442,8 @@ class App extends React.Component<ExcalidrawProps, AppState> {
       !event.metaKey &&
       this.state.draggingElement === null
     ) {
-      const targetKey = event.key.toLowerCase();
-      if (
-        shapesShortcutKeys.find((key) => {
-          if (typeof key === "string") {
-            return key === targetKey;
-          }
-          return key.includes(targetKey);
-        })
-      ) {
+      const shape = findShapeByKey(event.key);
+      if (shape) {
         this.selectShapeTool(shape);
       } else if (event.key === "q") {
         this.toggleLock();

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1444,7 +1444,15 @@ class App extends React.Component<ExcalidrawProps, AppState> {
       !event.metaKey &&
       this.state.draggingElement === null
     ) {
-      if (shapesShortcutKeys.includes(event.key.toLowerCase())) {
+      const targetKey = event.key.toLowerCase();
+      if (
+        shapesShortcutKeys.find((key) => {
+          if (typeof key === "string") {
+            return key === targetKey;
+          }
+          return key.includes(targetKey);
+        })
+      ) {
         this.selectShapeTool(shape);
       } else if (event.key === "q") {
         this.toggleLock();

--- a/src/components/ShortcutsDialog.tsx
+++ b/src/components/ShortcutsDialog.tsx
@@ -178,7 +178,7 @@ export const ShortcutsDialog = ({ onClose }: { onClose?: () => void }) => {
         <Columns>
           <Column>
             <ShortcutIsland caption={t("shortcutsDialog.shapes")}>
-              <Shortcut label={t("toolBar.selection")} shortcuts={["S", "1"]} />
+              <Shortcut label={t("toolBar.selection")} shortcuts={["V", "1"]} />
               <Shortcut label={t("toolBar.rectangle")} shortcuts={["R", "2"]} />
               <Shortcut label={t("toolBar.diamond")} shortcuts={["D", "3"]} />
               <Shortcut label={t("toolBar.ellipse")} shortcuts={["E", "4"]} />

--- a/src/components/ShortcutsDialog.tsx
+++ b/src/components/ShortcutsDialog.tsx
@@ -183,8 +183,11 @@ export const ShortcutsDialog = ({ onClose }: { onClose?: () => void }) => {
               <Shortcut label={t("toolBar.diamond")} shortcuts={["D", "3"]} />
               <Shortcut label={t("toolBar.ellipse")} shortcuts={["E", "4"]} />
               <Shortcut label={t("toolBar.arrow")} shortcuts={["A", "5"]} />
-              <Shortcut label={t("toolBar.line")} shortcuts={["L", "6"]} />
-              <Shortcut label={t("toolBar.draw")} shortcuts={["X", "7"]} />
+              <Shortcut label={t("toolBar.line")} shortcuts={["P", "6"]} />
+              <Shortcut
+                label={t("toolBar.draw")}
+                shortcuts={["Shift+P", "7"]}
+              />
               <Shortcut label={t("toolBar.text")} shortcuts={["T", "8"]} />
               <Shortcut
                 label={t("shortcutsDialog.textNewLine")}

--- a/src/shapes.tsx
+++ b/src/shapes.tsx
@@ -11,7 +11,7 @@ export const SHAPES = [
       </svg>
     ),
     value: "selection",
-    key: "v",
+    key: ["v", "s"] as string[],
   },
   {
     icon: (

--- a/src/shapes.tsx
+++ b/src/shapes.tsx
@@ -11,7 +11,7 @@ export const SHAPES = [
       </svg>
     ),
     value: "selection",
-    key: ["v", "s"] as string[],
+    key: ["v", "s"],
   },
   {
     icon: (
@@ -95,12 +95,15 @@ export const SHAPES = [
   },
 ] as const;
 
-export const shapesShortcutKeys = SHAPES.map((shape, index) => [
-  shape.key,
-  (index + 1).toString(),
-]).flat(1);
-
-export const findShapeByKey = (key: string) =>
-  SHAPES.find((shape, index) => {
-    return shape.key === key.toLowerCase() || key === (index + 1).toString();
-  })?.value || "selection";
+export const findShapeByKey = (key: string) => {
+  key = key.toLowerCase();
+  const shape = SHAPES.find((shape, index) => {
+    return (
+      key === (index + 1).toString() ||
+      (typeof shape.key === "string"
+        ? shape.key === key
+        : (shape.key as readonly string[]).includes(key))
+    );
+  });
+  return shape?.value || null;
+};

--- a/src/shapes.tsx
+++ b/src/shapes.tsx
@@ -11,7 +11,7 @@ export const SHAPES = [
       </svg>
     ),
     value: "selection",
-    key: "s",
+    key: "v",
   },
   {
     icon: (

--- a/src/shapes.tsx
+++ b/src/shapes.tsx
@@ -68,7 +68,7 @@ export const SHAPES = [
       </svg>
     ),
     value: "line",
-    key: "l",
+    key: ["p", "l"],
   },
   {
     icon: (
@@ -81,7 +81,7 @@ export const SHAPES = [
       </svg>
     ),
     value: "draw",
-    key: "x",
+    key: ["P", "x"],
   },
   {
     icon: (
@@ -96,7 +96,6 @@ export const SHAPES = [
 ] as const;
 
 export const findShapeByKey = (key: string) => {
-  key = key.toLowerCase();
   const shape = SHAPES.find((shape, index) => {
     return (
       key === (index + 1).toString() ||


### PR DESCRIPTION
Changed the defaults for these tools to align either with standards (`selection`, `line`), or Figma (`draw`). Kept previous shortcuts on top, for now.

- `selection` default changed to `V`
- `line` default changed to `P`
- `draw` default changed to `Shift+P` (Photoshop uses `P P`, that's why Figma probably went with `Shift+P` and I concur. It's an awkward shortcut, but we display numbers as primary shortcuts anyway)