### PR TITLE
Fix #2075 - Pinch zooming while typing text breaks the UI on Chrome Mac OS X

### DIFF
--- a/src/element/textWysiwyg.tsx
+++ b/src/element/textWysiwyg.tsx
@@ -130,6 +130,7 @@ export const textWysiwyg = ({
   };
 
   const stopEvent = (event: Event) => {
+    event.preventDefault();
     event.stopPropagation();
   };
 
@@ -198,7 +199,10 @@ export const textWysiwyg = ({
   //  device keyboard is opened.
   window.addEventListener("resize", updateWysiwygStyle);
   window.addEventListener("pointerdown", onPointerDown);
-  window.addEventListener("wheel", stopEvent, true);
+  window.addEventListener("wheel", stopEvent, {
+    passive: false,
+    capture: true,
+  });
   document.body.appendChild(editable);
   editable.focus();
   editable.select();


### PR DESCRIPTION
Looks like event.stopPropagation() is not enough to stop Chrome from handling the pinch zoom event when the cursor is over the <textarea> for the wysiwg text.

On this PR, I added `event.preventDefault()` so that the Chrome browser does not handle the pinch zoom.

I tested this on:
- Chrome 84 ✅ 
- Brave 1.12 (Chromium 84) ✅ 
- Firefox (was not affected by the problem and still works the same way) ✅ 
- Safari (zoom and panning on wysiwg is still broken) 🔴 