### PR TITLE
fix: mobile toolbar tooltip regression

### DIFF
--- a/src/css/styles.scss
+++ b/src/css/styles.scss
@@ -227,7 +227,8 @@
   .App-top-bar {
     z-index: var(--zIndex-layerUI);
     display: flex;
-    justify-content: center;
+    flex-direction: column;
+    align-items: center;
   }
 
   .App-bottom-bar {


### PR DESCRIPTION
fixing a regression caused in recent PR:

![image](https://user-images.githubusercontent.com/5153846/107050145-2fa07900-67cb-11eb-91b2-252ce7f795a7.png)
