### PR TITLE
chore: Remove engines from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,9 +62,6 @@
     "prettier": "2.2.1",
     "rewire": "5.0.0"
   },
-  "engines": {
-    "node": ">=12.0.0"
-  },
   "homepage": ".",
   "husky": {
     "hooks": {


### PR DESCRIPTION
Do we really needed? All GitHub actions are using 14... and we also get this from Vercel.

<img width="999" alt="Screenshot 2021-02-14 at 11 10 48 AM" src="https://user-images.githubusercontent.com/125676/107872779-4cb50600-6eb5-11eb-8e67-4c7da5d7a69a.png">
