### PR TITLE
feat: Add shortcut to focus on opacity slider

### DIFF
--- a/src/actions/actionProperties.tsx
+++ b/src/actions/actionProperties.tsx
@@ -22,6 +22,7 @@ import {
   StrokeStyleSolidIcon,
   StrokeWidthIcon,
 } from "../components/icons";
+import { OpacitySlider } from "../components/OpacitySlider";
 import { DEFAULT_FONT_FAMILY, DEFAULT_FONT_SIZE } from "../constants";
 import {
   getNonDeletedElements,
@@ -353,38 +354,34 @@ export const actionChangeOpacity = register({
     };
   },
   PanelComponent: ({ elements, appState, updateData }) => (
-    <label className="control-label">
-      {t("labels.opacity")}
-      <input
-        type="range"
-        min="0"
-        max="100"
-        step="10"
-        onChange={(event) => updateData(+event.target.value)}
-        onWheel={(event) => {
-          event.stopPropagation();
-          const target = event.target as HTMLInputElement;
-          const STEP = 10;
-          const MAX = 100;
-          const MIN = 0;
-          const value = +target.value;
+    <OpacitySlider
+      onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
+        updateData(+event.target.value)
+      }
+      onWheel={(event: React.WheelEvent<HTMLInputElement>) => {
+        event.stopPropagation();
 
-          if (event.deltaY < 0 && value < MAX) {
-            updateData(value + STEP);
-          } else if (event.deltaY > 0 && value > MIN) {
-            updateData(value - STEP);
-          }
-        }}
-        value={
-          getFormValue(
-            elements,
-            appState,
-            (element) => element.opacity,
-            appState.currentItemOpacity,
-          ) ?? undefined
+        const target = event.target as HTMLInputElement;
+        const STEP = 10;
+        const MAX = 100;
+        const MIN = 0;
+        const value = +target.value;
+
+        if (event.deltaY < 0 && value < MAX) {
+          updateData(value + STEP);
+        } else if (event.deltaY > 0 && value > MIN) {
+          updateData(value - STEP);
         }
-      />
-    </label>
+      }}
+      value={
+        getFormValue(
+          elements,
+          appState,
+          (element) => element.opacity,
+          appState.currentItemOpacity,
+        ) ?? undefined
+      }
+    />
   ),
 });
 

--- a/src/components/HelpDialog.tsx
+++ b/src/components/HelpDialog.tsx
@@ -244,6 +244,10 @@ export const HelpDialog = ({ onClose }: { onClose?: () => void }) => {
                   shortcuts={[getShortcutKey(`Shift+${t("helpDialog.click")}`)]}
                 />
                 <Shortcut
+                  label={t("labels.adjustOpacity")}
+                  shortcuts={[getShortcutKey("O")]}
+                />
+                <Shortcut
                   label={t("labels.moveCanvas")}
                   shortcuts={[
                     getShortcutKey(`Space+${t("helpDialog.drag")}`),

--- a/src/components/OpacitySlider.tsx
+++ b/src/components/OpacitySlider.tsx
@@ -1,0 +1,46 @@
+import React, { useEffect, ChangeEventHandler, WheelEventHandler } from "react";
+import { EVENT } from "../constants";
+import { t } from "../i18n";
+import { KEYS } from "../keys";
+
+export const OpacitySlider = ({
+  onChange,
+  onWheel,
+  value,
+}: {
+  onChange: ChangeEventHandler<HTMLInputElement>;
+  onWheel: WheelEventHandler<HTMLInputElement>;
+  value: number | undefined;
+}) => {
+  const opacityInput = React.useRef<HTMLInputElement>(null);
+
+  const handleKeyDown = (event: KeyboardEvent) => {
+    if (event.key === KEYS.O) {
+      opacityInput.current?.focus();
+    }
+  };
+
+  useEffect(() => {
+    document.addEventListener(EVENT.KEYDOWN, handleKeyDown, false);
+
+    return () => {
+      document.removeEventListener(EVENT.KEYDOWN, handleKeyDown, false);
+    };
+  });
+
+  return (
+    <label className="control-label">
+      {t("labels.opacity")}
+      <input
+        type="range"
+        min="0"
+        max="100"
+        step="10"
+        onChange={onChange}
+        onWheel={onWheel}
+        value={value}
+        ref={opacityInput}
+      />
+    </label>
+  );
+};

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -94,7 +94,8 @@
     "distributeVertically": "Distribute vertically",
     "viewMode": "View mode",
     "toggleExportColorScheme": "Toggle export color scheme",
-    "share": "Share"
+    "share": "Share",
+    "adjustOpacity": "Adjust element opacity"
   },
   "buttons": {
     "clearReset": "Reset the canvas",


### PR DESCRIPTION
Pressing `o` will focus on the selected element's opacity slider.

Checks off one item in #2649 