### PR TITLE
feat: export types for package @excalidraw/excalidraw 🎉 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ package-lock.json
 static
 yarn-debug.log*
 yarn-error.log*
+src/packages/excalidraw/types

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -89,3 +89,5 @@ interface Blob {
   handle?: import("browser-fs-acces").FileSystemHandle;
   name?: string;
 }
+
+declare module "*.scss";

--- a/src/packages/excalidraw/CHANGELOG.md
+++ b/src/packages/excalidraw/CHANGELOG.md
@@ -18,6 +18,7 @@ Please add the latest change on the top under the correct section.
 
 ### Features
 
+- Export types for the package so now it can be used with typescript[#3337](https://github.com/excalidraw/excalidraw/pull/3337).
 - Add `renderCustomStats` prop to render extra stats on host, and expose `setToastMessage` API via refs which can be used to show toast with custom message [#3360](https://github.com/excalidraw/excalidraw/pull/3360).
 - Support passing a CSRF token when importing libraries to prevent prompting before installation. The token is passed from [https://libraries.excalidraw.com](https://libraries.excalidraw.com/) using the `token` URL key [#3329](https://github.com/excalidraw/excalidraw/pull/3329).
 - #### BREAKING CHANGE

--- a/src/packages/excalidraw/CHANGELOG.md
+++ b/src/packages/excalidraw/CHANGELOG.md
@@ -18,7 +18,7 @@ Please add the latest change on the top under the correct section.
 
 ### Features
 
-- Export types for the package so now it can be used with typescript[#3337](https://github.com/excalidraw/excalidraw/pull/3337).
+- Export types for the package so now it can be used with typescript[#3337](https://github.com/excalidraw/excalidraw/pull/3337). The types are available at `@excalidraw/excalirdraw/types`.
 - Add `renderCustomStats` prop to render extra stats on host, and expose `setToastMessage` API via refs which can be used to show toast with custom message [#3360](https://github.com/excalidraw/excalidraw/pull/3360).
 - Support passing a CSRF token when importing libraries to prevent prompting before installation. The token is passed from [https://libraries.excalidraw.com](https://libraries.excalidraw.com/) using the `token` URL key [#3329](https://github.com/excalidraw/excalidraw/pull/3329).
 - #### BREAKING CHANGE

--- a/src/packages/excalidraw/README_NEXT.md
+++ b/src/packages/excalidraw/README_NEXT.md
@@ -186,7 +186,7 @@ export default function IndexPage() {
 }
 ```
 
-We also export the types, you can view [example for typescript](https://codesandbox.io/s/excalidraw-types-9h2dm)
+The `types` are available at `@excalidraw/excalidraw/types`, you can view [example for typescript](https://codesandbox.io/s/excalidraw-types-9h2dm)
 
 #### In Browser
 

--- a/src/packages/excalidraw/README_NEXT.md
+++ b/src/packages/excalidraw/README_NEXT.md
@@ -171,6 +171,8 @@ To view the full example visit :point_down:
 
 [![Edit excalidraw](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/excalidraw-ehlz3?fontsize=14&hidenavigation=1&theme=dark)
 
+</details>
+
 Since Excalidraw doesn't support server side rendering yet so you will have to make sure the component is rendered once host is mounted.
 
 ```js
@@ -184,7 +186,7 @@ export default function IndexPage() {
 }
 ```
 
-</details>
+We also export the types, you can view [example for typescript](https://codesandbox.io/s/excalidraw-types-9h2dm)
 
 #### In Browser
 

--- a/src/packages/excalidraw/package.json
+++ b/src/packages/excalidraw/package.json
@@ -2,6 +2,7 @@
   "name": "@excalidraw/excalidraw",
   "version": "0.5.0",
   "main": "dist/excalidraw.min.js",
+  "types": "dist/types/packages/excalidraw/index.d.ts",
   "files": [
     "dist/*"
   ],
@@ -58,6 +59,7 @@
     "sass-loader": "11.0.1",
     "terser-webpack-plugin": "5.1.1",
     "ts-loader": "8.0.18",
+    "typescript": "4.2.3",
     "webpack": "5.27.1",
     "webpack-bundle-analyzer": "4.4.0",
     "webpack-cli": "4.5.0"
@@ -66,7 +68,8 @@
   "repository": "https://github.com/excalidraw/excalidraw",
   "homepage": "https://github.com/excalidraw/excalidraw/tree/master/src/packages/excalidraw",
   "scripts": {
-    "build:umd": "cross-env NODE_ENV=production webpack --config webpack.prod.config.js",
+    "gen:types": "tsc --project ../../../tsconfig-types.json",
+    "build:umd": "cross-env NODE_ENV=production webpack --config webpack.prod.config.js && yarn gen:types",
     "build:umd:withAnalyzer": "cross-env NODE_ENV=production ANALYZER=true webpack --config webpack.prod.config.js",
     "pack": "yarn build:umd && yarn pack"
   }

--- a/src/packages/excalidraw/package.json
+++ b/src/packages/excalidraw/package.json
@@ -2,9 +2,10 @@
   "name": "@excalidraw/excalidraw",
   "version": "0.5.0",
   "main": "main.js",
-  "types": "dist/types/packages/excalidraw/index.d.ts",
+  "types": "types/packages/excalidraw/index.d.ts",
   "files": [
-    "dist/*"
+    "dist/*",
+    "types/*"
   ],
   "publishConfig": {
     "access": "public"

--- a/src/packages/excalidraw/yarn.lock
+++ b/src/packages/excalidraw/yarn.lock
@@ -2551,6 +2551,11 @@ tslib@^1.9.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
+typescript@4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.3.tgz#39062d8019912d43726298f09493d598048c1ce3"
+  integrity sha512-qOcYwxaByStAWrBf4x0fibwZvMRG+r4cQoTjbPtUlrWjBHbmCAww1i448U0GJ+3cNNEtebDteo/cHOR3xJ4wEw==
+
 unicode-canonical-property-names-ecmascript@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz#2619800c4c825800efdd8343af7dd9933cbe2818"

--- a/tsconfig-types.json
+++ b/tsconfig-types.json
@@ -6,12 +6,13 @@
     "emitDeclarationOnly": true,
     "outDir": "src/packages/excalidraw/dist/types",
     "jsx": "react-jsx",
-    "target": "es5",
+    "target": "es6",
     "lib": ["dom", "dom.iterable", "esnext"],
     "module": "esnext",
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "skipLibCheck": true,
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
+    "strict": true
   }
 }

--- a/tsconfig-types.json
+++ b/tsconfig-types.json
@@ -1,0 +1,16 @@
+{
+  "include": ["src/packages/excalidraw"],
+  "compilerOptions": {
+    "allowJs": true,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "outDir": "src/packages/excalidraw/dist/types",
+    "jsx": "react-jsx",
+    "target": "es5",
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "allowSyntheticDefaultImports": true
+  }
+}

--- a/tsconfig-types.json
+++ b/tsconfig-types.json
@@ -4,7 +4,7 @@
     "allowJs": true,
     "declaration": true,
     "emitDeclarationOnly": true,
-    "outDir": "src/packages/excalidraw/dist/types",
+    "outDir": "src/packages/excalidraw/types",
     "jsx": "react-jsx",
     "target": "es6",
     "lib": ["dom", "dom.iterable", "esnext"],

--- a/tsconfig-types.json
+++ b/tsconfig-types.json
@@ -1,5 +1,5 @@
 {
-  "include": ["src/packages/excalidraw"],
+  "include": ["src/packages/excalidraw", "src/global.d.ts"],
   "compilerOptions": {
     "allowJs": true,
     "declaration": true,
@@ -7,6 +7,7 @@
     "outDir": "src/packages/excalidraw/dist/types",
     "jsx": "react-jsx",
     "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
     "module": "esnext",
     "moduleResolution": "node",
     "resolveJsonModule": true,

--- a/tsconfig-types.json
+++ b/tsconfig-types.json
@@ -1,5 +1,5 @@
 {
-  "include": ["src/packages/excalidraw", "src/global.d.ts"],
+  "include": ["src/packages/excalidraw", "src/global.d.ts", "src/css.d.ts"],
   "compilerOptions": {
     "allowJs": true,
     "declaration": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,9 +14,7 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react-jsx",
-    "declaration": true,
-    "outDir": "dist"
+    "jsx": "react-jsx"
   },
   "include": ["src"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,9 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "declaration": true,
+    "outDir": "dist"
   },
   "include": ["src"]
 }


### PR DESCRIPTION
fixes https://github.com/excalidraw/excalidraw/issues/2514
pushed [here](https://codesandbox.io/s/excalidraw-types-9h2dm)

- [x] `excalidraw-app` types are shared with core hence getting added, fix it so it doesn't get added.
    - [x] Pre requirement https://github.com/excalidraw/excalidraw/pull/3353, reduces ~4 errors
    - [x] Pre requirement https://github.com/excalidraw/excalidraw/issues/3354, reduces ~1 error
- [x] There are ~73 errors still when exporting types which needs to be fixed so all types are exported correctly, the build action is failing for same reason 😉 
- [x] update readme/changelog
