### PR TITLE
wip: sloppy svg path

### DIFF
--- a/src/renderer/renderElement.ts
+++ b/src/renderer/renderElement.ts
@@ -383,7 +383,7 @@ const generateElementShape = (
         if (
           myRough &&
           element.strokeSharpness === "round" &&
-          points.length >= 3
+          points.length >= 4
         ) {
           const bcurve = curveToBezier(points as [number, number][]);
           let svgPath = "M 0 0";

--- a/src/renderer/renderSloppySvgPath.ts
+++ b/src/renderer/renderSloppySvgPath.ts
@@ -25,7 +25,7 @@ const getSloppyCurve = (
     ],
     1.0,
   );
-  const diff = 2 * roughness;
+  const diff = points.length * 0.1 * roughness;
   points.forEach((point, index) => {
     if (index > 1 && index < points.length - 2) {
       point[0] += Math.random() * diff - diff / 2;

--- a/src/renderer/renderSloppySvgPath.ts
+++ b/src/renderer/renderSloppySvgPath.ts
@@ -2,7 +2,10 @@ import { parsePath, normalize, absolutize } from "path-data-parser";
 import { curveToBezier } from "points-on-curve/lib/curve-to-bezier.js";
 import { Op, OpSet, ResolvedOptions } from "roughjs/bin/core";
 
+import { randomInteger, reseed } from "../random";
 import { Point } from "../types";
+
+const random = () => randomInteger() / 2 ** 31;
 
 const getSloppyLine = (
   x0: number,
@@ -13,8 +16,8 @@ const getSloppyLine = (
 ): number[][] => {
   const diff = 0.015 * Math.sqrt((x - x0) ** 2 + (y - y0) ** 2) * roughness;
   const getRandomMiddlePoint = (fraction: number): [number, number] => [
-    x0 + (x - x0) * fraction + Math.random() * diff - diff / 2,
-    y0 + (y - y0) * fraction + Math.random() * diff - diff / 2,
+    x0 + (x - x0) * fraction + random() * diff - diff / 2,
+    y0 + (y - y0) * fraction + random() * diff - diff / 2,
   ];
   const bcurve = curveToBezier([
     [x0, y0],
@@ -89,24 +92,24 @@ const getSloppyCurve = (
   const [p05, pp05] = splitBezier(pp07, 0.2 / 0.7);
   const [p07, pp03] = splitBezier(pp05, 0.2 / 0.5);
   const [p09, pp01] = splitBezier(pp03, 0.2 / 0.3);
-  const rand03x = Math.random() * diff - diff / 2;
-  const rand03y = Math.random() * diff - diff / 2;
+  const rand03x = random() * diff - diff / 2;
+  const rand03y = random() * diff - diff / 2;
   p03[4] += rand03x;
   p03[5] += rand03y;
   p03[6] += rand03x;
   p03[7] += rand03y;
   p05[2] += rand03x;
   p05[3] += rand03y;
-  const rand05x = Math.random() * diff - diff / 2;
-  const rand05y = Math.random() * diff - diff / 2;
+  const rand05x = random() * diff - diff / 2;
+  const rand05y = random() * diff - diff / 2;
   p05[4] += rand05x;
   p05[5] += rand05y;
   p05[6] += rand05x;
   p05[7] += rand05y;
   p07[2] += rand05x;
   p07[3] += rand05y;
-  const rand07x = Math.random() * diff - diff / 2;
-  const rand07y = Math.random() * diff - diff / 2;
+  const rand07x = random() * diff - diff / 2;
+  const rand07y = random() * diff - diff / 2;
   p07[4] += rand07x;
   p07[5] += rand07y;
   p07[6] += rand07x;
@@ -128,6 +131,7 @@ export const renderSloppySvgPath = (
   svgPath: string,
   options: ResolvedOptions,
 ): OpSet => {
+  reseed(options.seed);
   const segments = normalize(absolutize(parsePath(svgPath)));
   const ops: Op[] = [];
   let first: Point = [0, 0];

--- a/src/renderer/renderSloppySvgPath.ts
+++ b/src/renderer/renderSloppySvgPath.ts
@@ -1,0 +1,127 @@
+import { parsePath, normalize, absolutize } from "path-data-parser";
+import { pointsOnBezierCurves } from "points-on-curve";
+import { curveToBezier } from "points-on-curve/lib/curve-to-bezier.js";
+import { Op, OpSet, ResolvedOptions } from "roughjs/bin/core";
+
+import { Point } from "../types";
+
+const getSloppyCurve = (
+  x0: number,
+  y0: number,
+  x1: number,
+  y1: number,
+  x2: number,
+  y2: number,
+  x: number,
+  y: number,
+  roughness: number,
+): number[][] => {
+  const points = pointsOnBezierCurves(
+    [
+      [x0, y0],
+      [x1, y1],
+      [x2, y2],
+      [x, y],
+    ],
+    1.0,
+  );
+  const diff = Math.sqrt((x - x0) ** 2 + (y - y0) ** 2) * 0.03 * roughness;
+  points.forEach((point, index) => {
+    if (index > 0 && index < points.length - 1) {
+      point[0] += Math.random() * diff - diff / 2;
+      point[1] += Math.random() * diff - diff / 2;
+    }
+  });
+  if (points.length < 7) {
+    return [[x1, y1, x2, y2, x, y]];
+  }
+  const p25 = Math.round(points.length * 0.25);
+  const bcurve = curveToBezier([
+    points[0],
+    points[p25],
+    points[p25 * 2],
+    points[p25 * 3],
+    points[points.length - 1],
+  ]);
+  const arr: number[][] = [];
+  for (let i = 1; i + 2 < bcurve.length; i += 3) {
+    arr.push([
+      bcurve[i][0],
+      bcurve[i][1],
+      bcurve[i + 1][0],
+      bcurve[i + 1][1],
+      bcurve[i + 2][0],
+      bcurve[i + 2][1],
+    ]);
+  }
+  return arr;
+};
+
+export const renderSloppySvgPath = (
+  svgPath: string,
+  options: ResolvedOptions,
+): OpSet => {
+  const segments = normalize(absolutize(parsePath(svgPath)));
+  const ops: Op[] = [];
+  let first: Point = [0, 0];
+  let current: Point = [0, 0];
+  for (const { key, data } of segments) {
+    switch (key) {
+      case "M": {
+        ops.push({ op: "move", data });
+        current = [data[0], data[1]];
+        first = [data[0], data[1]];
+        break;
+      }
+      case "L":
+        const cx = (current[0] + data[0]) / 2;
+        const cy = (current[1] + data[1]) / 2;
+        const arr = getSloppyCurve(
+          current[0],
+          current[1],
+          cx,
+          cy,
+          cx,
+          cy,
+          data[0],
+          data[1],
+          options.roughness,
+        );
+        arr.forEach((data) => {
+          ops.push({
+            op: "bcurveTo",
+            data,
+          });
+        });
+        current = [data[0], data[1]];
+        break;
+      case "C": {
+        const [x1, y1, x2, y2, x, y] = data;
+        const arr = getSloppyCurve(
+          current[0],
+          current[1],
+          x1,
+          y1,
+          x2,
+          y2,
+          x,
+          y,
+          options.roughness,
+        );
+        arr.forEach((data) => {
+          ops.push({
+            op: "bcurveTo",
+            data,
+          });
+        });
+        current = [x, y];
+        break;
+      }
+      case "Z":
+        ops.push({ op: "lineTo", data: [first[0], first[1]] });
+        current = [first[0], first[1]];
+        break;
+    }
+  }
+  return { type: "path", ops };
+};

--- a/src/renderer/renderSloppySvgPath.ts
+++ b/src/renderer/renderSloppySvgPath.ts
@@ -14,10 +14,10 @@ const getSloppyLine = (
   y: number,
   roughness: number,
 ): number[][] => {
-  const diff = 0.015 * Math.sqrt((x - x0) ** 2 + (y - y0) ** 2) * roughness;
+  const delta = 0.015 * Math.sqrt((x - x0) ** 2 + (y - y0) ** 2) * roughness;
   const getRandomMiddlePoint = (fraction: number): [number, number] => [
-    x0 + (x - x0) * fraction + random() * diff - diff / 2,
-    y0 + (y - y0) * fraction + random() * diff - diff / 2,
+    x0 + (x - x0) * fraction + random() * delta - delta / 2,
+    y0 + (y - y0) * fraction + random() * delta - delta / 2,
   ];
   const bcurve = curveToBezier([
     [x0, y0],
@@ -86,30 +86,30 @@ const getSloppyCurve = (
   y: number,
   roughness: number,
 ): number[][] => {
-  const diff = 0.02 * Math.sqrt((x - x0) ** 2 + (y - y0) ** 2) * roughness;
+  const delta = 0.02 * Math.sqrt((x - x0) ** 2 + (y - y0) ** 2) * roughness;
   const [p01, pp09] = splitBezier([x0, y0, x1, y1, x2, y2, x, y], 0.1);
   const [p03, pp07] = splitBezier(pp09, 0.2 / 0.9);
   const [p05, pp05] = splitBezier(pp07, 0.2 / 0.7);
   const [p07, pp03] = splitBezier(pp05, 0.2 / 0.5);
   const [p09, pp01] = splitBezier(pp03, 0.2 / 0.3);
-  const rand03x = random() * diff - diff / 2;
-  const rand03y = random() * diff - diff / 2;
+  const rand03x = random() * delta - delta / 2;
+  const rand03y = random() * delta - delta / 2;
   p03[4] += rand03x;
   p03[5] += rand03y;
   p03[6] += rand03x;
   p03[7] += rand03y;
   p05[2] += rand03x;
   p05[3] += rand03y;
-  const rand05x = random() * diff - diff / 2;
-  const rand05y = random() * diff - diff / 2;
+  const rand05x = random() * delta - delta / 2;
+  const rand05y = random() * delta - delta / 2;
   p05[4] += rand05x;
   p05[5] += rand05y;
   p05[6] += rand05x;
   p05[7] += rand05y;
   p07[2] += rand05x;
   p07[3] += rand05y;
-  const rand07x = random() * diff - diff / 2;
-  const rand07y = random() * diff - diff / 2;
+  const rand07x = random() * delta - delta / 2;
+  const rand07y = random() * delta - delta / 2;
   p07[4] += rand07x;
   p07[5] += rand07y;
   p07[6] += rand07x;

--- a/src/renderer/renderSloppySvgPath.ts
+++ b/src/renderer/renderSloppySvgPath.ts
@@ -5,6 +5,39 @@ import { Op, OpSet, ResolvedOptions } from "roughjs/bin/core";
 
 import { Point } from "../types";
 
+const getSloppyLine = (
+  x0: number,
+  y0: number,
+  x: number,
+  y: number,
+  roughness: number,
+): number[][] => {
+  const diff = 0.015 * Math.sqrt((x - x0) ** 2 + (y - y0) ** 2) * roughness;
+  const getRandomMiddlePoint = (percentile: number): [number, number] => [
+    x0 + (x - x0) * percentile + Math.random() * diff - diff / 2,
+    y0 + (y - y0) * percentile + Math.random() * diff - diff / 2,
+  ];
+  const bcurve = curveToBezier([
+    [x0, y0],
+    getRandomMiddlePoint(0.25),
+    getRandomMiddlePoint(0.5),
+    getRandomMiddlePoint(0.75),
+    [x, y],
+  ]);
+  const arr: number[][] = [];
+  for (let i = 1; i + 2 < bcurve.length; i += 3) {
+    arr.push([
+      bcurve[i][0],
+      bcurve[i][1],
+      bcurve[i + 1][0],
+      bcurve[i + 1][1],
+      bcurve[i + 2][0],
+      bcurve[i + 2][1],
+    ]);
+  }
+  return arr;
+};
+
 const getSloppyCurve = (
   x0: number,
   y0: number,
@@ -25,7 +58,7 @@ const getSloppyCurve = (
     ],
     1.0,
   );
-  const diff = points.length * 0.1 * roughness;
+  const diff = points.length * 0.2 * roughness;
   points.forEach((point, index) => {
     if (index > 1 && index < points.length - 2) {
       point[0] += Math.random() * diff - diff / 2;
@@ -76,15 +109,9 @@ export const renderSloppySvgPath = (
         break;
       }
       case "L": {
-        const cx = (current[0] + data[0]) / 2;
-        const cy = (current[1] + data[1]) / 2;
-        const arr = getSloppyCurve(
+        const arr = getSloppyLine(
           current[0],
           current[1],
-          cx,
-          cy,
-          cx,
-          cy,
           data[0],
           data[1],
           options.roughness,
@@ -121,15 +148,9 @@ export const renderSloppySvgPath = (
         break;
       }
       case "Z": {
-        const cx = (current[0] + first[0]) / 2;
-        const cy = (current[1] + first[1]) / 2;
-        const arr = getSloppyCurve(
+        const arr = getSloppyLine(
           current[0],
           current[1],
-          cx,
-          cy,
-          cx,
-          cy,
           first[0],
           first[1],
           options.roughness,


### PR DESCRIPTION
While implementing #1931 , I wanted a way to draw shape with sloppiness and connected edges.
@vjeux seems to want something similar. So, I gave it a try.

I have been thinking about focusing on implementing only one shape "svgPath" and all other shapes can be converted to it, hopefully.

<img width="710" alt="image" src="https://user-images.githubusercontent.com/490574/90797457-a647d800-e34b-11ea-8b62-0e7cdf02a4ed.png">

TODOs:
- [x] fix round edge connection now being sharp
- [ ] fix round/sharp lines resizing
- [ ] fix lines with points less than 4
- [ ] fix bound box of ellipses (for lines too)
- [x] random seed
- [ ] support filling
- [ ] support arrow head