### PR TITLE
Improves distribute algorithm

### DIFF
--- a/src/disitrubte.ts
+++ b/src/disitrubte.ts
@@ -20,10 +20,7 @@ export const distributeElements = (
   selectedElements: ExcalidrawElement[],
   distribution: Distribution,
 ): ExcalidrawElement[] => {
-  const [start, end, mid] =
-    distribution.axis === "x"
-      ? (["minX", "maxX", "midX"] as const)
-      : (["minY", "maxY", "midY"] as const);
+  const mid = distribution.axis === "x" ? "midX" : "midY";
 
   const groups = getMaximumGroups(selectedElements)
     .map((group) => [group, getCommonBoundingBox(group)] as const)
@@ -41,15 +38,11 @@ export const distributeElements = (
   let pos = min;
 
   return groups.flatMap(([group, box], i) => {
-    const translation = {
-      x: 0,
-      y: 0,
-    };
+    const translation = { x: 0, y: 0 };
 
     if (i > 0 && i < groups.length - 1) {
       pos += step;
-      translation[distribution.axis] =
-        Math.round(pos - (box[end] - box[start]) / 2) - box[start];
+      translation[distribution.axis] = pos - box[mid];
     }
 
     return group.map((element) =>
@@ -85,7 +78,6 @@ export const getMaximumGroups = (
 
 const getCommonBoundingBox = (elements: ExcalidrawElement[]): Box => {
   const [minX, minY, maxX, maxY] = getCommonBounds(elements);
-
   return {
     minX,
     minY,

--- a/src/disitrubte.ts
+++ b/src/disitrubte.ts
@@ -25,18 +25,17 @@ export const distributeElements = (
       ? (["minX", "maxX", "midX"] as const)
       : (["minY", "maxY", "midY"] as const);
 
-  let max: number = null as any;
-  let min: number = null as any;
-
   const groups = getMaximumGroups(selectedElements)
-    .map((group) => {
-      const box = getCommonBoundingBox(group);
-      const tmp = (box[start] + box[end]) / 2;
-      max = max !== null ? Math.max(max, tmp) : tmp;
-      min = min !== null ? Math.min(min, tmp) : tmp;
-      return [group, box] as const;
-    })
+    .map((group) => [group, getCommonBoundingBox(group)] as const)
     .sort((a, b) => a[1][mid] - b[1][mid]);
+
+  const [max, min] = groups.reduce<number[]>((acc, cur) => {
+    const tmp = cur[1][mid];
+    return [
+      acc[0] !== undefined ? Math.max(acc[0], tmp) : tmp,
+      acc[1] !== undefined ? Math.min(acc[1], tmp) : tmp,
+    ];
+  }, []);
 
   const step = (max - min) / groups.length;
   let pos = min;
@@ -92,7 +91,7 @@ const getCommonBoundingBox = (elements: ExcalidrawElement[]): Box => {
     minY,
     maxX,
     maxY,
-    midX: minX + maxX / 2,
-    midY: minY + maxY / 2,
+    midX: (minX + maxX) / 2,
+    midY: (minY + maxY) / 2,
   };
 };


### PR DESCRIPTION
This PR adds a backup strategy to use when the total span of the selected items is larger than the extent of the selection box, as in the example below. 

![image](https://user-images.githubusercontent.com/23072548/100245508-02fcf500-2f30-11eb-98ab-4b3c0443da88.png)

# The problem: distribution is hard?
In the previous implementation, certain arrangements could produce an "unstable" distribution that would change with multiple iterations. 

![2020-11-25 at 15 56 34 - Copper Caribou](https://user-images.githubusercontent.com/23072548/100251628-e0baa580-2f36-11eb-91c4-157b8a40bd77.gif)

As it turns out, this isn't a rare issue—several other design tools have the same problem.

![2020-11-25 at 15 51 14 - Gray Piranha](https://user-images.githubusercontent.com/23072548/100251084-45c1cb80-2f36-11eb-81e5-d4a6c1f51773.gif)

![2020-11-25 at 9 57 28 - Aqua Wolverine](https://user-images.githubusercontent.com/23072548/100251102-4a867f80-2f36-11eb-97b9-76dd62a18cda.gif)

See [this issue](https://github.com/excalidraw/excalidraw/issues/2411) for more on what was going wrong.

# The solution: two solutions

In the original implementation, I used a "distribute by gaps" strategy that would attempt to position the selected items such that the space between between item was equal. In this PR's implementation, I've added a second backup strategy to use in cases where that first strategy would not work as expected. 

In this new "distribute by centers" strategy, we attempt to position the boxes such that their centers are evenly distributed.

![image](https://user-images.githubusercontent.com/23072548/100248202-18275300-2f33-11eb-9896-e677c52bfe82.png)

Compare against the original "distribute by gaps" strategy. (This strategy is also here improved, so that items are sorted by their midpoint rather than their minimum `x` or `y` values.)

![image](https://user-images.githubusercontent.com/23072548/100248715-b87d7780-2f33-11eb-9218-bd8cbc644a8a.png)

Both strategies in this PR will:
- preserve the original bounding box
- be stable over multiple distributions

There is one quirk: if a distribute action is used on a selection where the same item defines both the minimum and maximum of the selection group bounds, then items will appear to be centered instead. It's not clear to me how to solve this, or what the expected behavior would be in cases like this.

![image](https://user-images.githubusercontent.com/23072548/100249522-8e788500-2f34-11eb-8f86-8ef22e108f10.png)

## This could get complicated!

My research into other tools suggests that there isn't a "one size fits all" implementation for this feature: for example, at certain times, a user may _want_ to distribute their items by centers and expect that their bounding box would change. Ultimately this could only be addressed by offering different distribution options (as in Inkscape). 

In my original implementation, I left the opportunity open for more distribution options. We could consider adding those in future changes. However, I believe that the implementation in this PR covers the "most expected" behaviors.