### PR TITLE
fix: don't prompt on empty scenes

### DIFF
--- a/src/excalidraw-app/index.tsx
+++ b/src/excalidraw-app/index.tsx
@@ -80,7 +80,14 @@ const initializeScene = async (opts: {
   let roomLinkData = getCollaborationLinkData(window.location.href);
   const isExternalScene = !!(id || jsonMatch || roomLinkData);
   if (isExternalScene) {
-    if (roomLinkData || window.confirm(t("alerts.loadSceneOverridePrompt"))) {
+    if (
+      // don't prompt if scene is empty
+      !scene.elements.length ||
+      // don't prompt for collab scenes because we don't override local storage
+      roomLinkData ||
+      // otherwise, prompt whether user wants to override current scene
+      window.confirm(t("alerts.loadSceneOverridePrompt"))
+    ) {
       // Backwards compatibility with legacy url format
       if (id) {
         scene = await loadScene(id, null, initialData);


### PR DESCRIPTION
fix https://github.com/excalidraw/excalidraw/issues/2935

Turns out the `shouldForceLoadScene()` we removed was needed after all. I just inlined the empty-scene check. This fix aligns it with previous behavior.

Long-term we can also check for identical-scene, but that will require a little more work.