### PR TITLE
remove eslint two disabled rules & fix

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,8 +2,6 @@
   "extends": ["prettier", "react-app", "react-app/jest"],
   "plugins": ["prettier"],
   "rules": {
-    "@typescript-eslint/no-unused-vars": "off",
-    "@typescript-eslint/no-redeclare": "off",
     "import/no-anonymous-default-export": "off",
     "curly": "warn",
     "no-console": [

--- a/src/components/ContextMenu.tsx
+++ b/src/components/ContextMenu.tsx
@@ -38,9 +38,11 @@ const ContextMenu = ({ options, onCloseRequest, top, left }: Props) => {
           className="context-menu"
           onContextMenu={(event) => event.preventDefault()}
         >
-          {options.map((option, idx) => (
+          {options.map(({ action, label }, idx) => (
             <li key={idx} onClick={onCloseRequest}>
-              <ContextMenuOption {...option} />
+              <button className="context-menu-option" onClick={action}>
+                {label}
+              </button>
             </li>
           ))}
         </ul>
@@ -48,12 +50,6 @@ const ContextMenu = ({ options, onCloseRequest, top, left }: Props) => {
     </div>
   );
 };
-
-const ContextMenuOption = ({ label, action }: ContextMenuOption) => (
-  <button className="context-menu-option" onClick={action}>
-    {label}
-  </button>
-);
 
 let contextMenuNode: HTMLDivElement;
 const getContextMenuNode = (): HTMLDivElement => {

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 interface Document {
   fonts?: {
     ready?: Promise<void>;


### PR DESCRIPTION
- for the `@typescript-eslint/no-redeclare` I could have renamed the type, but in this case it's not really necessary to make the item into its own component.
- The `@typescript-eslint/no-unused-vars` is a false positive, but rather than disable the rule completely, let's just disable that one line.
- kept `import/no-anonymous-default-export` for now as it's not a high-profile rule.