### PR TITLE
feat: implemented zoomToFit on ref API

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,8 +85,8 @@
   "private": true,
   "scripts": {
     "build-node": "node ./scripts/build-node.js",
-    "build:app:docker": "REACT_APP_DISABLE_SENTRY=true react-scripts build",
-    "build:app": "REACT_APP_GIT_SHA=$VERCEL_GIT_COMMIT_SHA react-scripts build",
+    "build:app:docker": "cross-env REACT_APP_DISABLE_SENTRY=true react-scripts build",
+    "build:app": "cross-env REACT_APP_GIT_SHA=$VERCEL_GIT_COMMIT_SHA react-scripts build",
     "build:version": "node ./scripts/build-version.js",
     "build": "yarn build:app && yarn build:version",
     "eject": "react-scripts eject",

--- a/src/actions/actionCanvas.tsx
+++ b/src/actions/actionCanvas.tsx
@@ -195,6 +195,7 @@ export const actionResetZoom = register({
 const zoomValueToFitBoundsOnViewport = (
   bounds: [number, number, number, number],
   viewportDimensions: { width: number; height: number },
+  maxZoom: number = 1,
 ) => {
   const [x1, y1, x2, y2] = bounds;
   const commonBoundsWidth = x2 - x1;
@@ -206,15 +207,17 @@ const zoomValueToFitBoundsOnViewport = (
     Math.floor(smallestZoomValue / ZOOM_STEP) * ZOOM_STEP;
   const clampedZoomValueToFitElements = Math.min(
     Math.max(zoomAdjustedToSteps, ZOOM_STEP),
-    1,
+    maxZoom,
   );
   return clampedZoomValueToFitElements as NormalizedZoomValue;
 };
 
-const zoomToFitElements = (
+export const zoomToFitElements = (
   elements: readonly ExcalidrawElement[],
   appState: Readonly<AppState>,
   zoomToSelection: boolean,
+  maxZoom: number = 1,
+  margin: number = 0,
 ) => {
   const nonDeletedElements = getNonDeletedElements(elements);
   const selectedElements = getSelectedElements(nonDeletedElements, appState);
@@ -224,10 +227,14 @@ const zoomToFitElements = (
       ? getCommonBounds(selectedElements)
       : getCommonBounds(nonDeletedElements);
 
-  const zoomValue = zoomValueToFitBoundsOnViewport(commonBounds, {
-    width: appState.width,
-    height: appState.height,
-  });
+  const zoomValue = zoomValueToFitBoundsOnViewport(
+    commonBounds,
+    {
+      width: appState.width - appState.width * margin,
+      height: appState.height - appState.height * margin,
+    },
+    maxZoom,
+  );
   const newZoom = getNewZoom(zoomValue, appState.zoom, {
     left: appState.offsetLeft,
     top: appState.offsetTop,

--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -27,6 +27,7 @@ export {
   actionResetZoom,
   actionZoomToFit,
   actionToggleTheme,
+  zoomToFitElements,
 } from "./actionCanvas";
 
 export { actionFinalize } from "./actionFinalize";

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -28,6 +28,7 @@ import {
   actionToggleStats,
   actionToggleZenMode,
   actionUngroup,
+  zoomToFitElements,
 } from "../actions";
 import { createRedoAction, createUndoAction } from "../actions/actionHistory";
 import { ActionManager } from "../actions/manager";
@@ -292,6 +293,7 @@ class App extends React.Component<AppProps, AppState> {
           clear: this.resetHistory,
         },
         scrollToContent: this.scrollToContent,
+        zoomToFit: this.zoomToFit,
         getSceneElements: this.getSceneElements,
         getAppState: () => this.state,
         refresh: this.refresh,
@@ -1375,6 +1377,18 @@ class App extends React.Component<AppProps, AppState> {
         this.canvas,
       ),
     });
+  };
+
+  zoomToFit = (
+    target:
+      | ExcalidrawElement[]
+      | readonly ExcalidrawElement[] = this.scene.getElements(),
+    maxZoom: number = 1, //null will zoom to max based on viewport
+    margin: number = 0.03, //percentage of viewport width&height
+  ) => {
+    this.setState(
+      zoomToFitElements(target, this.state, false, maxZoom, margin).appState,
+    );
   };
 
   clearToast = () => {

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1385,7 +1385,7 @@ class App extends React.Component<AppProps, AppState> {
     margin: number = 0.03, //percentage of viewport width&height
   ) => {
     if(!target) target = this.scene.getElements();
-    if(target.length==0) maxZoom = 1;
+    if(target.length===0) maxZoom = 1;
     this.setState(
       zoomToFitElements(target, this.state, false, maxZoom, margin).appState,
     );

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1384,8 +1384,12 @@ class App extends React.Component<AppProps, AppState> {
     maxZoom: number = 1, //null will zoom to max based on viewport
     margin: number = 0.03, //percentage of viewport width&height
   ) => {
-    if(!target) target = this.scene.getElements();
-    if(target.length===0) maxZoom = 1;
+    if (!target) {
+      target = this.scene.getElements();
+    }
+    if (target.length === 0) {
+      maxZoom = 1;
+    }
     this.setState(
       zoomToFitElements(target, this.state, false, maxZoom, margin).appState,
     );

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1380,12 +1380,12 @@ class App extends React.Component<AppProps, AppState> {
   };
 
   zoomToFit = (
-    target:
-      | ExcalidrawElement[]
-      | readonly ExcalidrawElement[] = this.scene.getElements(),
+    target: readonly ExcalidrawElement[] = this.scene.getElements(),
     maxZoom: number = 1, //null will zoom to max based on viewport
     margin: number = 0.03, //percentage of viewport width&height
   ) => {
+    if(!target) target = this.scene.getElements();
+    if(target.length==0) maxZoom = 1;
     this.setState(
       zoomToFitElements(target, this.state, false, maxZoom, margin).appState,
     );

--- a/src/packages/excalidraw/README.md
+++ b/src/packages/excalidraw/README.md
@@ -449,10 +449,9 @@ You can pass a `ref` when you want to access some excalidraw APIs. We expose the
 | getAppState | <pre> () => <a href="https://github.com/excalidraw/excalidraw/blob/master/src/types.ts#L42">AppState</a></pre> | Returns current appState |
 | history | `{ clear: () => void }` | This is the history API. `history.clear()` will clear the history |
 | scrollToContent | <pre> (target?: <a href="https://github.com/excalidraw/excalidraw/blob/master/src/element/types.ts#L78">ExcalidrawElement</a> &#124; <a href="https://github.com/excalidraw/excalidraw/blob/master/src/element/types.ts#L78">ExcalidrawElement</a>[]) => void </pre> | Scroll the nearest element out of the elements supplied to the center. Defaults to the elements on the scene. |
-| refresh | `() => void` | Updates the offsets for the Excalidraw component so that the coordinates are computed correctly (for example the cursor position). You don't have to call this when the position is changed on page scroll or when the excalidraw container resizes (we handle that ourselves). For any other cases if the position of excalidraw is updated (example due to scroll on parent container and not page scroll) you should call this API. |
-| [importLibrary](#importlibrary) | `(url: string, token?: string) => void` | Imports library from given URL |
-| setToastMessage | `(message: string) => void` | This API can be used to show the toast with custom message. |
-| [id](#id) | string | Unique ID for the excalidraw component. |
+| zoomToFit | <pre>( target?: ExcalidrawElement[], |
+
+maxZoom: number=1, margin: number=0.03 ) => void </pre> | Zoom to fit elements on viewport. If no elements are supplied, the function will zoom to fit all elements. `maxZoom` is the maximum zoom level allowed (default 100%). `margin` is understood in % of viewport width and height. Default value is a minimum of 1.5% margin around the image compared to viewport . | | refresh | `() => void` | Updates the offsets for the Excalidraw component so that the coordinates are computed correctly (for example the cursor position). You don't have to call this when the position is changed on page scroll or when the excalidraw container resizes (we handle that ourselves). For any other cases if the position of excalidraw is updated (example due to scroll on parent container and not page scroll) you should call this API. | | [importLibrary](#importlibrary) | `(url: string, token?: string) => void` | Imports library from given URL | | setToastMessage | `(message: string) => void` | This API can be used to show the toast with custom message. | | [id](#id) | string | Unique ID for the excalidraw component. |
 
 #### `readyPromise`
 

--- a/src/packages/excalidraw/README.md
+++ b/src/packages/excalidraw/README.md
@@ -439,7 +439,7 @@ You might want to use this when you want to load excalidraw with some initial el
 You can pass a `ref` when you want to access some excalidraw APIs. We expose the below APIs:
 
 | API | signature | Usage |
-| --- | --- | --- |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | ready | `boolean` | This is set to true once Excalidraw is rendered |
 | readyPromise | [resolvablePromise](https://github.com/excalidraw/excalidraw/blob/master/src/utils.ts#L317) | This promise will be resolved with the api once excalidraw has rendered. This will be helpful when you want do some action on the host app once this promise resolves. For this to work you will have to pass ref as shown [here](#readyPromise) |
 | [updateScene](#updateScene) | <pre>(<a href="https://github.com/excalidraw/excalidraw/blob/master/src/types.ts#L207">sceneData</a>)) => void </pre> | updates the scene with the sceneData |
@@ -449,9 +449,8 @@ You can pass a `ref` when you want to access some excalidraw APIs. We expose the
 | getAppState | <pre> () => <a href="https://github.com/excalidraw/excalidraw/blob/master/src/types.ts#L42">AppState</a></pre> | Returns current appState |
 | history | `{ clear: () => void }` | This is the history API. `history.clear()` will clear the history |
 | scrollToContent | <pre> (target?: <a href="https://github.com/excalidraw/excalidraw/blob/master/src/element/types.ts#L78">ExcalidrawElement</a> &#124; <a href="https://github.com/excalidraw/excalidraw/blob/master/src/element/types.ts#L78">ExcalidrawElement</a>[]) => void </pre> | Scroll the nearest element out of the elements supplied to the center. Defaults to the elements on the scene. |
-| zoomToFit | <pre>( target?: ExcalidrawElement[], |
-
-maxZoom: number=1, margin: number=0.03 ) => void </pre> | Zoom to fit elements on viewport. If no elements are supplied, the function will zoom to fit all elements. `maxZoom` is the maximum zoom level allowed (default 100%). `margin` is understood in % of viewport width and height. Default value is a minimum of 1.5% margin around the image compared to viewport . | | refresh | `() => void` | Updates the offsets for the Excalidraw component so that the coordinates are computed correctly (for example the cursor position). You don't have to call this when the position is changed on page scroll or when the excalidraw container resizes (we handle that ourselves). For any other cases if the position of excalidraw is updated (example due to scroll on parent container and not page scroll) you should call this API. | | [importLibrary](#importlibrary) | `(url: string, token?: string) => void` | Imports library from given URL | | setToastMessage | `(message: string) => void` | This API can be used to show the toast with custom message. | | [id](#id) | string | Unique ID for the excalidraw component. |
+| zoomToFit | <pre>( target?: ExcalidrawElement[], maxZoom: number=1, margin: number=0.03 ) => void </pre> | Zoom to fit elements on viewport. If no elements are supplied, the function will zoom to fit all elements. `maxZoom` is the maximum zoom level allowed (default 100%). `margin` is understood in % of viewport width and height. Default value is a minimum of 1.5% margin around the image compared to viewport . |
+| refresh | `() => void` | Updates the offsets for the Excalidraw component so that the coordinates are computed correctly (for example the cursor position). You don't have to call this when the position is changed on page scroll or when the excalidraw container resizes (we handle that ourselves). For any other cases if the position of excalidraw is updated (example due to scroll on parent container and not page scroll) you should call this API. |  | [importLibrary](#importlibrary) | `(url: string, token?: string) => void` | Imports library from given URL |  | setToastMessage | `(message: string) => void` | This API can be used to show the toast with custom message. |  | [id](#id) | string | Unique ID for the excalidraw component. |
 
 #### `readyPromise`
 

--- a/src/packages/excalidraw/README.md
+++ b/src/packages/excalidraw/README.md
@@ -439,7 +439,7 @@ You might want to use this when you want to load excalidraw with some initial el
 You can pass a `ref` when you want to access some excalidraw APIs. We expose the below APIs:
 
 | API | signature | Usage |
-| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| --- | --- | --- |
 | ready | `boolean` | This is set to true once Excalidraw is rendered |
 | readyPromise | [resolvablePromise](https://github.com/excalidraw/excalidraw/blob/master/src/utils.ts#L317) | This promise will be resolved with the api once excalidraw has rendered. This will be helpful when you want do some action on the host app once this promise resolves. For this to work you will have to pass ref as shown [here](#readyPromise) |
 | [updateScene](#updateScene) | <pre>(<a href="https://github.com/excalidraw/excalidraw/blob/master/src/types.ts#L207">sceneData</a>)) => void </pre> | updates the scene with the sceneData |
@@ -449,8 +449,11 @@ You can pass a `ref` when you want to access some excalidraw APIs. We expose the
 | getAppState | <pre> () => <a href="https://github.com/excalidraw/excalidraw/blob/master/src/types.ts#L42">AppState</a></pre> | Returns current appState |
 | history | `{ clear: () => void }` | This is the history API. `history.clear()` will clear the history |
 | scrollToContent | <pre> (target?: <a href="https://github.com/excalidraw/excalidraw/blob/master/src/element/types.ts#L78">ExcalidrawElement</a> &#124; <a href="https://github.com/excalidraw/excalidraw/blob/master/src/element/types.ts#L78">ExcalidrawElement</a>[]) => void </pre> | Scroll the nearest element out of the elements supplied to the center. Defaults to the elements on the scene. |
-| zoomToFit | <pre>( target?: ExcalidrawElement[], maxZoom: number=1, margin: number=0.03 ) => void </pre> | Zoom to fit elements on viewport. If no elements are supplied, the function will zoom to fit all elements. `maxZoom` is the maximum zoom level allowed (default 100%). `margin` is understood in % of viewport width and height. Default value is a minimum of 1.5% margin around the image compared to viewport . |
-| refresh | `() => void` | Updates the offsets for the Excalidraw component so that the coordinates are computed correctly (for example the cursor position). You don't have to call this when the position is changed on page scroll or when the excalidraw container resizes (we handle that ourselves). For any other cases if the position of excalidraw is updated (example due to scroll on parent container and not page scroll) you should call this API. |  | [importLibrary](#importlibrary) | `(url: string, token?: string) => void` | Imports library from given URL |  | setToastMessage | `(message: string) => void` | This API can be used to show the toast with custom message. |  | [id](#id) | string | Unique ID for the excalidraw component. |
+| zoomToFit | `(target?:ExcalidrawElement[], maxZoom:number=1, margin:number=0.03) => void` | Zoom to fit elements on viewport. If no elements are supplied, the function will zoom to fit all elements. `maxZoom` is the maximum zoom level allowed (default 100%). `margin` is understood in % of viewport width and height. Default value is a minimum of 1.5% margin around the image compared to viewport . |
+| refresh | `() => void` | Updates the offsets for the Excalidraw component so that the coordinates are computed correctly (for example the cursor position). You don't have to call this when the position is changed on page scroll or when the excalidraw container resizes (we handle that ourselves). For any other cases if the position of excalidraw is updated (example due to scroll on parent container and not page scroll) you should call this API. |
+| [importLibrary](#importlibrary) | `(url: string, token?: string) => void` | Imports library from given URL |
+| setToastMessage | `(message: string) => void` | This API can be used to show the toast with custom message. |
+| [id](#id) | string | Unique ID for the excalidraw component. |
 
 #### `readyPromise`
 

--- a/src/packages/excalidraw/README_NEXT.md
+++ b/src/packages/excalidraw/README_NEXT.md
@@ -445,7 +445,7 @@ You might want to use this when you want to load excalidraw with some initial el
 You can pass a `ref` when you want to access some excalidraw APIs. We expose the below APIs:
 
 | API | signature | Usage |
-| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| --- | --- | --- |
 | ready | `boolean` | This is set to true once Excalidraw is rendered |
 | readyPromise | [resolvablePromise](https://github.com/excalidraw/excalidraw/blob/master/src/utils.ts#L317) | This promise will be resolved with the api once excalidraw has rendered. This will be helpful when you want do some action on the host app once this promise resolves. For this to work you will have to pass ref as shown [here](#readyPromise) |
 | [updateScene](#updateScene) | <pre>(<a href="https://github.com/excalidraw/excalidraw/blob/master/src/types.ts#L207">sceneData</a>)) => void </pre> | updates the scene with the sceneData |
@@ -455,8 +455,11 @@ You can pass a `ref` when you want to access some excalidraw APIs. We expose the
 | getAppState | <pre> () => <a href="https://github.com/excalidraw/excalidraw/blob/master/src/types.ts#L42">AppState</a></pre> | Returns current appState |
 | history | `{ clear: () => void }` | This is the history API. `history.clear()` will clear the history |
 | scrollToContent | <pre> (target?: <a href="https://github.com/excalidraw/excalidraw/blob/master/src/element/types.ts#L78">ExcalidrawElement</a> &#124; <a href="https://github.com/excalidraw/excalidraw/blob/master/src/element/types.ts#L78">ExcalidrawElement</a>[]) => void </pre> | Scroll the nearest element out of the elements supplied to the center. Defaults to the elements on the scene. |
-| zoomToFit | <pre>(target?:ExcalidrawElement[], maxZoom:number=1, margin:number=0.03)=>void</pre> | Zoom to fit elements on viewport. If no elements are supplied, the function will zoom to fit all elements. `maxZoom` is the maximum zoom level allowed (default 100%). `margin` is understood in % of viewport width and height. Default value is a minimum of 1.5% margin around the image compared to viewport . |
-| refresh | `() => void` | Updates the offsets for the Excalidraw component so that the coordinates are computed correctly (for example the cursor position). You don't have to call this when the position is changed on page scroll or when the excalidraw container resizes (we handle that ourselves). For any other cases if the position of excalidraw is updated (example due to scroll on parent container and not page scroll) you should call this API. |  | [importLibrary](#importlibrary) | `(url: string, token?: string) => void` | Imports library from given URL |  | setToastMessage | `(message: string) => void` | This API can be used to show the toast with custom message. |  | [id](#id) | string | Unique ID for the excalidraw component. |
+| zoomToFit | `(target?:ExcalidrawElement[], maxZoom:number=1, margin:number=0.03) => void` | Zoom to fit elements on viewport. If no elements are supplied, the function will zoom to fit all elements. `maxZoom` is the maximum zoom level allowed (default 100%). `margin` is understood in % of viewport width and height. Default value is a minimum of 1.5% margin around the image compared to viewport . |
+| refresh | `() => void` | Updates the offsets for the Excalidraw component so that the coordinates are computed correctly (for example the cursor position). You don't have to call this when the position is changed on page scroll or when the excalidraw container resizes (we handle that ourselves). For any other cases if the position of excalidraw is updated (example due to scroll on parent container and not page scroll) you should call this API. |
+| [importLibrary](#importlibrary) | `(url: string, token?: string) => void` | Imports library from given URL |
+| setToastMessage | `(message: string) => void` | This API can be used to show the toast with custom message. |
+| [id](#id) | string | Unique ID for the excalidraw component. |
 
 #### `readyPromise`
 

--- a/src/packages/excalidraw/README_NEXT.md
+++ b/src/packages/excalidraw/README_NEXT.md
@@ -445,7 +445,7 @@ You might want to use this when you want to load excalidraw with some initial el
 You can pass a `ref` when you want to access some excalidraw APIs. We expose the below APIs:
 
 | API | signature | Usage |
-| --- | --- | --- |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | ready | `boolean` | This is set to true once Excalidraw is rendered |
 | readyPromise | [resolvablePromise](https://github.com/excalidraw/excalidraw/blob/master/src/utils.ts#L317) | This promise will be resolved with the api once excalidraw has rendered. This will be helpful when you want do some action on the host app once this promise resolves. For this to work you will have to pass ref as shown [here](#readyPromise) |
 | [updateScene](#updateScene) | <pre>(<a href="https://github.com/excalidraw/excalidraw/blob/master/src/types.ts#L207">sceneData</a>)) => void </pre> | updates the scene with the sceneData |
@@ -455,9 +455,8 @@ You can pass a `ref` when you want to access some excalidraw APIs. We expose the
 | getAppState | <pre> () => <a href="https://github.com/excalidraw/excalidraw/blob/master/src/types.ts#L42">AppState</a></pre> | Returns current appState |
 | history | `{ clear: () => void }` | This is the history API. `history.clear()` will clear the history |
 | scrollToContent | <pre> (target?: <a href="https://github.com/excalidraw/excalidraw/blob/master/src/element/types.ts#L78">ExcalidrawElement</a> &#124; <a href="https://github.com/excalidraw/excalidraw/blob/master/src/element/types.ts#L78">ExcalidrawElement</a>[]) => void </pre> | Scroll the nearest element out of the elements supplied to the center. Defaults to the elements on the scene. |
-| zoomToFit | <pre>( target?: ExcalidrawElement[], |
-
-maxZoom: number=1, margin: number=0.03 ) => void </pre> | Zoom to fit elements on viewport. If no elements are supplied, the function will zoom to fit all elements. `maxZoom` is the maximum zoom level allowed (default 100%). `margin` is understood in % of viewport width and height. Default value is a minimum of 1.5% margin around the image compared to viewport . | | refresh | `() => void` | Updates the offsets for the Excalidraw component so that the coordinates are computed correctly (for example the cursor position). You don't have to call this when the position is changed on page scroll or when the excalidraw container resizes (we handle that ourselves). For any other cases if the position of excalidraw is updated (example due to scroll on parent container and not page scroll) you should call this API. | | [importLibrary](#importlibrary) | `(url: string, token?: string) => void` | Imports library from given URL | | setToastMessage | `(message: string) => void` | This API can be used to show the toast with custom message. | | [id](#id) | string | Unique ID for the excalidraw component. |
+| zoomToFit | <pre>(target?:ExcalidrawElement[], maxZoom:number=1, margin:number=0.03)=>void</pre> | Zoom to fit elements on viewport. If no elements are supplied, the function will zoom to fit all elements. `maxZoom` is the maximum zoom level allowed (default 100%). `margin` is understood in % of viewport width and height. Default value is a minimum of 1.5% margin around the image compared to viewport . |
+| refresh | `() => void` | Updates the offsets for the Excalidraw component so that the coordinates are computed correctly (for example the cursor position). You don't have to call this when the position is changed on page scroll or when the excalidraw container resizes (we handle that ourselves). For any other cases if the position of excalidraw is updated (example due to scroll on parent container and not page scroll) you should call this API. |  | [importLibrary](#importlibrary) | `(url: string, token?: string) => void` | Imports library from given URL |  | setToastMessage | `(message: string) => void` | This API can be used to show the toast with custom message. |  | [id](#id) | string | Unique ID for the excalidraw component. |
 
 #### `readyPromise`
 

--- a/src/packages/excalidraw/README_NEXT.md
+++ b/src/packages/excalidraw/README_NEXT.md
@@ -455,10 +455,9 @@ You can pass a `ref` when you want to access some excalidraw APIs. We expose the
 | getAppState | <pre> () => <a href="https://github.com/excalidraw/excalidraw/blob/master/src/types.ts#L42">AppState</a></pre> | Returns current appState |
 | history | `{ clear: () => void }` | This is the history API. `history.clear()` will clear the history |
 | scrollToContent | <pre> (target?: <a href="https://github.com/excalidraw/excalidraw/blob/master/src/element/types.ts#L78">ExcalidrawElement</a> &#124; <a href="https://github.com/excalidraw/excalidraw/blob/master/src/element/types.ts#L78">ExcalidrawElement</a>[]) => void </pre> | Scroll the nearest element out of the elements supplied to the center. Defaults to the elements on the scene. |
-| refresh | `() => void` | Updates the offsets for the Excalidraw component so that the coordinates are computed correctly (for example the cursor position). You don't have to call this when the position is changed on page scroll or when the excalidraw container resizes (we handle that ourselves). For any other cases if the position of excalidraw is updated (example due to scroll on parent container and not page scroll) you should call this API. |
-| [importLibrary](#importlibrary) | `(url: string, token?: string) => void` | Imports library from given URL |
-| setToastMessage | `(message: string) => void` | This API can be used to show the toast with custom message. |
-| [id](#id) | string | Unique ID for the excalidraw component. |
+| zoomToFit | <pre>( target?: ExcalidrawElement[], |
+
+maxZoom: number=1, margin: number=0.03 ) => void </pre> | Zoom to fit elements on viewport. If no elements are supplied, the function will zoom to fit all elements. `maxZoom` is the maximum zoom level allowed (default 100%). `margin` is understood in % of viewport width and height. Default value is a minimum of 1.5% margin around the image compared to viewport . | | refresh | `() => void` | Updates the offsets for the Excalidraw component so that the coordinates are computed correctly (for example the cursor position). You don't have to call this when the position is changed on page scroll or when the excalidraw container resizes (we handle that ourselves). For any other cases if the position of excalidraw is updated (example due to scroll on parent container and not page scroll) you should call this API. | | [importLibrary](#importlibrary) | `(url: string, token?: string) => void` | Imports library from given URL | | setToastMessage | `(message: string) => void` | This API can be used to show the toast with custom message. | | [id](#id) | string | Unique ID for the excalidraw component. |
 
 #### `readyPromise`
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -320,6 +320,7 @@ export type ExcalidrawImperativeAPI = {
     clear: InstanceType<typeof App>["resetHistory"];
   };
   scrollToContent: InstanceType<typeof App>["scrollToContent"];
+  zoomToFit: InstanceType<typeof App>["zoomToFit"];
   getSceneElements: InstanceType<typeof App>["getSceneElements"];
   getAppState: () => InstanceType<typeof App>["state"];
   refresh: InstanceType<typeof App>["refresh"];


### PR DESCRIPTION
Current zoomToFit has two limitations:
- only accessible via keystroke (SHIFT+1). This is an issue for integration; especially because in View mode SHIFT+1 does not work.
- only zooms to max 100%. This is an issue when using Excalidraw in full-screen mode, and using it as a presentation tool. (https://youtu.be/nMYUnnVkw2g)

This simple PR solves both of these issues.