### PR TITLE
Add gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
The pre-commit hook requires LF line endings to pass ([prettier default](https://prettier.io/docs/en/options.html#end-of-line)). Specifying this in gitattributes will save some headache for windows users.