### PR TITLE
refactor: Use the latest Virgil from official URL

### DIFF
--- a/public/fonts.css
+++ b/public/fonts.css
@@ -1,7 +1,7 @@
-/* http://www.eaglefonts.com/fg-virgil-ttf-131249.htm */
+/* https://github.com/excalidraw/virgil */
 @font-face {
   font-family: "Virgil";
-  src: url("Virgil.woff2");
+  src: url("https://virgil.excalidraw.com/Virgil.woff2");
   font-display: swap;
 }
 

--- a/public/index.html
+++ b/public/index.html
@@ -60,7 +60,7 @@
 
     <link
       rel="preload"
-      href="Virgil.woff2"
+      href="https://virgil.excalidraw.com/Virgil.woff2"
       as="font"
       type="font/woff2"
       crossorigin="anonymous"

--- a/src/scene/export.ts
+++ b/src/scene/export.ts
@@ -132,7 +132,7 @@ export const exportToSvg = (
     <style>
       @font-face {
         font-family: "Virgil";
-        src: url("https://excalidraw.com/Virgil.woff2");
+        src: url("https://virgil.excalidraw.com/Virgil.woff2");
       }
       @font-face {
         font-family: "Cascadia";

--- a/src/tests/fixtures/smiley_embedded_v2.svg
+++ b/src/tests/fixtures/smiley_embedded_v2.svg
@@ -5,7 +5,7 @@
     <style>
       @font-face {
         font-family: "Virgil";
-        src: url("https://excalidraw.com/Virgil.woff2");
+        src: url("https://virgil.excalidraw.com/Virgil.woff2");
       }
       @font-face {
         font-family: "Cascadia";

--- a/src/tests/fixtures/test_embedded_v1.svg
+++ b/src/tests/fixtures/test_embedded_v1.svg
@@ -5,7 +5,7 @@
     <style>
       @font-face {
         font-family: "Virgil";
-        src: url("https://excalidraw.com/Virgil.woff2");
+        src: url("https://virgil.excalidraw.com/Virgil.woff2");
       }
       @font-face {
         font-family: "Cascadia";


### PR DESCRIPTION
Would be nice (if possible) to remove the binary from the repo as we will have (hopefully) many updates now that the font is [open sourced](https://github.com/excalidraw/virgil), to avoid getting the repo big in size over time.

- [ ] https://github.com/excalidraw/excalidraw/blob/master/src/index-node.ts#L57 (what to do with this one)
- [x] ~~Remove `Virgil.woff2` from repo~~ (actually that's not possible, due to backwards compatibility with the exported SVGs)