### PR TITLE
fix: remove `100%` height from tooltip container to fix layout issues

### DIFF
--- a/src/actions/actionCanvas.tsx
+++ b/src/actions/actionCanvas.tsx
@@ -172,7 +172,7 @@ export const actionResetZoom = register({
     };
   },
   PanelComponent: ({ updateData, appState }) => (
-    <Tooltip label={t("buttons.resetZoom")}>
+    <Tooltip label={t("buttons.resetZoom")} style={{ height: "100%" }}>
       <ToolButton
         type="button"
         className="reset-zoom-button"

--- a/src/components/Tooltip.scss
+++ b/src/components/Tooltip.scss
@@ -29,7 +29,6 @@
 // wraps the element we want to apply the tooltip to
 .excalidraw-tooltip-wrapper {
   display: flex;
-  height: 100%;
 }
 
 .excalidraw-tooltip-icon {

--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -64,9 +64,15 @@ type TooltipProps = {
   children: React.ReactNode;
   label: string;
   long?: boolean;
+  style?: React.CSSProperties;
 };
 
-export const Tooltip = ({ children, label, long = false }: TooltipProps) => {
+export const Tooltip = ({
+  children,
+  label,
+  long = false,
+  style,
+}: TooltipProps) => {
   useEffect(() => {
     return () =>
       getTooltipDiv().classList.remove("excalidraw-tooltip--visible");
@@ -86,6 +92,7 @@ export const Tooltip = ({ children, label, long = false }: TooltipProps) => {
       onPointerLeave={() =>
         getTooltipDiv().classList.remove("excalidraw-tooltip--visible")
       }
+      style={style}
     >
       {children}
     </div>


### PR DESCRIPTION
reverting [`cefa6f5` (#3832)](https://github.com/excalidraw/excalidraw/pull/3832/commits/cefa6f5b566fd7a78b3a50276673f33210f614f6) to fix:

![image](https://user-images.githubusercontent.com/5153846/133437672-b0b4907a-c23a-41ac-9def-9678858cd631.png)
