### PR TITLE
feat: auto-position tooltip and suport overflowing container

### DIFF
--- a/src/actions/actionExport.tsx
+++ b/src/actions/actionExport.tsx
@@ -67,11 +67,7 @@ export const actionChangeExportEmbedScene = register({
         onChange={(event) => updateData(event.target.checked)}
       />{" "}
       {t("labels.exportEmbedScene")}
-      <Tooltip
-        label={t("labels.exportEmbedScene_details")}
-        position="above"
-        long={true}
-      >
+      <Tooltip label={t("labels.exportEmbedScene_details")} long={true}>
         <div className="TooltipIcon">{questionCircle}</div>
       </Tooltip>
     </label>

--- a/src/components/Tooltip.scss
+++ b/src/components/Tooltip.scss
@@ -1,58 +1,25 @@
 @import "../css/variables.module";
-.excalidraw {
-  .Tooltip {
-    position: relative;
-  }
+.ExcalidrawTooltip {
+  position: absolute;
+  z-index: 1000;
 
-  .Tooltip__label {
-    --arrow-size: 4px;
-    visibility: hidden;
-    background: $oc-black;
-    color: $oc-white;
-    text-align: center;
-    border-radius: 6px;
-    padding: 8px;
-    position: absolute;
-    z-index: 10;
-    font-size: 13px;
-    line-height: 1.5;
-    font-weight: 500;
-    // extra pixel offset for unknown reasons
-    left: calc(50% + var(--arrow-size) / 2 - 1px);
-    transform: translateX(-50%);
-    word-wrap: break-word;
+  padding: 8px;
+  border-radius: 6px;
+  box-sizing: border-box;
+  pointer-events: none;
+  word-wrap: break-word;
 
-    &::after {
-      content: "";
-      border: var(--arrow-size) solid transparent;
-      position: absolute;
-      left: calc(50% - var(--arrow-size));
-    }
+  background: $oc-black;
 
-    &--above {
-      bottom: calc(100% + var(--arrow-size) + 3px);
+  line-height: 1.5;
+  text-align: center;
+  font-size: 13px;
+  font-weight: 500;
+  color: $oc-white;
 
-      &::after {
-        border-top-color: $oc-black;
-        top: 100%;
-      }
-    }
+  display: none;
 
-    &--below {
-      top: calc(100% + var(--arrow-size) + 3px);
-
-      &::after {
-        border-bottom-color: $oc-black;
-        bottom: 100%;
-      }
-    }
-  }
-
-  .Tooltip:hover .Tooltip__label {
-    visibility: visible;
-  }
-
-  .Tooltip__label:hover {
-    visibility: visible;
+  &.is-shown {
+    display: block;
   }
 }

--- a/src/components/Tooltip.scss
+++ b/src/components/Tooltip.scss
@@ -1,5 +1,5 @@
 @import "../css/variables.module";
-.ExcalidrawTooltip {
+.excalidraw-tooltip {
   position: absolute;
   z-index: 1000;
 
@@ -19,7 +19,7 @@
 
   display: none;
 
-  &.is-shown {
+  &.excalidraw-tooltip--visible {
     display: block;
   }
 }

--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -1,31 +1,89 @@
 import "./Tooltip.scss";
 
-import React from "react";
+import React, { useEffect } from "react";
+
+const getTooltipDiv = () => {
+  const existingDiv = document.querySelector<HTMLDivElement>(
+    ".ExcalidrawTooltip",
+  );
+  if (existingDiv) {
+    return existingDiv;
+  }
+  const div = document.createElement("div");
+  document.body.appendChild(div);
+  div.classList.add("ExcalidrawTooltip");
+  return div;
+};
+
+const updateTooltip = (
+  item: HTMLDivElement,
+  tooltip: HTMLDivElement,
+  label: string,
+  long: boolean,
+) => {
+  tooltip.classList.add("is-shown");
+  tooltip.style.minWidth = long ? "50ch" : "10ch";
+  tooltip.style.maxWidth = long ? "50ch" : "15ch";
+
+  tooltip.textContent = label;
+
+  const {
+    x: itemX,
+    bottom: itemBottom,
+    top: itemTop,
+    width: itemWidth,
+  } = item.getBoundingClientRect();
+
+  const {
+    width: labelWidth,
+    height: labelHeight,
+  } = tooltip.getBoundingClientRect();
+
+  const viewportWidth = window.innerWidth;
+  const viewportHeight = window.innerHeight;
+
+  const margin = 5;
+
+  const left = itemX + itemWidth / 2 - labelWidth / 2;
+  const offsetLeft =
+    left + labelWidth >= viewportWidth ? left + labelWidth - viewportWidth : 0;
+
+  const top = itemBottom + margin;
+  const offsetTop =
+    top + labelHeight >= viewportHeight
+      ? itemBottom - itemTop + labelHeight + margin * 2
+      : 0;
+
+  Object.assign(tooltip.style, {
+    top: `${top - offsetTop}px`,
+    left: `${left - offsetLeft}px`,
+  });
+};
 
 type TooltipProps = {
   children: React.ReactNode;
   label: string;
-  position?: "above" | "below";
   long?: boolean;
 };
 
-export const Tooltip = ({
-  children,
-  label,
-  position = "below",
-  long = false,
-}: TooltipProps) => (
-  <div className="Tooltip">
-    <span
-      className={
-        position === "above"
-          ? "Tooltip__label Tooltip__label--above"
-          : "Tooltip__label Tooltip__label--below"
+export const Tooltip = ({ children, label, long = false }: TooltipProps) => {
+  useEffect(() => {
+    return () => getTooltipDiv().classList.remove("is-shown");
+  }, []);
+
+  return (
+    <div
+      onPointerEnter={(event) =>
+        updateTooltip(
+          event.currentTarget as HTMLDivElement,
+          getTooltipDiv(),
+          label,
+          long,
+        )
       }
-      style={{ width: long ? "50ch" : "10ch" }}
+      onPointerLeave={() => getTooltipDiv().classList.remove("is-shown")}
     >
-      {label}
-    </span>
-    {children}
-  </div>
-);
+      {children}
+    </div>
+  );
+};

--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -4,14 +4,14 @@ import React, { useEffect } from "react";
 
 const getTooltipDiv = () => {
   const existingDiv = document.querySelector<HTMLDivElement>(
-    ".ExcalidrawTooltip",
+    ".excalidraw-tooltip",
   );
   if (existingDiv) {
     return existingDiv;
   }
   const div = document.createElement("div");
   document.body.appendChild(div);
-  div.classList.add("ExcalidrawTooltip");
+  div.classList.add("excalidraw-tooltip");
   return div;
 };
 
@@ -21,7 +21,7 @@ const updateTooltip = (
   label: string,
   long: boolean,
 ) => {
-  tooltip.classList.add("is-shown");
+  tooltip.classList.add("excalidraw-tooltip--visible");
   tooltip.style.minWidth = long ? "50ch" : "10ch";
   tooltip.style.maxWidth = long ? "50ch" : "15ch";
 
@@ -68,7 +68,8 @@ type TooltipProps = {
 
 export const Tooltip = ({ children, label, long = false }: TooltipProps) => {
   useEffect(() => {
-    return () => getTooltipDiv().classList.remove("is-shown");
+    return () =>
+      getTooltipDiv().classList.remove("excalidraw-tooltip--visible");
   }, []);
 
   return (
@@ -81,7 +82,9 @@ export const Tooltip = ({ children, label, long = false }: TooltipProps) => {
           long,
         )
       }
-      onPointerLeave={() => getTooltipDiv().classList.remove("is-shown")}
+      onPointerLeave={() =>
+        getTooltipDiv().classList.remove("excalidraw-tooltip--visible")
+      }
     >
       {children}
     </div>

--- a/src/excalidraw-app/index.tsx
+++ b/src/excalidraw-app/index.tsx
@@ -340,7 +340,7 @@ const ExcalidrawWrapper = () => {
           rel="noopener noreferrer"
           aria-label={t("encrypted.link")}
         >
-          <Tooltip label={t("encrypted.tooltip")} position="above" long={true}>
+          <Tooltip label={t("encrypted.tooltip")} long={true}>
             {shield}
           </Tooltip>
         </a>


### PR DESCRIPTION
- tooltip is now autopositioned, ensuring it doesn't overflow viewport (thus, dropped `position` prop)
- tooltip is now rendered into an absolutely-positioned div in `body` which allows it to overflow containers which have `overflow: hidden`
- for now I dropped these two things:
	- the tooltip triangle. Can be reintroduced at any time, I just thought it's not worth the effort right now (it looks fine without it)
	- not auto-hiding the tooltip when you managed to mouseover it. Again, it can be reintroduced, but even in production it was nearly useless as you had to carefully navigate the mouse across the triangle

![image](https://user-images.githubusercontent.com/5153846/119348145-c02c9780-bc9c-11eb-907f-33e6bc8be765.png)


@ad1992 I'd like to export this compo so it can be reused by host apps. Thoughts?
