### PR TITLE
show lockicon on a second row on mobile

### DIFF
--- a/src/components/DarkModeToggle.tsx
+++ b/src/components/DarkModeToggle.tsx
@@ -13,7 +13,7 @@ export const DarkModeToggle = (props: {
 }) => {
   return (
     <label
-      className={`ToolIcon ToolIcon__lock ToolIcon_type_floating ToolIcon_size_M`}
+      className={`ToolIcon ToolIcon_type_floating ToolIcon_size_M`}
       title={t("buttons.toggleDarkMode")}
     >
       <input

--- a/src/components/ToolIcon.scss
+++ b/src/components/ToolIcon.scss
@@ -151,7 +151,7 @@
     }
   }
 
-  @media (max-width: 360px) {
+  @media (max-width: 760px) {
     .ToolIcon.ToolIcon__lock {
       display: inline-block;
       position: absolute;


### PR DESCRIPTION

# before 
<img src="https://user-images.githubusercontent.com/23306911/101276892-76b0c480-37b0-11eb-95ed-634c4ce27c93.jpg" width="320" />


# after 
<img src="https://user-images.githubusercontent.com/23306911/101276896-7b757880-37b0-11eb-8419-e7fd4350d304.jpg" width="320" />
