### PR TITLE
Fix middle mouse panning on windows

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -3781,6 +3781,11 @@ class App extends React.Component<ExcalidrawProps, AppState> {
 
   private handleWheel = withBatchedUpdates((event: WheelEvent) => {
     event.preventDefault();
+
+    if (isPanning) {
+      return;
+    }
+
     const { deltaX, deltaY } = event;
     const { selectedElementIds, previousSelectedElementIds } = this.state;
 


### PR DESCRIPTION
The middle mouse panning on Windows resulted in the canvas jumping the wrong direction.

Test plan:
* Test middle mouse behavior on windows. Before it's broken. Now it works.
* Test two finger pan on mac desktop touchpad. No regression.