### PR TITLE
Remove native gesture "support" from iOS

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1386,30 +1386,14 @@ class App extends React.Component<ExcalidrawProps, AppState> {
 
   private onGestureStart = withBatchedUpdates((event: GestureEvent) => {
     event.preventDefault();
-    this.setState({
-      selectedElementIds: {},
-    });
-    gesture.initialScale = this.state.zoom.value;
   });
 
   private onGestureChange = withBatchedUpdates((event: GestureEvent) => {
     event.preventDefault();
-    this.setState(({ zoom }) => ({
-      zoom: getNewZoom(
-        getNormalizedZoom(gesture.initialScale! * event.scale),
-        zoom,
-        { x: cursorX, y: cursorY },
-      ),
-    }));
   });
 
   private onGestureEnd = withBatchedUpdates((event: GestureEvent) => {
     event.preventDefault();
-    this.setState({
-      previousSelectedElementIds: {},
-      selectedElementIds: this.state.previousSelectedElementIds,
-    });
-    gesture.initialScale = null;
   });
 
   private handleTextWysiwyg(


### PR DESCRIPTION
We were processing both the touch move and gesture on iOS which was first firing twice as many set state, but also caused issues:
- The gesture implementation didn't support zooming on the center
- Touching down on a circle and then on the bottom chrome would freak out because initialScale was null

Touching down on the menu still isn't perfect as it shifts the shape around but doesn't completly break the zoom