### PR TITLE
fix: stop preventing canvas pointerdown/tapend events

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -112,7 +112,7 @@
           Roboto, Helvetica, Arial, sans-serif;
         font-family: var(--ui-font);
         -webkit-text-size-adjust: 100%;
-       
+
         width: 100vw;
         height: 100vh;
       }

--- a/public/index.html
+++ b/public/index.html
@@ -112,8 +112,7 @@
           Roboto, Helvetica, Arial, sans-serif;
         font-family: var(--ui-font);
         -webkit-text-size-adjust: 100%;
-        -webkit-user-select: none;
-        user-select: none;
+       
         width: 100vw;
         height: 100vh;
       }

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1079,7 +1079,6 @@ class App extends React.Component<ExcalidrawProps, AppState> {
   };
 
   private onTapEnd = (event: TouchEvent) => {
-    event.preventDefault();
     if (event.touches.length > 0) {
       this.setState({
         previousSelectedElementIds: {},

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -2109,13 +2109,6 @@ class App extends React.Component<ExcalidrawProps, AppState> {
 
     this.updateGestureOnPointerDown(event);
 
-    // Preventing the event above disables default behavior
-    // of defocusing potentially focused element, which is what we
-    // want when clicking inside the canvas.
-    if (document.activeElement instanceof HTMLElement) {
-      document.activeElement.blur();
-    }
-
     // don't select while panning
     if (gesture.pointers.size > 1) {
       return;

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -2109,8 +2109,6 @@ class App extends React.Component<ExcalidrawProps, AppState> {
 
     this.updateGestureOnPointerDown(event);
 
-    // fixes pointermove causing selection of UI texts #32
-    event.preventDefault();
     // Preventing the event above disables default behavior
     // of defocusing potentially focused element, which is what we
     // want when clicking inside the canvas.

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1589,10 +1589,12 @@ class App extends React.Component<ExcalidrawProps, AppState> {
           updateBoundElements(element);
         }
       }),
-      onSubmit: withBatchedUpdates((text) => {
+      onSubmit: withBatchedUpdates(({ text, viaKeyboard }) => {
         const isDeleted = !text.trim();
         updateElement(text, isDeleted);
-        if (!isDeleted) {
+        // select the created text element only if submitting via keyboard
+        // (when submitting via click it should act as signal to deselect)
+        if (!isDeleted && viaKeyboard) {
           this.setState((prevState) => ({
             selectedElementIds: {
               ...prevState.selectedElementIds,
@@ -2120,21 +2122,6 @@ class App extends React.Component<ExcalidrawProps, AppState> {
 
     if (this.handleDraggingScrollBar(event, pointerDownState)) {
       return;
-    }
-
-    // this branch must be executed before `clearSelectionIfNotUsingSelection()`
-    // below (not entirely sure why)
-    if (this.state.elementType === "text") {
-      // when creating text, we must prevent default otherwise the wysiwyg
-      // would get blurred (submitted) right away
-      event.preventDefault();
-    }
-    // Since we potentially prevent default above, we must manually blur any
-    // active inputs (e.g. wysiwyg) when clicking on canvas.
-    // For some reason, this must also be done so as to not select the text
-    // element when confirming it by clicking outside.
-    if (document.activeElement instanceof HTMLElement) {
-      document.activeElement.blur();
     }
 
     this.clearSelectionIfNotUsingSelection();

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -2122,6 +2122,21 @@ class App extends React.Component<ExcalidrawProps, AppState> {
       return;
     }
 
+    // this branch must be executed before `clearSelectionIfNotUsingSelection()`
+    // below (not entirely sure why)
+    if (this.state.elementType === "text") {
+      // when creating text, we must prevent default otherwise the wysiwyg
+      // would get blurred (submitted) right away
+      event.preventDefault();
+    }
+    // Since we potentially prevent default above, we must manually blur any
+    // active inputs (e.g. wysiwyg) when clicking on canvas.
+    // For some reason, this must also be done so as to not select the text
+    // element when confirming it by clicking outside.
+    if (document.activeElement instanceof HTMLElement) {
+      document.activeElement.blur();
+    }
+
     this.clearSelectionIfNotUsingSelection();
     this.updateBindingEnabledOnPointerMove(event);
 

--- a/src/css/styles.scss
+++ b/src/css/styles.scss
@@ -17,6 +17,11 @@
   left: 0;
   right: 0;
 
+  // serves 2 purposes:
+  // 1. prevent selecting text outside the component when double-clicking or
+  //    dragging inside it (e.g. on canvas)
+  // 2. prevent selecting UI, both from the inside, and from outside the
+  //    component (e.g. if you select text in a sidebar)
   user-select: none;
 
   a {
@@ -31,9 +36,6 @@
 
   canvas {
     touch-action: none;
-    // reset use-select so that clicking on canvas deselects selection
-    // outside the Excalidraw component
-    user-select: text;
 
     // following props improve blurriness at certain devicePixelRatios.
     // AFAIK it doesn't affect export (in fact, export seems sharp either way).

--- a/src/css/styles.scss
+++ b/src/css/styles.scss
@@ -17,6 +17,8 @@
   left: 0;
   right: 0;
 
+  user-select: none;
+
   a {
     font-weight: 500;
     text-decoration: none;
@@ -29,7 +31,7 @@
 
   canvas {
     touch-action: none;
-    user-select: none;
+    user-select: text;
 
     // following props improve blurriness at certain devicePixelRatios.
     // AFAIK it doesn't affect export (in fact, export seems sharp either way).

--- a/src/css/styles.scss
+++ b/src/css/styles.scss
@@ -31,6 +31,8 @@
 
   canvas {
     touch-action: none;
+    // reset use-select so that clicking on canvas deselects selection
+    // outside the Excalidraw component
     user-select: text;
 
     // following props improve blurriness at certain devicePixelRatios.

--- a/src/element/textWysiwyg.tsx
+++ b/src/element/textWysiwyg.tsx
@@ -210,8 +210,13 @@ export const textWysiwyg = ({
     editable.focus();
   });
 
+  // ---------------------------------------------------------------------------
+
   let isDestroyed = false;
 
+  // select on init (focusing is done separately inside the bindBlurEvent()
+  // because we need to happen *after* the blur event from `pointerdown`)
+  editable.select();
   bindBlurEvent();
 
   // reposition wysiwyg in case of canvas is resized. Using ResizeObserver
@@ -234,6 +239,4 @@ export const textWysiwyg = ({
   document
     .querySelector(".excalidraw-textEditorContainer")!
     .appendChild(editable);
-  editable.focus();
-  editable.select();
 };

--- a/src/element/textWysiwyg.tsx
+++ b/src/element/textWysiwyg.tsx
@@ -215,7 +215,7 @@ export const textWysiwyg = ({
   let isDestroyed = false;
 
   // select on init (focusing is done separately inside the bindBlurEvent()
-  // because we need to happen *after* the blur event from `pointerdown`)
+  // because we need it to happen *after* the blur event from `pointerdown`)
   editable.select();
   bindBlurEvent();
 


### PR DESCRIPTION
Attempt to fix https://github.com/excalidraw/excalidraw/issues/3151

~~Also, this fixes a case where clicking on canvas doesn't deselect selection outside Excalidraw component.~~