### PR TITLE
feat: adjust line-confirm-threshold based on zoom

### DIFF
--- a/src/actions/actionFinalize.tsx
+++ b/src/actions/actionFinalize.tsx
@@ -83,7 +83,7 @@ export const actionFinalize = register({
       // If the multi point line closes the loop,
       // set the last point to first point.
       // This ensures that loop remains closed at different scales.
-      const isLoop = isPathALoop(multiPointElement.points);
+      const isLoop = isPathALoop(multiPointElement.points, appState.zoom.value);
       if (
         multiPointElement.type === "line" ||
         multiPointElement.type === "draw"

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1860,7 +1860,7 @@ class App extends React.Component<ExcalidrawProps, AppState> {
           points: points.slice(0, -1),
         });
       } else {
-        if (isPathALoop(points)) {
+        if (isPathALoop(points, this.state.zoom.value)) {
           document.documentElement.style.cursor = CURSOR_TYPE.POINTER;
         }
         // update last uncommitted point
@@ -2533,7 +2533,10 @@ class App extends React.Component<ExcalidrawProps, AppState> {
       const { multiElement } = this.state;
 
       // finalize if completing a loop
-      if (multiElement.type === "line" && isPathALoop(multiElement.points)) {
+      if (
+        multiElement.type === "line" &&
+        isPathALoop(multiElement.points, this.state.zoom.value)
+      ) {
         mutateElement(multiElement, {
           lastCommittedPoint:
             multiElement.points[multiElement.points.length - 1],

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,8 +2,8 @@ import { FontFamily } from "./element/types";
 
 export const APP_NAME = "Excalidraw";
 
-export const DRAGGING_THRESHOLD = 10; // 10px
-export const LINE_CONFIRM_THRESHOLD = 10; // 10px
+export const DRAGGING_THRESHOLD = 10; // px
+export const LINE_CONFIRM_THRESHOLD = 8; // px
 export const ELEMENT_SHIFT_TRANSLATE_AMOUNT = 5;
 export const ELEMENT_TRANSLATE_AMOUNT = 1;
 export const TEXT_TO_CENTER_SNAP_THRESHOLD = 30;

--- a/src/element/linearElementEditor.ts
+++ b/src/element/linearElementEditor.ts
@@ -129,7 +129,7 @@ export class LinearElementEditor {
       isDragging &&
       (activePointIndex === 0 || activePointIndex === element.points.length - 1)
     ) {
-      if (isPathALoop(element.points)) {
+      if (isPathALoop(element.points, appState.zoom.value)) {
         LinearElementEditor.movePoint(
           element,
           activePointIndex,

--- a/src/math.ts
+++ b/src/math.ts
@@ -167,7 +167,7 @@ export const isPathALoop = (
       (LINE_CONFIRM_THRESHOLD / Math.log1p(zoomValue * k)) *
       // multiplying by log reciprocal will cancel it out when zoomValue
       // is 100%, so that threshold always results in LINE_CONFIRM_THRESHOLD
-      (Math.log1p(1 * k) / 1);
+      Math.log1p(k);
 
     return distance <= threshold;
   }

--- a/src/math.ts
+++ b/src/math.ts
@@ -151,13 +151,8 @@ export const isPathALoop = (
   zoomValue: Zoom["value"] = 1 as NormalizedZoomValue,
 ): boolean => {
   if (points.length >= 3) {
-    const [firstPoint, lastPoint] = [points[0], points[points.length - 1]];
-    const distance = distance2d(
-      firstPoint[0],
-      firstPoint[1],
-      lastPoint[0],
-      lastPoint[1],
-    );
+    const [first, last] = [points[0], points[points.length - 1]];
+    const distance = distance2d(first[0], first[1], last[0], last[1]);
 
     // Adjusting LINE_CONFIRM_THRESHOLD to current zoom so that when zoomed in
     // really close we make the threshold smaller, and vice versa.

--- a/src/math.ts
+++ b/src/math.ts
@@ -1,4 +1,4 @@
-import { Point } from "./types";
+import { NormalizedZoomValue, Point, Zoom } from "./types";
 import { LINE_CONFIRM_THRESHOLD } from "./constants";
 import { ExcalidrawLinearElement } from "./element/types";
 
@@ -148,11 +148,9 @@ export const centerPoint = (a: Point, b: Point): Point => {
 export const isPathALoop = (
   points: ExcalidrawLinearElement["points"],
   /** supply if you want the loop detection to account for current zoom */
-  zoomValue?: number,
+  zoomValue: Zoom["value"] = 1 as NormalizedZoomValue,
 ): boolean => {
   if (points.length >= 3) {
-    zoomValue = zoomValue ?? 1;
-
     const [firstPoint, lastPoint] = [points[0], points[points.length - 1]];
     const distance = distance2d(
       firstPoint[0],

--- a/src/math.ts
+++ b/src/math.ts
@@ -161,15 +161,7 @@ export const isPathALoop = (
 
     // Adjusting LINE_CONFIRM_THRESHOLD to current zoom so that when zoomed in
     // really close we make the threshold smaller, and vice versa.
-    // The formulas are a result of curve-fitting target values.
-    const k = 3 - 2 * Math.pow(zoomValue, 0.05);
-    const threshold =
-      (LINE_CONFIRM_THRESHOLD / Math.log1p(zoomValue * k)) *
-      // multiplying by log reciprocal will cancel it out when zoomValue
-      // is 100%, so that threshold always results in LINE_CONFIRM_THRESHOLD
-      Math.log1p(k);
-
-    return distance <= threshold;
+    return distance <= LINE_CONFIRM_THRESHOLD / zoomValue;
   }
   return false;
 };

--- a/src/math.ts
+++ b/src/math.ts
@@ -147,13 +147,31 @@ export const centerPoint = (a: Point, b: Point): Point => {
 // to be considered a loop
 export const isPathALoop = (
   points: ExcalidrawLinearElement["points"],
+  /** supply if you want the loop detection to account for current zoom */
+  zoomValue?: number,
 ): boolean => {
   if (points.length >= 3) {
+    zoomValue = zoomValue ?? 1;
+
     const [firstPoint, lastPoint] = [points[0], points[points.length - 1]];
-    return (
-      distance2d(firstPoint[0], firstPoint[1], lastPoint[0], lastPoint[1]) <=
-      LINE_CONFIRM_THRESHOLD
+    const distance = distance2d(
+      firstPoint[0],
+      firstPoint[1],
+      lastPoint[0],
+      lastPoint[1],
     );
+
+    // Adjusting LINE_CONFIRM_THRESHOLD to current zoom so that when zoomed in
+    // really close we make the threshold smaller, and vice versa.
+    // The formulas are a result of curve-fitting target values.
+    const k = 3 - 2 * Math.pow(zoomValue, 0.05);
+    const threshold =
+      (LINE_CONFIRM_THRESHOLD / Math.log1p(zoomValue * k)) *
+      // multiplying by log reciprocal will cancel it out when zoomValue
+      // is 100%, so that threshold always results in LINE_CONFIRM_THRESHOLD
+      (Math.log1p(1 * k) / 1);
+
+    return distance <= threshold;
   }
   return false;
 };


### PR DESCRIPTION
The line confirmation threshold that we also use for auto-closing of start/end points should account for zoom. If zoomed in a lot, the threshold should be smaller and vice versa.

I haven't applied this to shape filling, which still uses the threshold verbatim. It feels ok. The idea is so that you can create points close together without the line being confirmed, so that you can continue creating more points.

The formulas are a bit crazy. I came up with it by first coming up with a few reasonable values at given zoom values, and then fitting a curve through those points using a [calculator](https://mycurvefit.com/). Well, it was a bit harder than that because I also wanted to guarantee that the line threshold constant stays constant at 100% zoom.