### PR TITLE
Fix binding disabling when taking screenshots on macOS

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -171,6 +171,7 @@ import {
   isLinearElementSimpleAndAlreadyBound,
   isBindingEnabled,
   updateBoundElements,
+  shouldEnableBindingForPointerEvent,
 } from "../element/binding";
 import { MaybeTransformHandleType } from "../element/transformHandles";
 
@@ -2215,6 +2216,7 @@ class App extends React.Component<ExcalidrawProps, AppState> {
     }
 
     this.clearSelectionIfNotUsingSelection();
+    this.updateBindingEnabledOnPointerMove(event);
 
     if (this.handleSelectionOnPointerDown(event, pointerDownState)) {
       return;
@@ -3485,6 +3487,15 @@ class App extends React.Component<ExcalidrawProps, AppState> {
       }
     });
   }
+
+  private updateBindingEnabledOnPointerMove = (
+    event: React.PointerEvent<HTMLCanvasElement>,
+  ) => {
+    const shouldEnableBinding = shouldEnableBindingForPointerEvent(event);
+    if (this.state.isBindingEnabled !== shouldEnableBinding) {
+      this.setState({ isBindingEnabled: shouldEnableBinding });
+    }
+  };
 
   private maybeSuggestBindingAtCursor = (pointerCoords: {
     x: number;

--- a/src/element/binding.ts
+++ b/src/element/binding.ts
@@ -21,6 +21,7 @@ import { mutateElement } from "./mutateElement";
 import Scene from "../scene/Scene";
 import { LinearElementEditor } from "./linearElementEditor";
 import { tupleToCoors } from "../utils";
+import { KEYS } from "../keys";
 
 export type SuggestedBinding =
   | NonDeleted<ExcalidrawBindableElement>
@@ -31,6 +32,12 @@ export type SuggestedPointBinding = [
   "start" | "end" | "both",
   NonDeleted<ExcalidrawBindableElement>,
 ];
+
+export const shouldEnableBindingForPointerEvent = (
+  event: React.PointerEvent<HTMLCanvasElement>,
+) => {
+  return !event[KEYS.CTRL_OR_CMD];
+};
 
 export const isBindingEnabled = (appState: AppState): boolean => {
   return appState.isBindingEnabled;

--- a/src/tests/__snapshots__/regressionTests.test.tsx.snap
+++ b/src/tests/__snapshots__/regressionTests.test.tsx.snap
@@ -907,7 +907,7 @@ Object {
   "exportBackground": true,
   "gridSize": null,
   "height": 768,
-  "isBindingEnabled": true,
+  "isBindingEnabled": false,
   "isCollaborating": false,
   "isLibraryOpen": false,
   "isLoading": false,


### PR DESCRIPTION
Before this PR if you took a screenshot on macOS with CMD+SHIFT+4 et al, it would disable binding until the next CMD press. Now we check that CMD is pressed during pointer move, and if its state doesn't match the app state we update it.

Closes #2112 

In #2112 we discussed moving the state altogether to pointerDownState. That doesn't work (easily) for a few reasons:

1) We want to react to key press even if there is no pointer move
2) When editing multi-point elements we finish the binding from componentDidUpdate, which doesn't have access to pointerDownState (a module-level variable would be needed for this)
3) The code is currently simplified by not checking binding enabled/disabled when suggesting, instead checking it in renderScene - this would have to be reworked, complicating all the suggestions code.