### PR TITLE
improvement: Make arrowheads keybinds color accessible on dark mode

### DIFF
--- a/src/components/IconPicker.scss
+++ b/src/components/IconPicker.scss
@@ -102,6 +102,7 @@
     position: absolute;
     bottom: 2px;
     font-size: 0.7em;
+    color: var(--keybinding-color);
 
     :root[dir="ltr"] & {
       right: 2px;


### PR DESCRIPTION
## Before:
![Before](https://imgur.com/H45fbYT.png)

## After
![After](https://imgur.com/F1cun0E.png)

Fixes #2719 