### PR TITLE
fix: prevent selecting `.visually-hidden` elements

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -125,6 +125,7 @@
         overflow: hidden;
         clip: rect(1px, 1px, 1px, 1px);
         white-space: nowrap; /* added line */
+        user-select: none;
       }
 
       .LoadingMessage {

--- a/src/css/app.scss
+++ b/src/css/app.scss
@@ -5,6 +5,7 @@
   overflow: hidden;
   clip: rect(1px, 1px, 1px, 1px);
   white-space: nowrap; /* added line */
+  user-select: none;
 }
 
 .LoadingMessage {


### PR DESCRIPTION
attempt to fix https://github.com/excalidraw/excalidraw/issues/3468