### PR TITLE
Fix textbox element bindings on size changes

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1683,7 +1683,9 @@ class App extends React.Component<ExcalidrawProps, AppState> {
       },
       onChange: withBatchedUpdates((text) => {
         updateElement(text);
-        updateBoundElements(element as NonDeleted<ExcalidrawTextElement>);
+        if (isNonDeletedElement(element)) {
+          updateBoundElements(element);
+        }
       }),
       onSubmit: withBatchedUpdates((text) => {
         const isDeleted = !text.trim();

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1683,6 +1683,7 @@ class App extends React.Component<ExcalidrawProps, AppState> {
       },
       onChange: withBatchedUpdates((text) => {
         updateElement(text);
+        updateBoundElements(element as NonDeleted<ExcalidrawTextElement>);
       }),
       onSubmit: withBatchedUpdates((text) => {
         const isDeleted = !text.trim();

--- a/src/element/resizeElements.ts
+++ b/src/element/resizeElements.ts
@@ -88,6 +88,7 @@ export const transformElements = (
         pointerX,
         pointerY,
       );
+      updateBoundElements(element);
     } else if (transformHandleType) {
       resizeSingleElement(
         element,

--- a/src/element/textWysiwyg.tsx
+++ b/src/element/textWysiwyg.tsx
@@ -137,7 +137,6 @@ export const textWysiwyg = ({
 
   const handleSubmit = () => {
     onSubmit(normalizeText(editable.value));
-    updateBoundElements(element as NonDeletedExcalidrawElement);
     cleanup();
   };
 
@@ -158,6 +157,7 @@ export const textWysiwyg = ({
     window.removeEventListener("blur", handleSubmit);
 
     unbindUpdate();
+    updateBoundElements(element as NonDeletedExcalidrawElement);
 
     document.body.removeChild(editable);
   };

--- a/src/element/textWysiwyg.tsx
+++ b/src/element/textWysiwyg.tsx
@@ -3,8 +3,9 @@ import { isWritableElement, getFontString } from "../utils";
 import Scene from "../scene/Scene";
 import { isTextElement } from "./typeChecks";
 import { CLASSES } from "../constants";
-import { ExcalidrawElement } from "./types";
+import { ExcalidrawElement, NonDeletedExcalidrawElement } from "./types";
 import { AppState } from "../types";
+import { updateBoundElements } from "./binding";
 
 const normalizeText = (text: string) => {
   return (
@@ -136,6 +137,7 @@ export const textWysiwyg = ({
 
   const handleSubmit = () => {
     onSubmit(normalizeText(editable.value));
+    updateBoundElements(element as NonDeletedExcalidrawElement);
     cleanup();
   };
 

--- a/src/element/textWysiwyg.tsx
+++ b/src/element/textWysiwyg.tsx
@@ -3,9 +3,8 @@ import { isWritableElement, getFontString } from "../utils";
 import Scene from "../scene/Scene";
 import { isTextElement } from "./typeChecks";
 import { CLASSES } from "../constants";
-import { ExcalidrawElement, NonDeletedExcalidrawElement } from "./types";
+import { ExcalidrawElement } from "./types";
 import { AppState } from "../types";
-import { updateBoundElements } from "./binding";
 
 const normalizeText = (text: string) => {
   return (
@@ -157,7 +156,6 @@ export const textWysiwyg = ({
     window.removeEventListener("blur", handleSubmit);
 
     unbindUpdate();
-    updateBoundElements(element as NonDeletedExcalidrawElement);
 
     document.body.removeChild(editable);
   };


### PR DESCRIPTION
This PR fixes the small bug with textbox bindings not automatically updating until you move one of the connected elements.

- Bug seems to occur when:
  - The text input is changed
  - The textbox is resized

Before:
![2020-09-07_17-20-29](https://user-images.githubusercontent.com/32750050/92417176-e4584080-f12e-11ea-8dd7-5670404ed481.gif)

After:
![eAfGKduipn](https://user-images.githubusercontent.com/32750050/92488468-9558ec80-f1bc-11ea-8523-c806ae29aaee.gif)




closes #2134 