### PR TITLE
feat: Auto release @excalidraw/excalidraw-next on every change

### DIFF
--- a/.github/workflows/autorelease-excalidraw.yml
+++ b/.github/workflows/autorelease-excalidraw.yml
@@ -1,4 +1,4 @@
-name: Auto release @excalidraw/excalidraw
+name: Auto-release-excalidraw-next
 on:
   push:
     branches:

--- a/.github/workflows/autorelease-excalidraw.yml
+++ b/.github/workflows/autorelease-excalidraw.yml
@@ -11,6 +11,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
       - name: Setup Node.js 14.x
         uses: actions/setup-node@v2
         with:

--- a/.github/workflows/autorelease-excalidraw.yml
+++ b/.github/workflows/autorelease-excalidraw.yml
@@ -1,0 +1,25 @@
+name: Auto release @excalidraw/excalidraw
+on:
+  push:
+    branches:
+      - aakansha-autorelease
+      - master
+
+jobs:
+  Auto release @excalidraw/excalidraw:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Node.js 14.x
+        uses: actions/setup-node@v2
+        with:
+          node-version: 14.x
+      - name: Set up publish access
+        run: |
+          npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Auto release
+        run: |
+          yarn autorelease

--- a/.github/workflows/autorelease-excalidraw.yml
+++ b/.github/workflows/autorelease-excalidraw.yml
@@ -2,7 +2,6 @@ name: Auto release @excalidraw/excalidraw-next
 on:
   push:
     branches:
-      - aakansha-autorelease
       - master
 
 jobs:

--- a/.github/workflows/autorelease-excalidraw.yml
+++ b/.github/workflows/autorelease-excalidraw.yml
@@ -1,4 +1,4 @@
-name: Auto-release-excalidraw-next
+name: Auto release @excalidraw/excalidraw-next
 on:
   push:
     branches:
@@ -6,7 +6,7 @@ on:
       - master
 
 jobs:
-  Auto release @excalidraw/excalidraw:
+  Auto-release-excalidraw-next:
     runs-on: ubuntu-latest
 
     steps:

--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     "test:other": "yarn prettier --list-different",
     "test:typecheck": "tsc",
     "test:update": "yarn test:app --updateSnapshot --watchAll=false",
-    "test": "yarn test:app"
+    "test": "yarn test:app",
+    "autorelease": "node scripts/autorelease.js"
   }
 }

--- a/scripts/autorelease.js
+++ b/scripts/autorelease.js
@@ -1,0 +1,39 @@
+const fs = require("fs");
+const { exec, execSync } = require("child_process");
+
+const excalidrawDir = `${__dirname}/../src/packages/excalidraw`;
+const excalidrawPackage = `${excalidrawDir}/package.json`;
+const pkg = require(excalidrawPackage);
+
+const getShortCommitHash = () => {
+  return execSync("git rev-parse --short HEAD").toString().trim();
+};
+exec(
+  "git diff origin/master --cached --name-only",
+  async (error, stdout, stderr) => {
+    if (error || stderr) {
+      process.exit(1);
+    }
+
+    const changedFiles = stdout.trim().split("\n");
+    const filesToIgnoreRegex = /src\/excalidraw-app|packages\/utils/;
+
+    const excalidrawPackageFiles = changedFiles.filter((file) => {
+      return file.indexOf("src") >= 0 && !filesToIgnoreRegex.test(file);
+    });
+
+    if (!excalidrawPackageFiles.length) {
+      process.exit(0);
+    }
+    pkg.version = `${pkg.version}-${getShortCommitHash()}`;
+    pkg.name = "aakansha-excalidraw";
+    await fs.writeFileSync(
+      excalidrawPackage,
+      JSON.stringify(pkg, null, 2),
+      "utf8",
+    );
+
+    execSync(`yarn --cwd ${excalidrawDir} build:umd`);
+    execSync(`yarn --cwd ${excalidrawDir} publish`);
+  },
+);

--- a/scripts/autorelease.js
+++ b/scripts/autorelease.js
@@ -10,7 +10,8 @@ const getShortCommitHash = () => {
 };
 
 const commitHash = getShortCommitHash();
