### PR TITLE
update simplifier distance to reflect zoom

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -2885,8 +2885,15 @@ class App extends React.Component<ExcalidrawProps, AppState> {
           mutateElement(draggingElement, { points: [...points, [dx, dy]] });
         } else if (points.length > 1) {
           if (draggingElement.type === "draw") {
+            /**
+             * The constant .7 is fairly arbitrary but was chosen to maintain
+             * the same distance at zoom 100%
+             **/
             mutateElement(draggingElement, {
-              points: simplify([...(points as Point[]), [dx, dy]], 0.7),
+              points: simplify(
+                [...(points as Point[]), [dx, dy]],
+                0.7 / this.state.zoom,
+              ),
             });
           } else {
             mutateElement(draggingElement, {

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -2885,10 +2885,6 @@ class App extends React.Component<ExcalidrawProps, AppState> {
           mutateElement(draggingElement, { points: [...points, [dx, dy]] });
         } else if (points.length > 1) {
           if (draggingElement.type === "draw") {
-            /**
-             * The constant .7 is fairly arbitrary but was chosen to maintain
-             * the same distance at zoom 100%
-             **/
             mutateElement(draggingElement, {
               points: simplify(
                 [...(points as Point[]), [dx, dy]],


### PR DESCRIPTION
Implements #1981

The distance used in the iterative end-point fit algorithm to
determine if points can be removed no longer ignores the
zoom. As the zoom gets larger this distance will get smaller
and fewer points will be removed, thus making for finer grain
control over the drawing. As the zoom gets smaller the drawing
will get more coarse as more points are removed.