### PR TITLE
feat: increase max zoom

### DIFF
--- a/src/actions/actionCanvas.tsx
+++ b/src/actions/actionCanvas.tsx
@@ -3,6 +3,7 @@ import { getDefaultAppState } from "../appState";
 import { ColorPicker } from "../components/ColorPicker";
 import { resetZoom, trash, zoomIn, zoomOut } from "../components/icons";
 import { ToolButton } from "../components/ToolButton";
+import { ZOOM_STEP } from "../constants";
 import { getCommonBounds, getNonDeletedElements } from "../element";
 import { newElementWith } from "../element/mutateElement";
 import { ExcalidrawElement } from "../element/types";
@@ -74,8 +75,6 @@ export const actionClearCanvas = register({
     />
   ),
 });
-
-const ZOOM_STEP = 0.1;
 
 export const actionZoomIn = register({
   name: "zoomIn",

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -52,6 +52,7 @@ import {
   TAP_TWICE_TIMEOUT,
   TEXT_TO_CENTER_SNAP_THRESHOLD,
   TOUCH_CTX_MENU_TIMEOUT,
+  ZOOM_STEP,
 } from "../constants";
 import { exportCanvas, loadFromBlob } from "../data";
 import { isValidLibrary } from "../data/json";
@@ -3740,9 +3741,15 @@ class App extends React.Component<ExcalidrawProps, AppState> {
         }, 1000);
       }
 
+      let newZoom = this.state.zoom.value - delta / 100;
+      // increase zoom steps the more zoomed-in we are (applies to >100% only)
+      newZoom += Math.log10(Math.max(1, this.state.zoom.value)) * -sign;
+      // round to nearest step
+      newZoom = Math.round(newZoom * ZOOM_STEP * 100) / (ZOOM_STEP * 100);
+
       this.setState(({ zoom, offsetLeft, offsetTop }) => ({
         zoom: getNewZoom(
-          getNormalizedZoom(zoom.value - delta / 100),
+          getNormalizedZoom(newZoom),
           zoom,
           { left: offsetLeft, top: offsetTop },
           {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -91,3 +91,5 @@ export const TOUCH_CTX_MENU_TIMEOUT = 500;
 export const TITLE_TIMEOUT = 10000;
 export const TOAST_TIMEOUT = 5000;
 export const VERSION_TIMEOUT = 30000;
+
+export const ZOOM_STEP = 0.1;

--- a/src/scene/zoom.ts
+++ b/src/scene/zoom.ts
@@ -25,6 +25,6 @@ export const getNewZoom = (
 
 export const getNormalizedZoom = (zoom: number): NormalizedZoomValue => {
   const normalizedZoom = parseFloat(zoom.toFixed(2));
-  const clampedZoom = Math.max(0.1, Math.min(normalizedZoom, 2));
+  const clampedZoom = Math.max(0.1, Math.min(normalizedZoom, 10));
   return clampedZoom as NormalizedZoomValue;
 };


### PR DESCRIPTION
fix https://github.com/excalidraw/excalidraw/issues/2081

- max zoom is now 1000%
- wheel-scrolling step is get progressively larger the more you're zoomed in. Haven't made it adapt to wheel-scroll speed because that'd be more involved, plus I'd have to have access to continuous-scroll wheels to be confident I got it right.
- haven't changed touch zooming nor UI zooming speed. Touch zooming should be fine as is.

Lemme know if the current algo feels ok.