### PR TITLE
SVG export: add image size

### DIFF
--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -302,6 +302,7 @@ export const exportCanvas = async (
       exportBackground,
       viewBackgroundColor,
       exportPadding,
+      scale,
       shouldAddWatermark,
       metadata:
         appState.exportEmbedScene && type === "svg"

--- a/src/scene/export.ts
+++ b/src/scene/export.ts
@@ -83,11 +83,13 @@ export const exportToSvg = (
     exportBackground,
     exportPadding = 10,
     viewBackgroundColor,
+    scale = 1,
     shouldAddWatermark,
     metadata = "",
   }: {
     exportBackground: boolean;
     exportPadding?: number;
+    scale?: number;
     viewBackgroundColor: string;
     shouldAddWatermark: boolean;
     metadata?: string;
@@ -106,6 +108,8 @@ export const exportToSvg = (
   svgRoot.setAttribute("version", "1.1");
   svgRoot.setAttribute("xmlns", SVG_NS);
   svgRoot.setAttribute("viewBox", `0 0 ${width} ${height}`);
+  svgRoot.setAttribute("width", `${width * scale}`);
+  svgRoot.setAttribute("height", `${height * scale}`);
 
   svgRoot.innerHTML = `
   ${SVG_EXPORT_TAG}


### PR DESCRIPTION
The SVG root element has no width/height, so they end up drawn at unspecified size

Includes "width" and "height" attributes in root SVG element, including 1x/2x/3x scaling.

Fixes #2291