### PR TITLE
fix: toolbar unnecessarily eats too much width

### DIFF
--- a/src/components/MobileMenu.tsx
+++ b/src/components/MobileMenu.tsx
@@ -46,7 +46,7 @@ export const MobileMenu = ({
   renderCustomFooter,
   viewModeEnabled,
 }: MobileMenuProps) => {
-  const renderFixedSideContainer = () => {
+  const renderToolbar = () => {
     return (
       <FixedSideContainer side="top" className="App-top-bar">
         <Section heading="shapes">
@@ -136,7 +136,7 @@ export const MobileMenu = ({
   };
   return (
     <>
-      {!viewModeEnabled && renderFixedSideContainer()}
+      {!viewModeEnabled && renderToolbar()}
       <div
         className="App-bottom-bar"
         style={{

--- a/src/css/styles.scss
+++ b/src/css/styles.scss
@@ -226,6 +226,8 @@
 
   .App-top-bar {
     z-index: var(--zIndex-layerUI);
+    display: flex;
+    justify-content: center;
   }
 
   .App-bottom-bar {


### PR DESCRIPTION
Fixes toolbar on mobile making the canvas around it unusable due to being unnecessarily wide.

![image](https://user-images.githubusercontent.com/5153846/106917044-269aa380-6708-11eb-809c-4fa7855c0e6a.png)
