### PR TITLE
feat: support appearance when updating scene data

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1269,10 +1269,16 @@ class App extends React.Component<ExcalidrawProps, AppState> {
       history.resumeRecording();
     }
 
-    // currently we only support syncing background color
+    // currently we only support syncing background color and appearance
     if (sceneData.appState?.viewBackgroundColor) {
       this.setState({
         viewBackgroundColor: sceneData.appState.viewBackgroundColor,
+      });
+    }
+
+    if (sceneData.appState?.appearance) {
+      this.setState({
+        appearance: sceneData.appState.appearance,
       });
     }
 


### PR DESCRIPTION
I'm currently integrating excalidraw into a third party app. The app supports light and dark mode, so this will allow us to programatically switch excalidraw's theming when the app's theme changes.

I didn't see a test related to this method, but I'm happy to add on if one exists.  I tested it locally in the third party app and it works as intended. 