### PR TITLE
fix text color on dark mode changing to light mode color while its being edited.

### DIFF
--- a/src/element/textWysiwyg.tsx
+++ b/src/element/textWysiwyg.tsx
@@ -89,6 +89,9 @@ export const textWysiwyg = ({
   editable.dataset.type = "wysiwyg";
   // prevent line wrapping on Safari
   editable.wrap = "off";
+  editable.className = `excalidraw ${
+    appState.appearance === "dark" ? "Appearance_dark" : ""
+  }`;
 
   Object.assign(editable.style, {
     position: "fixed",


### PR DESCRIPTION
Hi, I noticed that on dark mode, the text element was changing color back to its light mode variant while being edited (white turns back to black, etc...).

Upon looking, I saw that --appearance-filter was not being applied to the floating textarea. It was only applied to the .excalidraw class while the floating textarea is being appended to the body which put it outside of .excalidraw.

This PR adds `.excalidraw` class to the floating textarea and also adds `.Appearance_dark` to it while the dark mode is on. 

### Before
![image](https://user-images.githubusercontent.com/8491552/94944474-84717180-0503-11eb-8cc2-63bf2f2e882c.png)

### After
![image](https://user-images.githubusercontent.com/8491552/94945011-3f9a0a80-0504-11eb-92ba-b25f872d189f.png)
