### PR TITLE
stop disabling ts for `handleCanvasDoubleClick`

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1204,13 +1204,16 @@ class App extends React.Component<AppProps, AppState> {
     // event.touches.length === 1 will also prevent inserting text when user's zooming
     if (didTapTwice && event.touches.length === 1) {
       const [touch] = event.touches;
-      this.handleCanvasDoubleClick({
-        clientX: touch.clientX,
-        clientY: touch.clientY,
-        ctrlKey: false,
-        metaKey: false,
-        altKey: false,
-      });
+      this.handleCanvasDoubleClick(
+        {
+          clientX: touch.clientX,
+          clientY: touch.clientY,
+          ctrlKey: false,
+          metaKey: false,
+          altKey: false,
+        },
+        false,
+      );
       didTapTwice = false;
       clearTimeout(tappedTwiceTimer);
     }
@@ -1882,6 +1885,7 @@ class App extends React.Component<AppProps, AppState> {
     sceneX,
     sceneY,
     insertAtParentCenter = true,
+    createTextIfNotExists = true,
   }: {
     /** X position to insert text at */
     sceneX: number;
@@ -1889,8 +1893,13 @@ class App extends React.Component<AppProps, AppState> {
     sceneY: number;
     /** whether to attempt to insert at element center if applicable */
     insertAtParentCenter?: boolean;
+    createTextIfNotExists?: boolean;
   }) => {
     const existingTextElement = this.getTextElementAtPosition(sceneX, sceneY);
+
+    if (!existingTextElement && !createTextIfNotExists) {
+      return;
+    }
 
     const parentCenterPosition =
       insertAtParentCenter &&
@@ -1967,6 +1976,7 @@ class App extends React.Component<AppProps, AppState> {
       React.PointerEvent<HTMLCanvasElement>,
       "clientX" | "clientY" | "ctrlKey" | "metaKey" | "altKey"
     >,
+    createTextIfNotExists = true,
   ) => {
     // case: double-clicking with arrow/line tool selected would both create
     // text and enter multiElement mode
@@ -2037,6 +2047,7 @@ class App extends React.Component<AppProps, AppState> {
         sceneX,
         sceneY,
         insertAtParentCenter: !event.altKey,
+        createTextIfNotExists,
       });
     }
   };

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -3206,7 +3206,7 @@ class App extends React.Component<AppProps, AppState> {
         const selectedElements = getSelectedElements(
           this.scene.getElements(),
           this.state,
-        );
+        ).filter((element) => element.id !== this.state.editingElement?.id);
         // prevent dragging even if we're no longer holding cmd/ctrl otherwise
         // it would have weird results (stuff jumping all over the screen)
         if (selectedElements.length > 0 && !pointerDownState.withCmdOrCtrl) {

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1204,10 +1204,12 @@ class App extends React.Component<AppProps, AppState> {
     // event.touches.length === 1 will also prevent inserting text when user's zooming
     if (didTapTwice && event.touches.length === 1) {
       const [touch] = event.touches;
-      // @ts-ignore
       this.handleCanvasDoubleClick({
         clientX: touch.clientX,
         clientY: touch.clientY,
+        ctrlKey: false,
+        metaKey: false,
+        altKey: false,
       });
       didTapTwice = false;
       clearTimeout(tappedTwiceTimer);
@@ -1961,7 +1963,10 @@ class App extends React.Component<AppProps, AppState> {
   };
 
   private handleCanvasDoubleClick = (
-    event: React.MouseEvent<HTMLCanvasElement>,
+    event: Pick<
+      React.PointerEvent<HTMLCanvasElement>,
+      "clientX" | "clientY" | "ctrlKey" | "metaKey" | "altKey"
+    >,
   ) => {
     // case: double-clicking with arrow/line tool selected would both create
     // text and enter multiElement mode


### PR DESCRIPTION
- disables double-tap to create text on mobile (kept double-tap to edit existing text as that is very useful and also more intuitive).
- fixed a case where double-tapping a (text) element and then dragging it (on the 2nd tap) caused the editing text element being dragged closely to a `[0,0]` position.