### PR TITLE
refactor: reuse scss variables in js for SSOT

### DIFF
--- a/src/components/Avatar.scss
+++ b/src/components/Avatar.scss
@@ -1,4 +1,4 @@
-@import "../css/_variables";
+@import "../css/variables.module";
 
 .excalidraw {
   .Avatar {

--- a/src/components/CollabButton.scss
+++ b/src/components/CollabButton.scss
@@ -1,4 +1,4 @@
-@import "../css/_variables";
+@import "../css/variables.module";
 
 .excalidraw {
   .CollabButton.is-collaborating {

--- a/src/components/ColorPicker.scss
+++ b/src/components/ColorPicker.scss
@@ -1,4 +1,4 @@
-@import "../css/_variables";
+@import "../css/variables.module";
 
 .excalidraw {
   .color-picker {

--- a/src/components/ContextMenu.scss
+++ b/src/components/ContextMenu.scss
@@ -1,4 +1,4 @@
-@import "../css/_variables";
+@import "../css/variables.module";
 
 .excalidraw {
   .context-menu {

--- a/src/components/Dialog.scss
+++ b/src/components/Dialog.scss
@@ -1,4 +1,4 @@
-@import "../css/_variables";
+@import "../css/variables.module";
 
 .excalidraw {
   .Dialog {

--- a/src/components/ExportDialog.scss
+++ b/src/components/ExportDialog.scss
@@ -1,4 +1,4 @@
-@import "../css/_variables";
+@import "../css/variables.module";
 
 .excalidraw {
   .ExportDialog__preview {

--- a/src/components/HelpDialog.scss
+++ b/src/components/HelpDialog.scss
@@ -1,4 +1,4 @@
-@import "../css/_variables";
+@import "../css/variables.module";
 
 .excalidraw {
   .HelpDialog h3 {

--- a/src/components/HintViewer.scss
+++ b/src/components/HintViewer.scss
@@ -1,4 +1,4 @@
-@import "../css/_variables";
+@import "../css/variables.module";
 
 // this is loosely based on the longest hint text
 $wide-viewport-width: 1000px;

--- a/src/components/IconPicker.scss
+++ b/src/components/IconPicker.scss
@@ -1,4 +1,4 @@
-@import "../css/_variables";
+@import "../css/variables.module";
 
 .excalidraw {
   .picker-container {

--- a/src/components/Modal.scss
+++ b/src/components/Modal.scss
@@ -1,4 +1,4 @@
-@import "../css/_variables";
+@import "../css/variables.module";
 
 .excalidraw {
   .Modal {

--- a/src/components/PasteChartDialog.scss
+++ b/src/components/PasteChartDialog.scss
@@ -1,4 +1,4 @@
-@import "../css/_variables";
+@import "../css/variables.module";
 
 .excalidraw {
   .PasteChartDialog {

--- a/src/components/Stats.scss
+++ b/src/components/Stats.scss
@@ -1,4 +1,4 @@
-@import "../css/_variables";
+@import "../css/variables.module";
 
 .Stats {
   position: fixed;

--- a/src/components/TextInput.scss
+++ b/src/components/TextInput.scss
@@ -1,4 +1,4 @@
-@import "../css/_variables.scss";
+@import "../css/variables.module";
 
 .excalidraw {
   .TextInput {

--- a/src/components/Toast.scss
+++ b/src/components/Toast.scss
@@ -1,4 +1,4 @@
-@import "../css/_variables";
+@import "../css/variables.module";
 
 .excalidraw {
   .Toast {

--- a/src/components/ToolIcon.scss
+++ b/src/components/ToolIcon.scss
@@ -1,5 +1,5 @@
 @import "open-color/open-color.scss";
-@import "../css/variables";
+@import "../css/variables.module";
 
 .excalidraw {
   .ToolIcon {

--- a/src/components/Tooltip.scss
+++ b/src/components/Tooltip.scss
@@ -1,4 +1,4 @@
-@import "../css/_variables";
+@import "../css/variables.module";
 .excalidraw {
   .Tooltip {
     position: relative;

--- a/src/css/styles.scss
+++ b/src/css/styles.scss
@@ -1,4 +1,4 @@
-@import "./_variables";
+@import "./variables.module";
 @import "./theme";
 
 .excalidraw {

--- a/src/css/variables.module.scss
+++ b/src/css/variables.module.scss
@@ -2,3 +2,7 @@
 
 // keep up to date with is-mobile.tsx
 $is-mobile-query: "(max-width: 600px), (max-height: 500px) and (max-width: 1000px)";
+
+:export {
+  isMobileQuery: unquote($is-mobile-query);
+}

--- a/src/excalidraw-app/collab/RoomDialog.scss
+++ b/src/excalidraw-app/collab/RoomDialog.scss
@@ -1,4 +1,4 @@
-@import "../../css/_variables";
+@import "../../css/variables.module";
 
 .excalidraw {
   .RoomDialog-linkContainer {

--- a/src/is-mobile.tsx
+++ b/src/is-mobile.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useRef, useContext } from "react";
+import variables from "./css/variables.module.scss";
 
 const context = React.createContext(false);
 
@@ -10,10 +11,7 @@ export const IsMobileProvider = ({
   const query = useRef<MediaQueryList>();
   if (!query.current) {
     query.current = window.matchMedia
-      ? window.matchMedia(
-          // keep up to date with _variables.scss
-          "(max-width: 600px), (max-height: 500px) and (max-width: 1000px)",
-        )
+      ? window.matchMedia(variables.isMobileQuery)
       : (({
           matches: false,
           addListener: () => {},


### PR DESCRIPTION
Import SCSS variables into JS so that we don't duplicate values which leads to regressions.

Had to suffix the `variables.scss` file with `.module` due to https://github.com/facebook/create-react-app/issues/10047#issuecomment-724227353