### PR TITLE
fix: `debounce.flush` invokes func even if never queued before

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -127,7 +127,10 @@ export const debounce = <T extends any[]>(
   const ret = (...args: T) => {
     lastArgs = args;
     clearTimeout(handle);
-    handle = window.setTimeout(() => fn(...args), timeout);
+    handle = window.setTimeout(() => {
+      fn(...args);
+      lastArgs = null;
+    }, timeout);
   };
   ret.flush = () => {
     clearTimeout(handle);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -128,15 +128,16 @@ export const debounce = <T extends any[]>(
     lastArgs = args;
     clearTimeout(handle);
     handle = window.setTimeout(() => {
-      fn(...args);
       lastArgs = null;
+      fn(...args);
     }, timeout);
   };
   ret.flush = () => {
     clearTimeout(handle);
     if (lastArgs) {
-      fn(...lastArgs);
+      const _lastArgs = lastArgs;
       lastArgs = null;
+      fn(..._lastArgs);
     }
   };
   ret.cancel = () => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -123,7 +123,7 @@ export const debounce = <T extends any[]>(
   timeout: number,
 ) => {
   let handle = 0;
-  let lastArgs: T;
+  let lastArgs: T | null = null;
   const ret = (...args: T) => {
     lastArgs = args;
     clearTimeout(handle);
@@ -131,9 +131,13 @@ export const debounce = <T extends any[]>(
   };
   ret.flush = () => {
     clearTimeout(handle);
-    fn(...(lastArgs || []));
+    if (lastArgs) {
+      fn(...lastArgs);
+      lastArgs = null;
+    }
   };
   ret.cancel = () => {
+    lastArgs = null;
     clearTimeout(handle);
   };
   return ret;


### PR DESCRIPTION
In my previous "fix" (https://github.com/excalidraw/excalidraw/pull/3281) I actually broke it even more (I've unthinkingly adapted a thing I had in a fork).

That said, the previous solution (checking for `lastArgs`) wasn't entirely correct because we weren't unsetting  them when should have. This PR should account for that. This fixes a case where your function would be invoked on `flush` even if it was previously cancelled, and potentially with stale args.

We may wanna add tests, or better yet, use the `debounce` from lodash :). (though, it's [quite big](https://bundlephobia.com/result?p=lodash.debounce@4.0.8))