### PR TITLE
Fix package-lock.json typo in volumes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
     volumes:
       - ./:/opt/node_app/app:delegated
       - ./package.json:/opt/node_app/package.json
-      - ./package-lock.lock:/opt/node_app/package-lock.lock
+      - ./package-lock.json:/opt/node_app/package-lock.json
       - notused:/opt/node_app/app/node_modules
 
 volumes:


### PR DESCRIPTION
I saw issue #2136  and decided to fix it 🙂 

changed the line 23 from

```yml
 - ./package-lock.lock:/opt/node_app/package-lock.lock
```

to

```yml
 - ./package-lock.json:/opt/node_app/package-lock.json
```