### PR TITLE
click on library icon should toggle the LibraryMenu

### DIFF
--- a/src/components/Actions.tsx
+++ b/src/components/Actions.tsx
@@ -184,7 +184,7 @@ export const ShapesSwitcher = ({
       );
     })}
     <ToolButton
-      className="Shape"
+      className="Shape ToolIcon_type_button__library"
       type="button"
       icon={LIBRARY_ICON}
       name="editor-library"

--- a/src/components/LayerUI.tsx
+++ b/src/components/LayerUI.tsx
@@ -210,12 +210,12 @@ const LibraryMenu = ({
   setAppState: React.Component<any, AppState>["setState"];
 }) => {
   const ref = useRef<HTMLDivElement | null>(null);
-  useOnClickOutside(ref, (ev) => {
+  useOnClickOutside(ref, (event) => {
     // If click on the library icon, do nothing.
-    if ((ev.target as Element).closest(".ToolIcon_type_button__library")) {
+    if ((event.target as Element).closest(".ToolIcon_type_button__library")) {
       return;
     }
-    onClickOutside(ev);
+    onClickOutside(event);
   });
 
   const [libraryItems, setLibraryItems] = useState<LibraryItems>([]);

--- a/src/components/LayerUI.tsx
+++ b/src/components/LayerUI.tsx
@@ -100,7 +100,6 @@ const LibraryMenuItems = ({
 }: {
   library: LibraryItems;
   pendingElements: LibraryItem;
-  onClickOutside: (event: MouseEvent) => void;
   onRemoveFromLibrary: (index: number) => void;
   onInsertShape: (elements: LibraryItem) => void;
   onAddToLibrary: (elements: LibraryItem) => void;
@@ -211,7 +210,13 @@ const LibraryMenu = ({
   setAppState: React.Component<any, AppState>["setState"];
 }) => {
   const ref = useRef<HTMLDivElement | null>(null);
-  useOnClickOutside(ref, onClickOutside);
+  useOnClickOutside(ref, (ev) => {
+    // If click on the library icon, do nothing.
+    if ((ev.target as Element).closest(".ToolIcon_type_button__library")) {
+      return;
+    }
+    onClickOutside(ev);
+  });
 
   const [libraryItems, setLibraryItems] = useState<LibraryItems>([]);
 
@@ -269,7 +274,6 @@ const LibraryMenu = ({
       ) : (
         <LibraryMenuItems
           library={libraryItems}
-          onClickOutside={onClickOutside}
           onRemoveFromLibrary={removeFromLibrary}
           onAddToLibrary={addToLibrary}
           onInsertShape={onInsertShape}


### PR DESCRIPTION
When clicking on the library icon,  LibraryMenu's `onClickOutside` callback should not try to set `isLibraryOpen`  to `false`. 

![image](https://user-images.githubusercontent.com/11426875/100369211-95d88500-303f-11eb-859d-223da6128ea8.png)
