### PR TITLE
feat: Bind keyboard events to the current  excalidraw container and add handleKeyboardGlobally prop to allow host to bind to document

### DIFF
--- a/src/actions/actionFinalize.tsx
+++ b/src/actions/actionFinalize.tsx
@@ -18,7 +18,7 @@ import { isBindingElement } from "../element/typeChecks";
 
 export const actionFinalize = register({
   name: "finalize",
-  perform: (elements, appState, _, { canvas }) => {
+  perform: (elements, appState, _, { canvas, focusContainer }) => {
     if (appState.editingLinearElement) {
       const {
         elementId,
@@ -51,7 +51,7 @@ export const actionFinalize = register({
 
     let newElements = elements;
     if (window.document.activeElement instanceof HTMLElement) {
-      window.document.activeElement.blur();
+      focusContainer();
     }
 
     const multiPointElement = appState.multiElement

--- a/src/actions/actionMenu.tsx
+++ b/src/actions/actionMenu.tsx
@@ -70,7 +70,10 @@ export const actionFullScreen = register({
 
 export const actionShortcuts = register({
   name: "toggleShortcuts",
-  perform: (_elements, appState) => {
+  perform: (_elements, appState, _, { focusContainer }) => {
+    if (appState.showHelpDialog) {
+      focusContainer();
+    }
     return {
       appState: {
         ...appState,

--- a/src/actions/manager.tsx
+++ b/src/actions/manager.tsx
@@ -12,7 +12,11 @@ import { MODES } from "../constants";
 
 // This is the <App> component, but for now we don't care about anything but its
 // `canvas` state.
-type App = { canvas: HTMLCanvasElement | null; props: AppProps };
+type App = {
+  canvas: HTMLCanvasElement | null;
+  focusContainer: () => void;
+  props: AppProps;
+};
 
 export class ActionManager implements ActionsManagerInterface {
   actions = {} as ActionsManagerInterface["actions"];

--- a/src/actions/manager.tsx
+++ b/src/actions/manager.tsx
@@ -55,7 +55,7 @@ export class ActionManager implements ActionsManagerInterface {
     actions.forEach((action) => this.registerAction(action));
   }
 
-  handleKeyDown(event: React.KeyboardEvent) {
+  handleKeyDown(event: React.KeyboardEvent | KeyboardEvent) {
     const canvasActions = this.app.props.UIOptions.canvasActions;
     const data = Object.values(this.actions)
       .sort((a, b) => (b.keyPriority || 0) - (a.keyPriority || 0))

--- a/src/actions/manager.tsx
+++ b/src/actions/manager.tsx
@@ -55,7 +55,7 @@ export class ActionManager implements ActionsManagerInterface {
     actions.forEach((action) => this.registerAction(action));
   }
 
-  handleKeyDown(event: KeyboardEvent) {
+  handleKeyDown(event: React.KeyboardEvent) {
     const canvasActions = this.app.props.UIOptions.canvasActions;
     const data = Object.values(this.actions)
       .sort((a, b) => (b.keyPriority || 0) - (a.keyPriority || 0))

--- a/src/actions/types.ts
+++ b/src/actions/types.ts
@@ -107,7 +107,7 @@ export interface Action {
   perform: ActionFn;
   keyPriority?: number;
   keyTest?: (
-    event: React.KeyboardEvent,
+    event: React.KeyboardEvent | KeyboardEvent,
     appState: AppState,
     elements: readonly ExcalidrawElement[],
   ) => boolean;
@@ -122,6 +122,6 @@ export interface Action {
 export interface ActionsManagerInterface {
   actions: Record<ActionName, Action>;
   registerAction: (action: Action) => void;
-  handleKeyDown: (event: React.KeyboardEvent) => boolean;
+  handleKeyDown: (event: React.KeyboardEvent | KeyboardEvent) => boolean;
   renderAction: (name: ActionName) => React.ReactElement | null;
 }

--- a/src/actions/types.ts
+++ b/src/actions/types.ts
@@ -15,11 +15,13 @@ export type ActionResult =
     }
   | false;
 
+type AppAPI = { canvas: HTMLCanvasElement | null; focusContainer(): void };
+
 type ActionFn = (
   elements: readonly ExcalidrawElement[],
   appState: Readonly<AppState>,
   formData: any,
-  app: { canvas: HTMLCanvasElement | null },
+  app: AppAPI,
 ) => ActionResult | Promise<ActionResult>;
 
 export type UpdaterFn = (res: ActionResult) => void;

--- a/src/actions/types.ts
+++ b/src/actions/types.ts
@@ -107,7 +107,7 @@ export interface Action {
   perform: ActionFn;
   keyPriority?: number;
   keyTest?: (
-    event: KeyboardEvent,
+    event: React.KeyboardEvent,
     appState: AppState,
     elements: readonly ExcalidrawElement[],
   ) => boolean;
@@ -122,6 +122,6 @@ export interface Action {
 export interface ActionsManagerInterface {
   actions: Record<ActionName, Action>;
   registerAction: (action: Action) => void;
-  handleKeyDown: (event: KeyboardEvent) => boolean;
+  handleKeyDown: (event: React.KeyboardEvent) => boolean;
   renderAction: (name: ActionName) => React.ReactElement | null;
 }

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -452,6 +452,7 @@ class App extends React.Component<AppProps, AppState> {
         ref={this.excalidrawContainerRef}
         onDrop={this.handleAppOnDrop}
         tabIndex={0}
+        onKeyDown={this.onKeyDown}
       >
         <IsMobileContext.Provider value={this.isMobile}>
           <LayerUI
@@ -857,11 +858,6 @@ class App extends React.Component<AppProps, AppState> {
       this.onScroll,
     );
 
-    this.excalidrawContainerRef.current!.removeEventListener(
-      EVENT.KEYDOWN,
-      this.onKeyDown,
-      false,
-    );
     document.removeEventListener(
       EVENT.MOUSE_MOVE,
       this.updateCurrentCursorPosition,
@@ -896,11 +892,6 @@ class App extends React.Component<AppProps, AppState> {
   private addEventListeners() {
     this.removeEventListeners();
     document.addEventListener(EVENT.COPY, this.onCopy);
-    this.excalidrawContainerRef.current!.addEventListener(
-      EVENT.KEYDOWN,
-      this.onKeyDown,
-      false,
-    );
     document.addEventListener(EVENT.KEYUP, this.onKeyUp, { passive: true });
     document.addEventListener(
       EVENT.MOUSE_MOVE,
@@ -1444,7 +1435,7 @@ class App extends React.Component<AppProps, AppState> {
 
   // Input handling
 
-  private onKeyDown = withBatchedUpdates((event: KeyboardEvent) => {
+  private onKeyDown = withBatchedUpdates((event: React.KeyboardEvent) => {
     // normalize `event.key` when CapsLock is pressed #2372
     if (
       "Proxy" in window &&

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -489,7 +489,6 @@ class App extends React.Component<AppProps, AppState> {
           />
           <div className="excalidraw-textEditorContainer" />
           <div className="excalidraw-contextMenuContainer" />
-          <div className="excalidraw-modal-container" />
           {this.state.showStats && (
             <Stats
               appState={this.state}

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -661,6 +661,8 @@ class App extends React.Component<AppProps, AppState> {
     } catch (error) {
       window.alert(t("alerts.errorLoadingLibrary"));
       console.error(error);
+    } finally {
+      this.focusContainer();
     }
   };
 

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -510,6 +510,10 @@ class App extends React.Component<AppProps, AppState> {
     );
   }
 
+  public focusContainer = () => {
+    this.excalidrawContainerRef.current?.focus();
+  };
+
   public getSceneElementsIncludingDeleted = () => {
     return this.scene.getElementsIncludingDeleted();
   };
@@ -788,6 +792,10 @@ class App extends React.Component<AppProps, AppState> {
 
     this.scene.addCallback(this.onSceneUpdated);
     this.addEventListeners();
+
+    if (this.excalidrawContainerRef.current) {
+      this.focusContainer();
+    }
 
     if ("ResizeObserver" in window && this.excalidrawContainerRef?.current) {
       this.resizeObserver = new ResizeObserver(() => {
@@ -1617,7 +1625,7 @@ class App extends React.Component<AppProps, AppState> {
       setCursorForShape(this.canvas, elementType);
     }
     if (isToolIcon(document.activeElement)) {
-      document.activeElement.blur();
+      this.focusContainer();
     }
     if (!isLinearElementType(elementType)) {
       this.setState({ suggestedBindings: [] });
@@ -1747,6 +1755,8 @@ class App extends React.Component<AppProps, AppState> {
         if (this.state.elementLocked) {
           setCursorForShape(this.canvas, this.state.elementType);
         }
+
+        this.focusContainer();
       }),
       element,
     });

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -452,7 +452,7 @@ class App extends React.Component<AppProps, AppState> {
         ref={this.excalidrawContainerRef}
         onDrop={this.handleAppOnDrop}
         tabIndex={0}
-        onKeyDown={this.onKeyDown}
+        onKeyDown={this.props.bindKeyGlobally ? undefined : this.onKeyDown}
       >
         <IsMobileContext.Provider value={this.isMobile}>
           <LayerUI
@@ -857,7 +857,7 @@ class App extends React.Component<AppProps, AppState> {
       EVENT.SCROLL,
       this.onScroll,
     );
-
+    document.removeEventListener(EVENT.KEYDOWN, this.onKeyDown, false);
     document.removeEventListener(
       EVENT.MOUSE_MOVE,
       this.updateCurrentCursorPosition,
@@ -892,6 +892,9 @@ class App extends React.Component<AppProps, AppState> {
   private addEventListeners() {
     this.removeEventListeners();
     document.addEventListener(EVENT.COPY, this.onCopy);
+    if (this.props.bindKeyGlobally) {
+      document.addEventListener(EVENT.KEYDOWN, this.onKeyDown, false);
+    }
     document.addEventListener(EVENT.KEYUP, this.onKeyUp, { passive: true });
     document.addEventListener(
       EVENT.MOUSE_MOVE,
@@ -1435,152 +1438,156 @@ class App extends React.Component<AppProps, AppState> {
 
   // Input handling
 
-  private onKeyDown = withBatchedUpdates((event: React.KeyboardEvent) => {
-    // normalize `event.key` when CapsLock is pressed #2372
-    if (
-      "Proxy" in window &&
-      ((!event.shiftKey && /^[A-Z]$/.test(event.key)) ||
-        (event.shiftKey && /^[a-z]$/.test(event.key)))
-    ) {
-      event = new Proxy(event, {
-        get(ev: any, prop) {
-          const value = ev[prop];
-          if (typeof value === "function") {
-            // fix for Proxies hijacking `this`
-            return value.bind(ev);
-          }
-          return prop === "key"
-            ? // CapsLock inverts capitalization based on ShiftKey, so invert
-              // it back
-              event.shiftKey
-              ? ev.key.toUpperCase()
-              : ev.key.toLowerCase()
-            : value;
-        },
-      });
-    }
-
-    if (
-      (isWritableElement(event.target) && event.key !== KEYS.ESCAPE) ||
-      // case: using arrows to move between buttons
-      (isArrowKey(event.key) && isInputLike(event.target))
-    ) {
-      return;
-    }
-
-    if (event.key === KEYS.QUESTION_MARK) {
-      this.setState({
-        showHelpDialog: true,
-      });
-    }
-
-    if (this.actionManager.handleKeyDown(event)) {
-      return;
-    }
-
-    if (this.state.viewModeEnabled) {
-      return;
-    }
-
-    if (event[KEYS.CTRL_OR_CMD] && this.state.isBindingEnabled) {
-      this.setState({ isBindingEnabled: false });
-    }
-
-    if (event.code === CODES.NINE) {
-      this.setState({ isLibraryOpen: !this.state.isLibraryOpen });
-    }
-
-    if (isArrowKey(event.key)) {
-      const step =
-        (this.state.gridSize &&
-          (event.shiftKey ? ELEMENT_TRANSLATE_AMOUNT : this.state.gridSize)) ||
-        (event.shiftKey
-          ? ELEMENT_SHIFT_TRANSLATE_AMOUNT
-          : ELEMENT_TRANSLATE_AMOUNT);
-
-      const selectedElements = this.scene
-        .getElements()
-        .filter((element) => this.state.selectedElementIds[element.id]);
-
-      let offsetX = 0;
-      let offsetY = 0;
-
-      if (event.key === KEYS.ARROW_LEFT) {
-        offsetX = -step;
-      } else if (event.key === KEYS.ARROW_RIGHT) {
-        offsetX = step;
-      } else if (event.key === KEYS.ARROW_UP) {
-        offsetY = -step;
-      } else if (event.key === KEYS.ARROW_DOWN) {
-        offsetY = step;
+  private onKeyDown = withBatchedUpdates(
+    (event: React.KeyboardEvent | KeyboardEvent) => {
+      // normalize `event.key` when CapsLock is pressed #2372
+      if (
+        "Proxy" in window &&
+        ((!event.shiftKey && /^[A-Z]$/.test(event.key)) ||
+          (event.shiftKey && /^[a-z]$/.test(event.key)))
+      ) {
+        event = new Proxy(event, {
+          get(ev: any, prop) {
+            const value = ev[prop];
+            if (typeof value === "function") {
+              // fix for Proxies hijacking `this`
+              return value.bind(ev);
+            }
+            return prop === "key"
+              ? // CapsLock inverts capitalization based on ShiftKey, so invert
+                // it back
+                event.shiftKey
+                ? ev.key.toUpperCase()
+                : ev.key.toLowerCase()
+              : value;
+          },
+        });
       }
-
-      selectedElements.forEach((element) => {
-        mutateElement(element, {
-          x: element.x + offsetX,
-          y: element.y + offsetY,
-        });
-
-        updateBoundElements(element, {
-          simultaneouslyUpdated: selectedElements,
-        });
-      });
-
-      this.maybeSuggestBindingForAll(selectedElements);
-
-      event.preventDefault();
-    } else if (event.key === KEYS.ENTER) {
-      const selectedElements = getSelectedElements(
-        this.scene.getElements(),
-        this.state,
-      );
 
       if (
-        selectedElements.length === 1 &&
-        isLinearElement(selectedElements[0])
+        (isWritableElement(event.target) && event.key !== KEYS.ESCAPE) ||
+        // case: using arrows to move between buttons
+        (isArrowKey(event.key) && isInputLike(event.target))
       ) {
-        if (
-          !this.state.editingLinearElement ||
-          this.state.editingLinearElement.elementId !== selectedElements[0].id
-        ) {
-          history.resumeRecording();
-          this.setState({
-            editingLinearElement: new LinearElementEditor(
-              selectedElements[0],
-              this.scene,
-            ),
-          });
-        }
-      } else if (
-        selectedElements.length === 1 &&
-        !isLinearElement(selectedElements[0])
-      ) {
-        const selectedElement = selectedElements[0];
-        this.startTextEditing({
-          sceneX: selectedElement.x + selectedElement.width / 2,
-          sceneY: selectedElement.y + selectedElement.height / 2,
-        });
-        event.preventDefault();
         return;
       }
-    } else if (
-      !event.ctrlKey &&
-      !event.altKey &&
-      !event.metaKey &&
-      this.state.draggingElement === null
-    ) {
-      const shape = findShapeByKey(event.key);
-      if (shape) {
-        this.selectShapeTool(shape);
-      } else if (event.key === KEYS.Q) {
-        this.toggleLock();
+
+      if (event.key === KEYS.QUESTION_MARK) {
+        this.setState({
+          showHelpDialog: true,
+        });
       }
-    }
-    if (event.key === KEYS.SPACE && gesture.pointers.size === 0) {
-      isHoldingSpace = true;
-      setCursor(this.canvas, CURSOR_TYPE.GRABBING);
-    }
-  });
+
+      if (this.actionManager.handleKeyDown(event)) {
+        return;
+      }
+
+      if (this.state.viewModeEnabled) {
+        return;
+      }
+
+      if (event[KEYS.CTRL_OR_CMD] && this.state.isBindingEnabled) {
+        this.setState({ isBindingEnabled: false });
+      }
+
+      if (event.code === CODES.NINE) {
+        this.setState({ isLibraryOpen: !this.state.isLibraryOpen });
+      }
+
+      if (isArrowKey(event.key)) {
+        const step =
+          (this.state.gridSize &&
+            (event.shiftKey
+              ? ELEMENT_TRANSLATE_AMOUNT
+              : this.state.gridSize)) ||
+          (event.shiftKey
+            ? ELEMENT_SHIFT_TRANSLATE_AMOUNT
+            : ELEMENT_TRANSLATE_AMOUNT);
+
+        const selectedElements = this.scene
+          .getElements()
+          .filter((element) => this.state.selectedElementIds[element.id]);
+
+        let offsetX = 0;
+        let offsetY = 0;
+
+        if (event.key === KEYS.ARROW_LEFT) {
+          offsetX = -step;
+        } else if (event.key === KEYS.ARROW_RIGHT) {
+          offsetX = step;
+        } else if (event.key === KEYS.ARROW_UP) {
+          offsetY = -step;
+        } else if (event.key === KEYS.ARROW_DOWN) {
+          offsetY = step;
+        }
+
+        selectedElements.forEach((element) => {
+          mutateElement(element, {
+            x: element.x + offsetX,
+            y: element.y + offsetY,
+          });
+
+          updateBoundElements(element, {
+            simultaneouslyUpdated: selectedElements,
+          });
+        });
+
+        this.maybeSuggestBindingForAll(selectedElements);
+
+        event.preventDefault();
+      } else if (event.key === KEYS.ENTER) {
+        const selectedElements = getSelectedElements(
+          this.scene.getElements(),
+          this.state,
+        );
+
+        if (
+          selectedElements.length === 1 &&
+          isLinearElement(selectedElements[0])
+        ) {
+          if (
+            !this.state.editingLinearElement ||
+            this.state.editingLinearElement.elementId !== selectedElements[0].id
+          ) {
+            history.resumeRecording();
+            this.setState({
+              editingLinearElement: new LinearElementEditor(
+                selectedElements[0],
+                this.scene,
+              ),
+            });
+          }
+        } else if (
+          selectedElements.length === 1 &&
+          !isLinearElement(selectedElements[0])
+        ) {
+          const selectedElement = selectedElements[0];
+          this.startTextEditing({
+            sceneX: selectedElement.x + selectedElement.width / 2,
+            sceneY: selectedElement.y + selectedElement.height / 2,
+          });
+          event.preventDefault();
+          return;
+        }
+      } else if (
+        !event.ctrlKey &&
+        !event.altKey &&
+        !event.metaKey &&
+        this.state.draggingElement === null
+      ) {
+        const shape = findShapeByKey(event.key);
+        if (shape) {
+          this.selectShapeTool(shape);
+        } else if (event.key === KEYS.Q) {
+          this.toggleLock();
+        }
+      }
+      if (event.key === KEYS.SPACE && gesture.pointers.size === 0) {
+        isHoldingSpace = true;
+        setCursor(this.canvas, CURSOR_TYPE.GRABBING);
+      }
+    },
+  );
 
   private onKeyUp = withBatchedUpdates((event: KeyboardEvent) => {
     if (event.key === KEYS.SPACE) {

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -451,6 +451,7 @@ class App extends React.Component<AppProps, AppState> {
         })}
         ref={this.excalidrawContainerRef}
         onDrop={this.handleAppOnDrop}
+        tabIndex={0}
       >
         <IsMobileContext.Provider value={this.isMobile}>
           <LayerUI
@@ -848,7 +849,11 @@ class App extends React.Component<AppProps, AppState> {
       this.onScroll,
     );
 
-    document.removeEventListener(EVENT.KEYDOWN, this.onKeyDown, false);
+    this.excalidrawContainerRef.current!.removeEventListener(
+      EVENT.KEYDOWN,
+      this.onKeyDown,
+      false,
+    );
     document.removeEventListener(
       EVENT.MOUSE_MOVE,
       this.updateCurrentCursorPosition,
@@ -883,7 +888,11 @@ class App extends React.Component<AppProps, AppState> {
   private addEventListeners() {
     this.removeEventListeners();
     document.addEventListener(EVENT.COPY, this.onCopy);
-    document.addEventListener(EVENT.KEYDOWN, this.onKeyDown, false);
+    this.excalidrawContainerRef.current!.addEventListener(
+      EVENT.KEYDOWN,
+      this.onKeyDown,
+      false,
+    );
     document.addEventListener(EVENT.KEYUP, this.onKeyUp, { passive: true });
     document.addEventListener(
       EVENT.MOUSE_MOVE,

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -487,6 +487,7 @@ class App extends React.Component<AppProps, AppState> {
             }
             libraryReturnUrl={this.props.libraryReturnUrl}
             UIOptions={this.props.UIOptions}
+            focusContainer={this.focusContainer}
           />
           <div className="excalidraw-textEditorContainer" />
           <div className="excalidraw-contextMenuContainer" />

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -452,7 +452,9 @@ class App extends React.Component<AppProps, AppState> {
         ref={this.excalidrawContainerRef}
         onDrop={this.handleAppOnDrop}
         tabIndex={0}
-        onKeyDown={this.props.bindKeyGlobally ? undefined : this.onKeyDown}
+        onKeyDown={
+          this.props.handleKeyboardGlobally ? undefined : this.onKeyDown
+        }
       >
         <IsMobileContext.Provider value={this.isMobile}>
           <LayerUI
@@ -895,7 +897,7 @@ class App extends React.Component<AppProps, AppState> {
   private addEventListeners() {
     this.removeEventListeners();
     document.addEventListener(EVENT.COPY, this.onCopy);
-    if (this.props.bindKeyGlobally) {
+    if (this.props.handleKeyboardGlobally) {
       document.addEventListener(EVENT.KEYDOWN, this.onKeyDown, false);
     }
     document.addEventListener(EVENT.KEYUP, this.onKeyUp, { passive: true });

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -489,6 +489,7 @@ class App extends React.Component<AppProps, AppState> {
           />
           <div className="excalidraw-textEditorContainer" />
           <div className="excalidraw-contextMenuContainer" />
+          <div className="excalidraw-modal-container" />
           {this.state.showStats && (
             <Stats
               appState={this.state}

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -445,7 +445,7 @@ class App extends React.Component<AppProps, AppState> {
 
     return (
       <div
-        className={clsx("excalidraw", {
+        className={clsx("excalidraw excalidraw-container", {
           "excalidraw--view-mode": viewModeEnabled,
           "excalidraw--mobile": this.isMobile,
         })}

--- a/src/components/ColorPicker.tsx
+++ b/src/components/ColorPicker.tsx
@@ -115,6 +115,7 @@ const Picker = ({
       onClose();
     }
     event.nativeEvent.stopImmediatePropagation();
+    event.stopPropagation();
   };
 
   return (

--- a/src/components/Dialog.tsx
+++ b/src/components/Dialog.tsx
@@ -18,7 +18,6 @@ export const Dialog = (props: {
   autofocus?: boolean;
 }) => {
   const [islandNode, setIslandNode] = useCallbackRefState<HTMLDivElement>();
-
   useEffect(() => {
     if (!islandNode) {
       return;

--- a/src/components/ErrorDialog.tsx
+++ b/src/components/ErrorDialog.tsx
@@ -2,7 +2,6 @@ import React, { useState } from "react";
 import { t } from "../i18n";
 
 import { Dialog } from "./Dialog";
-import { focusContainer } from "../utils";
 
 export const ErrorDialog = ({
   message,
@@ -19,7 +18,7 @@ export const ErrorDialog = ({
     if (onClose) {
       onClose();
     }
-    focusContainer();
+    document.querySelector<HTMLElement>(".excalidraw-container")?.focus();
   }, [onClose]);
 
   return (

--- a/src/components/ErrorDialog.tsx
+++ b/src/components/ErrorDialog.tsx
@@ -18,6 +18,7 @@ export const ErrorDialog = ({
     if (onClose) {
       onClose();
     }
+    document.querySelector<HTMLElement>(".excalidraw")!.focus();
   }, [onClose]);
 
   return (

--- a/src/components/ErrorDialog.tsx
+++ b/src/components/ErrorDialog.tsx
@@ -2,6 +2,7 @@ import React, { useState } from "react";
 import { t } from "../i18n";
 
 import { Dialog } from "./Dialog";
+import { focusContainer } from "../utils";
 
 export const ErrorDialog = ({
   message,
@@ -18,7 +19,7 @@ export const ErrorDialog = ({
     if (onClose) {
       onClose();
     }
-    document.querySelector<HTMLElement>(".excalidraw")!.focus();
+    focusContainer();
   }, [onClose]);
 
   return (

--- a/src/components/IconPicker.tsx
+++ b/src/components/IconPicker.tsx
@@ -88,6 +88,7 @@ function Picker<T>({
       onClose();
     }
     event.nativeEvent.stopImmediatePropagation();
+    event.stopPropagation();
   };
 
   return (

--- a/src/components/LayerUI.tsx
+++ b/src/components/LayerUI.tsx
@@ -72,6 +72,7 @@ interface LayerUIProps {
   viewModeEnabled: boolean;
   libraryReturnUrl: ExcalidrawProps["libraryReturnUrl"];
   UIOptions: AppProps["UIOptions"];
+  focusContainer: () => void;
 }
 
 const useOnClickOutside = (
@@ -111,6 +112,7 @@ const LibraryMenuItems = ({
   setAppState,
   setLibraryItems,
   libraryReturnUrl,
+  focusContainer,
 }: {
   library: LibraryItems;
   pendingElements: LibraryItem;
@@ -120,6 +122,7 @@ const LibraryMenuItems = ({
   setAppState: React.Component<any, AppState>["setState"];
   setLibraryItems: (library: LibraryItems) => void;
   libraryReturnUrl: ExcalidrawProps["libraryReturnUrl"];
+  focusContainer: () => void;
 }) => {
   const isMobile = useIsMobile();
   const numCells = library.length + (pendingElements.length > 0 ? 1 : 0);
@@ -178,6 +181,7 @@ const LibraryMenuItems = ({
               if (window.confirm(t("alerts.resetLibrary"))) {
                 Library.resetLibrary();
                 setLibraryItems([]);
+                focusContainer();
               }
             }}
           />
@@ -242,6 +246,7 @@ const LibraryMenu = ({
   onAddToLibrary,
   setAppState,
   libraryReturnUrl,
+  focusContainer,
 }: {
   pendingElements: LibraryItem;
   onClickOutside: (event: MouseEvent) => void;
@@ -249,6 +254,7 @@ const LibraryMenu = ({
   onAddToLibrary: () => void;
   setAppState: React.Component<any, AppState>["setState"];
   libraryReturnUrl: ExcalidrawProps["libraryReturnUrl"];
+  focusContainer: () => void;
 }) => {
   const ref = useRef<HTMLDivElement | null>(null);
   useOnClickOutside(ref, (event) => {
@@ -322,6 +328,7 @@ const LibraryMenu = ({
           setAppState={setAppState}
           setLibraryItems={setLibraryItems}
           libraryReturnUrl={libraryReturnUrl}
+          focusContainer={focusContainer}
         />
       )}
     </Island>
@@ -347,6 +354,7 @@ const LayerUI = ({
   viewModeEnabled,
   libraryReturnUrl,
   UIOptions,
+  focusContainer,
 }: LayerUIProps) => {
   const isMobile = useIsMobile();
 
@@ -517,6 +525,7 @@ const LayerUI = ({
       onAddToLibrary={deselectItems}
       setAppState={setAppState}
       libraryReturnUrl={libraryReturnUrl}
+      focusContainer={focusContainer}
     />
   ) : null;
 

--- a/src/components/LayerUI.tsx
+++ b/src/components/LayerUI.tsx
@@ -660,7 +660,15 @@ const LayerUI = ({
         />
       )}
       {appState.showHelpDialog && (
-        <HelpDialog onClose={() => setAppState({ showHelpDialog: false })} />
+        <HelpDialog
+          onClose={() => {
+            const helpIcon = document.querySelector(
+              ".help-icon",
+            )! as HTMLElement;
+            helpIcon.focus();
+            setAppState({ showHelpDialog: false });
+          }}
+        />
       )}
       {appState.pasteDialog.shown && (
         <PasteChartDialog

--- a/src/components/Modal.scss
+++ b/src/components/Modal.scss
@@ -52,6 +52,10 @@
     border-radius: 6px;
     box-sizing: border-box;
 
+    &:focus {
+      outline: none;
+    }
+
     @include isMobile {
       max-width: 100%;
       border: 0;

--- a/src/components/Modal.scss
+++ b/src/components/Modal.scss
@@ -1,9 +1,13 @@
 @import "../css/variables.module";
 
 .excalidraw {
-  &.excalidraw-modal-container {
-    position: absolute;
-    z-index: 10;
+  .excalidraw-modal-container {
+    &--visible {
+      position: absolute;
+      z-index: 10;
+      width: 100%;
+      height: 100%;
+    }
   }
 
   .Modal {

--- a/src/components/Modal.scss
+++ b/src/components/Modal.scss
@@ -1,13 +1,9 @@
 @import "../css/variables.module";
 
 .excalidraw {
-  .excalidraw-modal-container {
-    &--visible {
-      position: absolute;
-      z-index: 10;
-      width: 100%;
-      height: 100%;
-    }
+  &.excalidraw-modal-container {
+    position: absolute;
+    z-index: 10;
   }
 
   .Modal {

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -38,6 +38,7 @@ export const Modal = (props: {
       <div
         className="Modal__content"
         style={{ "--max-width": `${props.maxWidth}px` }}
+        tabIndex={0}
       >
         {props.children}
       </div>

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -65,20 +65,21 @@ const useBodyRoot = () => {
       .querySelector(".excalidraw")
       ?.classList.contains("theme--dark");
     const div = document.createElement("div");
-
-    div.classList.add("excalidraw", "excalidraw-modal-container");
+    const container = document.querySelector(".excalidraw-modal-container")!;
+    container.classList.add("excalidraw-modal-container--visible");
     div.classList.toggle("excalidraw--mobile", isMobileRef.current);
 
     if (isDarkTheme) {
       div.classList.add("theme--dark");
       div.classList.add("theme--dark-background-none");
     }
-    document.body.appendChild(div);
+    container.appendChild(div);
 
     setDiv(div);
 
     return () => {
-      document.body.removeChild(div);
+      container.classList.remove("excalidraw-modal-container--visible");
+      container!.removeChild(div);
     };
   }, []);
 

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -22,6 +22,7 @@ export const Modal = (props: {
   const handleKeydown = (event: React.KeyboardEvent) => {
     if (event.key === KEYS.ESCAPE) {
       event.nativeEvent.stopImmediatePropagation();
+      event.stopPropagation();
       props.onCloseRequest();
     }
   };

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -65,21 +65,20 @@ const useBodyRoot = () => {
       .querySelector(".excalidraw")
       ?.classList.contains("theme--dark");
     const div = document.createElement("div");
-    const container = document.querySelector(".excalidraw-modal-container")!;
-    container.classList.add("excalidraw-modal-container--visible");
+
+    div.classList.add("excalidraw", "excalidraw-modal-container");
     div.classList.toggle("excalidraw--mobile", isMobileRef.current);
 
     if (isDarkTheme) {
       div.classList.add("theme--dark");
       div.classList.add("theme--dark-background-none");
     }
-    container.appendChild(div);
+    document.body.appendChild(div);
 
     setDiv(div);
 
     return () => {
-      container.classList.remove("excalidraw-modal-container--visible");
-      container!.removeChild(div);
+      document.body.removeChild(div);
     };
   }, []);
 

--- a/src/components/ProjectName.tsx
+++ b/src/components/ProjectName.tsx
@@ -1,6 +1,7 @@
 import "./TextInput.scss";
 
 import React, { Component } from "react";
+import { focusNearestTabbableParent } from "../utils";
 
 type Props = {
   value: string;
@@ -17,14 +18,7 @@ export class ProjectName extends Component<Props, State> {
     fileName: this.props.value,
   };
   private handleBlur = (event: any) => {
-    let parent = (event.target as HTMLInputElement).parentElement;
-    while (parent) {
-      if (parent.tabIndex > -1) {
-        parent.focus();
-        break;
-      }
-      parent = parent.parentElement;
-    }
+    focusNearestTabbableParent(event.target);
     const value = event.target.value;
     if (value !== this.props.value) {
       this.props.onChange(value);

--- a/src/components/ProjectName.tsx
+++ b/src/components/ProjectName.tsx
@@ -17,6 +17,14 @@ export class ProjectName extends Component<Props, State> {
     fileName: this.props.value,
   };
   private handleBlur = (event: any) => {
+    let parent = (event.target as HTMLInputElement).parentElement;
+    while (parent) {
+      if (parent.tabIndex > -1) {
+        parent.focus();
+        break;
+      }
+      parent = parent.parentElement;
+    }
     const value = event.target.value;
     if (value !== this.props.value) {
       this.props.onChange(value);

--- a/src/components/ProjectName.tsx
+++ b/src/components/ProjectName.tsx
@@ -1,7 +1,7 @@
 import "./TextInput.scss";
 
 import React, { Component } from "react";
-import { focusNearestTabbableParent } from "../utils";
+import { focusNearestParent } from "../utils";
 
 type Props = {
   value: string;
@@ -18,7 +18,7 @@ export class ProjectName extends Component<Props, State> {
     fileName: this.props.value,
   };
   private handleBlur = (event: any) => {
-    focusNearestTabbableParent(event.target);
+    focusNearestParent(event.target);
     const value = event.target.value;
     if (value !== this.props.value) {
       this.props.onChange(value);

--- a/src/css/styles.scss
+++ b/src/css/styles.scss
@@ -19,6 +19,10 @@
   height: 100%;
   width: 100%;
 
+  &:focus {
+    outline: none;
+  }
+
   // serves 2 purposes:
   // 1. prevent selecting text outside the component when double-clicking or
   //    dragging inside it (e.g. on canvas)

--- a/src/data/library.ts
+++ b/src/data/library.ts
@@ -5,6 +5,7 @@ import { STORAGE_KEYS } from "../constants";
 import { getNonDeletedElements } from "../element";
 import { NonDeleted, ExcalidrawElement } from "../element/types";
 import { nanoid } from "nanoid";
+import { focusContainer } from "../utils";
 
 export class Library {
   private static libraryCache: LibraryItems | null = null;
@@ -13,7 +14,7 @@ export class Library {
   static resetLibrary = () => {
     Library.libraryCache = null;
     localStorage.removeItem(STORAGE_KEYS.LOCAL_STORAGE_LIBRARY);
-    document.querySelector<HTMLElement>(".excalidraw")!.focus();
+    focusContainer();
   };
 
   /** imports library (currently merges, removing duplicates) */

--- a/src/data/library.ts
+++ b/src/data/library.ts
@@ -13,6 +13,7 @@ export class Library {
   static resetLibrary = () => {
     Library.libraryCache = null;
     localStorage.removeItem(STORAGE_KEYS.LOCAL_STORAGE_LIBRARY);
+    document.querySelector<HTMLElement>(".excalidraw")!.focus();
   };
 
   /** imports library (currently merges, removing duplicates) */

--- a/src/data/library.ts
+++ b/src/data/library.ts
@@ -5,7 +5,6 @@ import { STORAGE_KEYS } from "../constants";
 import { getNonDeletedElements } from "../element";
 import { NonDeleted, ExcalidrawElement } from "../element/types";
 import { nanoid } from "nanoid";
-import { focusContainer } from "../utils";
 
 export class Library {
   private static libraryCache: LibraryItems | null = null;
@@ -14,7 +13,6 @@ export class Library {
   static resetLibrary = () => {
     Library.libraryCache = null;
     localStorage.removeItem(STORAGE_KEYS.LOCAL_STORAGE_LIBRARY);
-    focusContainer();
   };
 
   /** imports library (currently merges, removing duplicates) */

--- a/src/element/textWysiwyg.tsx
+++ b/src/element/textWysiwyg.tsx
@@ -159,11 +159,14 @@ export const textWysiwyg = ({
   // so that we don't need to create separate a callback for event handlers
   let submittedViaKeyboard = false;
   const handleSubmit = () => {
+    // cleanup must be run before onSubmit otherwise when app blurs the wysiwyg
+    // it'd get stuck in an infinite loop of blur→onSubmit after we re-focus the
+    // wysiwyg on update
+    cleanup();
     onSubmit({
       text: normalizeText(editable.value),
       viaKeyboard: submittedViaKeyboard,
     });
-    cleanup();
   };
 
   const cleanup = () => {

--- a/src/element/textWysiwyg.tsx
+++ b/src/element/textWysiwyg.tsx
@@ -70,10 +70,9 @@ export const textWysiwyg = ({
           appState.zoom.value -
         // margin-right of parent if any
         Number(
-          getComputedStyle(document.parentNode as Element).marginRight.slice(
-            0,
-            -2,
-          ),
+          getComputedStyle(
+            document.querySelector(".excalidraw")!.parentNode as Element,
+          ).marginRight.slice(0, -2),
         );
 
       Object.assign(editable.style, {

--- a/src/element/textWysiwyg.tsx
+++ b/src/element/textWysiwyg.tsx
@@ -70,9 +70,10 @@ export const textWysiwyg = ({
           appState.zoom.value -
         // margin-right of parent if any
         Number(
-          getComputedStyle(
-            document.querySelector(".excalidraw")!.parentNode as Element,
-          ).marginRight.slice(0, -2),
+          getComputedStyle(document.parentNode as Element).marginRight.slice(
+            0,
+            -2,
+          ),
         );
 
       Object.assign(editable.style, {

--- a/src/excalidraw-app/index.tsx
+++ b/src/excalidraw-app/index.tsx
@@ -325,7 +325,7 @@ const ExcalidrawWrapper = () => {
         langCode={langCode}
         renderCustomStats={renderCustomStats}
         detectScroll={false}
-        bindKeyGlobally={true}
+        handleKeyboardGlobally={true}
       />
       {excalidrawAPI && <CollabWrapper excalidrawAPI={excalidrawAPI} />}
       {errorMessage && (

--- a/src/excalidraw-app/index.tsx
+++ b/src/excalidraw-app/index.tsx
@@ -325,6 +325,7 @@ const ExcalidrawWrapper = () => {
         langCode={langCode}
         renderCustomStats={renderCustomStats}
         detectScroll={false}
+        bindKeyGlobally={true}
       />
       {excalidrawAPI && <CollabWrapper excalidrawAPI={excalidrawAPI} />}
       {errorMessage && (

--- a/src/packages/excalidraw/CHANGELOG.md
+++ b/src/packages/excalidraw/CHANGELOG.md
@@ -15,7 +15,14 @@ Please add the latest change on the top under the correct section.
 
 ## Excalidraw API
 
+### Features
+
 - Bind the keyboard events to component and added a prop [`bindKeyGlobally`](https://github.com/excalidraw/excalidraw/blob/master/src/packages/excalidraw/README.md#bindKeyGlobally) which if set to true will bind the keyboard events to document [#3430](https://github.com/excalidraw/excalidraw/pull/3430).
+
+  #### BREAKING CHNAGE
+
+  - Earlier keyboard events were bind to document but now its bind to Excalidraw component by default. So you will need to set [`bindKeyGlobally`](https://github.com/excalidraw/excalidraw/blob/master/src/packages/excalidraw/README.md#bindKeyGlobally) to true if you want the previous behaviour (bind the keyboard events to document).
+
 - Recompute offsets on `scroll` of the nearest scrollable container [#3408](https://github.com/excalidraw/excalidraw/pull/3408). This can be disabled by setting [`detectScroll`](https://github.com/excalidraw/excalidraw/blob/master/src/packages/excalidraw/README.md#detectScroll) to `false`.
 - Add `onPaste` prop to handle custom clipboard behaviours [#3420](https://github.com/excalidraw/excalidraw/pull/3420).
 

--- a/src/packages/excalidraw/CHANGELOG.md
+++ b/src/packages/excalidraw/CHANGELOG.md
@@ -17,11 +17,11 @@ Please add the latest change on the top under the correct section.
 
 ### Features
 
-- Bind the keyboard events to component and added a prop [`bindKeyGlobally`](https://github.com/excalidraw/excalidraw/blob/master/src/packages/excalidraw/README.md#bindKeyGlobally) which if set to true will bind the keyboard events to document [#3430](https://github.com/excalidraw/excalidraw/pull/3430).
+- Bind the keyboard events to component and added a prop [`handleKeyboardGlobally`](https://github.com/excalidraw/excalidraw/blob/master/src/packages/excalidraw/README.md#handleKeyboardGlobally) which if set to true will bind the keyboard events to document [#3430](https://github.com/excalidraw/excalidraw/pull/3430).
 
   #### BREAKING CHNAGE
 
-  - Earlier keyboard events were bind to document but now its bind to Excalidraw component by default. So you will need to set [`bindKeyGlobally`](https://github.com/excalidraw/excalidraw/blob/master/src/packages/excalidraw/README.md#bindKeyGlobally) to true if you want the previous behaviour (bind the keyboard events to document).
+  - Earlier keyboard events were bind to document but now its bind to Excalidraw component by default. So you will need to set [`handleKeyboardGlobally`](https://github.com/excalidraw/excalidraw/blob/master/src/packages/excalidraw/README.md#handleKeyboardGlobally) to true if you want the previous behaviour (bind the keyboard events to document).
 
 - Recompute offsets on `scroll` of the nearest scrollable container [#3408](https://github.com/excalidraw/excalidraw/pull/3408). This can be disabled by setting [`detectScroll`](https://github.com/excalidraw/excalidraw/blob/master/src/packages/excalidraw/README.md#detectScroll) to `false`.
 - Add `onPaste` prop to handle custom clipboard behaviours [#3420](https://github.com/excalidraw/excalidraw/pull/3420).

--- a/src/packages/excalidraw/CHANGELOG.md
+++ b/src/packages/excalidraw/CHANGELOG.md
@@ -15,6 +15,7 @@ Please add the latest change on the top under the correct section.
 
 ## Excalidraw API
 
+- Bind the keyboard events to component and added a prop [`bindKeyGlobally`](https://github.com/excalidraw/excalidraw/blob/master/src/packages/excalidraw/README.md#bindKeyGlobally) which if set to true will bind the keyboard events to document [#3430](https://github.com/excalidraw/excalidraw/pull/3430).
 - Recompute offsets on `scroll` of the nearest scrollable container [#3408](https://github.com/excalidraw/excalidraw/pull/3408). This can be disabled by setting [`detectScroll`](https://github.com/excalidraw/excalidraw/blob/master/src/packages/excalidraw/README.md#detectScroll) to `false`.
 - Add `onPaste` prop to handle custom clipboard behaviours [#3420](https://github.com/excalidraw/excalidraw/pull/3420).
 

--- a/src/packages/excalidraw/README_NEXT.md
+++ b/src/packages/excalidraw/README_NEXT.md
@@ -595,7 +595,9 @@ Indicates whether Excalidraw should listen for `scroll` event on the nearest scr
 
 ### bindKeyGlobally
 
-Indicates whether to bind keyboard events to document. By default this is false and keyboard events are bind to the excalidraw component.
+Indicates whether to bind keyboard events to `document`. Disabled by default, meaning the keyboard events are bound to the Excalidraw component. This allows for multiple Excalidraw components to live on the same page, and ensures that Excalidraw keyboard handling doesn't collide with your app's (or the browser) when the component isn't focused.
+
+Enable this if you want Excalidraw to handle keyboard even if the component isn't focused (e.g. a user is interacting with the navbar, sidebar, or similar).
 
 ### Extra API's
 

--- a/src/packages/excalidraw/README_NEXT.md
+++ b/src/packages/excalidraw/README_NEXT.md
@@ -366,6 +366,7 @@ To view the full example visit :point_down:
 | [`UIOptions`](#UIOptions) | <pre>{ canvasActions: <a href="https://github.com/excalidraw/excalidraw/blob/master/src/types.ts#L208"> CanvasActions<a/> }</pre> | [DEFAULT UI OPTIONS](https://github.com/excalidraw/excalidraw/blob/master/src/constants.ts#L129) | To customise UI options. Currently we support customising [`canvas actions`](#canvasActions) |
 | [`onPaste`](#onPaste) | <pre>(data: <a href="https://github.com/excalidraw/excalidraw/blob/master/src/clipboard.ts#L17">ClipboardData</a>, event: ClipboardEvent &#124; null) => boolean</pre> |  | Callback to be triggered if passed when the something is pasted in to the scene |
 | [`detectScroll`](#detectScroll) | boolean | true | Indicates whether to update the offsets when nearest ancestor is scrolled. |
+| [`bindKeyGlobally`](#bindKeyGlobally) | boolean | false | Indicates whether to bind the keyboard events to document. |
 
 ### Dimensions of Excalidraw
 
@@ -591,6 +592,10 @@ Try out the [Demo](#Demo) to see it in action.
 ### detectScroll
 
 Indicates whether Excalidraw should listen for `scroll` event on the nearest scrollable container in the DOM tree and recompute the coordinates (e.g. to correctly handle the cursor) when the component's position changes. You can disable this when you either know this doesn't affect your app or you want to take care of it yourself (calling the [`refresh()`](#ref) method).
+
+### bindKeyGlobally
+
+Indicates whether to bind keyboard events to document. By default this is false and keyboard events are bind to the excalidraw component.
 
 ### Extra API's
 

--- a/src/packages/excalidraw/README_NEXT.md
+++ b/src/packages/excalidraw/README_NEXT.md
@@ -366,7 +366,7 @@ To view the full example visit :point_down:
 | [`UIOptions`](#UIOptions) | <pre>{ canvasActions: <a href="https://github.com/excalidraw/excalidraw/blob/master/src/types.ts#L208"> CanvasActions<a/> }</pre> | [DEFAULT UI OPTIONS](https://github.com/excalidraw/excalidraw/blob/master/src/constants.ts#L129) | To customise UI options. Currently we support customising [`canvas actions`](#canvasActions) |
 | [`onPaste`](#onPaste) | <pre>(data: <a href="https://github.com/excalidraw/excalidraw/blob/master/src/clipboard.ts#L17">ClipboardData</a>, event: ClipboardEvent &#124; null) => boolean</pre> |  | Callback to be triggered if passed when the something is pasted in to the scene |
 | [`detectScroll`](#detectScroll) | boolean | true | Indicates whether to update the offsets when nearest ancestor is scrolled. |
-| [`bindKeyGlobally`](#bindKeyGlobally) | boolean | false | Indicates whether to bind the keyboard events to document. |
+| [`handleKeyboardGlobally`](#handleKeyboardGlobally) | boolean | false | Indicates whether to bind the keyboard events to document. |
 
 ### Dimensions of Excalidraw
 
@@ -593,7 +593,7 @@ Try out the [Demo](#Demo) to see it in action.
 
 Indicates whether Excalidraw should listen for `scroll` event on the nearest scrollable container in the DOM tree and recompute the coordinates (e.g. to correctly handle the cursor) when the component's position changes. You can disable this when you either know this doesn't affect your app or you want to take care of it yourself (calling the [`refresh()`](#ref) method).
 
-### bindKeyGlobally
+### handleKeyboardGlobally
 
 Indicates whether to bind keyboard events to `document`. Disabled by default, meaning the keyboard events are bound to the Excalidraw component. This allows for multiple Excalidraw components to live on the same page, and ensures that Excalidraw keyboard handling doesn't collide with your app's (or the browser) when the component isn't focused.
 

--- a/src/packages/excalidraw/index.tsx
+++ b/src/packages/excalidraw/index.tsx
@@ -31,6 +31,7 @@ const Excalidraw = (props: ExcalidrawProps) => {
     renderCustomStats,
     onPaste,
     detectScroll = true,
+    bindKeyGlobally = false,
   } = props;
 
   const canvasActions = props.UIOptions?.canvasActions;
@@ -82,6 +83,7 @@ const Excalidraw = (props: ExcalidrawProps) => {
         UIOptions={UIOptions}
         onPaste={onPaste}
         detectScroll={detectScroll}
+        bindKeyGlobally={bindKeyGlobally}
       />
     </InitializeApp>
   );

--- a/src/packages/excalidraw/index.tsx
+++ b/src/packages/excalidraw/index.tsx
@@ -31,7 +31,7 @@ const Excalidraw = (props: ExcalidrawProps) => {
     renderCustomStats,
     onPaste,
     detectScroll = true,
-    bindKeyGlobally = false,
+    handleKeyboardGlobally = false,
   } = props;
 
   const canvasActions = props.UIOptions?.canvasActions;
@@ -83,7 +83,7 @@ const Excalidraw = (props: ExcalidrawProps) => {
         UIOptions={UIOptions}
         onPaste={onPaste}
         detectScroll={detectScroll}
-        bindKeyGlobally={bindKeyGlobally}
+        handleKeyboardGlobally={handleKeyboardGlobally}
       />
     </InitializeApp>
   );

--- a/src/tests/__snapshots__/dragCreate.test.tsx.snap
+++ b/src/tests/__snapshots__/dragCreate.test.tsx.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`add element to the scene when pointer dragging long enough arrow 1`] = `1`;
+exports[`Test dragCreate add element to the scene when pointer dragging long enough arrow 1`] = `1`;
 
-exports[`add element to the scene when pointer dragging long enough arrow 2`] = `
+exports[`Test dragCreate add element to the scene when pointer dragging long enough arrow 2`] = `
 Object {
   "angle": 0,
   "backgroundColor": "transparent",
@@ -43,9 +43,9 @@ Object {
 }
 `;
 
-exports[`add element to the scene when pointer dragging long enough diamond 1`] = `1`;
+exports[`Test dragCreate add element to the scene when pointer dragging long enough diamond 1`] = `1`;
 
-exports[`add element to the scene when pointer dragging long enough diamond 2`] = `
+exports[`Test dragCreate add element to the scene when pointer dragging long enough diamond 2`] = `
 Object {
   "angle": 0,
   "backgroundColor": "transparent",
@@ -71,9 +71,9 @@ Object {
 }
 `;
 
-exports[`add element to the scene when pointer dragging long enough ellipse 1`] = `1`;
+exports[`Test dragCreate add element to the scene when pointer dragging long enough ellipse 1`] = `1`;
 
-exports[`add element to the scene when pointer dragging long enough ellipse 2`] = `
+exports[`Test dragCreate add element to the scene when pointer dragging long enough ellipse 2`] = `
 Object {
   "angle": 0,
   "backgroundColor": "transparent",
@@ -99,7 +99,7 @@ Object {
 }
 `;
 
-exports[`add element to the scene when pointer dragging long enough line 1`] = `
+exports[`Test dragCreate add element to the scene when pointer dragging long enough line 1`] = `
 Object {
   "angle": 0,
   "backgroundColor": "transparent",
@@ -140,9 +140,9 @@ Object {
 }
 `;
 
-exports[`add element to the scene when pointer dragging long enough rectangle 1`] = `1`;
+exports[`Test dragCreate add element to the scene when pointer dragging long enough rectangle 1`] = `1`;
 
-exports[`add element to the scene when pointer dragging long enough rectangle 2`] = `
+exports[`Test dragCreate add element to the scene when pointer dragging long enough rectangle 2`] = `
 Object {
   "angle": 0,
   "backgroundColor": "transparent",

--- a/src/tests/dragCreate.test.tsx
+++ b/src/tests/dragCreate.test.tsx
@@ -24,276 +24,282 @@ beforeEach(() => {
 
 const { h } = window;
 
-describe("add element to the scene when pointer dragging long enough", () => {
-  it("rectangle", async () => {
-    const { getByToolName, container } = await render(<ExcalidrawApp />);
-    // select tool
-    const tool = getByToolName("rectangle");
-    fireEvent.click(tool);
+describe("Test dragCreate", () => {
+  describe("add element to the scene when pointer dragging long enough", () => {
+    it("rectangle", async () => {
+      const { getByToolName, container } = await render(<ExcalidrawApp />);
+      // select tool
+      const tool = getByToolName("rectangle");
+      fireEvent.click(tool);
 
-    const canvas = container.querySelector("canvas")!;
+      const canvas = container.querySelector("canvas")!;
 
-    // start from (30, 20)
-    fireEvent.pointerDown(canvas, { clientX: 30, clientY: 20 });
+      // start from (30, 20)
+      fireEvent.pointerDown(canvas, { clientX: 30, clientY: 20 });
 
-    // move to (60,70)
-    fireEvent.pointerMove(canvas, { clientX: 60, clientY: 70 });
+      // move to (60,70)
+      fireEvent.pointerMove(canvas, { clientX: 60, clientY: 70 });
 
-    // finish (position does not matter)
-    fireEvent.pointerUp(canvas);
+      // finish (position does not matter)
+      fireEvent.pointerUp(canvas);
 
-    expect(renderScene).toHaveBeenCalledTimes(8);
-    expect(h.state.selectionElement).toBeNull();
+      expect(renderScene).toHaveBeenCalledTimes(8);
+      expect(h.state.selectionElement).toBeNull();
 
-    expect(h.elements.length).toEqual(1);
-    expect(h.elements[0].type).toEqual("rectangle");
-    expect(h.elements[0].x).toEqual(30);
-    expect(h.elements[0].y).toEqual(20);
-    expect(h.elements[0].width).toEqual(30); // 60 - 30
-    expect(h.elements[0].height).toEqual(50); // 70 - 20
+      expect(h.elements.length).toEqual(1);
+      expect(h.elements[0].type).toEqual("rectangle");
+      expect(h.elements[0].x).toEqual(30);
+      expect(h.elements[0].y).toEqual(20);
+      expect(h.elements[0].width).toEqual(30); // 60 - 30
+      expect(h.elements[0].height).toEqual(50); // 70 - 20
 
-    expect(h.elements.length).toMatchSnapshot();
-    h.elements.forEach((element) => expect(element).toMatchSnapshot());
+      expect(h.elements.length).toMatchSnapshot();
+      h.elements.forEach((element) => expect(element).toMatchSnapshot());
+    });
+
+    it("ellipse", async () => {
+      const { getByToolName, container } = await render(<ExcalidrawApp />);
+      // select tool
+      const tool = getByToolName("ellipse");
+      fireEvent.click(tool);
+
+      const canvas = container.querySelector("canvas")!;
+
+      // start from (30, 20)
+      fireEvent.pointerDown(canvas, { clientX: 30, clientY: 20 });
+
+      // move to (60,70)
+      fireEvent.pointerMove(canvas, { clientX: 60, clientY: 70 });
+
+      // finish (position does not matter)
+      fireEvent.pointerUp(canvas);
+
+      expect(renderScene).toHaveBeenCalledTimes(8);
+      expect(h.state.selectionElement).toBeNull();
+
+      expect(h.elements.length).toEqual(1);
+      expect(h.elements[0].type).toEqual("ellipse");
+      expect(h.elements[0].x).toEqual(30);
+      expect(h.elements[0].y).toEqual(20);
+      expect(h.elements[0].width).toEqual(30); // 60 - 30
+      expect(h.elements[0].height).toEqual(50); // 70 - 20
+
+      expect(h.elements.length).toMatchSnapshot();
+      h.elements.forEach((element) => expect(element).toMatchSnapshot());
+    });
+
+    it("diamond", async () => {
+      const { getByToolName, container } = await render(<ExcalidrawApp />);
+      // select tool
+      const tool = getByToolName("diamond");
+      fireEvent.click(tool);
+
+      const canvas = container.querySelector("canvas")!;
+
+      // start from (30, 20)
+      fireEvent.pointerDown(canvas, { clientX: 30, clientY: 20 });
+
+      // move to (60,70)
+      fireEvent.pointerMove(canvas, { clientX: 60, clientY: 70 });
+
+      // finish (position does not matter)
+      fireEvent.pointerUp(canvas);
+
+      expect(renderScene).toHaveBeenCalledTimes(8);
+      expect(h.state.selectionElement).toBeNull();
+
+      expect(h.elements.length).toEqual(1);
+      expect(h.elements[0].type).toEqual("diamond");
+      expect(h.elements[0].x).toEqual(30);
+      expect(h.elements[0].y).toEqual(20);
+      expect(h.elements[0].width).toEqual(30); // 60 - 30
+      expect(h.elements[0].height).toEqual(50); // 70 - 20
+
+      expect(h.elements.length).toMatchSnapshot();
+      h.elements.forEach((element) => expect(element).toMatchSnapshot());
+    });
+
+    it("arrow", async () => {
+      const { getByToolName, container } = await render(<ExcalidrawApp />);
+      // select tool
+      const tool = getByToolName("arrow");
+      fireEvent.click(tool);
+
+      const canvas = container.querySelector("canvas")!;
+
+      // start from (30, 20)
+      fireEvent.pointerDown(canvas, { clientX: 30, clientY: 20 });
+
+      // move to (60,70)
+      fireEvent.pointerMove(canvas, { clientX: 60, clientY: 70 });
+
+      // finish (position does not matter)
+      fireEvent.pointerUp(canvas);
+
+      expect(renderScene).toHaveBeenCalledTimes(8);
+      expect(h.state.selectionElement).toBeNull();
+
+      expect(h.elements.length).toEqual(1);
+
+      const element = h.elements[0] as ExcalidrawLinearElement;
+
+      expect(element.type).toEqual("arrow");
+      expect(element.x).toEqual(30);
+      expect(element.y).toEqual(20);
+      expect(element.points.length).toEqual(2);
+      expect(element.points[0]).toEqual([0, 0]);
+      expect(element.points[1]).toEqual([30, 50]); // (60 - 30, 70 - 20)
+
+      expect(h.elements.length).toMatchSnapshot();
+      h.elements.forEach((element) => expect(element).toMatchSnapshot());
+    });
+
+    it("line", async () => {
+      const { getByToolName, container } = await render(<ExcalidrawApp />);
+      // select tool
+      const tool = getByToolName("line");
+      fireEvent.click(tool);
+
+      const canvas = container.querySelector("canvas")!;
+
+      // start from (30, 20)
+      fireEvent.pointerDown(canvas, { clientX: 30, clientY: 20 });
+
+      // move to (60,70)
+      fireEvent.pointerMove(canvas, { clientX: 60, clientY: 70 });
+
+      // finish (position does not matter)
+      fireEvent.pointerUp(canvas);
+
+      expect(renderScene).toHaveBeenCalledTimes(8);
+      expect(h.state.selectionElement).toBeNull();
+
+      expect(h.elements.length).toEqual(1);
+
+      const element = h.elements[0] as ExcalidrawLinearElement;
+
+      expect(element.type).toEqual("line");
+      expect(element.x).toEqual(30);
+      expect(element.y).toEqual(20);
+      expect(element.points.length).toEqual(2);
+      expect(element.points[0]).toEqual([0, 0]);
+      expect(element.points[1]).toEqual([30, 50]); // (60 - 30, 70 - 20)
+
+      h.elements.forEach((element) => expect(element).toMatchSnapshot());
+    });
   });
 
-  it("ellipse", async () => {
-    const { getByToolName, container } = await render(<ExcalidrawApp />);
-    // select tool
-    const tool = getByToolName("ellipse");
-    fireEvent.click(tool);
+  describe("do not add element to the scene if size is too small", () => {
+    beforeAll(() => {
+      mockBoundingClientRect();
+    });
+    afterAll(() => {
+      restoreOriginalGetBoundingClientRect();
+    });
 
-    const canvas = container.querySelector("canvas")!;
+    it("rectangle", async () => {
+      const { getByToolName, container } = await render(<ExcalidrawApp />);
+      // select tool
+      const tool = getByToolName("rectangle");
+      fireEvent.click(tool);
 
-    // start from (30, 20)
-    fireEvent.pointerDown(canvas, { clientX: 30, clientY: 20 });
+      const canvas = container.querySelector("canvas")!;
 
-    // move to (60,70)
-    fireEvent.pointerMove(canvas, { clientX: 60, clientY: 70 });
+      // start from (30, 20)
+      fireEvent.pointerDown(canvas, { clientX: 30, clientY: 20 });
 
-    // finish (position does not matter)
-    fireEvent.pointerUp(canvas);
+      // finish (position does not matter)
+      fireEvent.pointerUp(canvas);
 
-    expect(renderScene).toHaveBeenCalledTimes(8);
-    expect(h.state.selectionElement).toBeNull();
+      expect(renderScene).toHaveBeenCalledTimes(6);
+      expect(h.state.selectionElement).toBeNull();
+      expect(h.elements.length).toEqual(0);
+    });
 
-    expect(h.elements.length).toEqual(1);
-    expect(h.elements[0].type).toEqual("ellipse");
-    expect(h.elements[0].x).toEqual(30);
-    expect(h.elements[0].y).toEqual(20);
-    expect(h.elements[0].width).toEqual(30); // 60 - 30
-    expect(h.elements[0].height).toEqual(50); // 70 - 20
+    it("ellipse", async () => {
+      const { getByToolName, container } = await render(<ExcalidrawApp />);
+      // select tool
+      const tool = getByToolName("ellipse");
+      fireEvent.click(tool);
 
-    expect(h.elements.length).toMatchSnapshot();
-    h.elements.forEach((element) => expect(element).toMatchSnapshot());
-  });
+      const canvas = container.querySelector("canvas")!;
 
-  it("diamond", async () => {
-    const { getByToolName, container } = await render(<ExcalidrawApp />);
-    // select tool
-    const tool = getByToolName("diamond");
-    fireEvent.click(tool);
+      // start from (30, 20)
+      fireEvent.pointerDown(canvas, { clientX: 30, clientY: 20 });
 
-    const canvas = container.querySelector("canvas")!;
+      // finish (position does not matter)
+      fireEvent.pointerUp(canvas);
 
-    // start from (30, 20)
-    fireEvent.pointerDown(canvas, { clientX: 30, clientY: 20 });
+      expect(renderScene).toHaveBeenCalledTimes(6);
+      expect(h.state.selectionElement).toBeNull();
+      expect(h.elements.length).toEqual(0);
+    });
 
-    // move to (60,70)
-    fireEvent.pointerMove(canvas, { clientX: 60, clientY: 70 });
+    it("diamond", async () => {
+      const { getByToolName, container } = await render(<ExcalidrawApp />);
+      // select tool
+      const tool = getByToolName("diamond");
+      fireEvent.click(tool);
 
-    // finish (position does not matter)
-    fireEvent.pointerUp(canvas);
+      const canvas = container.querySelector("canvas")!;
 
-    expect(renderScene).toHaveBeenCalledTimes(8);
-    expect(h.state.selectionElement).toBeNull();
+      // start from (30, 20)
+      fireEvent.pointerDown(canvas, { clientX: 30, clientY: 20 });
 
-    expect(h.elements.length).toEqual(1);
-    expect(h.elements[0].type).toEqual("diamond");
-    expect(h.elements[0].x).toEqual(30);
-    expect(h.elements[0].y).toEqual(20);
-    expect(h.elements[0].width).toEqual(30); // 60 - 30
-    expect(h.elements[0].height).toEqual(50); // 70 - 20
+      // finish (position does not matter)
+      fireEvent.pointerUp(canvas);
 
-    expect(h.elements.length).toMatchSnapshot();
-    h.elements.forEach((element) => expect(element).toMatchSnapshot());
-  });
+      expect(renderScene).toHaveBeenCalledTimes(6);
+      expect(h.state.selectionElement).toBeNull();
+      expect(h.elements.length).toEqual(0);
+    });
 
-  it("arrow", async () => {
-    const { getByToolName, container } = await render(<ExcalidrawApp />);
-    // select tool
-    const tool = getByToolName("arrow");
-    fireEvent.click(tool);
+    it("arrow", async () => {
+      const { getByToolName, container } = await render(<ExcalidrawApp />);
+      // select tool
+      const tool = getByToolName("arrow");
+      fireEvent.click(tool);
 
-    const canvas = container.querySelector("canvas")!;
+      const canvas = container.querySelector("canvas")!;
 
-    // start from (30, 20)
-    fireEvent.pointerDown(canvas, { clientX: 30, clientY: 20 });
+      // start from (30, 20)
+      fireEvent.pointerDown(canvas, { clientX: 30, clientY: 20 });
 
-    // move to (60,70)
-    fireEvent.pointerMove(canvas, { clientX: 60, clientY: 70 });
+      // finish (position does not matter)
+      fireEvent.pointerUp(canvas);
 
-    // finish (position does not matter)
-    fireEvent.pointerUp(canvas);
+      // we need to finalize it because arrows and lines enter multi-mode
+      fireEvent.keyDown(document.querySelector(".excalidraw")!, {
+        key: KEYS.ENTER,
+      });
 
-    expect(renderScene).toHaveBeenCalledTimes(8);
-    expect(h.state.selectionElement).toBeNull();
+      expect(renderScene).toHaveBeenCalledTimes(7);
+      expect(h.state.selectionElement).toBeNull();
+      expect(h.elements.length).toEqual(0);
+    });
 
-    expect(h.elements.length).toEqual(1);
+    it("line", async () => {
+      const { getByToolName, container } = await render(<ExcalidrawApp />);
+      // select tool
+      const tool = getByToolName("line");
+      fireEvent.click(tool);
 
-    const element = h.elements[0] as ExcalidrawLinearElement;
+      const canvas = container.querySelector("canvas")!;
 
-    expect(element.type).toEqual("arrow");
-    expect(element.x).toEqual(30);
-    expect(element.y).toEqual(20);
-    expect(element.points.length).toEqual(2);
-    expect(element.points[0]).toEqual([0, 0]);
-    expect(element.points[1]).toEqual([30, 50]); // (60 - 30, 70 - 20)
+      // start from (30, 20)
+      fireEvent.pointerDown(canvas, { clientX: 30, clientY: 20 });
 
-    expect(h.elements.length).toMatchSnapshot();
-    h.elements.forEach((element) => expect(element).toMatchSnapshot());
-  });
+      // finish (position does not matter)
+      fireEvent.pointerUp(canvas);
 
-  it("line", async () => {
-    const { getByToolName, container } = await render(<ExcalidrawApp />);
-    // select tool
-    const tool = getByToolName("line");
-    fireEvent.click(tool);
+      // we need to finalize it because arrows and lines enter multi-mode
+      fireEvent.keyDown(document.querySelector(".excalidraw")!, {
+        key: KEYS.ENTER,
+      });
 
-    const canvas = container.querySelector("canvas")!;
-
-    // start from (30, 20)
-    fireEvent.pointerDown(canvas, { clientX: 30, clientY: 20 });
-
-    // move to (60,70)
-    fireEvent.pointerMove(canvas, { clientX: 60, clientY: 70 });
-
-    // finish (position does not matter)
-    fireEvent.pointerUp(canvas);
-
-    expect(renderScene).toHaveBeenCalledTimes(8);
-    expect(h.state.selectionElement).toBeNull();
-
-    expect(h.elements.length).toEqual(1);
-
-    const element = h.elements[0] as ExcalidrawLinearElement;
-
-    expect(element.type).toEqual("line");
-    expect(element.x).toEqual(30);
-    expect(element.y).toEqual(20);
-    expect(element.points.length).toEqual(2);
-    expect(element.points[0]).toEqual([0, 0]);
-    expect(element.points[1]).toEqual([30, 50]); // (60 - 30, 70 - 20)
-
-    h.elements.forEach((element) => expect(element).toMatchSnapshot());
-  });
-});
-
-describe("do not add element to the scene if size is too small", () => {
-  beforeAll(() => {
-    mockBoundingClientRect();
-  });
-  afterAll(() => {
-    restoreOriginalGetBoundingClientRect();
-  });
-
-  it("rectangle", async () => {
-    const { getByToolName, container } = await render(<ExcalidrawApp />);
-    // select tool
-    const tool = getByToolName("rectangle");
-    fireEvent.click(tool);
-
-    const canvas = container.querySelector("canvas")!;
-
-    // start from (30, 20)
-    fireEvent.pointerDown(canvas, { clientX: 30, clientY: 20 });
-
-    // finish (position does not matter)
-    fireEvent.pointerUp(canvas);
-
-    expect(renderScene).toHaveBeenCalledTimes(6);
-    expect(h.state.selectionElement).toBeNull();
-    expect(h.elements.length).toEqual(0);
-  });
-
-  it("ellipse", async () => {
-    const { getByToolName, container } = await render(<ExcalidrawApp />);
-    // select tool
-    const tool = getByToolName("ellipse");
-    fireEvent.click(tool);
-
-    const canvas = container.querySelector("canvas")!;
-
-    // start from (30, 20)
-    fireEvent.pointerDown(canvas, { clientX: 30, clientY: 20 });
-
-    // finish (position does not matter)
-    fireEvent.pointerUp(canvas);
-
-    expect(renderScene).toHaveBeenCalledTimes(6);
-    expect(h.state.selectionElement).toBeNull();
-    expect(h.elements.length).toEqual(0);
-  });
-
-  it("diamond", async () => {
-    const { getByToolName, container } = await render(<ExcalidrawApp />);
-    // select tool
-    const tool = getByToolName("diamond");
-    fireEvent.click(tool);
-
-    const canvas = container.querySelector("canvas")!;
-
-    // start from (30, 20)
-    fireEvent.pointerDown(canvas, { clientX: 30, clientY: 20 });
-
-    // finish (position does not matter)
-    fireEvent.pointerUp(canvas);
-
-    expect(renderScene).toHaveBeenCalledTimes(6);
-    expect(h.state.selectionElement).toBeNull();
-    expect(h.elements.length).toEqual(0);
-  });
-
-  it("arrow", async () => {
-    const { getByToolName, container } = await render(<ExcalidrawApp />);
-    // select tool
-    const tool = getByToolName("arrow");
-    fireEvent.click(tool);
-
-    const canvas = container.querySelector("canvas")!;
-
-    // start from (30, 20)
-    fireEvent.pointerDown(canvas, { clientX: 30, clientY: 20 });
-
-    // finish (position does not matter)
-    fireEvent.pointerUp(canvas);
-
-    // we need to finalize it because arrows and lines enter multi-mode
-    fireEvent.keyDown(document, { key: KEYS.ENTER });
-
-    expect(renderScene).toHaveBeenCalledTimes(7);
-    expect(h.state.selectionElement).toBeNull();
-    expect(h.elements.length).toEqual(0);
-  });
-
-  it("line", async () => {
-    const { getByToolName, container } = await render(<ExcalidrawApp />);
-    // select tool
-    const tool = getByToolName("line");
-    fireEvent.click(tool);
-
-    const canvas = container.querySelector("canvas")!;
-
-    // start from (30, 20)
-    fireEvent.pointerDown(canvas, { clientX: 30, clientY: 20 });
-
-    // finish (position does not matter)
-    fireEvent.pointerUp(canvas);
-
-    // we need to finalize it because arrows and lines enter multi-mode
-    fireEvent.keyDown(document, { key: KEYS.ENTER });
-
-    expect(renderScene).toHaveBeenCalledTimes(7);
-    expect(h.state.selectionElement).toBeNull();
-    expect(h.elements.length).toEqual(0);
+      expect(renderScene).toHaveBeenCalledTimes(7);
+      expect(h.state.selectionElement).toBeNull();
+      expect(h.elements.length).toEqual(0);
+    });
   });
 });

--- a/src/tests/dragCreate.test.tsx
+++ b/src/tests/dragCreate.test.tsx
@@ -269,7 +269,7 @@ describe("Test dragCreate", () => {
       fireEvent.pointerUp(canvas);
 
       // we need to finalize it because arrows and lines enter multi-mode
-      fireEvent.keyDown(document.querySelector(".excalidraw")!, {
+      fireEvent.keyDown(document, {
         key: KEYS.ENTER,
       });
 
@@ -293,7 +293,7 @@ describe("Test dragCreate", () => {
       fireEvent.pointerUp(canvas);
 
       // we need to finalize it because arrows and lines enter multi-mode
-      fireEvent.keyDown(document.querySelector(".excalidraw")!, {
+      fireEvent.keyDown(document, {
         key: KEYS.ENTER,
       });
 

--- a/src/tests/helpers/ui.ts
+++ b/src/tests/helpers/ui.ts
@@ -40,7 +40,7 @@ export class Keyboard {
   };
 
   static keyDown = (key: string) => {
-    fireEvent.keyDown(document, {
+    fireEvent.keyDown(document.querySelector(".excalidraw")!, {
       key,
       ctrlKey,
       shiftKey,
@@ -49,7 +49,7 @@ export class Keyboard {
   };
 
   static keyUp = (key: string) => {
-    fireEvent.keyUp(document, {
+    fireEvent.keyUp(document.querySelector(".excalidraw")!, {
       key,
       ctrlKey,
       shiftKey,
@@ -63,7 +63,7 @@ export class Keyboard {
   };
 
   static codeDown = (code: string) => {
-    fireEvent.keyDown(document, {
+    fireEvent.keyDown(document.querySelector(".excalidraw")!, {
       code,
       ctrlKey,
       shiftKey,
@@ -72,7 +72,7 @@ export class Keyboard {
   };
 
   static codeUp = (code: string) => {
-    fireEvent.keyUp(document, {
+    fireEvent.keyUp(document.querySelector(".excalidraw")!, {
       code,
       ctrlKey,
       shiftKey,

--- a/src/tests/helpers/ui.ts
+++ b/src/tests/helpers/ui.ts
@@ -40,7 +40,7 @@ export class Keyboard {
   };
 
   static keyDown = (key: string) => {
-    fireEvent.keyDown(document.querySelector(".excalidraw")!, {
+    fireEvent.keyDown(document, {
       key,
       ctrlKey,
       shiftKey,
@@ -49,7 +49,7 @@ export class Keyboard {
   };
 
   static keyUp = (key: string) => {
-    fireEvent.keyUp(document.querySelector(".excalidraw")!, {
+    fireEvent.keyUp(document, {
       key,
       ctrlKey,
       shiftKey,
@@ -63,7 +63,7 @@ export class Keyboard {
   };
 
   static codeDown = (code: string) => {
-    fireEvent.keyDown(document.querySelector(".excalidraw")!, {
+    fireEvent.keyDown(document, {
       code,
       ctrlKey,
       shiftKey,
@@ -72,7 +72,7 @@ export class Keyboard {
   };
 
   static codeUp = (code: string) => {
-    fireEvent.keyUp(document.querySelector(".excalidraw")!, {
+    fireEvent.keyUp(document, {
       code,
       ctrlKey,
       shiftKey,

--- a/src/tests/multiPointCreate.test.tsx
+++ b/src/tests/multiPointCreate.test.tsx
@@ -99,7 +99,7 @@ describe("multi point mode in linear elements", () => {
     // done
     fireEvent.pointerDown(canvas);
     fireEvent.pointerUp(canvas);
-    fireEvent.keyDown(document.querySelector(".excalidraw")!, {
+    fireEvent.keyDown(document, {
       key: KEYS.ENTER,
     });
 
@@ -142,7 +142,7 @@ describe("multi point mode in linear elements", () => {
     // done
     fireEvent.pointerDown(canvas);
     fireEvent.pointerUp(canvas);
-    fireEvent.keyDown(document.querySelector(".excalidraw")!, {
+    fireEvent.keyDown(document, {
       key: KEYS.ENTER,
     });
 

--- a/src/tests/multiPointCreate.test.tsx
+++ b/src/tests/multiPointCreate.test.tsx
@@ -99,7 +99,9 @@ describe("multi point mode in linear elements", () => {
     // done
     fireEvent.pointerDown(canvas);
     fireEvent.pointerUp(canvas);
-    fireEvent.keyDown(document, { key: KEYS.ENTER });
+    fireEvent.keyDown(document.querySelector(".excalidraw")!, {
+      key: KEYS.ENTER,
+    });
 
     expect(renderScene).toHaveBeenCalledTimes(14);
     expect(h.elements.length).toEqual(1);
@@ -140,7 +142,9 @@ describe("multi point mode in linear elements", () => {
     // done
     fireEvent.pointerDown(canvas);
     fireEvent.pointerUp(canvas);
-    fireEvent.keyDown(document, { key: KEYS.ENTER });
+    fireEvent.keyDown(document.querySelector(".excalidraw")!, {
+      key: KEYS.ENTER,
+    });
 
     expect(renderScene).toHaveBeenCalledTimes(14);
     expect(h.elements.length).toEqual(1);

--- a/src/tests/regressionTests.test.tsx
+++ b/src/tests/regressionTests.test.tsx
@@ -413,20 +413,20 @@ describe("regression tests", () => {
 
   it("zoom hotkeys", () => {
     expect(h.state.zoom.value).toBe(1);
-    fireEvent.keyDown(document.querySelector(".excalidraw")!, {
+    fireEvent.keyDown(document, {
       code: CODES.EQUAL,
       ctrlKey: true,
     });
-    fireEvent.keyUp(document.querySelector(".excalidraw")!, {
+    fireEvent.keyUp(document, {
       code: CODES.EQUAL,
       ctrlKey: true,
     });
     expect(h.state.zoom.value).toBeGreaterThan(1);
-    fireEvent.keyDown(document.querySelector(".excalidraw")!, {
+    fireEvent.keyDown(document, {
       code: CODES.MINUS,
       ctrlKey: true,
     });
-    fireEvent.keyUp(document.querySelector(".excalidraw")!, {
+    fireEvent.keyUp(document, {
       code: CODES.MINUS,
       ctrlKey: true,
     });

--- a/src/tests/regressionTests.test.tsx
+++ b/src/tests/regressionTests.test.tsx
@@ -413,11 +413,23 @@ describe("regression tests", () => {
 
   it("zoom hotkeys", () => {
     expect(h.state.zoom.value).toBe(1);
-    fireEvent.keyDown(document, { code: CODES.EQUAL, ctrlKey: true });
-    fireEvent.keyUp(document, { code: CODES.EQUAL, ctrlKey: true });
+    fireEvent.keyDown(document.querySelector(".excalidraw")!, {
+      code: CODES.EQUAL,
+      ctrlKey: true,
+    });
+    fireEvent.keyUp(document.querySelector(".excalidraw")!, {
+      code: CODES.EQUAL,
+      ctrlKey: true,
+    });
     expect(h.state.zoom.value).toBeGreaterThan(1);
-    fireEvent.keyDown(document, { code: CODES.MINUS, ctrlKey: true });
-    fireEvent.keyUp(document, { code: CODES.MINUS, ctrlKey: true });
+    fireEvent.keyDown(document.querySelector(".excalidraw")!, {
+      code: CODES.MINUS,
+      ctrlKey: true,
+    });
+    fireEvent.keyUp(document.querySelector(".excalidraw")!, {
+      code: CODES.MINUS,
+      ctrlKey: true,
+    });
     expect(h.state.zoom.value).toBe(1);
   });
 

--- a/src/tests/selection.test.tsx
+++ b/src/tests/selection.test.tsx
@@ -100,7 +100,7 @@ describe("select single element on the scene", () => {
       fireEvent.pointerDown(canvas, { clientX: 30, clientY: 20 });
       fireEvent.pointerMove(canvas, { clientX: 60, clientY: 70 });
       fireEvent.pointerUp(canvas);
-      fireEvent.keyDown(document.querySelector(".excalidraw")!, {
+      fireEvent.keyDown(document, {
         key: KEYS.ESCAPE,
       });
     }
@@ -129,7 +129,7 @@ describe("select single element on the scene", () => {
       fireEvent.pointerDown(canvas, { clientX: 30, clientY: 20 });
       fireEvent.pointerMove(canvas, { clientX: 60, clientY: 70 });
       fireEvent.pointerUp(canvas);
-      fireEvent.keyDown(document.querySelector(".excalidraw")!, {
+      fireEvent.keyDown(document, {
         key: KEYS.ESCAPE,
       });
     }
@@ -158,7 +158,7 @@ describe("select single element on the scene", () => {
       fireEvent.pointerDown(canvas, { clientX: 30, clientY: 20 });
       fireEvent.pointerMove(canvas, { clientX: 60, clientY: 70 });
       fireEvent.pointerUp(canvas);
-      fireEvent.keyDown(document.querySelector(".excalidraw")!, {
+      fireEvent.keyDown(document, {
         key: KEYS.ESCAPE,
       });
     }
@@ -187,7 +187,7 @@ describe("select single element on the scene", () => {
       fireEvent.pointerDown(canvas, { clientX: 30, clientY: 20 });
       fireEvent.pointerMove(canvas, { clientX: 60, clientY: 70 });
       fireEvent.pointerUp(canvas);
-      fireEvent.keyDown(document.querySelector(".excalidraw")!, {
+      fireEvent.keyDown(document, {
         key: KEYS.ESCAPE,
       });
     }
@@ -228,7 +228,7 @@ describe("select single element on the scene", () => {
       fireEvent.pointerDown(canvas, { clientX: 30, clientY: 20 });
       fireEvent.pointerMove(canvas, { clientX: 60, clientY: 70 });
       fireEvent.pointerUp(canvas);
-      fireEvent.keyDown(document.querySelector(".excalidraw")!, {
+      fireEvent.keyDown(document, {
         key: KEYS.ESCAPE,
       });
     }

--- a/src/tests/selection.test.tsx
+++ b/src/tests/selection.test.tsx
@@ -100,7 +100,9 @@ describe("select single element on the scene", () => {
       fireEvent.pointerDown(canvas, { clientX: 30, clientY: 20 });
       fireEvent.pointerMove(canvas, { clientX: 60, clientY: 70 });
       fireEvent.pointerUp(canvas);
-      fireEvent.keyDown(document, { key: KEYS.ESCAPE });
+      fireEvent.keyDown(document.querySelector(".excalidraw")!, {
+        key: KEYS.ESCAPE,
+      });
     }
 
     const tool = getByToolName("selection");
@@ -127,7 +129,9 @@ describe("select single element on the scene", () => {
       fireEvent.pointerDown(canvas, { clientX: 30, clientY: 20 });
       fireEvent.pointerMove(canvas, { clientX: 60, clientY: 70 });
       fireEvent.pointerUp(canvas);
-      fireEvent.keyDown(document, { key: KEYS.ESCAPE });
+      fireEvent.keyDown(document.querySelector(".excalidraw")!, {
+        key: KEYS.ESCAPE,
+      });
     }
 
     const tool = getByToolName("selection");
@@ -154,7 +158,9 @@ describe("select single element on the scene", () => {
       fireEvent.pointerDown(canvas, { clientX: 30, clientY: 20 });
       fireEvent.pointerMove(canvas, { clientX: 60, clientY: 70 });
       fireEvent.pointerUp(canvas);
-      fireEvent.keyDown(document, { key: KEYS.ESCAPE });
+      fireEvent.keyDown(document.querySelector(".excalidraw")!, {
+        key: KEYS.ESCAPE,
+      });
     }
 
     const tool = getByToolName("selection");
@@ -181,7 +187,9 @@ describe("select single element on the scene", () => {
       fireEvent.pointerDown(canvas, { clientX: 30, clientY: 20 });
       fireEvent.pointerMove(canvas, { clientX: 60, clientY: 70 });
       fireEvent.pointerUp(canvas);
-      fireEvent.keyDown(document, { key: KEYS.ESCAPE });
+      fireEvent.keyDown(document.querySelector(".excalidraw")!, {
+        key: KEYS.ESCAPE,
+      });
     }
 
     /*
@@ -220,7 +228,9 @@ describe("select single element on the scene", () => {
       fireEvent.pointerDown(canvas, { clientX: 30, clientY: 20 });
       fireEvent.pointerMove(canvas, { clientX: 60, clientY: 70 });
       fireEvent.pointerUp(canvas);
-      fireEvent.keyDown(document, { key: KEYS.ESCAPE });
+      fireEvent.keyDown(document.querySelector(".excalidraw")!, {
+        key: KEYS.ESCAPE,
+      });
     }
 
     /*

--- a/src/types.ts
+++ b/src/types.ts
@@ -196,6 +196,7 @@ export interface ExcalidrawProps {
   ) => JSX.Element;
   UIOptions?: UIOptions;
   detectScroll?: boolean;
+  bindKeyGlobally?: boolean;
 }
 
 export type SceneData = {
@@ -230,4 +231,5 @@ export type AppProps = ExcalidrawProps & {
     canvasActions: Required<CanvasActions>;
   };
   detectScroll: boolean;
+  bindKeyGlobally: boolean;
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -196,7 +196,7 @@ export interface ExcalidrawProps {
   ) => JSX.Element;
   UIOptions?: UIOptions;
   detectScroll?: boolean;
-  bindKeyGlobally?: boolean;
+  handleKeyboardGlobally?: boolean;
 }
 
 export type SceneData = {
@@ -231,5 +231,5 @@ export type AppProps = ExcalidrawProps & {
     canvasActions: Required<CanvasActions>;
   };
   detectScroll: boolean;
-  bindKeyGlobally: boolean;
+  handleKeyboardGlobally: boolean;
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -438,3 +438,7 @@ export const focusNearestParent = (element: HTMLInputElement) => {
     parent = parent.parentElement;
   }
 };
+
+export const focusContainer = () => {
+  document.querySelector<HTMLElement>(".excalidraw")?.focus();
+};

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -427,3 +427,14 @@ export const getNearestScrollableContainer = (
   }
   return document;
 };
+
+export const focusNearestTabbableParent = (element: HTMLInputElement) => {
+  let parent = element.parentElement;
+  while (parent) {
+    if (parent.tabIndex > -1) {
+      parent.focus();
+      return;
+    }
+    parent = parent.parentElement;
+  }
+};

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -438,7 +438,3 @@ export const focusNearestParent = (element: HTMLInputElement) => {
     parent = parent.parentElement;
   }
 };
-
-export const focusContainer = () => {
-  document.querySelector<HTMLElement>(".excalidraw-container")?.focus();
-};

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -440,5 +440,5 @@ export const focusNearestParent = (element: HTMLInputElement) => {
 };
 
 export const focusContainer = () => {
-  document.querySelector<HTMLElement>(".excalidraw")?.focus();
+  document.querySelector<HTMLElement>(".excalidraw-container")?.focus();
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -428,7 +428,7 @@ export const getNearestScrollableContainer = (
   return document;
 };
 
-export const focusNearestTabbableParent = (element: HTMLInputElement) => {
+export const focusNearestParent = (element: HTMLInputElement) => {
   let parent = element.parentElement;
   while (parent) {
     if (parent.tabIndex > -1) {


### PR DESCRIPTION
fixes https://github.com/excalidraw/excalidraw/issues/3405
Also fixes handling keyboard events for individual excalidraw container when [multiple excalidraw](https://github.com/excalidraw/excalidraw/issues/3043) rendered
- [x] Keyboard shortcuts are no more binded after modal rendered so fix it.
- [x] Add handleKeyboardGlobally prop to allow host to bind to document
- [x] Testing
- [x] update changelog