### PR TITLE
Do not override cmd/ctrl-f for search

### DIFF
--- a/src/actions/actionMenu.tsx
+++ b/src/actions/actionMenu.tsx
@@ -66,7 +66,7 @@ export const actionFullScreen = register({
       commitToHistory: false,
     };
   },
-  keyTest: (event) => event.code === CODES.F,
+  keyTest: (event) => event.code === CODES.F && !event[KEYS.CTRL_OR_CMD],
 });
 
 export const actionShortcuts = register({


### PR DESCRIPTION
F is full screen but we shouldn't override cmd/ctrl-f for search. It's useful for searching in the list of key bindings