### PR TITLE
feat: zenMode can allow opening color pickers via shortcuts

### DIFF
--- a/src/actions/actionProperties.tsx
+++ b/src/actions/actionProperties.tsx
@@ -117,7 +117,7 @@ export const actionChangeStrokeColor = register({
       commitToHistory: !!value.currentItemStrokeColor,
     };
   },
-  PanelComponent: ({ elements, appState, updateData }) => (
+  PanelComponent: ({ elements, appState, updateData, excalidrawContainer }) => (
     <>
       <h3 aria-hidden="true">{t("labels.stroke")}</h3>
       <ColorPicker
@@ -134,6 +134,8 @@ export const actionChangeStrokeColor = register({
         setActive={(active) =>
           updateData({ openPopup: active ? "strokeColorPicker" : null })
         }
+        excalidrawContainer={excalidrawContainer}
+        zenModeEnabled={appState.zenModeEnabled}
       />
     </>
   ),
@@ -157,7 +159,7 @@ export const actionChangeBackgroundColor = register({
       commitToHistory: !!value.currentItemBackgroundColor,
     };
   },
-  PanelComponent: ({ elements, appState, updateData }) => (
+  PanelComponent: ({ elements, appState, updateData, excalidrawContainer }) => (
     <>
       <h3 aria-hidden="true">{t("labels.background")}</h3>
       <ColorPicker
@@ -174,6 +176,8 @@ export const actionChangeBackgroundColor = register({
         setActive={(active) =>
           updateData({ openPopup: active ? "backgroundColorPicker" : null })
         }
+        excalidrawContainer={excalidrawContainer}
+        zenModeEnabled={appState.zenModeEnabled}
       />
     </>
   ),

--- a/src/actions/manager.tsx
+++ b/src/actions/manager.tsx
@@ -111,7 +111,11 @@ export class ActionManager implements ActionsManagerInterface {
   /**
    * @param data additional data sent to the PanelComponent
    */
-  renderAction = (name: ActionName, data?: PanelComponentProps["data"]) => {
+  renderAction = (
+    name: ActionName,
+    data?: PanelComponentProps["data"],
+    excalidrawContainer?: HTMLElement,
+  ) => {
     const canvasActions = this.app.props.UIOptions.canvasActions;
 
     if (
@@ -141,6 +145,7 @@ export class ActionManager implements ActionsManagerInterface {
           updateData={updateData}
           appProps={this.app.props}
           data={data}
+          excalidrawContainer={excalidrawContainer}
         />
       );
     }

--- a/src/actions/types.ts
+++ b/src/actions/types.ts
@@ -109,6 +109,7 @@ export type PanelComponentProps = {
   updateData: (formData?: any) => void;
   appProps: ExcalidrawProps;
   data?: Partial<{ id: string; size: ToolButtonSize }>;
+  excalidrawContainer?: HTMLElement;
 };
 
 export interface Action {

--- a/src/components/Actions.tsx
+++ b/src/components/Actions.tsx
@@ -24,11 +24,13 @@ export const SelectedShapeActions = ({
   elements,
   renderAction,
   elementType,
+  excalidrawContainer,
 }: {
   appState: AppState;
   elements: readonly ExcalidrawElement[];
   renderAction: ActionManager["renderAction"];
   elementType: ExcalidrawElement["type"];
+  excalidrawContainer: HTMLElement;
 }) => {
   const targetElements = getTargetElements(
     getNonDeletedElements(elements),
@@ -50,8 +52,9 @@ export const SelectedShapeActions = ({
 
   return (
     <div className="panelColumn">
-      {renderAction("changeStrokeColor")}
-      {showChangeBackgroundIcons && renderAction("changeBackgroundColor")}
+      {renderAction("changeStrokeColor", undefined, excalidrawContainer)}
+      {showChangeBackgroundIcons &&
+        renderAction("changeBackgroundColor", undefined, excalidrawContainer)}
       {showFillIcons && renderAction("changeFillStyle")}
 
       {(hasStrokeWidth(elementType) ||

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -443,9 +443,11 @@ class App extends React.Component<AppProps, AppState> {
               focusContainer={this.focusContainer}
               library={this.library}
               id={this.id}
+              excalidrawContainer={this.excalidrawContainerRef.current!}
             />
             <div className="excalidraw-textEditorContainer" />
             <div className="excalidraw-contextMenuContainer" />
+            <div className="excalidraw-popoverContainer" />
             {this.state.showStats && (
               <Stats
                 appState={this.state}

--- a/src/components/ColorPicker.tsx
+++ b/src/components/ColorPicker.tsx
@@ -241,6 +241,8 @@ export const ColorPicker = ({
   label,
   isActive,
   setActive,
+  excalidrawContainer,
+  zenModeEnabled,
 }: {
   type: "canvasBackground" | "elementBackground" | "elementStroke";
   color: string | null;
@@ -248,11 +250,28 @@ export const ColorPicker = ({
   label: string;
   isActive: boolean;
   setActive: (active: boolean) => void;
+  excalidrawContainer?: HTMLElement;
+  zenModeEnabled?: boolean;
 }) => {
   const pickerButton = React.useRef<HTMLButtonElement>(null);
+  const mainRef = React.useRef<HTMLDivElement>(null);
+  const [top, setTop] = React.useState(0);
+
+  React.useEffect(() => {
+    if (
+      excalidrawContainer === undefined ||
+      mainRef.current === null ||
+      !zenModeEnabled
+    ) {
+      return;
+    }
+    const d1 = excalidrawContainer.getBoundingClientRect();
+    const d2 = mainRef.current.getBoundingClientRect();
+    setTop(d1.top + Math.abs(d2.bottom));
+  }, [excalidrawContainer, zenModeEnabled]);
 
   return (
-    <div>
+    <div ref={mainRef}>
       <div className="color-picker-control-container">
         <button
           className="color-picker-label-swatch"
@@ -271,21 +290,18 @@ export const ColorPicker = ({
       </div>
       <React.Suspense fallback="">
         {isActive ? (
-          <PopoverModal>
+          <PopoverModal
+            container={excalidrawContainer}
+            zenModeEnabled={zenModeEnabled}
+          >
             <Popover
               onCloseRequest={(event) =>
                 event.target !== pickerButton.current && setActive(false)
               }
               top={
-                type === "canvasBackground"
-                  ? 102
-                  : type === "elementStroke"
-                  ? 190
-                  : type === "elementBackground"
-                  ? 250
-                  : undefined
+                type === "canvasBackground" || !zenModeEnabled ? undefined : top
               }
-              left={10}
+              left={type === "canvasBackground" ? undefined : 10}
             >
               <Picker
                 colors={colors[type]}

--- a/src/components/ColorPicker.tsx
+++ b/src/components/ColorPicker.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Popover } from "./Popover";
+import { PopoverModal } from "./PopoverModal";
 
 import "./ColorPicker.scss";
 import { isArrowKey, KEYS } from "../keys";
@@ -270,26 +271,38 @@ export const ColorPicker = ({
       </div>
       <React.Suspense fallback="">
         {isActive ? (
-          <Popover
-            onCloseRequest={(event) =>
-              event.target !== pickerButton.current && setActive(false)
-            }
-          >
-            <Picker
-              colors={colors[type]}
-              color={color || null}
-              onChange={(changedColor) => {
-                onChange(changedColor);
-              }}
-              onClose={() => {
-                setActive(false);
-                pickerButton.current?.focus();
-              }}
-              label={label}
-              showInput={false}
-              type={type}
-            />
-          </Popover>
+          <PopoverModal>
+            <Popover
+              onCloseRequest={(event) =>
+                event.target !== pickerButton.current && setActive(false)
+              }
+              top={
+                type === "canvasBackground"
+                  ? 102
+                  : type === "elementStroke"
+                  ? 190
+                  : type === "elementBackground"
+                  ? 250
+                  : undefined
+              }
+              left={10}
+            >
+              <Picker
+                colors={colors[type]}
+                color={color || null}
+                onChange={(changedColor) => {
+                  onChange(changedColor);
+                }}
+                onClose={() => {
+                  setActive(false);
+                  pickerButton.current?.focus();
+                }}
+                label={label}
+                showInput={false}
+                type={type}
+              />
+            </Popover>
+          </PopoverModal>
         ) : null}
       </React.Suspense>
     </div>

--- a/src/components/LayerUI.tsx
+++ b/src/components/LayerUI.tsx
@@ -73,6 +73,7 @@ interface LayerUIProps {
   focusContainer: () => void;
   library: Library;
   id: string;
+  excalidrawContainer: HTMLElement;
 }
 
 const useOnClickOutside = (
@@ -381,6 +382,7 @@ const LayerUI = ({
   focusContainer,
   library,
   id,
+  excalidrawContainer,
 }: LayerUIProps) => {
   const isMobile = useIsMobile();
 
@@ -527,6 +529,7 @@ const LayerUI = ({
           elements={elements}
           renderAction={actionManager.renderAction}
           elementType={appState.elementType}
+          excalidrawContainer={excalidrawContainer}
         />
       </Island>
     </Section>
@@ -761,6 +764,7 @@ const LayerUI = ({
         renderCustomFooter={renderCustomFooter}
         viewModeEnabled={viewModeEnabled}
         showThemeBtn={showThemeBtn}
+        excalidrawContainer={excalidrawContainer}
       />
     </>
   ) : (

--- a/src/components/MobileMenu.tsx
+++ b/src/components/MobileMenu.tsx
@@ -33,6 +33,7 @@ type MobileMenuProps = {
   renderCustomFooter?: (isMobile: boolean, appState: AppState) => JSX.Element;
   viewModeEnabled: boolean;
   showThemeBtn: boolean;
+  excalidrawContainer: HTMLElement;
 };
 
 export const MobileMenu = ({
@@ -50,6 +51,7 @@ export const MobileMenu = ({
   renderCustomFooter,
   viewModeEnabled,
   showThemeBtn,
+  excalidrawContainer,
 }: MobileMenuProps) => {
   const renderToolbar = () => {
     return (
@@ -188,6 +190,7 @@ export const MobileMenu = ({
                 elements={elements}
                 renderAction={actionManager.renderAction}
                 elementType={appState.elementType}
+                excalidrawContainer={excalidrawContainer}
               />
             </Section>
           ) : null}

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -51,7 +51,7 @@ export const Modal = (props: {
   );
 };
 
-export const useBodyRoot = (theme: AppState["theme"]) => {
+const useBodyRoot = (theme: AppState["theme"]) => {
   const [div, setDiv] = useState<HTMLDivElement | null>(null);
 
   const isMobile = useIsMobile();

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -51,7 +51,7 @@ export const Modal = (props: {
   );
 };
 
-const useBodyRoot = (theme: AppState["theme"]) => {
+export const useBodyRoot = (theme: AppState["theme"]) => {
   const [div, setDiv] = useState<HTMLDivElement | null>(null);
 
   const isMobile = useIsMobile();

--- a/src/components/PopoverModal.tsx
+++ b/src/components/PopoverModal.tsx
@@ -2,18 +2,34 @@ import "./Modal.scss";
 
 import React from "react";
 import { createPortal } from "react-dom";
-import { useBodyRoot } from "./Modal";
-import { AppState } from "../types";
 
-export const PopoverModal = (props: {
-  theme?: AppState["theme"];
-  children: React.ReactNode;
-}) => {
-  const { theme = "light" } = props;
-  const modalRoot = useBodyRoot(theme);
+const popoverModalNodeByContainer = new WeakMap<HTMLElement, HTMLDivElement>();
 
-  if (!modalRoot) {
-    return null;
+const getPopoverModalNode = (container: HTMLElement): HTMLDivElement => {
+  let popoverModalNode = popoverModalNodeByContainer.get(container);
+  if (popoverModalNode) {
+    return popoverModalNode;
   }
-  return createPortal(<>{props.children}</>, modalRoot);
+  popoverModalNode = document.createElement("div");
+  container
+    .querySelector(".excalidraw-popoverContainer")!
+    .appendChild(popoverModalNode);
+  popoverModalNodeByContainer.set(container, popoverModalNode);
+  return popoverModalNode;
+};
+
+export const PopoverModal = ({
+  container,
+  children,
+  zenModeEnabled = false,
+}: {
+  container?: HTMLElement;
+  children: React.ReactNode;
+  zenModeEnabled?: boolean;
+}) => {
+  if (container === undefined || !zenModeEnabled) {
+    return <>{children}</>;
+  }
+
+  return createPortal(<>{children}</>, getPopoverModalNode(container));
 };

--- a/src/components/PopoverModal.tsx
+++ b/src/components/PopoverModal.tsx
@@ -1,0 +1,19 @@
+import "./Modal.scss";
+
+import React from "react";
+import { createPortal } from "react-dom";
+import { useBodyRoot } from "./Modal";
+import { AppState } from "../types";
+
+export const PopoverModal = (props: {
+  theme?: AppState["theme"];
+  children: React.ReactNode;
+}) => {
+  const { theme = "light" } = props;
+  const modalRoot = useBodyRoot(theme);
+
+  if (!modalRoot) {
+    return null;
+  }
+  return createPortal(<>{props.children}</>, modalRoot);
+};


### PR DESCRIPTION
Signed-off-by: gurkiran_singh <gurkiransinghk@gmail.com>

ZenMode can allow opening color pickers via shortcuts particularly using `s` and `g`. I am not sure if this is the best approach but please feel free to provide any feedback as I am beginner in the project contribution.
#3680 