### PR TITLE
chore: bump @dwelle/browser-fs-access to 0.21.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     ]
   },
   "dependencies": {
-    "@dwelle/browser-fs-access": "0.21.1",
+    "@dwelle/browser-fs-access": "0.21.3",
     "@sentry/browser": "6.2.5",
     "@sentry/integrations": "6.2.5",
     "@testing-library/jest-dom": "5.11.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1062,10 +1062,10 @@
     enabled "2.0.x"
     kuler "^2.0.0"
 
-"@dwelle/browser-fs-access@0.21.1":
-  version "0.21.1"
-  resolved "https://registry.yarnpkg.com/@dwelle/browser-fs-access/-/browser-fs-access-0.21.1.tgz#46a9c1c95a8b8da3887d95136dc8c1f65830cfa7"
-  integrity sha512-ryAWrTdFgB2IjUooBcKz2bSrVsAUqtjctLK6ByFGbqx7qxk+kqpjA4J54uiMcbvaJ17N/cYeserA6uxBIWIdsg==
+"@dwelle/browser-fs-access@0.21.3":
+  version "0.21.3"
+  resolved "https://registry.yarnpkg.com/@dwelle/browser-fs-access/-/browser-fs-access-0.21.3.tgz#6ff677db204b2bb7021fd8feddf257f5217fc992"
+  integrity sha512-htkHsrGeJjpoDoSW8en7axZboIqjERIVd1mv2Bor7zo4OAGll4iZILb8ZK/s3yRGNov1S5rnit+KFda7ImnMew==
 
 "@eslint/eslintrc@^0.4.0":
   version "0.4.0"


### PR DESCRIPTION
- fixes one issue in the fork: https://github.com/dwelle/browser-fs-access/commit/77f7ea0af085074cf6d2256914dac3e7dd768544, https://github.com/dwelle/browser-fs-access/commit/77f7ea0af085074cf6d2256914dac3e7dd768544