### PR TITLE
 Fix changelog workflow

### DIFF
--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -17,11 +17,12 @@ jobs:
           node-version: 14.x
       - name: Install and run changelog check
         run:
-          if [[ $GITHUB_HEAD_REF =~ dependabot || $GITHUB_HEAD_REF == "l10n_master" ]]
-          then exit 0;
+          if [[ $GITHUB_HEAD_REF =~ dependabot || $GITHUB_HEAD_REF == "l10n_master" ]]; then
+          echo "Skipping running changelog check"
+          exit 0
           else
-          npm ci;
-          npm run changelog:check;
+          npm ci
+          npm run changelog:check
           fi
         env:
           CI: true

--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -18,11 +18,11 @@ jobs:
       - name: Install and run changelog check
         run:
           if [[ $GITHUB_HEAD_REF =~ dependabot || $GITHUB_HEAD_REF == "l10n_master" ]]; then
-          echo "Skipping running changelog check"
-          exit 0
+          echo "Skipping running changelog check";
+          exit 0;
           else
-          npm ci
-          npm run changelog:check
+          npm ci;
+          npm run changelog:check;
           fi
         env:
           CI: true

--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -19,7 +19,6 @@ jobs:
         run:
           if [[ $GITHUB_HEAD_REF =~ dependabot || $GITHUB_HEAD_REF == "l10n_master" ]]; then
           echo "Skipping running changelog check";
-          exit 0;
           else
           npm ci;
           npm run changelog:check;

--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -2,24 +2,26 @@ name: Changelog in sync for packages
 
 on:
   push:
-    branches-ignore:
-      - "l10n_master"
-      - "dependabot/**"
+    branches:
+      - master
+  pull_request:
 jobs:
   test:
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v1
-
       - name: Setup Node.js 14.x
         uses: actions/setup-node@v1
         with:
           node-version: 14.x
-
       - name: Install and run changelog check
-        run: |
-          npm ci
-          npm run changelog:check
+        run:
+          if [[ $GITHUB_HEAD_REF =~ dependabot || $GITHUB_HEAD_REF == "l10n_master" ]];
+          then exit 0;
+          else
+          npm ci;
+          npm run changelog:check;
+          fi
         env:
           CI: true

--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -17,7 +17,7 @@ jobs:
           node-version: 14.x
       - name: Install and run changelog check
         run:
-          if [[ $GITHUB_HEAD_REF =~ dependabot || $GITHUB_HEAD_REF == "l10n_master" ]];
+          if [[ $GITHUB_HEAD_REF =~ dependabot || $GITHUB_HEAD_REF == "l10n_master" ]]
           then exit 0;
           else
           npm ci;

--- a/src/actions/actionAlign.tsx
+++ b/src/actions/actionAlign.tsx
@@ -44,7 +44,7 @@ const alignSelectedElements = (
 export const actionAlignTop = register({
   name: "alignTop",
   perform: (elements, appState) => {
-    trackEvent(EVENT_ALIGN, "align", "top");
+    trackEvent(EVENT_ALIGN, "align", "top1");
     return {
       appState,
       elements: alignSelectedElements(elements, appState, {

--- a/src/actions/actionAlign.tsx
+++ b/src/actions/actionAlign.tsx
@@ -44,7 +44,7 @@ const alignSelectedElements = (
 export const actionAlignTop = register({
   name: "alignTop",
   perform: (elements, appState) => {
-    trackEvent(EVENT_ALIGN, "align", "top1");
+    trackEvent(EVENT_ALIGN, "align", "top");
     return {
       appState,
       elements: alignSelectedElements(elements, appState, {


### PR DESCRIPTION
* Since `pull_request` was removed in https://github.com/excalidraw/excalidraw/commit/bfeb3c7dfd2486f6734de8a6f90f7208a07f731e the changelog checks stopped running for all pull requests which are made against forked branches example https://github.com/excalidraw/excalidraw/pull/2596 so I have added that again and it runs for forked pr's now https://github.com/excalidraw/excalidraw/pull/2603

* I digged into the workflows and looks like there is no way to stop running the actions for some particular head branches when pull request is made so added a condition for that to skip changelog check.

* tested its skipping the check for matched branches( notice the name of this branch)

* ~~I am not sure why the checks are running twice https://github.com/excalidraw/excalidraw/pull/2604/checks coz in first changelog:check it skips (notice the echo)  but in the second one it doesn't.~~
Fixed, it was happening as I was exiting the script when head branch matched.