### PR TITLE
fix: Add width/height for the lines in charts

### DIFF
--- a/src/charts.ts
+++ b/src/charts.ts
@@ -192,6 +192,7 @@ export const renderSpreadsheet = (
     y,
     startArrowhead: null,
     endArrowhead: null,
+    width: chartWidth,
     points: [
       [0, 0],
       [chartWidth, 0],
@@ -205,6 +206,7 @@ export const renderSpreadsheet = (
     y,
     startArrowhead: null,
     endArrowhead: null,
+    height: chartHeight,
     points: [
       [0, 0],
       [0, -chartHeight],
@@ -220,6 +222,7 @@ export const renderSpreadsheet = (
     endArrowhead: null,
     ...commonProps,
     strokeStyle: "dotted",
+    width: chartWidth,
     points: [
       [0, 0],
       [chartWidth, 0],

--- a/src/packages/excalidraw/CHANGELOG.MD
+++ b/src/packages/excalidraw/CHANGELOG.MD
@@ -23,8 +23,8 @@ Please add the latest change on the top under the correct section.
 - Support CSV graphs and improve the look and feel [#2495](https://github.com/excalidraw/excalidraw/pull/2495)
 
 ### Fixes
-- Fix Library Menu Layout [#2502](https://github.com/excalidraw/excalidraw/pull/2502)
 - Fix resizing the pasted charts [#2586](https://github.com/excalidraw/excalidraw/pull/2586)
+- Fix Library Menu Layout [#2502](https://github.com/excalidraw/excalidraw/pull/2502)
 
 ### Improvements
 - Add tooltip with icon for embedding scenes [#2532](https://github.com/excalidraw/excalidraw/pull/2532)

--- a/src/packages/excalidraw/CHANGELOG.MD
+++ b/src/packages/excalidraw/CHANGELOG.MD
@@ -24,6 +24,7 @@ Please add the latest change on the top under the correct section.
 
 ### Fixes
 - Fix Library Menu Layout [#2502](https://github.com/excalidraw/excalidraw/pull/2502)
+- Fix resizing the pasted charts [#2586](https://github.com/excalidraw/excalidraw/pull/2586)
 
 ### Improvements
 - Add tooltip with icon for embedding scenes [#2532](https://github.com/excalidraw/excalidraw/pull/2532)

--- a/src/packages/excalidraw/CHANGELOG.MD
+++ b/src/packages/excalidraw/CHANGELOG.MD
@@ -25,6 +25,7 @@ Please add the latest change on the top under the correct section.
 - Support CSV graphs and improve the look and feel [#2495](https://github.com/excalidraw/excalidraw/pull/2495)
 
 ### Fixes
+
 - Fix resizing the pasted charts [#2586](https://github.com/excalidraw/excalidraw/pull/2586)
 - Fix element visibility and zoom on cursor when canvas offset isn't 0. [#2534](https://github.com/excalidraw/excalidraw/pull/2534)
 - Fix Library Menu Layout [#2502](https://github.com/excalidraw/excalidraw/pull/2502)


### PR DESCRIPTION
Fixes #2585 

Even though the created line should do that automatically.