### PR TITLE
fix: align items in context menu

### DIFF
--- a/src/components/ContextMenu.scss
+++ b/src/components/ContextMenu.scss
@@ -32,6 +32,7 @@
 
     display: grid;
     grid-template-columns: 1fr 0.2fr;
+    align-items: center;
 
     &.dangerous {
       div:nth-child(1) {


### PR DESCRIPTION
change the css for context-menu to look the shortcut text a little bit better. It was not perfect, because the font-size of the shortcut is reduced.

Fixes #2641