### PR TITLE
chore: Run actions on pull requests as well

### DIFF
--- a/.github/workflows/cancel.yml
+++ b/.github/workflows/cancel.yml
@@ -1,6 +1,10 @@
 name: Cancel previous runs
 
-on: pull_request
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 
 jobs:
   cancel:

--- a/.github/workflows/cancel.yml
+++ b/.github/workflows/cancel.yml
@@ -1,6 +1,6 @@
 name: Cancel previous runs
 
-on: push
+on: [push, pull_request]
 
 jobs:
   cancel:

--- a/.github/workflows/cancel.yml
+++ b/.github/workflows/cancel.yml
@@ -1,6 +1,6 @@
 name: Cancel previous runs
 
-on: [push, pull_request]
+on: pull_request
 
 jobs:
   cancel:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,6 @@
 name: Lint
 
-on: push
+on: [push, pull_request]
 
 jobs:
   lint:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,6 @@
 name: Lint
 
-on: [push, pull_request]
+on: pull_request
 
 jobs:
   lint:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: Tests
 
-on: push
+on: [push, pull_request]
 
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: Tests
 
-on: [push, pull_request]
+on: pull_request
 
 jobs:
   test:


### PR DESCRIPTION
It seems that the actions are not running only on push when from other repositories.. #2916 

https://docs.github.com/en/actions/reference/events-that-trigger-workflows#example-using-a-single-event