### PR TITLE
restore elements on load from firebase

### DIFF
--- a/src/data/firebase.ts
+++ b/src/data/firebase.ts
@@ -2,6 +2,7 @@ import { createIV, getImportedKey } from "./index";
 import { ExcalidrawElement } from "../element/types";
 import { getSceneVersion } from "../element";
 import Portal from "../components/Portal";
+import { restoreElements } from "./restore";
 
 let firebasePromise: Promise<typeof import("firebase/app")> | null = null;
 
@@ -155,6 +156,5 @@ export async function loadFromFirebase(
   const storedScene = doc.data() as FirebaseStoredScene;
   const ciphertext = storedScene.ciphertext.toUint8Array();
   const iv = storedScene.iv.toUint8Array();
-  const plaintext = await decryptElements(roomKey, iv, ciphertext);
-  return plaintext;
+  return restoreElements(await decryptElements(roomKey, iv, ciphertext));
 }

--- a/src/data/restore.ts
+++ b/src/data/restore.ts
@@ -35,7 +35,7 @@ const restoreElementWithProperties = <T extends ExcalidrawElement>(
     //  newly added elements
     version: element.version || 1,
     versionNonce: element.versionNonce ?? 0,
-    isDeleted: false,
+    isDeleted: element.isDeleted ?? false,
     id: element.id || randomId(),
     fillStyle: element.fillStyle || "hachure",
     strokeWidth: element.strokeWidth || 1,


### PR DESCRIPTION
Made importing from firebase go through `restore()`. As such, needed to make `restoreElements()` not reset `element.isDeleted` to `false`.