### PR TITLE
chore: Consistent job names in GH actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,35 +1,33 @@
 version: 2
 updates:
   - package-ecosystem: npm
-    directory: "/"
+    directory: /
     schedule:
       interval: weekly
       day: sunday
-      time: "01:00"
-    open-pull-requests-limit: 99
+      time: 01:00
     reviewers:
       - lipis
     assignees:
       - lipis
 
   - package-ecosystem: npm
-    directory: "/src/packages/excalidraw/"
+    directory: /src/packages/excalidraw/
     schedule:
       interval: weekly
       day: sunday
-      time: "01:00"
-    open-pull-requests-limit: 99
+      time: 01:00
     reviewers:
       - ad1992
     assignees:
       - ad1992
 
   - package-ecosystem: npm
-    directory: "/src/packages/utils/"
+    directory: /src/packages/utils/
     schedule:
       interval: weekly
       day: sunday
-      time: "01:00"
+      time: 01:00
     open-pull-requests-limit: 99
     reviewers:
       - ad1992

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
     schedule:
       interval: weekly
       day: sunday
-      time: 01:00
+      time: "01:00"
     reviewers:
       - lipis
     assignees:
@@ -16,7 +16,7 @@ updates:
     schedule:
       interval: weekly
       day: sunday
-      time: 01:00
+      time: "01:00"
     reviewers:
       - ad1992
     assignees:
@@ -27,8 +27,7 @@ updates:
     schedule:
       interval: weekly
       day: sunday
-      time: 01:00
-    open-pull-requests-limit: 99
+      time: "01:00"
     reviewers:
       - ad1992
     assignees:

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -6,7 +6,7 @@ on:
       - master
 
 jobs:
-  build:
+  build-docker:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 jobs:
-  build:
+  packages:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/semantic-pr-title.yml
+++ b/.github/workflows/semantic-pr-title.yml
@@ -8,7 +8,7 @@ on:
       - synchronize
 
 jobs:
-  main:
+  semantic:
     runs-on: ubuntu-latest
     steps:
       - uses: amannn/action-semantic-pull-request@v3.0.0

--- a/.github/workflows/sentry-production.yml
+++ b/.github/workflows/sentry-production.yml
@@ -6,7 +6,7 @@ on:
       - master
 
 jobs:
-  release:
+  sentry:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
The `main` was confusing in the required checks

<img width="376" alt="Screenshot 2021-02-23 at 5 43 48 PM" src="https://user-images.githubusercontent.com/125676/108868251-b09aa580-75fe-11eb-9bdb-0ecdb1b476c4.png">

### Before

<img width="401" alt="Screenshot 2021-02-23 at 5 42 53 PM" src="https://user-images.githubusercontent.com/125676/108868127-91037d00-75fe-11eb-9d05-e0f82e302866.png">
