### PR TITLE
Expand canvas padding based on zoom.

### DIFF
--- a/src/renderer/renderElement.ts
+++ b/src/renderer/renderElement.ts
@@ -464,9 +464,11 @@ const drawElementFromCanvas = (
   context.drawImage(
     elementWithCanvas.canvas!,
     (-(x2 - x1) / 2) * window.devicePixelRatio -
-      (CANVAS_PADDING * sceneState.zoom.value) / elementWithCanvas.canvasZoom,
+      (CANVAS_PADDING * elementWithCanvas.canvasZoom) /
+        elementWithCanvas.canvasZoom,
     (-(y2 - y1) / 2) * window.devicePixelRatio -
-      (CANVAS_PADDING * sceneState.zoom.value) / elementWithCanvas.canvasZoom,
+      (CANVAS_PADDING * elementWithCanvas.canvasZoom) /
+        elementWithCanvas.canvasZoom,
     elementWithCanvas.canvas!.width / elementWithCanvas.canvasZoom,
     elementWithCanvas.canvas!.height / elementWithCanvas.canvasZoom,
   );

--- a/src/renderer/renderElement.ts
+++ b/src/renderer/renderElement.ts
@@ -57,29 +57,37 @@ const generateElementCanvas = (
     const [x1, y1, x2, y2] = getElementAbsoluteCoords(element);
     canvas.width =
       distance(x1, x2) * window.devicePixelRatio * zoom.value +
-      CANVAS_PADDING * 2;
+      CANVAS_PADDING * zoom.value * 2;
     canvas.height =
       distance(y1, y2) * window.devicePixelRatio * zoom.value +
-      CANVAS_PADDING * 2;
+      CANVAS_PADDING * zoom.value * 2;
 
     canvasOffsetX =
       element.x > x1
-        ? Math.floor(distance(element.x, x1)) * window.devicePixelRatio
+        ? Math.floor(distance(element.x, x1)) *
+          window.devicePixelRatio *
+          zoom.value
         : 0;
+
     canvasOffsetY =
       element.y > y1
-        ? Math.floor(distance(element.y, y1)) * window.devicePixelRatio
+        ? Math.floor(distance(element.y, y1)) *
+          window.devicePixelRatio *
+          zoom.value
         : 0;
-    context.translate(canvasOffsetX * zoom.value, canvasOffsetY * zoom.value);
+
+    context.translate(canvasOffsetX, canvasOffsetY);
   } else {
     canvas.width =
-      element.width * window.devicePixelRatio * zoom.value + CANVAS_PADDING * 2;
+      element.width * window.devicePixelRatio * zoom.value +
+      CANVAS_PADDING * zoom.value * 2;
     canvas.height =
       element.height * window.devicePixelRatio * zoom.value +
-      CANVAS_PADDING * 2;
+      CANVAS_PADDING * zoom.value * 2;
   }
 
-  context.translate(CANVAS_PADDING, CANVAS_PADDING);
+  context.translate(CANVAS_PADDING * zoom.value, CANVAS_PADDING * zoom.value);
+
   context.scale(
     window.devicePixelRatio * zoom.value,
     window.devicePixelRatio * zoom.value,
@@ -87,7 +95,10 @@ const generateElementCanvas = (
 
   const rc = rough.canvas(canvas);
   drawElementOnCanvas(element, rc, context);
-  context.translate(-CANVAS_PADDING, -CANVAS_PADDING);
+  context.translate(
+    -(CANVAS_PADDING * zoom.value),
+    -(CANVAS_PADDING * zoom.value),
+  );
   context.scale(
     1 / (window.devicePixelRatio * zoom.value),
     1 / (window.devicePixelRatio * zoom.value),
@@ -453,9 +464,9 @@ const drawElementFromCanvas = (
   context.drawImage(
     elementWithCanvas.canvas!,
     (-(x2 - x1) / 2) * window.devicePixelRatio -
-      CANVAS_PADDING / elementWithCanvas.canvasZoom,
+      (CANVAS_PADDING * sceneState.zoom.value) / elementWithCanvas.canvasZoom,
     (-(y2 - y1) / 2) * window.devicePixelRatio -
-      CANVAS_PADDING / elementWithCanvas.canvasZoom,
+      (CANVAS_PADDING * sceneState.zoom.value) / elementWithCanvas.canvasZoom,
     elementWithCanvas.canvas!.width / elementWithCanvas.canvasZoom,
     elementWithCanvas.canvas!.height / elementWithCanvas.canvasZoom,
   );


### PR DESCRIPTION
When we render an element, we draw that element onto a canvas. The size of this canvas is based on the size of the element, plus an extra 20px of padding just to be sure. This padding can sometimes be insufficient to catch certain arrowheads, causing them to appear clipped. The problem is most noticeable when zoomed in.

![Kapture 2020-12-12 at 14 03 48](https://user-images.githubusercontent.com/23072548/101985956-e0cedb00-3c82-11eb-8ee8-c0b426745656.gif)

The underlying problem is that arrowheads are ignored when calculating the bounds of the line. This is perhaps correct for the shape's bounding box; however, we should take them into account when calculating the size of the element's canvas. 

![Kapture 2020-12-12 at 13 47 54](https://user-images.githubusercontent.com/23072548/101985983-0e1b8900-3c83-11eb-8639-d0e4899ee9ca.gif)

This PR does not solve the underlying problem. Instead, this PR:
- expands the canvas padding from `20` to `28`
- makes the canvas padding width change with the canvas zoom. At 200% zoom, the shape will receive 56px padding (2 * 28px). At 50% zoom, it will receive 14px padding (.5 * 28px).

![Kapture 2020-12-12 at 14 16 52](https://user-images.githubusercontent.com/23072548/101986231-b41bc300-3c84-11eb-87fa-53a20717e280.gif)
