### PR TITLE
feat: Zoom controls are pushed to the right edge for Right-To-Left la…

### DIFF
--- a/src/css/styles.scss
+++ b/src/css/styles.scss
@@ -262,8 +262,14 @@ button,
   align-items: flex-start;
   cursor: default;
   pointer-events: none !important;
-  left: 0.25rem;
   z-index: 100;
+
+  :root[dir="ltr"] & {
+    left: 0.25rem;
+  }
+  :root[dir="rtl"] & {
+    right: 0.25rem;
+  }
 
   &--transition-left {
     section {


### PR DESCRIPTION
Zoom controls are now pushed to the right edge.

image
![image](https://user-images.githubusercontent.com/1239401/90278822-57d89c00-de68-11ea-87d4-b0252d8afef9.png)

closes #2021