### PR TITLE
Fix HintViewer positioning

### DIFF
--- a/src/components/HintViewer.scss
+++ b/src/components/HintViewer.scss
@@ -1,22 +1,31 @@
 @import "../css/_variables";
 
 .HintViewer {
+  pointer-events: none;
+  box-sizing: border-box;
+  position: absolute;
+  display: flex;
+  justify-content: center;
+  left: 0;
+  top: 100%;
+  max-width: 100%;
+  width: 100%;
+  margin-top: 6px;
+  text-align: center;
   color: $oc-gray-6;
   font-size: 0.8rem;
-  left: 50%;
-  pointer-events: none;
-  position: absolute;
-  top: 54px;
-  transform: translateX(calc(-50% - 16px)); /* 16px is half of lock icon */
-  padding: 0.2rem 0.4rem;
-  white-space: pre;
-  text-align: center;
-  background-color: var(--overlay-background-color);
-  border-radius: 4px;
+
+  @media (min-width: 1200px) {
+    white-space: pre;
+  }
 
   @media #{$media-query} {
     position: static;
-    transform: none;
-    margin-top: 0.5rem;
+  }
+
+  > span {
+    padding: 0.2rem 0.4rem;
+    background-color: var(--overlay-background-color);
+    border-radius: 3px;
   }
 }

--- a/src/components/HintViewer.scss
+++ b/src/components/HintViewer.scss
@@ -26,6 +26,6 @@
   > span {
     padding: 0.2rem 0.4rem;
     background-color: var(--overlay-background-color);
-    border-radius: 3px;
+    border-radius: 4px;
   }
 }

--- a/src/components/LayerUI.tsx
+++ b/src/components/LayerUI.tsx
@@ -431,7 +431,6 @@ const LayerUI = ({
 
     return (
       <FixedSideContainer side="top">
-        <HintViewer appState={appState} elements={elements} />
         <div className="App-menu App-menu_top">
           <Stack.Col
             gap={4}
@@ -445,6 +444,7 @@ const LayerUI = ({
               <Stack.Col gap={4} align="start">
                 <Stack.Row gap={1}>
                   <Island padding={1} className={zenModeEnabled && "zen-mode"}>
+                    <HintViewer appState={appState} elements={elements} />
                     {heading}
                     <Stack.Row gap={1}>
                       <ShapesSwitcher


### PR DESCRIPTION
So I've tried to fix some positioning issues with HintViewer

Also no more magic numbers stuff in css, like `calc(-50% - 16px)` (16px is half of lock icon) or `top: 54px;` (54px is height of Shapes menu)

**Before:**

<img width="394" alt="Screenshot 2020-08-31 at 13 34 53" src="https://user-images.githubusercontent.com/12836237/91711973-899f7180-eb8f-11ea-82c7-2364cd02d026.png">
<img width="859" alt="Screenshot 2020-08-31 at 13 35 32" src="https://user-images.githubusercontent.com/12836237/91711983-8dcb8f00-eb8f-11ea-99fd-69302013fed8.png">

**After:**

<img width="428" alt="Screenshot 2020-08-31 at 13 35 06" src="https://user-images.githubusercontent.com/12836237/91712037-a471e600-eb8f-11ea-8eac-60d76e4674c8.png">
<img width="826" alt="Screenshot 2020-08-31 at 13 35 54" src="https://user-images.githubusercontent.com/12836237/91712031-a20f8c00-eb8f-11ea-8f04-cbf1bc7aa8ff.png">