-exec(`git show --name-only ${commitHash}`, async (error, stdout, stderr) => {
+// get files changed between prev and head commit
+exec(`git diff --name-only HEAD^ HEAD`, async (error, stdout, stderr) => {
   if (error || stderr) {
     console.error(error);
     process.exit(1);

--- a/scripts/autorelease.js
+++ b/scripts/autorelease.js
@@ -43,8 +43,8 @@ exec(`git show --name-only ${commitHash}`, async (error, stdout, stderr) => {
     execSync(`yarn run build:umd`, { cwd: excalidrawDir });
     console.log("pkg build");
 
-    // execSync(`yarn --cwd ${excalidrawDir} publish`);
-    // console.log("publish");
+    execSync(`yarn --cwd ${excalidrawDir} publish`);
+    console.log("publish");
   } catch (e) {
     console.error(e);
   }

--- a/scripts/autorelease.js
+++ b/scripts/autorelease.js
@@ -35,6 +35,7 @@ exec(`git show --name-only ${commitHash}`, async (error, stdout, stderr) => {
   );
   console.log("pkg updated");
 
+  execSync(`yarn --frozen-lockfile --cwd ${excalidrawDir}`);
   execSync(`yarn --cwd ${excalidrawDir} build:umd`);
   console.log("pkg build");
 

--- a/scripts/autorelease.js
+++ b/scripts/autorelease.js
@@ -12,6 +12,7 @@ exec(
   "git diff origin/master --cached --name-only",
   async (error, stdout, stderr) => {
     if (error || stderr) {
+      console.error(error);
       process.exit(1);
     }
 
@@ -32,8 +33,12 @@ exec(
       JSON.stringify(pkg, null, 2),
       "utf8",
     );
+    console.log("pkg updated");
 
     execSync(`yarn --cwd ${excalidrawDir} build:umd`);
+    console.log("pkg build");
+
     execSync(`yarn --cwd ${excalidrawDir} publish`);
+    console.log("publish");
   },
 );

--- a/scripts/autorelease.js
+++ b/scripts/autorelease.js
@@ -36,7 +36,7 @@ exec(`git show --name-only ${commitHash}`, async (error, stdout, stderr) => {
   console.log("pkg updated");
 
   execSync(`yarn --frozen-lockfile --cwd ${excalidrawDir}`);
-  execSync(`yarn --cwd ${excalidrawDir} build:umd`);
+  execSync(`yarn --cwd ${excalidrawDir} run build:umd`);
   console.log("pkg build");
 
   execSync(`yarn --cwd ${excalidrawDir} publish`);

--- a/scripts/autorelease.js
+++ b/scripts/autorelease.js
@@ -9,7 +9,6 @@ const getShortCommitHash = () => {
   return execSync("git rev-parse --short HEAD").toString().trim();
 };
 
-const commitHash = getShortCommitHash();
 // get files changed between prev and head commit
 exec(`git diff --name-only HEAD^ HEAD`, async (error, stdout, stderr) => {
   if (error || stderr) {
@@ -28,7 +27,7 @@ exec(`git diff --name-only HEAD^ HEAD`, async (error, stdout, stderr) => {
     process.exit(0);
   }
 
-  pkg.version = `${pkg.version}-${commitHash}`;
+  pkg.version = `${pkg.version}-${getShortCommitHash()}`;
   pkg.name = "aakansha-excalidraw";
   await fs.writeFileSync(
     excalidrawPackage,

--- a/scripts/autorelease.js
+++ b/scripts/autorelease.js
@@ -23,6 +23,8 @@ exec(`git show --name-only ${commitHash}`, async (error, stdout, stderr) => {
     return file.indexOf("src") >= 0 && !filesToIgnoreRegex.test(file);
   });
 
+  console.log(excalidrawPackageFiles, "excalidrawPackageFiles", changedFiles);
+
   if (!excalidrawPackageFiles.length) {
     process.exit(0);
   }

--- a/scripts/autorelease.js
+++ b/scripts/autorelease.js
@@ -8,37 +8,36 @@ const pkg = require(excalidrawPackage);
 const getShortCommitHash = () => {
   return execSync("git rev-parse --short HEAD").toString().trim();
 };
-exec(
-  "git diff origin/master --cached --name-only",
-  async (error, stdout, stderr) => {
-    if (error || stderr) {
-      console.error(error);
-      process.exit(1);
-    }
 
-    const changedFiles = stdout.trim().split("\n");
-    const filesToIgnoreRegex = /src\/excalidraw-app|packages\/utils/;
+const commitHash = getShortCommitHash();
+exec(`git show --name-only ${commitHash}`, async (error, stdout, stderr) => {
+  if (error || stderr) {
+    console.error(error);
+    process.exit(1);
+  }
 
-    const excalidrawPackageFiles = changedFiles.filter((file) => {
-      return file.indexOf("src") >= 0 && !filesToIgnoreRegex.test(file);
-    });
+  const changedFiles = stdout.trim().split("\n");
+  const filesToIgnoreRegex = /src\/excalidraw-app|packages\/utils/;
 
-    if (!excalidrawPackageFiles.length) {
-      process.exit(0);
-    }
-    pkg.version = `${pkg.version}-${getShortCommitHash()}`;
-    pkg.name = "aakansha-excalidraw";
-    await fs.writeFileSync(
-      excalidrawPackage,
-      JSON.stringify(pkg, null, 2),
-      "utf8",
-    );
-    console.log("pkg updated");
+  const excalidrawPackageFiles = changedFiles.filter((file) => {
+    return file.indexOf("src") >= 0 && !filesToIgnoreRegex.test(file);
+  });
 
-    execSync(`yarn --cwd ${excalidrawDir} build:umd`);
-    console.log("pkg build");
+  if (!excalidrawPackageFiles.length) {
+    process.exit(0);
+  }
+  pkg.version = `${pkg.version}-${commitHash}`;
+  pkg.name = "aakansha-excalidraw";
+  await fs.writeFileSync(
+    excalidrawPackage,
+    JSON.stringify(pkg, null, 2),
+    "utf8",
+  );
+  console.log("pkg updated");
 
-    execSync(`yarn --cwd ${excalidrawDir} publish`);
-    console.log("publish");
-  },
-);
+  execSync(`yarn --cwd ${excalidrawDir} build:umd`);
+  console.log("pkg build");
+
+  execSync(`yarn --cwd ${excalidrawDir} publish`);
+  console.log("publish");
+});

--- a/scripts/autorelease.js
+++ b/scripts/autorelease.js
@@ -26,6 +26,7 @@ exec(`git show --name-only ${commitHash}`, async (error, stdout, stderr) => {
   if (!excalidrawPackageFiles.length) {
     process.exit(0);
   }
+
   pkg.version = `${pkg.version}-${commitHash}`;
   pkg.name = "aakansha-excalidraw";
   await fs.writeFileSync(
@@ -33,12 +34,16 @@ exec(`git show --name-only ${commitHash}`, async (error, stdout, stderr) => {
     JSON.stringify(pkg, null, 2),
     "utf8",
   );
+
   console.log("pkg updated");
+  try {
+    execSync(`yarn --frozen-lockfile --cwd ${excalidrawDir}`);
+    execSync(`yarn --cwd ${excalidrawDir} run build:umd`);
+    console.log("pkg build");
 
-  execSync(`yarn --frozen-lockfile --cwd ${excalidrawDir}`);
-  execSync(`yarn --cwd ${excalidrawDir} run build:umd`);
-  console.log("pkg build");
-
-  execSync(`yarn --cwd ${excalidrawDir} publish`);
-  console.log("publish");
+    execSync(`yarn --cwd ${excalidrawDir} publish`);
+    console.log("publish");
+  } catch (e) {
+    console.error(e);
+  }
 });

--- a/scripts/autorelease.js
+++ b/scripts/autorelease.js
@@ -35,16 +35,11 @@ exec(`git show --name-only ${commitHash}`, async (error, stdout, stderr) => {
     "utf8",
   );
 
-  console.log("pkg updated");
   try {
     execSync(`yarn  --frozen-lockfile`);
     execSync(`yarn --frozen-lockfile`, { cwd: excalidrawDir });
-    console.log("pkg install");
     execSync(`yarn run build:umd`, { cwd: excalidrawDir });
-    console.log("pkg build");
-
     execSync(`yarn --cwd ${excalidrawDir} publish`);
-    console.log("publish");
   } catch (e) {
     console.error(e);
   }

--- a/scripts/autorelease.js
+++ b/scripts/autorelease.js
@@ -38,6 +38,7 @@ exec(`git show --name-only ${commitHash}`, async (error, stdout, stderr) => {
   console.log("pkg updated");
   try {
     execSync(`yarn --frozen-lockfile --cwd ${excalidrawDir}`);
+    console.log("pkg install");
     execSync(`yarn --cwd ${excalidrawDir} run build:umd`);
     console.log("pkg build");
 

--- a/scripts/autorelease.js
+++ b/scripts/autorelease.js
@@ -37,13 +37,14 @@ exec(`git show --name-only ${commitHash}`, async (error, stdout, stderr) => {
 
   console.log("pkg updated");
   try {
-    execSync(`yarn --frozen-lockfile --cwd ${excalidrawDir}`);
+    execSync(`yarn  --frozen-lockfile`);
+    execSync(`yarn --frozen-lockfile`, { cwd: excalidrawDir });
     console.log("pkg install");
-    execSync(`yarn --cwd ${excalidrawDir} run build:umd`);
+    execSync(`yarn run build:umd`, { cwd: excalidrawDir });
     console.log("pkg build");
 
-    execSync(`yarn --cwd ${excalidrawDir} publish`);
-    console.log("publish");
+    // execSync(`yarn --cwd ${excalidrawDir} publish`);
+    // console.log("publish");
   } catch (e) {
     console.error(e);
   }

--- a/scripts/autorelease.js
+++ b/scripts/autorelease.js
@@ -40,7 +40,7 @@ exec(`git diff --name-only HEAD^ HEAD`, async (error, stdout, stderr) => {
 
   // update package.json
   pkg.version = `${pkg.version}-${getShortCommitHash()}`;
-  pkg.name = "aakansha-excalidraw";
+  pkg.name = "@excalidraw/excalidraw-next";
   fs.writeFileSync(excalidrawPackage, JSON.stringify(pkg, null, 2), "utf8");
 
   // update readme

--- a/scripts/autorelease.js
+++ b/scripts/autorelease.js
@@ -24,8 +24,6 @@ exec(`git diff --name-only HEAD^ HEAD`, async (error, stdout, stderr) => {
     return file.indexOf("src") >= 0 && !filesToIgnoreRegex.test(file);
   });
 
-  console.log(excalidrawPackageFiles, "excalidrawPackageFiles", changedFiles);
-
   if (!excalidrawPackageFiles.length) {
     process.exit(0);
   }

--- a/src/packages/excalidraw/README.md
+++ b/src/packages/excalidraw/README.md
@@ -24,7 +24,7 @@ By default it will try to load the files from `https://unpkg.com/@excalidraw/exc
 
 If you want to load assets from a different path you can set a variable `window.EXCALIDRAW_ASSET_PATH` depending on environment (for example if you have different URL's for dev and prod) to the url from where you want to load the assets.
 
-## Note
+#### Note
 
 **If you don't want to wait for the next stable release and try out the unreleased changes you can use [@excalidraw/excalidraw-next](https://www.npmjs.com/package/@excalidraw/excalidraw-next).**
 

--- a/src/packages/excalidraw/README.md
+++ b/src/packages/excalidraw/README.md
@@ -24,6 +24,10 @@ By default it will try to load the files from `https://unpkg.com/@excalidraw/exc
 
 If you want to load assets from a different path you can set a variable `window.EXCALIDRAW_ASSET_PATH` depending on environment (for example if you have different URL's for dev and prod) to the url from where you want to load the assets.
 
+## Note
+
+**If you don't want to wait for the next stable release and try out the unreleased changes you can use [@excalidraw/excalidraw-next](https://www.npmjs.com/package/@excalidraw/excalidraw-next).**
+
 ### Demo
 
 [Try here](https://codesandbox.io/s/excalidraw-ehlz3).

--- a/src/packages/excalidraw/README_NEXT.md
+++ b/src/packages/excalidraw/README_NEXT.md
@@ -1,6 +1,8 @@
 ## Note
 
-This is an unstable release and not recommended for production. If you don't want to wait for the stable release and try out the unreleased changes you can use this. For stable release please use [@excalidraw/excalidraw](https://www.npmjs.com/package/@excalidraw/excalidraw).
+This is an unstable release and not recommended for production. If you don't want to wait for the stable release and try out the unreleased changes you can use this.
+
+For stable release please use [@excalidraw/excalidraw](https://www.npmjs.com/package/@excalidraw/excalidraw).
 
 ### Excalidraw
 

--- a/src/packages/excalidraw/README_NEXT.md
+++ b/src/packages/excalidraw/README_NEXT.md
@@ -1,3 +1,7 @@
+## Note
+
+This is an unstable release and not recommended for production. If you don't want to wait for the stable release and try out the unreleased changes you can use this. For stable release please use [@excalidraw/excalidraw](https://www.npmjs.com/package/@excalidraw/excalidraw).
+
 ### Excalidraw
 
 Excalidraw exported as a component to directly embed in your projects.
@@ -7,20 +11,20 @@ Excalidraw exported as a component to directly embed in your projects.
 You can use npm
 
 ```
-npm install react react-dom @excalidraw/excalidraw
+npm install react react-dom @excalidraw/excalidraw-next
 ```
 
 or via yarn
 
 ```
-yarn add react react-dom @excalidraw/excalidraw
+yarn add react react-dom @excalidraw/excalidraw-next
 ```
 
 After installation you will see a folder `excalidraw-assets` and `excalidraw-assets-dev` in `dist` directory which contains the assets needed for this app in prod and dev mode respectively.
 
 Move the folder `excalidraw-assets` and `excalidraw-assets-dev` to the path where your assets are served.
 
-By default it will try to load the files from `https://unpkg.com/@excalidraw/excalidraw/{currentVersion}/dist/`
+By default it will try to load the files from `https://unpkg.com/@excalidraw/excalidraw-next/dist/`
 
 If you want to load assets from a different path you can set a variable `window.EXCALIDRAW_ASSET_PATH` depending on environment (for example if you have different URL's for dev and prod) to the url from where you want to load the assets.
 
@@ -38,7 +42,7 @@ If you are using a Web bundler (for instance, Webpack), you can import it as an 
 
 ```js
 import React, { useEffect, useState, useRef } from "react";
-import Excalidraw from "@excalidraw/excalidraw";
+import Excalidraw from "@excalidraw/excalidraw-next";
 import InitialData from "./initialData";
 
 import "./styles.scss";
@@ -156,13 +160,13 @@ import { useState, useEffect } from "react";
 export default function IndexPage() {
   const [Comp, setComp] = useState(null);
   useEffect(() => {
-    import("@excalidraw/excalidraw").then((comp) => setComp(comp.default));
+    import("@excalidraw/excalidraw-next").then((comp) => setComp(comp.default));
   });
   return <>{Comp && <Comp />}</>;
 }
 ```
 
-The `types` are available at `@excalidraw/excalidraw/types`, you can view [example for typescript](https://codesandbox.io/s/excalidraw-types-9h2dm)
+The `types` are available at `@excalidraw/excalidraw-next/types`, you can view [example for typescript](https://codesandbox.io/s/excalidraw-types-9h2dm)
 
 #### In Browser
 
@@ -173,7 +177,7 @@ For development use :point_down:
 ```js
 <script
   type="text/javascript"
-  src="https://unpkg.com/@excalidraw/excalidraw@0.8.0/dist/excalidraw.development.js"
+  src="https://unpkg.com/@excalidraw/excalidraw-next/dist/excalidraw.development.js"
 ></script>
 ```
 
@@ -182,7 +186,7 @@ For production use :point_down:
 ```js
 <script
   type="text/javascript"
-  src="https://unpkg.com/@excalidraw/excalidraw@0.8.0/dist/excalidraw.production.min.js"
+  src="https://unpkg.com/@excalidraw/excalidraw-next/dist/excalidraw.production.min.js"
 ></script>
 ```
 
@@ -201,7 +205,7 @@ You will need to make sure `react`, `react-dom` is available as shown in the bel
 
     <script
       type="text/javascript"
-      src="https://unpkg.com/@excalidraw/excalidraw@0.8.0/dist/excalidraw.development.js"
+      src="https://unpkg.com/@excalidraw/excalidraw-next/dist/excalidraw.development.js"
     ></script>
   </head>
 
@@ -495,7 +499,7 @@ This callback is triggered when the shareable-link button is clicked in the expo
 Determines the language of the UI. It should be one of the [available language codes](https://github.com/excalidraw/excalidraw/blob/master/src/i18n.ts#L14). Defaults to `en` (English). We also export default language and supported languages which you can import as shown below.
 
 ```js
-import { defaultLang, languages } from "@excalidraw/excalidraw";
+import { defaultLang, languages } from "@excalidraw/excalidraw-next";
 ```
 
 | name | type |
@@ -636,7 +640,7 @@ The unique id of the excalidraw component. This can be used to identify the exca
 **How to use**
 
 <pre>
-import { getSceneVersion } from "@excalidraw/excalidraw";
+import { getSceneVersion } from "@excalidraw/excalidraw-next";
 getSceneVersion(elements:  <a href="https://github.com/excalidraw/excalidraw/blob/master/src/element/types.ts#L78">ExcalidrawElement[]</a>)
 </pre>
 
@@ -653,7 +657,7 @@ isInvisiblySmallElement(element:  <a href="https://github.com/excalidraw/excalid
 **How to use**
 
 ```js
-import { isInvisiblySmallElement } from "@excalidraw/excalidraw";
+import { isInvisiblySmallElement } from "@excalidraw/excalidraw-next";
 ```
 
 Returns `true` if element is invisibly small (e.g. width & height are zero).
@@ -669,7 +673,7 @@ getElementsMap(elements:  <a href="https://github.com/excalidraw/excalidraw/blob
 **How to use**
 
 ```js
-import { getElementsMap } from "@excalidraw/excalidraw";
+import { getElementsMap } from "@excalidraw/excalidraw-next";
 ```
 
 This function returns an object where each element is mapped to its id.
@@ -687,7 +691,7 @@ restoreAppState(appState:  <a href="https://github.com/excalidraw/excalidraw/blo
 **_How to use_**
 
 ```js
-import { restoreAppState } from "@excalidraw/excalidraw";
+import { restoreAppState } from "@excalidraw/excalidraw-next";
 ```
 
 This function will make sure all the keys have appropriate values in [appState](https://github.com/excalidraw/excalidraw/blob/master/src/types.ts#L42) and if any key is missing, it will be set to default value. If you pass `localAppState`, `localAppState` value will be preferred over the `appState` passed in params.
@@ -703,7 +707,7 @@ restoreElements(elements:  <a href="https://github.com/excalidraw/excalidraw/blo
 **_How to use_**
 
 ```js
-import { restoreElements } from "@excalidraw/excalidraw";
+import { restoreElements } from "@excalidraw/excalidraw-next";
 ```
 
 This function will make sure all properties of element is correctly set and if any attribute is missing, it will be set to default value.
@@ -719,7 +723,7 @@ restoreElements(data:  <a href="https://github.com/excalidraw/excalidraw/blob/ma
 **_How to use_**
 
 ```js
-import { restore } from "@excalidraw/excalidraw";
+import { restore } from "@excalidraw/excalidraw-next";
 ```
 
 This function makes sure elements and state is set to appropriate values and set to default value if not present. It is combination of [restoreElements](#restoreElements) and [restoreAppState](#restoreAppState)
@@ -760,7 +764,7 @@ Takes the scene elements and state and returns a JSON string. Deleted `elements`
 **How to use**
 
 ```js
-import { exportToCanvas } from "@excalidraw/excalidraw";
+import { exportToCanvas } from "@excalidraw/excalidraw-next";
 ```
 
 This function returns the canvas with the exported elements, appState and dimensions.
@@ -786,7 +790,7 @@ exportToBlob(
 **How to use**
 
 ```js
-import { exportToBlob } from "@excalidraw/excalidraw";
+import { exportToBlob } from "@excalidraw/excalidraw-next";
 ```
 
 Returns a promise which resolves with a [blob](https://developer.mozilla.org/en-US/docs/Web/API/Blob). It internally uses [canvas.ToBlob](https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/toBlob).

--- a/src/packages/excalidraw/README_NEXT.md
+++ b/src/packages/excalidraw/README_NEXT.md
@@ -1,10 +1,12 @@
+<!-- stable-readme-start-->
+
 ## Note
 
 **This is an unstable release and not recommended for production. If you don't want to wait for the stable release and try out the unreleased changes you can use this.**
 
 For stable release please use [@excalidraw/excalidraw](https://www.npmjs.com/package/@excalidraw/excalidraw).
 
-<!-- stable-readme-start-->
+<!-- stable-readme-end-->
 
 ### Excalidraw
 
@@ -829,5 +831,3 @@ This function returns a svg with the exported elements.
 | viewBackgroundColor | string | #fff | The default background color |
 | shouldAddWatermark | boolean | false | Indicates whether watermark should be exported |
 | exportWithDarkMode | boolean | false | Indicates whether to export with dark mode |
-
- <!-- stable-readme-end-->

--- a/src/packages/excalidraw/README_NEXT.md
+++ b/src/packages/excalidraw/README_NEXT.md
@@ -4,6 +4,8 @@
 
 For stable release please use [@excalidraw/excalidraw](https://www.npmjs.com/package/@excalidraw/excalidraw).
 
+<!-- stable-readme-end-->
+
 ### Excalidraw
 
 Excalidraw exported as a component to directly embed in your projects.
@@ -827,3 +829,5 @@ This function returns a svg with the exported elements.
 | viewBackgroundColor | string | #fff | The default background color |
 | shouldAddWatermark | boolean | false | Indicates whether watermark should be exported |
 | exportWithDarkMode | boolean | false | Indicates whether to export with dark mode |
+
+ <!-- stable-readme-start-->

--- a/src/packages/excalidraw/README_NEXT.md
+++ b/src/packages/excalidraw/README_NEXT.md
@@ -4,7 +4,7 @@
 
 For stable release please use [@excalidraw/excalidraw](https://www.npmjs.com/package/@excalidraw/excalidraw).
 
-<!-- stable-readme-end-->
+<!-- stable-readme-start-->
 
 ### Excalidraw
 
@@ -830,4 +830,4 @@ This function returns a svg with the exported elements.
 | shouldAddWatermark | boolean | false | Indicates whether watermark should be exported |
 | exportWithDarkMode | boolean | false | Indicates whether to export with dark mode |
 
- <!-- stable-readme-start-->
+ <!-- stable-readme-end-->

--- a/src/packages/excalidraw/README_NEXT.md
+++ b/src/packages/excalidraw/README_NEXT.md
@@ -1,6 +1,8 @@
 ## Note
 
-This is an unstable release and not recommended for production. If you don't want to wait for the stable release and try out the unreleased changes you can use this.
+This is an unstable release and not recommended for production.
+
+If you don't want to wait for the stable release and try out the unreleased changes you can use this.
 
 For stable release please use [@excalidraw/excalidraw](https://www.npmjs.com/package/@excalidraw/excalidraw).
 

--- a/src/packages/excalidraw/README_NEXT.md
+++ b/src/packages/excalidraw/README_NEXT.md
@@ -1,8 +1,6 @@
 ## Note
 
-This is an unstable release and not recommended for production.
-
-If you don't want to wait for the stable release and try out the unreleased changes you can use this.
+**This is an unstable release and not recommended for production. If you don't want to wait for the stable release and try out the unreleased changes you can use this.**
 
 For stable release please use [@excalidraw/excalidraw](https://www.npmjs.com/package/@excalidraw/excalidraw).
 

--- a/src/packages/excalidraw/package.json
+++ b/src/packages/excalidraw/package.json
@@ -73,7 +73,6 @@
     "webpack-cli": "4.7.0"
   },
   "bugs": "https://github.com/excalidraw/excalidraw/issues",
-  "repository": "https://github.com/excalidraw/excalidraw",
   "homepage": "https://github.com/excalidraw/excalidraw/tree/master/src/packages/excalidraw",
   "scripts": {
     "gen:types": "tsc --project ../../../tsconfig-types.json",

--- a/src/packages/excalidraw/package.json
+++ b/src/packages/excalidraw/package.json
@@ -73,6 +73,7 @@
     "webpack-cli": "4.7.0"
   },
   "bugs": "https://github.com/excalidraw/excalidraw/issues",
+  "repository": "https://github.com/excalidraw/excalidraw",
   "homepage": "https://github.com/excalidraw/excalidraw/tree/master/src/packages/excalidraw",
   "scripts": {
     "gen:types": "tsc --project ../../../tsconfig-types.json",


### PR DESCRIPTION
If the commit needs a release, this GitHub action will update the package name to `@excalidraw/excalidraw-next` and append commit hash to the release name and then publish the package.

Here is the [auto released version](https://www.npmjs.com/package/@excalidraw/excalidraw-next).

TODOS before merge
- [x] Remove `aakansha-autorelease` from branches, so it only happens in master branch
- [x] Update package name to `@excalidraw/excalidraw-next`