### PR TITLE
improvement: Support numbers with commas in them

### DIFF
--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -11,14 +11,17 @@ export const EVENT_SHAPE = "shape";
 export const EVENT_SHARE = "share";
 export const EVENT_MAGIC = "magic";
 
-export const trackEvent = window.gtag
-  ? (category: string, name: string, label?: string, value?: number) => {
-      window.gtag("event", name, {
-        event_category: category,
-        event_label: label,
-        value,
-      });
-    }
-  : (category: string, name: string, label?: string, value?: number) => {
-      console.info("Track Event", category, name, label, value);
-    };
+export const trackEvent =
+  typeof window !== "undefined" && window.gtag
+    ? (category: string, name: string, label?: string, value?: number) => {
+        window.gtag("event", name, {
+          event_category: category,
+          event_label: label,
+          value,
+        });
+      }
+    : typeof process !== "undefined" && process?.env?.JEST_WORKER_ID
+    ? (category: string, name: string, label?: string, value?: number) => {}
+    : (category: string, name: string, label?: string, value?: number) => {
+        console.info("Track Event", category, name, label, value);
+      };

--- a/src/packages/excalidraw/CHANGELOG.MD
+++ b/src/packages/excalidraw/CHANGELOG.MD
@@ -31,6 +31,7 @@ Please add the latest change on the top under the correct section.
 - Fix resizing the pasted charts [#2586](https://github.com/excalidraw/excalidraw/pull/2586)
 - Fix element visibility and zoom on cursor when canvas offset isn't 0. [#2534](https://github.com/excalidraw/excalidraw/pull/2534)
 - Fix Library Menu Layout [#2502](https://github.com/excalidraw/excalidraw/pull/2502)
+- Support number with commas in charts [#2636](https://github.com/excalidraw/excalidraw/pull/2636)
 
 ### Improvements
 

--- a/src/tests/__snapshots__/charts.test.tsx.snap
+++ b/src/tests/__snapshots__/charts.test.tsx.snap
@@ -1,0 +1,20 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`tryParseSpreadsheet works for numbers with comma in them 1`] = `
+Object {
+  "spreadsheet": Object {
+    "labels": Array [
+      "Week 1",
+      "Week 2",
+      "Week 3",
+    ],
+    "title": "Users",
+    "values": Array [
+      814,
+      10301,
+      4264,
+    ],
+  },
+  "type": "VALID_SPREADSHEET",
+}
+`;

--- a/src/tests/charts.test.tsx
+++ b/src/tests/charts.test.tsx
@@ -1,0 +1,13 @@
+import { tryParseSpreadsheet } from "../charts";
+
+describe("tryParseSpreadsheet", () => {
+  it("works for numbers with comma in them", () => {
+    const result = tryParseSpreadsheet(
+      `Week Index${"\t"}Users
+Week 1${"\t"}814
+Week 2${"\t"}10,301
+Week 3${"\t"}4,264`,
+    );
+    expect(result).toMatchSnapshot();
+  });
+});


### PR DESCRIPTION
I tried to paste weekly active users from excel but isNumeric didn't recognize "10,000" as number and wouldn't recognize the data as a chart. This PR fixes it.