### PR TITLE
fix: Apply theme to only to active excalidraw component

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -341,6 +341,10 @@ class App extends React.Component<AppProps, AppState> {
       height: window.innerHeight,
     };
 
+    this.excalidrawInstanceValue = {
+      current: this.excalidrawContainerRef.current,
+    };
+
     if (excalidrawRef) {
       const readyPromise =
         ("current" in excalidrawRef && excalidrawRef.current?.readyPromise) ||

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -189,7 +189,6 @@ import { Toast } from "./Toast";
 import { actionToggleViewMode } from "../actions/actionToggleViewMode";
 
 export type ExcalidrawInstanceValue = {
-  focus: () => void;
   excalidrawInstance: HTMLDivElement | null;
 };
 export const IsMobileContext = React.createContext(false);
@@ -872,7 +871,6 @@ class App extends React.Component<AppProps, AppState> {
   private getExcalidrawInstanceValue = () => {
     return {
       excalidrawInstance: this.excalidrawContainerRef.current,
-      focus: this.focusContainer,
     };
   };
   private onResize = withBatchedUpdates(() => {

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -189,7 +189,7 @@ import { Toast } from "./Toast";
 import { actionToggleViewMode } from "../actions/actionToggleViewMode";
 
 export type ExcalidrawInstanceValue = {
-  excalidrawInstance: HTMLDivElement | null;
+  current: HTMLDivElement | null;
 };
 export const IsMobileContext = React.createContext(false);
 export const useIsMobile = () => useContext(IsMobileContext);
@@ -313,6 +313,9 @@ class App extends React.Component<AppProps, AppState> {
   private scene: Scene;
   private resizeObserver: ResizeObserver | undefined;
   private nearestScrollableContainer: HTMLElement | Document | undefined;
+  private excalidrawInstanceValue: {
+    current: HTMLDivElement | null;
+  };
 
   constructor(props: AppProps) {
     super(props);
@@ -467,7 +470,7 @@ class App extends React.Component<AppProps, AppState> {
         }
       >
         <ExcalidrawInstanceContext.Provider
-          value={this.getExcalidrawInstanceValue()}
+          value={this.excalidrawInstanceValue}
         >
           <IsMobileContext.Provider value={this.isMobile}>
             <LayerUI
@@ -816,7 +819,9 @@ class App extends React.Component<AppProps, AppState> {
         },
       });
     }
-
+    this.excalidrawInstanceValue = {
+      current: this.excalidrawContainerRef.current,
+    };
     this.scene.addCallback(this.onSceneUpdated);
     this.addEventListeners();
 
@@ -868,11 +873,6 @@ class App extends React.Component<AppProps, AppState> {
     touchTimeout = 0;
   }
 
-  private getExcalidrawInstanceValue = () => {
-    return {
-      excalidrawInstance: this.excalidrawContainerRef.current,
-    };
-  };
   private onResize = withBatchedUpdates(() => {
     this.scene
       .getElementsIncludingDeleted()

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -188,8 +188,17 @@ import { Stats } from "./Stats";
 import { Toast } from "./Toast";
 import { actionToggleViewMode } from "../actions/actionToggleViewMode";
 
+export type ExcalidrawInstanceValue = {
+  focus: () => void;
+  excalidrawInstance: HTMLDivElement | null;
+};
 export const IsMobileContext = React.createContext(false);
 export const useIsMobile = () => useContext(IsMobileContext);
+export const ExcalidrawInstanceContext = React.createContext<ExcalidrawInstanceValue | null>(
+  null,
+);
+export const useExcalidrawInstance = () =>
+  useContext(ExcalidrawInstanceContext);
 
 const { history } = createHistory();
 
@@ -305,6 +314,7 @@ class App extends React.Component<AppProps, AppState> {
   private scene: Scene;
   private resizeObserver: ResizeObserver | undefined;
   private nearestScrollableContainer: HTMLElement | Document | undefined;
+
   constructor(props: AppProps) {
     super(props);
     const defaultAppState = getDefaultAppState();
@@ -328,6 +338,7 @@ class App extends React.Component<AppProps, AppState> {
       width: window.innerWidth,
       height: window.innerHeight,
     };
+
     if (excalidrawRef) {
       const readyPromise =
         ("current" in excalidrawRef && excalidrawRef.current?.readyPromise) ||
@@ -456,60 +467,64 @@ class App extends React.Component<AppProps, AppState> {
           this.props.handleKeyboardGlobally ? undefined : this.onKeyDown
         }
       >
-        <IsMobileContext.Provider value={this.isMobile}>
-          <LayerUI
-            canvas={this.canvas}
-            appState={this.state}
-            setAppState={this.setAppState}
-            actionManager={this.actionManager}
-            elements={this.scene.getElements()}
-            onCollabButtonClick={onCollabButtonClick}
-            onLockToggle={this.toggleLock}
-            onInsertElements={(elements) =>
-              this.addElementsFromPasteOrLibrary(
-                elements,
-                DEFAULT_PASTE_X,
-                DEFAULT_PASTE_Y,
-              )
-            }
-            zenModeEnabled={zenModeEnabled}
-            toggleZenMode={this.toggleZenMode}
-            langCode={getLanguage().code}
-            isCollaborating={this.props.isCollaborating || false}
-            onExportToBackend={onExportToBackend}
-            renderCustomFooter={renderFooter}
-            viewModeEnabled={viewModeEnabled}
-            showExitZenModeBtn={
-              typeof this.props?.zenModeEnabled === "undefined" &&
-              zenModeEnabled
-            }
-            showThemeBtn={
-              typeof this.props?.theme === "undefined" &&
-              this.props.UIOptions.canvasActions.theme
-            }
-            libraryReturnUrl={this.props.libraryReturnUrl}
-            UIOptions={this.props.UIOptions}
-            focusContainer={this.focusContainer}
-          />
-          <div className="excalidraw-textEditorContainer" />
-          <div className="excalidraw-contextMenuContainer" />
-          {this.state.showStats && (
-            <Stats
+        <ExcalidrawInstanceContext.Provider
+          value={this.getExcalidrawInstanceValue()}
+        >
+          <IsMobileContext.Provider value={this.isMobile}>
+            <LayerUI
+              canvas={this.canvas}
               appState={this.state}
               setAppState={this.setAppState}
+              actionManager={this.actionManager}
               elements={this.scene.getElements()}
-              onClose={this.toggleStats}
-              renderCustomStats={renderCustomStats}
+              onCollabButtonClick={onCollabButtonClick}
+              onLockToggle={this.toggleLock}
+              onInsertElements={(elements) =>
+                this.addElementsFromPasteOrLibrary(
+                  elements,
+                  DEFAULT_PASTE_X,
+                  DEFAULT_PASTE_Y,
+                )
+              }
+              zenModeEnabled={zenModeEnabled}
+              toggleZenMode={this.toggleZenMode}
+              langCode={getLanguage().code}
+              isCollaborating={this.props.isCollaborating || false}
+              onExportToBackend={onExportToBackend}
+              renderCustomFooter={renderFooter}
+              viewModeEnabled={viewModeEnabled}
+              showExitZenModeBtn={
+                typeof this.props?.zenModeEnabled === "undefined" &&
+                zenModeEnabled
+              }
+              showThemeBtn={
+                typeof this.props?.theme === "undefined" &&
+                this.props.UIOptions.canvasActions.theme
+              }
+              libraryReturnUrl={this.props.libraryReturnUrl}
+              UIOptions={this.props.UIOptions}
+              focusContainer={this.focusContainer}
             />
-          )}
-          {this.state.toastMessage !== null && (
-            <Toast
-              message={this.state.toastMessage}
-              clearToast={this.clearToast}
-            />
-          )}
-          <main>{this.renderCanvas()}</main>
-        </IsMobileContext.Provider>
+            <div className="excalidraw-textEditorContainer" />
+            <div className="excalidraw-contextMenuContainer" />
+            {this.state.showStats && (
+              <Stats
+                appState={this.state}
+                setAppState={this.setAppState}
+                elements={this.scene.getElements()}
+                onClose={this.toggleStats}
+                renderCustomStats={renderCustomStats}
+              />
+            )}
+            {this.state.toastMessage !== null && (
+              <Toast
+                message={this.state.toastMessage}
+                clearToast={this.clearToast}
+              />
+            )}
+            <main>{this.renderCanvas()}</main>
+          </IsMobileContext.Provider>
+        </ExcalidrawInstanceContext.Provider>
       </div>
     );
   }
@@ -854,6 +869,12 @@ class App extends React.Component<AppProps, AppState> {
     touchTimeout = 0;
   }
 
+  private getExcalidrawInstanceValue = () => {
+    return {
+      excalidrawInstance: this.excalidrawContainerRef.current,
+      focus: this.focusContainer,
+    };
+  };
   private onResize = withBatchedUpdates(() => {
     this.scene
       .getElementsIncludingDeleted()
@@ -988,9 +1009,10 @@ class App extends React.Component<AppProps, AppState> {
       });
     }
 
-    document
-      .querySelector(".excalidraw")
-      ?.classList.toggle("theme--dark", this.state.theme === "dark");
+    this.excalidrawContainerRef.current?.classList.toggle(
+      "theme--dark",
+      this.state.theme === "dark",
+    );
 
     if (
       this.state.editingLinearElement &&

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -188,9 +188,9 @@ import { Stats } from "./Stats";
 import { Toast } from "./Toast";
 import { actionToggleViewMode } from "../actions/actionToggleViewMode";
 
-export const IsMobileContext = React.createContext(false);
+const IsMobileContext = React.createContext(false);
 export const useIsMobile = () => useContext(IsMobileContext);
-export const ExcalidrawContainerContext = React.createContext<HTMLDivElement | null>(
+const ExcalidrawContainerContext = React.createContext<HTMLDivElement | null>(
   null,
 );
 export const useExcalidrawContainer = () =>

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -188,16 +188,13 @@ import { Stats } from "./Stats";
 import { Toast } from "./Toast";
 import { actionToggleViewMode } from "../actions/actionToggleViewMode";
 
-export type ExcalidrawInstanceValue = {
-  current: HTMLDivElement | null;
-};
 export const IsMobileContext = React.createContext(false);
 export const useIsMobile = () => useContext(IsMobileContext);
-export const ExcalidrawInstanceContext = React.createContext<ExcalidrawInstanceValue | null>(
+export const ExcalidrawContainerContext = React.createContext<HTMLDivElement | null>(
   null,
 );
-export const useExcalidrawInstance = () =>
-  useContext(ExcalidrawInstanceContext);
+export const useExcalidrawContainer = () =>
+  useContext(ExcalidrawContainerContext);
 
 const { history } = createHistory();
 
@@ -313,9 +310,6 @@ class App extends React.Component<AppProps, AppState> {
   private scene: Scene;
   private resizeObserver: ResizeObserver | undefined;
   private nearestScrollableContainer: HTMLElement | Document | undefined;
-  private excalidrawInstanceValue: {
-    current: HTMLDivElement | null;
-  };
 
   constructor(props: AppProps) {
     super(props);
@@ -339,10 +333,6 @@ class App extends React.Component<AppProps, AppState> {
       name,
       width: window.innerWidth,
       height: window.innerHeight,
-    };
-
-    this.excalidrawInstanceValue = {
-      current: this.excalidrawContainerRef.current,
     };
 
     if (excalidrawRef) {
@@ -473,8 +463,8 @@ class App extends React.Component<AppProps, AppState> {
           this.props.handleKeyboardGlobally ? undefined : this.onKeyDown
         }
       >
-        <ExcalidrawInstanceContext.Provider
-          value={this.excalidrawInstanceValue}
+        <ExcalidrawContainerContext.Provider
+          value={this.excalidrawContainerRef.current}
         >
           <IsMobileContext.Provider value={this.isMobile}>
             <LayerUI
@@ -530,7 +520,7 @@ class App extends React.Component<AppProps, AppState> {
             )}
             <main>{this.renderCanvas()}</main>
           </IsMobileContext.Provider>
-        </ExcalidrawInstanceContext.Provider>
+        </ExcalidrawContainerContext.Provider>
       </div>
     );
   }
@@ -823,9 +813,7 @@ class App extends React.Component<AppProps, AppState> {
         },
       });
     }
-    this.excalidrawInstanceValue = {
-      current: this.excalidrawContainerRef.current,
-    };
+
     this.scene.addCallback(this.onSceneUpdated);
     this.addEventListeners();
 

--- a/src/components/Dialog.tsx
+++ b/src/components/Dialog.tsx
@@ -8,6 +8,7 @@ import "./Dialog.scss";
 import { back, close } from "./icons";
 import { Island } from "./Island";
 import { Modal } from "./Modal";
+import { AppState } from "../types";
 
 export const Dialog = (props: {
   children: React.ReactNode;
@@ -16,6 +17,7 @@ export const Dialog = (props: {
   onCloseRequest(): void;
   title: React.ReactNode;
   autofocus?: boolean;
+  theme?: AppState["theme"];
 }) => {
   const [islandNode, setIslandNode] = useCallbackRefState<HTMLDivElement>();
   useEffect(() => {
@@ -70,6 +72,7 @@ export const Dialog = (props: {
       labelledBy="dialog-title"
       maxWidth={props.small ? 550 : 800}
       onCloseRequest={props.onCloseRequest}
+      theme={props.theme}
     >
       <Island ref={setIslandNode}>
         <h2 id="dialog-title" className="Dialog__title">

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -58,7 +58,7 @@ const useBodyRoot = (theme: AppState["theme"]) => {
   const isMobileRef = useRef(isMobile);
   isMobileRef.current = isMobile;
 
-  const excalidrawContainer: HTMLDivElement | null = useExcalidrawContainer();
+  const excalidrawContainer = useExcalidrawContainer();
 
   useLayoutEffect(() => {
     if (div) {

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -58,7 +58,7 @@ const useBodyRoot = (theme: AppState["theme"]) => {
   const isMobileRef = useRef(isMobile);
   isMobileRef.current = isMobile;
 
-  const excalidrawInstance: HTMLDivElement | null = useExcalidrawContainer();
+  const excalidrawContainer: HTMLDivElement | null = useExcalidrawContainer();
 
   useLayoutEffect(() => {
     if (div) {
@@ -68,7 +68,7 @@ const useBodyRoot = (theme: AppState["theme"]) => {
 
   useLayoutEffect(() => {
     const isDarkTheme =
-      !!excalidrawInstance?.classList.contains("theme--dark") ||
+      !!excalidrawContainer?.classList.contains("theme--dark") ||
       theme === "dark";
     const div = document.createElement("div");
 
@@ -86,7 +86,7 @@ const useBodyRoot = (theme: AppState["theme"]) => {
     return () => {
       document.body.removeChild(div);
     };
-  }, [excalidrawInstance, theme]);
+  }, [excalidrawContainer, theme]);
 
   return div;
 };

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -69,9 +69,8 @@ const useBodyRoot = (theme: AppState["theme"]) => {
 
   useLayoutEffect(() => {
     const isDarkTheme =
-      !!excalidrawInstance?.excalidrawInstance?.classList.contains(
-        "theme--dark",
-      ) || theme === "dark";
+      !!excalidrawInstance?.current?.classList.contains("theme--dark") ||
+      theme === "dark";
     const div = document.createElement("div");
 
     div.classList.add("excalidraw", "excalidraw-modal-container");

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -4,7 +4,9 @@ import React, { useState, useLayoutEffect, useRef } from "react";
 import { createPortal } from "react-dom";
 import clsx from "clsx";
 import { KEYS } from "../keys";
-import { useIsMobile } from "../components/App";
+import { useExcalidrawInstance, useIsMobile } from "./App";
+import type { ExcalidrawInstanceValue } from "./App";
+import { AppState } from "../types";
 
 export const Modal = (props: {
   className?: string;
@@ -12,8 +14,10 @@ export const Modal = (props: {
   maxWidth?: number;
   onCloseRequest(): void;
   labelledBy: string;
+  theme?: AppState["theme"];
 }) => {
-  const modalRoot = useBodyRoot();
+  const { theme = "light" } = props;
+  const modalRoot = useBodyRoot(theme);
 
   if (!modalRoot) {
     return null;
@@ -48,12 +52,14 @@ export const Modal = (props: {
   );
 };
 
-const useBodyRoot = () => {
+const useBodyRoot = (theme: AppState["theme"]) => {
   const [div, setDiv] = useState<HTMLDivElement | null>(null);
 
   const isMobile = useIsMobile();
   const isMobileRef = useRef(isMobile);
   isMobileRef.current = isMobile;
+
+  const excalidrawInstance: ExcalidrawInstanceValue | null = useExcalidrawInstance();
 
   useLayoutEffect(() => {
     if (div) {
@@ -62,9 +68,10 @@ const useBodyRoot = () => {
   }, [div, isMobile]);
 
   useLayoutEffect(() => {
-    const isDarkTheme = !!document
-      .querySelector(".excalidraw")
-      ?.classList.contains("theme--dark");
+    const isDarkTheme =
+      !!excalidrawInstance?.excalidrawInstance?.classList.contains(
+        "theme--dark",
+      ) || theme === "dark";
     const div = document.createElement("div");
 
     div.classList.add("excalidraw", "excalidraw-modal-container");
@@ -81,7 +88,7 @@ const useBodyRoot = () => {
     return () => {
       document.body.removeChild(div);
     };
-  }, []);
+  }, [excalidrawInstance, theme]);
 
   return div;
 };

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -4,8 +4,7 @@ import React, { useState, useLayoutEffect, useRef } from "react";
 import { createPortal } from "react-dom";
 import clsx from "clsx";
 import { KEYS } from "../keys";
-import { useExcalidrawInstance, useIsMobile } from "./App";
-import type { ExcalidrawInstanceValue } from "./App";
+import { useExcalidrawContainer, useIsMobile } from "./App";
 import { AppState } from "../types";
 
 export const Modal = (props: {
@@ -59,7 +58,7 @@ const useBodyRoot = (theme: AppState["theme"]) => {
   const isMobileRef = useRef(isMobile);
   isMobileRef.current = isMobile;
 
-  const excalidrawInstance: ExcalidrawInstanceValue | null = useExcalidrawInstance();
+  const excalidrawInstance: HTMLDivElement | null = useExcalidrawContainer();
 
   useLayoutEffect(() => {
     if (div) {
@@ -69,7 +68,7 @@ const useBodyRoot = (theme: AppState["theme"]) => {
 
   useLayoutEffect(() => {
     const isDarkTheme =
-      !!excalidrawInstance?.current?.classList.contains("theme--dark") ||
+      !!excalidrawInstance?.classList.contains("theme--dark") ||
       theme === "dark";
     const div = document.createElement("div");
 

--- a/src/excalidraw-app/collab/CollabWrapper.tsx
+++ b/src/excalidraw-app/collab/CollabWrapper.tsx
@@ -640,6 +640,7 @@ class CollabWrapper extends PureComponent<Props, CollabState> {
             setErrorMessage={(errorMessage) => {
               this.setState({ errorMessage });
             }}
+            theme={this.excalidrawAPI.getAppState().theme}
           />
         )}
         {errorMessage && (

--- a/src/excalidraw-app/collab/RoomDialog.tsx
+++ b/src/excalidraw-app/collab/RoomDialog.tsx
@@ -13,6 +13,7 @@ import { ToolButton } from "../../components/ToolButton";
 import { t } from "../../i18n";
 import "./RoomDialog.scss";
 import Stack from "../../components/Stack";
+import { AppState } from "../../types";
 
 const getShareIcon = () => {
   const navigator = window.navigator as any;
@@ -36,6 +37,7 @@ const RoomDialog = ({
   onRoomCreate,
   onRoomDestroy,
   setErrorMessage,
+  theme,
 }: {
   handleClose: () => void;
   activeRoomLink: string;
@@ -44,6 +46,7 @@ const RoomDialog = ({
   onRoomCreate: () => void;
   onRoomDestroy: () => void;
   setErrorMessage: (message: string) => void;
+  theme: AppState["theme"];
 }) => {
   const roomLinkInput = useRef<HTMLInputElement>(null);
 
@@ -168,6 +171,7 @@ const RoomDialog = ({
       small
       onCloseRequest={handleClose}
       title={t("labels.liveCollaboration")}
+      theme={theme}
     >
       {renderRoomDialog()}
     </Dialog>

--- a/src/packages/excalidraw/CHANGELOG.md
+++ b/src/packages/excalidraw/CHANGELOG.md
@@ -28,7 +28,7 @@ Please add the latest change on the top under the correct section.
 
 ### Fixes
 
-- Apply theme to only current instance of Excalidraw, this fixes the issue where theme was always getting applied to first excalidraw instance when you have multiple excalidraw instances on the same page [#3446](https://github.com/excalidraw/excalidraw/pull/3446)
+- When switching theme, apply it only to the active Excalidraw component. This fixes a case where the theme was getting applied to the first Excalidraw component if you had multiple Excalidraw components on the same page [#3446](https://github.com/excalidraw/excalidraw/pull/3446)
 
 ## Types
 

--- a/src/packages/excalidraw/CHANGELOG.md
+++ b/src/packages/excalidraw/CHANGELOG.md
@@ -26,6 +26,10 @@ Please add the latest change on the top under the correct section.
 - Recompute offsets on `scroll` of the nearest scrollable container [#3408](https://github.com/excalidraw/excalidraw/pull/3408). This can be disabled by setting [`detectScroll`](https://github.com/excalidraw/excalidraw/blob/master/src/packages/excalidraw/README.md#detectScroll) to `false`.
 - Add `onPaste` prop to handle custom clipboard behaviours [#3420](https://github.com/excalidraw/excalidraw/pull/3420).
 
+### Fixes
+
+- Apply theme to only current instance of Excalidraw, this fixes the issue where theme was always getting applied to first excalidraw instance when you have multiple excalidraw instances on the same page [#3446](https://github.com/excalidraw/excalidraw/pull/3446)
+
 ## Types
 
 - Renamed the following types in case you depend on them (via [#3427](https://github.com/excalidraw/excalidraw/pull/3427)):


### PR DESCRIPTION
Make sure theme is only applied to the active Excalidraw component when  [multiple excalidraw](https://github.com/excalidraw/excalidraw/issues/3043)  rendered

Exposed a hook that gives access to the current instance, this will be useful when focusing the current instance as well(ex after dialog close, we can expose focus function as well for the same)
Since collab dialog is not in the hierarchy of App.tsx hence had to add a new prop theme so it can be used to add a `theme` to custom dialogs as well.

Try [here](https://k1xx5.csb.app/)