### PR TITLE
fix: make scrollbars draggable when offsets are set

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1823,10 +1823,11 @@ class App extends React.Component<ExcalidrawProps, AppState> {
     if (isHoldingSpace || isPanning || isDraggingScrollBar) {
       return;
     }
+
     const isPointerOverScrollBars = isOverScrollBars(
       currentScrollBars,
-      event.clientX,
-      event.clientY,
+      event.clientX - this.state.offsetLeft,
+      event.clientY - this.state.offsetTop,
     );
     const isOverScrollBar = isPointerOverScrollBars.isOverEither;
     if (!this.state.draggingElement && !this.state.multiElement) {
@@ -2282,8 +2283,8 @@ class App extends React.Component<ExcalidrawProps, AppState> {
       ),
       scrollbars: isOverScrollBars(
         currentScrollBars,
-        event.clientX,
-        event.clientY,
+        event.clientX - this.state.offsetLeft,
+        event.clientY - this.state.offsetTop,
       ),
       // we need to duplicate because we'll be updating this state
       lastCoords: { ...origin },


### PR DESCRIPTION
Cf https://github.com/excalidraw/excalidraw/issues/2915#issuecomment-772807009

Today when setting offsetLeft or offsetRight when using the package library, scrollbars will display, but can't be dragged. This is an attempt to fix it.