### PR TITLE
feat: remove `backdrop-filter` to improve perf

### DIFF
--- a/src/components/Island.scss
+++ b/src/components/Island.scss
@@ -2,7 +2,6 @@
   .Island {
     --padding: 0;
     background-color: var(--island-bg-color);
-    backdrop-filter: saturate(100%) blur(10px);
     box-shadow: var(--shadow-island);
     border-radius: 4px;
     padding: calc(var(--padding) * var(--space-factor));

--- a/src/components/Modal.scss
+++ b/src/components/Modal.scss
@@ -26,8 +26,7 @@
     right: 0;
     bottom: 0;
     z-index: 1;
-    background-color: transparentize($oc-black, 0.7);
-    backdrop-filter: blur(2px);
+    background-color: transparentize($oc-black, 0.3);
   }
 
   .Modal__content {
@@ -45,7 +44,6 @@
 
     // for modals, reset blurry bg
     background: var(--island-bg-color);
-    backdrop-filter: none;
 
     border: 1px solid var(--dialog-border-color);
     box-shadow: 0 2px 10px transparentize($oc-black, 0.75);

--- a/src/css/theme.scss
+++ b/src/css/theme.scss
@@ -18,7 +18,7 @@
   --input-border-color: #{$oc-gray-3};
   --input-hover-bg-color: #{$oc-gray-1};
   --input-label-color: #{$oc-gray-7};
-  --island-bg-color: rgba(255, 255, 255, 0.9);
+  --island-bg-color: rgba(255, 255, 255, 0.96);
   --keybinding-color: #{$oc-gray-5};
   --link-color: #{$oc-blue-7};
   --overlay-bg-color: #{transparentize($oc-white, 0.12)};
@@ -60,7 +60,7 @@
     --input-border-color: #2e2e2e;
     --input-hover-bg-color: #181818;
     --input-label-color: #{$oc-gray-2};
-    --island-bg-color: #1e1e1e;
+    --island-bg-color: rgba(30, 30, 30, 0.98);
     --keybinding-color: #{$oc-gray-6};
     --overlay-bg-color: #{transparentize($oc-gray-8, 0.88)};
     --popup-bg-color: #2c2c2c;


### PR DESCRIPTION
fix https://github.com/excalidraw/excalidraw/issues/3505

- [x] removed `backdrop-filter` from `.Island` which affected general performance of canvas on non-GPU accelerated devices.
- [x] removed `backdrop-filter` from Modal background which affected time-to-render when opening modal and scroll/rerender perf (and even on GPU-accelerated devices it makes the anim janky at times).

Kept transparency (and also added it to dark mode `.Island` bg which previously wasn't there).

before:

![image](https://user-images.githubusercontent.com/5153846/116152231-ee42aa00-a6e5-11eb-8d03-96333af7a610.png) ![image](https://user-images.githubusercontent.com/5153846/116152158-d9fead00-a6e5-11eb-85b9-931bbaad43c1.png)

after: 

![image](https://user-images.githubusercontent.com/5153846/116152034-b3407680-a6e5-11eb-8df6-09e7cd2c243f.png) ![image](https://user-images.githubusercontent.com/5153846/116152189-e08d2480-a6e5-11eb-9b46-0b5b962ceeeb.png)

