### PR TITLE
fix: fonts not cached by Service Worker

### DIFF
--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -36,3 +36,12 @@ workbox.routing.registerNavigationRoute(
     blacklist: [/^\/_/, /\/[^/?]+\.[^/]+$/],
   },
 );
+
+// Cache relevant font files
+workbox.routing.registerRoute(
+  new RegExp("/(fonts.css|.+.(ttf|woff2|otf))"),
+  new workbox.strategies.StaleWhileRevalidate({
+    cacheName: "fonts",
+    plugins: [new workbox.expiration.Plugin({ maxEntries: 10 })],
+  }),
+);


### PR DESCRIPTION
Cache relevant font files for offline usage.

Fixes #2276

> BTW: No problem in Firefox