### PR TITLE
Zoom controls are pushed to the right for right-to-left languages

### DIFF
--- a/src/css/styles.scss
+++ b/src/css/styles.scss
@@ -262,8 +262,14 @@ button,
   align-items: flex-start;
   cursor: default;
   pointer-events: none !important;
-  left: 0.25rem;
   z-index: 100;
+
+  :root[dir="ltr"] & {
+    left: 0.25rem;
+  }
+  :root[dir="rtl"] & {
+    right: 0.25rem;
+  }  
 
   &--transition-left {
     section {


### PR DESCRIPTION
Zoom controls are now pushed to the right edge.

![image](https://user-images.githubusercontent.com/1239401/90276468-3ecdec00-de64-11ea-8d1a-9f6e29e3bf35.png)


closes #2021