### PR TITLE
feat: Add separators on context menu

### DIFF
--- a/src/actions/actionAddToLibrary.ts
+++ b/src/actions/actionAddToLibrary.ts
@@ -17,6 +17,5 @@ export const actionAddToLibrary = register({
     });
     return false;
   },
-  contextMenuOrder: 6,
   contextItemLabel: "labels.addToLibrary",
 });

--- a/src/actions/actionClipboard.tsx
+++ b/src/actions/actionClipboard.tsx
@@ -1,0 +1,98 @@
+import { CODES, KEYS } from "../keys";
+import { register } from "./register";
+import { copyToClipboard } from "../clipboard";
+import { actionDeleteSelected } from "./actionDeleteSelected";
+import { getSelectedElements } from "../scene/selection";
+import { exportCanvas } from "../data/index";
+import { getNonDeletedElements } from "../element";
+
+export const actionCopy = register({
+  name: "copy",
+  perform: (elements, appState) => {
+    copyToClipboard(getNonDeletedElements(elements), appState);
+
+    return {
+      commitToHistory: false,
+    };
+  },
+  contextItemLabel: "labels.copy",
+  keyTest: (event) => event[KEYS.CTRL_OR_CMD] && event.code === CODES.C,
+});
+
+export const actionCut = register({
+  name: "cut",
+  perform: (elements, appState) => {
+    actionCopy.perform(elements, appState, null);
+    return actionDeleteSelected.perform(elements, appState, null);
+  },
+  contextItemLabel: "labels.cut",
+  keyTest: (event) => event[KEYS.CTRL_OR_CMD] && event.code === CODES.X,
+});
+
+export const actionCopyAsSvg = register({
+  name: "copyAsSvg",
+  perform: async (elements, appState, canvas) => {
+    const selectedElements = getSelectedElements(
+      getNonDeletedElements(elements),
+      appState,
+    );
+    try {
+      await exportCanvas(
+        "clipboard-svg",
+        selectedElements.length
+          ? selectedElements
+          : getNonDeletedElements(elements),
+        appState,
+        canvas,
+        appState,
+      );
+    } catch (error) {
+      console.error(error);
+      return {
+        appState: {
+          ...appState,
+          errorMessage: error.message,
+        },
+        commitToHistory: false,
+      };
+    }
+    return {
+      commitToHistory: false,
+    };
+  },
+  contextItemLabel: "labels.copyAsSvg",
+});
+
+export const actionCopyAsPng = register({
+  name: "copyAsPng",
+  perform: async (elements, appState, canvas) => {
+    const selectedElements = getSelectedElements(
+      getNonDeletedElements(elements),
+      appState,
+    );
+    try {
+      await exportCanvas(
+        "clipboard",
+        selectedElements.length
+          ? selectedElements
+          : getNonDeletedElements(elements),
+        appState,
+        canvas,
+        appState,
+      );
+    } catch (error) {
+      console.error(error);
+      return {
+        appState: {
+          ...appState,
+          errorMessage: error.message,
+        },
+        commitToHistory: false,
+      };
+    }
+    return {
+      commitToHistory: false,
+    };
+  },
+  contextItemLabel: "labels.copyAsPng",
+});

