### PR TITLE
do not prevent UI scrolling on mobile

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -68,7 +68,7 @@ document.addEventListener(
   "touchmove",
   (event) => {
     // @ts-ignore
-    if (event.scale !== 1) {
+    if (typeof event.scale === "number" && event.scale !== 1) {
       event.preventDefault();
     }
   },


### PR DESCRIPTION
We're effectively preventing `touchmove` on ~~non-safari~~ browsers that do not support `event.scale`. This manifests in scrolling (of overflowing containers) not working on mobile.