### PR TITLE
fix: don't render due to zoom after unmount

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -465,6 +465,7 @@ class App extends React.Component<ExcalidrawProps, AppState> {
   private onBlur = withBatchedUpdates(() => {
     isHoldingSpace = false;
     this.setState({ isBindingEnabled: true });
+    this.resetShouldCacheIgnoreZoomDebounced.flush();
   });
 
   private onUnload = () => {
@@ -3816,7 +3817,9 @@ class App extends React.Component<ExcalidrawProps, AppState> {
   };
 
   private resetShouldCacheIgnoreZoomDebounced = debounce(() => {
-    this.setState({ shouldCacheIgnoreZoom: false });
+    if (!this.unmounted) {
+      this.setState({ shouldCacheIgnoreZoom: false });
+    }
   }, 300);
 
   private getCanvasOffsets(offsets?: {

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -465,7 +465,6 @@ class App extends React.Component<ExcalidrawProps, AppState> {
   private onBlur = withBatchedUpdates(() => {
     isHoldingSpace = false;
     this.setState({ isBindingEnabled: true });
-    this.resetShouldCacheIgnoreZoomDebounced.flush();
   });
 
   private onUnload = () => {

--- a/src/packages/excalidraw/CHANGELOG.md
+++ b/src/packages/excalidraw/CHANGELOG.md
@@ -31,6 +31,7 @@ Please add the latest change on the top under the correct section.
 
 ### Fixes
 
+- Fix late-render due to debounced zoom [#2779](https://github.com/excalidraw/excalidraw/pull/2779)
 - Fix initialization when browser tab not focused [#2677](https://github.com/excalidraw/excalidraw/pull/2677)
 - Consistent case for export locale strings [#2622](https://github.com/excalidraw/excalidraw/pull/2622)
 - Remove unnecessary console.error as it was polluting Sentry [#2637](https://github.com/excalidraw/excalidraw/pull/2637)


### PR DESCRIPTION
fix #2778

Quick fix I had stashed for ages — wanted to fix more of these errors (tracked in #2738), but didn't have time.