### PR TITLE
build(webpack): bundle css files with js

### DIFF
--- a/src/packages/excalidraw/entry.js
+++ b/src/packages/excalidraw/entry.js
@@ -1,0 +1,6 @@
+import Excalidraw from "./index";
+
+import "../../../public/fonts.css";
+
+export default Excalidraw;
+export * from "./index";

--- a/src/packages/excalidraw/webpack.prod.config.js
+++ b/src/packages/excalidraw/webpack.prod.config.js
@@ -1,5 +1,4 @@
 const path = require("path");
-const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 const TerserPlugin = require("terser-webpack-plugin");
 const BundleAnalyzerPlugin = require("webpack-bundle-analyzer")
   .BundleAnalyzerPlugin;
@@ -7,8 +6,7 @@ const BundleAnalyzerPlugin = require("webpack-bundle-analyzer")
 module.exports = {
   mode: "production",
   entry: {
-    "excalidraw.min": "./index.tsx",
-    "fonts.min": "../../../public/fonts.css",
+    "excalidraw.min": "./entry.js",
   },
   output: {
     path: path.resolve(__dirname, "dist"),
@@ -26,11 +24,7 @@ module.exports = {
       {
         test: /\.(sa|sc|c)ss$/,
         exclude: /node_modules/,
-        use: [
-          MiniCssExtractPlugin.loader,
-          { loader: "css-loader" },
-          "sass-loader",
-        ],
+        use: ["style-loader", { loader: "css-loader" }, "sass-loader"],
       },
       {
         test: /\.(ts|tsx|js|jsx|mjs)$/,
@@ -94,7 +88,6 @@ module.exports = {
     },
   },
   plugins: [
-    new MiniCssExtractPlugin({ filename: "[name].css" }),
     ...(process.env.ANALYZER === "true" ? [new BundleAnalyzerPlugin()] : []),
   ],
   externals: {


### PR DESCRIPTION
no more importing CSS files seperately now as its bundled with js
pushed [here](https://codesandbox.io/s/excalidraw-v02-no-css-xggy7)

**Pros**
Host will no more have to import the css files and just importing the package would work

**Cons**
The bundle size would increase (~10 KiB)  since now the CSS is injected into DOM via js.

- [ ]  update changelog and readme