### PR TITLE
fix: Revert to position fixed for text editor

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1585,10 +1585,7 @@ class App extends React.Component<ExcalidrawProps, AppState> {
           },
           this.state,
         );
-        return [
-          viewportX - this.state.offsetLeft,
-          viewportY - this.state.offsetTop,
-        ];
+        return [viewportX, viewportY];
       },
       onChange: withBatchedUpdates((text) => {
         updateElement(text);

--- a/src/element/textWysiwyg.tsx
+++ b/src/element/textWysiwyg.tsx
@@ -80,19 +80,6 @@ export const textWysiwyg = ({
         color: updatedElement.strokeColor,
         opacity: updatedElement.opacity / 100,
         filter: "var(--appearance-filter)",
-        maxWidth: `${
-          appState.offsetLeft +
-          appState.width -
-          viewportX -
-          // margin-right of parent if any
-          Number(
-            getComputedStyle(
-              document.querySelector(".excalidraw")!.parentNode as Element,
-            ).marginRight.slice(0, -2),
-          ) -
-          // padding of layer ui footer
-          8
-        }px`,
       });
     }
   };
@@ -106,7 +93,7 @@ export const textWysiwyg = ({
   editable.wrap = "off";
 
   Object.assign(editable.style, {
-    position: "absolute",
+    position: "fixed",
     display: "inline-block",
     minHeight: "1em",
     backfaceVisibility: "hidden",


### PR DESCRIPTION
Since position absolute led to more bugs in the App, (#3215 and #3220 ) so reverting it.
The issues still remains in the package for #3215 and #3180 so will have to find better fix for this but before that lets push this so App is back stable.

EDIT
As discussed we will look for few more solutions ad if that doesn't work out, we will merge this PR