### PR TITLE
Add Cut to menus

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -873,8 +873,7 @@ class App extends React.Component<ExcalidrawProps, AppState> {
     if (isWritableElement(event.target)) {
       return;
     }
-    this.copyAll();
-    this.actionManager.executeAction(actionDeleteSelected);
+    this.cutAll();
     event.preventDefault();
   });
 
@@ -885,6 +884,11 @@ class App extends React.Component<ExcalidrawProps, AppState> {
     this.copyAll();
     event.preventDefault();
   });
+
+  private cutAll = () => {
+    this.copyAll();
+    this.actionManager.executeAction(actionDeleteSelected);
+  };
 
   private copyAll = () => {
     copyToClipboard(this.scene.getElements(), this.state);
@@ -3621,6 +3625,10 @@ class App extends React.Component<ExcalidrawProps, AppState> {
 
     ContextMenu.push({
       options: [
+        {
+          label: t("labels.cut"),
+          action: this.cutAll,
+        },
         navigator.clipboard && {
           label: t("labels.copy"),
           action: this.copyAll,

--- a/src/components/ShortcutsDialog.tsx
+++ b/src/components/ShortcutsDialog.tsx
@@ -241,6 +241,10 @@ export const ShortcutsDialog = ({ onClose }: { onClose?: () => void }) => {
                 isOr={true}
               />
               <Shortcut
+                label={t("labels.cut")}
+                shortcuts={[getShortcutKey("CtrlOrCmd+X")]}
+              />
+              <Shortcut
                 label={t("labels.copy")}
                 shortcuts={[getShortcutKey("CtrlOrCmd+C")]}
               />

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -4,6 +4,7 @@
     "selectAll": "Select all",
     "multiSelect": "Add element to selection",
     "moveCanvas": "Move canvas",
+    "cut": "Cut",
     "copy": "Copy",
     "copyAsPng": "Copy to clipboard as PNG",
     "copyAsSvg": "Copy to clipboard as SVG",

--- a/src/tests/regressionTests.test.tsx
+++ b/src/tests/regressionTests.test.tsx
@@ -657,6 +657,7 @@ describe("regression tests", () => {
     const contextMenu = document.querySelector(".context-menu");
     const options = contextMenu?.querySelectorAll(".context-menu-option");
     const expectedOptions = [
+      "Cut",
       "Copy styles",
       "Paste styles",
       "Delete",
@@ -669,7 +670,7 @@ describe("regression tests", () => {
     ];
 
     expect(contextMenu).not.toBeNull();
-    expect(contextMenu?.children.length).toBe(9);
+    expect(contextMenu?.children.length).toBe(10);
     options?.forEach((opt, i) => {
       expect(opt.textContent).toBe(expectedOptions[i]);
     });
@@ -699,6 +700,7 @@ describe("regression tests", () => {
     const contextMenu = document.querySelector(".context-menu");
     const options = contextMenu?.querySelectorAll(".context-menu-option");
     const expectedOptions = [
+      "Cut",
       "Copy styles",
       "Paste styles",
       "Delete",
@@ -712,7 +714,7 @@ describe("regression tests", () => {
     ];
 
     expect(contextMenu).not.toBeNull();
-    expect(contextMenu?.children.length).toBe(10);
+    expect(contextMenu?.children.length).toBe(11);
     options?.forEach((opt, i) => {
       expect(opt.textContent).toBe(expectedOptions[i]);
     });
@@ -746,6 +748,7 @@ describe("regression tests", () => {
     const contextMenu = document.querySelector(".context-menu");
     const options = contextMenu?.querySelectorAll(".context-menu-option");
     const expectedOptions = [
+      "Cut",
       "Copy styles",
       "Paste styles",
       "Delete",
@@ -759,7 +762,7 @@ describe("regression tests", () => {
     ];
 
     expect(contextMenu).not.toBeNull();
-    expect(contextMenu?.children.length).toBe(10);
+    expect(contextMenu?.children.length).toBe(11);
     options?.forEach((opt, i) => {
       expect(opt.textContent).toBe(expectedOptions[i]);
     });


### PR DESCRIPTION
## Summary

Adds "Cut" to the shortcuts menu (when you right click) and the keyboard shortcuts list (when you click the keyboard icon in the corner)

Responds to: [Missing "Cut" from list of keybindings and right click menu](https://github.com/excalidraw/excalidraw/issues/2510)

**TODO**: Add "Cut" to the other translation files!!

## Tests

Didn't _add_ any tests, but changed a few existing ones to expect "Cut" in the menus

![image](https://user-images.githubusercontent.com/30219253/101971282-da465200-3bf5-11eb-9762-c8c1384a8c1d.png)
