### PR TITLE
fix: Center zoom on iPhone and iPad

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1426,6 +1426,16 @@ class App extends React.Component<ExcalidrawProps, AppState> {
 
   private onGestureChange = withBatchedUpdates((event: GestureEvent) => {
     event.preventDefault();
+
+    // onGestureChange only has zoom factor but not the center.
+    // If we're on iPad or iPhone, then we recognize multi-touch and will
+    // zoom in at the right location on the touchMove handler already.
+    // On Macbook, we don't have those events so will zoom in at the
+    // current location instead.
+    if (gesture.pointers.size === 2) {
+      return;
+    }
+
     const initialScale = gesture.initialScale;
     if (initialScale) {
       this.setState(({ zoom, offsetLeft, offsetTop }) => ({


### PR DESCRIPTION
My last attempt removed the gesture handler altogether but broke macbooks. This one keeps it working on macbook but makes sure it zooms properly on iPhone and iPad.

Test plan:

For macbook:
<img width="591" alt="Screen Shot 2020-12-20 at 12 06 58 PM" src="https://user-images.githubusercontent.com/197597/102723382-57d82500-42bc-11eb-94cd-3157afb1614b.png">
