### PR TITLE
fix: ensure `s` and `g` shortcuts work on no selection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,9 +5,11 @@
 .env.test.local
 .envrc
 .eslintcache
+.history
 .idea
 .vercel
 .vscode
+.yarn
 *.log
 *.tgz
 build

--- a/.gitignore
+++ b/.gitignore
@@ -5,11 +5,9 @@
 .env.test.local
 .envrc
 .eslintcache
-.history
 .idea
 .vercel
 .vscode
-.yarn
 *.log
 *.tgz
 build

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1582,17 +1582,11 @@ class App extends React.Component<AppProps, AppState> {
       }
 
       if (event.key === KEYS.G || event.key === KEYS.S) {
-        const selectedElements = getSelectedElements(
-          this.scene.getElements(),
-          this.state,
-        );
-        if (selectedElements.length) {
-          if (event.key === KEYS.G) {
-            this.setState({ openPopup: "backgroundColorPicker" });
-          }
-          if (event.key === KEYS.S) {
-            this.setState({ openPopup: "strokeColorPicker" });
-          }
+        if (event.key === KEYS.G) {
+          this.setState({ openPopup: "backgroundColorPicker" });
+        }
+        if (event.key === KEYS.S) {
+          this.setState({ openPopup: "strokeColorPicker" });
         }
       }
     },

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -156,6 +156,7 @@ import {
   getElementsWithinSelection,
   getNormalizedZoom,
   getSelectedElements,
+  hasBackground,
   isOverScrollBars,
   isSomeElementSelected,
 } from "../scene";
@@ -1585,7 +1586,15 @@ class App extends React.Component<AppProps, AppState> {
         if (this.state.elementType === "selection") {
           return;
         }
-        if (event.key === KEYS.G) {
+
+        if (
+          event.key === KEYS.G &&
+          (hasBackground(this.state.elementType) ||
+            getSelectedElements(
+              this.scene.getElements(),
+              this.state,
+            ).some((element) => hasBackground(element.type)))
+        ) {
           this.setState({ openPopup: "backgroundColorPicker" });
         }
         if (event.key === KEYS.S) {

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1582,6 +1582,9 @@ class App extends React.Component<AppProps, AppState> {
       }
 
       if (event.key === KEYS.G || event.key === KEYS.S) {
+        if (this.state.elementType === "selection") {
+          return;
+        }
         if (event.key === KEYS.G) {
           this.setState({ openPopup: "backgroundColorPicker" });
         }

--- a/src/shapes.tsx
+++ b/src/shapes.tsx
@@ -11,7 +11,7 @@ export const SHAPES = [
       </svg>
     ),
     value: "selection",
-    key: [KEYS.V, KEYS.S],
+    key: KEYS.V,
   },
   {
     icon: (


### PR DESCRIPTION
fix #2649

### Motivation

> Why the s and g shortcut doesn't work to change the selected color while a tool is active and nothing is selected? Instead pressing s goes back to the Selection tool and pressing g does nothing.

cc @dwelle https://github.com/excalidraw/excalidraw/issues/2649#issuecomment-873642610

- also drops `S` shortcut for `selection` tool (legacy)