### PR TITLE
fix: scene not initialized properly when tab not focused

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -878,7 +878,7 @@ class App extends React.Component<ExcalidrawProps, AppState> {
     // do not notify consumers if we're still loading the scene. Among other
     // potential issues, this fixes a case where the tab isn't focused during
     // init, which would trigger onChange with empty elements, which would then
-    // override whatever is in localStorage currently
+    // override whatever is in localStorage currently.
     if (!this.state.isLoading) {
       this.props.onChange?.(
         this.scene.getElementsIncludingDeleted(),

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -875,7 +875,16 @@ class App extends React.Component<ExcalidrawProps, AppState> {
 
     history.record(this.state, this.scene.getElementsIncludingDeleted());
 
-    this.props.onChange?.(this.scene.getElementsIncludingDeleted(), this.state);
+    // do not notify consumers if we're still loading the scene. Among other
+    // potential issues, this fixes a case where the tab isn't focused during
+    // init, which would trigger onChange with empty elements, which would then
+    // override whatever is in localStorage currently
+    if (!this.state.isLoading) {
+      this.props.onChange?.(
+        this.scene.getElementsIncludingDeleted(),
+        this.state,
+      );
+    }
   }
 
   // Copy/paste

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -875,7 +875,7 @@ class App extends React.Component<ExcalidrawProps, AppState> {
 
     history.record(this.state, this.scene.getElementsIncludingDeleted());
 
-    // do not notify consumers if we're still loading the scene. Among other
+    // Do not notify consumers if we're still loading the scene. Among other
     // potential issues, this fixes a case where the tab isn't focused during
     // init, which would trigger onChange with empty elements, which would then
     // override whatever is in localStorage currently.

--- a/src/excalidraw-app/index.tsx
+++ b/src/excalidraw-app/index.tsx
@@ -123,13 +123,10 @@ const initializeScene = async (opts: {
     } else {
       // https://github.com/excalidraw/excalidraw/issues/1919
       if (document.hidden) {
-        return new Promise((resolve) => {
+        return new Promise((resolve, reject) => {
           window.addEventListener(
             "focus",
-            () =>
-              initializeScene(opts).then((scene) => {
-                resolve(scene);
-              }),
+            () => initializeScene(opts).then(resolve).catch(reject),
             {
               once: true,
             },

--- a/src/packages/excalidraw/CHANGELOG.md
+++ b/src/packages/excalidraw/CHANGELOG.md
@@ -27,6 +27,7 @@ Please add the latest change on the top under the correct section.
 
 ### Fixes
 
+- Fix initialization when browser tab not focused [#2677](https://github.com/excalidraw/excalidraw/pull/2677)
 - Consistent case for export locale strings [#2622](https://github.com/excalidraw/excalidraw/pull/2622)
 - Remove unnecessary console.error as it was polluting Sentry [#2637](https://github.com/excalidraw/excalidraw/pull/2637)
 - Fix scroll-to-center on init for non-zero canvas offsets [#2445](https://github.com/excalidraw/excalidraw/pull/2445)


### PR DESCRIPTION
- fixes a regression introduced during rewrite for npm package: by moving to promise-based initialization, we've been mistakenly been early-resolving in late-initialization scenarios which ended up not initializing the scene properly
- also fixed an issue where late initialization wasn't prompting due to `onChange` callback being called early and overriding localStorage with empty data