### PR TITLE
docs: specify to use yarn v1 not v2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,9 +5,11 @@
 .env.test.local
 .envrc
 .eslintcache
+.history
 .idea
 .vercel
 .vscode
+.yarn
 *.log
 *.tgz
 build

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ These instructions will get you a copy of the project up and running on your loc
 #### Requirements
 
 - [Node.js](https://nodejs.org/en/)
-- [Yarn](https://yarnpkg.com/getting-started/install) (v1)
+- [Yarn](https://yarnpkg.com/getting-started/install) (v1 or [v2.4.1+](https://github.com/yarnpkg/berry/blob/master/CHANGELOG.md#241))
 - [Git](https://git-scm.com/downloads)
 
 #### Clone the repo

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ These instructions will get you a copy of the project up and running on your loc
 #### Requirements
 
 - [Node.js](https://nodejs.org/en/)
-- [Yarn](https://yarnpkg.com/getting-started/install)
+- [Yarn](https://yarnpkg.com/getting-started/install) (v1)
 - [Git](https://git-scm.com/downloads)
 
 #### Clone the repo

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ These instructions will get you a copy of the project up and running on your loc
 #### Requirements
 
 - [Node.js](https://nodejs.org/en/)
-- [Yarn](https://yarnpkg.com/getting-started/install) (v1 or [v2.4.1+](https://github.com/yarnpkg/berry/blob/master/CHANGELOG.md#241))
+- [Yarn](https://yarnpkg.com/getting-started/install) (v1 or v2.4.2+)
 - [Git](https://git-scm.com/downloads)
 
 #### Clone the repo


### PR DESCRIPTION
got some errors with yarn v2, so had to downgrade
to even start working, I think it's a good idea
to put it in the README