### PR TITLE
improvement: adding zen mode to context menu

### DIFF
--- a/src/actions/shortcuts.ts
+++ b/src/actions/shortcuts.ts
@@ -53,7 +53,7 @@ const shortcutMap: Record<ShortcutName, string[]> = {
   group: [getShortcutKey("CtrlOrCmd+G")],
   ungroup: [getShortcutKey("CtrlOrCmd+Shift+G")],
   gridMode: [getShortcutKey("CtrlOrCmd+'")],
-  zenMode: [getShortcutKey("CtrlOrCmd+Alt+Z")],
+  zenMode: [getShortcutKey("Alt+Z")],
   stats: [],
   addToLibrary: [],
 };

--- a/src/actions/shortcuts.ts
+++ b/src/actions/shortcuts.ts
@@ -20,6 +20,7 @@ export type ShortcutName =
   | "group"
   | "ungroup"
   | "gridMode"
+  | "zenMode"
   | "stats"
   | "addToLibrary";
 
@@ -52,6 +53,7 @@ const shortcutMap: Record<ShortcutName, string[]> = {
   group: [getShortcutKey("CtrlOrCmd+G")],
   ungroup: [getShortcutKey("CtrlOrCmd+Shift+G")],
   gridMode: [getShortcutKey("CtrlOrCmd+'")],
+  zenMode: [getShortcutKey("CtrlOrCmd+Alt+Z")],
   stats: [],
   addToLibrary: [],
 };

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -3639,6 +3639,12 @@ class App extends React.Component<ExcalidrawProps, AppState> {
             action: this.toggleGridMode,
           },
           {
+            checked: this.state.gridSize !== null,
+            shortcutName: "zenMode",
+            label: t("buttons.zenMode"),
+            action: this.toggleZenMode,
+          },
+          {
             checked: this.state.showStats,
             shortcutName: "stats",
             label: t("stats.title"),

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -3639,7 +3639,7 @@ class App extends React.Component<ExcalidrawProps, AppState> {
             action: this.toggleGridMode,
           },
           {
-            checked: this.state.gridSize !== null,
+            checked: this.state.zenModeEnabled,
             shortcutName: "zenMode",
             label: t("buttons.zenMode"),
             action: this.toggleZenMode,

--- a/src/packages/excalidraw/CHANGELOG.md
+++ b/src/packages/excalidraw/CHANGELOG.md
@@ -28,7 +28,6 @@ Please add the latest change on the top under the correct section.
 - Add Cut to menus [#2511](https://github.com/excalidraw/excalidraw/pull/2511)
 - More Arrowheads: dot, bar [#2486](https://github.com/excalidraw/excalidraw/pull/2486)
 - Support CSV graphs and improve the look and feel [#2495](https://github.com/excalidraw/excalidraw/pull/2495)
-- Added Zen Mode to the context menu [#2734](https://github.com/excalidraw/excalidraw/pull/2734)
 
 ### Fixes
 
@@ -45,6 +44,7 @@ Please add the latest change on the top under the correct section.
 
 ### Improvements
 
+- Added Zen Mode to the context menu [#2734](https://github.com/excalidraw/excalidraw/pull/2734)
 - Do not reset to selection when using the draw tool [#2721](https://github.com/excalidraw/excalidraw/pull/2721)
 - Display proper tooltip for 2-point lines during resize, and normalize modifier key labels in hints [#2655](https://github.com/excalidraw/excalidraw/pull/2655)
 - Improve error message around importing images [#2619](https://github.com/excalidraw/excalidraw/pull/2619)

--- a/src/packages/excalidraw/CHANGELOG.md
+++ b/src/packages/excalidraw/CHANGELOG.md
@@ -28,6 +28,7 @@ Please add the latest change on the top under the correct section.
 - Add Cut to menus [#2511](https://github.com/excalidraw/excalidraw/pull/2511)
 - More Arrowheads: dot, bar [#2486](https://github.com/excalidraw/excalidraw/pull/2486)
 - Support CSV graphs and improve the look and feel [#2495](https://github.com/excalidraw/excalidraw/pull/2495)
+- Added Zen Mode to the context menu [#2734](https://github.com/excalidraw/excalidraw/pull/2734)
 
 ### Fixes
 

--- a/src/tests/regressionTests.test.tsx
+++ b/src/tests/regressionTests.test.tsx
@@ -621,6 +621,7 @@ describe("regression tests", () => {
     const expectedShortcutNames: ShortcutName[] = [
       "selectAll",
       "gridMode",
+      "zenMode",
       "stats",
     ];
 


### PR DESCRIPTION
Pros of this change:
I believe that more people will use zenmode if it's easier to find.  In addition, the keyboard binding is pretty awkward and can conflict with other global system bindings in certain environments.

Cons of this change:
Makes the action menu longer, however since we only show these "global options" when the user right clicks on the background it seems that the additional option is not too much.

Resolves: #1581