### PR TITLE
🐛 Fix emoji rendering

### DIFF
--- a/src/components/RoomDialog.scss
+++ b/src/components/RoomDialog.scss
@@ -42,6 +42,10 @@
   background-color: var(--button-gray-1);
 }
 
+.RoomDialog-emoji {
+  font-family: sans-serif;
+}
+
 .RoomDialog-usernameContainer {
   display: flex;
   margin: 1.5em 0;

--- a/src/components/RoomDialog.tsx
+++ b/src/components/RoomDialog.tsx
@@ -90,10 +90,15 @@ const RoomModal = ({
               onKeyPress={(event) => event.key === "Enter" && onPressingEnter()}
             />
           </div>
-          <p>{`🔒 ${t("roomDialog.desc_privacy")}`}</p>
           <p>
-            <span role="img" aria-hidden="true">
-              ⚠️
+            <span role="img" aria-hidden="true" className="RoomDialog-emoji">
+              {"🔒"}
+            </span>{" "}
+            {t("roomDialog.desc_privacy")}
+          </p>
+          <p>
+            <span role="img" aria-hidden="true" className="RoomDialog-emoji">
+              {"⚠️️"}
             </span>{" "}
             {t("roomDialog.desc_persistenceWarning")}
           </p>


### PR DESCRIPTION
In the Collaboration dialog, there are 2 emojis in paragraphs. The 🔒 one was always correctly displayed on macOS because the system font defaults to Emoji Presentation mode for this emoji, whereas the ⚠️ one rendered gray-scale because the system font defaults to Text Presentation mode for this emoji.

It may differ a lot based on the systems, so the most consistent way to have Emoji Presentation seems to be `font-family: sans-serif`. Even Variation Selector-16 didn't work here.