### PR TITLE
fix: permanent zoom mode

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -831,6 +831,7 @@ class App extends React.Component<AppProps, AppState> {
   });
 
   private removeEventListeners() {
+    document.removeEventListener(EVENT.POINTER_UP, this.removePointer);
     document.removeEventListener(EVENT.COPY, this.onCopy);
     document.removeEventListener(EVENT.PASTE, this.pasteFromClipboard);
     document.removeEventListener(EVENT.CUT, this.onCut);
@@ -872,6 +873,7 @@ class App extends React.Component<AppProps, AppState> {
 
   private addEventListeners() {
     this.removeEventListeners();
+    document.addEventListener(EVENT.POINTER_UP, this.removePointer); // #3553
     document.addEventListener(EVENT.COPY, this.onCopy);
     if (this.props.handleKeyboardGlobally) {
       document.addEventListener(EVENT.KEYDOWN, this.onKeyDown, false);
@@ -1328,7 +1330,7 @@ class App extends React.Component<AppProps, AppState> {
     this.setState(obj);
   };
 
-  removePointer = (event: React.PointerEvent<HTMLElement>) => {
+  removePointer = (event: React.PointerEvent<HTMLElement> | PointerEvent) => {
     // remove touch handler for context menu on touch devices
     if (event.pointerType === "touch" && touchTimeout) {
       clearTimeout(touchTimeout);


### PR DESCRIPTION
fix https://github.com/excalidraw/excalidraw/issues/3553

In specific cases (such as when starting to edit text), `pointerup` event may not be fired on `<cavas>` which results in not removing it from the `gesture.pointers` cache, which then results in buggy behavior.