### PR TITLE
fix: allow text-selecting in dialogs & reset cursor

### DIFF
--- a/src/components/Dialog.scss
+++ b/src/components/Dialog.scss
@@ -1,6 +1,11 @@
 @import "../css/_variables";
 
 .excalidraw {
+  .Dialog {
+    user-select: text;
+    cursor: text;
+  }
+
   .Dialog__title {
     display: grid;
     align-items: center;

--- a/src/components/Dialog.scss
+++ b/src/components/Dialog.scss
@@ -3,7 +3,6 @@
 .excalidraw {
   .Dialog {
     user-select: text;
-    cursor: text;
   }
 
   .Dialog__title {

--- a/src/components/Dialog.scss
+++ b/src/components/Dialog.scss
@@ -3,6 +3,7 @@
 .excalidraw {
   .Dialog {
     user-select: text;
+    cursor: auto;
   }
 
   .Dialog__title {

--- a/src/packages/excalidraw/CHANGELOG.md
+++ b/src/packages/excalidraw/CHANGELOG.md
@@ -31,6 +31,7 @@ Please add the latest change on the top under the correct section.
 
 ### Fixes
 
+- Allow text-selecting in dialogs & reset cursor [#2783](https://github.com/excalidraw/excalidraw/pull/2783)
 - Fix late-render due to debounced zoom [#2779](https://github.com/excalidraw/excalidraw/pull/2779)
 - Fix initialization when browser tab not focused [#2677](https://github.com/excalidraw/excalidraw/pull/2677)
 - Consistent case for export locale strings [#2622](https://github.com/excalidraw/excalidraw/pull/2622)


### PR DESCRIPTION
## What does it do ?

1. Enable text selection in keyboard modal
2. Convert cursor inside modal from crosshair to text