### PR TITLE
fix: refresh wysiwyg position on canvas resize

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3356,6 +3356,12 @@
         "@types/react": "*"
       }
     },
+    "@types/resize-observer-browser": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@types/resize-observer-browser/-/resize-observer-browser-0.1.5.tgz",
+      "integrity": "sha512-8k/67Z95Goa6Lznuykxkfhq9YU3l1Qe6LNZmwde1u7802a3x8v44oq0j91DICclxatTr0rNnhXx7+VTIetSrSQ==",
+      "dev": true
+    },
     "@types/resolve": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-0.0.8.tgz",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
   "devDependencies": {
     "@types/lodash.throttle": "4.1.6",
     "@types/pako": "1.0.1",
+    "@types/resize-observer-browser": "0.1.5",
     "eslint-config-prettier": "7.2.0",
     "eslint-plugin-prettier": "3.3.1",
     "firebase-tools": "9.3.0",

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1551,6 +1551,7 @@ class App extends React.Component<ExcalidrawProps, AppState> {
     textWysiwyg({
       id: element.id,
       appState: this.state,
+      canvas: this.canvas,
       getViewportCoords: (x, y) => {
         const { x: viewportX, y: viewportY } = sceneCoordsToViewportCoords(
           {


### PR DESCRIPTION
Replaced `resize` with `ResizeObserver`. This will ensure that wysiwyg position is refreshed when canvas is resized via other means, such as updating dimensions or offsets from the host app.

fix https://github.com/excalidraw/excalidraw/issues/2921 (kinda)