### PR TITLE
simplify by replacing draggingElementPointIndex with isDragging

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1877,7 +1877,7 @@ class App extends React.Component<ExcalidrawProps, AppState> {
 
     if (
       this.state.editingLinearElement &&
-      this.state.editingLinearElement.draggingElementPointIndex === null
+      !this.state.editingLinearElement.isDragging
     ) {
       const editingLinearElement = LinearElementEditor.handlePointerMove(
         event,

--- a/src/element/linearElementEditor.ts
+++ b/src/element/linearElementEditor.ts
@@ -16,6 +16,7 @@ export class LinearElementEditor {
     _brand: "excalidrawLinearElementId";
   };
   public activePointIndex: number | null;
+  /** whether you're dragging a point */
   public isDragging: boolean;
   public lastUncommittedPoint: Point | null;
 


### PR DESCRIPTION
/cc @dai-shi 

Also fixes a case where if you start dragging the whole line and during the drag the cursor happens to mover over an point (happens when moving mouse really fast), it started to drag the point instead.