### PR TITLE
feat: Add onPaste prop to customise clipboard paste event

### DIFF
--- a/src/clipboard.ts
+++ b/src/clipboard.ts
@@ -14,6 +14,13 @@ type ElementsClipboard = {
   elements: ExcalidrawElement[];
 };
 
+export interface ClipboardData {
+  spreadsheet?: Spreadsheet;
+  elements?: readonly ExcalidrawElement[];
+  text?: string;
+  errorMessage?: string;
+}
+
 let CLIPBOARD = "";
 let PREFER_APP_CLIPBOARD = false;
 
@@ -110,12 +117,7 @@ const getSystemClipboard = async (
  */
 export const parseClipboard = async (
   event: ClipboardEvent | null,
-): Promise<{
-  spreadsheet?: Spreadsheet;
-  elements?: readonly ExcalidrawElement[];
-  text?: string;
-  errorMessage?: string;
-}> => {
+): Promise<ClipboardData> => {
   const systemClipboard = await getSystemClipboard(event);
 
   // if system clipboard empty, couldn't be resolved, or contains previously

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1189,7 +1189,7 @@ class App extends React.Component<AppProps, AppState> {
       }
       const data = await parseClipboard(event);
       if (this.props.onPasteFromClipboard) {
-        if (this.props.onPasteFromClipboard(data)) {
+        if (this.props.onPasteFromClipboard(data, event)) {
           return;
         }
       }

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1189,7 +1189,7 @@ class App extends React.Component<AppProps, AppState> {
       }
       const data = await parseClipboard(event);
       if (this.props.onPasteFromClipboard) {
-        if (this.props.onPasteFromClipboard(data, event)) {
+        if (await this.props.onPasteFromClipboard(data, event)) {
           return;
         }
       }

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1188,6 +1188,11 @@ class App extends React.Component<AppProps, AppState> {
         return;
       }
       const data = await parseClipboard(event);
+      if (this.props.onPasteFromClipboard) {
+        if (this.props.onPasteFromClipboard(data)) {
+          return;
+        }
+      }
       if (data.errorMessage) {
         this.setState({ errorMessage: data.errorMessage });
       } else if (data.spreadsheet) {

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1188,8 +1188,8 @@ class App extends React.Component<AppProps, AppState> {
         return;
       }
       const data = await parseClipboard(event);
-      if (this.props.onPasteFromClipboard) {
-        if (await this.props.onPasteFromClipboard(data, event)) {
+      if (this.props.onPaste) {
+        if (await this.props.onPaste(data, event)) {
           return;
         }
       }

--- a/src/packages/excalidraw/CHANGELOG.md
+++ b/src/packages/excalidraw/CHANGELOG.md
@@ -18,6 +18,7 @@ Please add the latest change on the top under the correct section.
 ### Features
 
 - App now breaks into mobile view using the component dimensions, not viewport dimensions. This fixes a case where the app would break sooner than necessary when the component's size is smaller than viewport [#3414](https://github.com/excalidraw/excalidraw/pull/3414).
+- Add `onPaste` props to handle custom clipboard behaviours [#3420](https://github.com/excalidraw/excalidraw/pull/3420)
 
 ## 0.6.0 (2021-04-04)
 

--- a/src/packages/excalidraw/CHANGELOG.md
+++ b/src/packages/excalidraw/CHANGELOG.md
@@ -17,8 +17,8 @@ Please add the latest change on the top under the correct section.
 
 ### Features
 
+- Add `onPaste` prop to handle custom clipboard behaviours [#3420](https://github.com/excalidraw/excalidraw/pull/3420).
 - App now breaks into mobile view using the component dimensions, not viewport dimensions. This fixes a case where the app would break sooner than necessary when the component's size is smaller than viewport [#3414](https://github.com/excalidraw/excalidraw/pull/3414).
-- Add `onPaste` props to handle custom clipboard behaviours [#3420](https://github.com/excalidraw/excalidraw/pull/3420)
 
 ## 0.6.0 (2021-04-04)
 

--- a/src/packages/excalidraw/CHANGELOG.md
+++ b/src/packages/excalidraw/CHANGELOG.md
@@ -13,11 +13,14 @@ Please add the latest change on the top under the correct section.
 
 ## Unreleased
 
+## Excalidraw API
+
+- Add `onPaste` prop to handle custom clipboard behaviours [#3420](https://github.com/excalidraw/excalidraw/pull/3420).
+
 ## Excalidraw Library
 
 ### Features
 
-- Add `onPaste` prop to handle custom clipboard behaviours [#3420](https://github.com/excalidraw/excalidraw/pull/3420).
 - App now breaks into mobile view using the component dimensions, not viewport dimensions. This fixes a case where the app would break sooner than necessary when the component's size is smaller than viewport [#3414](https://github.com/excalidraw/excalidraw/pull/3414).
 
 ## 0.6.0 (2021-04-04)

--- a/src/packages/excalidraw/README_NEXT.md
+++ b/src/packages/excalidraw/README_NEXT.md
@@ -351,7 +351,6 @@ To view the full example visit :point_down:
 | [`initialData`](#initialData) | <pre>{elements?: <a href="https://github.com/excalidraw/excalidraw/blob/master/src/element/types.ts#L78">ExcalidrawElement[]</a>, appState?: <a href="https://github.com/excalidraw/excalidraw/blob/master/src/types.ts#L37">AppState<a> } </pre> | null | The initial data with which app loads. |
 | [`ref`](#ref) | [`createRef`](https://reactjs.org/docs/refs-and-the-dom.html#creating-refs) or [`callbackRef`](https://reactjs.org/docs/refs-and-the-dom.html#callback-refs) or <pre>{ current: { readyPromise: <a href="https://github.com/excalidraw/excalidraw/blob/master/src/utils.ts#L317">resolvablePromise</a> } }</pre> |  | Ref to be passed to Excalidraw |
 | [`onCollabButtonClick`](#onCollabButtonClick) | Function |  | Callback to be triggered when the collab button is clicked |
-| [`onPaste`](#onPaste) | Function |  | Callback to be triggered when the something is pasted to the scene |
 | [`isCollaborating`](#isCollaborating) | `boolean` |  | This implies if the app is in collaboration mode |
 | [`onPointerUpdate`](#onPointerUpdate) | Function |  | Callback triggered when mouse pointer is updated. |
 | [`onExportToBackend`](#onExportToBackend) | Function |  | Callback triggered when link button is clicked on export dialog |
@@ -365,6 +364,7 @@ To view the full example visit :point_down:
 | [`theme`](#theme) | `light` or `dark` |  | The theme of the Excalidraw component |
 | [`name`](#name) | string |  | Name of the drawing |
 | [`UIOptions`](#UIOptions) | <pre>{ canvasActions: <a href="https://github.com/excalidraw/excalidraw/blob/master/src/types.ts#L208"> CanvasActions<a/> }</pre> | [DEFAULT UI OPTIONS](https://github.com/excalidraw/excalidraw/blob/master/src/constants.ts#L129) | To customise UI options. Currently we support customising [`canvas actions`](#canvasActions) |
+| [`onPaste`](#onPaste) | <pre>(data: <a href="https://github.com/excalidraw/excalidraw/blob/master/src/clipboard.ts#L17">ClipboardData</a>, event: ClipboardEvent &#124; null) => boolean</pre> |  | Callback to be triggered if passed when the something is pasted in to the scene |
 
 ### Dimensions of Excalidraw
 
@@ -454,12 +454,6 @@ const excalidrawRef = { current: { readyPromise: <a href="https://github.com/exc
 
 This callback is triggered when clicked on the collab button in excalidraw. If not supplied, the collab dialog button is not rendered.
 
-#### `onPaste`
-
-This callback is triggered when something is pasted to the scene. This callback need to return a `boolean` to prevent or not the current clipboard management flow.
-
-Returning `true` will stop the native excalidraw clipboard management flow (nothing insert to the scene).
-
 #### `isCollaborating`
 
 This prop indicates if the app is in collaboration mode.
@@ -535,7 +529,7 @@ This prop controls Excalidraw's theme. When supplied, the value takes precedence
 
 This prop sets the name of the drawing which will be used when exporting the drawing. When supplied, the value takes precedence over `intialData.appState.name`, the `name` will be fully controlled by host app and the users won't be able to edit from within Excalidraw.
 
-### `UIOptions`
+#### `UIOptions`
 
 This prop can be used to customise UI of Excalidraw. Currently we support customising only [`canvasActions`](#canvasActions). It accepts the below parameters
 
@@ -543,7 +537,7 @@ This prop can be used to customise UI of Excalidraw. Currently we support custom
 { canvasActions: <a href="https://github.com/excalidraw/excalidraw/blob/master/src/types.ts#L208"> CanvasActions<a/> }
 </pre>
 
-#### canvasActions
+##### canvasActions
 
 | Attribute | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -554,6 +548,18 @@ This prop can be used to customise UI of Excalidraw. Currently we support custom
 | `saveAsScene` | boolean | true | Implies whether to show `Save as button` |
 | `saveScene` | boolean | true | Implies whether to show `Save button` |
 | `theme` | boolean | true | Implies whether to show `Theme toggle` |
+
+#### `onPaste`
+
+This callback is triggered if passed when something is pasted into the scene. You can use this callback in case you want to do something additional when the paste event occurs.
+
+<pre>
+(data: <a href="https://github.com/excalidraw/excalidraw/blob/master/src/clipboard.ts#L17">ClipboardData</a>, event: ClipboardEvent &#124; null) => boolean
+</pre>
+
+This callback must return a `boolean` value or a [promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/Promise) which resolves to a boolean value.
+
+In case you want to prevent the excalidraw paste action you must return `true`, it will stop the native excalidraw clipboard management flow (nothing will be pasted into the scene).
 
 ### Does it support collaboration ?
 

--- a/src/packages/excalidraw/README_NEXT.md
+++ b/src/packages/excalidraw/README_NEXT.md
@@ -351,6 +351,7 @@ To view the full example visit :point_down:
 | [`initialData`](#initialData) | <pre>{elements?: <a href="https://github.com/excalidraw/excalidraw/blob/master/src/element/types.ts#L78">ExcalidrawElement[]</a>, appState?: <a href="https://github.com/excalidraw/excalidraw/blob/master/src/types.ts#L37">AppState<a> } </pre> | null | The initial data with which app loads. |
 | [`ref`](#ref) | [`createRef`](https://reactjs.org/docs/refs-and-the-dom.html#creating-refs) or [`callbackRef`](https://reactjs.org/docs/refs-and-the-dom.html#callback-refs) or <pre>{ current: { readyPromise: <a href="https://github.com/excalidraw/excalidraw/blob/master/src/utils.ts#L317">resolvablePromise</a> } }</pre> |  | Ref to be passed to Excalidraw |
 | [`onCollabButtonClick`](#onCollabButtonClick) | Function |  | Callback to be triggered when the collab button is clicked |
+| [`onPaste`](#onPaste) | Function |  | Callback to be triggered when the something is pasted to the scene |
 | [`isCollaborating`](#isCollaborating) | `boolean` |  | This implies if the app is in collaboration mode |
 | [`onPointerUpdate`](#onPointerUpdate) | Function |  | Callback triggered when mouse pointer is updated. |
 | [`onExportToBackend`](#onExportToBackend) | Function |  | Callback triggered when link button is clicked on export dialog |
@@ -452,6 +453,12 @@ const excalidrawRef = { current: { readyPromise: <a href="https://github.com/exc
 #### `onCollabButtonClick`
 
 This callback is triggered when clicked on the collab button in excalidraw. If not supplied, the collab dialog button is not rendered.
+
+#### `onPaste`
+
+This callback is triggered when something is pasted to the scene. This callback need to return a `boolean` to prevent or not the current clipboard management flow.
+
+Returning `true` will stop the native excalidraw clipboard management flow (nothing insert to the scene).
 
 #### `isCollaborating`
 

--- a/src/packages/excalidraw/index.tsx
+++ b/src/packages/excalidraw/index.tsx
@@ -29,6 +29,7 @@ const Excalidraw = (props: ExcalidrawProps) => {
     theme,
     name,
     renderCustomStats,
+    onPasteFromClipboard,
   } = props;
 
   const canvasActions = props.UIOptions?.canvasActions;
@@ -78,6 +79,7 @@ const Excalidraw = (props: ExcalidrawProps) => {
         name={name}
         renderCustomStats={renderCustomStats}
         UIOptions={UIOptions}
+        onPasteFromClipboard={onPasteFromClipboard}
       />
     </InitializeApp>
   );

--- a/src/packages/excalidraw/index.tsx
+++ b/src/packages/excalidraw/index.tsx
@@ -29,7 +29,7 @@ const Excalidraw = (props: ExcalidrawProps) => {
     theme,
     name,
     renderCustomStats,
-    onPasteFromClipboard,
+    onPaste,
   } = props;
 
   const canvasActions = props.UIOptions?.canvasActions;
@@ -79,7 +79,7 @@ const Excalidraw = (props: ExcalidrawProps) => {
         name={name}
         renderCustomStats={renderCustomStats}
         UIOptions={UIOptions}
-        onPasteFromClipboard={onPasteFromClipboard}
+        onPaste={onPaste}
       />
     </InitializeApp>
   );

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,10 +17,10 @@ import { LinearElementEditor } from "./element/linearElementEditor";
 import { SuggestedBinding } from "./element/binding";
 import { ImportedDataState } from "./data/types";
 import { ExcalidrawImperativeAPI } from "./components/App";
-import type { ResolvablePromise, Awaited } from "./utils";
+import type { ResolvablePromise } from "./utils";
 import { Spreadsheet } from "./charts";
 import { Language } from "./i18n";
-import { parseClipboard } from "./clipboard";
+import { ClipboardData } from "./clipboard";
 
 export type Point = Readonly<RoughPoint>;
 
@@ -183,8 +183,8 @@ export interface ExcalidrawProps {
    *
    * Returns `true` to prevent default.
    */
-  onPasteFromClipboard?: (
-    data: Awaited<ReturnType<typeof parseClipboard>>,
+  onPaste?: (
+    data: ClipboardData,
     event: ClipboardEvent | null,
   ) => Promise<boolean> | boolean;
   renderFooter?: (isMobile: boolean) => JSX.Element;

--- a/src/types.ts
+++ b/src/types.ts
@@ -178,11 +178,6 @@ export interface ExcalidrawProps {
     appState: AppState,
     canvas: HTMLCanvasElement | null,
   ) => void;
-  /**
-   * Paste from clipboard.
-   *
-   * Returns `true` to prevent default.
-   */
   onPaste?: (
     data: ClipboardData,
     event: ClipboardEvent | null,

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,9 +17,10 @@ import { LinearElementEditor } from "./element/linearElementEditor";
 import { SuggestedBinding } from "./element/binding";
 import { ImportedDataState } from "./data/types";
 import { ExcalidrawImperativeAPI } from "./components/App";
-import type { ResolvablePromise } from "./utils";
+import type { ResolvablePromise, Awaited } from "./utils";
 import { Spreadsheet } from "./charts";
 import { Language } from "./i18n";
+import { parseClipboard } from "./clipboard";
 
 export type Point = Readonly<RoughPoint>;
 
@@ -177,6 +178,14 @@ export interface ExcalidrawProps {
     appState: AppState,
     canvas: HTMLCanvasElement | null,
   ) => void;
+  /**
+   * Paste from clipboard.
+   *
+   * Returns `true` to prevent default.
+   */
+  onPasteFromClipboard?: (
+    data: Awaited<ReturnType<typeof parseClipboard>>,
+  ) => boolean;
   renderFooter?: (isMobile: boolean) => JSX.Element;
   langCode?: Language["code"];
   viewModeEnabled?: boolean;

--- a/src/types.ts
+++ b/src/types.ts
@@ -185,6 +185,7 @@ export interface ExcalidrawProps {
    */
   onPasteFromClipboard?: (
     data: Awaited<ReturnType<typeof parseClipboard>>,
+    event: ClipboardEvent | null,
   ) => boolean;
   renderFooter?: (isMobile: boolean) => JSX.Element;
   langCode?: Language["code"];

--- a/src/types.ts
+++ b/src/types.ts
@@ -186,7 +186,7 @@ export interface ExcalidrawProps {
   onPasteFromClipboard?: (
     data: Awaited<ReturnType<typeof parseClipboard>>,
     event: ClipboardEvent | null,
-  ) => boolean;
+  ) => Promise<boolean> | boolean;
   renderFooter?: (isMobile: boolean) => JSX.Element;
   langCode?: Language["code"];
   viewModeEnabled?: boolean;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -335,9 +335,6 @@ export const isTransparent = (color: string) => {
   );
 };
 
-// From https://github.com/microsoft/TypeScript/issues/28105
-export type Awaited<T> = T extends Promise<infer U> ? U : never;
-
 export type ResolvablePromise<T> = Promise<T> & {
   resolve: [T] extends [undefined] ? (value?: T) => void : (value: T) => void;
   reject: (error: Error) => void;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -335,6 +335,9 @@ export const isTransparent = (color: string) => {
   );
 };
 
+// From https://github.com/microsoft/TypeScript/issues/28105
+export type Awaited<T> = T extends Promise<infer U> ? U : never;
+
 export type ResolvablePromise<T> = Promise<T> & {
   resolve: [T] extends [undefined] ? (value?: T) => void : (value: T) => void;
   reject: (error: Error) => void;


### PR DESCRIPTION
Add `onPasteFromClipboard` props to `@excalidraw/excalidraw`.

### Example

A simple example to add a custom element when the text `"special"` is pasted in the scene.

```tsx
import React, { useCallback, useRef } from "react";
import Excalidraw from "@excalidraw/excalidraw";
import {
  ExcalidrawAPIRefValue,
  ExcalidrawProps,
} from "@excalidraw/excalidraw/types/types";

export const App = () => {
  const ref = useRef<ExcalidrawAPIRefValue>(null);
  const onPasteFromClipboard = useCallback<Required<ExcalidrawProps>["onPasteFromClipboard"]>(
    (data) => {
      if (ref.current?.ready && data.text === "special") {
        /* do something special */
        const prev = ref.current.getSceneElementsIncludingDeleted();
        ref.current.updateScene({elements: [...prev, /* my special element */]})

        return true; // Prevent default paste action
      }

      return false; // Do the default paste action
    },
    []
  );

  return <Excalidraw ref={ref} onPasteFromClipboard={onPasteFromClipboard} />;
};
```