### PR TITLE
Fix multiline hint text cropping

### DIFF
--- a/src/components/HintViewer.scss
+++ b/src/components/HintViewer.scss
@@ -12,7 +12,7 @@
   white-space: pre;
   text-align: center;
   background-color: var(--overlay-background-color);
-  border-radius: 3px;
+  border-radius: 4px;
 
   @media #{$media-query} {
     position: static;

--- a/src/components/HintViewer.scss
+++ b/src/components/HintViewer.scss
@@ -8,17 +8,15 @@
   position: absolute;
   top: 54px;
   transform: translateX(calc(-50% - 16px)); /* 16px is half of lock icon */
+  padding: 0.2rem 0.4rem;
   white-space: pre;
   text-align: center;
+  background-color: var(--overlay-background-color);
+  border-radius: 3px;
+
   @media #{$media-query} {
     position: static;
     transform: none;
     margin-top: 0.5rem;
-  }
-
-  > span {
-    background-color: var(--overlay-background-color);
-    padding: 0.2rem 0.4rem;
-    border-radius: 3px;
   }
 }


### PR DESCRIPTION
Fixes #2063

I decided to go with this variant, just add background for the whole Hint block, because otherwise padding looks ugly anyway (see issue)

![image](https://user-images.githubusercontent.com/12836237/91175805-04791000-e6ea-11ea-9923-6a744883d0b8.png)


There is another issue with hint, it does not look great with small screens, I think I'll look into that with different PR

<img width="481" alt="Screenshot 2020-08-25 at 15 47 10" src="https://user-images.githubusercontent.com/12836237/91176061-6b96c480-e6ea-11ea-8c23-0b3d20ccfbe2.png">
