### PR TITLE
feat: Make library local to given excalidraw instance and allow consumer to control it

### DIFF
--- a/src/actions/actionAddToLibrary.ts
+++ b/src/actions/actionAddToLibrary.ts
@@ -2,18 +2,20 @@ import { register } from "./register";
 import { getSelectedElements } from "../scene";
 import { getNonDeletedElements } from "../element";
 import { deepCopyElement } from "../element/newElement";
-import { Library } from "../data/library";
 
 export const actionAddToLibrary = register({
   name: "addToLibrary",
-  perform: (elements, appState) => {
+  perform: (elements, appState, _, app) => {
     const selectedElements = getSelectedElements(
       getNonDeletedElements(elements),
       appState,
     );
 
-    Library.loadLibrary().then((items) => {
-      Library.saveLibrary([...items, selectedElements.map(deepCopyElement)]);
+    app.library.loadLibrary().then((items) => {
+      app.library.saveLibrary([
+        ...items,
+        selectedElements.map(deepCopyElement),
+      ]);
     });
     return false;
   },

--- a/src/actions/manager.tsx
+++ b/src/actions/manager.tsx
@@ -9,6 +9,7 @@ import {
 import { ExcalidrawElement } from "../element/types";
 import { AppProps, AppState } from "../types";
 import { MODES } from "../constants";
+import Library from "../data/library";
 
 // This is the <App> component, but for now we don't care about anything but its
 // `canvas` state.
@@ -16,6 +17,7 @@ type App = {
   canvas: HTMLCanvasElement | null;
   focusContainer: () => void;
   props: AppProps;
+  library: Library;
 };
 
 export class ActionManager implements ActionsManagerInterface {

--- a/src/actions/types.ts
+++ b/src/actions/types.ts
@@ -1,6 +1,7 @@
 import React from "react";
 import { ExcalidrawElement } from "../element/types";
 import { AppState, ExcalidrawProps } from "../types";
+import Library from "../data/library";
 
 /** if false, the action should be prevented */
 export type ActionResult =
@@ -15,7 +16,11 @@ export type ActionResult =
     }
   | false;
 
-type AppAPI = { canvas: HTMLCanvasElement | null; focusContainer(): void };
+type AppAPI = {
+  canvas: HTMLCanvasElement | null;
+  focusContainer(): void;
+  library: Library;
+};
 
 type ActionFn = (
   elements: readonly ExcalidrawElement[],

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -164,7 +164,14 @@ import Scene from "../scene/Scene";
 import { SceneState, ScrollBars } from "../scene/types";
 import { getNewZoom } from "../scene/zoom";
 import { findShapeByKey } from "../shapes";
-import { AppProps, AppState, Gesture, GestureEvent, SceneData } from "../types";
+import {
+  AppProps,
+  AppState,
+  Gesture,
+  GestureEvent,
+  LibraryItems,
+  SceneData,
+} from "../types";
 import {
   debounce,
   distance,
@@ -311,6 +318,7 @@ class App extends React.Component<AppProps, AppState> {
   private resizeObserver: ResizeObserver | undefined;
   private nearestScrollableContainer: HTMLElement | Document | undefined;
   public library: Library;
+  public libraryItemsFromStorage: LibraryItems | undefined;
 
   constructor(props: AppProps) {
     super(props);
@@ -365,7 +373,7 @@ class App extends React.Component<AppProps, AppState> {
       readyPromise.resolve(api);
     }
     this.scene = new Scene();
-    this.library = new Library();
+    this.library = new Library(this);
 
     this.actionManager = new ActionManager(
       this.syncActionResult,
@@ -737,6 +745,9 @@ class App extends React.Component<AppProps, AppState> {
     let initialData = null;
     try {
       initialData = (await this.props.initialData) || null;
+      if (initialData?.libraryItems) {
+        this.libraryItemsFromStorage = initialData.libraryItems;
+      }
     } catch (error) {
       console.error(error);
       initialData = {

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -68,7 +68,7 @@ import {
 } from "../constants";
 import { loadFromBlob } from "../data";
 import { isValidLibrary } from "../data/json";
-import { Library } from "../data/library";
+import Library from "../data/library";
 import { restore } from "../data/restore";
 import {
   dragNewElement,
@@ -310,6 +310,7 @@ class App extends React.Component<AppProps, AppState> {
   private scene: Scene;
   private resizeObserver: ResizeObserver | undefined;
   private nearestScrollableContainer: HTMLElement | Document | undefined;
+  public library: Library;
 
   constructor(props: AppProps) {
     super(props);
@@ -364,6 +365,7 @@ class App extends React.Component<AppProps, AppState> {
       readyPromise.resolve(api);
     }
     this.scene = new Scene();
+    this.library = new Library();
 
     this.actionManager = new ActionManager(
       this.syncActionResult,
@@ -500,6 +502,7 @@ class App extends React.Component<AppProps, AppState> {
               libraryReturnUrl={this.props.libraryReturnUrl}
               UIOptions={this.props.UIOptions}
               focusContainer={this.focusContainer}
+              library={this.library}
             />
             <div className="excalidraw-textEditorContainer" />
             <div className="excalidraw-contextMenuContainer" />
@@ -660,12 +663,12 @@ class App extends React.Component<AppProps, AppState> {
         throw new Error();
       }
       if (
-        token === Library.csrfToken ||
+        token === this.library.csrfToken ||
         window.confirm(
           t("alerts.confirmAddLibrary", { numShapes: json.library.length }),
         )
       ) {
-        await Library.importLibrary(blob);
+        await this.library.importLibrary(blob);
         // hack to rerender the library items after import
         if (this.state.isLibraryOpen) {
           this.setState({ isLibraryOpen: false });
@@ -3713,7 +3716,8 @@ class App extends React.Component<AppProps, AppState> {
       file?.type === MIME_TYPES.excalidrawlib ||
       file?.name?.endsWith(".excalidrawlib")
     ) {
-      Library.importLibrary(file)
+      this.library
+        .importLibrary(file)
         .then(() => {
           // Close and then open to get the libraries updated
           this.setState({ isLibraryOpen: false });
@@ -4248,7 +4252,6 @@ declare global {
       setState: React.Component<any, AppState>["setState"];
       history: SceneHistory;
       app: InstanceType<typeof App>;
-      library: typeof Library;
     };
   }
 }
@@ -4272,10 +4275,6 @@ if (
     history: {
       configurable: true,
       get: () => history,
-    },
-    library: {
-      configurable: true,
-      value: Library,
     },
   });
 }

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -4,6 +4,7 @@ import { RoughCanvas } from "roughjs/bin/canvas";
 import rough from "roughjs/bin/rough";
 import clsx from "clsx";
 import { supported } from "browser-fs-access";
+import { nanoid } from "nanoid";
 
 import {
   actionAddToLibrary,
@@ -297,6 +298,7 @@ export type ExcalidrawImperativeAPI = {
   setToastMessage: InstanceType<typeof App>["setToastMessage"];
   readyPromise: ResolvablePromise<ExcalidrawImperativeAPI>;
   ready: true;
+  id: string;
 };
 
 class App extends React.Component<AppProps, AppState> {
@@ -319,6 +321,7 @@ class App extends React.Component<AppProps, AppState> {
   private nearestScrollableContainer: HTMLElement | Document | undefined;
   public library: Library;
   public libraryItemsFromStorage: LibraryItems | undefined;
+  private id: string;
 
   constructor(props: AppProps) {
     super(props);
@@ -344,6 +347,8 @@ class App extends React.Component<AppProps, AppState> {
       height: window.innerHeight,
     };
 
+    this.id = nanoid();
+
     if (excalidrawRef) {
       const readyPromise =
         ("current" in excalidrawRef && excalidrawRef.current?.readyPromise) ||
@@ -364,6 +369,7 @@ class App extends React.Component<AppProps, AppState> {
         refresh: this.refresh,
         importLibrary: this.importLibraryFromUrl,
         setToastMessage: this.setToastMessage,
+        id: this.id,
       } as const;
       if (typeof excalidrawRef === "function") {
         excalidrawRef(api);
@@ -511,6 +517,7 @@ class App extends React.Component<AppProps, AppState> {
               UIOptions={this.props.UIOptions}
               focusContainer={this.focusContainer}
               library={this.library}
+              id={this.id}
             />
             <div className="excalidraw-textEditorContainer" />
             <div className="excalidraw-contextMenuContainer" />
@@ -671,7 +678,7 @@ class App extends React.Component<AppProps, AppState> {
         throw new Error();
       }
       if (
-        token === this.library.csrfToken ||
+        token === this.id ||
         window.confirm(
           t("alerts.confirmAddLibrary", { numShapes: json.library.length }),
         )

--- a/src/components/LayerUI.tsx
+++ b/src/components/LayerUI.tsx
@@ -303,10 +303,13 @@ const LibraryMenu = ({
     async (indexToRemove) => {
       const items = await library.loadLibrary();
       const nextItems = items.filter((_, index) => index !== indexToRemove);
-      library.saveLibrary(nextItems);
+      library.saveLibrary(nextItems).catch((error) => {
+        setLibraryItems(items);
+        setAppState({ errorMessage: error.message });
+      });
       setLibraryItems(nextItems);
     },
-    [library],
+    [library, setAppState],
   );
 
   const addToLibrary = useCallback(
@@ -314,10 +317,13 @@ const LibraryMenu = ({
       const items = await library.loadLibrary();
       const nextItems = [...items, elements];
       onAddToLibrary();
-      library.saveLibrary(nextItems);
+      library.saveLibrary(nextItems).catch((error) => {
+        setLibraryItems(items);
+        setAppState({ errorMessage: error.message });
+      });
       setLibraryItems(nextItems);
     },
-    [onAddToLibrary, library],
+    [onAddToLibrary, library, setAppState],
   );
 
   return loadingState === "preloading" ? null : (

--- a/src/components/LayerUI.tsx
+++ b/src/components/LayerUI.tsx
@@ -305,7 +305,7 @@ const LibraryMenu = ({
       const nextItems = items.filter((_, index) => index !== indexToRemove);
       library.saveLibrary(nextItems).catch((error) => {
         setLibraryItems(items);
-        setAppState({ errorMessage: error.message });
+        setAppState({ errorMessage: t("alerts.errorRemovingFromLibrary") });
       });
       setLibraryItems(nextItems);
     },
@@ -319,7 +319,7 @@ const LibraryMenu = ({
       onAddToLibrary();
       library.saveLibrary(nextItems).catch((error) => {
         setLibraryItems(items);
-        setAppState({ errorMessage: error.message });
+        setAppState({ errorMessage: t("alerts.errorAddingToLibrary") });
       });
       setLibraryItems(nextItems);
     },

--- a/src/components/LayerUI.tsx
+++ b/src/components/LayerUI.tsx
@@ -74,6 +74,7 @@ interface LayerUIProps {
   UIOptions: AppProps["UIOptions"];
   focusContainer: () => void;
   library: Library;
+  id: string;
 }
 
 const useOnClickOutside = (
@@ -115,6 +116,7 @@ const LibraryMenuItems = ({
   libraryReturnUrl,
   focusContainer,
   library,
+  id,
 }: {
   libraryItems: LibraryItems;
   pendingElements: LibraryItem;
@@ -126,6 +128,7 @@ const LibraryMenuItems = ({
   libraryReturnUrl: ExcalidrawProps["libraryReturnUrl"];
   focusContainer: () => void;
   library: Library;
+  id: string;
 }) => {
   const isMobile = useIsMobile();
   const numCells = libraryItems.length + (pendingElements.length > 0 ? 1 : 0);
@@ -193,7 +196,7 @@ const LibraryMenuItems = ({
       <a
         href={`https://libraries.excalidraw.com?target=${
           window.name || "_blank"
-        }&referrer=${referrer}&useHash=true&token=${library.csrfToken}`}
+        }&referrer=${referrer}&useHash=true&token=${id}`}
         target="_excalidraw_libraries"
       >
         {t("labels.libraries")}
@@ -251,6 +254,7 @@ const LibraryMenu = ({
   libraryReturnUrl,
   focusContainer,
   library,
+  id,
 }: {
   pendingElements: LibraryItem;
   onClickOutside: (event: MouseEvent) => void;
@@ -260,6 +264,7 @@ const LibraryMenu = ({
   libraryReturnUrl: ExcalidrawProps["libraryReturnUrl"];
   focusContainer: () => void;
   library: Library;
+  id: string;
 }) => {
   const ref = useRef<HTMLDivElement | null>(null);
   useOnClickOutside(ref, (event) => {
@@ -344,6 +349,7 @@ const LibraryMenu = ({
           libraryReturnUrl={libraryReturnUrl}
           focusContainer={focusContainer}
           library={library}
+          id={id}
         />
       )}
     </Island>
@@ -371,6 +377,7 @@ const LayerUI = ({
   UIOptions,
   focusContainer,
   library,
+  id,
 }: LayerUIProps) => {
   const isMobile = useIsMobile();
 
@@ -543,6 +550,7 @@ const LayerUI = ({
       libraryReturnUrl={libraryReturnUrl}
       focusContainer={focusContainer}
       library={library}
+      id={id}
     />
   ) : null;
 

--- a/src/components/LayerUI.tsx
+++ b/src/components/LayerUI.tsx
@@ -10,7 +10,6 @@ import { ActionManager } from "../actions/manager";
 import { CLASSES } from "../constants";
 import { exportCanvas } from "../data";
 import { importLibraryFromJSON, saveLibraryAsJSON } from "../data/json";
-import { Library } from "../data/library";
 import { isTextElement, showSelectedShapeActions } from "../element";
 import { NonDeletedExcalidrawElement } from "../element/types";
 import { Language, t } from "../i18n";
@@ -47,6 +46,7 @@ import Stack from "./Stack";
 import { ToolButton } from "./ToolButton";
 import { Tooltip } from "./Tooltip";
 import { UserList } from "./UserList";
+import Library from "../data/library";
 
 interface LayerUIProps {
   actionManager: ActionManager;
@@ -73,6 +73,7 @@ interface LayerUIProps {
   libraryReturnUrl: ExcalidrawProps["libraryReturnUrl"];
   UIOptions: AppProps["UIOptions"];
   focusContainer: () => void;
+  library: Library;
 }
 
 const useOnClickOutside = (
@@ -104,7 +105,7 @@ const useOnClickOutside = (
 };
 
 const LibraryMenuItems = ({
-  library,
+  libraryItems,
   onRemoveFromLibrary,
   onAddToLibrary,
   onInsertShape,
@@ -113,8 +114,9 @@ const LibraryMenuItems = ({
   setLibraryItems,
   libraryReturnUrl,
   focusContainer,
+  library,
 }: {
-  library: LibraryItems;
+  libraryItems: LibraryItems;
   pendingElements: LibraryItem;
   onRemoveFromLibrary: (index: number) => void;
   onInsertShape: (elements: LibraryItem) => void;
@@ -123,9 +125,10 @@ const LibraryMenuItems = ({
   setLibraryItems: (library: LibraryItems) => void;
   libraryReturnUrl: ExcalidrawProps["libraryReturnUrl"];
   focusContainer: () => void;
+  library: Library;
 }) => {
   const isMobile = useIsMobile();
-  const numCells = library.length + (pendingElements.length > 0 ? 1 : 0);
+  const numCells = libraryItems.length + (pendingElements.length > 0 ? 1 : 0);
   const CELLS_PER_ROW = isMobile ? 4 : 6;
   const numRows = Math.max(1, Math.ceil(numCells / CELLS_PER_ROW));
   const rows = [];
@@ -143,7 +146,7 @@ const LibraryMenuItems = ({
         aria-label={t("buttons.load")}
         icon={load}
         onClick={() => {
-          importLibraryFromJSON()
+          importLibraryFromJSON(library)
             .then(() => {
               // Close and then open to get the libraries updated
               setAppState({ isLibraryOpen: false });
@@ -155,7 +158,7 @@ const LibraryMenuItems = ({
             });
         }}
       />
-      {!!library.length && (
+      {!!libraryItems.length && (
         <>
           <ToolButton
             key="export"
@@ -164,7 +167,7 @@ const LibraryMenuItems = ({
             aria-label={t("buttons.export")}
             icon={exportFile}
             onClick={() => {
-              saveLibraryAsJSON()
+              saveLibraryAsJSON(library)
                 .catch(muteFSAbortError)
                 .catch((error) => {
                   setAppState({ errorMessage: error.message });
@@ -179,7 +182,7 @@ const LibraryMenuItems = ({
             icon={trash}
             onClick={() => {
               if (window.confirm(t("alerts.resetLibrary"))) {
-                Library.resetLibrary();
+                library.resetLibrary();
                 setLibraryItems([]);
                 focusContainer();
               }
@@ -190,7 +193,7 @@ const LibraryMenuItems = ({
       <a
         href={`https://libraries.excalidraw.com?target=${
           window.name || "_blank"
-        }&referrer=${referrer}&useHash=true&token=${Library.csrfToken}`}
+        }&referrer=${referrer}&useHash=true&token=${library.csrfToken}`}
         target="_excalidraw_libraries"
       >
         {t("labels.libraries")}
@@ -205,13 +208,13 @@ const LibraryMenuItems = ({
       const shouldAddPendingElements: boolean =
         pendingElements.length > 0 &&
         !addedPendingElements &&
-        y + x >= library.length;
+        y + x >= libraryItems.length;
       addedPendingElements = addedPendingElements || shouldAddPendingElements;
 
       children.push(
         <Stack.Col key={x}>
           <LibraryUnit
-            elements={library[y + x]}
+            elements={libraryItems[y + x]}
             pendingElements={
               shouldAddPendingElements ? pendingElements : undefined
             }
@@ -219,7 +222,7 @@ const LibraryMenuItems = ({
             onClick={
               shouldAddPendingElements
                 ? onAddToLibrary.bind(null, pendingElements)
-                : onInsertShape.bind(null, library[y + x])
+                : onInsertShape.bind(null, libraryItems[y + x])
             }
           />
         </Stack.Col>,
@@ -247,6 +250,7 @@ const LibraryMenu = ({
   setAppState,
   libraryReturnUrl,
   focusContainer,
+  library,
 }: {
   pendingElements: LibraryItem;
   onClickOutside: (event: MouseEvent) => void;
@@ -255,6 +259,7 @@ const LibraryMenu = ({
   setAppState: React.Component<any, AppState>["setState"];
   libraryReturnUrl: ExcalidrawProps["libraryReturnUrl"];
   focusContainer: () => void;
+  library: Library;
 }) => {
   const ref = useRef<HTMLDivElement | null>(null);
   useOnClickOutside(ref, (event) => {
@@ -280,7 +285,7 @@ const LibraryMenu = ({
           resolve("loading");
         }, 100);
       }),
-      Library.loadLibrary().then((items) => {
+      library.loadLibrary().then((items) => {
         setLibraryItems(items);
         setIsLoading("ready");
       }),
@@ -292,24 +297,27 @@ const LibraryMenu = ({
     return () => {
       clearTimeout(loadingTimerRef.current!);
     };
-  }, []);
+  }, [library]);
 
-  const removeFromLibrary = useCallback(async (indexToRemove) => {
-    const items = await Library.loadLibrary();
-    const nextItems = items.filter((_, index) => index !== indexToRemove);
-    Library.saveLibrary(nextItems);
-    setLibraryItems(nextItems);
-  }, []);
+  const removeFromLibrary = useCallback(
+    async (indexToRemove) => {
+      const items = await library.loadLibrary();
+      const nextItems = items.filter((_, index) => index !== indexToRemove);
+      library.saveLibrary(nextItems);
+      setLibraryItems(nextItems);
+    },
+    [library],
+  );
 
   const addToLibrary = useCallback(
     async (elements: LibraryItem) => {
-      const items = await Library.loadLibrary();
+      const items = await library.loadLibrary();
       const nextItems = [...items, elements];
       onAddToLibrary();
-      Library.saveLibrary(nextItems);
+      library.saveLibrary(nextItems);
       setLibraryItems(nextItems);
     },
-    [onAddToLibrary],
+    [onAddToLibrary, library],
   );
 
   return loadingState === "preloading" ? null : (
@@ -320,7 +328,7 @@ const LibraryMenu = ({
         </div>
       ) : (
         <LibraryMenuItems
-          library={libraryItems}
+          libraryItems={libraryItems}
           onRemoveFromLibrary={removeFromLibrary}
           onAddToLibrary={addToLibrary}
           onInsertShape={onInsertShape}
@@ -329,6 +337,7 @@ const LibraryMenu = ({
           setLibraryItems={setLibraryItems}
           libraryReturnUrl={libraryReturnUrl}
           focusContainer={focusContainer}
+          library={library}
         />
       )}
     </Island>
@@ -355,6 +364,7 @@ const LayerUI = ({
   libraryReturnUrl,
   UIOptions,
   focusContainer,
+  library,
 }: LayerUIProps) => {
   const isMobile = useIsMobile();
 
@@ -526,6 +536,7 @@ const LayerUI = ({
       setAppState={setAppState}
       libraryReturnUrl={libraryReturnUrl}
       focusContainer={focusContainer}
+      library={library}
     />
   ) : null;
 

--- a/src/data/json.ts
+++ b/src/data/json.ts
@@ -5,12 +5,13 @@ import { clearElementsForExport } from "../element";
 import { ExcalidrawElement } from "../element/types";
 import { AppState } from "../types";
 import { loadFromBlob } from "./blob";
-import { Library } from "./library";
+
 import {
   ExportedDataState,
   ImportedDataState,
   ExportedLibraryData,
 } from "./types";
+import Library from "./library";
 
 export const serializeAsJSON = (
   elements: readonly ExcalidrawElement[],
@@ -88,13 +89,13 @@ export const isValidLibrary = (json: any) => {
   );
 };
 
-export const saveLibraryAsJSON = async () => {
-  const library = await Library.loadLibrary();
+export const saveLibraryAsJSON = async (library: Library) => {
+  const libraryItems = await library.loadLibrary();
   const data: ExportedLibraryData = {
     type: EXPORT_DATA_TYPES.excalidrawLibrary,
     version: 1,
     source: EXPORT_SOURCE,
-    library,
+    library: libraryItems,
   };
   const serialized = JSON.stringify(data, null, 2);
   const fileName = "library.excalidrawlib";
@@ -108,7 +109,7 @@ export const saveLibraryAsJSON = async () => {
   });
 };
 
-export const importLibraryFromJSON = async () => {
+export const importLibraryFromJSON = async (library: Library) => {
   const blob = await fileOpen({
     description: "Excalidraw library files",
     // ToDo: Be over-permissive until https://bugs.webkit.org/show_bug.cgi?id=34442
@@ -117,5 +118,5 @@ export const importLibraryFromJSON = async () => {
     extensions: [".json", ".excalidrawlib"],
     */
   });
-  await Library.importLibrary(blob);
+  await library.importLibrary(blob);
 };

--- a/src/data/library.ts
+++ b/src/data/library.ts
@@ -3,12 +3,10 @@ import { LibraryItems, LibraryItem } from "../types";
 import { restoreElements } from "./restore";
 import { getNonDeletedElements } from "../element";
 import { NonDeleted, ExcalidrawElement } from "../element/types";
-import { nanoid } from "nanoid";
 import App from "../components/App";
 
 class Library {
   private libraryCache: LibraryItems | null = null;
-  public csrfToken = nanoid();
   private app: App;
 
   constructor(app: App) {

--- a/src/data/library.ts
+++ b/src/data/library.ts
@@ -15,9 +15,9 @@ class Library {
     this.app = app;
   }
 
-  resetLibrary = () => {
-    this.app.props.onLibraryChange?.([]);
-    this.libraryCache = null;
+  resetLibrary = async () => {
+    await this.app.props.onLibraryChange?.([]);
+    this.libraryCache = [];
   };
 
   /** imports library (currently merges, removing duplicates) */
@@ -61,7 +61,7 @@ class Library {
       return acc;
     }, [] as (readonly NonDeleted<ExcalidrawElement>[])[]);
 
-    this.saveLibrary([...existingLibraryItems, ...filtered]);
+    await this.saveLibrary([...existingLibraryItems, ...filtered]);
   }
 
   loadLibrary = (): Promise<LibraryItems> => {

--- a/src/data/library.ts
+++ b/src/data/library.ts
@@ -9,14 +9,14 @@ import App from "../components/App";
 class Library {
   private libraryCache: LibraryItems | null = null;
   public csrfToken = nanoid();
-  private app: any;
+  private app: App;
 
   constructor(app: App) {
     this.app = app;
   }
 
   resetLibrary = () => {
-    this.app?.props?.resetLibrary?.();
+    this.app.props.resetLibrary?.();
     this.libraryCache = null;
   };
 
@@ -71,14 +71,14 @@ class Library {
       }
 
       try {
-        const libraryItems = this.app?.libraryItemsFromStorage;
+        const libraryItems = this.app.libraryItemsFromStorage;
         if (!libraryItems) {
           return resolve([]);
         }
 
-        const items = libraryItems.map((elements: ExcalidrawElement[]) =>
-          restoreElements(elements),
-        ) as Mutable<LibraryItems>;
+        const items = libraryItems.map(
+          (elements) => restoreElements(elements) as LibraryItem,
+        );
 
         // clone to ensure we don't mutate the cached library elements in the app
         this.libraryCache = JSON.parse(JSON.stringify(items));
@@ -91,18 +91,17 @@ class Library {
     });
   };
 
-  saveLibrary = (items: LibraryItems) => {
-    this.app?.props?.addToLibrary?.(items);
-
+  saveLibrary = async (items: LibraryItems) => {
     const prevLibraryItems = this.libraryCache;
     try {
       const serializedItems = JSON.stringify(items);
-      // cache optimistically so that consumers have access to the latest
+      // cache optimistically so that the app has access to the latest
       // immediately
       this.libraryCache = JSON.parse(serializedItems);
+      await this.app.props.addToLibrary?.(items);
     } catch (error) {
       this.libraryCache = prevLibraryItems;
-      console.error(error);
+      throw error;
     }
   };
 }

--- a/src/data/library.ts
+++ b/src/data/library.ts
@@ -16,7 +16,7 @@ class Library {
   }
 
   resetLibrary = () => {
-    this.app.props.resetLibrary?.();
+    this.app.props.onLibraryChange?.([]);
     this.libraryCache = null;
   };
 
@@ -98,7 +98,7 @@ class Library {
       // cache optimistically so that the app has access to the latest
       // immediately
       this.libraryCache = JSON.parse(serializedItems);
-      await this.app.props.addToLibrary?.(items);
+      await this.app.props.onLibraryChange?.(items);
     } catch (error) {
       this.libraryCache = prevLibraryItems;
       throw error;

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -17,6 +17,7 @@ export interface ImportedDataState {
   elements?: readonly ExcalidrawElement[] | null;
   appState?: Readonly<Partial<AppState>> | null;
   scrollToContent?: boolean;
+  libraryItems?: LibraryItems;
 }
 
 export interface ExportedLibraryData {

--- a/src/excalidraw-app/index.tsx
+++ b/src/excalidraw-app/index.tsx
@@ -327,13 +327,9 @@ const ExcalidrawWrapper = () => {
     localStorage.removeItem(STORAGE_KEYS.LOCAL_STORAGE_LIBRARY);
   };
 
-  const addToLibrary = (items: LibraryItems) => {
-    try {
-      const serializedItems = JSON.stringify(items);
-      localStorage.setItem(STORAGE_KEYS.LOCAL_STORAGE_LIBRARY, serializedItems);
-    } catch (error) {
-      console.error(error);
-    }
+  const addToLibrary = async (items: LibraryItems) => {
+    const serializedItems = JSON.stringify(items);
+    localStorage.setItem(STORAGE_KEYS.LOCAL_STORAGE_LIBRARY, serializedItems);
   };
   return (
     <>

--- a/src/excalidraw-app/index.tsx
+++ b/src/excalidraw-app/index.tsx
@@ -330,8 +330,6 @@ const ExcalidrawWrapper = () => {
   const addToLibrary = (items: LibraryItems) => {
     try {
       const serializedItems = JSON.stringify(items);
-      // cache optimistically so that consumers have access to the latest
-      // immediately
       localStorage.setItem(STORAGE_KEYS.LOCAL_STORAGE_LIBRARY, serializedItems);
     } catch (error) {
       console.error(error);

--- a/src/excalidraw-app/index.tsx
+++ b/src/excalidraw-app/index.tsx
@@ -323,11 +323,11 @@ const ExcalidrawWrapper = () => {
     );
   };
 
-  const resetlibrary = () => {
-    localStorage.removeItem(STORAGE_KEYS.LOCAL_STORAGE_LIBRARY);
-  };
-
-  const addToLibrary = async (items: LibraryItems) => {
+  const onLibraryChange = async (items: LibraryItems) => {
+    if (!items.length) {
+      localStorage.removeItem(STORAGE_KEYS.LOCAL_STORAGE_LIBRARY);
+      return;
+    }
     const serializedItems = JSON.stringify(items);
     localStorage.setItem(STORAGE_KEYS.LOCAL_STORAGE_LIBRARY, serializedItems);
   };
@@ -346,8 +346,7 @@ const ExcalidrawWrapper = () => {
         renderCustomStats={renderCustomStats}
         detectScroll={false}
         handleKeyboardGlobally={true}
-        resetLibrary={resetlibrary}
-        addToLibrary={addToLibrary}
+        onLibraryChange={onLibraryChange}
       />
       {excalidrawAPI && <CollabWrapper excalidrawAPI={excalidrawAPI} />}
       {errorMessage && (

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -142,6 +142,8 @@
     "loadSceneOverridePrompt": "Loading external drawing will replace your existing content. Do you wish to continue?",
     "collabStopOverridePrompt": "Stopping the session will overwrite your previous, locally stored drawing. Are you sure?\n\n(If you want to keep your local drawing, simply close the browser tab instead.)",
     "errorLoadingLibrary": "There was an error loading the third party library.",
+    "errorAddingToLibrary": "Couldn't add item to the library",
+    "errorRemovingFromLibrary": "Couldn't remove item from library",
     "confirmAddLibrary": "This will add {{numShapes}} shape(s) to your library. Are you sure?",
     "imageDoesNotContainScene": "Importing images isn't supported at the moment.\n\nDid you want to import a scene? This image does not seem to contain any scene data. Have you enabled this during export?",
     "cannotRestoreFromImage": "Scene couldn't be restored from this image file",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -143,7 +143,7 @@
     "collabStopOverridePrompt": "Stopping the session will overwrite your previous, locally stored drawing. Are you sure?\n\n(If you want to keep your local drawing, simply close the browser tab instead.)",
     "errorLoadingLibrary": "There was an error loading the third party library.",
     "errorAddingToLibrary": "Couldn't add item to the library",
-    "errorRemovingFromLibrary": "Couldn't remove item from library",
+    "errorRemovingFromLibrary": "Couldn't remove item from the library",
     "confirmAddLibrary": "This will add {{numShapes}} shape(s) to your library. Are you sure?",
     "imageDoesNotContainScene": "Importing images isn't supported at the moment.\n\nDid you want to import a scene? This image does not seem to contain any scene data. Have you enabled this during export?",
     "cannotRestoreFromImage": "Scene couldn't be restored from this image file",

--- a/src/packages/excalidraw/CHANGELOG.md
+++ b/src/packages/excalidraw/CHANGELOG.md
@@ -17,6 +17,15 @@ Please add the latest change on the top under the correct section.
 
 ### Features
 
+- Don't share library & attach to the excalidraw instance [#3451](https://github.com/excalidraw/excalidraw/pull/3451).
+
+  - Added prop [onLibraryChange](https://github.com/excalidraw/excalidraw/blob/master/src/packages/excalidraw/README.md#onLibraryChange) which if supplied will be called when library is updated.
+  - Added attribute `libraryItems` to prop [initialData](https://github.com/excalidraw/excalidraw/blob/master/src/packages/excalidraw/README.md#initialdata) which can be used to load excalidraw with existing library items.
+
+  #### BREAKING CHANGE
+
+  - Earlier since there was no API to control the library hence was using local storage in the consumer. Now onwards with above API support the consumer will be responsible for handling the storage for the library.
+
 - Bind the keyboard events to component and added a prop [`handleKeyboardGlobally`](https://github.com/excalidraw/excalidraw/blob/master/src/packages/excalidraw/README.md#handleKeyboardGlobally) which if set to true will bind the keyboard events to document [#3430](https://github.com/excalidraw/excalidraw/pull/3430).
 
   #### BREAKING CHNAGE

--- a/src/packages/excalidraw/CHANGELOG.md
+++ b/src/packages/excalidraw/CHANGELOG.md
@@ -21,6 +21,7 @@ Please add the latest change on the top under the correct section.
 
   - Added prop [onLibraryChange](https://github.com/excalidraw/excalidraw/blob/master/src/packages/excalidraw/README.md#onLibraryChange) which if supplied will be called when library is updated.
   - Added attribute `libraryItems` to prop [initialData](https://github.com/excalidraw/excalidraw/blob/master/src/packages/excalidraw/README.md#initialdata) which can be used to load excalidraw with existing library items.
+  - Assign an [unique ID](https://github.com/excalidraw/excalidraw/blob/master/src/packages/excalidraw/README.md#Id) to the excalidraw component which can be accessed via [`ref`](https://github.com/excalidraw/excalidraw/blob/master/src/components/App.tsx#L265).
 
   #### BREAKING CHANGE
 
@@ -28,7 +29,7 @@ Please add the latest change on the top under the correct section.
 
 - Bind the keyboard events to component and added a prop [`handleKeyboardGlobally`](https://github.com/excalidraw/excalidraw/blob/master/src/packages/excalidraw/README.md#handleKeyboardGlobally) which if set to true will bind the keyboard events to document [#3430](https://github.com/excalidraw/excalidraw/pull/3430).
 
-  #### BREAKING CHNAGE
+  #### BREAKING CHANGE
 
   - Earlier keyboard events were bind to document but now its bind to Excalidraw component by default. So you will need to set [`handleKeyboardGlobally`](https://github.com/excalidraw/excalidraw/blob/master/src/packages/excalidraw/README.md#handleKeyboardGlobally) to true if you want the previous behaviour (bind the keyboard events to document).
 

--- a/src/packages/excalidraw/CHANGELOG.md
+++ b/src/packages/excalidraw/CHANGELOG.md
@@ -17,15 +17,15 @@ Please add the latest change on the top under the correct section.
 
 ### Features
 
-- Don't share library & attach to the excalidraw instance [#3451](https://github.com/excalidraw/excalidraw/pull/3451).
+- Make library local to given excalidraw instance (previously, all instances on the same page shared one global library) [#3451](https://github.com/excalidraw/excalidraw/pull/3451).
 
   - Added prop [onLibraryChange](https://github.com/excalidraw/excalidraw/blob/master/src/packages/excalidraw/README.md#onLibraryChange) which if supplied will be called when library is updated.
   - Added attribute `libraryItems` to prop [initialData](https://github.com/excalidraw/excalidraw/blob/master/src/packages/excalidraw/README.md#initialdata) which can be used to load excalidraw with existing library items.
-  - Assign an [unique ID](https://github.com/excalidraw/excalidraw/blob/master/src/packages/excalidraw/README.md#Id) to the excalidraw component which can be accessed via [`ref`](https://github.com/excalidraw/excalidraw/blob/master/src/components/App.tsx#L265).
+  - Assign a [unique id](https://github.com/excalidraw/excalidraw/blob/master/src/packages/excalidraw/README.md#Id) to the excalidraw component. The id can be accessed via [`ref`](https://github.com/excalidraw/excalidraw/blob/master/src/components/App.tsx#L265).
 
   #### BREAKING CHANGE
 
-  - Earlier since there was no API to control the library hence was using local storage in the consumer. Now onwards with above API support the consumer will be responsible for handling the storage for the library.
+  - From now on the host application is responsible for [persisting the library]((https://github.com/excalidraw/excalidraw/blob/master/src/packages/excalidraw/README.md#onLibraryChange) to LocalStorage (or elsewhere), and [importing it on mount]((https://github.com/excalidraw/excalidraw/blob/master/src/packages/excalidraw/README.md#initialdata).
 
 - Bind the keyboard events to component and added a prop [`handleKeyboardGlobally`](https://github.com/excalidraw/excalidraw/blob/master/src/packages/excalidraw/README.md#handleKeyboardGlobally) which if set to true will bind the keyboard events to document [#3430](https://github.com/excalidraw/excalidraw/pull/3430).
 

--- a/src/packages/excalidraw/README_NEXT.md
+++ b/src/packages/excalidraw/README_NEXT.md
@@ -610,6 +610,8 @@ Ths callback if supplied will get triggered when the library is updated and has 
 (items: <a href="https://github.com/excalidraw/excalidraw/blob/master/src/types.ts#L200">LibraryItems</a>) => void | Promise<any>
 </pre>
 
+It is invoked with empty items when user clears the library.
+
 ### id
 
 The unique Id for the excalidraw component. This can be used to identify the excalidraw component for example importing the library items to the correct excalidraw component when you have multiple excalidraw components rendered on the same page.

--- a/src/packages/excalidraw/README_NEXT.md
+++ b/src/packages/excalidraw/README_NEXT.md
@@ -367,6 +367,7 @@ To view the full example visit :point_down:
 | [`onPaste`](#onPaste) | <pre>(data: <a href="https://github.com/excalidraw/excalidraw/blob/master/src/clipboard.ts#L17">ClipboardData</a>, event: ClipboardEvent &#124; null) => boolean</pre> |  | Callback to be triggered if passed when the something is pasted in to the scene |
 | [`detectScroll`](#detectScroll) | boolean | true | Indicates whether to update the offsets when nearest ancestor is scrolled. |
 | [`handleKeyboardGlobally`](#handleKeyboardGlobally) | boolean | false | Indicates whether to bind the keyboard events to document. |
+| [`onLibraryChange`](#onLibraryChange) | <pre>(items: <a href="https://github.com/excalidraw/excalidraw/blob/master/src/types.ts#L200">LibraryItems</a>) => void &#124; Promise&lt;any&gt; </pre> |  | The callback if supplied is triggered when the library is updated and receives the library items. |
 
 ### Dimensions of Excalidraw
 
@@ -395,6 +396,7 @@ This helps to load Excalidraw with `initialData`. It must be an object or a [pro
 | `elements` | [ExcalidrawElement[]](https://github.com/excalidraw/excalidraw/blob/master/src/element/types.ts#L78) | The elements with which Excalidraw should be mounted. |
 | `appState` | [AppState](https://github.com/excalidraw/excalidraw/blob/master/src/types.ts#L37) | The App state with which Excalidraw should be mounted. |
 | `scrollToContent` | boolean | This attribute implies whether to scroll to the nearest element to center once Excalidraw is mounted. By default, it will not scroll the nearest element to the center. Make sure you pass `initialData.appState.scrollX` and `initialData.appState.scrollY` when `scrollToContent` is false so that scroll positions are retained |
+| `libraryItems` | [LibraryItems](https://github.com/excalidraw/excalidraw/blob/master/src/types.ts#L151) | This library items with which Excalidraw should be mounted. |
 
 ```json
 {
@@ -598,6 +600,14 @@ Indicates whether Excalidraw should listen for `scroll` event on the nearest scr
 Indicates whether to bind keyboard events to `document`. Disabled by default, meaning the keyboard events are bound to the Excalidraw component. This allows for multiple Excalidraw components to live on the same page, and ensures that Excalidraw keyboard handling doesn't collide with your app's (or the browser) when the component isn't focused.
 
 Enable this if you want Excalidraw to handle keyboard even if the component isn't focused (e.g. a user is interacting with the navbar, sidebar, or similar).
+
+### onLibraryChange
+
+Ths callback if supplied will get triggered when the library is updated and has the below signature.
+
+<pre>
+(items: <a href="https://github.com/excalidraw/excalidraw/blob/master/src/types.ts#L200">LibraryItems</a>) => void | Promise<any>
+</pre>
 
 ### Extra API's
 

--- a/src/packages/excalidraw/README_NEXT.md
+++ b/src/packages/excalidraw/README_NEXT.md
@@ -447,6 +447,7 @@ You can pass a `ref` when you want to access some excalidraw APIs. We expose the
 | refresh | `() => void` | Updates the offsets for the Excalidraw component so that the coordinates are computed correctly (for example the cursor position). You don't have to call this when the position is changed on page scroll or when the excalidraw container resizes (we handle that ourselves). For any other cases if the position of excalidraw is updated (example due to scroll on parent container and not page scroll) you should call this API. |
 | [importLibrary](#importlibrary) | `(url: string, token?: string) => void` | Imports library from given URL |
 | setToastMessage | `(message: string) => void` | This API can be used to show the toast with custom message. |
+| [id](#id) | string | Unique ID for the excalidraw component. |
 
 #### `readyPromise`
 
@@ -608,6 +609,10 @@ Ths callback if supplied will get triggered when the library is updated and has 
 <pre>
 (items: <a href="https://github.com/excalidraw/excalidraw/blob/master/src/types.ts#L200">LibraryItems</a>) => void | Promise<any>
 </pre>
+
+### id
+
+The unique Id for the excalidraw component. This can be used to identify the excalidraw component for example importing the library items to the correct excalidraw component when you have multiple excalidraw components rendered on the same page.
 
 ### Extra API's
 

--- a/src/packages/excalidraw/README_NEXT.md
+++ b/src/packages/excalidraw/README_NEXT.md
@@ -610,7 +610,7 @@ Ths callback if supplied will get triggered when the library is updated and has 
 (items: <a href="https://github.com/excalidraw/excalidraw/blob/master/src/types.ts#L200">LibraryItems</a>) => void | Promise<any>
 </pre>
 
-It is invoked with empty items when user clears the library.
+It is invoked with empty items when user clears the library. You can use this callback when you want to do something additional when library is updated for example persisting it to local storage.
 
 ### id
 

--- a/src/packages/excalidraw/README_NEXT.md
+++ b/src/packages/excalidraw/README_NEXT.md
@@ -614,7 +614,7 @@ It is invoked with empty items when user clears the library. You can use this ca
 
 ### id
 
-The unique Id for the excalidraw component. This can be used to identify the excalidraw component for example importing the library items to the correct excalidraw component when you have multiple excalidraw components rendered on the same page.
+The unique id of the excalidraw component. This can be used to identify the excalidraw component, for example importing the library items to the excalidraw component from where it was initiated when you have multiple excalidraw components rendered on the same page as shown in [multiple excalidraw demo](https://codesandbox.io/s/multiple-excalidraw-k1xx5).
 
 ### Extra API's
 

--- a/src/packages/excalidraw/index.tsx
+++ b/src/packages/excalidraw/index.tsx
@@ -32,8 +32,7 @@ const Excalidraw = (props: ExcalidrawProps) => {
     onPaste,
     detectScroll = true,
     handleKeyboardGlobally = false,
-    resetLibrary,
-    addToLibrary,
+    onLibraryChange,
   } = props;
 
   const canvasActions = props.UIOptions?.canvasActions;
@@ -86,8 +85,7 @@ const Excalidraw = (props: ExcalidrawProps) => {
         onPaste={onPaste}
         detectScroll={detectScroll}
         handleKeyboardGlobally={handleKeyboardGlobally}
-        resetLibrary={resetLibrary}
-        addToLibrary={addToLibrary}
+        onLibraryChange={onLibraryChange}
       />
     </InitializeApp>
   );

--- a/src/packages/excalidraw/index.tsx
+++ b/src/packages/excalidraw/index.tsx
@@ -32,6 +32,8 @@ const Excalidraw = (props: ExcalidrawProps) => {
     onPaste,
     detectScroll = true,
     handleKeyboardGlobally = false,
+    resetLibrary,
+    addToLibrary,
   } = props;
 
   const canvasActions = props.UIOptions?.canvasActions;
@@ -84,6 +86,8 @@ const Excalidraw = (props: ExcalidrawProps) => {
         onPaste={onPaste}
         detectScroll={detectScroll}
         handleKeyboardGlobally={handleKeyboardGlobally}
+        resetLibrary={resetLibrary}
+        addToLibrary={addToLibrary}
       />
     </InitializeApp>
   );

--- a/src/packages/excalidraw/package.json
+++ b/src/packages/excalidraw/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@excalidraw/excalidraw",
-  "version": "0.6.0",
+  "name": "aakansha-excalidraw",
+  "version": "0.7.0-lib",
   "main": "main.js",
   "types": "types/packages/excalidraw/index.d.ts",
   "files": [

--- a/src/packages/excalidraw/package.json
+++ b/src/packages/excalidraw/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "aakansha-excalidraw",
-  "version": "0.7.0-lib",
+  "name": "@excalidraw/excalidraw",
+  "version": "0.6.0",
   "main": "main.js",
   "types": "types/packages/excalidraw/index.d.ts",
   "files": [

--- a/src/tests/library.test.tsx
+++ b/src/tests/library.test.tsx
@@ -9,17 +9,17 @@ const { h } = window;
 
 describe("library", () => {
   beforeEach(async () => {
-    h.library.resetLibrary();
     await render(<ExcalidrawApp />);
+    h.app.library.resetLibrary();
   });
 
   it("import library via drag&drop", async () => {
-    expect(await h.library.loadLibrary()).toEqual([]);
+    expect(await h.app.library.loadLibrary()).toEqual([]);
     await API.drop(
       await API.loadFile("./fixtures/fixture_library.excalidrawlib"),
     );
     await waitFor(async () => {
-      expect(await h.library.loadLibrary()).toEqual([
+      expect(await h.app.library.loadLibrary()).toEqual([
         [expect.objectContaining({ id: "A" })],
       ]);
     });

--- a/src/types.ts
+++ b/src/types.ts
@@ -197,7 +197,7 @@ export interface ExcalidrawProps {
   UIOptions?: UIOptions;
   detectScroll?: boolean;
   handleKeyboardGlobally?: boolean;
-  onLibraryChange?: (libraryItems: LibraryItems) => void;
+  onLibraryChange?: (libraryItems: LibraryItems) => void | Promise<any>;
 }
 
 export type SceneData = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -197,8 +197,7 @@ export interface ExcalidrawProps {
   UIOptions?: UIOptions;
   detectScroll?: boolean;
   handleKeyboardGlobally?: boolean;
-  resetLibrary?: () => void;
-  addToLibrary?: (libraryItems: LibraryItems) => void;
+  onLibraryChange?: (libraryItems: LibraryItems) => void;
 }
 
 export type SceneData = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -197,6 +197,8 @@ export interface ExcalidrawProps {
   UIOptions?: UIOptions;
   detectScroll?: boolean;
   handleKeyboardGlobally?: boolean;
+  resetLibrary?: () => void;
+  addToLibrary?: (libraryItems: LibraryItems) => void;
 }
 
 export type SceneData = {


### PR DESCRIPTION
An attempt to attach the library to each excalidraw instance so each instance has its own library when [multiple excalidraw](https://github.com/excalidraw/excalidraw/issues/3043) rendered.

fixes https://github.com/excalidraw/excalidraw/issues/3400

Try [here](https://k1xx5.csb.app/#token=Kc18ngwqu2Pf7ZuRuLG0o)

- [x] Add props
   1. `onLibraryChange` which will get triggered on every library change.
   2. `initialData.libraryItems` with which host can load excalidraw with existing library items.
   3. Add unique id to excalidraw component which will be available to host via ref.
  
- [x] Testing
- [x] Update changelog & readme