### PR TITLE
Support CSV graphs and improve the look and feel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,6 @@ logs
 node_modules
 npm-debug.log*
 static
-temp
 yarn-debug.log*
 yarn-error.log*
 yarn.lock

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ logs
 node_modules
 npm-debug.log*
 static
+temp
 yarn-debug.log*
 yarn-error.log*
 yarn.lock

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -9,6 +9,7 @@ export const EVENT_LIBRARY = "library";
 export const EVENT_LOAD = "load";
 export const EVENT_SHAPE = "shape";
 export const EVENT_SHARE = "share";
+export const EVENT_MAGIC = "magic";
 
 export const trackEvent = window.gtag
   ? (category: string, name: string, label?: string, value?: number) => {

--- a/src/charts.ts
+++ b/src/charts.ts
@@ -33,11 +33,8 @@ const tryParseNumber = (s: string): number | null => {
   return parseFloat(match[1]);
 };
 
-const isNumericColumn = (lines: string[][], columnIndex: number) => {
-  return lines
-    .slice(1)
-    .every((line) => tryParseNumber(line[columnIndex]) !== null);
-};
+const isNumericColumn = (lines: string[][], columnIndex: number) =>
+  lines.slice(1).every((line) => tryParseNumber(line[columnIndex]) !== null);
 
 const tryParseCells = (cells: string[][]): ParseSpreadsheetResult => {
   const numCols = cells[0].length;
@@ -103,7 +100,6 @@ const transposeCells = (cells: string[][]) => {
     }
     nextCells.push(nextCellRow);
   }
-
   return nextCells;
 };
 
