### PR TITLE
chore: [Idle detection] Deal with users on systems that don't handle emoji

### DIFF
--- a/src/renderer/renderScene.ts
+++ b/src/renderer/renderScene.ts
@@ -504,11 +504,11 @@ export const renderScene = (
           : "🟢"
       }`;
     } else {
-      usernameAndIdleState = `${username ? `${username} ` : ""}${
+      usernameAndIdleState = `${username ? `${username}` : ""}${
         userState === UserIdleState.AWAY
-          ? `(${UserIdleState.AWAY})`
+          ? ` (${UserIdleState.AWAY})`
           : userState === UserIdleState.IDLE
-          ? `(${UserIdleState.IDLE})`
+          ? ` (${UserIdleState.IDLE})`
           : ""
       }`;
     }

--- a/src/renderer/renderScene.ts
+++ b/src/renderer/renderScene.ts
@@ -451,7 +451,7 @@ export const renderScene = (
 
     const userState = sceneState.remotePointerUserStates[clientId];
     if (isOutOfBounds || userState === UserIdleState.AWAY) {
-      context.globalAlpha = 0.2;
+      context.globalAlpha = 0.48;
     }
 
     if (

--- a/src/renderer/renderScene.ts
+++ b/src/renderer/renderScene.ts
@@ -47,8 +47,10 @@ import {
   TransformHandles,
   TransformHandleType,
 } from "../element/transformHandles";
-import { viewportCoordsToSceneCoords } from "../utils";
+import { viewportCoordsToSceneCoords, supportsEmoji } from "../utils";
 import { UserIdleState } from "../excalidraw-app/collab/types";
+
+const hasEmojiSupport = supportsEmoji();
 
 const strokeRectWithRotation = (
   context: CanvasRenderingContext2D,
@@ -172,19 +174,6 @@ const renderLinearPointHandles = (
   context.lineWidth = lineWidth;
   context.translate(-sceneState.scrollX, -sceneState.scrollY);
   context.strokeStyle = origStrokeStyle;
-};
-
-// From https://github.com/Modernizr/Modernizr/blob/master/feature-detects/emoji.js
-const supportsEmoji = () => {
-  const canvas = document.createElement("canvas");
-  const ctx = canvas.getContext("2d");
-  const backingStoreRatio = ctx.backingStorePixelRatio || 1;
-  const offset = 12 * backingStoreRatio;
-  ctx.fillStyle = "#f00";
-  ctx.textBaseline = "top";
-  ctx.font = "32px Arial";
-  ctx.fillText("\ud83d\udc28", 0, 0); // U+1F428 KOALA
-  return ctx.getImageData(offset, offset, 1, 1).data[0] !== 0;
 };
 
 export const renderScene = (
@@ -495,7 +484,7 @@ export const renderScene = (
 
     const username = sceneState.remotePointerUsernames[clientId];
     let usernameAndIdleState;
-    if (supportsEmoji) {
+    if (hasEmojiSupport) {
       usernameAndIdleState = `${username ? `${username} ` : ""}${
         userState === UserIdleState.AWAY
           ? "⚫️"

--- a/src/renderer/renderScene.ts
+++ b/src/renderer/renderScene.ts
@@ -174,6 +174,19 @@ const renderLinearPointHandles = (
   context.strokeStyle = origStrokeStyle;
 };
 
+// From https://github.com/Modernizr/Modernizr/blob/master/feature-detects/emoji.js
+const supportsEmoji = () => {
+  const canvas = document.createElement("canvas");
+  const ctx = canvas.getContext("2d");
+  const backingStoreRatio = ctx.backingStorePixelRatio || 1;
+  const offset = 12 * backingStoreRatio;
+  ctx.fillStyle = "#f00";
+  ctx.textBaseline = "top";
+  ctx.font = "32px Arial";
+  ctx.fillText("\ud83d\udc28", 0, 0); // U+1F428 KOALA
+  return ctx.getImageData(offset, offset, 1, 1).data[0] !== 0;
+};
+
 export const renderScene = (
   elements: readonly NonDeletedExcalidrawElement[],
   appState: AppState,
@@ -481,13 +494,24 @@ export const renderScene = (
     context.stroke();
 
     const username = sceneState.remotePointerUsernames[clientId];
-    const usernameAndIdleState = `${username ? `${username} ` : ""}${
-      userState === UserIdleState.AWAY
-        ? "⚫️"
-        : userState === UserIdleState.IDLE
-        ? "💤"
-        : "🟢"
-    }`;
+    let usernameAndIdleState;
+    if (supportsEmoji) {
+      usernameAndIdleState = `${username ? `${username} ` : ""}${
+        userState === UserIdleState.AWAY
+          ? "⚫️"
+          : userState === UserIdleState.IDLE
+          ? "💤"
+          : "🟢"
+      }`;
+    } else {
+      usernameAndIdleState = `${username ? `${username} ` : ""}${
+        userState === UserIdleState.AWAY
+          ? `(${UserIdleState.AWAY})`
+          : userState === UserIdleState.IDLE
+          ? `(${UserIdleState.IDLE})`
+          : ""
+      }`;
+    }
 
     if (!isOutOfBounds && usernameAndIdleState) {
       const offsetX = x + width;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -369,3 +369,18 @@ export const getVersion = () => {
     DEFAULT_VERSION
   );
 };
+
+// From https://github.com/Modernizr/Modernizr/blob/master/feature-detects/emoji.js
+export const supportsEmoji = () => {
+  const canvas = document.createElement("canvas");
+  const ctx = canvas.getContext("2d");
+  if (!ctx) {
+    return false;
+  }
+  const offset = 12;
+  ctx.fillStyle = "#f00";
+  ctx.textBaseline = "top";
+  ctx.font = "32px Arial";
+  ctx.fillText("\ud83d\udc28", 0, 0); // U+1F428 KOALA
+  return ctx.getImageData(offset, offset, 1, 1).data[0] !== 0;
+};

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -370,7 +370,7 @@ export const getVersion = () => {
   );
 };
 
-// From https://github.com/Modernizr/Modernizr/blob/master/feature-detects/emoji.js
+// Adapted from https://github.com/Modernizr/Modernizr/blob/master/feature-detects/emoji.js
 export const supportsEmoji = () => {
   const canvas = document.createElement("canvas");
   const ctx = canvas.getContext("2d");
@@ -381,6 +381,8 @@ export const supportsEmoji = () => {
   ctx.fillStyle = "#f00";
   ctx.textBaseline = "top";
   ctx.font = "32px Arial";
-  ctx.fillText("\ud83d\udc28", 0, 0); // U+1F428 KOALA
+  // Modernizr used 🐨, but it is sort of supported on Windows 7.
+  // Luckily 😀 isn't supported.
+  ctx.fillText("😀", 0, 0);
   return ctx.getImageData(offset, offset, 1, 1).data[0] !== 0;
 };


### PR DESCRIPTION
As discussed on chat, at least some Windows 7 users can't display emoji. This PR deals with this fact by providing a textual fallback for 💤 ("idle") and ⚫️ ("away"). The default state, 🟢, is ignored on purpose. 