### PR TITLE
fix: disable UI pointer-events on canvas drag

### DIFF
--- a/src/components/LayerUI.tsx
+++ b/src/components/LayerUI.tsx
@@ -602,7 +602,11 @@ const LayerUI = ({
       />
     </>
   ) : (
-    <div className="layer-ui__wrapper">
+    <div
+      className={clsx("layer-ui__wrapper", {
+        "disable-pointerEvents": appState.cursorButton === "down",
+      })}
+    >
       {dialogs}
       {renderFixedSideContainer()}
       {renderBottomAppMenu()}

--- a/src/components/Tooltip.scss
+++ b/src/components/Tooltip.scss
@@ -48,15 +48,7 @@
     }
   }
 
-  // the following 3 rules ensure that the tooltip doesn't show (nor affect
-  // the cursor) when you drag over when you draw on canvas, but at the same
-  // time it still works when clicking on the link/shield
-
-  body:active & .Tooltip:not(:hover) {
-    pointer-events: none;
-  }
-
-  body:not(:active) & .Tooltip:hover .Tooltip__label {
+  .Tooltip:hover .Tooltip__label {
     visibility: visible;
   }
 

--- a/src/css/styles.scss
+++ b/src/css/styles.scss
@@ -282,7 +282,7 @@
     pointer-events: none !important;
   }
 
-  .App-menu_top > * {
+  .layer-ui__wrapper:not(.disable-pointerEvents) .App-menu_top > * {
     pointer-events: all;
   }
 
@@ -323,7 +323,7 @@
     }
   }
 
-  .App-menu_bottom > * {
+  .layer-ui__wrapper:not(.disable-pointerEvents) .App-menu_bottom > * {
     pointer-events: all;
   }
 

--- a/src/packages/excalidraw/CHANGELOG.md
+++ b/src/packages/excalidraw/CHANGELOG.md
@@ -26,6 +26,7 @@ Please add the latest change on the top under the correct section.
 
 ### Fixes
 
+- Fix UI pointer-events not disabled when dragging on canvas [#2856](https://github.com/excalidraw/excalidraw/pull/2856).
 - Fix remote pointers not accounting for offset [#2855](https://github.com/excalidraw/excalidraw/pull/2855).
 
 ## 0.2.1


### PR DESCRIPTION
Fixes (among other things) this issue:

- when you drag element in collab session and you drag the element underneath a UI, the remote pointer gets stuck because the `handleCanvasPointerMove` callback is not called.

	![excal_bug_remote_pointers_ui_clip](https://user-images.githubusercontent.com/5153846/105706785-4a910480-5f12-11eb-9ba5-b7e686c2aa08.gif)

This fix is somewhat of a hack, but we're already hacking it in one place (the privacy shield icon — this hack can now be removed).

It could be fixed in other ways, such as not handling `canvas` `pointermove` and instead use the `document` event handler, but it'd introduce other issues. And ultimately, we still want to disable menu pointer-events when drawing on canvas (so that cursor doesn't change, the drag isn't stuck on `input` elements etc.).

AFAIK the only problematic thing about this hack is if the `pointerup` isn't called (which we track in separate issue https://github.com/excalidraw/excalidraw/issues/668), but it usually isn't app-breaking since you just need to click once.

NOTE: not handling mobile UI. It somewhat looks already handled? Haven't investigated.
