### PR TITLE
fix: Use `VERCEL_GIT_COMMIT_SHA` env variable

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
   "scripts": {
     "build-node": "node ./scripts/build-node.js",
     "build:app:docker": "REACT_APP_DISABLE_SENTRY=true react-scripts build",
-    "build:app": "REACT_APP_GIT_SHA=$NOW_GITHUB_COMMIT_SHA react-scripts build",
+    "build:app": "REACT_APP_GIT_SHA=$VERCEL_GITHUB_COMMIT_SHA react-scripts build",
     "build:version": "node ./scripts/build-version.js",
     "build": "npm run build:app && npm run build:version",
     "eject": "react-scripts eject",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
   "scripts": {
     "build-node": "node ./scripts/build-node.js",
     "build:app:docker": "REACT_APP_DISABLE_SENTRY=true react-scripts build",
-    "build:app": "REACT_APP_GIT_SHA=$VERCEL_GITHUB_COMMIT_SHA react-scripts build",
+    "build:app": "REACT_APP_GIT_SHA=$VERCEL_GIT_COMMIT_SHA react-scripts build",
     "build:version": "node ./scripts/build-version.js",
     "build": "npm run build:app && npm run build:version",
     "eject": "react-scripts eject",


### PR DESCRIPTION
On Vercel `NOW_GITHUB_COMMIT_SHA` are legacy system environment variables and we can update them to the new `VERCEL_GITHUB_COMMIT_SHA`.

To make it work, the "Automatically expose System Environment Variables" option should also be enabled in the Project, like described here: https://vercel.com/docs/environment-variables#system-environment-variables.

