### PR TITLE
feat: Add guides

### DIFF
--- a/src/components/HelpDialog.tsx
+++ b/src/components/HelpDialog.tsx
@@ -9,14 +9,6 @@ const Header = () => (
   <div className="HelpDialog--header">
     <a
       className="HelpDialog--btn"
-      href="https://github.com/excalidraw/excalidraw#documentation"
-      target="_blank"
-      rel="noopener noreferrer"
-    >
-      {t("helpDialog.documentation")}
-    </a>
-    <a
-      className="HelpDialog--btn"
       href="https://blog.excalidraw.com"
       target="_blank"
       rel="noopener noreferrer"


### PR DESCRIPTION
I was thinking about directly showing guides in the help menu:

![image](https://user-images.githubusercontent.com/9438102/104847354-ce7a3980-58df-11eb-9183-a54e5b430f90.png)

Should I implement [react-markdown](https://github.com/remarkjs/react-markdown) in `HelpDialog`?