### PR TITLE
Fix "Copy | Look Up"  popup issue on mobile device

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -108,6 +108,7 @@
           Roboto, Helvetica, Arial, sans-serif;
         font-family: var(--ui-font);
         -webkit-text-size-adjust: 100%;
+        -webkit-user-select: none;
         user-select: none;
         width: 100vw;
         height: 100vh;


### PR DESCRIPTION
On my iPhone, the "Copy | Loop Up" native context menu still shows up on both Safari and Chrome. Add a `-webkit-` prefix to the user-select fixes it.

![IMG_2816 3](https://user-images.githubusercontent.com/11426875/99976757-cec5ef00-2dde-11eb-924e-ad98f3c44088.jpg)


![IMG_2817](https://user-images.githubusercontent.com/11426875/99976771-d2597600-2dde-11eb-914c-62607bd47edf.jpg)



