### PR TITLE
fix(app.tsx): add safe check for readyPromise

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -301,8 +301,7 @@ class App extends React.Component<ExcalidrawProps, AppState> {
     };
     if (excalidrawRef) {
       const readyPromise =
-        // @ts-ignore
-        excalidrawRef.current?.readyPromise ??
+        ("current" in excalidrawRef && excalidrawRef.current?.readyPromise) ||
         resolvablePromise<ExcalidrawImperativeAPI>();
 
       const api: ExcalidrawImperativeAPI = {

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -301,9 +301,10 @@ class App extends React.Component<ExcalidrawProps, AppState> {
     };
     if (excalidrawRef) {
       const readyPromise =
-        typeof excalidrawRef === "function"
-          ? resolvablePromise<ExcalidrawImperativeAPI>()
-          : excalidrawRef.current!.readyPromise;
+        // @ts-ignore
+        excalidrawRef.current?.readyPromise ??
+        resolvablePromise<ExcalidrawImperativeAPI>();
+
       const api: ExcalidrawImperativeAPI = {
         ready: true,
         readyPromise,

--- a/src/excalidraw-app/index.tsx
+++ b/src/excalidraw-app/index.tsx
@@ -24,7 +24,9 @@ import { ExcalidrawElement } from "../element/types";
 import { SAVE_TO_LOCAL_STORAGE_TIMEOUT } from "./app_constants";
 import { EVENT_LOAD, EVENT_SHARE, trackEvent } from "../analytics";
 
-const excalidrawRef: React.MutableRefObject<ExcalidrawAPIRefValue> = {
+const excalidrawRef: React.MutableRefObject<
+  MarkRequired<ExcalidrawAPIRefValue, "ready" | "readyPromise">
+> = {
   current: {
     readyPromise: resolvablePromise(),
     ready: false,

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -43,6 +43,9 @@ type ResolutionType<T extends (...args: any) => any> = T extends (
 // https://github.com/krzkaczor/ts-essentials
 type MarkOptional<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;
 
+type MarkRequired<T, RK extends keyof T> = Exclude<T, RK> &
+  Required<Pick<T, RK>>;
+
 // PNG encoding/decoding
 // -----------------------------------------------------------------------------
 type TEXtChunk = { name: "tEXt"; data: Uint8Array };

--- a/src/types.ts
+++ b/src/types.ts
@@ -133,14 +133,16 @@ export declare class GestureEvent extends UIEvent {
 export type LibraryItem = readonly NonDeleted<ExcalidrawElement>[];
 export type LibraryItems = readonly LibraryItem[];
 
+// NOTE ready/readyPromise props are optional for host apps' sake (our own
+// implem guarantees existence)
 export type ExcalidrawAPIRefValue =
   | (ExcalidrawImperativeAPI & {
-      readyPromise: ResolvablePromise<ExcalidrawImperativeAPI>;
-      ready: true;
+      readyPromise?: ResolvablePromise<ExcalidrawImperativeAPI>;
+      ready?: true;
     })
   | {
-      readyPromise: ResolvablePromise<ExcalidrawImperativeAPI>;
-      ready: false;
+      readyPromise?: ResolvablePromise<ExcalidrawImperativeAPI>;
+      ready?: false;
     };
 
 export interface ExcalidrawProps {


### PR DESCRIPTION
If host app doesn't want to use `readyPromise` or uses `createRef` then the App will break so added safe check,