### PR TITLE
fix: use random IV for link-sharing encryption (#2829)

### DIFF
--- a/src/excalidraw-app/data/index.ts
+++ b/src/excalidraw-app/data/index.ts
@@ -80,8 +80,10 @@ export type SocketUpdateData = SocketUpdateDataSource[keyof SocketUpdateDataSour
   _brand: "socketUpdateData";
 };
 
+const IV_LENGTH_BYTES = 12; // 96 bits
+
 export const createIV = () => {
-  const arr = new Uint8Array(12);
+  const arr = new Uint8Array(IV_LENGTH_BYTES);
   return window.crypto.getRandomValues(arr);
 };
 
@@ -190,15 +192,18 @@ const importFromBackend = async (
     let data: ImportedDataState;
     if (privateKey) {
       const buffer = await response.arrayBuffer();
+      // Response contains both the IV (fixed length) and encrypted data
+      const iv = buffer.slice(0, IV_LENGTH_BYTES);
+      const encrypted = buffer.slice(IV_LENGTH_BYTES, buffer.byteLength);
+
       const key = await getImportedKey(privateKey, "decrypt");
-      const iv = new Uint8Array(12);
       const decrypted = await window.crypto.subtle.decrypt(
         {
           name: "AES-GCM",
           iv,
         },
         key,
-        buffer,
+        encrypted,
       );
       // We need to convert the decrypted array buffer to a string
       const string = new window.TextDecoder("utf-8").decode(
@@ -263,9 +268,8 @@ export const exportToBackend = async (
     true, // extractable
     ["encrypt", "decrypt"],
   );
-  // The iv is set to 0. We are never going to reuse the same key so we don't
-  // need to have an iv. (I hope that's correct...)
-  const iv = new Uint8Array(12);
+
+  const iv = createIV();
   // We use symmetric encryption. AES-GCM is the recommended algorithm and
   // includes checks that the ciphertext has not been modified by an attacker.
   const encrypted = await window.crypto.subtle.encrypt(
@@ -276,6 +280,11 @@ export const exportToBackend = async (
     key,
     encoded,
   );
+
+  // Concatenate IV with encrypted data (IV does not have to be secret).
+  const payloadBlob = new Blob([iv.buffer, encrypted]);
+  const payload = await new Response(payloadBlob).arrayBuffer();
+
   // We use jwk encoding to be able to extract just the base64 encoded key.
   // We will hardcode the rest of the attributes when importing back the key.
   const exportedKey = await window.crypto.subtle.exportKey("jwk", key);
@@ -283,7 +292,7 @@ export const exportToBackend = async (
   try {
     const response = await fetch(BACKEND_V2_POST, {
       method: "POST",
-      body: encrypted,
+      body: payload,
     });
     const json = await response.json();
     if (json.id) {


### PR DESCRIPTION
This change introduces random IV (Initialization Vector) for link-sharing feature, as described in #2829, in order to improve end-to-end encryption. Generated IV is being concatenated with encrypted content and sent to the backend on export. Since IV has a fixed length, when importing from the backend we can simply retrieve it based on its length. 

The assumption here is that after introducing change, there won't be a need for supporting previously-generated links (without IV being exported). If such backward compatibility is required, the approach would have to be adjusted a bit.

Since this is my first PR to the Excalidraw, please try to forgive me if something would be missing or wrong.