### PR TITLE
feat: Support custom extensions of `ExcalidrawElement` in @excalidraw/excalidraw

### DIFF
--- a/src/actions/actionBoundText.tsx
+++ b/src/actions/actionBoundText.tsx
@@ -3,9 +3,9 @@ import { getNonDeletedElements, isTextElement } from "../element";
 import { mutateElement } from "../element/mutateElement";
 import {
   getBoundTextElement,
-  measureText,
   redrawTextBoundingBox,
 } from "../element/textElement";
+import { measureTextElement } from "../element/textWysiwyg";
 import {
   hasBoundTextElement,
   isTextBindableContainer,
@@ -15,7 +15,6 @@ import {
   ExcalidrawTextElement,
 } from "../element/types";
 import { getSelectedElements } from "../scene";
-import { getFontString } from "../utils";
 import { register } from "./register";
 
 export const actionUnbindText = register({
@@ -34,10 +33,8 @@ export const actionUnbindText = register({
     selectedElements.forEach((element) => {
       const boundTextElement = getBoundTextElement(element);
       if (boundTextElement) {
-        const { width, height, baseline } = measureText(
-          boundTextElement.originalText,
-          getFontString(boundTextElement),
-        );
+        const { width, height, baseline } =
+          measureTextElement(boundTextElement);
         mutateElement(boundTextElement as ExcalidrawTextElement, {
           containerId: null,
           width,

--- a/src/actions/actionProperties.tsx
+++ b/src/actions/actionProperties.tsx
@@ -81,7 +81,7 @@ import { register } from "./register";
 
 const FONT_SIZE_RELATIVE_INCREASE_STEP = 0.1;
 
-const changeProperty = (
+export const changeProperty = (
   elements: readonly ExcalidrawElement[],
   appState: AppState,
   callback: (element: ExcalidrawElement) => ExcalidrawElement,
@@ -101,7 +101,7 @@ const changeProperty = (
   });
 };
 
-const getFormValue = function <T>(
+export const getFormValue = function <T>(
   elements: readonly ExcalidrawElement[],
   appState: AppState,
   getAttribute: (element: ExcalidrawElement) => T,

--- a/src/actions/guards.ts
+++ b/src/actions/guards.ts
@@ -1,0 +1,25 @@
+import { Action, ActionName, DisableFn, EnableFn } from "./types";
+
+const disablers = {} as Record<ActionName, DisableFn[]>;
+const enablers = {} as Record<Action["name"], EnableFn[]>;
+
+export const getActionDisablers = () => disablers;
+export const getActionEnablers = () => enablers;
+
+export const registerDisableFn = (name: ActionName, disabler: DisableFn) => {
+  if (!(name in disablers)) {
+    disablers[name] = [] as DisableFn[];
+  }
+  if (!disablers[name].includes(disabler)) {
+    disablers[name].push(disabler);
+  }
+};
+
+export const registerEnableFn = (name: Action["name"], enabler: EnableFn) => {
+  if (!(name in enablers)) {
+    enablers[name] = [] as EnableFn[];
+  }
+  if (!enablers[name].includes(enabler)) {
+    enablers[name].push(enabler);
+  }
+};

--- a/src/actions/manager.tsx
+++ b/src/actions/manager.tsx
@@ -6,7 +6,11 @@ import {
   ActionResult,
   PanelComponentProps,
   ActionSource,
+  DisableFn,
+  EnableFn,
+  isActionName,
 } from "./types";
+import { getActionDisablers, getActionEnablers } from "./guards";
 import { ExcalidrawElement } from "../element/types";
 import { AppClassProperties, AppState } from "../types";
 import { MODES } from "../constants";
@@ -41,7 +45,10 @@ const trackAction = (
 };
 
 export class ActionManager {
-  actions = {} as Record<ActionName, Action>;
+  actions = {} as Record<ActionName | Action["name"], Action>;
+
+  disablers = {} as Record<ActionName, DisableFn[]>;
+  enablers = {} as Record<Action["name"], EnableFn[]>;
 
   updater: (actionResult: ActionResult | Promise<ActionResult>) => void;
 
@@ -69,6 +76,58 @@ export class ActionManager {
     this.app = app;
   }
 
+  public registerActionGuards() {
+    const disablers = getActionDisablers();
+    for (const d in disablers) {
+      const dName = d as ActionName;
+      disablers[dName].forEach((disabler) =>
+        this.registerDisableFn(dName, disabler),
+      );
+    }
+    const enablers = getActionEnablers();
+    for (const e in enablers) {
+      const eName = e as Action["name"];
+      enablers[e].forEach((enabler) => this.registerEnableFn(eName, enabler));
+    }
+  }
+
+  private registerDisableFn(name: ActionName, disabler: DisableFn) {
+    if (!(name in this.disablers)) {
+      this.disablers[name] = [] as DisableFn[];
+    }
+    if (!this.disablers[name].includes(disabler)) {
+      this.disablers[name].push(disabler);
+    }
+  }
+
+  private registerEnableFn(name: Action["name"], enabler: EnableFn) {
+    if (!(name in this.enablers)) {
+      this.enablers[name] = [] as EnableFn[];
+    }
+    if (!this.enablers[name].includes(enabler)) {
+      this.enablers[name].push(enabler);
+    }
+  }
+
+  public isActionEnabled(
+    elements: readonly ExcalidrawElement[],
+    appState: AppState,
+    actionName: Action["name"],
+  ): boolean {
+    if (isActionName(actionName)) {
+      return !(
+        actionName in this.disablers &&
+        this.disablers[actionName].some((fn) =>
+          fn(elements, appState, actionName),
+        )
+      );
+    }
+    return (
+      actionName in this.enablers &&
+      this.enablers[actionName].some((fn) => fn(elements, appState, actionName))
+    );
+  }
+
   registerAction(action: Action) {
     this.actions[action.name] = action;
   }
@@ -85,7 +144,11 @@ export class ActionManager {
         (action) =>
           (action.name in canvasActions
             ? canvasActions[action.name as keyof typeof canvasActions]
-            : true) &&
+            : this.isActionEnabled(
+                this.getElementsIncludingDeleted(),
+                this.getAppState(),
+                action.name,
+              )) &&
           action.keyTest &&
           action.keyTest(
             event,
@@ -135,14 +198,21 @@ export class ActionManager {
   /**
    * @param data additional data sent to the PanelComponent
    */
-  renderAction = (name: ActionName, data?: PanelComponentProps["data"]) => {
+  renderAction = (
+    name: ActionName | Action["name"],
+    data?: PanelComponentProps["data"],
+  ) => {
     const canvasActions = this.app.props.UIOptions.canvasActions;
     if (
       this.actions[name] &&
       "PanelComponent" in this.actions[name] &&
       (name in canvasActions
         ? canvasActions[name as keyof typeof canvasActions]
-        : true)
+        : this.isActionEnabled(
+            this.getElementsIncludingDeleted(),
+            this.getAppState(),
+            name,
+          ))
     ) {
       const action = this.actions[name];
       const PanelComponent = action.PanelComponent!;
@@ -164,6 +234,7 @@ export class ActionManager {
 
       return (
         <PanelComponent
+          key={name}
           elements={this.getElementsIncludingDeleted()}
           appState={this.getAppState()}
           updateData={updateData}

--- a/src/actions/register.ts
+++ b/src/actions/register.ts
@@ -1,8 +1,14 @@
-import { Action } from "./types";
+import { Action, isActionName } from "./types";
 
-export let actions: readonly Action[] = [];
+let actions: readonly Action[] = [];
+let customActions: readonly Action[] = [];
+export const getCustomActions = () => customActions;
+export const getActions = () => actions;
 
 export const register = <T extends Action>(action: T) => {
+  if (!isActionName(action.name)) {
+    customActions = customActions.concat(action);
+  }
   actions = actions.concat(action);
   return action as T & {
     keyTest?: unknown extends T["keyTest"] ? never : T["keyTest"];

--- a/src/actions/shortcuts.ts
+++ b/src/actions/shortcuts.ts
@@ -71,8 +71,23 @@ const shortcutMap: Record<ShortcutName, string[]> = {
   toggleLock: [getShortcutKey("CtrlOrCmd+Shift+L")],
 };
 
-export const getShortcutFromShortcutName = (name: ShortcutName) => {
-  const shortcuts = shortcutMap[name];
+export type CustomShortcutName = string;
+
+let customShortcutMap: Record<CustomShortcutName, string[]> = {};
+
+export const registerCustomShortcuts = (
+  shortcuts: Record<CustomShortcutName, string[]>,
+) => {
+  customShortcutMap = { ...customShortcutMap, ...shortcuts };
+};
+
+export const getShortcutFromShortcutName = (
+  name: ShortcutName | CustomShortcutName,
+) => {
+  const shortcuts =
+    name in customShortcutMap
+      ? customShortcutMap[name as CustomShortcutName]
+      : shortcutMap[name as ShortcutName];
   // if multiple shortcuts available, take the first one
   return shortcuts && shortcuts.length > 0 ? shortcuts[0] : "";
 };

--- a/src/actions/types.ts
+++ b/src/actions/types.ts
@@ -31,88 +31,109 @@ type ActionFn = (
   app: AppClassProperties,
 ) => ActionResult | Promise<ActionResult>;
 
+// Return `true` to indicate the standard Action with name `actionName`
+// should be disabled given `elements` and `appState`.
+export type DisableFn = (
+  elements: readonly ExcalidrawElement[],
+  appState: AppState,
+  actionName: ActionName,
+) => boolean;
+
+// Return `true` to indicate the custom Action with name `actionName`
+// should be enabled given `elements` and `appState`.
+export type EnableFn = (
+  elements: readonly ExcalidrawElement[],
+  appState: AppState,
+  actionName: Action["name"],
+) => boolean;
+
 export type UpdaterFn = (res: ActionResult) => void;
 export type ActionFilterFn = (action: Action) => void;
 
-export type ActionName =
-  | "copy"
-  | "cut"
-  | "paste"
-  | "copyAsPng"
-  | "copyAsSvg"
-  | "copyText"
-  | "sendBackward"
-  | "bringForward"
-  | "sendToBack"
-  | "bringToFront"
-  | "copyStyles"
-  | "selectAll"
-  | "pasteStyles"
-  | "gridMode"
-  | "zenMode"
-  | "stats"
-  | "changeStrokeColor"
-  | "changeBackgroundColor"
-  | "changeFillStyle"
-  | "changeStrokeWidth"
-  | "changeStrokeShape"
-  | "changeSloppiness"
-  | "changeStrokeStyle"
-  | "changeArrowhead"
-  | "changeOpacity"
-  | "changeFontSize"
-  | "toggleCanvasMenu"
-  | "toggleEditMenu"
-  | "undo"
-  | "redo"
-  | "finalize"
-  | "changeProjectName"
-  | "changeExportBackground"
-  | "changeExportEmbedScene"
-  | "changeExportScale"
-  | "saveToActiveFile"
-  | "saveFileToDisk"
-  | "loadScene"
-  | "duplicateSelection"
-  | "deleteSelectedElements"
-  | "changeViewBackgroundColor"
-  | "clearCanvas"
-  | "zoomIn"
-  | "zoomOut"
-  | "resetZoom"
-  | "zoomToFit"
-  | "zoomToSelection"
-  | "changeFontFamily"
-  | "changeTextAlign"
-  | "changeVerticalAlign"
-  | "toggleFullScreen"
-  | "toggleShortcuts"
-  | "group"
-  | "ungroup"
-  | "goToCollaborator"
-  | "addToLibrary"
-  | "changeSharpness"
-  | "alignTop"
-  | "alignBottom"
-  | "alignLeft"
-  | "alignRight"
-  | "alignVerticallyCentered"
-  | "alignHorizontallyCentered"
-  | "distributeHorizontally"
-  | "distributeVertically"
-  | "flipHorizontal"
-  | "flipVertical"
-  | "viewMode"
-  | "exportWithDarkMode"
-  | "toggleTheme"
-  | "increaseFontSize"
-  | "decreaseFontSize"
-  | "unbindText"
-  | "hyperlink"
-  | "eraser"
-  | "bindText"
-  | "toggleLock"
-  | "toggleLinearEditor";
+const actionNames = [
+  "copy",
+  "cut",
+  "paste",
+  "copyAsPng",
+  "copyAsSvg",
+  "copyText",
+  "sendBackward",
+  "bringForward",
+  "sendToBack",
+  "bringToFront",
+  "copyStyles",
+  "selectAll",
+  "pasteStyles",
+  "gridMode",
+  "zenMode",
+  "stats",
+  "changeStrokeColor",
+  "changeBackgroundColor",
+  "changeFillStyle",
+  "changeStrokeWidth",
+  "changeStrokeShape",
+  "changeSloppiness",
+  "changeStrokeStyle",
+  "changeArrowhead",
+  "changeOpacity",
+  "changeFontSize",
+  "toggleCanvasMenu",
+  "toggleEditMenu",
+  "undo",
+  "redo",
+  "finalize",
+  "changeProjectName",
+  "changeExportBackground",
+  "changeExportEmbedScene",
+  "changeExportScale",
+  "saveToActiveFile",
+  "saveFileToDisk",
+  "loadScene",
+  "duplicateSelection",
+  "deleteSelectedElements",
+  "changeViewBackgroundColor",
+  "clearCanvas",
+  "zoomIn",
+  "zoomOut",
+  "resetZoom",
+  "zoomToFit",
+  "zoomToSelection",
+  "changeFontFamily",
+  "changeTextAlign",
+  "changeVerticalAlign",
+  "toggleFullScreen",
+  "toggleShortcuts",
+  "group",
+  "ungroup",
+  "goToCollaborator",
+  "addToLibrary",
+  "changeSharpness",
+  "alignTop",
+  "alignBottom",
+  "alignLeft",
+  "alignRight",
+  "alignVerticallyCentered",
+  "alignHorizontallyCentered",
+  "distributeHorizontally",
+  "distributeVertically",
+  "flipHorizontal",
+  "flipVertical",
+  "viewMode",
+  "exportWithDarkMode",
+  "toggleTheme",
+  "increaseFontSize",
+  "decreaseFontSize",
+  "unbindText",
+  "hyperlink",
+  "eraser",
+  "bindText",
+  "toggleLock",
+] as const;
+
+// So we can have the `isActionName` type guard
+export type ActionName = typeof actionNames[number];
+export const isActionName = (n: any): n is ActionName =>
+  actionNames.includes(n);
 
 export type PanelComponentProps = {
   elements: readonly ExcalidrawElement[];
@@ -123,14 +144,23 @@ export type PanelComponentProps = {
 };
 
 export interface Action {
-  name: ActionName;
+  name: string;
   PanelComponent?: React.FC<PanelComponentProps>;
+  panelComponentPredicate?: (
+    elements: readonly ExcalidrawElement[],
+    appState: AppState,
+  ) => boolean;
   perform: ActionFn;
   keyPriority?: number;
   keyTest?: (
     event: React.KeyboardEvent | KeyboardEvent,
     appState: AppState,
     elements: readonly ExcalidrawElement[],
+  ) => boolean;
+  shapeConfigPredicate?: (
+    elements: readonly ExcalidrawElement[],
+    appState: AppState,
+    data?: Record<string, any>,
   ) => boolean;
   contextItemLabel?:
     | string

--- a/src/appState.ts
+++ b/src/appState.ts
@@ -137,6 +137,8 @@ const APP_STATE_STORAGE_CONF = (<
   editingGroupId: { browser: true, export: false, server: false },
   editingLinearElement: { browser: false, export: false, server: false },
   activeTool: { browser: true, export: false, server: false },
+  activeSubtypes: { browser: true, export: false, server: false },
+  customData: { browser: true, export: false, server: false },
   penMode: { browser: true, export: false, server: false },
   penDetected: { browser: true, export: false, server: false },
   errorMessage: { browser: false, export: false, server: false },

--- a/src/charts.ts
+++ b/src/charts.ts
@@ -8,6 +8,8 @@ import {
 import { newElement, newLinearElement, newTextElement } from "./element";
 import { NonDeletedExcalidrawElement } from "./element/types";
 import { randomId } from "./random";
+import { AppState } from "./types";
+import { selectSubtype } from "./subtypes";
 
 export type ChartElements = readonly NonDeletedExcalidrawElement[];
 
@@ -20,6 +22,8 @@ export interface Spreadsheet {
   title: string | null;
   labels: string[] | null;
   values: number[];
+  activeSubtypes?: AppState["activeSubtypes"];
+  customData?: AppState["customData"];
 }
 
 export const NOT_SPREADSHEET = "NOT_SPREADSHEET";
@@ -193,13 +197,17 @@ const chartXLabels = (
   groupId: string,
   backgroundColor: string,
 ): ChartElements => {
+  const custom = selectSubtype(spreadsheet, "text");
   return (
     spreadsheet.labels?.map((label, index) => {
       return newTextElement({
         groupIds: [groupId],
         backgroundColor,
         ...commonProps,
-        text: label.length > 8 ? `${label.slice(0, 5)}...` : label,
+        text:
+          label.length > 8 && custom.subtype === undefined
+            ? `${label.slice(0, 5)}...`
+            : label,
         x: x + index * (BAR_WIDTH + BAR_GAP) + BAR_GAP * 2,
         y: y + BAR_GAP / 2,
         width: BAR_WIDTH,
@@ -207,6 +215,7 @@ const chartXLabels = (
         fontSize: 16,
         textAlign: "center",
         verticalAlign: "top",
+        ...custom,
       });
     }) || []
   );
@@ -227,6 +236,7 @@ const chartYLabels = (
     y: y - BAR_GAP,
     text: "0",
     textAlign: "right",
+    ...selectSubtype(spreadsheet, "text"),
   });
 
   const maxYLabel = newTextElement({
@@ -237,6 +247,7 @@ const chartYLabels = (
     y: y - BAR_HEIGHT - minYLabel.height / 2,
     text: Math.max(...spreadsheet.values).toLocaleString(),
     textAlign: "right",
+    ...selectSubtype(spreadsheet, "text"),
   });
 
   return [minYLabel, maxYLabel];
@@ -264,6 +275,7 @@ const chartLines = (
       [0, 0],
       [chartWidth, 0],
     ],
+    ...selectSubtype(spreadsheet, "line"),
   });
 
   const yLine = newLinearElement({
@@ -280,6 +292,7 @@ const chartLines = (
       [0, 0],
       [0, -chartHeight],
     ],
+    ...selectSubtype(spreadsheet, "line"),
   });
 
   const maxLine = newLinearElement({
@@ -298,6 +311,7 @@ const chartLines = (
       [0, 0],
       [chartWidth, 0],
     ],
+    ...selectSubtype(spreadsheet, "line"),
   });
 
   return [xLine, yLine, maxLine];
@@ -325,6 +339,7 @@ const chartBaseElements = (
         strokeSharpness: "sharp",
         strokeStyle: "solid",
         textAlign: "center",
+        ...selectSubtype(spreadsheet, "text"),
       })
     : null;
 
@@ -341,6 +356,7 @@ const chartBaseElements = (
         strokeColor: colors.elementStroke[0],
         fillStyle: "solid",
         opacity: 6,
+        ...selectSubtype(spreadsheet, "rectangle"),
       })
     : null;
 
@@ -373,6 +389,7 @@ const chartTypeBar = (
       y: y - barHeight - BAR_GAP,
       width: BAR_WIDTH,
       height: barHeight,
+      ...selectSubtype(spreadsheet, "rectangle"),
     });
   });
 
@@ -425,6 +442,7 @@ const chartTypeLine = (
     width: maxX - minX,
     strokeWidth: 2,
     points: points as any,
+    ...selectSubtype(spreadsheet, "line"),
   });
 
   const dots = spreadsheet.values.map((value, index) => {
@@ -441,6 +459,7 @@ const chartTypeLine = (
       y: y + cy - BAR_GAP * 2,
       width: BAR_GAP,
       height: BAR_GAP,
+      ...selectSubtype(spreadsheet, "ellipse"),
     });
   });
 
@@ -463,6 +482,7 @@ const chartTypeLine = (
         [0, 0],
         [0, cy],
       ],
+      ...selectSubtype(spreadsheet, "line"),
     });
   });
 

--- a/src/clipboard.ts
+++ b/src/clipboard.ts
@@ -129,6 +129,7 @@ const getSystemClipboard = async (
  */
 export const parseClipboard = async (
   event: ClipboardEvent | null,
+  appState?: AppState,
 ): Promise<ClipboardData> => {
   const systemClipboard = await getSystemClipboard(event);
 
@@ -143,6 +144,10 @@ export const parseClipboard = async (
   // technically possible it's staler than in-app clipboard
   const spreadsheetResult = parsePotentialSpreadsheet(systemClipboard);
   if (spreadsheetResult) {
+    if ("spreadsheet" in spreadsheetResult) {
+      spreadsheetResult.spreadsheet.activeSubtypes = appState?.activeSubtypes;
+      spreadsheetResult.spreadsheet.customData = appState?.customData;
+    }
     return spreadsheetResult;
   }
 

--- a/src/components/Actions.tsx
+++ b/src/components/Actions.tsx
@@ -28,6 +28,7 @@ import { trackEvent } from "../analytics";
 import { hasBoundTextElement, isBoundToContainer } from "../element/typeChecks";
 import clsx from "clsx";
 import { actionToggleZenMode } from "../actions";
+import { getCustomActions } from "../actions/register";
 
 export const SelectedShapeActions = ({
   appState,
@@ -85,6 +86,15 @@ export const SelectedShapeActions = ({
         targetElements.some((element) => hasStrokeColor(element.type))) &&
         renderAction("changeStrokeColor")}
       {showChangeBackgroundIcons && renderAction("changeBackgroundColor")}
+      {getCustomActions().map((action) => {
+        if (
+          action.panelComponentPredicate &&
+          action.panelComponentPredicate(targetElements, appState)
+        ) {
+          return renderAction(action.name);
+        }
+        return null;
+      })}
       {showFillIcons && renderAction("changeFillStyle")}
 
       {(hasStrokeWidth(appState.activeTool.type) ||

--- a/src/components/ButtonSelect.tsx
+++ b/src/components/ButtonSelect.tsx
@@ -23,7 +23,15 @@ export const ButtonSelect = <T extends Object>({
           onChange={() => onChange(option.value)}
           checked={value === option.value}
         />
-        {option.text}
+        <span
+          style={{
+            color: "var(--icon-fill-color)",
+            fontWeight: "bold",
+            opacity: value === option.value ? 1.0 : 0.6,
+          }}
+        >
+          {option.text}
+        </span>
       </label>
     ))}
   </div>

--- a/src/components/ContextMenu.tsx
+++ b/src/components/ContextMenu.tsx
@@ -6,6 +6,7 @@ import { t } from "../i18n";
 import "./ContextMenu.scss";
 import {
   getShortcutFromShortcutName,
+  CustomShortcutName,
   ShortcutName,
 } from "../actions/shortcuts";
 import { Action } from "../actions/types";
@@ -77,7 +78,9 @@ const ContextMenu = ({
                 <div className="context-menu-option__label">{label}</div>
                 <kbd className="context-menu-option__shortcut">
                   {actionName
-                    ? getShortcutFromShortcutName(actionName as ShortcutName)
+                    ? getShortcutFromShortcutName(
+                        actionName as ShortcutName | CustomShortcutName,
+                      )
                     : ""}
                 </kbd>
               </button>

--- a/src/components/LayerUI.tsx
+++ b/src/components/LayerUI.tsx
@@ -58,6 +58,7 @@ interface LayerUIProps {
   showExitZenModeBtn: boolean;
   langCode: Language["code"];
   isCollaborating: boolean;
+  renderShapeToggles?: (JSX.Element | null)[];
   renderTopRightUI?: ExcalidrawProps["renderTopRightUI"];
   renderCustomFooter?: ExcalidrawProps["renderFooter"];
   renderCustomStats?: ExcalidrawProps["renderCustomStats"];
@@ -82,6 +83,7 @@ const LayerUI = ({
   onInsertElements,
   showExitZenModeBtn,
   isCollaborating,
+  renderShapeToggles,
   renderTopRightUI,
   renderCustomFooter,
   renderCustomStats,
@@ -315,6 +317,7 @@ const LayerUI = ({
                             });
                           }}
                         />
+                        {renderShapeToggles}
                       </Stack.Row>
                     </Island>
                     <LibraryButton
@@ -403,6 +406,7 @@ const LayerUI = ({
           onPenModeToggle={onPenModeToggle}
           canvas={canvas}
           isCollaborating={isCollaborating}
+          renderShapeToggles={renderShapeToggles}
           renderCustomFooter={renderCustomFooter}
           onImageAction={onImageAction}
           renderTopRightUI={renderTopRightUI}

--- a/src/components/MobileMenu.tsx
+++ b/src/components/MobileMenu.tsx
@@ -33,6 +33,7 @@ type MobileMenuProps = {
   onPenModeToggle: () => void;
   canvas: HTMLCanvasElement | null;
   isCollaborating: boolean;
+  renderShapeToggles?: (JSX.Element | null)[];
   renderCustomFooter?: (
     isMobile: boolean,
     appState: AppState,
@@ -59,6 +60,7 @@ export const MobileMenu = ({
   onPenModeToggle,
   canvas,
   isCollaborating,
+  renderShapeToggles,
   renderCustomFooter,
   onImageAction,
   renderTopRightUI,
@@ -87,6 +89,7 @@ export const MobileMenu = ({
                         });
                       }}
                     />
+                    {renderShapeToggles}
                   </Stack.Row>
                 </Island>
                 {renderTopRightUI && renderTopRightUI(true, appState)}

--- a/src/components/PasteChartDialog.tsx
+++ b/src/components/PasteChartDialog.tsx
@@ -8,6 +8,12 @@ import { exportToSvg } from "../scene/export";
 import { AppState, LibraryItem } from "../types";
 import { Dialog } from "./Dialog";
 import "./PasteChartDialog.scss";
+import { ensureSubtypesLoaded } from "../subtypes";
+import { isTextElement } from "../element";
+import {
+  getContainerElement,
+  redrawTextBoundingBox,
+} from "../element/textElement";
 
 type OnInsertChart = (chartType: ChartType, elements: ChartElements) => void;
 
@@ -23,40 +29,53 @@ const ChartPreviewBtn = (props: {
   );
 
   useLayoutEffect(() => {
-    if (!props.spreadsheet) {
-      return;
-    }
-
-    const elements = renderSpreadsheet(
-      props.chartType,
-      props.spreadsheet,
-      0,
-      0,
-    );
-    setChartElements(elements);
     let svg: SVGSVGElement;
     const previewNode = previewRef.current!;
-
     (async () => {
-      svg = await exportToSvg(
-        elements,
-        {
-          exportBackground: false,
-          viewBackgroundColor: oc.white,
-        },
-        null, // files
-      );
-      previewNode.replaceChildren();
-      previewNode.appendChild(svg);
+      (async () => {
+        let elements: ChartElements;
+        await ensureSubtypesLoaded(
+          props.spreadsheet?.activeSubtypes ?? [],
+          () => {
+            if (!props.spreadsheet) {
+              return;
+            }
 
-      if (props.selected) {
-        (previewNode.parentNode as HTMLDivElement).focus();
-      }
+            elements = renderSpreadsheet(
+              props.chartType,
+              props.spreadsheet,
+              0,
+              0,
+            );
+            elements.forEach(
+              (el) =>
+                isTextElement(el) &&
+                redrawTextBoundingBox(el, getContainerElement(el)),
+            );
+            setChartElements(elements);
+          },
+        ).then(async () => {
+          svg = await exportToSvg(
+            elements,
+            {
+              exportBackground: false,
+              viewBackgroundColor: oc.white,
+            },
+            null, // files
+          );
+          previewNode.replaceChildren();
+          previewNode.appendChild(svg);
+
+          if (props.selected) {
+            (previewNode.parentNode as HTMLDivElement).focus();
+          }
+        });
+      })();
+
+      return () => {
+        previewNode.replaceChildren();
+      };
     })();
-
-    return () => {
-      previewNode.replaceChildren();
-    };
   }, [props.spreadsheet, props.chartType, props.selected]);
 
   return (

--- a/src/components/SubtypeButton.tsx
+++ b/src/components/SubtypeButton.tsx
@@ -1,0 +1,102 @@
+import { getShortcutKey, updateActiveTool } from "../utils";
+import { t } from "../i18n";
+import { Action } from "../actions/types";
+import { ToolButton } from "./ToolButton";
+import clsx from "clsx";
+import { Subtype, isValidSubtype, subtypeCollides } from "../subtypes";
+import { ExcalidrawElement, Theme } from "../element/types";
+
+export const SubtypeButton = (
+  subtype: Subtype,
+  parentType: ExcalidrawElement["type"],
+  icon: ({ theme }: { theme: Theme }) => JSX.Element,
+  key?: string,
+) => {
+  const title = key !== undefined ? ` - ${getShortcutKey(key)}` : "";
+  const keyTest: Action["keyTest"] =
+    key !== undefined ? (event) => event.code === `Key${key}` : undefined;
+  const subtypeAction: Action = {
+    name: subtype,
+    trackEvent: false,
+    perform: (elements, appState) => {
+      const inactive = !appState.activeSubtypes?.includes(subtype) ?? true;
+      const activeSubtypes: Subtype[] = [];
+      if (appState.activeSubtypes) {
+        activeSubtypes.push(...appState.activeSubtypes);
+      }
+      let activated = false;
+      if (inactive) {
+        // Ensure `element.subtype` is well-defined
+        if (!subtypeCollides(subtype, activeSubtypes)) {
+          activeSubtypes.push(subtype);
+          activated = true;
+        }
+      } else {
+        // Can only be active if appState.activeSubtypes is defined
+        // and contains subtype.
+        activeSubtypes.splice(activeSubtypes.indexOf(subtype), 1);
+      }
+      const type =
+        appState.activeTool.type !== "custom" &&
+        isValidSubtype(subtype, appState.activeTool.type)
+          ? appState.activeTool.type
+          : parentType;
+      const activeTool = !inactive
+        ? appState.activeTool
+        : updateActiveTool(appState, { type });
+      const selectedElementIds = activated ? {} : appState.selectedElementIds;
+      const selectedGroupIds = activated ? {} : appState.selectedGroupIds;
+
+      return {
+        appState: {
+          ...appState,
+          activeSubtypes,
+          selectedElementIds,
+          selectedGroupIds,
+          activeTool,
+        },
+        commitToHistory: true,
+      };
+    },
+    keyTest,
+    PanelComponent: ({ elements, appState, updateData, data }) => (
+      <ToolButton
+        type="icon"
+        icon={icon.call(this, { theme: appState.theme })}
+        selected={
+          appState.activeSubtypes !== undefined &&
+          appState.activeSubtypes.includes(subtype)
+        }
+        className={clsx({
+          selected:
+            appState.activeSubtypes &&
+            appState.activeSubtypes.includes(subtype),
+        })}
+        title={`${t(`toolBar.${subtype}`)}${title}`}
+        aria-label={t(`toolBar.${subtype}`)}
+        onClick={() => {
+          updateData(null);
+        }}
+        onContextMenu={
+          data && "onContextMenu" in data
+            ? (event: React.MouseEvent) => {
+                if (
+                  appState.activeSubtypes === undefined ||
+                  (appState.activeSubtypes !== undefined &&
+                    !appState.activeSubtypes.includes(subtype))
+                ) {
+                  updateData(null);
+                }
+                data.onContextMenu(event, subtype);
+              }
+            : undefined
+        }
+        size={data?.size || "medium"}
+      ></ToolButton>
+    ),
+  };
+  if (key === "") {
+    delete subtypeAction.keyTest;
+  }
+  return subtypeAction;
+};

--- a/src/components/ToolButton.tsx
+++ b/src/components/ToolButton.tsx
@@ -43,6 +43,7 @@ type ToolButtonProps =
       type: "icon";
       children?: React.ReactNode;
       onClick?(): void;
+      onContextMenu?: React.MouseEventHandler;
     })
   | (ToolButtonBaseProps & {
       type: "radio";
@@ -120,6 +121,7 @@ export const ToolButton = React.forwardRef((props: ToolButtonProps, ref) => {
         aria-label={props["aria-label"]}
         type={type}
         onClick={onClick}
+        onContextMenu={props.type === "icon" ? props.onContextMenu : undefined}
         ref={innerRef}
         disabled={isLoading || props.isLoading}
       >

--- a/src/components/icons.tsx
+++ b/src/components/icons.tsx
@@ -16,7 +16,7 @@ import { THEME } from "../constants";
 const activeElementColor = (theme: Theme) =>
   theme === THEME.LIGHT ? oc.orange[4] : oc.orange[9];
 
-const iconFillColor = (theme: Theme) => "var(--icon-fill-color)";
+export const iconFillColor = (theme: Theme) => "var(--icon-fill-color)";
 
 const handlerColor = (theme: Theme) =>
   theme === THEME.LIGHT ? oc.white : "#1e1e1e";

--- a/src/data/restore.ts
+++ b/src/data/restore.ts
@@ -29,6 +29,7 @@ import { LinearElementEditor } from "../element/linearElementEditor";
 import { bumpVersion } from "../element/mutateElement";
 import { getUpdatedTimestamp, updateActiveTool } from "../utils";
 import { arrayToMap } from "../utils";
+import { isValidSubtype } from "../subtypes";
 
 type RestoredAppState = Omit<
   AppState,
@@ -68,7 +69,8 @@ const getFontFamilyByName = (fontFamilyName: string): FontFamilyValues => {
 };
 
 const restoreElementWithProperties = <
-  T extends Required<Omit<ExcalidrawElement, "customData">> & {
+  T extends Required<Omit<ExcalidrawElement, "subtype" | "customData">> & {
+    subtype?: ExcalidrawElement["subtype"];
     customData?: ExcalidrawElement["customData"];
     /** @deprecated */
     boundElementIds?: readonly ExcalidrawElement["id"][];
@@ -121,6 +123,9 @@ const restoreElementWithProperties = <
     locked: element.locked ?? false,
   };
 
+  if ("subtype" in element && isValidSubtype(element.subtype, base.type)) {
+    base.subtype = element.subtype;
+  }
   if ("customData" in element) {
     base.customData = element.customData;
   }
@@ -328,6 +333,12 @@ export const restoreAppState = (
         : defaultValue;
   }
 
+  if ("activeSubtypes" in appState) {
+    nextAppState.activeSubtypes = appState.activeSubtypes;
+  }
+  if ("customData" in appState) {
+    nextAppState.customData = appState.customData;
+  }
   return {
     ...nextAppState,
     cursorButton: localAppState?.cursorButton || "up",

--- a/src/element/mutateElement.ts
+++ b/src/element/mutateElement.ts
@@ -5,11 +5,22 @@ import { getSizeFromPoints } from "../points";
 import { randomInteger } from "../random";
 import { Point } from "../types";
 import { getUpdatedTimestamp } from "../utils";
+import { maybeGetSubtypeProps } from "./newElement";
+import { getSubtypeMethods } from "../subtypes";
 
 type ElementUpdate<TElement extends ExcalidrawElement> = Omit<
   Partial<TElement>,
   "id" | "version" | "versionNonce"
 >;
+
+const cleanUpdates = <TElement extends Mutable<ExcalidrawElement>>(
+  element: TElement,
+  updates: ElementUpdate<TElement>,
+): ElementUpdate<TElement> => {
+  const subtype = maybeGetSubtypeProps(element, element.type).subtype;
+  const map = getSubtypeMethods(subtype);
+  return map?.clean ? (map.clean(updates) as typeof updates) : updates;
+};
 
 // This function tracks updates of text elements for the purposes for collaboration.
 // The version is used to compare updates when more than one user is working in
@@ -21,6 +32,8 @@ export const mutateElement = <TElement extends Mutable<ExcalidrawElement>>(
   informMutation = true,
 ): TElement => {
   let didChange = false;
+  let increment = false;
+  const oldUpdates = cleanUpdates(element, updates);
 
   // casting to any because can't use `in` operator
   // (see https://github.com/microsoft/TypeScript/issues/21732)
@@ -76,6 +89,7 @@ export const mutateElement = <TElement extends Mutable<ExcalidrawElement>>(
 
       (element as any)[key] = value;
       didChange = true;
+      key in oldUpdates && (increment = true);
     }
   }
   if (!didChange) {
@@ -91,9 +105,11 @@ export const mutateElement = <TElement extends Mutable<ExcalidrawElement>>(
     invalidateShapeForElement(element);
   }
 
-  element.version++;
-  element.versionNonce = randomInteger();
-  element.updated = getUpdatedTimestamp();
+  if (increment) {
+    element.version++;
+    element.versionNonce = randomInteger();
+    element.updated = getUpdatedTimestamp();
+  }
 
   if (informMutation) {
     Scene.getScene(element)?.informMutation();
@@ -107,6 +123,8 @@ export const newElementWith = <TElement extends ExcalidrawElement>(
   updates: ElementUpdate<TElement>,
 ): TElement => {
   let didChange = false;
+  let increment = false;
+  const oldUpdates = cleanUpdates(element, updates);
   for (const key in updates) {
     const value = (updates as any)[key];
     if (typeof value !== "undefined") {
@@ -118,6 +136,7 @@ export const newElementWith = <TElement extends ExcalidrawElement>(
         continue;
       }
       didChange = true;
+      key in oldUpdates && (increment = true);
     }
   }
 
@@ -125,6 +144,9 @@ export const newElementWith = <TElement extends ExcalidrawElement>(
     return element;
   }
 
+  if (!increment) {
+    return { ...element, ...updates };
+  }
   return {
     ...element,
     ...updates,

--- a/src/element/resizeElements.ts
+++ b/src/element/resizeElements.ts
@@ -42,8 +42,8 @@ import {
   getBoundTextElement,
   getBoundTextElementId,
   handleBindTextResize,
-  measureText,
 } from "./textElement";
+import { measureTextElement } from "./textWysiwyg";
 
 export const normalizeAngle = (angle: number): number => {
   if (angle >= 2 * Math.PI) {
@@ -289,9 +289,9 @@ const measureFontSizeFromWH = (
   if (nextFontSize < MIN_FONT_SIZE) {
     return null;
   }
-  const metrics = measureText(
-    element.text,
-    getFontString({ fontSize: nextFontSize, fontFamily: element.fontFamily }),
+  const metrics = measureTextElement(
+    element,
+    { fontSize: nextFontSize },
     element.containerId ? element.width : null,
   );
   return {

--- a/src/element/textElement.ts
+++ b/src/element/textElement.ts
@@ -1,4 +1,4 @@
-import { getFontString, arrayToMap, isTestEnv } from "../utils";
+import { arrayToMap, isTestEnv } from "../utils";
 import {
   ExcalidrawElement,
   ExcalidrawTextElement,
@@ -11,6 +11,7 @@ import { BOUND_TEXT_PADDING, TEXT_ALIGN, VERTICAL_ALIGN } from "../constants";
 import { MaybeTransformHandleType } from "./transformHandles";
 import Scene from "../scene/Scene";
 import { isTextElement } from ".";
+import { measureTextElement, wrapTextElement } from "./textWysiwyg";
 import { getMaxContainerHeight, getMaxContainerWidth } from "./newElement";
 
 export const redrawTextBoundingBox = (
@@ -22,15 +23,11 @@ export const redrawTextBoundingBox = (
 
   if (container) {
     maxWidth = getMaxContainerWidth(container);
-    text = wrapText(
-      textElement.originalText,
-      getFontString(textElement),
-      getMaxContainerWidth(container),
-    );
+    text = wrapTextElement(textElement, getMaxContainerWidth(container));
   }
-  const metrics = measureText(
-    textElement.originalText,
-    getFontString(textElement),
+  const metrics = measureTextElement(
+    textElement,
+    { text: textElement.originalText },
     maxWidth,
   );
   let coordY = textElement.y;
@@ -133,16 +130,12 @@ export const handleBindTextResize = (
       let nextBaseLine = textElement.baseline;
       if (transformHandleType !== "n" && transformHandleType !== "s") {
         if (text) {
-          text = wrapText(
-            textElement.originalText,
-            getFontString(textElement),
-            getMaxContainerWidth(element),
-          );
+          text = wrapTextElement(textElement, getMaxContainerWidth(element));
         }
 
-        const dimensions = measureText(
-          text,
-          getFontString(textElement),
+        const dimensions = measureTextElement(
+          textElement,
+          { text },
           element.width,
         );
         nextHeight = dimensions.height;
@@ -249,7 +242,7 @@ export const getApproxLineHeight = (font: FontString) => {
 };
 
 let canvas: HTMLCanvasElement | undefined;
-const getTextWidth = (text: string, font: FontString) => {
+export const getTextWidth = (text: string, font: FontString) => {
   if (!canvas) {
     canvas = document.createElement("canvas");
   }

--- a/src/element/textWysiwyg.test.tsx
+++ b/src/element/textWysiwyg.test.tsx
@@ -823,8 +823,8 @@ describe("textWysiwyg", () => {
       resize(rectangle, "ne", [rectangle.x + 100, rectangle.y - 100]);
       expect([h.elements[1].x, h.elements[1].y]).toMatchInlineSnapshot(`
         Array [
-          109.5,
-          17,
+          10,
+          4.5,
         ]
       `);
 
@@ -848,7 +848,7 @@ describe("textWysiwyg", () => {
       expect([h.elements[1].x, h.elements[1].y]).toMatchInlineSnapshot(`
         Array [
           15,
-          90,
+          65,
         ]
       `);
 
@@ -871,7 +871,7 @@ describe("textWysiwyg", () => {
       resize(rectangle, "ne", [rectangle.x + 100, rectangle.y - 100]);
       expect([h.elements[1].x, h.elements[1].y]).toMatchInlineSnapshot(`
         Array [
-          424,
+          5,
           -539,
         ]
       `);

--- a/src/element/types.ts
+++ b/src/element/types.ts
@@ -1,3 +1,4 @@
+import { Subtype } from "../subtypes";
 import { Point } from "../types";
 import { FONT_FAMILY, TEXT_ALIGN, THEME, VERTICAL_ALIGN } from "../constants";
 
@@ -56,6 +57,7 @@ type _ExcalidrawElementBase = Readonly<{
   updated: number;
   link: string | null;
   locked: boolean;
+  subtype?: Subtype;
   customData?: Record<string, any>;
 }>;
 

--- a/src/excalidraw-app/data/LocalData.ts
+++ b/src/excalidraw-app/data/LocalData.ts
@@ -37,12 +37,15 @@ class LocalFileManager extends FileManager {
 const saveDataStateToLocalStorage = (
   elements: readonly ExcalidrawElement[],
   appState: AppState,
+  appStateOnly = false,
 ) => {
   try {
-    localStorage.setItem(
-      STORAGE_KEYS.LOCAL_STORAGE_ELEMENTS,
-      JSON.stringify(clearElementsForLocalStorage(elements)),
-    );
+    if (!appStateOnly) {
+      localStorage.setItem(
+        STORAGE_KEYS.LOCAL_STORAGE_ELEMENTS,
+        JSON.stringify(clearElementsForLocalStorage(elements)),
+      );
+    }
     localStorage.setItem(
       STORAGE_KEYS.LOCAL_STORAGE_APP_STATE,
       JSON.stringify(clearAppStateForLocalStorage(appState)),
@@ -63,8 +66,12 @@ export class LocalData {
       appState: AppState,
       files: BinaryFiles,
       onFilesSaved: () => void,
+      appStateOnly = false,
     ) => {
-      saveDataStateToLocalStorage(elements, appState);
+      saveDataStateToLocalStorage(elements, appState, appStateOnly);
+      if (appStateOnly) {
+        return;
+      }
 
       await this.fileStorage.saveFiles({
         elements,
@@ -85,6 +92,14 @@ export class LocalData {
     // we need to make the `isSavePaused` check synchronously (undebounced)
     if (!this.isSavePaused()) {
       this._save(elements, appState, files, onFilesSaved);
+    }
+  };
+
+  /** Saves the AppState, only if saving is paused. */
+  static saveAppState = (appState: AppState) => {
+    // we need to make the `isSavePaused` check synchronously (undebounced)
+    if (this.isSavePaused()) {
+      this._save([], appState, {}, () => {}, true);
     }
   };
 

--- a/src/excalidraw-app/index.tsx
+++ b/src/excalidraw-app/index.tsx
@@ -199,7 +199,7 @@ const initializeScene = async (opts: {
           ...restoreAppState(
             {
               ...scene?.appState,
-              theme: localDataState?.appState?.theme || scene?.appState?.theme,
+              ...localDataState?.appState,
             },
             excalidrawAPI.getAppState(),
           ),
@@ -569,6 +569,8 @@ const ExcalidrawWrapper = () => {
           }
         }
       });
+    } else {
+      LocalData.saveAppState(appState);
     }
   };
 

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -80,6 +80,22 @@ if (process.env.NODE_ENV === ENV.DEVELOPMENT) {
 let currentLang: Language = defaultLang;
 let currentLangData = {};
 
+const auxCurrentLangData = Array<Object>();
+const auxFallbackLangData = Array<Object>();
+const auxSetLanguageFuncs =
+  Array<(langCode: string) => Promise<Object | undefined>>();
+
+export const registerAuxLangData = (
+  fallbackLangData: Object,
+  setLanguageAux: (langCode: string) => Promise<Object | undefined>,
+) => {
+  if (auxFallbackLangData.includes(fallbackLangData)) {
+    return;
+  }
+  auxFallbackLangData.push(fallbackLangData);
+  auxSetLanguageFuncs.push(setLanguageAux);
+};
+
 export const setLanguage = async (lang: Language) => {
   currentLang = lang;
   document.documentElement.dir = currentLang.rtl ? "rtl" : "ltr";
@@ -91,6 +107,17 @@ export const setLanguage = async (lang: Language) => {
     currentLangData = await import(
       /* webpackChunkName: "locales/[request]" */ `./locales/${currentLang.code}.json`
     );
+    // Empty the auxCurrentLangData array
+    while (auxCurrentLangData.length > 0) {
+      auxCurrentLangData.pop();
+    }
+    // Fill the auxCurrentLangData array with each locale file found in auxLangDataRoots for this language
+    auxSetLanguageFuncs.forEach(async (setLanguageFn) => {
+      const condData = await setLanguageFn(currentLang.code);
+      if (condData) {
+        auxCurrentLangData.push(condData);
+      }
+    });
   }
 };
 
@@ -125,6 +152,13 @@ export const t = (
   let translation =
     findPartsForData(currentLangData, parts) ||
     findPartsForData(fallbackLangData, parts);
+  const auxData = Array<Object>().concat(
+    auxCurrentLangData,
+    auxFallbackLangData,
+  );
+  for (let i = 0; i < auxData.length; i++) {
+    translation = translation || findPartsForData(auxData[i], parts);
+  }
   if (translation === undefined) {
     throw new Error(`Can't find translation for ${path}`);
   }

--- a/src/renderer/renderElement.ts
+++ b/src/renderer/renderElement.ts
@@ -29,6 +29,7 @@ import { isPathALoop } from "../math";
 import rough from "roughjs/bin/rough";
 import { AppState, BinaryFiles, Zoom } from "../types";
 import { getDefaultAppState } from "../appState";
+import { getSubtypeMethods } from "../subtypes";
 import {
   BOUND_TEXT_PADDING,
   MAX_DECIMALS_FOR_SVG_EXPORT,
@@ -196,6 +197,12 @@ const drawElementOnCanvas = (
   renderConfig: RenderConfig,
 ) => {
   context.globalAlpha = element.opacity / 100;
+  const map = getSubtypeMethods(element.subtype);
+  if (map?.render) {
+    map.render(element, context, renderConfig.renderCb);
+    context.globalAlpha = 1;
+    return;
+  }
   switch (element.type) {
     case "rectangle":
     case "diamond":
@@ -861,6 +868,11 @@ export const renderElementToSvg = (
     root = anchorTag;
   }
 
+  const map = getSubtypeMethods(element.subtype);
+  if (map?.renderSvg) {
+    map.renderSvg(svgRoot, root, element, { offsetX, offsetY });
+    return;
+  }
   switch (element.type) {
     case "selection": {
       // Since this is used only during editing experience, which is canvas based,

--- a/src/scene/export.ts
+++ b/src/scene/export.ts
@@ -11,6 +11,7 @@ import {
   getInitializedImageElements,
   updateImageCache,
 } from "../element/image";
+import { ensureSubtypesLoadedForElements } from "../subtypes";
 
 export const SVG_EXPORT_TAG = `<!-- svg-source:excalidraw -->`;
 
@@ -51,30 +52,48 @@ export const exportToCanvas = async (
     files,
   });
 
-  renderScene({
-    elements,
-    appState,
-    scale,
-    rc: rough.canvas(canvas),
-    canvas,
-    renderConfig: {
-      viewBackgroundColor: exportBackground ? viewBackgroundColor : null,
-      scrollX: -minX + exportPadding,
-      scrollY: -minY + exportPadding,
-      zoom: defaultAppState.zoom,
-      remotePointerViewportCoords: {},
-      remoteSelectedElementIds: {},
-      shouldCacheIgnoreZoom: false,
-      remotePointerUsernames: {},
-      remotePointerUserStates: {},
-      theme: appState.exportWithDarkMode ? "dark" : "light",
-      imageCache,
-      renderScrollbars: false,
-      renderSelection: false,
-      renderGrid: false,
-      isExporting: true,
+  let refreshTimer = 0;
+
+  const renderConfig = {
+    viewBackgroundColor: exportBackground ? viewBackgroundColor : null,
+    scrollX: -minX + exportPadding,
+    scrollY: -minY + exportPadding,
+    zoom: defaultAppState.zoom,
+    remotePointerViewportCoords: {},
+    remoteSelectedElementIds: {},
+    shouldCacheIgnoreZoom: false,
+    remotePointerUsernames: {},
+    remotePointerUserStates: {},
+    theme: appState.exportWithDarkMode ? "dark" : "light",
+    imageCache,
+    renderScrollbars: false,
+    renderSelection: false,
+    renderGrid: false,
+    isExporting: true,
+    renderCb: () => {
+      if (refreshTimer !== 0) {
+        window.clearTimeout(refreshTimer);
+      }
+      refreshTimer = window.setTimeout(() => {
+        renderConfig.renderCb = () => {};
+        window.clearTimeout(refreshTimer);
+        // Here instead of setState({}), call renderScene() again
+        render();
+      }, 50);
     },
-  });
+  };
+
+  const render = () => {
+    renderScene({
+      elements,
+      appState,
+      scale,
+      rc: rough.canvas(canvas),
+      canvas,
+      renderConfig,
+    });
+  };
+  render();
 
   return canvas;
 };
@@ -163,10 +182,12 @@ export const exportToSvg = async (
   }
 
   const rsvg = rough.svg(svgRoot);
-  renderSceneToSvg(elements, rsvg, svgRoot, files || {}, {
-    offsetX: -minX + exportPadding,
-    offsetY: -minY + exportPadding,
-    exportWithDarkMode: appState.exportWithDarkMode,
+  await ensureSubtypesLoadedForElements(elements, () => {
+    renderSceneToSvg(elements, rsvg, svgRoot, files || {}, {
+      offsetX: -minX + exportPadding,
+      offsetY: -minY + exportPadding,
+      exportWithDarkMode: appState.exportWithDarkMode,
+    });
   });
 
   return svgRoot;

--- a/src/scene/types.ts
+++ b/src/scene/types.ts
@@ -24,6 +24,7 @@ export type RenderConfig = {
   renderScrollbars?: boolean;
   renderSelection?: boolean;
   renderGrid?: boolean;
+  renderCb?: () => void;
   /** when exporting the behavior is slightly different (e.g. we can't use
     CSS filters), and we disable render optimizations for best output */
   isExporting: boolean;

--- a/src/subtypes.ts
+++ b/src/subtypes.ts
@@ -1,0 +1,411 @@
+import {
+  ExcalidrawElement,
+  ExcalidrawTextElement,
+  NonDeleted,
+} from "./element/types";
+import { getNonDeletedElements } from "./element";
+import { getSelectedElements } from "./scene";
+import { AppState } from "./types";
+import { registerAuxLangData } from "./i18n";
+
+import { Action, ActionName, DisableFn, EnableFn } from "./actions/types";
+import {
+  CustomShortcutName,
+  registerCustomShortcuts,
+} from "./actions/shortcuts";
+import { register } from "./actions/register";
+import { registerDisableFn, registerEnableFn } from "./actions/guards";
+import { hasBoundTextElement } from "./element/typeChecks";
+import { getBoundTextElement } from "./element/textElement";
+
+// Use "let" instead of "const" so we can dynamically add subtypes
+let subtypeNames: readonly Subtype[] = [];
+let parentTypeMap: readonly {
+  subtype: Subtype;
+  parentType: ExcalidrawElement["type"];
+}[] = [];
+let subtypeActionMap: readonly {
+  subtype: Subtype;
+  actions: readonly SubtypeActionName[];
+}[] = [];
+let disabledActionMap: readonly {
+  subtype: Subtype;
+  actions: readonly DisabledActionName[];
+}[] = [];
+let alwaysEnabledMap: readonly {
+  subtype: Subtype;
+  actions: readonly SubtypeActionName[];
+}[] = [];
+
+export type SubtypeRecord = Readonly<{
+  subtype: Subtype;
+  parents: readonly ExcalidrawElement["type"][];
+  actionNames: readonly SubtypeActionName[];
+  disabledNames: readonly DisabledActionName[];
+  shortcutMap: Record<CustomShortcutName, string[]>;
+  alwaysEnabledNames?: readonly SubtypeActionName[];
+}>;
+
+// Subtype Names
+export type Subtype = string;
+export const getSubtypeNames = (): readonly Subtype[] => {
+  return subtypeNames;
+};
+export const isValidSubtype = (s: any, t: any): s is Subtype =>
+  parentTypeMap.find(
+    (val) => val.subtype === (s as string) && val.parentType === (t as string),
+  ) !== undefined;
+const isSubtypeName = (s: any): s is Subtype => subtypeNames.includes(s);
+
+// Subtype Actions
+
+// Used for context menus in the shape chooser
+export const hasAlwaysEnabledActions = (s: any): boolean => {
+  if (!isSubtypeName(s)) {
+    return false;
+  }
+  return alwaysEnabledMap.some((value) => value.subtype === s);
+};
+
+type SubtypeActionName = string;
+
+const isSubtypeActionName = (s: any): s is SubtypeActionName =>
+  subtypeActionMap.some((val) => val.actions.includes(s));
+
+const addSubtypeAction = (action: Action) => {
+  if (isSubtypeActionName(action.name) || isSubtypeName(action.name)) {
+    register(action);
+  }
+};
+
+// Standard actions disabled by subtypes
+type DisabledActionName = ActionName;
+
+const isDisabledActionName = (s: any): s is DisabledActionName =>
+  disabledActionMap.some((val) => val.actions.includes(s));
+
+// Is the `actionName` one of the subtype actions for `subtype`
+// (if `isAdded` is true) or one of the standard actions disabled
+// by `subtype` (if `isAdded` is false)?
+const isForSubtype = (
+  subtype: ExcalidrawElement["subtype"],
+  actionName: ActionName | SubtypeActionName,
+  isAdded: boolean,
+) => {
+  const actions = isAdded ? subtypeActionMap : disabledActionMap;
+  const map = actions.find((value) => value.subtype === subtype);
+  if (map) {
+    return map.actions.includes(actionName);
+  }
+  return false;
+};
+
+const isActionDisabled: DisableFn = function (elements, appState, actionName) {
+  return !isActionEnabled(elements, appState, actionName);
+};
+
+const isActionEnabled: EnableFn = function (elements, appState, actionName) {
+  // We always enable subtype actions.  Also let through standard actions
+  // which no subtypes might have disabled.
+  if (
+    isSubtypeName(actionName) ||
+    (!isSubtypeActionName(actionName) && !isDisabledActionName(actionName))
+  ) {
+    return true;
+  }
+  const selectedElements = getSelectedElements(
+    getNonDeletedElements(elements),
+    appState,
+  );
+  const chosen = appState.editingElement
+    ? [appState.editingElement, ...selectedElements]
+    : selectedElements;
+  // Now handle actions added by subtypes
+  if (isSubtypeActionName(actionName)) {
+    // Has any ExcalidrawElement enabled this actionName through having
+    // its subtype?
+    return (
+      chosen.some((el) => {
+        const e = hasBoundTextElement(el) ? getBoundTextElement(el)! : el;
+        return isForSubtype(e.subtype, actionName, true);
+      }) ||
+      // Or has any active subtype enabled this actionName?
+      (appState.activeSubtypes !== undefined &&
+        appState.activeSubtypes?.some((subtype) => {
+          if (!isValidSubtype(subtype, appState.activeTool.type)) {
+            return false;
+          }
+          return isForSubtype(subtype, actionName, true);
+        })) ||
+      alwaysEnabledMap.some((value) => {
+        return value.actions.includes(actionName);
+      })
+    );
+  }
+  // Now handle standard actions disabled by subtypes
+  if (isDisabledActionName(actionName)) {
+    return (
+      // Has every ExcalidrawElement not disabled this actionName?
+      (chosen.every((el) => {
+        const e = hasBoundTextElement(el) ? getBoundTextElement(el)! : el;
+        return !isForSubtype(e.subtype, actionName, false);
+      }) &&
+        // And has every active subtype not disabled this actionName?
+        (appState.activeSubtypes === undefined ||
+          appState.activeSubtypes?.every((subtype) => {
+            if (!isValidSubtype(subtype, appState.activeTool.type)) {
+              return true;
+            }
+            return !isForSubtype(subtype, actionName, false);
+          }))) ||
+      // Or is there an ExcalidrawElement without a subtype which would
+      // disable this action if it had a subtype?
+      chosen.some((el) => {
+        const e = hasBoundTextElement(el) ? getBoundTextElement(el)! : el;
+        return parentTypeMap.some(
+          (value) =>
+            value.parentType === e.type &&
+            e.subtype === undefined &&
+            disabledActionMap
+              .find((val) => val.subtype === value.subtype)!
+              .actions.includes(actionName),
+        );
+      })
+    );
+  }
+  // Shouldn't happen
+  return true;
+};
+
+// Are any of the parent types of `subtype` shared by any subtype
+// in the array?
+export const subtypeCollides = (subtype: Subtype, subtypeArray: Subtype[]) => {
+  const subtypeParents = parentTypeMap
+    .filter((value) => value.subtype === subtype)
+    .map((value) => value.parentType);
+  const subtypeArrayParents = subtypeArray.flatMap((s) =>
+    parentTypeMap
+      .filter((value) => value.subtype === s)
+      .map((value) => value.parentType),
+  );
+  return subtypeParents.some((t) => subtypeArrayParents.includes(t));
+};
+
+// Subtype Methods
+export type SubtypeMethods = {
+  clean: (
+    updates: Omit<
+      Partial<ExcalidrawElement>,
+      "id" | "version" | "versionNonce"
+    >,
+  ) => Omit<Partial<ExcalidrawElement>, "id" | "version" | "versionNonce">;
+  ensureLoaded: (callback?: () => void) => Promise<void>;
+  measureText: (
+    element: Pick<
+      ExcalidrawTextElement,
+      "subtype" | "customData" | "fontSize" | "fontFamily" | "text"
+    >,
+    next?: {
+      fontSize?: number;
+      text?: string;
+      customData?: ExcalidrawElement["customData"];
+    },
+    maxWidth?: number | null,
+  ) => { width: number; height: number; baseline: number };
+  render: (
+    element: NonDeleted<ExcalidrawElement>,
+    context: CanvasRenderingContext2D,
+    renderCb?: () => void,
+  ) => void;
+  renderSvg: (
+    svgRoot: SVGElement,
+    root: SVGElement,
+    element: NonDeleted<ExcalidrawElement>,
+    opt?: { offsetX?: number; offsetY?: number },
+  ) => void;
+  wrapText: (
+    element: Pick<
+      ExcalidrawTextElement,
+      "subtype" | "customData" | "fontSize" | "fontFamily" | "originalText"
+    >,
+    containerWidth: number,
+    next?: {
+      fontSize?: number;
+      text?: string;
+      customData?: ExcalidrawElement["customData"];
+    },
+  ) => string;
+};
+
+type MethodMap = { subtype: Subtype; methods: Partial<SubtypeMethods> };
+const methodMaps = [] as Array<MethodMap>;
+
+// Use `getSUbtypeMethods` to call subtype-specialized methods, like `render`.
+export const getSubtypeMethods = (subtype: Subtype | undefined) => {
+  const map = methodMaps.find((method) => method.subtype === subtype);
+  return map?.methods;
+};
+
+export const addSubtypeMethods = (
+  subtype: Subtype,
+  methods: Partial<SubtypeMethods>,
+) => {
+  if (!methodMaps.find((method) => method.subtype === subtype)) {
+    methodMaps.push({ subtype, methods });
+  }
+};
+
+// For a given `ExcalidrawElement` type, return the active subtype
+// and associated customData (if any) from the AppState.  Assume
+// only one subtype is active for a given `ExcalidrawElement` type
+// at any given time.
+export const selectSubtype = (
+  appState: {
+    activeSubtypes?: AppState["activeSubtypes"];
+    customData?: AppState["customData"];
+  },
+  type: ExcalidrawElement["type"],
+): {
+  subtype?: ExcalidrawElement["subtype"];
+  customData?: ExcalidrawElement["customData"];
+} => {
+  if (appState.activeSubtypes === undefined) {
+    return {};
+  }
+  const subtype = appState.activeSubtypes.find((subtype) =>
+    isValidSubtype(subtype, type),
+  );
+  if (subtype === undefined) {
+    return {};
+  }
+  if (appState.customData === undefined || !(subtype in appState.customData)) {
+    return { subtype };
+  }
+  const customData = appState.customData?.subtype;
+  return { subtype, customData };
+};
+
+// Callback to re-render subtyped `ExcalidrawElement`s after completing
+// async loading of the subtype.
+export type SubtypeLoadedCb = (
+  hasSubtype: (element: ExcalidrawElement) => boolean,
+) => void;
+
+// Functions to prepare subtypes for use
+export type SubtypePrepFn = (
+  addSubtypeAction: (action: Action) => void,
+  addLangData: (
+    fallbackLangData: Object,
+    setLanguageAux: (langCode: string) => Promise<Object | undefined>,
+  ) => void,
+  onSubtypeLoaded?: SubtypeLoadedCb,
+) => {
+  actions: Action[];
+  methods: Partial<SubtypeMethods>;
+};
+
+// This is the main method to set up the subtype.  The optional
+// `onSubtypeLoaded` callback may be used to re-render subtyped
+// `ExcalidrawElement`s after the subtype has finished async loading.
+// See the MathJax extension in `@excalidraw/extensions` for example.
+export const prepareSubtype = (
+  record: SubtypeRecord,
+  subtypePrepFn: SubtypePrepFn,
+  onSubtypeLoaded?: SubtypeLoadedCb,
+): { actions: Action[] | null; methods: Partial<SubtypeMethods> } => {
+  const map = getSubtypeMethods(record.subtype);
+  if (map) {
+    return { actions: null, methods: map };
+  }
+
+  // Check for undefined/null subtypes and parentTypes
+  if (
+    record.subtype === undefined ||
+    record.subtype === "" ||
+    record.parents === undefined ||
+    record.parents.length === 0
+  ) {
+    return { actions: null, methods: {} };
+  }
+
+  // Register the types
+  const subtype = record.subtype;
+  subtypeNames = [...subtypeNames, subtype];
+  record.parents.forEach((parentType) => {
+    parentTypeMap = [...parentTypeMap, { subtype, parentType }];
+  });
+  subtypeActionMap = [
+    ...subtypeActionMap,
+    { subtype, actions: record.actionNames },
+  ];
+  disabledActionMap = [
+    ...disabledActionMap,
+    { subtype, actions: record.disabledNames },
+  ];
+  if (record.alwaysEnabledNames) {
+    alwaysEnabledMap = [
+      ...alwaysEnabledMap,
+      { subtype, actions: record.alwaysEnabledNames },
+    ];
+  }
+  registerCustomShortcuts(record.shortcutMap);
+
+  // Prepare the subtype
+  const { actions, methods } = subtypePrepFn(
+    addSubtypeAction,
+    registerAuxLangData,
+    onSubtypeLoaded,
+  );
+
+  record.disabledNames.forEach((name) => {
+    registerDisableFn(name, isActionDisabled);
+  });
+  record.actionNames.forEach((name) => {
+    registerEnableFn(name, isActionEnabled);
+  });
+  registerEnableFn(record.subtype, isActionEnabled);
+  // Register the subtype's methods
+  addSubtypeMethods(record.subtype, methods);
+  return { actions, methods };
+};
+
+// Ensure all subtypes are loaded before continuing, eg to
+// render SVG previews of new charts.  Chart-relevant subtypes
+// include math equations in titles or non hand-drawn line styles.
+export const ensureSubtypesLoadedForElements = async (
+  elements: readonly ExcalidrawElement[],
+  callback?: () => void,
+) => {
+  // Only ensure the loading of subtypes which are actually needed.
+  // We don't want to be held up by eg downloading the MathJax SVG fonts
+  // if we don't actually need them yet.
+  const subtypesUsed = [] as Subtype[];
+  elements.forEach((el) => {
+    if (
+      "subtype" in el &&
+      isValidSubtype(el.subtype, el.type) &&
+      !subtypesUsed.includes(el.subtype)
+    ) {
+      subtypesUsed.push(el.subtype);
+    }
+  });
+  await ensureSubtypesLoaded(subtypesUsed, callback);
+};
+
+export const ensureSubtypesLoaded = async (
+  subtypes: Subtype[],
+  callback?: () => void,
+) => {
+  // Use a for loop so we can do `await map.ensureLoaded()`
+  for (let i = 0; i < subtypes.length; i++) {
+    const subtype = subtypes[i];
+    // Should be defined if prepareSubtype() has run
+    const map = getSubtypeMethods(subtype);
+    if (map?.ensureLoaded) {
+      await map.ensureLoaded();
+    }
+  }
+  if (callback) {
+    callback();
+  }
+};

--- a/src/tests/customActions.test.tsx
+++ b/src/tests/customActions.test.tsx
@@ -1,0 +1,85 @@
+import { ExcalidrawElement } from "../element/types";
+import { getShortcutKey } from "../utils";
+import { API } from "./helpers/api";
+import {
+  CustomShortcutName,
+  getShortcutFromShortcutName,
+  registerCustomShortcuts,
+} from "../actions/shortcuts";
+import { Action, ActionName, DisableFn, EnableFn } from "../actions/types";
+import {
+  getActionDisablers,
+  getActionEnablers,
+  registerDisableFn,
+  registerEnableFn,
+} from "../actions/guards";
+
+const { h } = window;
+
+describe("regression tests", () => {
+  it("should retrieve custom shortcuts", () => {
+    const shortcuts: Record<CustomShortcutName, string[]> = {
+      test: [getShortcutKey("CtrlOrCmd+1"), getShortcutKey("CtrlOrCmd+2")],
+    };
+    registerCustomShortcuts(shortcuts);
+    expect(getShortcutFromShortcutName("test")).toBe("Ctrl+1");
+  });
+
+  it("should follow action guards", () => {
+    // Create the test elements
+    const text1 = API.createElement({ type: "rectangle", id: "A", y: 0 });
+    const text2 = API.createElement({ type: "rectangle", id: "B", y: 30 });
+    const text3 = API.createElement({ type: "rectangle", id: "C", y: 60 });
+    const el12: ExcalidrawElement[] = [text1, text2];
+    const el13: ExcalidrawElement[] = [text1, text3];
+    const el23: ExcalidrawElement[] = [text2, text3];
+    const el123: ExcalidrawElement[] = [text1, text2, text3];
+    // Set up the custom Action enablers
+    const enableName = "custom" as Action["name"];
+    const enabler: EnableFn = function (elements) {
+      if (elements.some((el) => el.y === 30)) {
+        return true;
+      }
+      return false;
+    };
+    registerEnableFn(enableName, enabler);
+    // Set up the standard Action disablers
+    const disableName1 = "changeFontFamily" as ActionName;
+    const disableName2 = "changeFontSize" as ActionName;
+    const disabler: DisableFn = function (elements) {
+      if (elements.some((el) => el.y === 0)) {
+        return true;
+      }
+      return false;
+    };
+    registerDisableFn(disableName1, disabler);
+    // Test the custom Action enablers
+    const enablers = getActionEnablers();
+    const isCustomEnabled = function (
+      elements: ExcalidrawElement[],
+      name: string,
+    ) {
+      return (
+        name in enablers &&
+        enablers[name].some((enabler) => enabler(elements, h.state, name))
+      );
+    };
+    expect(isCustomEnabled(el12, enableName)).toBe(true);
+    expect(isCustomEnabled(el13, enableName)).toBe(false);
+    expect(isCustomEnabled(el23, enableName)).toBe(true);
+    // Test the standard Action disablers
+    const disablers = getActionDisablers();
+    const isStandardDisabled = function (
+      elements: ExcalidrawElement[],
+      name: ActionName,
+    ) {
+      return (
+        name in disablers &&
+        disablers[name].some((disabler) => disabler(elements, h.state, name))
+      );
+    };
+    expect(isStandardDisabled(el12, disableName1)).toBe(true);
+    expect(isStandardDisabled(el23, disableName1)).toBe(false);
+    expect(isStandardDisabled(el123, disableName2)).toBe(false);
+  });
+});

--- a/src/tests/helpers/api.ts
+++ b/src/tests/helpers/api.ts
@@ -15,15 +15,26 @@ import fs from "fs";
 import util from "util";
 import path from "path";
 import { getMimeType } from "../../data/blob";
-import { newFreeDrawElement, newImageElement } from "../../element/newElement";
+import {
+  maybeGetSubtypeProps,
+  newFreeDrawElement,
+  newImageElement,
+} from "../../element/newElement";
 import { Point } from "../../types";
 import { getSelectedElements } from "../../scene/selection";
+import { selectSubtype } from "../../subtypes";
 
 const readFile = util.promisify(fs.readFile);
 
 const { h } = window;
 
 export class API {
+  constructor() {
+    if (true) {
+      // Call `prepareSubtype()` here for `@excalidraw/excalidraw`-specific subtypes
+    }
+  }
+
   static setSelectedElements = (elements: ExcalidrawElement[]) => {
     h.setState({
       selectedElementIds: elements.reduce((acc, element) => {
@@ -100,6 +111,8 @@ export class API {
     verticalAlign?: T extends "text"
       ? ExcalidrawTextElement["verticalAlign"]
       : never;
+    subtype?: ExcalidrawElement["subtype"];
+    customData?: ExcalidrawElement["customData"];
     boundElements?: ExcalidrawGenericElement["boundElements"];
     containerId?: T extends "text"
       ? ExcalidrawTextElement["containerId"]
@@ -122,7 +135,16 @@ export class API {
 
     const appState = h?.state || getDefaultAppState();
 
+    const custom = maybeGetSubtypeProps(
+      {
+        subtype: rest.subtype ?? selectSubtype(appState, type)?.subtype,
+        customData:
+          rest.customData ?? selectSubtype(appState, type)?.customData,
+      },
+      type,
+    );
     const base = {
+      ...custom,
       x,
       y,
       angle: rest.angle ?? 0,

--- a/src/tests/helpers/locales/en.json
+++ b/src/tests/helpers/locales/en.json
@@ -1,0 +1,7 @@
+{
+  "toolBar": {
+    "test": "Test",
+    "test2": "Test 2",
+    "test3": "Test 3"
+  }
+}

--- a/src/tests/subtypes.test.tsx
+++ b/src/tests/subtypes.test.tsx
@@ -1,0 +1,205 @@
+import fallbackLangData from "./helpers/locales/en.json";
+import {
+  SubtypeRecord,
+  SubtypeMethods,
+  SubtypePrepFn,
+  isValidSubtype,
+  prepareSubtype,
+  subtypeCollides,
+} from "../subtypes";
+
+import { render } from "./test-utils";
+import { API } from "./helpers/api";
+import ExcalidrawApp from "../excalidraw-app";
+
+import { Theme } from "../element/types";
+import { createIcon, iconFillColor } from "../components/icons";
+import { SubtypeButton } from "../components/SubtypeButton";
+import { registerAuxLangData } from "../i18n";
+
+const getLangData = async (langCode: string): Promise<Object | undefined> => {
+  try {
+    const condData = await import(
+      /* webpackChunkName: "locales/[request]" */ `./helpers/locales/${langCode}.json`
+    );
+    if (condData) {
+      return condData;
+    }
+  } catch (e) {}
+  return undefined;
+};
+
+const testSubtypeIcon = ({ theme }: { theme: Theme }) =>
+  createIcon(
+    <path
+      stroke={iconFillColor(theme)}
+      strokeWidth={2}
+      strokeLinecap="round"
+      fill="none"
+    />,
+    { width: 40, height: 20, mirror: true },
+  );
+
+const test1: SubtypeRecord = {
+  subtype: "test",
+  parents: ["line", "arrow", "rectangle", "diamond", "ellipse"],
+  actionNames: [],
+  disabledNames: ["changeSloppiness"],
+  shortcutMap: {},
+};
+
+const test1NonParent = "text" as const;
+
+const test2: SubtypeRecord = {
+  subtype: "test2",
+  parents: ["text"],
+  actionNames: [],
+  disabledNames: [],
+  shortcutMap: {},
+};
+
+const test3: SubtypeRecord = {
+  subtype: "test3",
+  parents: ["text", "line"],
+  actionNames: [],
+  disabledNames: [],
+  shortcutMap: {},
+};
+
+const cleanTestElementUpdate = function (updates) {
+  const oldUpdates = {};
+  for (const key in updates) {
+    if (key !== "roughness") {
+      (oldUpdates as any)[key] = (updates as any)[key];
+    }
+  }
+  (updates as any).roughness = 0;
+  return oldUpdates;
+} as SubtypeMethods["clean"];
+
+const prepareTest1Subtype = function (
+  addSubtypeAction,
+  addLangData,
+  onSubtypeLoaded,
+) {
+  const methods = {} as SubtypeMethods;
+  methods.clean = cleanTestElementUpdate;
+
+  addLangData(fallbackLangData, getLangData);
+  registerAuxLangData(fallbackLangData, getLangData);
+
+  const actions = [SubtypeButton("test", "line", testSubtypeIcon)];
+  actions.forEach((action) => addSubtypeAction(action));
+
+  return { actions, methods };
+} as SubtypePrepFn;
+
+const prepareTest2Subtype = function (
+  addSubtypeAction,
+  addLangData,
+  onSubtypeLoaded,
+) {
+  const methods = {} as SubtypeMethods;
+
+  addLangData(fallbackLangData, getLangData);
+  registerAuxLangData(fallbackLangData, getLangData);
+
+  const actions = [SubtypeButton("test2", "text", testSubtypeIcon)];
+  actions.forEach((action) => addSubtypeAction(action));
+
+  return { actions, methods };
+} as SubtypePrepFn;
+
+const prepareTest3Subtype = function (
+  addSubtypeAction,
+  addLangData,
+  onSubtypeLoaded,
+) {
+  const methods = {} as SubtypeMethods;
+
+  addLangData(fallbackLangData, getLangData);
+  registerAuxLangData(fallbackLangData, getLangData);
+
+  const actions = [SubtypeButton("test3", "text", testSubtypeIcon)];
+  actions.forEach((action) => addSubtypeAction(action));
+
+  return { actions, methods };
+} as SubtypePrepFn;
+
+const { h } = window;
+
+prepareSubtype(test1, prepareTest1Subtype);
+prepareSubtype(test2, prepareTest2Subtype);
+prepareSubtype(test3, prepareTest3Subtype);
+
+describe("subtypes", () => {
+  it("should correctly validate", async () => {
+    test1.parents.forEach((p) => {
+      expect(isValidSubtype(test1.subtype, p)).toBe(true);
+      expect(isValidSubtype(undefined, p)).toBe(false);
+    });
+    expect(isValidSubtype(test1.subtype, test1NonParent)).toBe(false);
+    expect(isValidSubtype(test1.subtype, undefined)).toBe(false);
+    expect(isValidSubtype(undefined, undefined)).toBe(false);
+  });
+  it("should collide with themselves", async () => {
+    expect(subtypeCollides(test1.subtype, [test1.subtype])).toBe(true);
+    expect(subtypeCollides(test1.subtype, [test1.subtype, test2.subtype])).toBe(
+      true,
+    );
+  });
+  it("should not collide without type overlap", async () => {
+    expect(subtypeCollides(test1.subtype, [test2.subtype])).toBe(false);
+  });
+  it("should collide with type overlap", async () => {
+    expect(subtypeCollides(test1.subtype, [test3.subtype])).toBe(true);
+  });
+  it("should apply to ExcalidrawElements", async () => {
+    await render(<ExcalidrawApp />, {
+      localStorageData: {
+        elements: [
+          API.createElement({ type: "line", id: "A", subtype: test1.subtype }),
+          API.createElement({ type: "arrow", id: "B", subtype: test1.subtype }),
+          API.createElement({
+            type: "rectangle",
+            id: "C",
+            subtype: test1.subtype,
+          }),
+          API.createElement({
+            type: "diamond",
+            id: "D",
+            subtype: test1.subtype,
+          }),
+          API.createElement({
+            type: "ellipse",
+            id: "E",
+            subtype: test1.subtype,
+          }),
+        ],
+      },
+    });
+    h.elements.forEach((el) => expect(el.subtype).toBe(test1.subtype));
+  });
+  it("should enforce prop value restrictions", async () => {
+    await render(<ExcalidrawApp />, {
+      localStorageData: {
+        elements: [
+          API.createElement({
+            type: "line",
+            id: "A",
+            subtype: test1.subtype,
+            roughness: 1,
+          }),
+          API.createElement({ type: "line", id: "B", roughness: 1 }),
+        ],
+      },
+    });
+    h.elements.forEach((el) => {
+      if (el.subtype === test1.subtype) {
+        expect(el.roughness).toBe(0);
+      } else {
+        expect(el.roughness).toBe(1);
+      }
+    });
+  });
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,6 +14,7 @@ import {
   ExcalidrawImageElement,
   Theme,
 } from "./element/types";
+import { Action } from "./actions/types";
 import { SHAPES } from "./shapes";
 import { Point as RoughPoint } from "roughjs/bin/geometry";
 import { LinearElementEditor } from "./element/linearElementEditor";
@@ -29,6 +30,12 @@ import { MaybeTransformHandleType } from "./element/transformHandles";
 import Library from "./data/library";
 import type { FileSystemHandle } from "./data/filesystem";
 import type { ALLOWED_IMAGE_MIME_TYPES, MIME_TYPES } from "./constants";
+import {
+  SubtypeMethods,
+  Subtype,
+  SubtypePrepFn,
+  SubtypeRecord,
+} from "./subtypes";
 
 export type Point = Readonly<RoughPoint>;
 
@@ -92,6 +99,10 @@ export type AppState = {
   // (e.g. text element when typing into the input)
   editingElement: NonDeletedExcalidrawElement | null;
   editingLinearElement: LinearElementEditor | null;
+  activeSubtypes?: Subtype[];
+  customData?: {
+    [subtype: Subtype]: ExcalidrawElement["customData"];
+  };
   activeTool:
     | {
         type: typeof SHAPES[number]["value"] | "eraser";
@@ -476,6 +487,11 @@ export type ExcalidrawImperativeAPI = {
   getSceneElements: InstanceType<typeof App>["getSceneElements"];
   getAppState: () => InstanceType<typeof App>["state"];
   getFiles: () => InstanceType<typeof App>["files"];
+  actionManager: InstanceType<typeof App>["actionManager"];
+  addSubtype: (
+    record: SubtypeRecord,
+    subtypePrepFn: SubtypePrepFn,
+  ) => { actions: Action[] | null; methods: Partial<SubtypeMethods> };
   refresh: InstanceType<typeof App>["refresh"];
   setToast: InstanceType<typeof App>["setToast"];
   addFiles: (data: BinaryFileData[]) => void;


### PR DESCRIPTION
#3915 is a rollup subset of #2993.  #2993 contributes three features: an initial `@excalidraw/plugins` package; custom `ExcalidrawElement` subtype extensions; and MathJax support as a plugin.  MathJax support is essentially stable.  Further commits to #2993 primarily refine the initial `@excalidraw/plugins` package and `ExcalidrawElement` subtypes system.

#3915 demonstrates the custom `ExcalidrawElement` subtypes feature independently of `@excalidraw/plugins` and MathJax.

Overview of PR #3915:
This PR allows creating custom extensions of `ExcalidrawElement` with specialized, non-WYSIWYG rendering.  An interface is provided to make the specifics of individual subtype implementations transparent to the rest of the Excalidraw codebase.

Motivated by what the use of MathJax entails, the following features are provided:
- Callbacks to optionally refresh the canvas (including in export dialogs) after rendering an `ExcalidrawElement` (eg post lazy-loading), using timeouts to avoid performance degradation
- Inclusion of subtype-specific extra properties (in the field `customProps`)
- Enforcement of values for standard `ExcalidrawElement` properties
- Selection of subtypes from the shape chooser island
- Modification of which standard `ExcalidrawElement` properties are shown in the properties sidebar
- Subtype-specific actions in the context menu/elsewhere, with/without keyboard shortcuts
- Mechanism for a subtype to provide its own i18n locale files

The subtypes interface includes the following custom subtype methods:
- `clean`: Enforce valid property values when creating or mutating an `ExcalidrawElement`
- `ensureLoaded`: Ensure the subtype has finished its loading process (used eg in charts creation)
- `measureText`: Obtain the rendered width, height, and baseline of an `ExcalidrawTextElement`
- `render`: Render the `ExcalidrawElement` to a canvas
- `renderSvg`: Render the `ExcalidrawElement` to an SVG
- `wrapText`: Wrap the rendered text (rather than the contents seen while editing) for bounded text, etc

When adding a new subtype to `@excalidraw/excalidraw`, only two files are touched in `src/` outside of `src/element/subtypes/`.  The new subtype's implementation goes in `src/element/subtypes/subtype_name/`, and the files `src/components/App.tsx` and `src/tests/helpers/api.ts` are modified to pull in two bits from `src/element/subtypes/subtype_name/`.

This PR provides an example "Crisp" subtype in `@excalidraw/excalidraw` which makes all relevant `ExcalidrawElement` types have only "Architect" sloppiness (ie non "hand-drawn").  For an example of using subtypes in `@excalidraw/plugins`, see the MathJax PR #5311 (which incorporates this PR).