### PR TITLE
feat: browse libraries styles fixed

### DIFF
--- a/src/components/LayerUI.scss
+++ b/src/components/LayerUI.scss
@@ -7,11 +7,17 @@
     align-items: center;
     justify-content: center;
 
-    .browse-libraries {
-      position: absolute;
-      right: 12px;
-      top: 16px;
-      white-space: nowrap;
+    .browse-libraries-container {
+      align-items: center;
+      display: flex;
+      flex-direction: row-reverse;
+      justify-content: space-between;
+      width: 100%;
+
+      a {
+        padding-right: 17px;
+        white-space: nowrap;
+      }
     }
   }
 

--- a/src/components/LayerUI.scss
+++ b/src/components/LayerUI.scss
@@ -20,7 +20,8 @@
 
       a {
         margin-left: auto;
-        padding-right: 17px;
+        // 17px for scrollbar (needed for overlay scrollbars on Big Sur?) + 1px extra
+        padding-right: 18px;
         white-space: nowrap;
       }
     }

--- a/src/components/LayerUI.scss
+++ b/src/components/LayerUI.scss
@@ -7,15 +7,20 @@
     align-items: center;
     justify-content: center;
 
-    .browse-libraries-container {
-      align-items: center;
+    .layer-ui__library-header {
       display: flex;
-      flex-direction: row-reverse;
+      align-items: center;
       justify-content: space-between;
       width: 100%;
+      margin: 2px 0;
+
+      button {
+        margin-right: 4px;
+      }
 
       a {
-        padding-right: 17px;
+        margin-left: auto;
+        padding-right: 5px;
         white-space: nowrap;
       }
     }

--- a/src/components/LayerUI.scss
+++ b/src/components/LayerUI.scss
@@ -14,12 +14,13 @@
       margin: 2px 0;
 
       button {
-        margin-right: 4px;
+        // 2px from the left to account for focus border of left-most button
+        margin: 0 2px;
       }
 
       a {
         margin-left: auto;
-        padding-right: 5px;
+        padding-right: 17px;
         white-space: nowrap;
       }
     }

--- a/src/components/LayerUI.scss
+++ b/src/components/LayerUI.scss
@@ -10,7 +10,6 @@
     .layer-ui__library-header {
       display: flex;
       align-items: center;
-      justify-content: space-between;
       width: 100%;
       margin: 2px 0;
 

--- a/src/components/LayerUI.tsx
+++ b/src/components/LayerUI.tsx
@@ -124,7 +124,41 @@ const LibraryMenuItems = ({
   let addedPendingElements = false;
 
   rows.push(
-    <div className="browse-libraries-container">
+    <div className="layer-ui__library-header">
+      <ToolButton
+        key="import"
+        type="button"
+        title={t("buttons.load")}
+        aria-label={t("buttons.load")}
+        icon={load}
+        onClick={() => {
+          importLibraryFromJSON()
+            .then(() => {
+              // Maybe we should close and open the menu so that the items get updated.
+              // But for now we just close the menu.
+              setAppState({ isLibraryOpen: false });
+            })
+            .catch(muteFSAbortError)
+            .catch((error) => {
+              setAppState({ errorMessage: error.message });
+            });
+        }}
+      />
+      <ToolButton
+        key="export"
+        type="button"
+        title={t("buttons.export")}
+        aria-label={t("buttons.export")}
+        icon={exportFile}
+        onClick={() => {
+          saveLibraryAsJSON()
+            .catch(muteFSAbortError)
+            .catch((error) => {
+              setAppState({ errorMessage: error.message });
+            });
+        }}
+      />
+
       <a
         href="https://libraries.excalidraw.com"
         target="_excalidraw_libraries"
@@ -134,47 +168,6 @@ const LibraryMenuItems = ({
       >
         {t("labels.libraries")}
       </a>
-
-      <Stack.Row
-        align="center"
-        gap={1}
-        key={"actions"}
-        style={{ padding: "2px" }}
-      >
-        <ToolButton
-          key="import"
-          type="button"
-          title={t("buttons.load")}
-          aria-label={t("buttons.load")}
-          icon={load}
-          onClick={() => {
-            importLibraryFromJSON()
-              .then(() => {
-                // Maybe we should close and open the menu so that the items get updated.
-                // But for now we just close the menu.
-                setAppState({ isLibraryOpen: false });
-              })
-              .catch(muteFSAbortError)
-              .catch((error) => {
-                setAppState({ errorMessage: error.message });
-              });
-          }}
-        />
-        <ToolButton
-          key="export"
-          type="button"
-          title={t("buttons.export")}
-          aria-label={t("buttons.export")}
-          icon={exportFile}
-          onClick={() => {
-            saveLibraryAsJSON()
-              .catch(muteFSAbortError)
-              .catch((error) => {
-                setAppState({ errorMessage: error.message });
-              });
-          }}
-        />
-      </Stack.Row>
     </div>,
   );
 

--- a/src/components/LayerUI.tsx
+++ b/src/components/LayerUI.tsx
@@ -124,9 +124,8 @@ const LibraryMenuItems = ({
   let addedPendingElements = false;
 
   rows.push(
-    <>
+    <div className="browse-libraries-container">
       <a
-        className="browse-libraries"
         href="https://libraries.excalidraw.com"
         target="_excalidraw_libraries"
         onClick={() => {
@@ -176,7 +175,7 @@ const LibraryMenuItems = ({
           }}
         />
       </Stack.Row>
-    </>,
+    </div>,
   );
 
   for (let row = 0; row < numRows; row++) {


### PR DESCRIPTION
I did some stylings changes in order to fix the "Brose Libraries" link button when the scrollbar appears.
The 17px padding is because of windows scroll width, so when the user see the scroll, its not on top of the link button.
You can appreciate in the gif below that when scrollbar expands in Mac OS, then the scrollbar is not on top of the link button.

![browse-libraries](https://user-images.githubusercontent.com/53273645/103447200-aeebdb80-4c66-11eb-8806-2c0536016e8d.gif)
