### PR TITLE
refactor: Delete React SyntheticEvent persist

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -2233,8 +2233,6 @@ class App extends React.Component<AppProps, AppState> {
   private handleCanvasPointerDown = (
     event: React.PointerEvent<HTMLCanvasElement>,
   ) => {
-    event.persist();
-
     // remove any active selection when we start to interact with canvas
     // (mainly, we care about removing selection outside the component which
     //  would prevent our copy handling otherwise)


### PR DESCRIPTION
In React v17, `persist` is no longer required.
I thought `event.persist()` could be removed.

Reference:
> As of v17, e.persist() doesn’t do anything because the SyntheticEvent is no longer pooled.
https://reactjs.org/docs/events.html#overview