### PR TITLE
fix: disable pointer-events on footer-center container

### DIFF
--- a/src/components/LayerUI.scss
+++ b/src/components/LayerUI.scss
@@ -108,5 +108,16 @@
         transition-delay: 0.8s;
       }
     }
+
+    .layer-ui__wrapper__footer-center {
+      pointer-events: none;
+      & > * {
+        pointer-events: all;
+      }
+    }
+    .layer-ui__wrapper__footer-left,
+    .layer-ui__wrapper__footer-right {
+      pointer-events: all;
+    }
   }
 }

--- a/src/css/styles.scss
+++ b/src/css/styles.scss
@@ -358,10 +358,6 @@
     }
   }
 
-  .layer-ui__wrapper:not(.disable-pointerEvents) .App-menu_bottom > * {
-    pointer-events: all;
-  }
-
   .App-menu_bottom > *:first-child {
     justify-self: flex-start;
   }


### PR DESCRIPTION
When we split footer into 3 containers we've inadvertently re-enabled pointer events on the center footer which prevents interacting with the canvas at the bottom.