### PR TITLE
fix: manually confirm active wysiwyg on pointerdown

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -322,6 +322,8 @@ class App extends React.Component<AppProps, AppState> {
   private id: string;
   private history: History;
 
+  private activeWysiwyg: null | { handleSubmit: () => void } = null;
+
   constructor(props: AppProps) {
     super(props);
     const defaultAppState = getDefaultAppState();
@@ -1763,7 +1765,7 @@ class App extends React.Component<AppProps, AppState> {
       ]);
     };
 
-    textWysiwyg({
+    const { handleSubmit } = textWysiwyg({
       id: element.id,
       appState: this.state,
       canvas: this.canvas,
@@ -1787,6 +1789,7 @@ class App extends React.Component<AppProps, AppState> {
         }
       }),
       onSubmit: withBatchedUpdates(({ text, viaKeyboard }) => {
+        this.activeWysiwyg = null;
         const isDeleted = !text.trim();
         updateElement(text, isDeleted);
         // select the created text element only if submitting via keyboard
@@ -1828,6 +1831,8 @@ class App extends React.Component<AppProps, AppState> {
     // do an initial update to re-initialize element position since we were
     // modifying element's x/y for sake of editor (case: syncing to remote)
     updateElement(element.text);
+
+    this.activeWysiwyg = { handleSubmit };
   }
 
   private getTextElementAtPosition(
@@ -2284,6 +2289,10 @@ class App extends React.Component<AppProps, AppState> {
     event: React.PointerEvent<HTMLCanvasElement>,
   ) => {
     event.persist();
+
+    if (this.activeWysiwyg) {
+      this.activeWysiwyg.handleSubmit();
+    }
 
     // remove any active selection when we start to interact with canvas
     // (mainly, we care about removing selection outside the component which

--- a/src/element/textWysiwyg.test.tsx
+++ b/src/element/textWysiwyg.test.tsx
@@ -16,7 +16,7 @@ describe("textWysiwyg", () => {
 
     const element = UI.createElement("text");
 
-    new Pointer("mouse").clickOn(element);
+    new Pointer("mouse").doubleClickOn(element);
     textarea = document.querySelector(
       ".excalidraw-textEditorContainer > textarea",
     )!;

--- a/src/element/textWysiwyg.tsx
+++ b/src/element/textWysiwyg.tsx
@@ -368,4 +368,6 @@ export const textWysiwyg = ({
   excalidrawContainer
     ?.querySelector(".excalidraw-textEditorContainer")!
     .appendChild(editable);
+
+  return { handleSubmit };
 };


### PR DESCRIPTION
Attempt to address https://github.com/excalidraw/excalidraw/issues/3553.

It seems that at least on some input devices pointer-dragging the canvas while editing text doesn't blur the textarea for some reason. I couldn't figure out whether this is native behavior or something to do with how we do things (I tried removing all `event.preventDefault` calls and `pointer-events: none` rules, to no avail).

Thus, this solution simply confirms active editor on canvas `pointerdown`.

Purposefully not closing the issue because it's not clear if there aren't more things at play.