### PR TITLE
feat: resave to svg if you opened an svg with a scene in it

### DIFF
--- a/src/actions/actionExport.tsx
+++ b/src/actions/actionExport.tsx
@@ -100,19 +100,21 @@ export const actionSaveScene = register({
     const fileHandleExists = !!appState.fileHandle;
     try {
       const { fileHandle } = await saveAsJSON(elements, appState);
+      const toastMessage = fileHandleExists
+        ? fileHandle.name
+          ? t("toast.fileSavedToFilename").replace(
+              "{filename}",
+              `"${fileHandle.name}"`,
+            )
+          : t("toast.fileSaved")
+        : null;
+
       return {
         commitToHistory: false,
         appState: {
           ...appState,
           fileHandle,
-          toastMessage: fileHandleExists
-            ? fileHandle.name
-              ? t("toast.fileSavedToFilename").replace(
-                  "{filename}",
-                  `"${fileHandle.name}"`,
-                )
-              : t("toast.fileSaved")
-            : null,
+          toastMessage,
         },
       };
     } catch (error) {

--- a/src/actions/actionExport.tsx
+++ b/src/actions/actionExport.tsx
@@ -6,7 +6,7 @@ import { ToolButton } from "../components/ToolButton";
 import "../components/ToolIcon.scss";
 import { Tooltip } from "../components/Tooltip";
 import { DarkModeToggle, Appearence } from "../components/DarkModeToggle";
-import { loadFromJSON, saveAsJSON } from "../data";
+import { loadFromFilesystem, saveToFilesystem } from "../data";
 import { t } from "../i18n";
 import useIsMobile from "../is-mobile";
 import { KEYS } from "../keys";
@@ -99,7 +99,7 @@ export const actionSaveScene = register({
   perform: async (elements, appState, value) => {
     const fileHandleExists = !!appState.fileHandle;
     try {
-      const { fileHandle } = await saveAsJSON(elements, appState);
+      const { fileHandle } = await saveToFilesystem(elements, appState);
       const toastMessage = fileHandleExists
         ? fileHandle.name
           ? t("toast.fileSavedToFilename").replace(
@@ -142,7 +142,7 @@ export const actionSaveAsScene = register({
   name: "saveAsScene",
   perform: async (elements, appState, value) => {
     try {
-      const { fileHandle } = await saveAsJSON(elements, {
+      const { fileHandle } = await saveToFilesystem(elements, {
         ...appState,
         fileHandle: null,
       });
@@ -178,7 +178,7 @@ export const actionLoadScene = register({
       const {
         elements: loadedElements,
         appState: loadedAppState,
-      } = await loadFromJSON(appState);
+      } = await loadFromFilesystem(appState);
       return {
         elements: loadedElements,
         appState: loadedAppState,

--- a/src/appState.ts
+++ b/src/appState.ts
@@ -121,6 +121,7 @@ const APP_STATE_STORAGE_CONF = (<
   exportEmbedScene: { browser: true, export: false },
   exportWithDarkMode: { browser: true, export: false },
   fileHandle: { browser: false, export: false },
+  saveType: { browser: false, export: false },
   gridSize: { browser: true, export: true },
   height: { browser: false, export: false },
   isBindingEnabled: { browser: false, export: false },

--- a/src/appState.ts
+++ b/src/appState.ts
@@ -56,6 +56,7 @@ export const getDefaultAppState = (): Omit<
     pasteDialog: { shown: false, data: null },
     previousSelectedElementIds: {},
     resizingElement: null,
+    saveType: "excalidraw",
     scrolledOutside: false,
     scrollX: 0,
     scrollY: 0,

--- a/src/clipboard.ts
+++ b/src/clipboard.ts
@@ -6,7 +6,6 @@ import { getSelectedElements } from "./scene";
 import { AppState } from "./types";
 import { SVG_EXPORT_TAG } from "./scene/export";
 import { tryParseSpreadsheet, Spreadsheet, VALID_SPREADSHEET } from "./charts";
-import { canvasToBlob } from "./data/blob";
 
 const TYPE_ELEMENTS = "excalidraw/elements";
 
@@ -151,8 +150,7 @@ export const parseClipboard = async (
   }
 };
 
-export const copyCanvasToClipboardAsPng = async (canvas: HTMLCanvasElement) => {
-  const blob = await canvasToBlob(canvas);
+export const copyBlobToClipboardAsPng = async (blob: Blob) => {
   await navigator.clipboard.write([
     new window.ClipboardItem({ "image/png": blob }),
   ]);

--- a/src/components/ExportDialog.tsx
+++ b/src/components/ExportDialog.tsx
@@ -17,7 +17,9 @@ import Stack from "./Stack";
 import { ToolButton } from "./ToolButton";
 
 const scales = [1, 2, 3];
-const defaultScale = scales.includes(devicePixelRatio) ? devicePixelRatio : 1;
+export const defaultScale = scales.includes(devicePixelRatio)
+  ? devicePixelRatio
+  : 1;
 
 const supportsContextFilters =
   "filter" in document.createElement("canvas").getContext("2d")!;

--- a/src/components/LayerUI.tsx
+++ b/src/components/LayerUI.tsx
@@ -363,6 +363,7 @@ const LayerUI = ({
           viewBackgroundColor: appState.viewBackgroundColor,
           scale,
           shouldAddWatermark: appState.shouldAddWatermark,
+          exportEmbedScene: appState.exportEmbedScene,
         })
           .catch(muteFSAbortError)
           .catch((error) => {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -82,7 +82,7 @@ export const GRID_SIZE = 20; // TODO make it configurable?
 export const MIME_TYPES = {
   excalidraw: "application/vnd.excalidraw+json",
   excalidrawlib: "application/vnd.excalidrawlib+json",
-};
+} as const;
 
 export const STORAGE_KEYS = {
   LOCAL_STORAGE_LIBRARY: "excalidraw-library",

--- a/src/data/blob.ts
+++ b/src/data/blob.ts
@@ -1,9 +1,9 @@
 import { cleanAppStateForExport } from "../appState";
-import { MIME_TYPES } from "../constants";
 import { clearElementsForExport } from "../element";
 import { CanvasError } from "../errors";
 import { t } from "../i18n";
 import { calculateScrollCenter } from "../scene";
+import { SaveType } from "../scene/types";
 import { AppState } from "../types";
 import { isValidExcalidrawData } from "./json";
 import { restore } from "./restore";
@@ -79,6 +79,18 @@ export const getMimeType = (blob: Blob | string): string => {
   return "";
 };
 
+export const getSaveType = (blob: Blob | string): SaveType | null => {
+  const mime = getMimeType(blob);
+  if (mime === "application/json") {
+    return "excalidraw";
+  } else if (mime === "image/png") {
+    return "png";
+  } else if (mime === "image/svg+xml") {
+    return "svg";
+  }
+  return null;
+};
+
 export const loadFromBlob = async (
   blob: Blob,
   /** @see restore.localAppState */
@@ -96,15 +108,8 @@ export const loadFromBlob = async (
         appState: {
           theme: localAppState?.theme,
           fileHandle:
-            blob.handle &&
-            [
-              "application/json",
-              MIME_TYPES.excalidraw,
-              "image/png",
-              "image/svg+xml",
-            ].includes(getMimeType(blob))
-              ? blob.handle
-              : null,
+            blob.handle && getSaveType(blob) != null ? blob.handle : null,
+          saveType: getSaveType(blob),
           ...cleanAppStateForExport(data.appState || {}),
           ...(localAppState
             ? calculateScrollCenter(data.elements || [], localAppState, null)

--- a/src/data/blob.ts
+++ b/src/data/blob.ts
@@ -97,9 +97,12 @@ export const loadFromBlob = async (
           theme: localAppState?.theme,
           fileHandle:
             blob.handle &&
-            ["application/json", MIME_TYPES.excalidraw].includes(
-              getMimeType(blob),
-            )
+            [
+              "application/json",
+              MIME_TYPES.excalidraw,
+              "image/png",
+              "image/svg+xml",
+            ].includes(getMimeType(blob))
               ? blob.handle
               : null,
           ...cleanAppStateForExport(data.appState || {}),

--- a/src/data/image.ts
+++ b/src/data/image.ts
@@ -42,7 +42,7 @@ export const encodePngMetadata = async ({
 }: {
   blob: Blob;
   metadata: string;
-}) => {
+}): Promise<Blob> => {
   const chunks = decodePng(new Uint8Array(await blobToArrayBuffer(blob)));
 
   const metadataChunk = tEXt.encode(

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -13,7 +13,7 @@ import { canvasToBlob } from "./blob";
 import { serializeAsJSON } from "./json";
 
 export { loadFromBlob } from "./blob";
-export { loadFromJSON, saveAsJSON } from "./json";
+export { saveToFilesystem, loadFromFilesystem } from "./json";
 
 type ExportOptions = {
   exportBackground: boolean;

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -105,24 +105,17 @@ const exportToPNGForReal = async (
     exportEmbedScene,
   }: ExportOptions,
 ) => {
-  let blob = await serializeAsPngBlob(elements, appState, {
+  const blob = await serializeAsPngBlob(elements, appState, {
     exportBackground,
     viewBackgroundColor,
     exportPadding,
     scale,
     shouldAddWatermark,
+    exportEmbedScene,
   });
 
   if (type === "png") {
     const fileName = `${name}.png`;
-    if (exportEmbedScene) {
-      blob = await (
-        await import(/* webpackChunkName: "image" */ "./image")
-      ).encodePngMetadata({
-        blob,
-        metadata: serializeAsJSON(elements, appState),
-      });
-    }
 
     // FIXME: extract this as a shared helper?
     const fileHandle = await fileSave(

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -6,7 +6,7 @@ import {
 import { NonDeletedExcalidrawElement } from "../element/types";
 import { t } from "../i18n";
 // FIXME: rename these to exportToCanvasElement and exportToSvgElement?
-import { exportToCanvas, exportToSvg } from "../scene/export";
+import { exportToCanvas, serializeToSvg } from "../scene/export";
 import { ExportType } from "../scene/types";
 import { AppState } from "../types";
 import { canvasToBlob } from "./blob";
@@ -57,7 +57,7 @@ const exportToSVGForReal = async (
     exportEmbedScene,
   }: ExportOptions,
 ) => {
-  const tempSvg = exportToSvg(elements, {
+  const svgData = serializeToSvg(elements, {
     exportBackground,
     exportWithDarkMode: appState.exportWithDarkMode,
     viewBackgroundColor,
@@ -76,7 +76,7 @@ const exportToSVGForReal = async (
   if (type === "svg") {
     // FIXME: extract this as a shared helper?
     const fileHandle = await fileSave(
-      new Blob([tempSvg.outerHTML], { type: "image/svg+xml" }),
+      new Blob([svgData], { type: "image/svg+xml" }),
       {
         fileName: `${name}.svg`,
         extensions: [".svg"],
@@ -87,7 +87,7 @@ const exportToSVGForReal = async (
       appState.fileHandle = fileHandle;
     }
   } else if (type === "clipboard-svg") {
-    copyTextToSystemClipboard(tempSvg.outerHTML);
+    copyTextToSystemClipboard(svgData);
   }
 };
 

--- a/src/data/json.ts
+++ b/src/data/json.ts
@@ -49,7 +49,7 @@ const serializeAsBlob = async (
         elements as NonDeletedExcalidrawElement[],
         appState,
         {
-          // FIXME: I'm not sure if we can expext these pieces of appState
+          // FIXME: I'm not sure if we can expect these pieces of appState
           // to be defined correctly at this time.
           exportBackground: appState.exportBackground,
           viewBackgroundColor: appState.viewBackgroundColor,
@@ -79,7 +79,7 @@ export const saveToFilesystem = async (
 
   // FIXME: it feel really fishy that the user can select a png file
   // at this point, and we will blindly overwrite it with json.
-  // I think it should be possible to recognise that this has happened
+  // I think it should be possible to recognize that this has happened
   // and attempt another save with actually valid png data?
   // Maybe there is another way, where we can read the file and extract
   // metadata out of it before attempting to overwrite it?

--- a/src/data/json.ts
+++ b/src/data/json.ts
@@ -7,7 +7,7 @@ import {
   ExcalidrawElement,
   NonDeletedExcalidrawElement,
 } from "../element/types";
-import { serializeAsPngBlob } from "../scene/export";
+import { serializeAsPngBlob, serializeToSvg } from "../scene/export";
 import { AppState } from "../types";
 import { loadFromBlob } from "./blob";
 import { Library } from "./library";
@@ -35,8 +35,26 @@ const serializeAsBlob = async (
 ): Promise<Blob> => {
   switch (appState.saveType) {
     case "svg": {
-      // FIXME: serializeAsSvg()?
-      const serialized = serializeAsJSON(elements, appState);
+      // FIXME: rename to serializeAsSvgString()?
+      // FIXME: see notes about parameters from serializeAsPngBlob, below.
+      const serialized = serializeToSvg(
+        elements as NonDeletedExcalidrawElement[],
+        {
+          exportBackground: appState.exportBackground,
+          exportWithDarkMode: appState.exportWithDarkMode,
+          viewBackgroundColor: appState.viewBackgroundColor,
+          exportPadding: 10,
+          scale: defaultScale,
+          shouldAddWatermark: appState.shouldAddWatermark,
+          // FIXME: push this down, and pass in exportEmbedScene: bool
+          // instead, like how serializeAsPngBlob() does it.
+          metadata: await (
+            await import(/* webpackChunkName: "image" */ "./image")
+          ).encodeSvgMetadata({
+            text: serializeAsJSON(elements, appState),
+          }),
+        },
+      );
       return new Blob([serialized], {
         type: "image/svg+xml",
       });

--- a/src/data/json.ts
+++ b/src/data/json.ts
@@ -24,14 +24,41 @@ export const serializeAsJSON = (
     2,
   );
 
+const serializeAsBlob = (
+  elements: readonly ExcalidrawElement[],
+  appState: AppState,
+): Blob => {
+  switch (appState.saveType) {
+    case "svg": {
+      // FIXME: serializeAsSvg()?
+      const serialized = serializeAsJSON(elements, appState);
+      return new Blob([serialized], {
+        type: "image/svg+xml",
+      });
+    }
+    case "png": {
+      // FIXME: serializeAsPng()?
+      const serialized = serializeAsJSON(elements, appState);
+      return new Blob([serialized], {
+        type: "image/png",
+      });
+    }
+    case "excalidraw":
+    case null:
+    case undefined: {
+      const serialized = serializeAsJSON(elements, appState);
+      return new Blob([serialized], {
+        type: MIME_TYPES.excalidraw,
+      });
+    }
+  }
+};
+
 export const saveToFilesystem = async (
   elements: readonly ExcalidrawElement[],
   appState: AppState,
 ) => {
-  const serialized = serializeAsJSON(elements, appState);
-  const blob = new Blob([serialized], {
-    type: MIME_TYPES.excalidraw,
-  });
+  const blob = serializeAsBlob(elements, appState);
 
   const fileHandle = await fileSave(
     blob,

--- a/src/data/json.ts
+++ b/src/data/json.ts
@@ -24,7 +24,7 @@ export const serializeAsJSON = (
     2,
   );
 
-export const saveAsJSON = async (
+export const saveToFilesystem = async (
   elements: readonly ExcalidrawElement[],
   appState: AppState,
 ) => {
@@ -45,7 +45,7 @@ export const saveAsJSON = async (
   return { fileHandle };
 };
 
-export const loadFromJSON = async (localAppState: AppState) => {
+export const loadFromFilesystem = async (localAppState: AppState) => {
   const blob = await fileOpen({
     description: "Excalidraw files",
     // ToDo: Be over-permissive until https://bugs.webkit.org/show_bug.cgi?id=34442

--- a/src/data/json.ts
+++ b/src/data/json.ts
@@ -11,7 +11,7 @@ import { serializeAsPngBlob, serializeToSvg } from "../scene/export";
 import { AppState } from "../types";
 import { loadFromBlob } from "./blob";
 import { Library } from "./library";
-import { ImportedDataState } from "./types";
+import { DataState, ImportedDataState } from "./types";
 
 export const serializeAsJSON = (
   elements: readonly ExcalidrawElement[],
@@ -113,7 +113,9 @@ export const saveToFilesystem = async (
   return { fileHandle };
 };
 
-export const loadFromFilesystem = async (localAppState: AppState) => {
+export const loadFromFilesystem = async (
+  localAppState: AppState,
+): Promise<DataState> => {
   const blob = await fileOpen({
     description: "Excalidraw files",
     // ToDo: Be over-permissive until https://bugs.webkit.org/show_bug.cgi?id=34442

--- a/src/scene/export.ts
+++ b/src/scene/export.ts
@@ -13,6 +13,7 @@ import {
   THEME_FILTER,
 } from "../constants";
 import { getDefaultAppState } from "../appState";
+import { canvasToBlob } from "../data/blob";
 
 export const SVG_EXPORT_TAG = `<!-- svg-source:excalidraw -->`;
 const WATERMARK_HEIGHT = 16;
@@ -84,6 +85,29 @@ export const exportToCanvas = (
   );
 
   return tempCanvas;
+};
+
+export const serializeAsPngBlob = async (
+  elements: readonly NonDeletedExcalidrawElement[],
+  appState: AppState,
+  // FIXME: remove options?
+  options: {
+    exportBackground: boolean;
+    exportPadding?: number;
+    scale?: number;
+    viewBackgroundColor: string;
+    shouldAddWatermark: boolean;
+  },
+  // ??? do we need to be able to provide createCanvas for tests?
+): Promise<Blob> => {
+  const tempCanvas = exportToCanvas(elements, appState, options);
+
+  tempCanvas.style.display = "none";
+  document.body.appendChild(tempCanvas);
+  const blob = await canvasToBlob(tempCanvas);
+  tempCanvas.remove();
+
+  return blob;
 };
 
 export const exportToSvg = (

--- a/src/scene/export.ts
+++ b/src/scene/export.ts
@@ -228,3 +228,17 @@ export const getExportSize = (
 
   return [width, height];
 };
+
+export const serializeToSvg = (
+  elements: readonly NonDeletedExcalidrawElement[],
+  // FIXME: extract a type for this, or delete exportToSvg and inline?
+  options: {
+    exportBackground: boolean;
+    exportPadding?: number;
+    scale?: number;
+    viewBackgroundColor: string;
+    exportWithDarkMode?: boolean;
+    shouldAddWatermark: boolean;
+    metadata?: string;
+  },
+): string => exportToSvg(elements, options).outerHTML;

--- a/src/scene/types.ts
+++ b/src/scene/types.ts
@@ -25,12 +25,14 @@ export interface Scene {
   elements: ExcalidrawTextElement[];
 }
 
+export type SaveType = "png" | "svg" | "excalidraw";
+
 export type ExportType =
   | "png"
+  | "svg"
   | "clipboard"
   | "clipboard-svg"
-  | "backend"
-  | "svg";
+  | "backend";
 
 export type ScrollBars = {
   horizontal: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -107,7 +107,7 @@ export type AppState = {
 
   isLibraryOpen: boolean;
   fileHandle: import("browser-fs-access").FileSystemHandle | null;
-  saveType?: SaveType;
+  saveType?: SaveType | null;
   collaborators: Map<string, Collaborator>;
   showStats: boolean;
   currentChartType: ChartType;

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,6 +21,7 @@ import type { ResolvablePromise } from "./utils";
 import { Spreadsheet } from "./charts";
 import { Language } from "./i18n";
 import { UserIdleState } from "./excalidraw-app/collab/types";
+import { SaveType } from "./scene/types";
 
 export type Point = Readonly<RoughPoint>;
 
@@ -106,6 +107,7 @@ export type AppState = {
 
   isLibraryOpen: boolean;
   fileHandle: import("browser-fs-access").FileSystemHandle | null;
+  saveType?: SaveType;
   collaborators: Map<string, Collaborator>;
   showStats: boolean;
   currentChartType: ChartType;


### PR DESCRIPTION
This is a sketch of how I might go about fixing https://github.com/excalidraw/excalidraw/issues/2261 

I ended up doing a bunch of refactors while I was exploring the codebase. Some of them are valuable, but not all of them are needed.

It would be nice to have some feedback on whether this is a reasonable approach, but I will probably not try to get this merged. It will be better to close this PR, and split out a series of smaller PRs with refactorings, followed by a PR that implements the feature cleanly.

Summary of changes, in the order they appear as you see them in the PR diff view:

src/actions/actionExport.tsx
- [keep - last PR] rename loadFromJSON, saveAsJSON to loadFromFilesystem, saveToFilesystem
  - [ ] Maybe saveSceneToFilesystem, to be more explicit?
- [scrap]: pointless refactor in actionSaveScene

src/appState.ts:
- [keep - last PR] Add saveType to appState (svg | png | excalidraw)

src/clipboard.ts (also src/data/json.ts):
- [keep - first PR] Try to pass `string` or `Blob` around in the export modules, rather than Canvas or HtmlSvgElement or whatever

src/components/ExportDialog.tsx:
- [hack] export defaultScale  from ExportDialog for use in saveToFilesystem
  - [ ] (should really save this into the svg file and load it if possible?)

src/components/LayerUI.tsx:
- [keep - first PR] add exportEmbedScene as an option to the serialisation functions, rather than plucking it out of appState
  - [ ] need to finish this refactor in a few places

src/data/blob.ts:
- [keep - last PR] infer a saveType (svg | png | excalidraw) when loading scene from filesystem and add it to appState

src/data/image.ts:
- [keep] explicit return type for encodePngMetadata() (should we have a linter rule about this?)

src/data/index.ts:
- [scrap] split out `exportToSVGForReal()` and `exportToPNGForReal()` - This is what happens when you try to refactor bottom-up rather than top-down. When I tried again top-down, from saveSceneToFilesystem(), I realised that it was much nicer to clean up the serlialisation helpers.
- [keep - first PR] serializeToSvg() helper that returns a string
  - [ ] rename to serializeToSvgString() or somehow work out whether it's reasonable to return a Blob, for symmetry with below?
- [keep - first PR] serializeAsPngBlob helper that wraps exportToCanvas() and takes care of deleting the 
- [scrap] messing about with how the export functions call fileSave - this was definitely a bad idea
- [???] remove really strange thing where we compare tempCanvas with [app.]canvas. What is actually going on here?

src/data/json.ts:
- [ ] rename this file to something else, now that it doesn't just deal with the .excalidraw json format?
- [keep - last PR] switch on saveType to decide how to serialise the scene
  - [ ] how to deal with NonDeletedExcalidrawElement vs ExcalidrawElement?
  - [ ] audit the serializeTo*() parameters, and work out how we should deal with each of these
  - [ ] explicitly think about how SaveAs should work now

Misc:
- [ ] [first PR] I've made a bunch of changes to where we are importing/using various functions. It would be good to look over the dependencies between modules, and decide whether we want to shuffle things about.
- [ ] write some tests, maybe?


The call tree for exportToCanvas is here (with scene embedded):

![status-quo](https://user-images.githubusercontent.com/254647/118286272-345f8200-b4ca-11eb-8cdf-df61c43871b0.png)

I would like it to look like this:

![plan](https://user-images.githubusercontent.com/254647/118292230-522fe580-b4d0-11eb-87c9-ca8ca3718dae.png)

I think that ??? will probably be called resaveAsImageWithScene() or something.