### PR TITLE
Proper error message when file is too big to be uploaded to the server #1257

### DIFF
--- a/src/appState.ts
+++ b/src/appState.ts
@@ -68,6 +68,7 @@ export const getDefaultAppState = (): Omit<
     width: window.innerWidth,
     height: window.innerHeight,
     isLibraryOpen: false,
+    tooManyElements: 1250,
   };
 };
 
@@ -143,6 +144,7 @@ const APP_STATE_STORAGE_CONF = (<
   zoom: { browser: true, export: false },
   offsetTop: { browser: false, export: false },
   offsetLeft: { browser: false, export: false },
+  tooManyElements: { browser: false, export: false },
 });
 
 const _clearAppStateForStorage = <ExportType extends "export" | "browser">(

--- a/src/components/ExportDialog.tsx
+++ b/src/components/ExportDialog.tsx
@@ -34,8 +34,8 @@ const ExportModal = ({
   onExportToClipboard,
   onExportToBackend,
 }: {
-  appState: AppState;
   elements: readonly NonDeletedExcalidrawElement[];
+  appState: AppState;
   exportPadding?: number;
   actionManager: ActionsManagerInterface;
   onExportToPng: ExportCB;
@@ -64,16 +64,25 @@ const ExportModal = ({
 
   useEffect(() => {
     const previewNode = previewRef.current;
-    const canvas = exportToCanvas(exportedElements, appState, {
-      exportBackground,
-      viewBackgroundColor,
-      exportPadding,
-      scale,
-      shouldAddWatermark,
-    });
-    previewNode?.appendChild(canvas);
+    if (exportedElements.length < appState.tooManyElements) {
+      const canvas = exportToCanvas(exportedElements, appState, {
+        exportBackground,
+        viewBackgroundColor,
+        exportPadding,
+        scale,
+        shouldAddWatermark,
+      });
+      previewNode?.appendChild(canvas);
+      return () => {
+        previewNode?.removeChild(canvas);
+      };
+    }
+    const cantPreview = document
+      .createElement("p")
+      .appendChild(document.createTextNode(t("alerts.cantPreviewTooBig")));
+    previewNode?.appendChild(cantPreview);
     return () => {
-      previewNode?.removeChild(canvas);
+      previewNode?.removeChild(cantPreview);
     };
   }, [
     appState,

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -220,6 +220,8 @@ export const exportToBackend = async (
       const urlString = url.toString();
 
       window.prompt(`🔒${t("alerts.uploadedSecurly")}`, urlString);
+    } else if (elements.length > appState.tooManyElements) {
+      window.alert(t("alerts.couldNotCreateShareableLinkTooBig"));
     } else {
       window.alert(t("alerts.couldNotCreateShareableLink"));
     }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -106,6 +106,7 @@
   "alerts": {
     "clearReset": "This will clear the whole canvas. Are you sure?",
     "couldNotCreateShareableLink": "Couldn't create shareable link.",
+    "couldNotCreateShareableLinkTooBig": "Couldn't create shareable link, too many elements in canvas",
     "couldNotLoadInvalidFile": "Couldn't load invalid file",
     "importBackendFailed": "Importing from backend failed.",
     "cannotExportEmptyCanvas": "Cannot export empty canvas.",
@@ -114,7 +115,8 @@
     "uploadedSecurly": "The upload has been secured with end-to-end encryption, which means that Excalidraw server and third parties can't read the content.",
     "loadSceneOverridePrompt": "Loading external drawing will replace your existing content. Do you wish to continue?",
     "errorLoadingLibrary": "There was an error loading the third party library.",
-    "confirmAddLibrary": "This will add {{numShapes}} shape(s) to your library. Are you sure?"
+    "confirmAddLibrary": "This will add {{numShapes}} shape(s) to your library. Are you sure?",
+    "cantPreviewTooBig": "Sorry we can't preview your work, too many elements :("
   },
   "toolBar": {
     "selection": "Selection",

--- a/src/types.ts
+++ b/src/types.ts
@@ -82,6 +82,7 @@ export type AppState = {
   zenModeEnabled: boolean;
   appearance: "light" | "dark";
   gridSize: number | null;
+  tooManyElements: number;
 
   /** top-most selected groups (i.e. does not include nested groups) */
   selectedGroupIds: { [groupId: string]: boolean };


### PR DESCRIPTION
https://github.com/excalidraw/excalidraw/issues/1257

feat: add tooMany elements on appstate(detect when upload/preview will crash), feat: show specific error message when upload fail because file is too big. feat: don't preview if too many elements selected (when canvas crash)