### PR TITLE
UI Changes

### DIFF
--- a/src/components/Actions.tsx
+++ b/src/components/Actions.tsx
@@ -164,7 +164,7 @@ export const ZoomActions = ({
       {renderAction("zoomIn")}
       {renderAction("zoomOut")}
       {renderAction("resetZoom")}
-      <div style={{ marginInlineStart: 4 }}>{(zoom * 100).toFixed(0)}%</div>
+      <div className="zoomValue">{(zoom * 100).toFixed(0)}%</div>
     </Stack.Row>
   </Stack.Col>
 );

--- a/src/components/ColorPicker.scss
+++ b/src/components/ColorPicker.scss
@@ -54,8 +54,8 @@
 
 .color-picker-swatch {
   position: relative;
-  height: 1.875rem;
-  width: 1.875rem;
+  height: var(--button-height);
+  width: var(--button-width);
   cursor: pointer;
   border-radius: 4px;
   margin: 0;
@@ -87,8 +87,8 @@
 
 .color-picker-hash {
   background: $oc-gray-3;
-  height: 1.875rem;
-  width: 1.875rem;
+  height: var(--button-height);
+  width: var(--button-width);
   :root[dir="ltr"] & {
     border-radius: 4px 0px 0px 4px;
   }
@@ -133,6 +133,7 @@
 
 .color-input-container {
   display: flex;
+  padding: 0.5rem;
 }
 
 .color-picker-input {
@@ -142,7 +143,7 @@
   color: $oc-gray-8;
   border: 0px;
   outline: none;
-  height: 1.75em;
+  height: 1.85rem; // a rem value needed here since var(--button-height) is too large
   box-shadow: $oc-gray-3 0px 0px 0px 1px inset;
   :root[dir="ltr"] & {
     border-radius: 0px 4px 4px 0px;
@@ -157,8 +158,8 @@
 }
 
 .color-picker-label-swatch {
-  height: 1.875rem;
-  width: 1.875rem;
+  height: var(--button-height);
+  width: var(--button-width);
   margin-inline-end: 0.25rem;
   border: 1px solid $oc-gray-3;
   position: relative;

--- a/src/components/ColorPicker.tsx
+++ b/src/components/ColorPicker.tsx
@@ -180,6 +180,13 @@ const Picker = ({
           />
         )}
       </div>
+      <ColorInput
+        color={color}
+        label={label}
+        onChange={(color) => {
+          onChange(color);
+        }}
+      />
     </div>
   );
 };
@@ -262,13 +269,6 @@ export const ColorPicker = ({
           }
           onClick={() => setActive(!isActive)}
           ref={pickerButton}
-        />
-        <ColorInput
-          color={color}
-          label={label}
-          onChange={(color) => {
-            onChange(color);
-          }}
         />
       </div>
       <React.Suspense fallback="">

--- a/src/components/LayerUI.scss
+++ b/src/components/LayerUI.scss
@@ -147,4 +147,9 @@
       transition-delay: 0.8s;
     }
   }
+
+  .zoomValue {
+    font-size: 0.8rem;
+    padding: 0 4px;
+  }
 }

--- a/src/components/LayerUI.tsx
+++ b/src/components/LayerUI.tsx
@@ -313,9 +313,9 @@ const LayerUI = ({
     >
       {/* the zIndex ensures this menu has higher stacking order,
          see https://github.com/excalidraw/excalidraw/pull/1445 */}
-      <Island padding={4} style={{ zIndex: 1 }}>
+      <Island padding={1} style={{ zIndex: 1, width: "fit-content" }}>
         <Stack.Col gap={4}>
-          <Stack.Row gap={1} justifyContent="space-between">
+          <Stack.Col gap={1} justifyContent="space-between">
             {actionManager.renderAction("loadScene")}
             {actionManager.renderAction("saveScene")}
             {actionManager.renderAction("saveAsScene")}
@@ -329,7 +329,7 @@ const LayerUI = ({
               onRoomCreate={onRoomCreate}
               onRoomDestroy={onRoomDestroy}
             />
-          </Stack.Row>
+          </Stack.Col>
           {actionManager.renderAction("changeViewBackgroundColor")}
         </Stack.Col>
       </Island>

--- a/src/components/ToolIcon.scss
+++ b/src/components/ToolIcon.scss
@@ -19,8 +19,9 @@
 }
 
 .ToolIcon__icon {
-  width: 2.5rem;
-  height: 2.5rem;
+  width: var(--button-width);
+  height: var(--button-height);
+  border: 1px solid var(--button-gray-1);
 
   display: flex;
   justify-content: center;
@@ -30,7 +31,7 @@
 
   svg {
     position: relative;
-    height: 1em;
+    height: 0.8em;
   }
 
   & + .ToolIcon__label {

--- a/src/css/styles.scss
+++ b/src/css/styles.scss
@@ -11,12 +11,16 @@
   --shadow-island: 0 1px 5px #{transparentize($oc-black, 0.85)};
   --border-radius-m: 4px;
   --space-factor: 0.25rem;
+  --ui-font: system-ui, BlinkMacSystemFont, -apple-system, Segoe UI, Roboto,
+    Helvetica, Arial, sans-serif;
+}
+
+html {
+  font-family: var(--ui-font);
 }
 
 body {
   margin: 0;
-  --ui-font: system-ui, BlinkMacSystemFont, -apple-system, Segoe UI, Roboto,
-    Helvetica, Arial, sans-serif;
   font-family: var(--ui-font);
   color: var(--text-color-primary);
   -webkit-text-size-adjust: 100%;

--- a/src/css/theme.scss
+++ b/src/css/theme.scss
@@ -5,4 +5,7 @@
   --bg-color-island: rgba(255, 255, 255, 0.9);
   --border-radius-m: 4px;
   --space-factor: 0.25rem;
+
+  --button-width: 2rem;
+  --button-height: 2rem;
 }


### PR DESCRIPTION
Changes in this Diff include:
- global CSS variable for button width and height for posterity and future consistency
- updated the location of the `ColorPicker` to be within the Popover rather than beside the canvas color element
- adjusted padding so that the UI is a little more compact, optimizing the real-estate for maximum canvas use
- modified layout of file menu to be vertical instead of horizontal

Before:
<img width="1674" alt="Screen Shot 2020-07-25 at 11 23 23 PM" src="https://user-images.githubusercontent.com/1207134/88473034-5c93db00-cece-11ea-9dfe-61e9c8a4962d.png">


After:
<img width="1674" alt="Screen Shot 2020-07-25 at 11 23 49 PM" src="https://user-images.githubusercontent.com/1207134/88473037-6289bc00-cece-11ea-9eb9-8c4abd801ed1.png">

Annotated:  
<img width="1674" alt="Screen Shot 2020-07-25 at 11 23 49 PM" src="https://user-images.githubusercontent.com/1207134/88473053-995fd200-cece-11ea-848c-a87979e9f240.png">
