### PR TITLE
feat: support supplying custom scale when exporting canvas

### DIFF
--- a/src/packages/utils.ts
+++ b/src/packages/utils.ts
@@ -36,7 +36,7 @@ export const exportToCanvas = ({
       canvas.width = ret.width;
       canvas.height = ret.height;
 
-      return canvas;
+      return { canvas, scale: ret.scale };
     },
   );
 };

--- a/src/scene/export.ts
+++ b/src/scene/export.ts
@@ -29,14 +29,14 @@ export const exportToCanvas = (
     viewBackgroundColor: string;
     shouldAddWatermark: boolean;
   },
-  createCanvas: (width: number, height: number) => HTMLCanvasElement = (
-    width,
-    height,
-  ) => {
+  createCanvas: (
+    width: number,
+    height: number,
+  ) => { canvas: HTMLCanvasElement; scale: number } = (width, height) => {
     const tempCanvas = document.createElement("canvas");
     tempCanvas.width = width * scale;
     tempCanvas.height = height * scale;
-    return tempCanvas;
+    return { canvas: tempCanvas, scale: 1 };
   },
 ) => {
   const sceneElements = getElementsAndWatermark(elements, shouldAddWatermark);
@@ -47,13 +47,16 @@ export const exportToCanvas = (
     shouldAddWatermark,
   );
 
-  const tempCanvas = createCanvas(width, height);
+  const { canvas: tempCanvas, scale: newScale = scale } = createCanvas(
+    width,
+    height,
+  );
 
   renderScene(
     sceneElements,
     appState,
     null,
-    scale,
+    newScale,
     rough.canvas(tempCanvas),
     tempCanvas,
     {


### PR DESCRIPTION
I didn't notice that we've forgot to integrate `scale` when supplying custom `getDimensions` during canvas export. This PR is technically a breaking change of the API, but since we haven't yet documented `getDimensions()`, we don't need a changelog for this.