### PR TITLE
 add separate entry point for fonts as its messing up the js bundle

### DIFF
--- a/src/packages/excalidraw/webpack.prod.config.js
+++ b/src/packages/excalidraw/webpack.prod.config.js
@@ -7,7 +7,8 @@ const BundleAnalyzerPlugin = require("webpack-bundle-analyzer")
 module.exports = {
   mode: "production",
   entry: {
-    "excalidraw.min": ["./index.tsx", "../../../public/fonts.css"],
+    "excalidraw.min": "./index.tsx",
+    "fonts.min": "../../../public/fonts.css",
   },
   output: {
     path: path.resolve(__dirname, "dist"),


### PR DESCRIPTION
Though combining the entry points was combining the CSS files correctly but it's messing up the exports in the JS bundle which is breaking rendering.

Tried removing the `MiniCssExtractPlugin` so CSS is combined with js but in the build, it is not working out well so will have to check more as the bundle seems to get messed up.

Will look more into these more after the initial release.