### PR TITLE
Fix padding in the library loading buttons

### DIFF
--- a/src/components/ColorPicker.tsx
+++ b/src/components/ColorPicker.tsx
@@ -260,11 +260,7 @@ export const ColorPicker = ({
         <button
           className="color-picker-label-swatch"
           aria-label={label}
-          style={
-            color
-              ? ({ "--swatch-color": color } as React.CSSProperties)
-              : undefined
-          }
+          style={color ? { "--swatch-color": color } : undefined}
           onClick={() => setActive(!isActive)}
           ref={pickerButton}
         />

--- a/src/components/Island.tsx
+++ b/src/components/Island.tsx
@@ -14,7 +14,7 @@ export const Island = React.forwardRef<HTMLDivElement, IslandProps>(
   ({ children, padding, className, style }, ref) => (
     <div
       className={clsx("Island", className)}
-      style={{ "--padding": padding, ...style } as React.CSSProperties}
+      style={{ "--padding": padding, ...style }}
       ref={ref}
     >
       {children}

--- a/src/components/LayerUI.tsx
+++ b/src/components/LayerUI.tsx
@@ -114,7 +114,12 @@ const LibraryMenuItems = ({
   let addedPendingElements = false;
 
   rows.push(
-    <Stack.Row align="center" gap={1} key={"actions"}>
+    <Stack.Row
+      align="center"
+      gap={1}
+      key={"actions"}
+      style={{ padding: "2px 0" }}
+    >
       <ToolButton
         key="import"
         type="button"

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -36,13 +36,11 @@ export const Modal = (props: {
       <div className="Modal__background" onClick={props.onCloseRequest}></div>
       <div
         className="Modal__content"
-        style={
-          {
-            "--max-width": `${props.maxWidth}px`,
-            maxHeight: "100%",
-            overflowY: "scroll",
-          } as any
-        }
+        style={{
+          "--max-width": `${props.maxWidth}px`,
+          maxHeight: "100%",
+          overflowY: "scroll",
+        }}
       >
         {props.children}
       </div>

--- a/src/components/Stack.tsx
+++ b/src/components/Stack.tsx
@@ -23,14 +23,12 @@ const RowStack = ({
   return (
     <div
       className={clsx("Stack Stack_horizontal", className)}
-      style={
-        {
-          "--gap": gap,
-          alignItems: align,
-          justifyContent,
-          ...style,
-        } as React.CSSProperties
-      }
+      style={{
+        "--gap": gap,
+        alignItems: align,
+        justifyContent,
+        ...style,
+      }}
     >
       {children}
     </div>
@@ -47,13 +45,11 @@ const ColStack = ({
   return (
     <div
       className={clsx("Stack Stack_vertical", className)}
-      style={
-        {
-          "--gap": gap,
-          justifyItems: align,
-          justifyContent,
-        } as React.CSSProperties
-      }
+      style={{
+        "--gap": gap,
+        justifyItems: align,
+        justifyContent,
+      }}
     >
       {children}
     </div>

--- a/src/components/Stack.tsx
+++ b/src/components/Stack.tsx
@@ -9,6 +9,7 @@ type StackProps = {
   align?: "start" | "center" | "end" | "baseline";
   justifyContent?: "center" | "space-around" | "space-between";
   className?: string | boolean;
+  style?: object;
 };
 
 const RowStack = ({
@@ -17,6 +18,7 @@ const RowStack = ({
   align,
   justifyContent,
   className,
+  style,
 }: StackProps) => {
   return (
     <div
@@ -26,6 +28,7 @@ const RowStack = ({
           "--gap": gap,
           alignItems: align,
           justifyContent,
+          ...style,
         } as React.CSSProperties
       }
     >

--- a/src/components/Stack.tsx
+++ b/src/components/Stack.tsx
@@ -9,7 +9,7 @@ type StackProps = {
   align?: "start" | "center" | "end" | "baseline";
   justifyContent?: "center" | "space-around" | "space-between";
   className?: string | boolean;
-  style?: object;
+  style?: React.CSSProperties;
 };
 
 const RowStack = ({

--- a/src/css.d.ts
+++ b/src/css.d.ts
@@ -1,0 +1,10 @@
+import "csstype";
+
+declare module "csstype" {
+  interface Properties {
+    "--max-width"?: number | string;
+    "--swatch-color"?: string;
+    "--gap"?: number | string;
+    "--padding"?: number | string;
+  }
+}


### PR DESCRIPTION
Fixes #2306 

### Before 
<img width="185" alt="Screenshot 2020-11-03 at 6 40 15 PM" src="https://user-images.githubusercontent.com/125676/98014221-07882f00-1e04-11eb-9cb6-87ff9b981f9a.png">

### After

<img width="136" alt="Screenshot 2020-11-03 at 6 40 56 PM" src="https://user-images.githubusercontent.com/125676/98014296-1d95ef80-1e04-11eb-9435-d978dd96e2fd.png">
