### PR TITLE
fix: remove `draw` element from codebase

### DIFF
--- a/src/data/restore.ts
+++ b/src/data/restore.ts
@@ -21,6 +21,20 @@ type RestoredAppState = Omit<
   "offsetTop" | "offsetLeft" | "width" | "height"
 >;
 
+export const AllowedExcalidrawElementTypes: Record<
+  ExcalidrawElement["type"],
+  true
+> = {
+  selection: true,
+  text: true,
+  rectangle: true,
+  diamond: true,
+  ellipse: true,
+  line: true,
+  arrow: true,
+  freedraw: true,
+};
+
 export type RestoredDataState = {
   elements: ExcalidrawElement[];
   appState: RestoredAppState;
@@ -107,7 +121,6 @@ const restoreElement = (
         pressures: element.pressures,
       });
     }
-    case "draw":
     case "line":
     case "arrow": {
       const {
@@ -116,7 +129,10 @@ const restoreElement = (
       } = element;
 
       return restoreElementWithProperties(element, {
-        type: element.type === "draw" ? "line" : element.type,
+        type:
+          (element.type as ExcalidrawElement["type"] | "draw") === "draw"
+            ? "line"
+            : element.type,
         startBinding: element.startBinding,
         endBinding: element.endBinding,
         points:
@@ -187,6 +203,9 @@ export const restoreAppState = (
 
   return {
     ...nextAppState,
+    elementType: AllowedExcalidrawElementTypes[nextAppState.elementType]
+      ? nextAppState.elementType
+      : "selection",
     // Migrates from previous version where appState.zoom was a number
     zoom:
       typeof appState.zoom === "number"

--- a/src/element/collision.ts
+++ b/src/element/collision.ts
@@ -180,7 +180,6 @@ const hitTestPointAgainstElement = (args: HitTestArgs): boolean => {
     }
     case "arrow":
     case "line":
-    case "draw":
       return hitTestLinear(args);
     case "selection":
       console.warn(

--- a/src/element/types.ts
+++ b/src/element/types.ts
@@ -114,7 +114,7 @@ export type Arrowhead = "arrow" | "bar" | "dot";
 
 export type ExcalidrawLinearElement = _ExcalidrawElementBase &
   Readonly<{
-    type: "line" | "draw" | "arrow";
+    type: "line" | "arrow";
     points: readonly Point[];
     lastCommittedPoint: Point | null;
     startBinding: PointBinding | null;

--- a/src/renderer/renderElement.ts
+++ b/src/renderer/renderElement.ts
@@ -142,7 +142,6 @@ const drawElementOnCanvas = (
       break;
     }
     case "arrow":
-    case "draw":
     case "line": {
       context.lineJoin = "round";
       context.lineCap = "round";
@@ -270,7 +269,6 @@ export const generateRoughOptions = (element: ExcalidrawElement): Options => {
       }
       return options;
     }
-    case "draw":
     case "line": {
       if (isPathALoop(element.points)) {
         options.fillStyle = element.fillStyle;
@@ -359,7 +357,6 @@ const generateElementShape = (
           generateRoughOptions(element),
         );
         break;
-      case "draw":
       case "line":
       case "arrow": {
         const options = generateRoughOptions(element);
@@ -589,7 +586,6 @@ export const renderElement = (
     case "rectangle":
     case "diamond":
     case "ellipse":
-    case "draw":
     case "line":
     case "arrow":
     case "text": {
@@ -661,7 +657,6 @@ export const renderElementToSvg = (
       svgRoot.appendChild(node);
       break;
     }
-    case "draw":
     case "line":
     case "arrow": {
       generateElementShape(element, generator);


### PR DESCRIPTION
Removing `draw` type (replaced by `freedraw`) from codebase. It should be dead code and migrations should take care of it.

Also introduces migration for `appState.elementType`.