### PR TITLE
🐛 Remove unnecessary class name props

### DIFF
--- a/src/components/Avatar.tsx
+++ b/src/components/Avatar.tsx
@@ -4,22 +4,12 @@ import React from "react";
 
 type AvatarProps = {
   children: string;
-  className?: string;
   onClick: (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => void;
   color: string;
 };
 
-export const Avatar = ({
-  children,
-  className,
-  color,
-  onClick,
-}: AvatarProps) => (
-  <div
-    className={`Avatar ${className}`}
-    style={{ background: color }}
-    onClick={onClick}
-  >
+export const Avatar = ({ children, color, onClick }: AvatarProps) => (
+  <div className={`Avatar`} style={{ background: color }} onClick={onClick}>
     {children}
   </div>
 );


### PR DESCRIPTION
It's unused and serialized to `undefined`.