### PR TITLE
feat: switch to selection tool on library item insert

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1282,6 +1282,7 @@ class App extends React.Component<AppProps, AppState> {
         this.scene.getElements(),
       ),
     );
+    this.selectShapeTool("selection");
   };
 
   private addTextFromPaste(text: any) {

--- a/src/tests/library.test.tsx
+++ b/src/tests/library.test.tsx
@@ -4,6 +4,7 @@ import ExcalidrawApp from "../excalidraw-app";
 import { API } from "./helpers/api";
 import { MIME_TYPES } from "../constants";
 import { LibraryItem } from "../types";
+import { UI } from "./helpers/ui";
 
 const { h } = window;
 
@@ -39,5 +40,22 @@ describe("library", () => {
     await waitFor(() => {
       expect(h.elements).toEqual([expect.objectContaining({ id: "A_copy" })]);
     });
+  });
+
+  it("inserting library item should revert to selection tool", async () => {
+    UI.clickTool("rectangle");
+    expect(h.elements).toEqual([]);
+    const libraryItems: LibraryItem = JSON.parse(
+      await API.readFile("./fixtures/fixture_library.excalidrawlib", "utf8"),
+    ).library[0];
+    await API.drop(
+      new Blob([JSON.stringify(libraryItems)], {
+        type: MIME_TYPES.excalidrawlib,
+      }),
+    );
+    await waitFor(() => {
+      expect(h.elements).toEqual([expect.objectContaining({ id: "A_copy" })]);
+    });
+    expect(h.state.elementType).toBe("selection");
   });
 });


### PR DESCRIPTION
- fixes #3765
- I see that there's a test file for library (library.test.tsx) but not quite sure how to use it. Will definitely work on a test if I can get guidance/pointers!
- attached a video showing tests before and after change

https://user-images.githubusercontent.com/37394743/123556943-0b364080-d75c-11eb-96f5-39cf9307a553.mov

