### PR TITLE
fix portal teardown

### DIFF
--- a/src/components/Portal.tsx
+++ b/src/components/Portal.tsx
@@ -49,6 +49,8 @@ class Portal {
     this.socket = null;
     this.roomID = null;
     this.roomKey = null;
+    this.socketInitialized = false;
+    this.broadcastedElementVersions = new Map();
   }
 
   isOpen() {


### PR DESCRIPTION
We weren't properly resetting portal state on `portal.close()` which resulted in issues on reconnecting or connecting to new rooms.

Making it as a separate PR from https://github.com/excalidraw/excalidraw/pull/2313 — the sooner this lands to production the better.