### PR TITLE
feat: rotating multiple elements

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -205,6 +205,8 @@ type PointerDownState = Readonly<{
     offset: { x: number; y: number };
     // This is determined on the initial pointer down event
     arrowDirection: "origin" | "end";
+    // This is a list of angles of selected elements determined on the initial pointer down event (rotation only)
+    angles: readonly number[];
   };
   hit: {
     // The element the pointer is "hitting", is determined on the initial
@@ -2213,6 +2215,10 @@ class App extends React.Component<ExcalidrawProps, AppState> {
       this.canvas,
       window.devicePixelRatio,
     );
+    const selectedElements = getSelectedElements(
+      globalSceneState.getElements(),
+      this.state,
+    );
 
     return {
       origin,
@@ -2231,6 +2237,7 @@ class App extends React.Component<ExcalidrawProps, AppState> {
         isResizing: false,
         offset: { x: 0, y: 0 },
         arrowDirection: "origin",
+        angles: selectedElements.map((element) => element.angle),
       },
       hit: {
         element: null,
@@ -2709,6 +2716,7 @@ class App extends React.Component<ExcalidrawProps, AppState> {
             getResizeCenterPointKey(event),
             resizeX,
             resizeY,
+            pointerDownState.resize.angles,
           )
         ) {
           return;

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -205,7 +205,9 @@ type PointerDownState = Readonly<{
     offset: { x: number; y: number };
     // This is determined on the initial pointer down event
     arrowDirection: "origin" | "end";
-    // This is a list of angles of selected elements determined on the initial pointer down event (rotation only)
+    // This is a center point of selected elements determined on the initial pointer down event (for rotation only)
+    center: { x: number; y: number };
+    // This is a list of angles of selected elements determined on the initial pointer down event (for rotation only)
     angles: readonly number[];
   };
   hit: {
@@ -2219,6 +2221,7 @@ class App extends React.Component<ExcalidrawProps, AppState> {
       globalSceneState.getElements(),
       this.state,
     );
+    const [minX, minY, maxX, maxY] = getCommonBounds(selectedElements);
 
     return {
       origin,
@@ -2237,6 +2240,7 @@ class App extends React.Component<ExcalidrawProps, AppState> {
         isResizing: false,
         offset: { x: 0, y: 0 },
         arrowDirection: "origin",
+        center: { x: (maxX + minX) / 2, y: (maxY + minY) / 2 },
         angles: selectedElements.map((element) => element.angle),
       },
       hit: {
@@ -2716,6 +2720,8 @@ class App extends React.Component<ExcalidrawProps, AppState> {
             getResizeCenterPointKey(event),
             resizeX,
             resizeY,
+            pointerDownState.resize.center.x,
+            pointerDownState.resize.center.y,
             pointerDownState.resize.angles,
           )
         ) {

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -207,8 +207,8 @@ type PointerDownState = Readonly<{
     arrowDirection: "origin" | "end";
     // This is a center point of selected elements determined on the initial pointer down event (for rotation only)
     center: { x: number; y: number };
-    // This is a list of angles of selected elements determined on the initial pointer down event (for rotation only)
-    angles: readonly number[];
+    // This is a list of selected elements determined on the initial pointer down event (for rotation only)
+    originalElements: readonly NonDeleted<ExcalidrawElement>[];
   };
   hit: {
     // The element the pointer is "hitting", is determined on the initial
@@ -2241,7 +2241,7 @@ class App extends React.Component<ExcalidrawProps, AppState> {
         offset: { x: 0, y: 0 },
         arrowDirection: "origin",
         center: { x: (maxX + minX) / 2, y: (maxY + minY) / 2 },
-        angles: selectedElements.map((element) => element.angle),
+        originalElements: selectedElements.map((element) => ({ ...element })),
       },
       hit: {
         element: null,
@@ -2722,7 +2722,7 @@ class App extends React.Component<ExcalidrawProps, AppState> {
             resizeY,
             pointerDownState.resize.center.x,
             pointerDownState.resize.center.y,
-            pointerDownState.resize.angles,
+            pointerDownState.resize.originalElements,
           )
         ) {
           return;

--- a/src/element/handlerRectangles.ts
+++ b/src/element/handlerRectangles.ts
@@ -18,7 +18,6 @@ export const OMIT_SIDES_FOR_MULTIPLE_ELEMENTS = {
   s: true,
   n: true,
   w: true,
-  rotation: true,
 };
 
 const OMIT_SIDES_FOR_TEXT_ELEMENT = {

--- a/src/element/resizeElements.ts
+++ b/src/element/resizeElements.ts
@@ -35,7 +35,7 @@ type ResizeTestType = ReturnType<typeof resizeTest>;
 export const resizeElements = (
   resizeHandle: ResizeTestType,
   setResizeHandle: (nextResizeHandle: ResizeTestType) => void,
-  selectedElements: NonDeletedExcalidrawElement[],
+  selectedElements: readonly NonDeletedExcalidrawElement[],
   resizeArrowDirection: "origin" | "end",
   isRotateWithDiscreteAngle: boolean,
   isResizeWithSidesSameLength: boolean,
@@ -44,7 +44,7 @@ export const resizeElements = (
   pointerY: number,
   centerX: number,
   centerY: number,
-  origAngles: readonly number[],
+  originalElements: readonly NonDeletedExcalidrawElement[],
 ) => {
   if (selectedElements.length === 1) {
     const [element] = selectedElements;
@@ -119,7 +119,7 @@ export const resizeElements = (
         isRotateWithDiscreteAngle,
         centerX,
         centerY,
-        origAngles,
+        originalElements,
       );
       return true;
     } else if (
@@ -568,7 +568,7 @@ const rotateMultipleElements = (
   isRotateWithDiscreteAngle: boolean,
   centerX: number,
   centerY: number,
-  origAngles: readonly number[],
+  originalElements: readonly NonDeletedExcalidrawElement[],
 ) => {
   let centerAngle =
     (5 * Math.PI) / 2 + Math.atan2(pointerY - centerY, pointerX - centerX);
@@ -577,21 +577,66 @@ const rotateMultipleElements = (
     centerAngle -= centerAngle % SHIFT_LOCKING_ANGLE;
   }
   elements.forEach((element, index) => {
-    const [x1, y1, x2, y2] = getElementAbsoluteCoords(element);
-    const cx = (x1 + x2) / 2;
-    const cy = (y1 + y2) / 2;
-    const [rotatedCX, rotatedCY] = rotate(
-      cx,
-      cy,
-      centerX,
-      centerY,
-      centerAngle + origAngles[index] - element.angle,
-    );
-    mutateElement(element, {
-      x: element.x + (rotatedCX - cx),
-      y: element.y + (rotatedCY - cy),
-      angle: normalizeAngle(centerAngle + origAngles[index]),
-    });
+    if (isLinearElement(element) && element.points.length === 2) {
+      // FIXME this is a bit tricky (how can we make this more readable?)
+      const originalElement = originalElements[index];
+      if (
+        !isLinearElement(originalElement) ||
+        originalElement.points.length !== 2
+      ) {
+        throw new Error("original element not compatible"); // should not happen
+      }
+      const [x1, y1, x2, y2] = getElementAbsoluteCoords(originalElement);
+      const cx = (x1 + x2) / 2;
+      const cy = (y1 + y2) / 2;
+      const [rotatedCX, rotatedCY] = rotate(
+        cx,
+        cy,
+        centerX,
+        centerY,
+        centerAngle,
+      );
+      const { points } = originalElement;
+      const [rotatedX, rotatedY] = rotate(
+        points[1][0],
+        points[1][1],
+        points[0][0],
+        points[0][1],
+        centerAngle,
+      );
+      mutateElement(element, {
+        x:
+          originalElement.x +
+          (rotatedCX - cx) +
+          ((originalElement.points[0][0] + originalElement.points[1][0]) / 2 -
+            (points[0][0] + rotatedX) / 2),
+        y:
+          originalElement.y +
+          (rotatedCY - cy) +
+          ((originalElement.points[0][1] + originalElement.points[1][1]) / 2 -
+            (points[0][1] + rotatedY) / 2),
+        points: [
+          [points[0][0], points[0][1]],
+          [rotatedX, rotatedY],
+        ],
+      });
+    } else {
+      const [x1, y1, x2, y2] = getElementAbsoluteCoords(element);
+      const cx = (x1 + x2) / 2;
+      const cy = (y1 + y2) / 2;
+      const [rotatedCX, rotatedCY] = rotate(
+        cx,
+        cy,
+        centerX,
+        centerY,
+        centerAngle + originalElements[index].angle - element.angle,
+      );
+      mutateElement(element, {
+        x: element.x + (rotatedCX - cx),
+        y: element.y + (rotatedCY - cy),
+        angle: normalizeAngle(centerAngle + originalElements[index].angle),
+      });
+    }
   });
 };
 

--- a/src/element/resizeElements.ts
+++ b/src/element/resizeElements.ts
@@ -35,6 +35,7 @@ export const resizeElements = (
   isResizeCenterPoint: boolean,
   pointerX: number,
   pointerY: number,
+  origAngles: readonly number[],
 ) => {
   if (selectedElements.length === 1) {
     const [element] = selectedElements;
@@ -107,6 +108,7 @@ export const resizeElements = (
         pointerX,
         pointerY,
         isRotateWithDiscreteAngle,
+        origAngles,
       );
       return true;
     } else if (
@@ -555,20 +557,18 @@ const rotateMultipleElements = (
   pointerX: number,
   pointerY: number,
   isRotateWithDiscreteAngle: boolean,
+  origAngles: readonly number[],
 ) => {
   const [gx1, gy1, gx2, gy2] = getCommonBounds(elements);
   const centerX = (gx1 + gx2) / 2;
   const centerY = (gy1 + gy2) / 2;
-  let angle =
+  let centerAngle =
     (5 * Math.PI) / 2 + Math.atan2(pointerY - centerY, pointerX - centerX);
   if (isRotateWithDiscreteAngle) {
-    angle += SHIFT_LOCKING_ANGLE / 2;
-    angle -= angle % SHIFT_LOCKING_ANGLE;
+    centerAngle += SHIFT_LOCKING_ANGLE / 2;
+    centerAngle -= centerAngle % SHIFT_LOCKING_ANGLE;
   }
-  if (angle >= 2 * Math.PI) {
-    angle -= 2 * Math.PI;
-  }
-  elements.forEach((element) => {
+  elements.forEach((element, index) => {
     const [x1, y1, x2, y2] = getElementAbsoluteCoords(element);
     const cx = (x1 + x2) / 2;
     const cy = (y1 + y2) / 2;
@@ -577,8 +577,12 @@ const rotateMultipleElements = (
       cy,
       centerX,
       centerY,
-      angle - element.angle,
+      centerAngle - element.angle + origAngles[index],
     );
+    let angle = centerAngle + origAngles[index];
+    if (angle >= 2 * Math.PI) {
+      angle -= 2 * Math.PI;
+    }
     mutateElement(element, {
       x: element.x + (rotatedCX - cx),
       y: element.y + (rotatedCY - cy),

--- a/src/element/resizeElements.ts
+++ b/src/element/resizeElements.ts
@@ -42,6 +42,8 @@ export const resizeElements = (
   isResizeCenterPoint: boolean,
   pointerX: number,
   pointerY: number,
+  centerX: number,
+  centerY: number,
   origAngles: readonly number[],
 ) => {
   if (selectedElements.length === 1) {
@@ -115,6 +117,8 @@ export const resizeElements = (
         pointerX,
         pointerY,
         isRotateWithDiscreteAngle,
+        centerX,
+        centerY,
         origAngles,
       );
       return true;
@@ -562,11 +566,10 @@ const rotateMultipleElements = (
   pointerX: number,
   pointerY: number,
   isRotateWithDiscreteAngle: boolean,
+  centerX: number,
+  centerY: number,
   origAngles: readonly number[],
 ) => {
-  const [gx1, gy1, gx2, gy2] = getCommonBounds(elements);
-  const centerX = (gx1 + gx2) / 2;
-  const centerY = (gy1 + gy2) / 2;
   let centerAngle =
     (5 * Math.PI) / 2 + Math.atan2(pointerY - centerY, pointerX - centerX);
   if (isRotateWithDiscreteAngle) {
@@ -582,7 +585,7 @@ const rotateMultipleElements = (
       cy,
       centerX,
       centerY,
-      centerAngle - element.angle + origAngles[index],
+      centerAngle + origAngles[index] - element.angle,
     );
     mutateElement(element, {
       x: element.x + (rotatedCX - cx),

--- a/src/element/resizeElements.ts
+++ b/src/element/resizeElements.ts
@@ -23,6 +23,13 @@ import {
 } from "./resizeTest";
 import { measureText, getFontString } from "../utils";
 
+const normalizeAngle = (angle: number): number => {
+  if (angle >= 2 * Math.PI) {
+    return angle - 2 * Math.PI;
+  }
+  return angle;
+};
+
 type ResizeTestType = ReturnType<typeof resizeTest>;
 
 export const resizeElements = (
@@ -143,9 +150,7 @@ const rotateSingleElement = (
     angle += SHIFT_LOCKING_ANGLE / 2;
     angle -= angle % SHIFT_LOCKING_ANGLE;
   }
-  if (angle >= 2 * Math.PI) {
-    angle -= 2 * Math.PI;
-  }
+  angle = normalizeAngle(angle);
   mutateElement(element, { angle });
 };
 
@@ -579,14 +584,10 @@ const rotateMultipleElements = (
       centerY,
       centerAngle - element.angle + origAngles[index],
     );
-    let angle = centerAngle + origAngles[index];
-    if (angle >= 2 * Math.PI) {
-      angle -= 2 * Math.PI;
-    }
     mutateElement(element, {
       x: element.x + (rotatedCX - cx),
       y: element.y + (rotatedCY - cy),
-      angle,
+      angle: normalizeAngle(centerAngle + origAngles[index]),
     });
   });
 };

--- a/src/renderer/renderScene.ts
+++ b/src/renderer/renderScene.ts
@@ -399,7 +399,7 @@ export const renderScene = (
         }
       });
       context.translate(-sceneState.scrollX, -sceneState.scrollY);
-    } else if (locallySelectedElements.length > 1) {
+    } else if (locallySelectedElements.length > 1 && !appState.isRotating) {
       const dashedLinePadding = 4 / sceneState.zoom;
       context.translate(sceneState.scrollX, sceneState.scrollY);
       context.fillStyle = oc.white;
@@ -433,15 +433,13 @@ export const renderScene = (
           const lineWidth = context.lineWidth;
           context.lineWidth = 1 / sceneState.zoom;
           if (key === "rotation") {
-            if (!appState.isRotating) {
-              strokeCircle(
-                context,
-                handler[0],
-                handler[1],
-                handler[2],
-                handler[3],
-              );
-            }
+            strokeCircle(
+              context,
+              handler[0],
+              handler[1],
+              handler[2],
+              handler[3],
+            );
           } else {
             strokeRectWithRotation(
               context,

--- a/src/renderer/renderScene.ts
+++ b/src/renderer/renderScene.ts
@@ -432,17 +432,27 @@ export const renderScene = (
         if (handler !== undefined) {
           const lineWidth = context.lineWidth;
           context.lineWidth = 1 / sceneState.zoom;
-          strokeRectWithRotation(
-            context,
-            handler[0],
-            handler[1],
-            handler[2],
-            handler[3],
-            handler[0] + handler[2] / 2,
-            handler[1] + handler[3] / 2,
-            0,
-            true, // fill before stroke
-          );
+          if (key === "rotation") {
+            strokeCircle(
+              context,
+              handler[0],
+              handler[1],
+              handler[2],
+              handler[3],
+            );
+          } else {
+            strokeRectWithRotation(
+              context,
+              handler[0],
+              handler[1],
+              handler[2],
+              handler[3],
+              handler[0] + handler[2] / 2,
+              handler[1] + handler[3] / 2,
+              0,
+              true, // fill before stroke
+            );
+          }
           context.lineWidth = lineWidth;
         }
       });

--- a/src/renderer/renderScene.ts
+++ b/src/renderer/renderScene.ts
@@ -433,13 +433,15 @@ export const renderScene = (
           const lineWidth = context.lineWidth;
           context.lineWidth = 1 / sceneState.zoom;
           if (key === "rotation") {
-            strokeCircle(
-              context,
-              handler[0],
-              handler[1],
-              handler[2],
-              handler[3],
-            );
+            if (!appState.isRotating) {
+              strokeCircle(
+                context,
+                handler[0],
+                handler[1],
+                handler[2],
+                handler[3],
+              );
+            }
           } else {
             strokeRectWithRotation(
               context,


### PR DESCRIPTION
close #1168 

- [x] implement basic math
- [x] rotate (in addition) already rotated elements (requires not only math, but also a state)
- [x] tweak ui (hide the rotate handle while dragging?)

![excal76](https://user-images.githubusercontent.com/490574/88447797-67208700-ce72-11ea-8793-27df6b273c69.gif)
