### PR TITLE
fix: Exporting freedraw with color to svg 

### DIFF
--- a/src/renderer/renderElement.ts
+++ b/src/renderer/renderElement.ts
@@ -708,7 +708,7 @@ export const renderElementToSvg = (
       );
       const path = svgRoot.ownerDocument!.createElementNS(SVG_NS, "path");
       node.setAttribute("stroke", "none");
-      node.setAttribute("fill", element.strokeStyle);
+      node.setAttribute("fill", element.strokeColor);
       path.setAttribute("d", getFreeDrawSvgPath(element));
       node.appendChild(path);
       svgRoot.appendChild(node);


### PR DESCRIPTION
This PR fixes the bug reported here: https://github.com/excalidraw/excalidraw/issues/3561

The SVG export for freedraw elements was setting the path's `fill` to `strokeStyle` rather than `strokeColor`.

(Note that with freedraw lines, because the line is actually a polygon shape, we use the element's strokeColor as its fill. This fact is unrelated to the above bug but is worth mentioning somewhere.)