### PR TITLE
fix: Reduce the scroll debounce timeout to 100ms and update only if offset changes

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1008,7 +1008,14 @@ class App extends React.Component<ExcalidrawProps, AppState> {
   }
 
   private onScroll = debounce(() => {
-    this.setState({ ...this.getCanvasOffsets() });
+    const { offsetTop, offsetLeft } = this.getCanvasOffsets();
+    if (
+      this.state.offsetLeft === offsetLeft &&
+      this.state.offsetTop === offsetTop
+    ) {
+      return;
+    }
+    this.setState({ offsetTop, offsetLeft });
   }, SCROLL_TIMEOUT);
 
   // Copy/paste

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1009,13 +1009,12 @@ class App extends React.Component<ExcalidrawProps, AppState> {
 
   private onScroll = debounce(() => {
     const { offsetTop, offsetLeft } = this.getCanvasOffsets();
-    if (
-      this.state.offsetLeft === offsetLeft &&
-      this.state.offsetTop === offsetTop
-    ) {
-      return;
-    }
-    this.setState({ offsetTop, offsetLeft });
+    this.setState((state) => {
+      if (state.offsetLeft === offsetLeft && state.offsetTop === offsetTop) {
+        return null;
+      }
+      return { offsetTop, offsetLeft };
+    });
   }, SCROLL_TIMEOUT);
 
   // Copy/paste

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -94,7 +94,7 @@ export const TOUCH_CTX_MENU_TIMEOUT = 500;
 export const TITLE_TIMEOUT = 10000;
 export const TOAST_TIMEOUT = 5000;
 export const VERSION_TIMEOUT = 30000;
-export const SCROLL_TIMEOUT = 500;
+export const SCROLL_TIMEOUT = 100;
 
 export const ZOOM_STEP = 0.1;
 

--- a/src/packages/excalidraw/CHANGELOG.md
+++ b/src/packages/excalidraw/CHANGELOG.md
@@ -18,7 +18,7 @@ Please add the latest change on the top under the correct section.
 
 ### Fixes
 
-- Reduce the scroll debounce timeout to 100ms so offsets gets updated faster when container scrolled.
+- Reduce the scroll debounce timeout to `100ms` so `offsets` gets updated faster if changed when container scrolled [#3182](https://github.com/excalidraw/excalidraw/pull/3182).
 
 ---
 

--- a/src/packages/excalidraw/CHANGELOG.md
+++ b/src/packages/excalidraw/CHANGELOG.md
@@ -12,6 +12,16 @@ The change should be grouped under one of the below section and must contain PR 
 Please add the latest change on the top under the correct section.
 -->
 
+## Unreleased
+
+## Excalidraw API
+
+### Fixes
+
+- Reduce the scroll debounce timeout to 100ms so offsets gets updated faster when container scrolled.
+
+---
+
 ## 0.4.1
 
 ## Excalidraw API


### PR DESCRIPTION
fixes #3175 
This can go into the patch version release along with #3174 
try it out [here](https://3scmb.csb.app/)