### PR TITLE
fix: Added alert for bad encryption key

### DIFF
--- a/src/excalidraw-app/data/index.ts
+++ b/src/excalidraw-app/data/index.ts
@@ -137,6 +137,10 @@ export const decryptAESGEM = async (
 export const getCollaborationLinkData = (link: string) => {
   const hash = new URL(link).hash;
   const match = hash.match(/^#room=([a-zA-Z0-9_-]+),([a-zA-Z0-9_-]+)$/);
+  if (match && match[2].length !== 22) {
+    window.alert(t("alerts.invalidEncryptionKey"));
+    return null;
+  }
   return match ? { roomId: match[1], roomKey: match[2] } : null;
 };
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -157,7 +157,8 @@
     "imageDoesNotContainScene": "Importing images isn't supported at the moment.\n\nDid you want to import a scene? This image does not seem to contain any scene data. Have you enabled this during export?",
     "cannotRestoreFromImage": "Scene couldn't be restored from this image file",
     "invalidSceneUrl": "Couldn't import scene from the supplied URL. It's either malformed, or doesn't contain valid Excalidraw JSON data.",
-    "resetLibrary": "This will clear your library. Are you sure?"
+    "resetLibrary": "This will clear your library. Are you sure?",
+    "invalidEncryptionKey": "Encryption key must be of 22 characters. Live collaboration is disabled."
   },
   "toolBar": {
     "selection": "Selection",


### PR DESCRIPTION
The changes in this PR resolves #3994 by adding a check to ensure that the encryption key is of 22 characters, and alerts the user + disables live collaboration mode if that's not the case.  🙂