### PR TITLE
Support rotating two-point lines (angle can be non-zero)

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -20,7 +20,7 @@ import {
   getDrawingVersion,
   getSyncableElements,
   newLinearElement,
-  resizeElements,
+  transformElements,
   getElementWithTransformHandleType,
   getResizeOffsetXY,
   getResizeArrowDirection,
@@ -2899,7 +2899,7 @@ class App extends React.Component<ExcalidrawProps, AppState> {
           this.state.gridSize,
         );
         if (
-          resizeElements(
+          transformElements(
             transformHandleType,
             (newTransformHandle) => {
               pointerDownState.resize.handleType = newTransformHandle;

--- a/src/element/index.ts
+++ b/src/element/index.ts
@@ -38,7 +38,7 @@ export {
   getTransformHandleTypeFromCoords,
 } from "./resizeTest";
 export {
-  resizeElements,
+  transformElements,
   getResizeOffsetXY,
   getResizeArrowDirection,
 } from "./resizeElements";

--- a/src/element/resizeElements.ts
+++ b/src/element/resizeElements.ts
@@ -34,8 +34,8 @@ const normalizeAngle = (angle: number): number => {
   return angle;
 };
 
-// Returns true when a resize (scaling/rotation) happened
-export const resizeElements = (
+// Returns true when transform (resizing/rotation) happened
+export const transformElements = (
   transformHandleType: MaybeTransformHandleType,
   setTransformHandle: (nextTransformHandle: MaybeTransformHandleType) => void,
   selectedElements: readonly NonDeletedExcalidrawElement[],

--- a/src/element/resizeElements.ts
+++ b/src/element/resizeElements.ts
@@ -164,7 +164,7 @@ const rotateSingleElement = (
   mutateElement(element, { angle });
 };
 
-// XXX just to make sure while developing and testing
+// used in DEV only
 const validateTwoPointElementNormalized = (
   element: NonDeleted<ExcalidrawLinearElement>,
 ) => {
@@ -177,6 +177,19 @@ const validateTwoPointElementNormalized = (
   ) {
     throw new Error("Two-point element is not normalized");
   }
+};
+
+const getPerfectElementSizeWithRotation = (
+  elementType: string,
+  width: number,
+  height: number,
+  angle: number,
+): [number, number] => {
+  const size = getPerfectElementSize(
+    elementType,
+    ...rotate(width, height, 0, 0, angle),
+  );
+  return rotate(size.width, size.height, 0, 0, -angle);
 };
 
 const reshapeSingleTwoPointElement = (
@@ -208,7 +221,12 @@ const reshapeSingleTwoPointElement = (
           element.y + element.points[1][1] - rotatedY,
         ];
   if (isRotateWithDiscreteAngle) {
-    ({ width, height } = getPerfectElementSize(element.type, width, height));
+    [width, height] = getPerfectElementSizeWithRotation(
+      element.type,
+      width,
+      height,
+      element.angle,
+    );
   }
   const [nextElementX, nextElementY] = adjustXYWithRotation(
     resizeArrowDirection === "end"

--- a/src/element/resizeElements.ts
+++ b/src/element/resizeElements.ts
@@ -186,7 +186,9 @@ const reshapeSingleTwoPointElement = (
   pointerX: number,
   pointerY: number,
 ) => {
-  validateTwoPointElementNormalized(element);
+  if (process.env.NODE_ENV !== "production") {
+    validateTwoPointElementNormalized(element);
+  }
   const [x1, y1, x2, y2] = getElementAbsoluteCoords(element);
   const cx = (x1 + x2) / 2;
   const cy = (y1 + y2) / 2;

--- a/src/element/resizeElements.ts
+++ b/src/element/resizeElements.ts
@@ -187,37 +187,6 @@ const reshapeSingleTwoPointElement = (
   pointerY: number,
 ) => {
   validateTwoPointElementNormalized(element);
-  if (isRotateWithDiscreteAngle && element.angle === 0) {
-    // FIXME shift locking only works for unrotated lines
-    if (resizeArrowDirection === "end") {
-      const { width, height } = getPerfectElementSize(
-        element.type,
-        pointerX - element.x,
-        pointerY - element.y,
-      );
-      mutateElement(element, {
-        points: [
-          [0, 0],
-          [width, height],
-        ],
-      });
-    } else {
-      const { width, height } = getPerfectElementSize(
-        element.type,
-        element.x + element.width - pointerX,
-        element.y + element.height - pointerY,
-      );
-      mutateElement(element, {
-        x: element.x + element.width - width,
-        y: element.y + element.height - height,
-        points: [
-          [0, 0],
-          [width, height],
-        ],
-      });
-    }
-    return;
-  }
   const [x1, y1, x2, y2] = getElementAbsoluteCoords(element);
   const cx = (x1 + x2) / 2;
   const cy = (y1 + y2) / 2;
@@ -229,13 +198,16 @@ const reshapeSingleTwoPointElement = (
     cy,
     -element.angle,
   );
-  const [width, height] =
+  let [width, height] =
     resizeArrowDirection === "end"
       ? [rotatedX - element.x, rotatedY - element.y]
       : [
           element.x + element.points[1][0] - rotatedX,
           element.y + element.points[1][1] - rotatedY,
         ];
+  if (isRotateWithDiscreteAngle) {
+    ({ width, height } = getPerfectElementSize(element.type, width, height));
+  }
   const [nextElementX, nextElementY] = adjustXYWithRotation(
     resizeArrowDirection === "end"
       ? { s: true, e: true }

--- a/src/element/resizeElements.ts
+++ b/src/element/resizeElements.ts
@@ -613,66 +613,21 @@ const rotateMultipleElements = (
     centerAngle -= centerAngle % SHIFT_LOCKING_ANGLE;
   }
   elements.forEach((element, index) => {
-    if (isLinearElement(element) && element.points.length === 2) {
-      // FIXME this is a bit tricky (how can we make this more readable?)
-      const originalElement = originalElements[index];
-      if (
-        !isLinearElement(originalElement) ||
-        originalElement.points.length !== 2
-      ) {
-        throw new Error("original element not compatible"); // should not happen
-      }
-      const [x1, y1, x2, y2] = getElementAbsoluteCoords(originalElement);
-      const cx = (x1 + x2) / 2;
-      const cy = (y1 + y2) / 2;
-      const [rotatedCX, rotatedCY] = rotate(
-        cx,
-        cy,
-        centerX,
-        centerY,
-        centerAngle,
-      );
-      const { points } = originalElement;
-      const [rotatedX, rotatedY] = rotate(
-        points[1][0],
-        points[1][1],
-        points[0][0],
-        points[0][1],
-        centerAngle,
-      );
-      mutateElement(element, {
-        x:
-          originalElement.x +
-          (rotatedCX - cx) +
-          ((originalElement.points[0][0] + originalElement.points[1][0]) / 2 -
-            (points[0][0] + rotatedX) / 2),
-        y:
-          originalElement.y +
-          (rotatedCY - cy) +
-          ((originalElement.points[0][1] + originalElement.points[1][1]) / 2 -
-            (points[0][1] + rotatedY) / 2),
-        points: [
-          [points[0][0], points[0][1]],
-          [rotatedX, rotatedY],
-        ],
-      });
-    } else {
-      const [x1, y1, x2, y2] = getElementAbsoluteCoords(element);
-      const cx = (x1 + x2) / 2;
-      const cy = (y1 + y2) / 2;
-      const [rotatedCX, rotatedCY] = rotate(
-        cx,
-        cy,
-        centerX,
-        centerY,
-        centerAngle + originalElements[index].angle - element.angle,
-      );
-      mutateElement(element, {
-        x: element.x + (rotatedCX - cx),
-        y: element.y + (rotatedCY - cy),
-        angle: normalizeAngle(centerAngle + originalElements[index].angle),
-      });
-    }
+    const [x1, y1, x2, y2] = getElementAbsoluteCoords(element);
+    const cx = (x1 + x2) / 2;
+    const cy = (y1 + y2) / 2;
+    const [rotatedCX, rotatedCY] = rotate(
+      cx,
+      cy,
+      centerX,
+      centerY,
+      centerAngle + originalElements[index].angle - element.angle,
+    );
+    mutateElement(element, {
+      x: element.x + (rotatedCX - cx),
+      y: element.y + (rotatedCY - cy),
+      angle: normalizeAngle(centerAngle + originalElements[index].angle),
+    });
   });
 };
 

--- a/src/element/transformHandles.ts
+++ b/src/element/transformHandles.ts
@@ -49,7 +49,6 @@ const OMIT_SIDES_FOR_LINE_SLASH = {
   w: true,
   nw: true,
   se: true,
-  rotation: true,
 };
 
 const OMIT_SIDES_FOR_LINE_BACKSLASH = {
@@ -59,7 +58,6 @@ const OMIT_SIDES_FOR_LINE_BACKSLASH = {
   w: true,
   ne: true,
   sw: true,
-  rotation: true,
 };
 
 const generateTransformHandle = (


### PR DESCRIPTION
We had a discussion in #1994 about various ideas and ended up with just fix the issue at first.

Previously, we only allowed and assumed `angle=0` for two-point lines and arrows, because there is no notation of angle for 1-d lines. This PR changes that assumption and support `angle` for two-point lines, because otherwise we can't fix #1994. close #1994 

Now, we can rotate two-point lines. close #1673 and close #1663 

Furthermore, group rotation with two-point lines are much nicer with stable bounding box.

![excal91](https://user-images.githubusercontent.com/490574/91445627-528c4000-e8b1-11ea-9be2-ec8675940989.gif)


