### PR TITLE
refactor: Removed redundant import from `App.tsx`

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -4,7 +4,6 @@ import { RoughCanvas } from "roughjs/bin/canvas";
 import rough from "roughjs/bin/rough";
 import clsx from "clsx";
 
-import "../actions";
 import {
   actionAddToLibrary,
   actionBringForward,


### PR DESCRIPTION
Given it's followed by qualified import - unqualified import looks redundant, unless I'm missing some tricky edge case.