### PR TITLE
Fix pinch-to-zoom performance

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -3808,7 +3808,9 @@ class App extends React.Component<ExcalidrawProps, AppState> {
           Object.keys(selectedElementIds).length !== 0
             ? selectedElementIds
             : previousSelectedElementIds,
+        shouldCacheIgnoreZoom: true,
       }));
+      this.resetShouldCacheIgnoreZoomDebounced();
       return;
     }
 


### PR DESCRIPTION
Pinch-to-zoom is pretty unusable on large drawings using Chrome on my MacBook Pro. This introduces the debounced cache busting that is used in other parts of the codebase.

Test plan: pinched to zoom on a large drawing. Before, it was slow. Now it's fast (and blurry for up to 300ms before it rerenders).