### PR TITLE
fix: Adjust default hand cursor to match expected behavior

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -368,7 +368,7 @@ class App extends React.Component<ExcalidrawProps, AppState> {
           style={{
             width: canvasDOMWidth,
             height: canvasDOMHeight,
-            cursor: "grabbing",
+            cursor: "grab",
           }}
           width={canvasWidth}
           height={canvasHeight}
@@ -1429,7 +1429,7 @@ class App extends React.Component<ExcalidrawProps, AppState> {
     }
     if (event.key === KEYS.SPACE && gesture.pointers.size === 0) {
       isHoldingSpace = true;
-      document.documentElement.style.cursor = CURSOR_TYPE.GRABBING;
+      document.documentElement.style.cursor = CURSOR_TYPE.GRAB;
     }
   });
 
@@ -2214,7 +2214,7 @@ class App extends React.Component<ExcalidrawProps, AppState> {
     let nextPastePrevented = false;
     const isLinux = /Linux/.test(window.navigator.platform);
 
-    document.documentElement.style.cursor = CURSOR_TYPE.GRABBING;
+    document.documentElement.style.cursor = CURSOR_TYPE.GRAB;
     let { clientX: lastX, clientY: lastY } = event;
     const onPointerMove = withBatchedUpdates((event: PointerEvent) => {
       const deltaX = lastX - event.clientX;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -11,7 +11,7 @@ export const SHIFT_LOCKING_ANGLE = Math.PI / 12;
 export const CURSOR_TYPE = {
   TEXT: "text",
   CROSSHAIR: "crosshair",
-  GRABBING: "grabbing",
+  GRAB: "grab",
   POINTER: "pointer",
   MOVE: "move",
   AUTO: "",


### PR DESCRIPTION
Hello! This is a pretty small change. If there are strong opinions on this happy to close it as well. Regardless, love the app and been really enjoying using it for quite a while. I got a bit disoriented the first time I used these features, so figured I'd open a PR instead of an issue :)

This changes the default hand icon from the closed "grabbing" hand to an open hand. Reasoning here is that you still have to mouse click in order to drag the canvas around; clicking spacebar and moving around the mouse doesn't in and of itself move the canvas. Was thinking of adding functionality to change the hand to the "grabbing" version when clicking, but figured this would still be a win in the meantime.

🍻 ,
Kyle