### PR TITLE
Include Dark mode css styles in Excalidraw component package

### DIFF
--- a/src/packages/excalidraw/index.tsx
+++ b/src/packages/excalidraw/index.tsx
@@ -5,6 +5,7 @@ import App, { ExcalidrawImperativeAPI } from "../../components/App";
 
 import "../../css/app.scss";
 import "../../css/styles.scss";
+import "../../css/theme.scss";
 
 import { ExcalidrawProps } from "../../types";
 import { IsMobileProvider } from "../../is-mobile";


### PR DESCRIPTION
With this change, now the Dark mode css styles are included in excalidraw.min.js which will allow tools built on top of Excalidraw to use Dark mode.

See this issue for more details: https://github.com/scastiel/excalidraw-slides/issues/1