### PR TITLE
Fix history initialization

### DIFF
--- a/src/actions/actionExport.tsx
+++ b/src/actions/actionExport.tsx
@@ -125,7 +125,7 @@ export const actionLoadScene = register({
         ...loadedAppState,
         errorMessage: error,
       },
-      commitToHistory: false,
+      commitToHistory: true,
     };
   },
   PanelComponent: ({ updateData, appState }) => (

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -3602,7 +3602,7 @@ class App extends React.Component<ExcalidrawProps, AppState> {
               ...(appState || this.state),
               isLoading: false,
             },
-            commitToHistory: false,
+            commitToHistory: true,
           }),
         )
         .catch((error) => {

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -554,7 +554,11 @@ class App extends React.Component<ExcalidrawProps, AppState> {
           ),
         };
       }
-      this.syncActionResult(scene);
+      history.clear();
+      this.syncActionResult({
+        ...scene,
+        commitToHistory: true,
+      });
     }
   };
 
@@ -1162,11 +1166,12 @@ class App extends React.Component<ExcalidrawProps, AppState> {
 
       const updateScene = (
         decryptedData: SocketUpdateDataSource[SCENE.INIT | SCENE.UPDATE],
-        { scrollToContent = false }: { scrollToContent?: boolean } = {},
+        { init = false }: { init?: boolean } = {},
       ) => {
         const { elements: remoteElements } = decryptedData.payload;
 
-        if (scrollToContent) {
+        if (init) {
+          history.resumeRecording();
           this.setState({
             ...this.state,
             ...calculateScrollCenter(
@@ -1291,7 +1296,7 @@ class App extends React.Component<ExcalidrawProps, AppState> {
               return;
             case SCENE.INIT: {
               if (!this.portal.socketInitialized) {
-                updateScene(decryptedData, { scrollToContent: true });
+                updateScene(decryptedData, { init: true });
               }
               break;
             }

--- a/src/element/newElement.test.ts
+++ b/src/element/newElement.test.ts
@@ -1,9 +1,6 @@
-import {
-  newTextElement,
-  duplicateElement,
-  newLinearElement,
-} from "./newElement";
+import { duplicateElement } from "./newElement";
 import { mutateElement } from "./mutateElement";
+import { API } from "../tests/helpers/api";
 
 const isPrimitive = (val: any) => {
   const type = typeof val;
@@ -22,7 +19,7 @@ const assertCloneObjects = (source: any, clone: any) => {
 };
 
 it("clones arrow element", () => {
-  const element = newLinearElement({
+  const element = API.createElement({
     type: "arrow",
     x: 0,
     y: 0,
@@ -68,7 +65,8 @@ it("clones arrow element", () => {
 });
 
 it("clones text element", () => {
-  const element = newTextElement({
+  const element = API.createElement({
+    type: "text",
     x: 0,
     y: 0,
     strokeColor: "#000000",

--- a/src/tests/__snapshots__/regressionTests.test.tsx.snap
+++ b/src/tests/__snapshots__/regressionTests.test.tsx.snap
@@ -167,6 +167,16 @@ Object {
         "editingGroupId": null,
         "editingLinearElement": null,
         "name": "Untitled-201933152653",
+        "selectedElementIds": Object {},
+        "viewBackgroundColor": "#ffffff",
+      },
+      "elements": Array [],
+    },
+    Object {
+      "appState": Object {
+        "editingGroupId": null,
+        "editingLinearElement": null,
+        "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
         },
@@ -610,6 +620,16 @@ Object {
         "editingGroupId": null,
         "editingLinearElement": null,
         "name": "Untitled-201933152653",
+        "selectedElementIds": Object {},
+        "viewBackgroundColor": "#ffffff",
+      },
+      "elements": Array [],
+    },
+    Object {
+      "appState": Object {
+        "editingGroupId": null,
+        "editingLinearElement": null,
+        "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
         },
@@ -1034,6 +1054,16 @@ Object {
   "recording": false,
   "redoStack": Array [],
   "stateHistory": Array [
+    Object {
+      "appState": Object {
+        "editingGroupId": null,
+        "editingLinearElement": null,
+        "name": "Untitled-201933152653",
+        "selectedElementIds": Object {},
+        "viewBackgroundColor": "#ffffff",
+      },
+      "elements": Array [],
+    },
     Object {
       "appState": Object {
         "editingGroupId": null,
@@ -1732,6 +1762,16 @@ Object {
         "editingGroupId": null,
         "editingLinearElement": null,
         "name": "Untitled-201933152653",
+        "selectedElementIds": Object {},
+        "viewBackgroundColor": "#ffffff",
+      },
+      "elements": Array [],
+    },
+    Object {
+      "appState": Object {
+        "editingGroupId": null,
+        "editingLinearElement": null,
+        "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
         },
@@ -1967,6 +2007,16 @@ Object {
   "recording": false,
   "redoStack": Array [],
   "stateHistory": Array [
+    Object {
+      "appState": Object {
+        "editingGroupId": null,
+        "editingLinearElement": null,
+        "name": "Untitled-201933152653",
+        "selectedElementIds": Object {},
+        "viewBackgroundColor": "#ffffff",
+      },
+      "elements": Array [],
+    },
     Object {
       "appState": Object {
         "editingGroupId": null,
@@ -2370,6 +2420,16 @@ Object {
         "editingGroupId": null,
         "editingLinearElement": null,
         "name": "Untitled-201933152653",
+        "selectedElementIds": Object {},
+        "viewBackgroundColor": "#ffffff",
+      },
+      "elements": Array [],
+    },
+    Object {
+      "appState": Object {
+        "editingGroupId": null,
+        "editingLinearElement": null,
+        "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
         },
@@ -2569,6 +2629,16 @@ Object {
         "editingGroupId": null,
         "editingLinearElement": null,
         "name": "Untitled-201933152653",
+        "selectedElementIds": Object {},
+        "viewBackgroundColor": "#ffffff",
+      },
+      "elements": Array [],
+    },
+    Object {
+      "appState": Object {
+        "editingGroupId": null,
+        "editingLinearElement": null,
+        "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
         },
@@ -2758,6 +2828,16 @@ Object {
   "recording": false,
   "redoStack": Array [],
   "stateHistory": Array [
+    Object {
+      "appState": Object {
+        "editingGroupId": null,
+        "editingLinearElement": null,
+        "name": "Untitled-201933152653",
+        "selectedElementIds": Object {},
+        "viewBackgroundColor": "#ffffff",
+      },
+      "elements": Array [],
+    },
     Object {
       "appState": Object {
         "editingGroupId": null,
@@ -3160,6 +3240,16 @@ Object {
         "editingGroupId": null,
         "editingLinearElement": null,
         "name": "Untitled-201933152653",
+        "selectedElementIds": Object {},
+        "viewBackgroundColor": "#ffffff",
+      },
+      "elements": Array [],
+    },
+    Object {
+      "appState": Object {
+        "editingGroupId": null,
+        "editingLinearElement": null,
+        "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
         },
@@ -3446,6 +3536,16 @@ Object {
         "editingGroupId": null,
         "editingLinearElement": null,
         "name": "Untitled-201933152653",
+        "selectedElementIds": Object {},
+        "viewBackgroundColor": "#ffffff",
+      },
+      "elements": Array [],
+    },
+    Object {
+      "appState": Object {
+        "editingGroupId": null,
+        "editingLinearElement": null,
+        "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
         },
@@ -3622,6 +3722,16 @@ Object {
   "recording": false,
   "redoStack": Array [],
   "stateHistory": Array [
+    Object {
+      "appState": Object {
+        "editingGroupId": null,
+        "editingLinearElement": null,
+        "name": "Untitled-201933152653",
+        "selectedElementIds": Object {},
+        "viewBackgroundColor": "#ffffff",
+      },
+      "elements": Array [],
+    },
     Object {
       "appState": Object {
         "editingGroupId": null,
@@ -3865,6 +3975,16 @@ Object {
   "recording": false,
   "redoStack": Array [],
   "stateHistory": Array [
+    Object {
+      "appState": Object {
+        "editingGroupId": null,
+        "editingLinearElement": null,
+        "name": "Untitled-201933152653",
+        "selectedElementIds": Object {},
+        "viewBackgroundColor": "#ffffff",
+      },
+      "elements": Array [],
+    },
     Object {
       "appState": Object {
         "editingGroupId": null,
@@ -4119,6 +4239,16 @@ Object {
   "recording": false,
   "redoStack": Array [],
   "stateHistory": Array [
+    Object {
+      "appState": Object {
+        "editingGroupId": null,
+        "editingLinearElement": null,
+        "name": "Untitled-201933152653",
+        "selectedElementIds": Object {},
+        "viewBackgroundColor": "#ffffff",
+      },
+      "elements": Array [],
+    },
     Object {
       "appState": Object {
         "editingGroupId": null,
@@ -4476,6 +4606,16 @@ Object {
         "editingGroupId": null,
         "editingLinearElement": null,
         "name": "Untitled-201933152653",
+        "selectedElementIds": Object {},
+        "viewBackgroundColor": "#ffffff",
+      },
+      "elements": Array [],
+    },
+    Object {
+      "appState": Object {
+        "editingGroupId": null,
+        "editingLinearElement": null,
+        "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
         },
@@ -4719,6 +4859,16 @@ Object {
   "recording": false,
   "redoStack": Array [],
   "stateHistory": Array [
+    Object {
+      "appState": Object {
+        "editingGroupId": null,
+        "editingLinearElement": null,
+        "name": "Untitled-201933152653",
+        "selectedElementIds": Object {},
+        "viewBackgroundColor": "#ffffff",
+      },
+      "elements": Array [],
+    },
     Object {
       "appState": Object {
         "editingGroupId": null,
@@ -5000,6 +5150,16 @@ Object {
         "editingGroupId": null,
         "editingLinearElement": null,
         "name": "Untitled-201933152653",
+        "selectedElementIds": Object {},
+        "viewBackgroundColor": "#ffffff",
+      },
+      "elements": Array [],
+    },
+    Object {
+      "appState": Object {
+        "editingGroupId": null,
+        "editingLinearElement": null,
+        "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
         },
@@ -5156,6 +5316,16 @@ Object {
   "recording": false,
   "redoStack": Array [],
   "stateHistory": Array [
+    Object {
+      "appState": Object {
+        "editingGroupId": null,
+        "editingLinearElement": null,
+        "name": "Untitled-201933152653",
+        "selectedElementIds": Object {},
+        "viewBackgroundColor": "#ffffff",
+      },
+      "elements": Array [],
+    },
     Object {
       "appState": Object {
         "editingGroupId": null,
@@ -5353,6 +5523,16 @@ Object {
   "recording": false,
   "redoStack": Array [],
   "stateHistory": Array [
+    Object {
+      "appState": Object {
+        "editingGroupId": null,
+        "editingLinearElement": null,
+        "name": "Untitled-201933152653",
+        "selectedElementIds": Object {},
+        "viewBackgroundColor": "#ffffff",
+      },
+      "elements": Array [],
+    },
     Object {
       "appState": Object {
         "editingGroupId": null,
@@ -5756,6 +5936,16 @@ Object {
   "recording": false,
   "redoStack": Array [],
   "stateHistory": Array [
+    Object {
+      "appState": Object {
+        "editingGroupId": null,
+        "editingLinearElement": null,
+        "name": "Untitled-201933152653",
+        "selectedElementIds": Object {},
+        "viewBackgroundColor": "#ffffff",
+      },
+      "elements": Array [],
+    },
     Object {
       "appState": Object {
         "editingGroupId": null,
@@ -8043,6 +8233,16 @@ Object {
         "editingGroupId": null,
         "editingLinearElement": null,
         "name": "Untitled-201933152653",
+        "selectedElementIds": Object {},
+        "viewBackgroundColor": "#ffffff",
+      },
+      "elements": Array [],
+    },
+    Object {
+      "appState": Object {
+        "editingGroupId": null,
+        "editingLinearElement": null,
+        "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
         },
@@ -9101,6 +9301,16 @@ Object {
         "editingGroupId": null,
         "editingLinearElement": null,
         "name": "Untitled-201933152653",
+        "selectedElementIds": Object {},
+        "viewBackgroundColor": "#ffffff",
+      },
+      "elements": Array [],
+    },
+    Object {
+      "appState": Object {
+        "editingGroupId": null,
+        "editingLinearElement": null,
+        "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
         },
@@ -9240,6 +9450,16 @@ Object {
         "editingGroupId": null,
         "editingLinearElement": null,
         "name": "Untitled-201933152653",
+        "selectedElementIds": Object {},
+        "viewBackgroundColor": "#ffffff",
+      },
+      "elements": Array [],
+    },
+    Object {
+      "appState": Object {
+        "editingGroupId": null,
+        "editingLinearElement": null,
+        "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
         },
@@ -9374,6 +9594,16 @@ Object {
   "recording": false,
   "redoStack": Array [],
   "stateHistory": Array [
+    Object {
+      "appState": Object {
+        "editingGroupId": null,
+        "editingLinearElement": null,
+        "name": "Untitled-201933152653",
+        "selectedElementIds": Object {},
+        "viewBackgroundColor": "#ffffff",
+      },
+      "elements": Array [],
+    },
     Object {
       "appState": Object {
         "editingGroupId": null,
@@ -9526,6 +9756,16 @@ Object {
   "recording": false,
   "redoStack": Array [],
   "stateHistory": Array [
+    Object {
+      "appState": Object {
+        "editingGroupId": null,
+        "editingLinearElement": null,
+        "name": "Untitled-201933152653",
+        "selectedElementIds": Object {},
+        "viewBackgroundColor": "#ffffff",
+      },
+      "elements": Array [],
+    },
     Object {
       "appState": Object {
         "editingGroupId": null,
@@ -9696,6 +9936,16 @@ Object {
         "editingGroupId": null,
         "editingLinearElement": null,
         "name": "Untitled-201933152653",
+        "selectedElementIds": Object {},
+        "viewBackgroundColor": "#ffffff",
+      },
+      "elements": Array [],
+    },
+    Object {
+      "appState": Object {
+        "editingGroupId": null,
+        "editingLinearElement": null,
+        "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
         },
@@ -9856,6 +10106,16 @@ Object {
   "recording": false,
   "redoStack": Array [],
   "stateHistory": Array [
+    Object {
+      "appState": Object {
+        "editingGroupId": null,
+        "editingLinearElement": null,
+        "name": "Untitled-201933152653",
+        "selectedElementIds": Object {},
+        "viewBackgroundColor": "#ffffff",
+      },
+      "elements": Array [],
+    },
     Object {
       "appState": Object {
         "editingGroupId": null,
@@ -10026,6 +10286,16 @@ Object {
         "editingGroupId": null,
         "editingLinearElement": null,
         "name": "Untitled-201933152653",
+        "selectedElementIds": Object {},
+        "viewBackgroundColor": "#ffffff",
+      },
+      "elements": Array [],
+    },
+    Object {
+      "appState": Object {
+        "editingGroupId": null,
+        "editingLinearElement": null,
+        "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
         },
@@ -10178,6 +10448,16 @@ Object {
         "editingGroupId": null,
         "editingLinearElement": null,
         "name": "Untitled-201933152653",
+        "selectedElementIds": Object {},
+        "viewBackgroundColor": "#ffffff",
+      },
+      "elements": Array [],
+    },
+    Object {
+      "appState": Object {
+        "editingGroupId": null,
+        "editingLinearElement": null,
+        "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
         },
@@ -10312,6 +10592,16 @@ Object {
   "recording": false,
   "redoStack": Array [],
   "stateHistory": Array [
+    Object {
+      "appState": Object {
+        "editingGroupId": null,
+        "editingLinearElement": null,
+        "name": "Untitled-201933152653",
+        "selectedElementIds": Object {},
+        "viewBackgroundColor": "#ffffff",
+      },
+      "elements": Array [],
+    },
     Object {
       "appState": Object {
         "editingGroupId": null,
@@ -10469,6 +10759,16 @@ Object {
         "editingGroupId": null,
         "editingLinearElement": null,
         "name": "Untitled-201933152653",
+        "selectedElementIds": Object {},
+        "viewBackgroundColor": "#ffffff",
+      },
+      "elements": Array [],
+    },
+    Object {
+      "appState": Object {
+        "editingGroupId": null,
+        "editingLinearElement": null,
+        "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
         },
@@ -10621,6 +10921,16 @@ Object {
         "editingGroupId": null,
         "editingLinearElement": null,
         "name": "Untitled-201933152653",
+        "selectedElementIds": Object {},
+        "viewBackgroundColor": "#ffffff",
+      },
+      "elements": Array [],
+    },
+    Object {
+      "appState": Object {
+        "editingGroupId": null,
+        "editingLinearElement": null,
+        "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
         },
@@ -10768,6 +11078,16 @@ Object {
   "recording": false,
   "redoStack": Array [],
   "stateHistory": Array [
+    Object {
+      "appState": Object {
+        "editingGroupId": null,
+        "editingLinearElement": null,
+        "name": "Untitled-201933152653",
+        "selectedElementIds": Object {},
+        "viewBackgroundColor": "#ffffff",
+      },
+      "elements": Array [],
+    },
     Object {
       "appState": Object {
         "editingGroupId": null,
@@ -11073,6 +11393,16 @@ Object {
   "recording": false,
   "redoStack": Array [],
   "stateHistory": Array [
+    Object {
+      "appState": Object {
+        "editingGroupId": null,
+        "editingLinearElement": null,
+        "name": "Untitled-201933152653",
+        "selectedElementIds": Object {},
+        "viewBackgroundColor": "#ffffff",
+      },
+      "elements": Array [],
+    },
     Object {
       "appState": Object {
         "editingGroupId": null,
@@ -11646,6 +11976,16 @@ Object {
         "editingGroupId": null,
         "editingLinearElement": null,
         "name": "Untitled-201933152653",
+        "selectedElementIds": Object {},
+        "viewBackgroundColor": "#ffffff",
+      },
+      "elements": Array [],
+    },
+    Object {
+      "appState": Object {
+        "editingGroupId": null,
+        "editingLinearElement": null,
+        "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
         },
@@ -11812,7 +12152,18 @@ exports[`regression tests pinch-to-zoom works: [end of test] history 1`] = `
 Object {
   "recording": false,
   "redoStack": Array [],
-  "stateHistory": Array [],
+  "stateHistory": Array [
+    Object {
+      "appState": Object {
+        "editingGroupId": null,
+        "editingLinearElement": null,
+        "name": "Untitled-201933152653",
+        "selectedElementIds": Object {},
+        "viewBackgroundColor": "#ffffff",
+      },
+      "elements": Array [],
+    },
+  ],
 }
 `;
 
@@ -11886,7 +12237,18 @@ exports[`regression tests rerenders UI on language change: [end of test] history
 Object {
   "recording": false,
   "redoStack": Array [],
-  "stateHistory": Array [],
+  "stateHistory": Array [
+    Object {
+      "appState": Object {
+        "editingGroupId": null,
+        "editingLinearElement": null,
+        "name": "Untitled-201933152653",
+        "selectedElementIds": Object {},
+        "viewBackgroundColor": "#ffffff",
+      },
+      "elements": Array [],
+    },
+  ],
 }
 `;
 
@@ -12005,6 +12367,16 @@ Object {
   "recording": false,
   "redoStack": Array [],
   "stateHistory": Array [
+    Object {
+      "appState": Object {
+        "editingGroupId": null,
+        "editingLinearElement": null,
+        "name": "Untitled-201933152653",
+        "selectedElementIds": Object {},
+        "viewBackgroundColor": "#ffffff",
+      },
+      "elements": Array [],
+    },
     Object {
       "appState": Object {
         "editingGroupId": null,
@@ -12868,6 +13240,16 @@ Object {
         "editingGroupId": null,
         "editingLinearElement": null,
         "name": "Untitled-201933152653",
+        "selectedElementIds": Object {},
+        "viewBackgroundColor": "#ffffff",
+      },
+      "elements": Array [],
+    },
+    Object {
+      "appState": Object {
+        "editingGroupId": null,
+        "editingLinearElement": null,
+        "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
         },
@@ -13292,6 +13674,16 @@ Object {
         "editingGroupId": null,
         "editingLinearElement": null,
         "name": "Untitled-201933152653",
+        "selectedElementIds": Object {},
+        "viewBackgroundColor": "#ffffff",
+      },
+      "elements": Array [],
+    },
+    Object {
+      "appState": Object {
+        "editingGroupId": null,
+        "editingLinearElement": null,
+        "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
         },
@@ -13629,6 +14021,16 @@ Object {
         "editingGroupId": null,
         "editingLinearElement": null,
         "name": "Untitled-201933152653",
+        "selectedElementIds": Object {},
+        "viewBackgroundColor": "#ffffff",
+      },
+      "elements": Array [],
+    },
+    Object {
+      "appState": Object {
+        "editingGroupId": null,
+        "editingLinearElement": null,
+        "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
         },
@@ -13883,6 +14285,16 @@ Object {
         "editingGroupId": null,
         "editingLinearElement": null,
         "name": "Untitled-201933152653",
+        "selectedElementIds": Object {},
+        "viewBackgroundColor": "#ffffff",
+      },
+      "elements": Array [],
+    },
+    Object {
+      "appState": Object {
+        "editingGroupId": null,
+        "editingLinearElement": null,
+        "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
         },
@@ -14069,6 +14481,16 @@ Object {
   "recording": false,
   "redoStack": Array [],
   "stateHistory": Array [
+    Object {
+      "appState": Object {
+        "editingGroupId": null,
+        "editingLinearElement": null,
+        "name": "Untitled-201933152653",
+        "selectedElementIds": Object {},
+        "viewBackgroundColor": "#ffffff",
+      },
+      "elements": Array [],
+    },
     Object {
       "appState": Object {
         "editingGroupId": null,
@@ -14886,6 +15308,16 @@ Object {
         "editingGroupId": null,
         "editingLinearElement": null,
         "name": "Untitled-201933152653",
+        "selectedElementIds": Object {},
+        "viewBackgroundColor": "#ffffff",
+      },
+      "elements": Array [],
+    },
+    Object {
+      "appState": Object {
+        "editingGroupId": null,
+        "editingLinearElement": null,
+        "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
         },
@@ -15595,6 +16027,16 @@ Object {
         "editingGroupId": null,
         "editingLinearElement": null,
         "name": "Untitled-201933152653",
+        "selectedElementIds": Object {},
+        "viewBackgroundColor": "#ffffff",
+      },
+      "elements": Array [],
+    },
+    Object {
+      "appState": Object {
+        "editingGroupId": null,
+        "editingLinearElement": null,
+        "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
         },
@@ -16205,6 +16647,16 @@ Object {
         "editingGroupId": null,
         "editingLinearElement": null,
         "name": "Untitled-201933152653",
+        "selectedElementIds": Object {},
+        "viewBackgroundColor": "#ffffff",
+      },
+      "elements": Array [],
+    },
+    Object {
+      "appState": Object {
+        "editingGroupId": null,
+        "editingLinearElement": null,
+        "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
         },
@@ -16721,6 +17173,16 @@ Object {
         "editingGroupId": null,
         "editingLinearElement": null,
         "name": "Untitled-201933152653",
+        "selectedElementIds": Object {},
+        "viewBackgroundColor": "#ffffff",
+      },
+      "elements": Array [],
+    },
+    Object {
+      "appState": Object {
+        "editingGroupId": null,
+        "editingLinearElement": null,
+        "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
         },
@@ -17190,6 +17652,16 @@ Object {
         "editingGroupId": null,
         "editingLinearElement": null,
         "name": "Untitled-201933152653",
+        "selectedElementIds": Object {},
+        "viewBackgroundColor": "#ffffff",
+      },
+      "elements": Array [],
+    },
+    Object {
+      "appState": Object {
+        "editingGroupId": null,
+        "editingLinearElement": null,
+        "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
         },
@@ -17570,6 +18042,16 @@ Object {
         "editingGroupId": null,
         "editingLinearElement": null,
         "name": "Untitled-201933152653",
+        "selectedElementIds": Object {},
+        "viewBackgroundColor": "#ffffff",
+      },
+      "elements": Array [],
+    },
+    Object {
+      "appState": Object {
+        "editingGroupId": null,
+        "editingLinearElement": null,
+        "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
         },
@@ -17865,6 +18347,16 @@ Object {
         "editingGroupId": null,
         "editingLinearElement": null,
         "name": "Untitled-201933152653",
+        "selectedElementIds": Object {},
+        "viewBackgroundColor": "#ffffff",
+      },
+      "elements": Array [],
+    },
+    Object {
+      "appState": Object {
+        "editingGroupId": null,
+        "editingLinearElement": null,
+        "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
         },
@@ -18090,6 +18582,16 @@ Object {
   "recording": false,
   "redoStack": Array [],
   "stateHistory": Array [
+    Object {
+      "appState": Object {
+        "editingGroupId": null,
+        "editingLinearElement": null,
+        "name": "Untitled-201933152653",
+        "selectedElementIds": Object {},
+        "viewBackgroundColor": "#ffffff",
+      },
+      "elements": Array [],
+    },
     Object {
       "appState": Object {
         "editingGroupId": null,
@@ -18960,6 +19462,16 @@ Object {
         "editingGroupId": null,
         "editingLinearElement": null,
         "name": "Untitled-201933152653",
+        "selectedElementIds": Object {},
+        "viewBackgroundColor": "#ffffff",
+      },
+      "elements": Array [],
+    },
+    Object {
+      "appState": Object {
+        "editingGroupId": null,
+        "editingLinearElement": null,
+        "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
         },
@@ -19720,6 +20232,16 @@ Object {
         "editingGroupId": null,
         "editingLinearElement": null,
         "name": "Untitled-201933152653",
+        "selectedElementIds": Object {},
+        "viewBackgroundColor": "#ffffff",
+      },
+      "elements": Array [],
+    },
+    Object {
+      "appState": Object {
+        "editingGroupId": null,
+        "editingLinearElement": null,
+        "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
         },
@@ -20379,6 +20901,16 @@ Object {
         "editingGroupId": null,
         "editingLinearElement": null,
         "name": "Untitled-201933152653",
+        "selectedElementIds": Object {},
+        "viewBackgroundColor": "#ffffff",
+      },
+      "elements": Array [],
+    },
+    Object {
+      "appState": Object {
+        "editingGroupId": null,
+        "editingLinearElement": null,
+        "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
         },
@@ -20933,6 +21465,16 @@ Object {
         "editingGroupId": null,
         "editingLinearElement": null,
         "name": "Untitled-201933152653",
+        "selectedElementIds": Object {},
+        "viewBackgroundColor": "#ffffff",
+      },
+      "elements": Array [],
+    },
+    Object {
+      "appState": Object {
+        "editingGroupId": null,
+        "editingLinearElement": null,
+        "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
         },
@@ -21093,6 +21635,16 @@ Object {
   "recording": false,
   "redoStack": Array [],
   "stateHistory": Array [
+    Object {
+      "appState": Object {
+        "editingGroupId": null,
+        "editingLinearElement": null,
+        "name": "Untitled-201933152653",
+        "selectedElementIds": Object {},
+        "viewBackgroundColor": "#ffffff",
+      },
+      "elements": Array [],
+    },
     Object {
       "appState": Object {
         "editingGroupId": null,
@@ -21381,6 +21933,16 @@ Object {
         "editingGroupId": null,
         "editingLinearElement": null,
         "name": "Untitled-201933152653",
+        "selectedElementIds": Object {},
+        "viewBackgroundColor": "#ffffff",
+      },
+      "elements": Array [],
+    },
+    Object {
+      "appState": Object {
+        "editingGroupId": null,
+        "editingLinearElement": null,
+        "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
         },
@@ -21638,6 +22200,16 @@ Object {
         "editingGroupId": null,
         "editingLinearElement": null,
         "name": "Untitled-201933152653",
+        "selectedElementIds": Object {},
+        "viewBackgroundColor": "#ffffff",
+      },
+      "elements": Array [],
+    },
+    Object {
+      "appState": Object {
+        "editingGroupId": null,
+        "editingLinearElement": null,
+        "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
         },
@@ -21770,6 +22342,16 @@ Object {
   "recording": false,
   "redoStack": Array [],
   "stateHistory": Array [
+    Object {
+      "appState": Object {
+        "editingGroupId": null,
+        "editingLinearElement": null,
+        "name": "Untitled-201933152653",
+        "selectedElementIds": Object {},
+        "viewBackgroundColor": "#ffffff",
+      },
+      "elements": Array [],
+    },
     Object {
       "appState": Object {
         "editingGroupId": null,
@@ -21969,6 +22551,16 @@ Object {
   "recording": false,
   "redoStack": Array [],
   "stateHistory": Array [
+    Object {
+      "appState": Object {
+        "editingGroupId": null,
+        "editingLinearElement": null,
+        "name": "Untitled-201933152653",
+        "selectedElementIds": Object {},
+        "viewBackgroundColor": "#ffffff",
+      },
+      "elements": Array [],
+    },
     Object {
       "appState": Object {
         "editingGroupId": null,
@@ -22203,6 +22795,16 @@ Object {
   "recording": false,
   "redoStack": Array [],
   "stateHistory": Array [
+    Object {
+      "appState": Object {
+        "editingGroupId": null,
+        "editingLinearElement": null,
+        "name": "Untitled-201933152653",
+        "selectedElementIds": Object {},
+        "viewBackgroundColor": "#ffffff",
+      },
+      "elements": Array [],
+    },
     Object {
       "appState": Object {
         "editingGroupId": null,
@@ -22492,6 +23094,16 @@ Object {
   "recording": false,
   "redoStack": Array [],
   "stateHistory": Array [
+    Object {
+      "appState": Object {
+        "editingGroupId": null,
+        "editingLinearElement": null,
+        "name": "Untitled-201933152653",
+        "selectedElementIds": Object {},
+        "viewBackgroundColor": "#ffffff",
+      },
+      "elements": Array [],
+    },
     Object {
       "appState": Object {
         "editingGroupId": null,
@@ -23311,6 +23923,16 @@ Object {
         "editingGroupId": null,
         "editingLinearElement": null,
         "name": "Untitled-201933152653",
+        "selectedElementIds": Object {},
+        "viewBackgroundColor": "#ffffff",
+      },
+      "elements": Array [],
+    },
+    Object {
+      "appState": Object {
+        "editingGroupId": null,
+        "editingLinearElement": null,
+        "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
         },
@@ -23589,6 +24211,16 @@ Object {
   "recording": false,
   "redoStack": Array [],
   "stateHistory": Array [
+    Object {
+      "appState": Object {
+        "editingGroupId": null,
+        "editingLinearElement": null,
+        "name": "Untitled-201933152653",
+        "selectedElementIds": Object {},
+        "viewBackgroundColor": "#ffffff",
+      },
+      "elements": Array [],
+    },
     Object {
       "appState": Object {
         "editingGroupId": null,
@@ -23876,6 +24508,16 @@ Object {
   "recording": false,
   "redoStack": Array [],
   "stateHistory": Array [
+    Object {
+      "appState": Object {
+        "editingGroupId": null,
+        "editingLinearElement": null,
+        "name": "Untitled-201933152653",
+        "selectedElementIds": Object {},
+        "viewBackgroundColor": "#ffffff",
+      },
+      "elements": Array [],
+    },
     Object {
       "appState": Object {
         "editingGroupId": null,
@@ -24208,6 +24850,16 @@ Object {
         "editingGroupId": null,
         "editingLinearElement": null,
         "name": "Untitled-201933152653",
+        "selectedElementIds": Object {},
+        "viewBackgroundColor": "#ffffff",
+      },
+      "elements": Array [],
+    },
+    Object {
+      "appState": Object {
+        "editingGroupId": null,
+        "editingLinearElement": null,
+        "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
         },
@@ -24377,6 +25029,16 @@ Object {
   "recording": false,
   "redoStack": Array [],
   "stateHistory": Array [
+    Object {
+      "appState": Object {
+        "editingGroupId": null,
+        "editingLinearElement": null,
+        "name": "Untitled-201933152653",
+        "selectedElementIds": Object {},
+        "viewBackgroundColor": "#ffffff",
+      },
+      "elements": Array [],
+    },
     Object {
       "appState": Object {
         "editingGroupId": null,
@@ -24675,6 +25337,16 @@ Object {
         "editingGroupId": null,
         "editingLinearElement": null,
         "name": "Untitled-201933152653",
+        "selectedElementIds": Object {},
+        "viewBackgroundColor": "#ffffff",
+      },
+      "elements": Array [],
+    },
+    Object {
+      "appState": Object {
+        "editingGroupId": null,
+        "editingLinearElement": null,
+        "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
         },
@@ -24911,6 +25583,16 @@ Object {
         "editingGroupId": null,
         "editingLinearElement": null,
         "name": "Untitled-201933152653",
+        "selectedElementIds": Object {},
+        "viewBackgroundColor": "#ffffff",
+      },
+      "elements": Array [],
+    },
+    Object {
+      "appState": Object {
+        "editingGroupId": null,
+        "editingLinearElement": null,
+        "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
         },
@@ -25141,7 +25823,18 @@ exports[`regression tests shows context menu for canvas: [end of test] history 1
 Object {
   "recording": false,
   "redoStack": Array [],
-  "stateHistory": Array [],
+  "stateHistory": Array [
+    Object {
+      "appState": Object {
+        "editingGroupId": null,
+        "editingLinearElement": null,
+        "name": "Untitled-201933152653",
+        "selectedElementIds": Object {},
+        "viewBackgroundColor": "#ffffff",
+      },
+      "elements": Array [],
+    },
+  ],
 }
 `;
 
@@ -25244,6 +25937,16 @@ Object {
   "recording": false,
   "redoStack": Array [],
   "stateHistory": Array [
+    Object {
+      "appState": Object {
+        "editingGroupId": null,
+        "editingLinearElement": null,
+        "name": "Untitled-201933152653",
+        "selectedElementIds": Object {},
+        "viewBackgroundColor": "#ffffff",
+      },
+      "elements": Array [],
+    },
     Object {
       "appState": Object {
         "editingGroupId": null,
@@ -25484,6 +26187,16 @@ Object {
   "recording": false,
   "redoStack": Array [],
   "stateHistory": Array [
+    Object {
+      "appState": Object {
+        "editingGroupId": null,
+        "editingLinearElement": null,
+        "name": "Untitled-201933152653",
+        "selectedElementIds": Object {},
+        "viewBackgroundColor": "#ffffff",
+      },
+      "elements": Array [],
+    },
     Object {
       "appState": Object {
         "editingGroupId": null,
@@ -26150,7 +26863,18 @@ exports[`regression tests spacebar + drag scrolls the canvas: [end of test] hist
 Object {
   "recording": false,
   "redoStack": Array [],
-  "stateHistory": Array [],
+  "stateHistory": Array [
+    Object {
+      "appState": Object {
+        "editingGroupId": null,
+        "editingLinearElement": null,
+        "name": "Untitled-201933152653",
+        "selectedElementIds": Object {},
+        "viewBackgroundColor": "#ffffff",
+      },
+      "elements": Array [],
+    },
+  ],
 }
 `;
 
@@ -26313,6 +27037,16 @@ Object {
   "recording": false,
   "redoStack": Array [],
   "stateHistory": Array [
+    Object {
+      "appState": Object {
+        "editingGroupId": null,
+        "editingLinearElement": null,
+        "name": "Untitled-201933152653",
+        "selectedElementIds": Object {},
+        "viewBackgroundColor": "#ffffff",
+      },
+      "elements": Array [],
+    },
     Object {
       "appState": Object {
         "editingGroupId": null,
@@ -27063,6 +27797,16 @@ Object {
         "editingGroupId": null,
         "editingLinearElement": null,
         "name": "Untitled-201933152653",
+        "selectedElementIds": Object {},
+        "viewBackgroundColor": "#ffffff",
+      },
+      "elements": Array [],
+    },
+    Object {
+      "appState": Object {
+        "editingGroupId": null,
+        "editingLinearElement": null,
+        "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
         },
@@ -27415,6 +28159,16 @@ Object {
         "editingGroupId": null,
         "editingLinearElement": null,
         "name": "Untitled-201933152653",
+        "selectedElementIds": Object {},
+        "viewBackgroundColor": "#ffffff",
+      },
+      "elements": Array [],
+    },
+    Object {
+      "appState": Object {
+        "editingGroupId": null,
+        "editingLinearElement": null,
+        "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
         },
@@ -27581,7 +28335,18 @@ exports[`regression tests two-finger scroll works: [end of test] history 1`] = `
 Object {
   "recording": false,
   "redoStack": Array [],
-  "stateHistory": Array [],
+  "stateHistory": Array [
+    Object {
+      "appState": Object {
+        "editingGroupId": null,
+        "editingLinearElement": null,
+        "name": "Untitled-201933152653",
+        "selectedElementIds": Object {},
+        "viewBackgroundColor": "#ffffff",
+      },
+      "elements": Array [],
+    },
+  ],
 }
 `;
 
@@ -27958,6 +28723,16 @@ Object {
         "editingGroupId": null,
         "editingLinearElement": null,
         "name": "Untitled-201933152653",
+        "selectedElementIds": Object {},
+        "viewBackgroundColor": "#ffffff",
+      },
+      "elements": Array [],
+    },
+    Object {
+      "appState": Object {
+        "editingGroupId": null,
+        "editingLinearElement": null,
+        "name": "Untitled-201933152653",
         "selectedElementIds": Object {
           "id0": true,
         },
@@ -28207,7 +28982,18 @@ exports[`regression tests zoom hotkeys: [end of test] history 1`] = `
 Object {
   "recording": false,
   "redoStack": Array [],
-  "stateHistory": Array [],
+  "stateHistory": Array [
+    Object {
+      "appState": Object {
+        "editingGroupId": null,
+        "editingLinearElement": null,
+        "name": "Untitled-201933152653",
+        "selectedElementIds": Object {},
+        "viewBackgroundColor": "#ffffff",
+      },
+      "elements": Array [],
+    },
+  ],
 }
 `;
 

--- a/src/tests/helpers/api.ts
+++ b/src/tests/helpers/api.ts
@@ -1,4 +1,12 @@
-import { ExcalidrawElement } from "../../element/types";
+import {
+  ExcalidrawElement,
+  ExcalidrawGenericElement,
+  ExcalidrawTextElement,
+  ExcalidrawLinearElement,
+} from "../../element/types";
+import { newElement, newTextElement, newLinearElement } from "../../element";
+import { DEFAULT_VERTICAL_ALIGN } from "../../constants";
+import { getDefaultAppState } from "../../appState";
 
 const { h } = window;
 
@@ -28,5 +36,103 @@ export class API {
     // @ts-ignore
     h.app.clearSelection(null);
     expect(API.getSelectedElements().length).toBe(0);
+  };
+
+  static createElement = <
+    T extends Exclude<ExcalidrawElement["type"], "selection">
+  >({
+    type,
+    id,
+    x = 0,
+    y = x,
+    width = 100,
+    height = width,
+    isDeleted = false,
+    ...rest
+  }: {
+    type: T;
+    x?: number;
+    y?: number;
+    height?: number;
+    width?: number;
+    id?: string;
+    isDeleted?: boolean;
+    // generic element props
+    strokeColor?: ExcalidrawGenericElement["strokeColor"];
+    backgroundColor?: ExcalidrawGenericElement["backgroundColor"];
+    fillStyle?: ExcalidrawGenericElement["fillStyle"];
+    strokeWidth?: ExcalidrawGenericElement["strokeWidth"];
+    strokeStyle?: ExcalidrawGenericElement["strokeStyle"];
+    strokeSharpness?: ExcalidrawGenericElement["strokeSharpness"];
+    roughness?: ExcalidrawGenericElement["roughness"];
+    opacity?: ExcalidrawGenericElement["opacity"];
+    // text props
+    text?: T extends "text" ? ExcalidrawTextElement["text"] : never;
+    fontSize?: T extends "text" ? ExcalidrawTextElement["fontSize"] : never;
+    fontFamily?: T extends "text" ? ExcalidrawTextElement["fontFamily"] : never;
+    textAlign?: T extends "text" ? ExcalidrawTextElement["textAlign"] : never;
+    verticalAlign?: T extends "text"
+      ? ExcalidrawTextElement["verticalAlign"]
+      : never;
+  }): T extends "arrow" | "line" | "draw"
+    ? ExcalidrawLinearElement
+    : T extends "text"
+    ? ExcalidrawTextElement
+    : ExcalidrawGenericElement => {
+    let element: Mutable<ExcalidrawElement> = null!;
+
+    const appState = h?.state || getDefaultAppState();
+
+    const base = {
+      x,
+      y,
+      strokeColor: rest.strokeColor ?? appState.currentItemStrokeColor,
+      backgroundColor:
+        rest.backgroundColor ?? appState.currentItemBackgroundColor,
+      fillStyle: rest.fillStyle ?? appState.currentItemFillStyle,
+      strokeWidth: rest.strokeWidth ?? appState.currentItemStrokeWidth,
+      strokeStyle: rest.strokeStyle ?? appState.currentItemStrokeStyle,
+      strokeSharpness:
+        rest.strokeSharpness ?? appState.currentItemStrokeSharpness,
+      roughness: rest.roughness ?? appState.currentItemRoughness,
+      opacity: rest.opacity ?? appState.currentItemOpacity,
+    };
+    switch (type) {
+      case "rectangle":
+      case "diamond":
+      case "ellipse":
+        element = newElement({
+          type: type as "rectangle" | "diamond" | "ellipse",
+          width,
+          height,
+          ...base,
+        });
+        break;
+      case "text":
+        element = newTextElement({
+          ...base,
+          text: rest.text || "test",
+          fontSize: rest.fontSize ?? appState.currentItemFontSize,
+          fontFamily: rest.fontFamily ?? appState.currentItemFontFamily,
+          textAlign: rest.textAlign ?? appState.currentItemTextAlign,
+          verticalAlign: rest.verticalAlign ?? DEFAULT_VERTICAL_ALIGN,
+        });
+        break;
+      case "arrow":
+      case "line":
+      case "draw":
+        element = newLinearElement({
+          type: type as "arrow" | "line" | "draw",
+          ...base,
+        });
+        break;
+    }
+    if (id) {
+      element.id = id;
+    }
+    if (isDeleted) {
+      element.isDeleted = isDeleted;
+    }
+    return element as any;
   };
 }

--- a/src/tests/helpers/ui.ts
+++ b/src/tests/helpers/ui.ts
@@ -192,7 +192,7 @@ export class UI {
       size?: number;
       width?: number;
       height?: number;
-    },
+    } = {},
   ): T extends "arrow" | "line" | "draw"
     ? ExcalidrawLinearElement
     : T extends "text"

--- a/src/tests/history.test.tsx
+++ b/src/tests/history.test.tsx
@@ -1,16 +1,16 @@
 import React from "react";
-import { render } from "./test-utils";
+import { render, GlobalTestState } from "./test-utils";
 import App from "../components/App";
 import { UI } from "./helpers/ui";
 import { API } from "./helpers/api";
 import { getDefaultAppState } from "../appState";
-import { waitFor } from "@testing-library/react";
+import { waitFor, fireEvent, createEvent } from "@testing-library/react";
 import { createUndoAction, createRedoAction } from "../actions/actionHistory";
 
 const { h } = window;
 
 describe("history", () => {
-  it("initializing scene should end up with single history entry", async () => {
+  it.only("initializing scene should end up with single history entry", async () => {
     render(
       <App
         initialData={{
@@ -58,5 +58,70 @@ describe("history", () => {
       expect.objectContaining({ id: rectangle.id, isDeleted: false }),
     ]);
     expect(API.getStateHistory().length).toBe(2);
+  });
+
+  it("scene import via drag&drop should create new history entry", async () => {
+    render(
+      <App
+        initialData={{
+          appState: {
+            ...getDefaultAppState(),
+            viewBackgroundColor: "#FFF",
+          },
+          elements: [API.createElement({ type: "rectangle", id: "A" })],
+        }}
+      />,
+    );
+
+    await waitFor(() => expect(h.state.viewBackgroundColor).toBe("#FFF"));
+    await waitFor(() =>
+      expect(h.elements).toEqual([expect.objectContaining({ id: "A" })]),
+    );
+    const fileDropEvent = createEvent.drop(GlobalTestState.canvas);
+    const file = new Blob(
+      [
+        JSON.stringify({
+          type: "excalidraw",
+          appState: {
+            ...getDefaultAppState(),
+            viewBackgroundColor: "#000",
+          },
+          elements: [API.createElement({ type: "rectangle", id: "B" })],
+        }),
+      ],
+      {
+        type: "application/json",
+      },
+    );
+    Object.defineProperty(fileDropEvent, "dataTransfer", {
+      value: {
+        files: [file],
+        getData: (_type: string) => {
+          return "";
+        },
+      },
+    });
+    fireEvent(GlobalTestState.canvas, fileDropEvent);
+
+    await waitFor(() => expect(API.getStateHistory().length).toBe(2));
+    expect(h.state.viewBackgroundColor).toBe("#000");
+    expect(h.elements).toEqual([
+      expect.objectContaining({ id: "B", isDeleted: false }),
+    ]);
+
+    const undoAction = createUndoAction(h.history);
+    const redoAction = createRedoAction(h.history);
+    h.app.actionManager.executeAction(undoAction);
+    expect(h.elements).toEqual([
+      expect.objectContaining({ id: "A", isDeleted: false }),
+      expect.objectContaining({ id: "B", isDeleted: true }),
+    ]);
+    expect(h.state.viewBackgroundColor).toBe("#FFF");
+    h.app.actionManager.executeAction(redoAction);
+    expect(h.state.viewBackgroundColor).toBe("#000");
+    expect(h.elements).toEqual([
+      expect.objectContaining({ id: "B", isDeleted: false }),
+      expect.objectContaining({ id: "A", isDeleted: true }),
+    ]);
   });
 });

--- a/src/tests/history.test.tsx
+++ b/src/tests/history.test.tsx
@@ -10,7 +10,7 @@ import { createUndoAction, createRedoAction } from "../actions/actionHistory";
 const { h } = window;
 
 describe("history", () => {
-  it.only("initializing scene should end up with single history entry", async () => {
+  it("initializing scene should end up with single history entry", async () => {
     render(
       <App
         initialData={{

--- a/src/tests/history.test.tsx
+++ b/src/tests/history.test.tsx
@@ -1,0 +1,62 @@
+import React from "react";
+import { render } from "./test-utils";
+import App from "../components/App";
+import { UI } from "./helpers/ui";
+import { API } from "./helpers/api";
+import { getDefaultAppState } from "../appState";
+import { waitFor } from "@testing-library/react";
+import { createUndoAction, createRedoAction } from "../actions/actionHistory";
+
+const { h } = window;
+
+describe("history", () => {
+  it("initializing scene should end up with single history entry", async () => {
+    render(
+      <App
+        initialData={{
+          appState: {
+            ...getDefaultAppState(),
+            zenModeEnabled: true,
+          },
+          elements: [API.createElement({ type: "rectangle", id: "A" })],
+        }}
+      />,
+    );
+
+    await waitFor(() => expect(h.state.zenModeEnabled).toBe(true));
+    await waitFor(() =>
+      expect(h.elements).toEqual([expect.objectContaining({ id: "A" })]),
+    );
+    const undoAction = createUndoAction(h.history);
+    const redoAction = createRedoAction(h.history);
+    h.app.actionManager.executeAction(undoAction);
+    expect(h.elements).toEqual([
+      expect.objectContaining({ id: "A", isDeleted: false }),
+    ]);
+    const rectangle = UI.createElement("rectangle");
+    expect(h.elements).toEqual([
+      expect.objectContaining({ id: "A" }),
+      expect.objectContaining({ id: rectangle.id }),
+    ]);
+    h.app.actionManager.executeAction(undoAction);
+    expect(h.elements).toEqual([
+      expect.objectContaining({ id: "A", isDeleted: false }),
+      expect.objectContaining({ id: rectangle.id, isDeleted: true }),
+    ]);
+
+    // noop
+    h.app.actionManager.executeAction(undoAction);
+    expect(h.elements).toEqual([
+      expect.objectContaining({ id: "A", isDeleted: false }),
+      expect.objectContaining({ id: rectangle.id, isDeleted: true }),
+    ]);
+    expect(API.getStateHistory().length).toBe(1);
+
+    h.app.actionManager.executeAction(redoAction);
+    expect(h.elements).toEqual([
+      expect.objectContaining({ id: "A", isDeleted: false }),
+      expect.objectContaining({ id: rectangle.id, isDeleted: false }),
+    ]);
+    expect(API.getStateHistory().length).toBe(2);
+  });
+});

--- a/src/tests/regressionTests.test.tsx
+++ b/src/tests/regressionTests.test.tsx
@@ -451,10 +451,7 @@ describe("regression tests", () => {
   });
 
   it("noop interaction after undo shouldn't create history entry", () => {
-    // NOTE: this will fail if this test case is run in isolation. There's
-    //  some leaking state or race conditions in initialization/teardown
-    //  (couldn't figure out)
-    expect(API.getStateHistory().length).toBe(0);
+    expect(API.getStateHistory().length).toBe(1);
 
     UI.clickTool("rectangle");
     mouse.down(10, 10);
@@ -468,35 +465,35 @@ describe("regression tests", () => {
 
     const secondElementEndPoint = mouse.getPosition();
 
-    expect(API.getStateHistory().length).toBe(2);
+    expect(API.getStateHistory().length).toBe(3);
 
     Keyboard.withModifierKeys({ ctrl: true }, () => {
       Keyboard.keyPress("z");
     });
 
-    expect(API.getStateHistory().length).toBe(1);
+    expect(API.getStateHistory().length).toBe(2);
 
     // clicking an element shouldn't add to history
     mouse.restorePosition(...firstElementEndPoint);
     mouse.click();
-    expect(API.getStateHistory().length).toBe(1);
+    expect(API.getStateHistory().length).toBe(2);
 
     Keyboard.withModifierKeys({ shift: true, ctrl: true }, () => {
       Keyboard.keyPress("z");
     });
 
-    expect(API.getStateHistory().length).toBe(2);
+    expect(API.getStateHistory().length).toBe(3);
 
     // clicking an element shouldn't add to history
     mouse.click();
-    expect(API.getStateHistory().length).toBe(2);
+    expect(API.getStateHistory().length).toBe(3);
 
     const firstSelectedElementId = API.getSelectedElement().id;
 
     // same for clicking the element just redo-ed
     mouse.restorePosition(...secondElementEndPoint);
     mouse.click();
-    expect(API.getStateHistory().length).toBe(2);
+    expect(API.getStateHistory().length).toBe(3);
 
     expect(API.getSelectedElement().id).not.toEqual(firstSelectedElementId);
   });

--- a/src/tests/zindex.test.tsx
+++ b/src/tests/zindex.test.tsx
@@ -3,14 +3,13 @@ import ReactDOM from "react-dom";
 import { render } from "./test-utils";
 import App from "../components/App";
 import { reseed } from "../random";
-import { newElement } from "../element";
 import {
   actionSendBackward,
   actionBringForward,
   actionBringToFront,
   actionSendToBack,
 } from "../actions";
-import { ExcalidrawElement } from "../element/types";
+import { API } from "./helpers/api";
 
 // Unmount ReactDOM from root
 ReactDOM.unmountComponentAtNode(document.getElementById("root")!);
@@ -28,21 +27,7 @@ const populateElements = (
   const selectedElementIds: any = {};
 
   h.elements = elements.map(({ id, isDeleted = false, isSelected = false }) => {
-    const element: Mutable<ExcalidrawElement> = newElement({
-      type: "rectangle",
-      x: 100,
-      y: 100,
-      strokeColor: h.state.currentItemStrokeColor,
-      backgroundColor: h.state.currentItemBackgroundColor,
-      fillStyle: h.state.currentItemFillStyle,
-      strokeWidth: h.state.currentItemStrokeWidth,
-      strokeStyle: h.state.currentItemStrokeStyle,
-      strokeSharpness: h.state.currentItemStrokeSharpness,
-      roughness: h.state.currentItemRoughness,
-      opacity: h.state.currentItemOpacity,
-    });
-    element.id = id;
-    element.isDeleted = isDeleted;
+    const element = API.createElement({ type: "rectangle", id, isDeleted });
     if (isSelected) {
       selectedElementIds[element.id] = true;
     }


### PR DESCRIPTION
This PR fixes history when initialiazing scene (local/remote, except collab where we still keep history disabled) so that the first history entry contains the initialized state.

Previously if you loaded a scene and hit `Cmd-Z` you ended up with empty scene (similarly if you made an edit and undoed it).

I've also made loading from blob to push to history entries to make it undoable --- previously it was undoable but suffered from similar problems as described above. From backend we could in theory do that too, but since it involves re-init (user pastes it to url bar), and often a full-page refresh, I thought we might don't want to.