### PR TITLE
fix: handle render errors

### DIFF
--- a/src/renderer/renderElement.ts
+++ b/src/renderer/renderElement.ts
@@ -206,7 +206,7 @@ const drawElementOnCanvas = (
           context.canvas.remove();
         }
       } else {
-        console.error(`Unimplemented type ${element.type}`);
+        throw new Error(`Unimplemented type ${element.type}`);
       }
     }
   }

--- a/src/renderer/renderScene.ts
+++ b/src/renderer/renderScene.ts
@@ -269,7 +269,11 @@ export const renderScene = (
   );
 
   visibleElements.forEach((element) => {
-    renderElement(element, rc, context, renderOptimizations, sceneState);
+    try {
+      renderElement(element, rc, context, renderOptimizations, sceneState);
+    } catch (error) {
+      console.error(error);
+    }
   });
 
   if (appState.editingLinearElement) {
@@ -283,13 +287,17 @@ export const renderScene = (
 
   // Paint selection element
   if (selectionElement) {
-    renderElement(
-      selectionElement,
-      rc,
-      context,
-      renderOptimizations,
-      sceneState,
-    );
+    try {
+      renderElement(
+        selectionElement,
+        rc,
+        context,
+        renderOptimizations,
+        sceneState,
+      );
+    } catch (error) {
+      console.error(error);
+    }
   }
 
   if (isBindingEnabled(appState)) {
@@ -834,13 +842,17 @@ export const renderSceneToSvg = (
   // render elements
   elements.forEach((element) => {
     if (!element.isDeleted) {
-      renderElementToSvg(
-        element,
-        rsvg,
-        svgRoot,
-        element.x + offsetX,
-        element.y + offsetY,
-      );
+      try {
+        renderElementToSvg(
+          element,
+          rsvg,
+          svgRoot,
+          element.x + offsetX,
+          element.y + offsetY,
+        );
+      } catch (error) {
+        console.error(error);
+      }
     }
   });
 };


### PR DESCRIPTION
Instead of muting the errors I'm catching the render calls, because we may not want to mute errors for render calls across the board as that would not be nice for upstream consumers using those util methods directly.