### PR TITLE
Revert the changelog check of excluding the branches 

### DIFF
--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -4,12 +4,7 @@ on:
   push:
     branches:
       - master
-      - "!l10n_master"
-      - "!dependabot/**"
   pull_request:
-    branches:
-      - "!l10n_master"
-      - "!dependabot/**"
 
 jobs:
   test:

--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - master
+      - "!l10n_master"
+      - "!dependabot/**"
   pull_request:
     branches:
       - "!l10n_master"

--- a/src/actions/actionAlign.tsx
+++ b/src/actions/actionAlign.tsx
@@ -44,7 +44,7 @@ const alignSelectedElements = (
 export const actionAlignTop = register({
   name: "alignTop",
   perform: (elements, appState) => {
-    trackEvent(EVENT_ALIGN, "align", "top");
+    trackEvent(EVENT_ALIGN, "align", "top1");
     return {
       appState,
       elements: alignSelectedElements(elements, appState, {

--- a/src/actions/actionAlign.tsx
+++ b/src/actions/actionAlign.tsx
@@ -44,7 +44,7 @@ const alignSelectedElements = (
 export const actionAlignTop = register({
   name: "alignTop",
   perform: (elements, appState) => {
-    trackEvent(EVENT_ALIGN, "align", "top1");
+    trackEvent(EVENT_ALIGN, "align", "top");
     return {
       appState,
       elements: alignSelectedElements(elements, appState, {


### PR DESCRIPTION
Revert the changelog check of excluding the branches since the changelog stopped running for all pull requests now
I will check more on this and push a proper fix