### PR TITLE
clear scene when joining a room

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -810,10 +810,6 @@ class App extends React.Component<ExcalidrawProps, AppState> {
       .querySelector(".excalidraw")
       ?.classList.toggle("Appearance_dark", this.state.appearance === "dark");
 
-    if (this.state.isCollaborating && !this.portal.socket) {
-      this.initializeSocketClient({ showLoadingState: true });
-    }
-
     if (
       this.state.editingLinearElement &&
       !this.state.selectedElementIds[this.state.editingLinearElement.elementId]

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -610,9 +610,8 @@ class App extends React.Component<ExcalidrawProps, AppState> {
 
     if (isCollaborationScene) {
       // when joining a room we don't want user's local scene data to be merged
-      //  into the remote scene
-      this.resetScene();
-      this.initializeSocketClient({ showLoadingState: true });
+      //  into the remote scene, so set `clearScene`
+      this.initializeSocketClient({ showLoadingState: true, clearScene: true });
     } else if (scene) {
       if (scene.appState) {
         scene.appState = {
@@ -1222,9 +1221,13 @@ class App extends React.Component<ExcalidrawProps, AppState> {
 
   private initializeSocketClient = async (opts: {
     showLoadingState: boolean;
+    clearScene?: boolean;
   }) => {
     if (this.portal.socket) {
       return;
+    }
+    if (opts.clearScene) {
+      this.resetScene();
     }
     const roomMatch = getCollaborationLinkData(window.location.href);
     if (roomMatch) {

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -521,6 +521,18 @@ class App extends React.Component<ExcalidrawProps, AppState> {
     }
   };
 
+  /** Completely resets scene & history.
+   * Do not use for clear scene user action. */
+  private resetScene = withBatchedUpdates(() => {
+    this.scene.replaceAllElements([]);
+    this.setState({
+      ...getDefaultAppState(),
+      appearance: this.state.appearance,
+      username: this.state.username,
+    });
+    history.clear();
+  });
+
   private initializeScene = async () => {
     if ("launchQueue" in window && "LaunchParams" in window) {
       (window as any).launchQueue.setConsumer(
@@ -597,6 +609,9 @@ class App extends React.Component<ExcalidrawProps, AppState> {
     }
 
     if (isCollaborationScene) {
+      // when joining a room we don't want user's local scene data to be merged
+      //  into the remote scene
+      this.resetScene();
       this.initializeSocketClient({ showLoadingState: true });
     } else if (scene) {
       if (scene.appState) {


### PR DESCRIPTION
When joining a room, we don't want the local scene to be potentially merged into the remote one.

This PR clears the scene before joining the room (not when creating one).