### PR TITLE
Remove last committed point json

### DIFF
--- a/src/data/blob.ts
+++ b/src/data/blob.ts
@@ -6,6 +6,7 @@ import { LibraryData, ImportedDataState } from "./types";
 import { calculateScrollCenter } from "../scene";
 import { MIME_TYPES } from "../constants";
 import { CanvasError } from "../errors";
+import { clearElementsForExport } from "../element";
 
 export const parseFileContents = async (blob: Blob | File) => {
   let contents: string;
@@ -90,7 +91,7 @@ export const loadFromBlob = async (
     }
     return restore(
       {
-        elements: data.elements,
+        elements: clearElementsForExport(data.elements || []),
         appState: {
           appearance: localAppState?.appearance,
           fileHandle:

--- a/src/data/json.ts
+++ b/src/data/json.ts
@@ -6,6 +6,7 @@ import { fileOpen, fileSave } from "browser-nativefs";
 import { loadFromBlob } from "./blob";
 import { Library } from "./library";
 import { MIME_TYPES } from "../constants";
+import { clearElementsForExport } from "../element";
 
 export const serializeAsJSON = (
   elements: readonly ExcalidrawElement[],
@@ -16,7 +17,7 @@ export const serializeAsJSON = (
       type: "excalidraw",
       version: 2,
       source: window.location.origin,
-      elements: elements.filter((element) => !element.isDeleted),
+      elements: clearElementsForExport(elements),
       appState: cleanAppStateForExport(appState),
     },
     null,

--- a/src/data/localStorage.ts
+++ b/src/data/localStorage.ts
@@ -61,17 +61,16 @@ export const importFromLocalStorage = () => {
     console.error(error);
   }
 
-  let elements = [];
+  let elements: ExcalidrawElement[] = [];
   if (savedElements) {
     try {
-      elements = JSON.parse(savedElements);
+      elements = clearElementsForLocalStorage(JSON.parse(savedElements));
     } catch (error) {
       console.error(error);
       // Do nothing because elements array is already empty
     }
   }
 
-  elements = clearElementsForLocalStorage(elements) as any[];
   let appState = null;
   if (savedState) {
     try {

--- a/src/data/localStorage.ts
+++ b/src/data/localStorage.ts
@@ -2,6 +2,7 @@ import { ExcalidrawElement } from "../element/types";
 import { AppState } from "../types";
 import { clearAppStateForLocalStorage, getDefaultAppState } from "../appState";
 import { STORAGE_KEYS } from "../constants";
+import { clearElementsForLocalStorage } from "../element";
 
 export const saveUsernameToLocalStorage = (username: string) => {
   try {
@@ -36,7 +37,7 @@ export const saveToLocalStorage = (
   try {
     localStorage.setItem(
       STORAGE_KEYS.LOCAL_STORAGE_ELEMENTS,
-      JSON.stringify(elements.filter((element) => !element.isDeleted)),
+      JSON.stringify(clearElementsForLocalStorage(elements)),
     );
     localStorage.setItem(
       STORAGE_KEYS.LOCAL_STORAGE_APP_STATE,
@@ -70,6 +71,7 @@ export const importFromLocalStorage = () => {
     }
   }
 
+  elements = clearElementsForLocalStorage(elements) as any[];
   let appState = null;
   if (savedState) {
     try {

--- a/src/element/index.ts
+++ b/src/element/index.ts
@@ -87,12 +87,14 @@ export const isNonDeletedElement = <T extends ExcalidrawElement>(
   element: T,
 ): element is NonDeleted<T> => !element.isDeleted;
 
-const _clearElements = (elements: readonly ExcalidrawElement[]) =>
+const _clearElements = (
+  elements: readonly ExcalidrawElement[],
+): ExcalidrawElement[] =>
   getNonDeletedElements(elements).map((element) =>
     isLinearElementType(element.type)
-      ? { ...element, lastCommittedPoint: undefined }
+      ? { ...element, lastCommittedPoint: null }
       : element,
-  ) as readonly ExcalidrawElement[];
+  );
 
 export const clearElementsForExport = (
   elements: readonly ExcalidrawElement[],

--- a/src/element/index.ts
+++ b/src/element/index.ts
@@ -4,6 +4,7 @@ import {
   NonDeleted,
 } from "./types";
 import { isInvisiblySmallElement } from "./sizeHelpers";
+import { isLinearElementType } from "./typeChecks";
 
 export {
   newElement,
@@ -85,3 +86,18 @@ export const getNonDeletedElements = (elements: readonly ExcalidrawElement[]) =>
 export const isNonDeletedElement = <T extends ExcalidrawElement>(
   element: T,
 ): element is NonDeleted<T> => !element.isDeleted;
+
+const _clearElements = (elements: readonly ExcalidrawElement[]) =>
+  getNonDeletedElements(elements).map((element) =>
+    isLinearElementType(element.type)
+      ? { ...element, lastCommittedPoint: undefined }
+      : element,
+  ) as readonly ExcalidrawElement[];
+
+export const clearElementsForExport = (
+  elements: readonly ExcalidrawElement[],
+) => _clearElements(elements);
+
+export const clearElementsForLocalStorage = (
+  elements: readonly ExcalidrawElement[],
+) => _clearElements(elements);


### PR DESCRIPTION
clearElementsForExport()  and clearElementsForLocalStorage() to remove ```lastComittedPoint``` from (liniear) elements. Use it on importing / saving.
That fixes #1353