### PR TITLE
fix collab MOUSE_LOCATION payload naming for legacy versions

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1297,12 +1297,17 @@ class App extends React.Component<ExcalidrawProps, AppState> {
               break;
             case "MOUSE_LOCATION": {
               const {
-                socketId,
                 pointer,
                 button,
                 username,
                 selectedElementIds,
               } = decryptedData.payload;
+
+              const socketId: SocketUpdateDataSource["MOUSE_LOCATION"]["payload"]["socketId"] =
+                decryptedData.payload.socketId ||
+                // @ts-ignore legacy, see #2094 (#2097)
+                decryptedData.payload.socketID;
+
               // NOTE purposefully mutating collaborators map in case of
               //  pointer updates so as not to trigger LayerUI rerender
               this.setState((state) => {


### PR DESCRIPTION
fix https://github.com/excalidraw/excalidraw/issues/2094

We've unfortunately changed naming of the MOUSE_LOCATION payload prop from `socketID` → `socketId`. I've missed this would cause issues due to SW caching.