### PR TITLE
fix: overscroll on touch devices

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -117,6 +117,7 @@
 
         width: 100%;
         height: 100%;
+        overflow: hidden;
       }
 
       .visually-hidden {


### PR DESCRIPTION
Previously, swiping up and down on an Island would cause the page to rubberband. Adding `overflow: hidden` fixes this.