### PR TITLE
feat: add a proper error message when file is too big

### DIFF
--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -218,13 +218,13 @@ export const exportToBackend = async (
       // of queryParam in order to never send it to the server
       url.hash = `json=${json.id},${exportedKey.k!}`;
       const urlString = url.toString();
-
       window.prompt(`🔒${t("alerts.uploadedSecurly")}`, urlString);
+    } else if (json.error_class === "RequestTooLargeError") {
+      window.alert(t("alerts.couldNotCreateShareableLinkTooBig"));
     } else {
       window.alert(t("alerts.couldNotCreateShareableLink"));
     }
   } catch (error) {
-    console.error(error);
     window.alert(t("alerts.couldNotCreateShareableLink"));
   }
 };

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -225,7 +225,7 @@ export const exportToBackend = async (
       window.alert(t("alerts.couldNotCreateShareableLink"));
     }
   } catch (error) {
-    console.log(error)
+    console.error(error);
     window.alert(t("alerts.couldNotCreateShareableLink"));
   }
 };

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -225,6 +225,7 @@ export const exportToBackend = async (
       window.alert(t("alerts.couldNotCreateShareableLink"));
     }
   } catch (error) {
+    console.log(error)
     window.alert(t("alerts.couldNotCreateShareableLink"));
   }
 };

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -106,6 +106,7 @@
   "alerts": {
     "clearReset": "This will clear the whole canvas. Are you sure?",
     "couldNotCreateShareableLink": "Couldn't create shareable link.",
+    "couldNotCreateShareableLinkTooBig": "Sorry we couldn't create your shareable link, your canvas is too big",
     "couldNotLoadInvalidFile": "Couldn't load invalid file",
     "importBackendFailed": "Importing from backend failed.",
     "cannotExportEmptyCanvas": "Cannot export empty canvas.",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -106,7 +106,7 @@
   "alerts": {
     "clearReset": "This will clear the whole canvas. Are you sure?",
     "couldNotCreateShareableLink": "Couldn't create shareable link.",
-    "couldNotCreateShareableLinkTooBig": "Sorry we couldn't create your shareable link, your canvas is too big",
+    "couldNotCreateShareableLinkTooBig": "Couldn't create shareable link: the scene is too big",
     "couldNotLoadInvalidFile": "Couldn't load invalid file",
     "importBackendFailed": "Importing from backend failed.",
     "cannotExportEmptyCanvas": "Cannot export empty canvas.",


### PR DESCRIPTION
[#1257](https://github.com/excalidraw/excalidraw/issues/1257)
[old overkill merge request](https://github.com/excalidraw/excalidraw/pull/2231)

feat: check if error_class in server reponse is RequestTooLargeError and display a proper error message. 

P-S: In dev env the server isn't responding with error_class -> RequestTooLargeError