--- a/src/actions/actionClipboard.tsx
+++ b/src/actions/actionClipboard.tsx
@@ -21,9 +21,9 @@ export const actionCopy = register({
 
 export const actionCut = register({
   name: "cut",
-  perform: (elements, appState) => {
-    actionCopy.perform(elements, appState, null);
-    return actionDeleteSelected.perform(elements, appState, null);
+  perform: (elements, appState, data, app) => {
+    actionCopy.perform(elements, appState, data, app);
+    return actionDeleteSelected.perform(elements, appState, data, app);
   },
   contextItemLabel: "labels.cut",
   keyTest: (event) => event[KEYS.CTRL_OR_CMD] && event.code === CODES.X,
@@ -31,7 +31,12 @@ export const actionCut = register({
 
 export const actionCopyAsSvg = register({
   name: "copyAsSvg",
-  perform: async (elements, appState, canvas) => {
+  perform: async (elements, appState, _data, app) => {
+    if (!app.canvas) {
+      return {
+        commitToHistory: false,
+      };
+    }
     const selectedElements = getSelectedElements(
       getNonDeletedElements(elements),
       appState,
@@ -43,9 +48,12 @@ export const actionCopyAsSvg = register({
           ? selectedElements
           : getNonDeletedElements(elements),
         appState,
-        canvas,
+        app.canvas,
         appState,
       );
+      return {
+        commitToHistory: false,
+      };
     } catch (error) {
       console.error(error);
       return {
@@ -56,16 +64,18 @@ export const actionCopyAsSvg = register({
         commitToHistory: false,
       };
     }
-    return {
-      commitToHistory: false,
-    };
   },
   contextItemLabel: "labels.copyAsSvg",
 });
 
 export const actionCopyAsPng = register({
   name: "copyAsPng",
-  perform: async (elements, appState, canvas) => {
+  perform: async (elements, appState, _data, app) => {
+    if (!app.canvas) {
+      return {
+        commitToHistory: false,
+      };
+    }
     const selectedElements = getSelectedElements(
       getNonDeletedElements(elements),
       appState,
@@ -77,9 +87,12 @@ export const actionCopyAsPng = register({
           ? selectedElements
           : getNonDeletedElements(elements),
         appState,
-        canvas,
+        app.canvas,
         appState,
       );
+      return {
+        commitToHistory: false,
+      };
     } catch (error) {
       console.error(error);
       return {
@@ -90,9 +103,6 @@ export const actionCopyAsPng = register({
         commitToHistory: false,
       };
     }
-    return {
-      commitToHistory: false,
-    };
   },
   contextItemLabel: "labels.copyAsPng",
 });

--- a/src/actions/actionDeleteSelected.tsx
+++ b/src/actions/actionDeleteSelected.tsx
@@ -136,7 +136,6 @@ export const actionDeleteSelected = register({
     };
   },
   contextItemLabel: "labels.delete",
-  contextMenuOrder: 999999,
   keyTest: (event) => event.key === KEYS.BACKSPACE || event.key === KEYS.DELETE,
   PanelComponent: ({ elements, appState, updateData }) => (
     <ToolButton

--- a/src/actions/actionGroup.tsx
+++ b/src/actions/actionGroup.tsx
@@ -125,7 +125,6 @@ export const actionGroup = register({
       commitToHistory: true,
     };
   },
-  contextMenuOrder: 4,
   contextItemLabel: "labels.group",
   contextItemPredicate: (elements, appState) =>
     enableActionGroup(elements, appState),
@@ -174,7 +173,6 @@ export const actionUngroup = register({
   },
   keyTest: (event) =>
     event.shiftKey && event[KEYS.CTRL_OR_CMD] && event.code === CODES.G,
-  contextMenuOrder: 5,
   contextItemLabel: "labels.ungroup",
   contextItemPredicate: (elements, appState) =>
     getSelectedGroupIds(appState).length > 0,

--- a/src/actions/actionStyles.ts
+++ b/src/actions/actionStyles.ts
@@ -34,7 +34,6 @@ export const actionCopyStyles = register({
   contextItemLabel: "labels.copyStyles",
   keyTest: (event) =>
     event[KEYS.CTRL_OR_CMD] && event.altKey && event.code === CODES.C,
-  contextMenuOrder: 0,
 });
 
 export const actionPasteStyles = register({
@@ -74,5 +73,4 @@ export const actionPasteStyles = register({
   contextItemLabel: "labels.pasteStyles",
   keyTest: (event) =>
     event[KEYS.CTRL_OR_CMD] && event.altKey && event.code === CODES.V,
-  contextMenuOrder: 1,
 });

--- a/src/actions/actionToggleGridMode.tsx
+++ b/src/actions/actionToggleGridMode.tsx
@@ -1,0 +1,21 @@
+import { CODES, KEYS } from "../keys";
+import { register } from "./register";
+import { GRID_SIZE } from "../constants";
+
+export const actionToggleGridMode = register({
+  name: "gridMode",
+  perform(elements, appState) {
+    this.checked = !this.checked;
+    return {
+      appState: {
+        ...appState,
+        gridSize: appState.gridSize ? null : GRID_SIZE,
+      },
+      commitToHistory: false,
+    };
+  },
+  checked: false,
+  contextItemLabel: "labels.gridMode",
+  // Wrong event code
+  keyTest: (event) => event[KEYS.CTRL_OR_CMD] && event.code === CODES.QUOTE,
+});

--- a/src/actions/actionToggleStats.tsx
+++ b/src/actions/actionToggleStats.tsx
@@ -1,0 +1,17 @@
+import { register } from "./register";
+
+export const actionToggleStats = register({
+  name: "stats",
+  perform(elements, appState) {
+    this.checked = !this.checked;
+    return {
+      appState: {
+        ...appState,
+        showStats: !appState.showStats,
+      },
+      commitToHistory: false,
+    };
+  },
+  checked: false,
+  contextItemLabel: "stats.title",
+});

--- a/src/actions/actionToggleZenMode.tsx
+++ b/src/actions/actionToggleZenMode.tsx
@@ -1,21 +1,20 @@
 import { CODES, KEYS } from "../keys";
 import { register } from "./register";
-import { GRID_SIZE } from "../constants";
 
-export const actionToggleGridMode = register({
-  name: "gridMode",
+export const actionToggleZenMode = register({
+  name: "zenMode",
   perform(elements, appState) {
     this.checked = !this.checked;
     return {
       appState: {
         ...appState,
-        gridSize: this.checked ? GRID_SIZE : null,
+        zenModeEnabled: this.checked,
       },
       commitToHistory: false,
     };
   },
   checked: false,
-  contextItemLabel: "labels.gridMode",
+  contextItemLabel: "buttons.zenMode",
   // Wrong event code
   keyTest: (event) => event[KEYS.CTRL_OR_CMD] && event.code === CODES.QUOTE,
 });

--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -74,5 +74,6 @@ export {
 } from "./actionClipboard";
 
 export { actionToggleGridMode } from "./actionToggleGridMode";
+export { actionToggleZenMode } from "./actionToggleZenMode";
 
 export { actionToggleStats } from "./actionToggleStats";

--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -65,3 +65,14 @@ export {
   distributeHorizontally,
   distributeVertically,
 } from "./actionDistribute";
+
+export {
+  actionCopy,
+  actionCut,
+  actionCopyAsPng,
+  actionCopyAsSvg,
+} from "./actionClipboard";
+
+export { actionToggleGridMode } from "./actionToggleGridMode";
+
+export { actionToggleStats } from "./actionToggleStats";

--- a/src/actions/manager.tsx
+++ b/src/actions/manager.tsx
@@ -3,14 +3,11 @@ import {
   Action,
   ActionsManagerInterface,
   UpdaterFn,
-  ActionFilterFn,
   ActionName,
   ActionResult,
 } from "./types";
 import { ExcalidrawElement } from "../element/types";
 import { AppState } from "../types";
-import { t } from "../i18n";
-import { ShortcutName } from "./shortcuts";
 
 export class ActionManager implements ActionsManagerInterface {
   actions = {} as ActionsManagerInterface["actions"];
@@ -75,47 +72,14 @@ export class ActionManager implements ActionsManagerInterface {
     return true;
   }
 
-  executeAction(action: Action) {
+  executeAction(action: Action, data: HTMLCanvasElement | null = null) {
     this.updater(
       action.perform(
         this.getElementsIncludingDeleted(),
         this.getAppState(),
-        null,
+        data,
       ),
     );
-  }
-
-  getContextMenuItems(actionFilter: ActionFilterFn = (action) => action) {
-    return Object.values(this.actions)
-      .filter(actionFilter)
-      .filter((action) => "contextItemLabel" in action)
-      .filter((action) =>
-        action.contextItemPredicate
-          ? action.contextItemPredicate(
-              this.getElementsIncludingDeleted(),
-              this.getAppState(),
-            )
-          : true,
-      )
-      .sort(
-        (a, b) =>
-          (a.contextMenuOrder !== undefined ? a.contextMenuOrder : 999) -
-          (b.contextMenuOrder !== undefined ? b.contextMenuOrder : 999),
-      )
-      .map((action) => ({
-        // take last bit of the label  "labels.<shortcutName>"
-        shortcutName: action.contextItemLabel?.split(".").pop() as ShortcutName,
-        label: action.contextItemLabel ? t(action.contextItemLabel) : "",
-        action: () => {
-          this.updater(
-            action.perform(
-              this.getElementsIncludingDeleted(),
-              this.getAppState(),
-              null,
-            ),
-          );
-        },
-      }));
   }
 
   // Id is an attribute that we can use to pass in data like keys.

--- a/src/actions/manager.tsx
+++ b/src/actions/manager.tsx
@@ -9,19 +9,24 @@ import {
 import { ExcalidrawElement } from "../element/types";
 import { AppState } from "../types";
 
+// This is the <App> component, but for now we don't care about anything but its
+// `canvas` state.
+type App = { canvas: HTMLCanvasElement | null };
+
 export class ActionManager implements ActionsManagerInterface {
   actions = {} as ActionsManagerInterface["actions"];
 
   updater: (actionResult: ActionResult | Promise<ActionResult>) => void;
 
   getAppState: () => Readonly<AppState>;
-
   getElementsIncludingDeleted: () => readonly ExcalidrawElement[];
+  app: App;
 
   constructor(
     updater: UpdaterFn,
     getAppState: () => AppState,
     getElementsIncludingDeleted: () => readonly ExcalidrawElement[],
+    app: App,
   ) {
     this.updater = (actionResult) => {
       if (actionResult && "then" in actionResult) {
@@ -34,6 +39,7 @@ export class ActionManager implements ActionsManagerInterface {
     };
     this.getAppState = getAppState;
     this.getElementsIncludingDeleted = getElementsIncludingDeleted;
+    this.app = app;
   }
 
   registerAction(action: Action) {
@@ -67,17 +73,19 @@ export class ActionManager implements ActionsManagerInterface {
         this.getElementsIncludingDeleted(),
         this.getAppState(),
         null,
+        this.app,
       ),
     );
     return true;
   }
 
-  executeAction(action: Action, data: HTMLCanvasElement | null = null) {
+  executeAction(action: Action) {
     this.updater(
       action.perform(
         this.getElementsIncludingDeleted(),
         this.getAppState(),
-        data,
+        null,
+        this.app,
       ),
     );
   }
@@ -96,6 +104,7 @@ export class ActionManager implements ActionsManagerInterface {
             this.getElementsIncludingDeleted(),
             this.getAppState(),
             formState,
+            this.app,
           ),
         );
       };

--- a/src/actions/shortcuts.ts
+++ b/src/actions/shortcuts.ts
@@ -9,7 +9,7 @@ export type ShortcutName =
   | "copyStyles"
   | "pasteStyles"
   | "selectAll"
-  | "delete"
+  | "deleteSelectedElements"
   | "duplicateSelection"
   | "sendBackward"
   | "bringForward"
@@ -31,7 +31,7 @@ const shortcutMap: Record<ShortcutName, string[]> = {
   copyStyles: [getShortcutKey("CtrlOrCmd+Alt+C")],
   pasteStyles: [getShortcutKey("CtrlOrCmd+Alt+V")],
   selectAll: [getShortcutKey("CtrlOrCmd+A")],
-  delete: [getShortcutKey("Del")],
+  deleteSelectedElements: [getShortcutKey("Del")],
   duplicateSelection: [
     getShortcutKey("CtrlOrCmd+D"),
     getShortcutKey(`Alt+${t("helpDialog.drag")}`),

--- a/src/actions/types.ts
+++ b/src/actions/types.ts
@@ -16,6 +16,7 @@ type ActionFn = (
   elements: readonly ExcalidrawElement[],
   appState: Readonly<AppState>,
   formData: any,
+  app: { canvas: HTMLCanvasElement | null },
 ) => ActionResult | Promise<ActionResult>;
 
 export type UpdaterFn = (res: ActionResult) => void;

--- a/src/actions/types.ts
+++ b/src/actions/types.ts
@@ -22,6 +22,11 @@ export type UpdaterFn = (res: ActionResult) => void;
 export type ActionFilterFn = (action: Action) => void;
 
 export type ActionName =
+  | "copy"
+  | "cut"
+  | "paste"
+  | "copyAsPng"
+  | "copyAsSvg"
   | "sendBackward"
   | "bringForward"
   | "sendToBack"
@@ -29,6 +34,9 @@ export type ActionName =
   | "copyStyles"
   | "selectAll"
   | "pasteStyles"
+  | "gridMode"
+  | "zenMode"
+  | "stats"
   | "changeStrokeColor"
   | "changeBackgroundColor"
   | "changeFillStyle"
@@ -93,19 +101,16 @@ export interface Action {
     elements: readonly ExcalidrawElement[],
   ) => boolean;
   contextItemLabel?: string;
-  contextMenuOrder?: number;
   contextItemPredicate?: (
     elements: readonly ExcalidrawElement[],
     appState: AppState,
   ) => boolean;
+  checked?: boolean;
 }
 
 export interface ActionsManagerInterface {
   actions: Record<ActionName, Action>;
   registerAction: (action: Action) => void;
   handleKeyDown: (event: KeyboardEvent) => boolean;
-  getContextMenuItems: (
-    actionFilter: ActionFilterFn,
-  ) => { label: string; action: () => void }[];
   renderAction: (name: ActionName) => React.ReactElement | null;
 }

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -3,6 +3,28 @@ import React from "react";
 import { RoughCanvas } from "roughjs/bin/canvas";
 import rough from "roughjs/bin/rough";
 import "../actions";
+import {
+  actionAddToLibrary,
+  actionBringForward,
+  actionBringToFront,
+  actionCopy,
+  actionCopyAsPng,
+  actionCopyAsSvg,
+  actionCopyStyles,
+  actionCut,
+  actionDeleteSelected,
+  actionDuplicateSelection,
+  actionFinalize,
+  actionGroup,
+  actionPasteStyles,
+  actionSelectAll,
+  actionSendBackward,
+  actionSendToBack,
+  actionToggleGridMode,
+  actionToggleStats,
+  actionToggleZenMode,
+  actionUngroup,
+} from "../actions";
 import { createRedoAction, createUndoAction } from "../actions/actionHistory";
 import { ActionManager } from "../actions/manager";
 import { actions } from "../actions/register";
@@ -24,7 +46,6 @@ import {
   ELEMENT_TRANSLATE_AMOUNT,
   ENV,
   EVENT,
-  GRID_SIZE,
   LINE_CONFIRM_THRESHOLD,
   MIME_TYPES,
   POINTER_BUTTON,
@@ -85,30 +106,6 @@ import {
   isLinearElement,
   isLinearElementType,
 } from "../element/typeChecks";
-
-import {
-  actionCut,
-  actionCopy,
-  actionCopyAsPng,
-  actionCopyAsSvg,
-  actionCopyStyles,
-  actionPasteStyles,
-  actionGroup,
-  actionUngroup,
-  actionAddToLibrary,
-  actionBringForward,
-  actionBringToFront,
-  actionSendBackward,
-  actionSendToBack,
-  actionFinalize,
-  actionDuplicateSelection,
-  actionDeleteSelected,
-  actionSelectAll,
-  actionToggleGridMode,
-  actionToggleStats,
-  actionToggleZenMode,
-} from "../actions";
-
 import {
   ExcalidrawBindableElement,
   ExcalidrawElement,

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -333,6 +333,7 @@ class App extends React.Component<ExcalidrawProps, AppState> {
       this.syncActionResult,
       () => this.state,
       () => this.scene.getElementsIncludingDeleted(),
+      this,
     );
     this.actionManager.registerAll(actions);
 
@@ -3674,7 +3675,6 @@ class App extends React.Component<ExcalidrawProps, AppState> {
         top: clientY,
         left: clientX,
         actionManager: this.actionManager,
-        canvas: this.canvas,
       });
       return;
     }
@@ -3720,7 +3720,6 @@ class App extends React.Component<ExcalidrawProps, AppState> {
       top: clientY,
       left: clientX,
       actionManager: this.actionManager,
-      canvas: this.canvas,
     });
   };
 

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -106,6 +106,7 @@ import {
   actionSelectAll,
   actionToggleGridMode,
   actionToggleStats,
+  actionToggleZenMode,
 } from "../actions";
 
 import {
@@ -1149,15 +1150,11 @@ class App extends React.Component<ExcalidrawProps, AppState> {
   };
 
   toggleZenMode = () => {
-    this.setState({
-      zenModeEnabled: !this.state.zenModeEnabled,
-    });
+    this.actionManager.executeAction(actionToggleZenMode);
   };
 
   toggleGridMode = () => {
-    this.setState({
-      gridSize: this.state.gridSize ? null : GRID_SIZE,
-    });
+    this.actionManager.executeAction(actionToggleGridMode);
   };
 
   toggleStats = () => {
@@ -3659,17 +3656,7 @@ class App extends React.Component<ExcalidrawProps, AppState> {
           actionSelectAll,
           separator,
           actionToggleGridMode,
-          {
-            name: "zenMode",
-            perform: (elements, appState) => {
-              this.toggleZenMode();
-              return {
-                commitToHistory: false,
-              };
-            },
-            checked: this.state.zenModeEnabled,
-            contextItemLabel: "buttons.zenMode",
-          },
+          actionToggleZenMode,
           actionToggleStats,
         ],
         top: clientY,

--- a/src/components/ContextMenu.scss
+++ b/src/components/ContextMenu.scss
@@ -12,6 +12,7 @@
     padding: 0.5rem 0;
     background-color: var(--popup-secondary-background-color);
     border: 1px solid var(--button-gray-3);
+    cursor: default;
   }
 
   .context-menu button {

--- a/src/components/ContextMenu.scss
+++ b/src/components/ContextMenu.scss
@@ -9,7 +9,7 @@
     list-style: none;
     user-select: none;
     margin: -0.25rem 0 0 0.125rem;
-    padding: 0.25rem 0;
+    padding: 0.5rem 0;
     background-color: var(--popup-secondary-background-color);
     border: 1px solid var(--button-gray-3);
   }
@@ -87,5 +87,10 @@
         display: none;
       }
     }
+  }
+
+  .context-menu-option-separator {
+    border: none;
+    border-top: 1px solid $oc-gray-5;
   }
 }

--- a/src/components/ContextMenu.tsx
+++ b/src/components/ContextMenu.tsx
@@ -14,13 +14,12 @@ import { ActionManager } from "../actions/manager";
 
 type ContextMenuOption = "separator" | Action;
 
-type Props = {
+type ContextMenuProps = {
   options: ContextMenuOption[];
   onCloseRequest?(): void;
   top: number;
   left: number;
   actionManager: ActionManager;
-  canvas: HTMLCanvasElement | null;
 };
 
 const ContextMenu = ({
@@ -29,8 +28,7 @@ const ContextMenu = ({
   top,
   left,
   actionManager,
-  canvas,
-}: Props) => {
+}: ContextMenuProps) => {
   const isDarkTheme = !!document
     .querySelector(".excalidraw")
     ?.classList.contains("Appearance_dark");
@@ -66,14 +64,7 @@ const ContextMenu = ({
                   className={`context-menu-option
                   ${actionName === "deleteSelectedElements" ? "dangerous" : ""}
                   ${option.checked ? "checkmark" : ""}`}
-                  onClick={() => {
-                    actionManager.executeAction(
-                      option,
-                      option.name === "copyAsPng" || option.name === "copyAsSvg"
-                        ? canvas
-                        : null,
-                    );
-                  }}
+                  onClick={() => actionManager.executeAction(option)}
                 >
                   <div className="context-menu-option__label">{label}</div>
                   <div className="context-menu-option__shortcut">
@@ -103,10 +94,9 @@ const getContextMenuNode = (): HTMLDivElement => {
 
 type ContextMenuParams = {
   options: (ContextMenuOption | false | null | undefined)[];
-  top: number;
-  left: number;
-  actionManager: ActionManager;
-  canvas: HTMLCanvasElement | null;
+  top: ContextMenuProps["top"];
+  left: ContextMenuProps["left"];
+  actionManager: ContextMenuProps["actionManager"];
 };
 
 const handleClose = () => {
@@ -129,7 +119,6 @@ export default {
           options={options}
           onCloseRequest={handleClose}
           actionManager={params.actionManager}
-          canvas={params.canvas}
         />,
         getContextMenuNode(),
       );

--- a/src/components/ContextMenu.tsx
+++ b/src/components/ContextMenu.tsx
@@ -67,11 +67,11 @@ const ContextMenu = ({
                   onClick={() => actionManager.executeAction(option)}
                 >
                   <div className="context-menu-option__label">{label}</div>
-                  <div className="context-menu-option__shortcut">
+                  <kbd className="context-menu-option__shortcut">
                     {actionName
                       ? getShortcutFromShortcutName(actionName as ShortcutName)
                       : ""}
-                  </div>
+                  </kbd>
                 </button>
               </li>
             );

--- a/src/components/ContextMenu.tsx
+++ b/src/components/ContextMenu.tsx
@@ -53,28 +53,23 @@ const ContextMenu = ({
         >
           {options.map((option, idx) => {
             if (option === "separator") {
-              return (
-                <hr key={idx} className="context-menu-option-separator"></hr>
-              );
+              return <hr key={idx} className="context-menu-option-separator" />;
             }
 
-            const action = option;
-            const shortcutName = action.name;
-            const label = action.contextItemLabel
-              ? t(action.contextItemLabel)
+            const actionName = option.name;
+            const label = option.contextItemLabel
+              ? t(option.contextItemLabel)
               : "";
             return (
-              <li key={idx} data-testid={shortcutName} onClick={onCloseRequest}>
+              <li key={idx} data-testid={actionName} onClick={onCloseRequest}>
                 <button
-                  className={`context-menu-option 
-                  ${
-                    shortcutName === "deleteSelectedElements" ? "dangerous" : ""
-                  }
-                  ${action.checked ? "checkmark" : ""}`}
+                  className={`context-menu-option
+                  ${actionName === "deleteSelectedElements" ? "dangerous" : ""}
+                  ${option.checked ? "checkmark" : ""}`}
                   onClick={() => {
                     actionManager.executeAction(
-                      action,
-                      action.name === "copyAsPng" || action.name === "copyAsSvg"
+                      option,
+                      option.name === "copyAsPng" || option.name === "copyAsSvg"
                         ? canvas
                         : null,
                     );
@@ -82,10 +77,8 @@ const ContextMenu = ({
                 >
                   <div className="context-menu-option__label">{label}</div>
                   <div className="context-menu-option__shortcut">
-                    {shortcutName
-                      ? getShortcutFromShortcutName(
-                          shortcutName as ShortcutName,
-                        )
+                    {actionName
+                      ? getShortcutFromShortcutName(actionName as ShortcutName)
                       : ""}
                   </div>
                 </button>

--- a/src/is-mobile.tsx
+++ b/src/is-mobile.tsx
@@ -12,7 +12,7 @@ export const IsMobileProvider = ({
     query.current = window.matchMedia
       ? window.matchMedia(
           // keep up to date with _variables.scss
-          "(max-width: 640px), (max-height: 500px) and (max-width: 1000px)",
+          "(max-width: 600px), (max-height: 500px) and (max-width: 1000px)",
         )
       : (({
           matches: false,

--- a/src/keys.ts
+++ b/src/keys.ts
@@ -18,6 +18,7 @@ export const CODES = {
   F: "KeyF",
   H: "KeyH",
   V: "KeyV",
+  X: "KeyX",
   Z: "KeyZ",
 } as const;
 

--- a/src/tests/regressionTests.test.tsx
+++ b/src/tests/regressionTests.test.tsx
@@ -618,6 +618,7 @@ describe("regression tests", () => {
       clientY: 1,
     });
     const contextMenu = document.querySelector(".context-menu");
+    const contextMenuOptions = document.querySelectorAll(".context-menu li");
     const expectedShortcutNames: ShortcutName[] = [
       "selectAll",
       "gridMode",
@@ -626,7 +627,7 @@ describe("regression tests", () => {
     ];
 
     expect(contextMenu).not.toBeNull();
-    expect(contextMenu?.children.length).toBe(expectedShortcutNames.length);
+    expect(contextMenuOptions.length).toBe(expectedShortcutNames.length);
     expectedShortcutNames.forEach((shortcutName) => {
       expect(
         contextMenu?.querySelector(`li[data-testid="${shortcutName}"]`),
@@ -645,11 +646,12 @@ describe("regression tests", () => {
       clientY: 1,
     });
     const contextMenu = document.querySelector(".context-menu");
+    const contextMenuOptions = document.querySelectorAll(".context-menu li");
     const expectedShortcutNames: ShortcutName[] = [
       "cut",
       "copyStyles",
       "pasteStyles",
-      "delete",
+      "deleteSelectedElements",
       "addToLibrary",
       "sendBackward",
       "bringForward",
@@ -659,7 +661,7 @@ describe("regression tests", () => {
     ];
 
     expect(contextMenu).not.toBeNull();
-    expect(contextMenu?.children.length).toBe(expectedShortcutNames.length);
+    expect(contextMenuOptions.length).toBe(expectedShortcutNames.length);
     expectedShortcutNames.forEach((shortcutName) => {
       expect(
         contextMenu?.querySelector(`li[data-testid="${shortcutName}"]`),
@@ -689,11 +691,12 @@ describe("regression tests", () => {
     });
 
     const contextMenu = document.querySelector(".context-menu");
+    const contextMenuOptions = document.querySelectorAll(".context-menu li");
     const expectedShortcutNames: ShortcutName[] = [
       "cut",
       "copyStyles",
       "pasteStyles",
-      "delete",
+      "deleteSelectedElements",
       "group",
       "addToLibrary",
       "sendBackward",
@@ -704,7 +707,7 @@ describe("regression tests", () => {
     ];
 
     expect(contextMenu).not.toBeNull();
-    expect(contextMenu?.children.length).toBe(expectedShortcutNames.length);
+    expect(contextMenuOptions.length).toBe(expectedShortcutNames.length);
     expectedShortcutNames.forEach((shortcutName) => {
       expect(
         contextMenu?.querySelector(`li[data-testid="${shortcutName}"]`),
@@ -738,11 +741,12 @@ describe("regression tests", () => {
     });
 
     const contextMenu = document.querySelector(".context-menu");
+    const contextMenuOptions = document.querySelectorAll(".context-menu li");
     const expectedShortcutNames: ShortcutName[] = [
       "cut",
       "copyStyles",
       "pasteStyles",
-      "delete",
+      "deleteSelectedElements",
       "ungroup",
       "addToLibrary",
       "sendBackward",
@@ -753,7 +757,7 @@ describe("regression tests", () => {
     ];
 
     expect(contextMenu).not.toBeNull();
-    expect(contextMenu?.children.length).toBe(expectedShortcutNames.length);
+    expect(contextMenuOptions.length).toBe(expectedShortcutNames.length);
     expectedShortcutNames.forEach((shortcutName) => {
       expect(
         contextMenu?.querySelector(`li[data-testid="${shortcutName}"]`),


### PR DESCRIPTION
Fixes #2506 - Check the [**preview**](https://excalidraw-git-fork-kartik1397-addseparatorsoncontextmenu.excalidraw.vercel.app/).

This is my first try toward implementing separators in context menu.
One thing which I can improve in this implementation is to use constant varible instead of hard coded numerical value for order and group.
If there is a more clever way to implement this, please suggest me.
### Screenshots
![image](https://user-images.githubusercontent.com/24036721/102889907-7b989800-4481-11eb-9dc8-f7438b6bab57.png)
![image](https://user-images.githubusercontent.com/24036721/102889839-5efc6000-4481-11eb-83e1-60ea1c9e9e5c.png)
![image](https://user-images.githubusercontent.com/24036721/102889814-54da6180-4481-11eb-9924-f5a98fb916bb.png)
