### PR TITLE
Assign file handle to dropped files 

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -3600,8 +3600,8 @@ class App extends React.Component<ExcalidrawProps, AppState> {
           // but can be safely ignored on older releases.
           const item = event.dataTransfer.items[0];
           (window as any).handle = await (item as any).getAsFileSystemHandle();
-        } catch (err) {
-          console.warn(err.name, err.message);
+        } catch (error) {
+          console.warn(error.name, error.message);
         }
       }
       loadFromBlob(file, this.state)

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -3595,8 +3595,14 @@ class App extends React.Component<ExcalidrawProps, AppState> {
         "chooseFileSystemEntries" in window ||
         "showOpenFilePicker" in window
       ) {
-        const item = event.dataTransfer.items[0];
-        (window as any).handle = await (item as any).getAsFileSystemHandle();
+        try {
+          // This will only work as of Chrome 86,
+          // but can be safely ignored on older releases.
+          const item = event.dataTransfer.items[0];
+          (window as any).handle = await (item as any).getAsFileSystemHandle();
+        } catch (err) {
+          console.warn(err.name, err.message);
+        }
       }
       loadFromBlob(file, this.state)
         .then(({ elements, appState }) =>

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -3570,7 +3570,9 @@ class App extends React.Component<ExcalidrawProps, AppState> {
     }
   };
 
-  private handleCanvasOnDrop = (event: React.DragEvent<HTMLCanvasElement>) => {
+  private handleCanvasOnDrop = async (
+    event: React.DragEvent<HTMLCanvasElement>,
+  ) => {
     const libraryShapes = event.dataTransfer.getData(
       "application/vnd.excalidrawlib+json",
     );
@@ -3589,6 +3591,13 @@ class App extends React.Component<ExcalidrawProps, AppState> {
       file?.name.endsWith(".excalidraw")
     ) {
       this.setState({ isLoading: true });
+      if (
+        "chooseFileSystemEntries" in window ||
+        "showOpenFilePicker" in window
+      ) {
+        const item = event.dataTransfer.items[0];
+        (window as any).handle = await (item as any).getAsFileSystemHandle();
+      }
       loadFromBlob(file, this.state)
         .then(({ elements, appState }) =>
           this.syncActionResult({


### PR DESCRIPTION
If the Native File System API is supported, dropped files are now assigned a file handle, which makes them save-able immediately like a native app. Before this, you had to go through the "save" or "save as" flow to associate the currently edited file with the file that was dropped. 