### PR TITLE
chore(actions): Use cancel workflow action

### DIFF
--- a/.github/workflows/cancel.yml
+++ b/.github/workflows/cancel.yml
@@ -1,0 +1,12 @@
+name: Cancel
+on: [push]
+jobs:
+  cancel:
+    name: "Cancel Previous Runs"
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - uses: styfle/cancel-workflow-action@0.6.0
+        with:
+          workflow_id: 400555, 400556, 905313, 1451724, 1710116, 3185001, 3438604
+          access_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Runs on:
1. build-docker.yml
1. build-packages.yml 
1. lint.yml
1. locales-coverage.yml
1. publish-docker.yml
1. sentry-production.yml
1. test.yml

To check workflow ids, go to https://api.github.com/repos/excalidraw/excalidraw/actions/workflows

Resolves #2437