### PR TITLE
Remove Native File System OT token for good

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -13,12 +13,6 @@
 
     <meta name="theme-color" content="#000" />
 
-    <!-- Origin Trial token for the Native File System API v2 https://developers.chrome.com/origintrials/#/view_trial/4019462667428167681 (Sept. 30) -->
-    <!-- <meta
-      http-equiv="origin-trial"
-      content="AqNSxPYulsq3Q4VMz1qjnI3aGAr98CDJl8f8Lealo1VeWLjO9g9xtraFQcr7CH3Yrmc7UG/N3eKFPAg2+1bcxg0AAABZeyJvcmlnaW4iOiJodHRwczovL2V4Y2FsaWRyYXcuY29tOjQ0MyIsImZlYXR1cmUiOiJOYXRpdmVGaWxlU3lzdGVtMiIsImV4cGlyeSI6MTYwMTQyMzk5OX0="
-    /> -->
-
     <!-- General tags -->
     <meta
       name="description"


### PR DESCRIPTION
The [Origin Trial](https://developers.chrome.com/origintrials/#/view_trial/4019462667428167681) ends on September 30 anyway; given the recent hiccups let's just make the removal of the token final, so only users with Chrome >=86 use the API.