### PR TITLE
move all chunks inside excalidraw-assets folder when bundling

### DIFF
--- a/src/packages/excalidraw/webpack.prod.config.js
+++ b/src/packages/excalidraw/webpack.prod.config.js
@@ -15,7 +15,8 @@ module.exports = {
     library: "Excalidraw",
     libraryTarget: "umd",
     filename: "[name].js",
-    publicPath: "/excalidraw-assets/",
+    publicPath: "/",
+    chunkFilename: "excalidraw-assets/[name].js",
   },
   resolve: {
     extensions: [".js", ".ts", ".tsx", ".css", ".scss"],
@@ -68,6 +69,7 @@ module.exports = {
             loader: "file-loader",
             options: {
               name: "[name].[ext]",
+              outputPath: "excalidraw-assets",
             },
           },
         ],

--- a/src/packages/excalidraw/webpack.prod.config.js
+++ b/src/packages/excalidraw/webpack.prod.config.js
@@ -7,8 +7,7 @@ const BundleAnalyzerPlugin = require("webpack-bundle-analyzer")
 module.exports = {
   mode: "production",
   entry: {
-    "excalidraw.min": "./index.tsx",
-    "fonts.min": "../../../public/fonts.css",
+    "excalidraw.min": ["./index.tsx", "../../../public/fonts.css"],
   },
   output: {
     path: path.resolve(__dirname, "dist"),


### PR DESCRIPTION
remove excalidraw-assets from publicPath as its not needed

This will help users to copy the folder `excalidraw-assets` as it is to serve the assets 

Check [here](https://codesandbox.io/s/excalidraw-ehlz3)