### PR TITLE
[WIP] build(package/excalidraw): use cdn to serve the assets. no more copying files :)

### DIFF
--- a/src/packages/excalidraw/package.json
+++ b/src/packages/excalidraw/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@excalidraw/excalidraw",
-  "version": "0.1.1",
+  "name": "aakansha-excalidraw",
+  "version": "0.2.1-cdn",
   "main": "dist/excalidraw.min.js",
   "files": [
     "dist/*"

--- a/src/packages/excalidraw/webpack.prod.config.js
+++ b/src/packages/excalidraw/webpack.prod.config.js
@@ -15,7 +15,7 @@ module.exports = {
     library: "Excalidraw",
     libraryTarget: "umd",
     filename: "[name].js",
-    publicPath: "/",
+    publicPath: "https://unpkg.com/aakansha-excalidraw@0.2.1-cdn/dist/",
     chunkFilename: "excalidraw-assets/[name].js",
   },
   resolve: {


### PR DESCRIPTION
for https://github.com/excalidraw/excalidraw/issues/2605
All the assets will be served from https://unpkg.com/
check it out [here](https://codesandbox.io/s/aakansha-testing-xig4w?file=/src/App.js)
package: `aakansha-excalidraw@0.2.1-cdn`

- [ ] Update the script to read the version from the package so we need no update manually
- [ ] Update readme