### PR TITLE
Fix scrollbars when no elements

### DIFF
--- a/src/scene/scrollbars.ts
+++ b/src/scene/scrollbars.ts
@@ -23,6 +23,12 @@ export const getScrollBars = (
     zoom: Zoom;
   },
 ): ScrollBars => {
+  if (elements.length === 0) {
+    return {
+      horizontal: null,
+      vertical: null,
+    };
+  }
   // This is the bounding box of all the elements
   const [
     elementsMinX,


### PR DESCRIPTION
I already fixed this but a special case for no elements was added in getCommonBounds to return 0 and reintroduce this bug. I'm not exactly sure where to put this check tbh. Fixing it here so that I'm not annoyed anymore at least.

I checked some of the callsites, some of them related to selection will never pass an empty array, some to export will break if we remove the 0, 0, 0, 0 fix.

Fixes #2064