### PR TITLE
feat: Aligned onPaste with onDrop to make these functions more semantically correct

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1193,9 +1193,12 @@ class App extends React.Component<AppProps, AppState> {
       }
       const data = await parseClipboard(event);
       if (this.props.onPaste) {
-        if (await this.props.onPaste(data, event)) {
-          return;
-        }
+        try {
+          if ((await this.props.onPaste(data, event)) === false) {
+            return;
+          } catch (e) {
+            console.error(e);
+          }
       }
       if (data.errorMessage) {
         this.setState({ errorMessage: data.errorMessage });

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1196,9 +1196,10 @@ class App extends React.Component<AppProps, AppState> {
         try {
           if ((await this.props.onPaste(data, event)) === false) {
             return;
-          } catch (e) {
-            console.error(e);
-          }
+          } 
+        } catch (e) {
+          console.error(e);
+        }
       }
       if (data.errorMessage) {
         this.setState({ errorMessage: data.errorMessage });

--- a/src/packages/excalidraw/CHANGELOG.md
+++ b/src/packages/excalidraw/CHANGELOG.md
@@ -21,6 +21,10 @@ Please add the latest change on the top under the correct section.
 
 ## Excalidraw API
 
+### BREAKING CHANGE
+
+- `onPaste` was changed. In case you want to prevent the excalidraw paste action you must return `false`, it will stop the native excalidraw clipboard management flow (nothing will be pasted into the scene). This is a change from the previous version requiring a `true` return value for the same effect. The change to `false` to stop the native action aligns onPaste with onDrop and makes the function semantically more correct.
+
 ### Docs
 
 - Correct exportToBackend in README to onExportToBackend [#3952](https://github.com/excalidraw/excalidraw/pull/3952)

--- a/src/packages/excalidraw/README_NEXT.md
+++ b/src/packages/excalidraw/README_NEXT.md
@@ -610,7 +610,7 @@ This callback is triggered if passed when something is pasted into the scene. Yo
 
 This callback must return a `boolean` value or a [promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/Promise) which resolves to a boolean value.
 
-In case you want to prevent the excalidraw paste action you must return `true`, it will stop the native excalidraw clipboard management flow (nothing will be pasted into the scene).
+In case you want to prevent the excalidraw paste action you must return `false`, it will stop the native excalidraw clipboard management flow (nothing will be pasted into the scene).
 
 ### Does it support collaboration ?
 


### PR DESCRIPTION
https://github.com/excalidraw/excalidraw/pull/3960#discussion_r705996751

`onPaste` was changed. In case you want to prevent the excalidraw paste action you must return `false`, it will stop the native excalidraw clipboard management flow (nothing will be pasted into the scene). This is a change from the previous version requiring a `true` return value for the same effect. The change to `false` to stop the native action aligns onPaste with onDrop and makes the function semantically more correct.