### PR TITLE
fix: help-icon now visible on Safari

### DIFF
--- a/src/css/styles.scss
+++ b/src/css/styles.scss
@@ -443,11 +443,16 @@
     display: flex;
     cursor: pointer;
     fill: $oc-gray-6;
-    width: 1.5rem;
     padding: 0;
     margin: 0;
     background: none;
     color: var(--icon-fill-color);
+
+    svg {
+      width: 1.5rem;
+      height: 1.5rem;
+    }
+
     &:hover {
       background: none;
     }


### PR DESCRIPTION
fix https://github.com/excalidraw/excalidraw/issues/3938