### PR TITLE
Use "chiffrés" over "cryptés" in french encrypted tooltip message

### DIFF
--- a/src/locales/fr-FR.json
+++ b/src/locales/fr-FR.json
@@ -206,7 +206,7 @@
     "preventBinding": "Empêcher la liaison de la flèche"
   },
   "encrypted": {
-    "tooltip": "Vos dessins sont cryptés de bout en bout, les serveurs d'Excalidraw ne les verront jamais."
+    "tooltip": "Vos dessins sont chiffrés de bout en bout, les serveurs d'Excalidraw ne les verront jamais."
   },
   "charts": {
     "noNumericColumn": "Vous avez collé une feuille de calcul sans données numérique.",


### PR DESCRIPTION
The verb "crypter" is not correct in french (widely used though 😕)
The official translation for `encrypted` is `chiffré`
https://www.larousse.fr/dictionnaires/francais/crypter/20845?q=crypter#20725