### PR TITLE
chore: Make deploy source and logs public

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,5 @@
 {
+  "public": true,
   "headers": [
     {
       "source": "/(.*)",


### PR DESCRIPTION
Live demo: https://excalidraw-d2qs5vtbq-excalidraw.vercel.app/_src

This helps people verify that the code they’re downloading from `excalidraw.com` matches the `master` branch on GitHub:

<img src="https://user-images.githubusercontent.com/25517624/118507852-a15a5e00-b6fc-11eb-9fdb-7d44707c7339.png" alt="screenshot of a Tweet, see below for direct link" width=300/>
<sup><a href="https://mobile.twitter.com/agentofuser/status/1393972173350576133">source</a></sup>