### PR TITLE
Make File Handling actually work 🎉

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -14,7 +14,7 @@
       "sizes": "256x256"
     }
   ],
-  "start_url": ".",
+  "start_url": "/",
   "display": "standalone",
   "theme_color": "#000000",
   "background_color": "#ffffff",

--- a/src/actions/actionExport.tsx
+++ b/src/actions/actionExport.tsx
@@ -66,6 +66,7 @@ export const actionChangeShouldAddWatermark = register({
 export const actionSaveScene = register({
   name: "saveScene",
   perform: (elements, appState, value) => {
+    // TODO: Make this part of `AppState`.
     saveAsJSON(elements, appState, (window as any).handle)
       .catch(muteFSAbortError)
       .catch((error) => console.error(error));

--- a/src/data/blob.ts
+++ b/src/data/blob.ts
@@ -29,6 +29,7 @@ const loadFileContents = async (blob: any) => {
  */
 export const loadFromBlob = async (blob: any, appState?: AppState) => {
   if (blob.handle) {
+    // TODO: Make this part of `AppState`.
     (window as any).handle = blob.handle;
   }
 

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -66,9 +66,7 @@ export type SocketUpdateDataIncoming =
       type: "INVALID_RESPONSE";
     };
 
-// TODO: Defined globally, since file handles aren't yet serializable.
-// Once `FileSystemFileHandle` can be serialized, make this
-// part of `AppState`.
+// TODO: Make this part of `AppState`.
 (window as any).handle = null;
 
 const byteToHex = (byte: number): string => `0${byte.toString(16)}`.slice(-2);

--- a/src/data/json.ts
+++ b/src/data/json.ts
@@ -33,6 +33,7 @@ export const saveAsJSON = async (
     type: "application/json",
   });
   const name = `${appState.name}.excalidraw`;
+  // TODO: Make this part of `AppState`.
   (window as any).handle = await fileSave(
     blob,
     {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -8,7 +8,6 @@ import { TopErrorBoundary } from "./components/TopErrorBoundary";
 import Excalidraw from "./excalidraw-embed/index";
 import { register as registerServiceWorker } from "./serviceWorker";
 
-import { loadFromBlob } from "./data";
 import { debounce } from "./utils";
 import {
   importFromLocalStorage,
@@ -182,16 +181,3 @@ registerServiceWorker({
     }
   },
 });
-
-if ("launchQueue" in window && "LaunchParams" in window) {
-  (window as any).launchQueue.setConsumer(
-    async (launchParams: { files: any[] }) => {
-      if (!launchParams.files.length) {
-        return;
-      }
-      const fileHandle = launchParams.files[0];
-      const blob = await fileHandle.getFile();
-      loadFromBlob(blob);
-    },
-  );
-}


### PR DESCRIPTION
Follow-up from #1736. 
   
Test this with the [`#file-handling-api`](chrome://flags/#file-handling-api) flag set. Note that the app needs to be installed. If it doesn't work immediately and the app already was installed, uninstall and then re-install for the file handler to be picked up by the OS.

1. <img width="800" alt="Screen Shot 2020-09-22 at 15 06 25" src="https://user-images.githubusercontent.com/145676/93886153-5d39c980-fce5-11ea-8d04-998d3ba73b4d.png">
1. <img width="244" alt="Screen Shot 2020-09-22 at 15 06 37" src="https://user-images.githubusercontent.com/145676/93886160-5f9c2380-fce5-11ea-9b65-e2714753319a.png">
1. <img width="800" alt="Screen Shot 2020-09-22 at 15 06 47" src="https://user-images.githubusercontent.com/145676/93886162-5f9c2380-fce5-11ea-9eba-1f1cefd6e2b7.png">


