### PR TITLE
hide stats and scrollToContent-button when mobile menus open

### DIFF
--- a/src/components/MobileMenu.tsx
+++ b/src/components/MobileMenu.tsx
@@ -154,7 +154,7 @@ export const MobileMenu = ({
             )}
             {actionManager.renderAction("deleteSelectedElements")}
           </div>
-          {appState.scrolledOutside && (
+          {appState.scrolledOutside && !appState.openMenu && (
             <button
               className="scroll-back-to-content"
               onClick={() => {

--- a/src/components/Stats.tsx
+++ b/src/components/Stats.tsx
@@ -6,6 +6,7 @@ import {
   getTotalStorageSize,
 } from "../excalidraw-app/data/localStorage";
 import { t } from "../i18n";
+import useIsMobile from "../is-mobile";
 import { getTargetElements } from "../scene";
 import { AppState } from "../types";
 import { debounce, nFormatter } from "../utils";
@@ -27,6 +28,7 @@ export const Stats = (props: {
   elements: readonly NonDeletedExcalidrawElement[];
   onClose: () => void;
 }) => {
+  const isMobile = useIsMobile();
   const [storageSizes, setStorageSizes] = useState<StorageSizes>({
     scene: 0,
     total: 0,
@@ -43,6 +45,10 @@ export const Stats = (props: {
   const boundingBox = getCommonBounds(props.elements);
   const selectedElements = getTargetElements(props.elements, props.appState);
   const selectedBoundingBox = getCommonBounds(selectedElements);
+
+  if (isMobile && props.appState.openMenu) {
+    return null;
+  }
 
   return (
     <div className="Stats">


### PR DESCRIPTION
This was bothering me since forever and I never got around to fix it :)

![image](https://user-images.githubusercontent.com/5153846/101948982-36f43d80-3bf3-11eb-9a1d-f5f8113b37a6.png)
