### PR TITLE
fix: delay version logging & prevent duplicates

### DIFF
--- a/src/excalidraw-app/index.tsx
+++ b/src/excalidraw-app/index.tsx
@@ -229,7 +229,19 @@ function ExcalidrawWrapper(props: { collab: CollabAPI }) {
   const { collab } = props;
 
   useEffect(() => {
-    trackEvent("load", "version", getVersion());
+    // delayed by 15 sec so that the app has a time to load the latest SW
+    setTimeout(() => {
+      const version = getVersion();
+      const loggedVersion = window.localStorage.getItem(
+        "excalidraw-lastLoggedVersion",
+      );
+      // prevent logging on multiple visits
+      if (version && version !== loggedVersion) {
+        window.localStorage.setItem("excalidraw-lastLoggedVersion", version);
+        trackEvent("load", "version", version);
+      }
+    }, 15000);
+
     excalidrawRef.current!.readyPromise.then((excalidrawApi) => {
       initializeScene({
         resetScene: excalidrawApi.resetScene,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -364,6 +364,8 @@ export const nFormatter = (num: number, digits: number): string => {
 };
 
 export const getVersion = () => {
-  const version = document.querySelector('meta[name="version"]');
-  return version ? (version as any).content : DEFAULT_VERSION;
+  return (
+    document.querySelector<HTMLMetaElement>('meta[name="version"]')?.content ||
+    DEFAULT_VERSION
+  );
 };


### PR DESCRIPTION
- Tried to tie it into the SW thing, but it was too complex, so ended up with a simple timeout.
- Also made it so we don't log same version multiple times on repeated visits from the same device.