### PR TITLE
One-click installable libraries

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -175,6 +175,7 @@ import {
 } from "../element/binding";
 import { MaybeTransformHandleType } from "../element/transformHandles";
 import { renderSpreadsheet } from "../charts";
+import { isValidLibrary } from "../data/json";
 
 /**
  * @param func handler taking at most single parameter (event).
@@ -492,6 +493,31 @@ class App extends React.Component<ExcalidrawProps, AppState> {
     return false;
   }
 
+  private addToLibrary = async (url: string) => {
+    window.history.replaceState({}, "Excalidraw", window.location.origin);
+    try {
+      const request = await fetch(url);
+      const blob = await request.blob();
+      const json = JSON.parse(await blob.text());
+      if (!isValidLibrary(json)) {
+        throw new Error();
+      }
+      if (
+        window.confirm(
+          t("alerts.confirmAddLibrary", { numShapes: json.library.length }),
+        )
+      ) {
+        await Library.importLibrary(blob);
+        this.setState({
+          isLibraryOpen: true,
+        });
+      }
+    } catch (e) {
+      window.alert(t("alerts.errorLoadingLibrary"));
+      console.error(e);
+    }
+  };
+
   private initializeScene = async () => {
     const searchParams = new URLSearchParams(window.location.search);
     const id = searchParams.get("id");
@@ -562,6 +588,12 @@ class App extends React.Component<ExcalidrawProps, AppState> {
         ...scene,
         commitToHistory: true,
       });
+    }
+
+    const addToLibraryUrl = searchParams.get("addLibrary");
+
+    if (addToLibraryUrl) {
+      await this.addToLibrary(addToLibraryUrl);
     }
   };
 

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -512,9 +512,9 @@ class App extends React.Component<ExcalidrawProps, AppState> {
           isLibraryOpen: true,
         });
       }
-    } catch (e) {
+    } catch (error) {
       window.alert(t("alerts.errorLoadingLibrary"));
-      console.error(e);
+      console.error(error);
     }
   };
 

--- a/src/data/json.ts
+++ b/src/data/json.ts
@@ -53,6 +53,15 @@ export const loadFromJSON = async (appState: AppState) => {
   return loadFromBlob(blob, appState);
 };
 
+export const isValidLibrary = (json: any) => {
+  return (
+    typeof json === "object" &&
+    json &&
+    json.type === "excalidrawlib" &&
+    json.version === 1
+  );
+};
+
 export const saveLibraryAsJSON = async () => {
   const library = await loadLibrary();
   const serialized = JSON.stringify(

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -112,7 +112,9 @@
     "couldNotCopyToClipboard": "Couldn't copy to clipboard. Try using Chrome browser.",
     "decryptFailed": "Couldn't decrypt data.",
     "uploadedSecurly": "The upload has been secured with end-to-end encryption, which means that Excalidraw server and third parties can't read the content.",
-    "loadSceneOverridePrompt": "Loading external drawing will replace your existing content. Do you wish to continue?"
+    "loadSceneOverridePrompt": "Loading external drawing will replace your existing content. Do you wish to continue?",
+    "errorLoadingLibrary": "There was an error loading the third party library.",
+    "confirmAddLibrary": "This will add {{numShapes}} shape(s) to your library. Are you sure?"
   },
   "toolBar": {
     "selection": "Selection",


### PR DESCRIPTION
This introduces a lightweight way of sharing libraries. Library authors can put their libraries up as static file somewhere (github gists work just great) and share clickable links for users to install them.

If this is accepted, I think we should create a wiki page where the community can add their own shape libraries.

To try it, click this link: https://excalidraw-git-fork-petehunt-add-to-library-link.excalidraw.vercel.app/?addLibrary=https://gist.githubusercontent.com/petehunt/cf25a65e1e343ecdedd68cf1cdaedced/raw/8f2d943481b898c62a42e2a20e7bde973d494e83/library.excalidrawlib

This is a v0. I think there are a few ways we could expand on it, but for now, this is an v0 that will enable library authors to easily share their work.