### PR TITLE
Reduce the padding of the left 'Islands'

### DIFF
--- a/src/components/LayerUI.tsx
+++ b/src/components/LayerUI.tsx
@@ -444,7 +444,7 @@ const LayerUI = ({
             {(heading) => (
               <Stack.Col gap={4} align="start">
                 <Stack.Row gap={1}>
-                  <Island padding={2} className={zenModeEnabled && "zen-mode"}>
+                  <Island padding={1} className={zenModeEnabled && "zen-mode"}>
                     {heading}
                     <Stack.Row gap={1}>
                       <ShapesSwitcher

--- a/src/components/LayerUI.tsx
+++ b/src/components/LayerUI.tsx
@@ -356,7 +356,7 @@ const LayerUI = ({
     >
       {/* the zIndex ensures this menu has higher stacking order,
          see https://github.com/excalidraw/excalidraw/pull/1445 */}
-      <Island padding={4} style={{ zIndex: 1 }}>
+      <Island padding={1} style={{ zIndex: 1 }}>
         <Stack.Col gap={4}>
           <Stack.Row gap={1} justifyContent="space-between">
             {actionManager.renderAction("loadScene")}
@@ -388,7 +388,7 @@ const LayerUI = ({
       heading="selectedShapeActions"
       className={`zen-mode-transition ${zenModeEnabled && "transition-left"}`}
     >
-      <Island className={CLASSES.SHAPE_ACTIONS_MENU} padding={4}>
+      <Island className={CLASSES.SHAPE_ACTIONS_MENU} padding={1}>
         <SelectedShapeActions
           appState={appState}
           elements={elements}

--- a/src/components/LayerUI.tsx
+++ b/src/components/LayerUI.tsx
@@ -356,7 +356,7 @@ const LayerUI = ({
     >
       {/* the zIndex ensures this menu has higher stacking order,
          see https://github.com/excalidraw/excalidraw/pull/1445 */}
-      <Island padding={1} style={{ zIndex: 1 }}>
+      <Island padding={2} style={{ zIndex: 1 }}>
         <Stack.Col gap={4}>
           <Stack.Row gap={1} justifyContent="space-between">
             {actionManager.renderAction("loadScene")}
@@ -388,7 +388,7 @@ const LayerUI = ({
       heading="selectedShapeActions"
       className={`zen-mode-transition ${zenModeEnabled && "transition-left"}`}
     >
-      <Island className={CLASSES.SHAPE_ACTIONS_MENU} padding={1}>
+      <Island className={CLASSES.SHAPE_ACTIONS_MENU} padding={2}>
         <SelectedShapeActions
           appState={appState}
           elements={elements}
@@ -444,7 +444,7 @@ const LayerUI = ({
             {(heading) => (
               <Stack.Col gap={4} align="start">
                 <Stack.Row gap={1}>
-                  <Island padding={1} className={zenModeEnabled && "zen-mode"}>
+                  <Island padding={2} className={zenModeEnabled && "zen-mode"}>
                     {heading}
                     <Stack.Row gap={1}>
                       <ShapesSwitcher


### PR DESCRIPTION
Mainly to have all the top icons on the same level.. plus we have more real estate by removing the extra padding.

### Before

<img width="779" alt="Screenshot 2020-08-19 at 4 29 47 PM" src="https://user-images.githubusercontent.com/125676/90641000-5d9ffa00-e239-11ea-9f71-131d27adafd8.png">

### After

<img width="788" alt="Screenshot 2020-08-19 at 4 29 34 PM" src="https://user-images.githubusercontent.com/125676/90641026-64c70800-e239-11ea-98a3-07f575b1dbe8.png">
