### PR TITLE
fix: allow pointer events for disable zen mode button

### DIFF
--- a/src/components/LayerUI.scss
+++ b/src/components/LayerUI.scss
@@ -116,7 +116,8 @@
       }
     }
     .layer-ui__wrapper__footer-left,
-    .layer-ui__wrapper__footer-right {
+    .layer-ui__wrapper__footer-right,
+    .disable-zen-mode--visible {
       pointer-events: all;
     }
   }


### PR DESCRIPTION
Disable zen mode is broken in prod since https://github.com/excalidraw/excalidraw/pull/3629 was merged as pointer events were disabed