### PR TITLE
fix: Hide scrollbars on mobile

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -283,6 +283,7 @@ class App extends React.Component<ExcalidrawProps, AppState> {
   unmounted: boolean = false;
   actionManager: ActionManager;
   private excalidrawContainerRef = React.createRef<HTMLDivElement>();
+  _isMobile: boolean;
 
   public static defaultProps: Partial<ExcalidrawProps> = {
     width: window.innerWidth,
@@ -350,6 +351,8 @@ class App extends React.Component<ExcalidrawProps, AppState> {
 
     this.actionManager.registerAction(createUndoAction(history));
     this.actionManager.registerAction(createRedoAction(history));
+
+    this._isMobile = isMobile();
   }
 
   private renderCanvas() {
@@ -972,6 +975,7 @@ class App extends React.Component<ExcalidrawProps, AppState> {
       },
       {
         renderOptimizations: true,
+        renderScrollbars: !this._isMobile,
       },
     );
     if (scrollBars) {
@@ -3693,8 +3697,6 @@ class App extends React.Component<ExcalidrawProps, AppState> {
 
     const separator = "separator";
 
-    const _isMobile = isMobile();
-
     const elements = this.scene.getElements();
     const element = this.getElementAtPosition(x, y);
     const options: ContextMenuOption[] = [];
@@ -3730,7 +3732,7 @@ class App extends React.Component<ExcalidrawProps, AppState> {
 
       ContextMenu.push({
         options: [
-          _isMobile &&
+          this._isMobile &&
             navigator.clipboard && {
               name: "paste",
               perform: (elements, appStates) => {
@@ -3741,7 +3743,7 @@ class App extends React.Component<ExcalidrawProps, AppState> {
               },
               contextItemLabel: "labels.paste",
             },
-          _isMobile && navigator.clipboard && separator,
+          this._isMobile && navigator.clipboard && separator,
           probablySupportsClipboardBlob &&
             elements.length > 0 &&
             actionCopyAsPng,
@@ -3786,9 +3788,9 @@ class App extends React.Component<ExcalidrawProps, AppState> {
 
     ContextMenu.push({
       options: [
-        _isMobile && actionCut,
-        _isMobile && navigator.clipboard && actionCopy,
-        _isMobile &&
+        this._isMobile && actionCut,
+        this._isMobile && navigator.clipboard && actionCopy,
+        this._isMobile &&
           navigator.clipboard && {
             name: "paste",
             perform: (elements, appStates) => {
@@ -3799,7 +3801,7 @@ class App extends React.Component<ExcalidrawProps, AppState> {
             },
             contextItemLabel: "labels.paste",
           },
-        _isMobile && separator,
+        this._isMobile && separator,
         ...options,
         separator,
         actionCopyStyles,

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -972,6 +972,7 @@ class App extends React.Component<ExcalidrawProps, AppState> {
       },
       {
         renderOptimizations: true,
+        renderScrollbars: !isMobile(),
       },
     );
     if (scrollBars) {

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -283,7 +283,6 @@ class App extends React.Component<ExcalidrawProps, AppState> {
   unmounted: boolean = false;
   actionManager: ActionManager;
   private excalidrawContainerRef = React.createRef<HTMLDivElement>();
-  _isMobile: boolean;
 
   public static defaultProps: Partial<ExcalidrawProps> = {
     width: window.innerWidth,
@@ -351,8 +350,6 @@ class App extends React.Component<ExcalidrawProps, AppState> {
 
     this.actionManager.registerAction(createUndoAction(history));
     this.actionManager.registerAction(createRedoAction(history));
-
-    this._isMobile = isMobile();
   }
 
   private renderCanvas() {
@@ -975,7 +972,6 @@ class App extends React.Component<ExcalidrawProps, AppState> {
       },
       {
         renderOptimizations: true,
-        renderScrollbars: !this._isMobile,
       },
     );
     if (scrollBars) {
@@ -3697,6 +3693,8 @@ class App extends React.Component<ExcalidrawProps, AppState> {
 
     const separator = "separator";
 
+    const _isMobile = isMobile();
+
     const elements = this.scene.getElements();
     const element = this.getElementAtPosition(x, y);
     const options: ContextMenuOption[] = [];
@@ -3732,7 +3730,7 @@ class App extends React.Component<ExcalidrawProps, AppState> {
 
       ContextMenu.push({
         options: [
-          this._isMobile &&
+          _isMobile &&
             navigator.clipboard && {
               name: "paste",
               perform: (elements, appStates) => {
@@ -3743,7 +3741,7 @@ class App extends React.Component<ExcalidrawProps, AppState> {
               },
               contextItemLabel: "labels.paste",
             },
-          this._isMobile && navigator.clipboard && separator,
+          _isMobile && navigator.clipboard && separator,
           probablySupportsClipboardBlob &&
             elements.length > 0 &&
             actionCopyAsPng,
@@ -3788,9 +3786,9 @@ class App extends React.Component<ExcalidrawProps, AppState> {
 
     ContextMenu.push({
       options: [
-        this._isMobile && actionCut,
-        this._isMobile && navigator.clipboard && actionCopy,
-        this._isMobile &&
+        _isMobile && actionCut,
+        _isMobile && navigator.clipboard && actionCopy,
+        _isMobile &&
           navigator.clipboard && {
             name: "paste",
             perform: (elements, appStates) => {
@@ -3801,7 +3799,7 @@ class App extends React.Component<ExcalidrawProps, AppState> {
             },
             contextItemLabel: "labels.paste",
           },
-        this._isMobile && separator,
+        _isMobile && separator,
         ...options,
         separator,
         actionCopyStyles,

--- a/src/renderer/renderScene.ts
+++ b/src/renderer/renderScene.ts
@@ -49,7 +49,6 @@ import {
 } from "../element/transformHandles";
 import { viewportCoordsToSceneCoords, supportsEmoji } from "../utils";
 import { UserIdleState } from "../excalidraw-app/collab/types";
-import { isMobile } from "../is-mobile";
 
 const hasEmojiSupport = supportsEmoji();
 
@@ -187,7 +186,7 @@ export const renderScene = (
   sceneState: SceneState,
   // extra options, currently passed by export helper
   {
-    renderScrollbars = !isMobile(),
+    renderScrollbars = true,
     renderSelection = true,
     // Whether to employ render optimizations to improve performance.
     // Should not be turned on for export operations and similar, because it

--- a/src/renderer/renderScene.ts
+++ b/src/renderer/renderScene.ts
@@ -49,6 +49,7 @@ import {
 } from "../element/transformHandles";
 import { viewportCoordsToSceneCoords, supportsEmoji } from "../utils";
 import { UserIdleState } from "../excalidraw-app/collab/types";
+import { isMobile } from "../is-mobile";
 
 const hasEmojiSupport = supportsEmoji();
 
@@ -186,7 +187,7 @@ export const renderScene = (
   sceneState: SceneState,
   // extra options, currently passed by export helper
   {
-    renderScrollbars = true,
+    renderScrollbars = !isMobile(),
     renderSelection = true,
     // Whether to employ render optimizations to improve performance.
     // Should not be turned on for export operations and similar, because it


### PR DESCRIPTION
There seems to be another issue. On Firefox, The scrollbars render by default (mobile & desktop) even on an empty canvas. Is this known?

Resolves:
#2923