### PR TITLE
refactor: Converting span to kbd tag

### DIFF
--- a/src/components/ContextMenu.scss
+++ b/src/components/ContextMenu.scss
@@ -54,6 +54,7 @@
     .context-menu-option__shortcut {
       justify-self: end;
       opacity: 0.6;
+      font-family: inherit;
       font-size: 0.7rem;
     }
   }

--- a/src/components/ContextMenu.tsx
+++ b/src/components/ContextMenu.tsx
@@ -52,11 +52,11 @@ const ContextMenu = ({ options, onCloseRequest, top, left }: Props) => {
                 onClick={action}
               >
                 <div className="context-menu-option__label">{label}</div>
-                <div className="context-menu-option__shortcut">
+                <kbd className="context-menu-option__shortcut">
                   {shortcutName
                     ? getShortcutFromShortcutName(shortcutName)
                     : ""}
-                </div>
+                </kbd>
               </button>
             </li>
           ))}

--- a/src/components/ShortcutsDialog.scss
+++ b/src/components/ShortcutsDialog.scss
@@ -29,6 +29,7 @@
     box-sizing: border-box;
     display: flex;
     align-items: center;
+    font-family: inherit;
   }
 
   .ShortcutsDialog-footer {

--- a/src/components/ShortcutsDialog.tsx
+++ b/src/components/ShortcutsDialog.tsx
@@ -82,7 +82,7 @@ Shortcut.defaultProps = {
 };
 
 const ShortcutKey = (props: { children: React.ReactNode }) => (
-  <span className="ShorcutsDialog-key" {...props} />
+  <kbd className="ShorcutsDialog-key" {...props} />
 );
 
 const Footer = () => (


### PR DESCRIPTION
## What type of PR is this?

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## What does it do?

1. kbd tag is used to keyboard shortcuts
2. converting span to kbd tag to be more semtantic

## Related issue

NA

## QA Instructions, Screenshots, Recordings

1. checkout the branch
2. view keyboard shortcut modal it should use kbd tag instead of span nothing else should have changed
 
### UI accessibility concerns?
* With the way keybard shortcut is now rendered it uses single tag for rendering a combination. For example **ctrl + c** gets rendered inside a single tag it would be better if **ctrl** and **c** gets rendered as a separate tag
* This is more of a preference than an actual accessibility concerns

## Tests?

- [ ] yes
- [ ] no, reason?   
- [x] I need help with writing tests   
There were no existing snapshot covering this I was not sure if I should add one
