### PR TITLE
docs(readme): link to @excalidraw/excalidraw npm package to give more visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ The second set of digits is the encryption key. The Excalidraw server doesn’t 
 
 Find a growing list of libraries containing assets for your drawings at [libraries.excalidraw.com](https://libraries.excalidraw.com).
 
-## Embed Excalidraw in your App?
+## Embedding Excalidraw in your App?
 
 Try out [`@excalidraw/excalidraw`](https://www.npmjs.com/package/@excalidraw/excalidraw). This package allows you to easily embed Excalidraw as a React component into your apps.
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ If you like the project, you can become a sponsor at [Open Collective](https://o
 
 <a href="https://opencollective.com/excalidraw#category-CONTRIBUTE" target="_blank"><img src="https://opencollective.com/excalidraw/tiers/backers.svg?avatarHeight=32"/></a>
 
+## Embed Excalidraw in your App ?
+
+Try out [@excalidraw/excalidraw](https://www.npmjs.com/package/@excalidraw/excalidraw).
+
 ## Documentation
 
 ### Shortcuts

--- a/README.md
+++ b/README.md
@@ -28,10 +28,6 @@ If you like the project, you can become a sponsor at [Open Collective](https://o
 
 <a href="https://opencollective.com/excalidraw#category-CONTRIBUTE" target="_blank"><img src="https://opencollective.com/excalidraw/tiers/backers.svg?avatarHeight=32"/></a>
 
-## Embed Excalidraw in your App?
-
-Try out [`@excalidraw/excalidraw`](https://www.npmjs.com/package/@excalidraw/excalidraw). This package allows you to easily embed Excalidraw as a React component into your apps.
-
 ## Documentation
 
 ### Shortcuts
@@ -73,6 +69,10 @@ The second set of digits is the encryption key. The Excalidraw server doesn’t 
 ## Shape libraries
 
 Find a growing list of libraries containing assets for your drawings at [libraries.excalidraw.com](https://libraries.excalidraw.com).
+
+## Embed Excalidraw in your App?
+
+Try out [`@excalidraw/excalidraw`](https://www.npmjs.com/package/@excalidraw/excalidraw). This package allows you to easily embed Excalidraw as a React component into your apps.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ If you like the project, you can become a sponsor at [Open Collective](https://o
 
 <a href="https://opencollective.com/excalidraw#category-CONTRIBUTE" target="_blank"><img src="https://opencollective.com/excalidraw/tiers/backers.svg?avatarHeight=32"/></a>
 
-## Embed Excalidraw in your App ?
+## Embed Excalidraw in your App?
 
-Try out [@excalidraw/excalidraw](https://www.npmjs.com/package/@excalidraw/excalidraw).
+Try out [`@excalidraw/excalidraw`](https://www.npmjs.com/package/@excalidraw/excalidraw). This package allows you to easily embed Excalidraw as a React component into your apps.
 
 ## Documentation
 


### PR DESCRIPTION
Adding link to the main readme to increase the visibility of the package since it resides in the same repo