### PR TITLE
Make iOS "safe area" respect dark mode

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -724,7 +724,7 @@ class App extends React.Component<ExcalidrawProps, AppState> {
       });
     }
 
-    document.body.classList.toggle(
+    document.documentElement.classList.toggle(
       "Appearance_dark",
       this.state.appearance === "dark",
     );

--- a/src/css/theme.scss
+++ b/src/css/theme.scss
@@ -37,6 +37,10 @@
   --popup-text-inverted-color: #{$oc-white};
 }
 
+:root.Appearance_dark {
+  background-color: #000;
+}
+
 .Appearance_dark {
   --text-color-primary: #{$oc-gray-4};
   --bg-color-island: #1e1e1e;


### PR DESCRIPTION
Before (note the bottom):

<img width="570" alt="Screen Shot 2020-08-20 at 09 19 06" src="https://user-images.githubusercontent.com/145676/90730234-13198e80-e2c8-11ea-9b08-c4851e4b1dea.png">

After (note the bottom):

<img width="570" alt="Screen Shot 2020-08-20 at 09 34 52" src="https://user-images.githubusercontent.com/145676/90730432-6b509080-e2c8-11ea-9e4e-2ea2da0dcfbc.png">
