### PR TITLE
fix: Use Array.from when spreading over set so that typescript transpiles correctly in the umd build

### DIFF
--- a/src/element/binding.ts
+++ b/src/element/binding.ts
@@ -183,7 +183,9 @@ const bindLinearElement = (
   });
   mutateElement(hoveredElement, {
     boundElementIds: [
-      ...new Set([...(hoveredElement.boundElementIds ?? []), linearElement.id]),
+      ...Array.from(
+        new Set([...(hoveredElement.boundElementIds ?? []), linearElement.id]),
+      ),
     ],
   });
 };

--- a/src/element/binding.ts
+++ b/src/element/binding.ts
@@ -182,11 +182,9 @@ const bindLinearElement = (
     } as PointBinding,
   });
   mutateElement(hoveredElement, {
-    boundElementIds: [
-      ...Array.from(
-        new Set([...(hoveredElement.boundElementIds ?? []), linearElement.id]),
-      ),
-    ],
+    boundElementIds: Array.from(
+      new Set([...(hoveredElement.boundElementIds ?? []), linearElement.id]),
+    ),
   });
 };
 

--- a/src/packages/excalidraw/CHANGELOG.md
+++ b/src/packages/excalidraw/CHANGELOG.md
@@ -12,6 +12,27 @@ The change should be grouped under one of the below section and must contain PR 
 Please add the latest change on the top under the correct section.
 -->
 
+## 0.4.1
+
+## Excalidraw API
+
+### Fixes
+
+- Use `Array.from` when spreading over set so that typescript transpiles correctly in the umd build[#3165](https://github.com/excalidraw/excalidraw/pull/3165).
+
+## Excalidraw Library
+
+### Features
+
+- Add export info on copy PNG to clipboard toast message [#3159](https://github.com/excalidraw/excalidraw/pull/3159)
+- Use the latest version of Virgil [#3124](https://github.com/excalidraw/excalidraw/pull/3124)
+- Support exporting with dark mode [#3046](https://github.com/excalidraw/excalidraw/pull/3046)
+
+### Fixes
+
+- Cursor being leaked outside of canvas [#3161](https://github.com/excalidraw/excalidraw/pull/3161)
+- Hide scrollbars in zenMode [#3144](https://github.com/excalidraw/excalidraw/pull/3144)
+
 ## 0.4.0
 
 ## Excalidraw API

--- a/src/packages/excalidraw/CHANGELOG.md
+++ b/src/packages/excalidraw/CHANGELOG.md
@@ -24,14 +24,14 @@ Please add the latest change on the top under the correct section.
 
 ### Features
 
-- Add export info on copy PNG to clipboard toast message [#3159](https://github.com/excalidraw/excalidraw/pull/3159)
-- Use the latest version of Virgil [#3124](https://github.com/excalidraw/excalidraw/pull/3124)
-- Support exporting with dark mode [#3046](https://github.com/excalidraw/excalidraw/pull/3046)
+- Add export info on copy PNG to clipboard toast message [#3159](https://github.com/excalidraw/excalidraw/pull/3159).
+- Use the latest version of Virgil [#3124](https://github.com/excalidraw/excalidraw/pull/3124).
+- Support exporting with dark mode [#3046](https://github.com/excalidraw/excalidraw/pull/3046).
 
 ### Fixes
 
-- Cursor being leaked outside of canvas [#3161](https://github.com/excalidraw/excalidraw/pull/3161)
-- Hide scrollbars in zenMode [#3144](https://github.com/excalidraw/excalidraw/pull/3144)
+- Cursor being leaked outside of canvas [#3161](https://github.com/excalidraw/excalidraw/pull/3161).
+- Hide scrollbars in zenMode [#3144](https://github.com/excalidraw/excalidraw/pull/3144).
 
 ## 0.4.0
 

--- a/src/packages/excalidraw/package.json
+++ b/src/packages/excalidraw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@excalidraw/excalidraw",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "main": "dist/excalidraw.min.js",
   "files": [
     "dist/*"


### PR DESCRIPTION
fixes #3164 
fixes https://github.com/excalidraw/excalidraw/issues/3153
[spreadArrays](https://www.typescriptlang.org/docs/handbook/release-notes/overview.html#more-accurate-array-spread) introduced in 3.6 only supports arrays by default. We can enable the flag `downlevelIteration` to make it work with other types but it increases bundle size by `~20kb`which is unnecessary so using `Array.from` instead.

Try it out [here](https://y0ld3.csb.app/)
TODOS

- [x] update changelog
- [x] Release patch version