### PR TITLE
feat: expose variable window.EXCALIDRAW_ASSET_PATH to allow host define the path for excalidraw assets

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -86,7 +86,9 @@
     />
 
     <link rel="stylesheet" href="fonts.css" type="text/css" />
-
+    <script>
+      window.EXCALIDRAW_ASSET_PATH = "/";
+    </script>
     <% if (process.env.REACT_APP_GOOGLE_ANALYTICS_ID) { %>
     <script
       async

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -89,4 +89,3 @@ interface Blob {
   handle?: import("browser-fs-acces").FileSystemHandle;
   name?: string;
 }
-declare let __webpack_public_path__: string;

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -12,6 +12,7 @@ interface Document {
 interface Window {
   ClipboardItem: any;
   __EXCALIDRAW_SHA__: string | undefined;
+  EXCALIDRAW_ASSET_PATH: string | undefined;
   gtag: Function;
 }
 
@@ -88,3 +89,4 @@ interface Blob {
   handle?: import("browser-fs-acces").FileSystemHandle;
   name?: string;
 }
+declare let __webpack_public_path__: string;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,7 +4,6 @@ import ExcalidrawApp from "./excalidraw-app";
 
 import "./excalidraw-app/pwa";
 import "./excalidraw-app/sentry";
-
 window.__EXCALIDRAW_SHA__ = process.env.REACT_APP_GIT_SHA;
 
 ReactDOM.render(<ExcalidrawApp />, document.getElementById("root"));

--- a/src/packages/excalidraw/CHANGELOG.md
+++ b/src/packages/excalidraw/CHANGELOG.md
@@ -18,6 +18,10 @@ Please add the latest change on the top under the correct section.
 
 ### Features
 
+- Expose `window.EXCALIDRAW_ASSET_PATH` which host can use to load assets from a different URL. By default it will be loaded from `https://unpkg.com/@excalidraw/excalidraw{currentVersion}/dist/`.
+
+  Also now the assets will have a hash in filename so cache bursting can easily happen with version bump.
+
 - Add support for `scrollToCenter` in [initialData](https://github.com/excalidraw/excalidraw/blob/master/src/element/types.ts#L18) so host can control whether to scroll to center on mount [#3070](https://github.com/excalidraw/excalidraw/pull/3070).
 
 - Export [`restore`](https://github.com/excalidraw/excalidraw/blob/master/src/data/restore.ts#L182), [`restoreAppState`](https://github.com/excalidraw/excalidraw/blob/master/src/data/restore.ts#L144) and [`restoreElements`](https://github.com/excalidraw/excalidraw/blob/master/src/data/restore.ts#L128) to host

--- a/src/packages/excalidraw/CHANGELOG.md
+++ b/src/packages/excalidraw/CHANGELOG.md
@@ -12,7 +12,7 @@ The change should be grouped under one of the below section and must contain PR 
 Please add the latest change on the top under the correct section.
 -->
 
-## [Unreleased]
+## 0.4.0
 
 ## Excalidraw API
 
@@ -24,11 +24,21 @@ Please add the latest change on the top under the correct section.
 
 - Add support for `scrollToCenter` in [initialData](https://github.com/excalidraw/excalidraw/blob/master/src/element/types.ts#L18) so host can control whether to scroll to center on mount [#3070](https://github.com/excalidraw/excalidraw/pull/3070).
 
-- Export [`restore`](https://github.com/excalidraw/excalidraw/blob/master/src/data/restore.ts#L182), [`restoreAppState`](https://github.com/excalidraw/excalidraw/blob/master/src/data/restore.ts#L144) and [`restoreElements`](https://github.com/excalidraw/excalidraw/blob/master/src/data/restore.ts#L128) to host
+- Export [`restore`](https://github.com/excalidraw/excalidraw/blob/master/src/data/restore.ts#L182), [`restoreAppState`](https://github.com/excalidraw/excalidraw/blob/master/src/data/restore.ts#L144) and [`restoreElements`](https://github.com/excalidraw/excalidraw/blob/master/src/data/restore.ts#L128) to host [#3049](https://github.com/excalidraw/excalidraw/pull/3049)
 
 ### Fixes
 
 - Show user state only when [userState](https://github.com/excalidraw/excalidraw/blob/master/src/types.ts#L35) is passed on remote pointers during collaboration [#3050](https://github.com/excalidraw/excalidraw/pull/3050)
+
+## Excalidraw Library
+
+### Features
+
+- Adjust line-confirm-threshold based on zoom [#2884](https://github.com/excalidraw/excalidraw/pull/2884)
+
+### Fixes
+
+- Hide scrollbars on mobile [#3044](https://github.com/excalidraw/excalidraw/pull/3044)
 
 ## 0.3.1
 

--- a/src/packages/excalidraw/README.md
+++ b/src/packages/excalidraw/README.md
@@ -20,13 +20,9 @@ After installation you will see a folder `excalidraw-assets` in `dist` directory
 
 Move the folder `excalidraw-assets` to the path where your assets are served.
 
-By default it will try to load the files from `{rootUrl}/excalidraw-assets/`
+By default it will try to load the files from `https://unpkg.com/@excalidraw/excalidraw/{currentVersion}/dist/`
 
-With **Webpack**, if you want to load the files from different path you can use <pre><a href="https://webpack.js.org/guides/public-path/#on-the-fly">`__webpack_public_path__`</a></pre>.
-
-With **create-react-app**, the assets can be served from `public/static/js/excalidraw-assets`since CRA tries to load the assets from `{rootUrl}/static/js` path by default.
-
-You can update the value of `PUBLIC_URL` if you want to serve it from a different URL.
+If you want to load assets from a different path you can set a variable `window.EXCALIDRAW_ASSET_PATH` to the url from where you want to load the assets.
 
 ### Demo
 

--- a/src/packages/excalidraw/index.tsx
+++ b/src/packages/excalidraw/index.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, forwardRef } from "react";
+import "./publicPath";
 
 import { InitializeApp } from "../../components/InitializeApp";
 import App from "../../components/App";

--- a/src/packages/excalidraw/package.json
+++ b/src/packages/excalidraw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@excalidraw/excalidraw",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "main": "dist/excalidraw.min.js",
   "files": [
     "dist/*"

--- a/src/packages/excalidraw/publicPath.js
+++ b/src/packages/excalidraw/publicPath.js
@@ -5,5 +5,5 @@ if (process.env.NODE_ENV !== ENV.TEST) {
   /* global __webpack_public_path__:writable */
   __webpack_public_path__ =
     window.EXCALIDRAW_ASSET_PATH ||
-    `https://unpkg.com/@excalidraw/excalidraw@${pkg.version}/dist/`;
+    `https://unpkg.com/${pkg.name}@${pkg.version}/dist/`;
 }

--- a/src/packages/excalidraw/publicPath.js
+++ b/src/packages/excalidraw/publicPath.js
@@ -1,0 +1,6 @@
+/* eslint-disable */
+/* global __webpack_public_path__:writable */
+//@ts-ignore
+__webpack_public_path__ =
+  window.EXCALIDRAW_ASSET_PATH ||
+  "https://unpkg.com/aakansha-excalidraw@0.4.0-asset/dist/";

--- a/src/packages/excalidraw/publicPath.js
+++ b/src/packages/excalidraw/publicPath.js
@@ -1,6 +1,5 @@
 /* eslint-disable */
 /* global __webpack_public_path__:writable */
-//@ts-ignore
 __webpack_public_path__ =
   window.EXCALIDRAW_ASSET_PATH ||
   "https://unpkg.com/aakansha-excalidraw@0.4.0-asset/dist/";

--- a/src/packages/excalidraw/publicPath.js
+++ b/src/packages/excalidraw/publicPath.js
@@ -1,9 +1,9 @@
 import { ENV } from "../../constants";
-
+import pkg from "./package.json";
 if (process.env.NODE_ENV !== ENV.TEST) {
   /* eslint-disable */
   /* global __webpack_public_path__:writable */
   __webpack_public_path__ =
     window.EXCALIDRAW_ASSET_PATH ||
-    "https://unpkg.com/aakansha-excalidraw@0.4.0-asset/dist/";
+    `https://unpkg.com/@excalidraw/excalidraw@${pkg.version}/dist/`;
 }

--- a/src/packages/excalidraw/publicPath.js
+++ b/src/packages/excalidraw/publicPath.js
@@ -1,5 +1,9 @@
-/* eslint-disable */
-/* global __webpack_public_path__:writable */
-__webpack_public_path__ =
-  window.EXCALIDRAW_ASSET_PATH ||
-  "https://unpkg.com/aakansha-excalidraw@0.4.0-asset/dist/";
+import { ENV } from "../../constants";
+
+if (process.env.NODE_ENV !== ENV.TEST) {
+  /* eslint-disable */
+  /* global __webpack_public_path__:writable */
+  __webpack_public_path__ =
+    window.EXCALIDRAW_ASSET_PATH ||
+    "https://unpkg.com/aakansha-excalidraw@0.4.0-asset/dist/";
+}

--- a/src/packages/excalidraw/webpack.prod.config.js
+++ b/src/packages/excalidraw/webpack.prod.config.js
@@ -14,6 +14,7 @@ module.exports = {
     libraryTarget: "umd",
     filename: "[name].js",
     chunkFilename: "excalidraw-assets/[name].js",
+    publicPath: "",
   },
   resolve: {
     extensions: [".js", ".ts", ".tsx", ".css", ".scss"],

--- a/src/packages/excalidraw/webpack.prod.config.js
+++ b/src/packages/excalidraw/webpack.prod.config.js
@@ -13,7 +13,7 @@ module.exports = {
     library: "Excalidraw",
     libraryTarget: "umd",
     filename: "[name].js",
-    chunkFilename: "excalidraw-assets/[name].js",
+    chunkFilename: "excalidraw-assets/[name]-[contenthash].js",
     publicPath: "",
   },
   resolve: {


### PR DESCRIPTION
CSB is also working now, no more chunk errors 🎉 [try here](https://i86kx.csb.app/)

No more __webpack_public_path__ needed explicitly in the host and it will default to unpkg CDN if window.EXCALIDRAW_ASSET_PATH is not defined.

for #3061, #3013, #3060

I had tried this approach earlier but unfortunately, I was assigning __webpack_public_path__ at the wrong place in `entry.js` :/. 

This will make hosting the excalidraw assets for the host much easier as its now scoped down to just Excalidraw.

TODOS
- [x] Test in non CRA
- [x] Test in CRA
- [x] Append content hash to excalidraw-assets so cache bursting happens when version update
- [x] update changelog and readme
- [x] Release version v0.4.0 🎉 

