### PR TITLE
 use cursorx, cursory in onGestureChange

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1743,12 +1743,11 @@ class App extends React.Component<ExcalidrawProps, AppState> {
 
   private onGestureChange = withBatchedUpdates((event: GestureEvent) => {
     event.preventDefault();
-    const gestureCenter = getCenter(gesture.pointers);
     this.setState(({ zoom }) => ({
       zoom: getNewZoom(
         getNormalizedZoom(gesture.initialScale! * event.scale),
         zoom,
-        gestureCenter,
+        { x: cursorX, y: cursorY },
       ),
     }));
   });


### PR DESCRIPTION
gesture.pointers are empty which leads NaN values of coords when `gesture.pointers` is triggered.
We should move away from [GestureEvent Api](https://developer.mozilla.org/en-US/docs/Web/API/GestureEvent) soon as its an unstable API
fixes https://github.com/excalidraw/excalidraw/issues/2347