### PR TITLE
feat: Show version in the stats dialog

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -457,6 +457,7 @@ class App extends React.Component<ExcalidrawProps, AppState> {
         {this.state.showStats && (
           <Stats
             appState={this.state}
+            setAppState={this.setAppState}
             elements={this.scene.getElements()}
             onClose={this.toggleStats}
           />

--- a/src/components/Stats.tsx
+++ b/src/components/Stats.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from "react";
+import { copyTextToSystemClipboard } from "../clipboard";
 import { getCommonBounds } from "../element/bounds";
 import { NonDeletedExcalidrawElement } from "../element/types";
 import {
@@ -51,7 +52,7 @@ export const Stats = (props: {
   }
 
   let version = getVersion();
-  let hash = "123456";
+  let hash = "1234567";
 
   if (version.length > 16) {
     hash = version.substr(21, 7);
@@ -168,7 +169,12 @@ export const Stats = (props: {
               <th colSpan={2}>{t("stats.version")}</th>
             </tr>
             <tr>
-              <td colSpan={2} style={{ textAlign: "center" }}>
+              <td
+                colSpan={2}
+                style={{ textAlign: "center", cursor: "pointer" }}
+                onClick={() => copyTextToSystemClipboard(getVersion())}
+                title={t("stats.versionCopy")}
+              >
                 {version}
                 <br />
                 {hash}

--- a/src/components/Stats.tsx
+++ b/src/components/Stats.tsx
@@ -181,11 +181,11 @@ export const Stats = (props: {
                   try {
                     await copyTextToSystemClipboard(getVersion());
                     props.setAppState({
-                      toastMessage: t("stats.versionCopied"),
+                      toastMessage: t("toast.copyToClipboard"),
                     });
                   } catch {}
                 }}
-                title={t("toast.copyToClipboard")}
+                title={t("stats.versionCopy")}
               >
                 {timestamp}
                 <br />

--- a/src/components/Stats.tsx
+++ b/src/components/Stats.tsx
@@ -26,6 +26,7 @@ const getStorageSizes = debounce((cb: (sizes: StorageSizes) => void) => {
 
 export const Stats = (props: {
   appState: AppState;
+  setAppState: React.Component<any, AppState>["setState"];
   elements: readonly NonDeletedExcalidrawElement[];
   onClose: () => void;
 }) => {
@@ -51,12 +52,15 @@ export const Stats = (props: {
     return null;
   }
 
-  let version = getVersion();
-  let hash = "1234567";
+  const version = getVersion();
+  let hash;
+  let timestamp;
 
   if (version.length > 16) {
-    hash = version.substr(21, 7);
-    version = version.substr(0, 16).replace("T", " ");
+    timestamp = version.slice(0, 16).replace("T", " ");
+    hash = version.slice(21);
+  } else {
+    timestamp = "Version data not available";
   }
 
   return (
@@ -172,10 +176,17 @@ export const Stats = (props: {
               <td
                 colSpan={2}
                 style={{ textAlign: "center", cursor: "pointer" }}
-                onClick={() => copyTextToSystemClipboard(getVersion())}
+                onClick={async () => {
+                  try {
+                    await copyTextToSystemClipboard(getVersion());
+                    props.setAppState({
+                      toastMessage: "copied to clipboard",
+                    });
+                  } catch {}
+                }}
                 title={t("stats.versionCopy")}
               >
-                {version}
+                {timestamp}
                 <br />
                 {hash}
               </td>

--- a/src/components/Stats.tsx
+++ b/src/components/Stats.tsx
@@ -61,7 +61,7 @@ export const Stats = (props: {
     timestamp = version.slice(0, 16).replace("T", " ");
     hash = version.slice(21);
   } else {
-    timestamp = "Version not available";
+    timestamp = t("stats.versionNotAvailable");
   }
 
   return (
@@ -181,7 +181,7 @@ export const Stats = (props: {
                   try {
                     await copyTextToSystemClipboard(getVersion());
                     props.setAppState({
-                      toastMessage: "copied to clipboard",
+                      toastMessage: t("stats.versionCopied"),
                     });
                   } catch {}
                 }}

--- a/src/components/Stats.tsx
+++ b/src/components/Stats.tsx
@@ -9,7 +9,7 @@ import { t } from "../i18n";
 import useIsMobile from "../is-mobile";
 import { getTargetElements } from "../scene";
 import { AppState } from "../types";
-import { debounce, getHumanVersion, nFormatter } from "../utils";
+import { debounce, getVersion, nFormatter } from "../utils";
 import { close } from "./icons";
 import { Island } from "./Island";
 import "./Stats.scss";
@@ -48,6 +48,14 @@ export const Stats = (props: {
 
   if (isMobile && props.appState.openMenu) {
     return null;
+  }
+
+  let version = getVersion();
+  let hash = "123456";
+
+  if (version.length > 16) {
+    hash = version.substr(21, 7);
+    version = version.substr(0, 16).replace("T", " ");
   }
 
   return (
@@ -161,7 +169,9 @@ export const Stats = (props: {
             </tr>
             <tr>
               <td colSpan={2} style={{ textAlign: "center" }}>
-                {getHumanVersion()}
+                {version}
+                <br />
+                {hash}
               </td>
             </tr>
           </tbody>

--- a/src/components/Stats.tsx
+++ b/src/components/Stats.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { copyTextToSystemClipboard } from "../clipboard";
+import { DEFAULT_VERSION } from "../constants";
 import { getCommonBounds } from "../element/bounds";
 import { NonDeletedExcalidrawElement } from "../element/types";
 import {
@@ -56,11 +57,11 @@ export const Stats = (props: {
   let hash;
   let timestamp;
 
-  if (version.length > 16) {
+  if (version !== DEFAULT_VERSION) {
     timestamp = version.slice(0, 16).replace("T", " ");
     hash = version.slice(21);
   } else {
-    timestamp = "Version data not available";
+    timestamp = "Version not available";
   }
 
   return (

--- a/src/components/Stats.tsx
+++ b/src/components/Stats.tsx
@@ -9,7 +9,7 @@ import { t } from "../i18n";
 import useIsMobile from "../is-mobile";
 import { getTargetElements } from "../scene";
 import { AppState } from "../types";
-import { debounce, nFormatter } from "../utils";
+import { debounce, nFormatter, getVersion } from "../utils";
 import { close } from "./icons";
 import { Island } from "./Island";
 import "./Stats.scss";
@@ -156,6 +156,14 @@ export const Stats = (props: {
                 </td>
               </tr>
             )}
+            <tr>
+              <th colSpan={2}>{t("stats.version")}</th>
+            </tr>
+            <tr>
+              <td colSpan={2} style={{ textAlign: "center" }}>
+                {getVersion()}
+              </td>
+            </tr>
           </tbody>
         </table>
       </Island>

--- a/src/components/Stats.tsx
+++ b/src/components/Stats.tsx
@@ -185,7 +185,7 @@ export const Stats = (props: {
                     });
                   } catch {}
                 }}
-                title={t("stats.versionCopy")}
+                title={t("toast.copyToClipboard")}
               >
                 {timestamp}
                 <br />

--- a/src/components/Stats.tsx
+++ b/src/components/Stats.tsx
@@ -9,7 +9,7 @@ import { t } from "../i18n";
 import useIsMobile from "../is-mobile";
 import { getTargetElements } from "../scene";
 import { AppState } from "../types";
-import { debounce, nFormatter, getVersion } from "../utils";
+import { debounce, getHumanVersion, nFormatter } from "../utils";
 import { close } from "./icons";
 import { Island } from "./Island";
 import "./Stats.scss";
@@ -161,7 +161,7 @@ export const Stats = (props: {
             </tr>
             <tr>
               <td colSpan={2} style={{ textAlign: "center" }}>
-                {getVersion()}
+                {getHumanVersion()}
               </td>
             </tr>
           </tbody>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -236,6 +236,8 @@
     "total": "Total",
     "version": "Version",
     "versionCopy": "Click to copy",
+    "versionCopied": "Version copied to clipboard",
+    "versionNotAvailable": "Version not available",
     "width": "Width"
   },
   "toast": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -237,12 +237,12 @@
     "total": "Total",
     "version": "Version",
     "versionCopy": "Click to copy",
-    "versionCopied": "Version copied to clipboard",
     "versionNotAvailable": "Version not available",
     "width": "Width"
   },
   "toast": {
     "copyStyles": "Copied styles.",
+    "copyToClipboard": "Copied to clipboard",
     "copyToClipboardAsPng": "Copied to clipboard as PNG."
   }
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -242,7 +242,7 @@
   },
   "toast": {
     "copyStyles": "Copied styles.",
-    "copyToClipboard": "Copied to clipboard",
+    "copyToClipboard": "Copied to clipboard.",
     "copyToClipboardAsPng": "Copied to clipboard as PNG."
   }
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -235,6 +235,7 @@
     "title": "Stats for nerds",
     "total": "Total",
     "version": "Version",
+    "versionCopy": "Click to copy",
     "width": "Width"
   },
   "toast": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -234,6 +234,7 @@
     "storage": "Storage",
     "title": "Stats for nerds",
     "total": "Total",
+    "version": "Version",
     "width": "Width"
   },
   "toast": {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -369,11 +369,3 @@ export const getVersion = () => {
     DEFAULT_VERSION
   );
 };
-
-export const getHumanVersion = () => {
-  const version = getVersion();
-  if (version.length === 28) {
-    return version.substr(0, 16).replace("T", " ");
-  }
-  return version;
-};

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -369,3 +369,11 @@ export const getVersion = () => {
     DEFAULT_VERSION
   );
 };
+
+export const getHumanVersion = () => {
+  const version = getVersion();
+  if (version.length === 28) {
+    return version.substr(0, 16).replace("T", " ");
+  }
+  return version;
+};


### PR DESCRIPTION
Not sure if needed.. but sometime it's good to know when filing an issue for example.. thoughts?

- [x] Click to copy (or link to https://stats.excalidraw.com?)
- [x] Parse day and show human friendlier version