@@ -162,9 +158,7 @@ export const renderSpreadsheet = (
   const chartHeight = BAR_HEIGHT + BAR_GAP * 2;
   const chartWidth = (BAR_WIDTH + BAR_GAP) * values.length + BAR_GAP;
   const maxColors = colors.elementBackground.length;
-  const backgrounds = colors.elementBackground.slice(2, maxColors);
-  const color = backgrounds[Math.floor(Math.random() * backgrounds.length)];
-  const groupIds = [randomId()];
+  const bgColors = colors.elementBackground.slice(2, maxColors);
 
   // Put all the common properties here so when the whole chart is selected
   // the properties dialog shows the correct selected values
@@ -182,11 +176,11 @@ export const renderSpreadsheet = (
     strokeWidth: number;
     verticalAlign: VerticalAlign;
   } = {
-    backgroundColor: color,
+    backgroundColor: bgColors[Math.floor(Math.random() * bgColors.length)],
     fillStyle: "hachure",
     fontFamily: DEFAULT_FONT_FAMILY,
     fontSize: DEFAULT_FONT_SIZE,
-    groupIds,
+    groupIds: [randomId()],
     opacity: 100,
     roughness: 1,
     strokeColor: colors.elementStroke[0],

--- a/src/charts.ts
+++ b/src/charts.ts
@@ -108,11 +108,10 @@ const transposeCells = (cells: string[][]) => {
 };
 
 export const tryParseSpreadsheet = (text: string): ParseSpreadsheetResult => {
-  // copy/paste from excel, in-browser excel, google sheets is tsv
-  // we also check for csv
-  // for now we only accept 2 columns with an optional header
-  // TODO: Try maybe something smarter to understand if we can parse it
-  // Check for Tab separeted values
+  // Copy/paste from excel, spreadhseets, tsv, csv.
+  // For now we only accept 2 columns with an optional header
+
+  // Check for tab separeted values
   let lines = text
     .trim()
     .split("\n")
@@ -131,11 +130,9 @@ export const tryParseSpreadsheet = (text: string): ParseSpreadsheetResult => {
   }
 
   const numColsFirstLine = lines[0].length;
-  const isASpreadsheet = lines.every(
-    (line) => line.length === numColsFirstLine,
-  );
+  const isSpreadsheet = lines.every((line) => line.length === numColsFirstLine);
 
-  if (!isASpreadsheet) {
+  if (!isSpreadsheet) {
     return { type: NOT_SPREADSHEET };
   }
 
@@ -153,8 +150,6 @@ export const tryParseSpreadsheet = (text: string): ParseSpreadsheetResult => {
 const BAR_WIDTH = 32;
 const BAR_GAP = 12;
 const BAR_HEIGHT = 256;
-
-const ANGLE = 5.87;
 
 // For the maths behind it https://excalidraw.com/#json=6320864370884608,O_5xfD-Agh32tytHpRJx1g
 export const renderSpreadsheet = (
@@ -175,15 +170,16 @@ export const renderSpreadsheet = (
   // the properties dialog shows the correct selected values
   const commonProps: {
     backgroundColor: string;
+    fillStyle: FillStyle;
     fontFamily: FontFamily;
     fontSize: number;
     groupIds: any;
     opacity: number;
     roughness: number;
-    strokeWidth: number;
-    fillStyle: FillStyle;
-    strokeStyle: StrokeStyle;
+    strokeColor: string;
     strokeSharpness: StrokeSharpness;
+    strokeStyle: StrokeStyle;
+    strokeWidth: number;
     verticalAlign: VerticalAlign;
   } = {
     backgroundColor: color,
@@ -193,28 +189,25 @@ export const renderSpreadsheet = (
     groupIds,
     opacity: 100,
     roughness: 1,
+    strokeColor: colors.elementStroke[0],
     strokeSharpness: "sharp",
     strokeStyle: "solid",
     strokeWidth: 1,
     verticalAlign: "middle",
   };
 
-  // Min value label
   const minYLabel = newTextElement({
     ...commonProps,
     x: x - BAR_GAP,
     y: y - BAR_GAP,
-    strokeColor: colors.elementStroke[0],
     text: "0",
     textAlign: "right",
   });
 
-  // Max value label
   const maxYLabel = newTextElement({
     ...commonProps,
     x: x - BAR_GAP,
     y: y - BAR_HEIGHT - minYLabel.height / 2,
-    strokeColor: colors.elementStroke[0],
     text: max.toLocaleString(),
     textAlign: "right",
   });
@@ -234,7 +227,6 @@ export const renderSpreadsheet = (
       y: y - barHeight - BAR_GAP,
       width: BAR_WIDTH,
       height: barHeight,
-      strokeColor: colors.elementStroke[0],
     });
   });
 
@@ -246,43 +238,38 @@ export const renderSpreadsheet = (
         x: x + index * (BAR_WIDTH + BAR_GAP) + BAR_GAP * 2,
         y: y + BAR_GAP / 2,
         width: BAR_WIDTH,
-        angle: ANGLE,
+        angle: 5.87,
         fontSize: 16,
-        strokeColor: colors.elementStroke[0],
         textAlign: "center",
         verticalAlign: "top",
       });
     }) || [];
 
-  // Title on top of the chart in the middle
   const title = spreadsheet.title
     ? newTextElement({
         ...commonProps,
         text: spreadsheet.title,
         x: x + chartWidth / 2,
         y: y - BAR_HEIGHT - BAR_GAP * 3 - maxYLabel.height,
-        strokeColor: colors.elementStroke[0],
         strokeSharpness: "sharp",
         strokeStyle: "solid",
         textAlign: "center",
       })
     : null;
 
-  // TODO: delete this element
-  const testRect = newElement({
+  const debugRect = newElement({
     ...commonProps,
     type: "rectangle",
     x,
     y: y - chartHeight,
     width: chartWidth,
     height: chartHeight,
-    strokeColor: colors.elementStroke[0],
     fillStyle: "solid",
     opacity: 6,
   });
 
   trackEvent(EVENT_MAGIC, "chart", "bars", bars.length);
-  return [...bars, title, minYLabel, maxYLabel, ...xLabels, testRect].filter(
+  return [...bars, title, minYLabel, maxYLabel, ...xLabels, debugRect].filter(
     (element) => element !== null,
   ) as ExcalidrawElement[];
 };

--- a/src/charts.ts
+++ b/src/charts.ts
@@ -209,6 +209,9 @@ export const renderSpreadsheet = (
 
   // TODO: X-axis arrow: Start: [x, y], End: [x + chartWidth + BAR_GAP * 2, y]
   // TODO: Y-axis arrow: Start: [x, y], End: [x, y - chartHeight - BAR_GAP * 2]
+  // TODO: Dashed horizontal line for max value:
+  //       Start [x, y - BAR_HEIGHT - BAR_GAP]
+  //       End:  [x + chartWidth, y - BAR_HEIGHT - BAR_GAP]
 
   const bars = values.map((value, index) => {
     const barHeight = (value / max) * BAR_HEIGHT;

--- a/src/charts.ts
+++ b/src/charts.ts
@@ -164,7 +164,11 @@ export const renderSpreadsheet = (
   const chartWidth =
     (BAR_WIDTH + BAR_GAP) * spreadsheet.values.length + BAR_GAP;
 
-  const color = colors.elementBackground[7];
+  const backgrounds = colors.elementBackground.slice(
+    2,
+    colors.elementBackground.length,
+  );
+  const color = backgrounds[Math.floor(Math.random() * backgrounds.length)];
 
   // Min value label
   const minYLabel = newTextElement({
@@ -275,6 +279,7 @@ export const renderSpreadsheet = (
       })
     : null;
 
+  // TODO: delete this element
   const testRect = newElement({
     type: "rectangle",
     x,
@@ -282,12 +287,12 @@ export const renderSpreadsheet = (
     width: chartWidth,
     height: chartHeight,
     strokeColor: colors.elementStroke[0],
-    backgroundColor: colors.elementBackground[3],
+    backgroundColor: color,
     fillStyle: "solid",
     strokeWidth: 1,
     strokeStyle: "solid",
-    roughness: 1,
-    opacity: 8,
+    roughness: 0,
+    opacity: 6,
     strokeSharpness: "sharp",
     groupIds,
   });

--- a/src/charts.ts
+++ b/src/charts.ts
@@ -206,11 +206,15 @@ export const renderSpreadsheet = (
     textAlign: "right",
   });
 
-  // TODO: X-axis arrow: Start: [x, y], End: [x + chartWidth + BAR_GAP * 2, y]
-  // TODO: Y-axis arrow: Start: [x, y], End: [x, y - chartHeight - BAR_GAP * 2]
-  // TODO: Dashed horizontal line for max value:
-  //       Start [x, y - BAR_HEIGHT - BAR_GAP]
-  //       End:  [x + chartWidth, y - BAR_HEIGHT - BAR_GAP]
+  /**
+   * TODO:
+   *   - X-axis arrow or line: Start: [x, y], End: [x + chartWidth + BAR_GAP * 2, y]
+   *   - Y-axis arrow or line: Start: [x, y], End: [x, y - chartHeight - BAR_GAP * 2]
+   *     (The above arrows or line, could be essentially one with sharp edges)
+   *   - Dashed horizontal line for max value:
+   *     Start [x, y - BAR_HEIGHT - BAR_GAP]
+   *     End:  [x + chartWidth, y - BAR_HEIGHT - BAR_GAP]
+   */
 
   const bars = values.map((value, index) => {
     const barHeight = (value / max) * BAR_HEIGHT;

--- a/src/charts.ts
+++ b/src/charts.ts
@@ -158,17 +158,14 @@ export const renderSpreadsheet = (
   x: number,
   y: number,
 ): ExcalidrawElement[] => {
-  const max = Math.max(...spreadsheet.values);
-  const groupIds = [randomId()];
+  const values = spreadsheet.values;
+  const max = Math.max(...values);
   const chartHeight = BAR_HEIGHT + BAR_GAP * 2;
-  const chartWidth =
-    (BAR_WIDTH + BAR_GAP) * spreadsheet.values.length + BAR_GAP;
-
-  const backgrounds = colors.elementBackground.slice(
-    2,
-    colors.elementBackground.length,
-  );
+  const chartWidth = (BAR_WIDTH + BAR_GAP) * values.length + BAR_GAP;
+  const maxColors = colors.elementBackground.length;
+  const backgrounds = colors.elementBackground.slice(2, maxColors);
   const color = backgrounds[Math.floor(Math.random() * backgrounds.length)];
+  const groupIds = [randomId()];
 
   // Min value label
   const minYLabel = newTextElement({
@@ -210,7 +207,10 @@ export const renderSpreadsheet = (
     verticalAlign: "middle",
   });
 
-  const bars = spreadsheet.values.map((value, index) => {
+  // TODO: X-axis arrow: Start: [x, y], End: [x + chartWidth + BAR_GAP * 2, y]
+  // TODO: Y-axis arrow: Start: [x, y], End: [x, y - chartHeight - BAR_GAP * 2]
+
+  const bars = values.map((value, index) => {
     const barHeight = (value / max) * BAR_HEIGHT;
     return newElement({
       type: "rectangle",

--- a/src/charts.ts
+++ b/src/charts.ts
@@ -207,7 +207,7 @@ export const renderSpreadsheet = (
     textAlign: "right",
   });
 
-  const axesLine = newLinearElement({
+  const xAxisLine = newLinearElement({
     type: "line",
     x,
     y,
@@ -215,11 +215,25 @@ export const renderSpreadsheet = (
     endArrowhead: null,
     ...commonProps,
   });
-  mutateElement(axesLine, {
+  mutateElement(xAxisLine, {
     points: [
-      [0, -chartHeight],
       [0, 0],
       [chartWidth, 0],
+    ],
+  });
+
+  const yAxisLine = newLinearElement({
+    type: "line",
+    x,
+    y,
+    startArrowhead: null,
+    endArrowhead: null,
+    ...commonProps,
+  });
+  mutateElement(yAxisLine, {
+    points: [
+      [0, 0],
+      [0, -chartHeight],
     ],
   });
 
@@ -283,7 +297,8 @@ export const renderSpreadsheet = (
     title,
     ...bars,
     ...xLabels,
-    axesLine,
+    xAxisLine,
+    yAxisLine,
     maxValueLine,
     minYLabel,
     maxYLabel,

--- a/src/charts.ts
+++ b/src/charts.ts
@@ -218,9 +218,9 @@ export const renderSpreadsheet = (
 
   mutateElement(axesLine, {
     points: [
-      [0, -chartHeight - BAR_GAP],
+      [0, -chartHeight],
       [0, 0],
-      [chartWidth + BAR_GAP, 0],
+      [chartWidth, 0],
     ],
   });
 
@@ -273,7 +273,7 @@ export const renderSpreadsheet = (
         ...commonProps,
         text: spreadsheet.title,
         x: x + chartWidth / 2,
-        y: y - BAR_HEIGHT - BAR_GAP * 3 - maxYLabel.height,
+        y: y - BAR_HEIGHT - BAR_GAP * 2 - maxYLabel.height,
         strokeSharpness: "sharp",
         strokeStyle: "solid",
         textAlign: "center",

--- a/src/charts.ts
+++ b/src/charts.ts
@@ -215,7 +215,6 @@ export const renderSpreadsheet = (
     endArrowhead: null,
     ...commonProps,
   });
-
   mutateElement(axesLine, {
     points: [
       [0, -chartHeight],
@@ -232,7 +231,6 @@ export const renderSpreadsheet = (
     endArrowhead: null,
     ...commonProps,
   });
-
   mutateElement(maxValueLine, {
     points: [
       [0, 0],

--- a/src/charts.ts
+++ b/src/charts.ts
@@ -107,7 +107,7 @@ export const tryParseSpreadsheet = (text: string): ParseSpreadsheetResult => {
   // copy/paste from excel, in-browser excel, google sheets is tsv
   // we also check for csv
   // for now we only accept 2 columns with an optional header
-
+  // TODO: Try maybe something smarter to understand if we can parse it
   // Check for Tab separeted values
   let lines = text
     .trim()
@@ -115,7 +115,7 @@ export const tryParseSpreadsheet = (text: string): ParseSpreadsheetResult => {
     .map((line) => line.trim().split("\t"));
 
   // Check for comma separeted files
-  if (lines.length !== 0) {
+  if (lines.length !== 0 && lines[0].length !== 2) {
     lines = text
       .trim()
       .split("\n")

--- a/src/charts.ts
+++ b/src/charts.ts
@@ -111,7 +111,7 @@ export const tryParseSpreadsheet = (text: string): ParseSpreadsheetResult => {
     .map((line) => line.trim().split("\t"));
 
   // Check for comma separeted files
-  if (lines.length !== 0 && lines[0].length !== 2) {
+  if (lines.length && lines[0].length !== 2) {
     lines = text
       .trim()
       .split("\n")

--- a/src/charts.ts
+++ b/src/charts.ts
@@ -2,15 +2,7 @@ import { EVENT_MAGIC, trackEvent } from "./analytics";
 import colors from "./colors";
 import { DEFAULT_FONT_FAMILY, DEFAULT_FONT_SIZE } from "./constants";
 import { newElement, newTextElement, newLinearElement } from "./element";
-import { mutateElement } from "./element/mutateElement";
-import {
-  ExcalidrawElement,
-  FillStyle,
-  FontFamily,
-  StrokeSharpness,
-  StrokeStyle,
-  VerticalAlign,
-} from "./element/types";
+import { ExcalidrawElement } from "./element/types";
 import { randomId } from "./random";
 
 const BAR_WIDTH = 32;
@@ -163,20 +155,7 @@ export const renderSpreadsheet = (
 
   // Put all the common properties here so when the whole chart is selected
   // the properties dialog shows the correct selected values
-  const commonProps: {
-    backgroundColor: string;
-    fillStyle: FillStyle;
-    fontFamily: FontFamily;
-    fontSize: number;
-    groupIds: any;
-    opacity: number;
-    roughness: number;
-    strokeColor: string;
-    strokeSharpness: StrokeSharpness;
-    strokeStyle: StrokeStyle;
-    strokeWidth: number;
-    verticalAlign: VerticalAlign;
-  } = {
+  const commonProps = {
     backgroundColor: bgColors[Math.floor(Math.random() * bgColors.length)],
     fillStyle: "hachure",
     fontFamily: DEFAULT_FONT_FAMILY,
@@ -189,7 +168,7 @@ export const renderSpreadsheet = (
     strokeStyle: "solid",
     strokeWidth: 1,
     verticalAlign: "middle",
-  };
+  } as const;
 
   const minYLabel = newTextElement({
     ...commonProps,
@@ -213,13 +192,11 @@ export const renderSpreadsheet = (
     y,
     startArrowhead: null,
     endArrowhead: null,
-    ...commonProps,
-  });
-  mutateElement(xAxisLine, {
     points: [
       [0, 0],
       [chartWidth, 0],
     ],
+    ...commonProps,
   });
 
   const yAxisLine = newLinearElement({
@@ -228,13 +205,11 @@ export const renderSpreadsheet = (
     y,
     startArrowhead: null,
     endArrowhead: null,
-    ...commonProps,
-  });
-  mutateElement(yAxisLine, {
     points: [
       [0, 0],
       [0, -chartHeight],
     ],
+    ...commonProps,
   });
 
   const maxValueLine = newLinearElement({
@@ -244,13 +219,11 @@ export const renderSpreadsheet = (
     startArrowhead: null,
     endArrowhead: null,
     ...commonProps,
-  });
-  mutateElement(maxValueLine, {
+    strokeStyle: "dotted",
     points: [
       [0, 0],
       [chartWidth, 0],
     ],
-    strokeStyle: "dotted",
   });
 
   const bars = values.map((value, index) => {

--- a/src/charts.ts
+++ b/src/charts.ts
@@ -1,28 +1,25 @@
-import { ExcalidrawElement } from "./element/types";
+import colors from "./colors";
+import {
+  DEFAULT_VERTICAL_ALIGN,
+  DEFAULT_FONT_FAMILY,
+  DEFAULT_FONT_SIZE,
+} from "./constants";
 import { newElement, newTextElement } from "./element";
-import { AppState } from "./types";
-import { t } from "./i18n";
-import { DEFAULT_VERTICAL_ALIGN } from "./constants";
+import { ExcalidrawElement } from "./element/types";
+import { randomId } from "./random";
 
 export interface Spreadsheet {
-  yAxisLabel: string | null;
+  title: string | null;
   labels: string[] | null;
   values: number[];
 }
 
 export const NOT_SPREADSHEET = "NOT_SPREADSHEET";
-export const MALFORMED_SPREADSHEET = "MALFORMED_SPREADSHEET";
 export const VALID_SPREADSHEET = "VALID_SPREADSHEET";
 
 type ParseSpreadsheetResult =
-  | {
-      type: typeof NOT_SPREADSHEET;
-    }
-  | { type: typeof VALID_SPREADSHEET; spreadsheet: Spreadsheet }
-  | {
-      type: typeof MALFORMED_SPREADSHEET;
-      error: string;
-    };
+  | { type: typeof NOT_SPREADSHEET }
+  | { type: typeof VALID_SPREADSHEET; spreadsheet: Spreadsheet };
 
 const tryParseNumber = (s: string): number | null => {
   const match = /^[$€£¥₩]?([0-9]+(\.[0-9]+)?)$/.exec(s);
@@ -42,7 +39,7 @@ const tryParseCells = (cells: string[][]): ParseSpreadsheetResult => {
   const numCols = cells[0].length;
 
   if (numCols > 2) {
-    return { type: MALFORMED_SPREADSHEET, error: t("charts.tooManyColumns") };
+    return { type: NOT_SPREADSHEET };
   }
 
   if (numCols === 1) {
@@ -62,7 +59,7 @@ const tryParseCells = (cells: string[][]): ParseSpreadsheetResult => {
     return {
       type: VALID_SPREADSHEET,
       spreadsheet: {
-        yAxisLabel: hasHeader ? cells[0][0] : null,
+        title: hasHeader ? cells[0][0] : null,
         labels: null,
         values: values as number[],
       },
@@ -72,10 +69,7 @@ const tryParseCells = (cells: string[][]): ParseSpreadsheetResult => {
   const valueColumnIndex = isNumericColumn(cells, 0) ? 0 : 1;
 
   if (!isNumericColumn(cells, valueColumnIndex)) {
-    return {
-      type: MALFORMED_SPREADSHEET,
-      error: t("charts.noNumericColumn"),
-    };
+    return { type: NOT_SPREADSHEET };
   }
 
   const labelColumnIndex = (valueColumnIndex + 1) % 2;
@@ -89,7 +83,7 @@ const tryParseCells = (cells: string[][]): ParseSpreadsheetResult => {
   return {
     type: VALID_SPREADSHEET,
     spreadsheet: {
-      yAxisLabel: hasHeader ? cells[0][valueColumnIndex] : null,
+      title: hasHeader ? cells[0][valueColumnIndex] : null,
       labels: rows.map((row) => row[labelColumnIndex]),
       values: rows.map((row) => tryParseNumber(row[valueColumnIndex])!),
     },
@@ -110,12 +104,23 @@ const transposeCells = (cells: string[][]) => {
 };
 
 export const tryParseSpreadsheet = (text: string): ParseSpreadsheetResult => {
-  // copy/paste from excel, in-browser excel, and google sheets is tsv
+  // copy/paste from excel, in-browser excel, google sheets is tsv
+  // we also check for csv
   // for now we only accept 2 columns with an optional header
-  const lines = text
+
+  // Check for Tab separeted values
+  let lines = text
     .trim()
     .split("\n")
     .map((line) => line.trim().split("\t"));
+
+  // Check for comma separeted files
+  if (lines.length !== 0) {
+    lines = text
+      .trim()
+      .split("\n")
+      .map((line) => line.trim().split(","));
+  }
 
   if (lines.length === 0) {
     return { type: NOT_SPREADSHEET };
@@ -142,130 +147,152 @@ export const tryParseSpreadsheet = (text: string): ParseSpreadsheetResult => {
 };
 
 const BAR_WIDTH = 32;
-const BAR_SPACING = 12;
-const BAR_HEIGHT = 192;
-const LABEL_SPACING = 3 * BAR_SPACING;
-const Y_AXIS_LABEL_SPACING = LABEL_SPACING;
+const BAR_GAP = 12;
+const BAR_HEIGHT = 256;
+
 const ANGLE = 5.87;
 
+// For the maths behind it https://excalidraw.com/#json=6320864370884608,O_5xfD-Agh32tytHpRJx1g
 export const renderSpreadsheet = (
-  appState: AppState,
   spreadsheet: Spreadsheet,
   x: number,
   y: number,
 ): ExcalidrawElement[] => {
   const max = Math.max(...spreadsheet.values);
-  const min = Math.min(0, ...spreadsheet.values);
-  const range = max - min;
+  const groupIds = [randomId()];
+  const chartHeight = BAR_HEIGHT + BAR_GAP * 2;
+  const chartWidth =
+    (BAR_WIDTH + BAR_GAP) * spreadsheet.values.length + BAR_GAP;
 
+  const color = colors.elementBackground[7];
+
+  // Min value label
   const minYLabel = newTextElement({
-    x,
-    y: y + BAR_HEIGHT,
-    strokeColor: appState.currentItemStrokeColor,
-    backgroundColor: appState.currentItemBackgroundColor,
-    fillStyle: appState.currentItemFillStyle,
-    strokeWidth: appState.currentItemStrokeWidth,
-    strokeStyle: appState.currentItemStrokeStyle,
-    roughness: appState.currentItemRoughness,
-    opacity: appState.currentItemOpacity,
-    strokeSharpness: appState.currentItemStrokeSharpness,
-    text: min.toLocaleString(),
-    fontSize: 16,
-    fontFamily: appState.currentItemFontFamily,
-    textAlign: appState.currentItemTextAlign,
-    verticalAlign: DEFAULT_VERTICAL_ALIGN,
+    x: x - BAR_GAP,
+    y: y - BAR_GAP,
+    backgroundColor: color,
+    fillStyle: "cross-hatch",
+    fontFamily: DEFAULT_FONT_FAMILY,
+    fontSize: DEFAULT_FONT_SIZE,
+    groupIds,
+    opacity: 100,
+    roughness: 1,
+    strokeColor: colors.elementStroke[0],
+    strokeSharpness: "sharp",
+    strokeStyle: "solid",
+    strokeWidth: 1,
+    text: "0",
+    textAlign: "right",
+    verticalAlign: "middle",
   });
 
+  // Max value label
   const maxYLabel = newTextElement({
-    x,
-    y,
-    strokeColor: appState.currentItemStrokeColor,
-    backgroundColor: appState.currentItemBackgroundColor,
-    fillStyle: appState.currentItemFillStyle,
-    strokeWidth: appState.currentItemStrokeWidth,
-    strokeStyle: appState.currentItemStrokeStyle,
-    roughness: appState.currentItemRoughness,
-    opacity: appState.currentItemOpacity,
-    strokeSharpness: appState.currentItemStrokeSharpness,
+    x: x - BAR_GAP,
+    y: y - BAR_HEIGHT - minYLabel.height / 2,
+    backgroundColor: color,
+    fillStyle: "cross-hatch",
+    fontFamily: DEFAULT_FONT_FAMILY,
+    fontSize: DEFAULT_FONT_SIZE,
+    groupIds,
+    opacity: 100,
+    roughness: 1,
+    strokeColor: colors.elementStroke[0],
+    strokeSharpness: "sharp",
+    strokeStyle: "solid",
+    strokeWidth: 1,
     text: max.toLocaleString(),
-    fontSize: 16,
-    fontFamily: appState.currentItemFontFamily,
-    textAlign: appState.currentItemTextAlign,
-    verticalAlign: DEFAULT_VERTICAL_ALIGN,
+    textAlign: "right",
+    verticalAlign: "middle",
   });
 
   const bars = spreadsheet.values.map((value, index) => {
-    const valueBarHeight = value - min;
-    const percentBarHeight = valueBarHeight / range;
-    const barHeight = percentBarHeight * BAR_HEIGHT;
-    const barX = index * (BAR_WIDTH + BAR_SPACING) + LABEL_SPACING;
-    const barY = BAR_HEIGHT - barHeight;
+    const barHeight = (value / max) * BAR_HEIGHT;
     return newElement({
       type: "rectangle",
-      x: barX + x,
-      y: barY + y,
+      x: x + index * (BAR_WIDTH + BAR_GAP) + BAR_GAP,
+      y: y - barHeight - BAR_GAP,
       width: BAR_WIDTH,
       height: barHeight,
-      strokeColor: appState.currentItemStrokeColor,
-      backgroundColor: appState.currentItemBackgroundColor,
-      fillStyle: appState.currentItemFillStyle,
-      strokeWidth: appState.currentItemStrokeWidth,
-      strokeStyle: appState.currentItemStrokeStyle,
-      roughness: appState.currentItemRoughness,
-      opacity: appState.currentItemOpacity,
-      strokeSharpness: appState.currentItemStrokeSharpness,
+
+      backgroundColor: color,
+      fillStyle: "hachure",
+      groupIds,
+      opacity: 100,
+      roughness: 1,
+      strokeColor: colors.elementStroke[0],
+      strokeSharpness: "sharp",
+      strokeStyle: "solid",
+      strokeWidth: 1,
     });
   });
 
   const xLabels =
     spreadsheet.labels?.map((label, index) => {
-      const labelX =
-        index * (BAR_WIDTH + BAR_SPACING) + LABEL_SPACING + BAR_SPACING;
-      const labelY = BAR_HEIGHT + BAR_SPACING;
       return newTextElement({
         text: label.length > 8 ? `${label.slice(0, 5)}...` : label,
-        x: x + labelX,
-        y: y + labelY,
-        strokeColor: appState.currentItemStrokeColor,
-        backgroundColor: appState.currentItemBackgroundColor,
-        fillStyle: appState.currentItemFillStyle,
-        strokeWidth: appState.currentItemStrokeWidth,
-        strokeStyle: appState.currentItemStrokeStyle,
-        roughness: appState.currentItemRoughness,
-        opacity: appState.currentItemOpacity,
-        strokeSharpness: appState.currentItemStrokeSharpness,
+        x: x + index * (BAR_WIDTH + BAR_GAP) + BAR_GAP * 2,
+        y: y + BAR_GAP / 2,
+
+        angle: ANGLE,
+        backgroundColor: color,
+        fillStyle: "hachure",
+        fontFamily: DEFAULT_FONT_FAMILY,
         fontSize: 16,
-        fontFamily: appState.currentItemFontFamily,
+        groupIds,
+        opacity: 100,
+        roughness: 1,
+        strokeColor: colors.elementStroke[0],
+        strokeSharpness: "sharp",
+        strokeStyle: "solid",
+        strokeWidth: 1,
         textAlign: "center",
         verticalAlign: DEFAULT_VERTICAL_ALIGN,
         width: BAR_WIDTH,
-        angle: ANGLE,
       });
     }) || [];
 
-  const yAxisLabel = spreadsheet.yAxisLabel
+  // Title on top of the chart in the middle
+  const title = spreadsheet.title
     ? newTextElement({
-        text: spreadsheet.yAxisLabel,
-        x: x - Y_AXIS_LABEL_SPACING,
-        y: y + BAR_HEIGHT / 2 - 10,
-        strokeColor: appState.currentItemStrokeColor,
-        backgroundColor: appState.currentItemBackgroundColor,
-        fillStyle: appState.currentItemFillStyle,
-        strokeWidth: appState.currentItemStrokeWidth,
-        strokeStyle: appState.currentItemStrokeStyle,
-        roughness: appState.currentItemRoughness,
-        opacity: appState.currentItemOpacity,
-        strokeSharpness: appState.currentItemStrokeSharpness,
-        fontSize: 20,
-        fontFamily: appState.currentItemFontFamily,
+        text: spreadsheet.title,
+        x: x + chartWidth / 2,
+        y: y - BAR_HEIGHT - BAR_GAP * 3 - maxYLabel.height,
+
+        backgroundColor: color,
+        fillStyle: "cross-hatch",
+        fontFamily: DEFAULT_FONT_FAMILY,
+        fontSize: DEFAULT_FONT_SIZE,
+        groupIds,
+        opacity: 100,
+        roughness: 1,
+        strokeColor: colors.elementStroke[0],
+        strokeSharpness: "sharp",
+        strokeStyle: "solid",
+        strokeWidth: 1,
         textAlign: "center",
         verticalAlign: DEFAULT_VERTICAL_ALIGN,
-        width: BAR_WIDTH,
-        angle: ANGLE,
       })
     : null;
 
-  return [...bars, yAxisLabel, minYLabel, maxYLabel, ...xLabels].filter(
+  const testRect = newElement({
+    type: "rectangle",
+    x,
+    y: y - chartHeight,
+    width: chartWidth,
+    height: chartHeight,
+    strokeColor: colors.elementStroke[0],
+    backgroundColor: colors.elementBackground[3],
+    fillStyle: "solid",
+    strokeWidth: 1,
+    strokeStyle: "solid",
+    roughness: 1,
+    opacity: 8,
+    strokeSharpness: "sharp",
+    groupIds,
+  });
+
+  return [...bars, title, minYLabel, maxYLabel, ...xLabels, testRect].filter(
     (element) => element !== null,
   ) as ExcalidrawElement[];
 };

--- a/src/clipboard.ts
+++ b/src/clipboard.ts
@@ -5,12 +5,7 @@ import {
 import { getSelectedElements } from "./scene";
 import { AppState } from "./types";
 import { SVG_EXPORT_TAG } from "./scene/export";
-import {
-  tryParseSpreadsheet,
-  Spreadsheet,
-  VALID_SPREADSHEET,
-  MALFORMED_SPREADSHEET,
-} from "./charts";
+import { tryParseSpreadsheet, Spreadsheet, VALID_SPREADSHEET } from "./charts";
 import { canvasToBlob } from "./data/blob";
 
 const TYPE_ELEMENTS = "excalidraw/elements";
@@ -82,8 +77,6 @@ const parsePotentialSpreadsheet = (
   const result = tryParseSpreadsheet(text);
   if (result.type === VALID_SPREADSHEET) {
     return { spreadsheet: result.spreadsheet };
-  } else if (result.type === MALFORMED_SPREADSHEET) {
-    return { errorMessage: result.error };
   }
   return null;
 };

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -990,7 +990,7 @@ class App extends React.Component<ExcalidrawProps, AppState> {
         this.setState({ errorMessage: data.errorMessage });
       } else if (data.spreadsheet) {
         this.addElementsFromPasteOrLibrary(
-          renderSpreadsheet(this.state, data.spreadsheet, cursorX, cursorY),
+          renderSpreadsheet(data.spreadsheet, cursorX, cursorY),
         );
       } else if (data.elements) {
         this.addElementsFromPasteOrLibrary(data.elements);

--- a/src/element/newElement.ts
+++ b/src/element/newElement.ts
@@ -217,11 +217,12 @@ export const newLinearElement = (
     type: ExcalidrawLinearElement["type"];
     startArrowhead: Arrowhead | null;
     endArrowhead: Arrowhead | null;
+    points?: ExcalidrawLinearElement["points"];
   } & ElementConstructorOpts,
 ): NonDeleted<ExcalidrawLinearElement> => {
   return {
     ..._newElementBase<ExcalidrawLinearElement>(opts.type, opts),
-    points: [],
+    points: opts.points || [],
     lastCommittedPoint: null,
     startBinding: null,
     endBinding: null,

--- a/src/element/types.ts
+++ b/src/element/types.ts
@@ -3,16 +3,28 @@ import { FONT_FAMILY } from "../constants";
 
 export type GroupId = string;
 
+export type FillStyle = "hachure" | "cross-hatch" | "solid";
+export type StrokeStyle = "solid" | "dashed" | "dotted";
+export type StrokeSharpness = "round" | "sharp";
+
+export type PointerType = "mouse" | "pen" | "touch";
+
+export type TextAlign = "left" | "center" | "right";
+export type VerticalAlign = "top" | "middle";
+
+export type FontFamily = keyof typeof FONT_FAMILY;
+export type FontString = string & { _brand: "fontString" };
+
 type _ExcalidrawElementBase = Readonly<{
   id: string;
   x: number;
   y: number;
   strokeColor: string;
   backgroundColor: string;
-  fillStyle: "hachure" | "cross-hatch" | "solid";
+  fillStyle: FillStyle;
   strokeWidth: number;
-  strokeStyle: "solid" | "dashed" | "dotted";
-  strokeSharpness: "round" | "sharp";
+  strokeStyle: StrokeStyle;
+  strokeSharpness: StrokeSharpness;
   roughness: number;
   opacity: number;
   width: number;
@@ -102,11 +114,3 @@ export type ExcalidrawLinearElement = _ExcalidrawElementBase &
     startArrowhead: Arrowhead | null;
     endArrowhead: Arrowhead | null;
   }>;
-
-export type PointerType = "mouse" | "pen" | "touch";
-
-export type TextAlign = "left" | "center" | "right";
-export type VerticalAlign = "top" | "middle";
-
-export type FontFamily = keyof typeof FONT_FAMILY;
-export type FontString = string & { _brand: "fontString" };

--- a/src/element/types.ts
+++ b/src/element/types.ts
@@ -1,19 +1,15 @@
 import { Point } from "../types";
 import { FONT_FAMILY } from "../constants";
 
-export type GroupId = string;
-
 export type FillStyle = "hachure" | "cross-hatch" | "solid";
-export type StrokeStyle = "solid" | "dashed" | "dotted";
-export type StrokeSharpness = "round" | "sharp";
-
-export type PointerType = "mouse" | "pen" | "touch";
-
-export type TextAlign = "left" | "center" | "right";
-export type VerticalAlign = "top" | "middle";
-
 export type FontFamily = keyof typeof FONT_FAMILY;
 export type FontString = string & { _brand: "fontString" };
+export type GroupId = string;
+export type PointerType = "mouse" | "pen" | "touch";
+export type StrokeSharpness = "round" | "sharp";
+export type StrokeStyle = "solid" | "dashed" | "dotted";
+export type TextAlign = "left" | "center" | "right";
+export type VerticalAlign = "top" | "middle";
 
 type _ExcalidrawElementBase = Readonly<{
   id: string;

--- a/src/element/types.ts
+++ b/src/element/types.ts
@@ -9,7 +9,7 @@ type _ExcalidrawElementBase = Readonly<{
   y: number;
   strokeColor: string;
   backgroundColor: string;
-  fillStyle: string;
+  fillStyle: "hachure" | "cross-hatch" | "solid";
   strokeWidth: number;
   strokeStyle: "solid" | "dashed" | "dotted";
   strokeSharpness: "round" | "sharp";

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -215,10 +215,6 @@
   "encrypted": {
     "tooltip": "Your drawings are end-to-end encrypted so Excalidraw's servers will never see them."
   },
-  "charts": {
-    "noNumericColumn": "You pasted a spreadsheet without a numeric column.",
-    "tooManyColumns": "You pasted a spreadsheet with more than two columns."
-  },
   "stats": {
     "angle": "Angle",
     "element": "Element",

--- a/src/types.ts
+++ b/src/types.ts
@@ -52,7 +52,7 @@ export type AppState = {
   shouldAddWatermark: boolean;
   currentItemStrokeColor: string;
   currentItemBackgroundColor: string;
-  currentItemFillStyle: string;
+  currentItemFillStyle: ExcalidrawElement["fillStyle"];
   currentItemStrokeWidth: number;
   currentItemStrokeStyle: ExcalidrawElement["strokeStyle"];
   currentItemRoughness: number;


### PR DESCRIPTION
## Preview: https://excalidraw-git-charts.excalidraw.vercel.app/

### tldr: Support for more formats, better sensible defaults and other improvements for pasting charts.

#### The [anatomy of the chart](https://excalidraw.com/#json=4821735631224832,tjIfS4qOGvy52vpGHZylVQ).

<img width="613" alt="Screenshot 2020-12-10 at 11 53 15 PM" src="https://user-images.githubusercontent.com/125676/101834326-e2918500-3b42-11eb-9f4a-55ad3186a6c4.png">

------

- [x] **Support copy/pasting CSV**. You can basically write a few values in text editor and copy/paste the graph.
- [x] Better approach with the labels (set the correct alignment).
  - [x] Y-axis label was changed to Title in the spreadsheet and now displayed in the middle on top of the chart.
  - [x] Max Y value is properly aligned right outside of the chart box.
  - [x] **Change the min Y value to 0**. As we don't support negative charts yet it's more natural to have 0 for the Y-axis.
- [x] X-axis arrow (or line?).
- [x] Y-axis arrow (or line?).
- [x] Dashed horizontal line for the max value across the chart
- [x] **Sensible defaults so the chart looks good every time**. Getting the properties of the current scene could lead to very ugly charts, and people won't expect this to be the case. Instead we can have sensible defaults and with a click users can change the look and feel of it instantly, while the chart is still selected. Some [examples of what could go wrong](https://excalidraw.com/#json=5105208908578816,it0d_GjCzD90onySG6jKUw), just by modifying the last element with some properties, pasting the chart could end up very ugly.
  - [x] Random color from the background options **`[2 - 15]`**
  - [x] Stroke color: **Black**
  - [x] Fill: **Hachure**
  - [x] Stroke: **Solid**
  - [x] Sloppiness: **Artist**
  - [x] Edges: **Sharp**
- [x] **Paste the chart as a group**. Easier to move around inside the document, and if people want to change the style it's much easier just selecting the group and update the properties.
- [x] **Don't display errors and paste text instead.** That error was too intrusive and didn't even pasted the text, which could be a valid case. If people know about this feature, they will figure it out that there was an error and try pasting again.
- [x] Track the chart rendering
- [x] Remove debug rectangle before merging.


-------


### Try it out with the following data:


```
Month,Accounts
Jan,98
Feb,769
Mar,263
Apr,356
May,431
Jun,985
Jul,548
Aug,738
Sep,748
Oct,69
Nov,376
Dec,424
```

### Or from an HTML table

| Month | Accounts |
| ----- | -------- |
| Jan   | 653      |
| Feb   | 751      |
| Mar   | 941      |
| Apr   | 116      |
| May   | 828      |
| Jun   | 85       |
| Jul   | 169      |
| Aug   | 666      |
| Sep   | 127      |
| Oct   | 484      |
| Nov   | 288      |
| Dec   | 687      |


### Or tabulated data

```
Day	Commits
Sun	143
Mon	167
Tue	92
Wed	114
Thu	128
Fri	155
Sat	193
```

### Known issues (maybe for future improvements)

The following issues are currently on master as well.

- Doesn't work for negative numbers
- Only works for one or two columns (maybe later we can paste multiple charts.. or a combination. Not something for this PR)