### PR TITLE
feat: add hint around canvas panning

### DIFF
--- a/src/components/HintViewer.tsx
+++ b/src/components/HintViewer.tsx
@@ -39,6 +39,15 @@ const getHints = ({ appState, elements }: Hint) => {
   }
 
   const selectedElements = getSelectedElements(elements, appState);
+
+  if (
+    elementType === "selection" &&
+    appState.draggingElement?.type === "selection" &&
+    !selectedElements.length
+  ) {
+    return t("hints.canvasPanning");
+  }
+
   if (
     isResizing &&
     lastPointerDownWith === "mouse" &&

--- a/src/components/HintViewer.tsx
+++ b/src/components/HintViewer.tsx
@@ -11,13 +11,13 @@ import {
 } from "../element/typeChecks";
 import { getShortcutKey } from "../utils";
 
-interface Hint {
+interface HintViewerProps {
   appState: AppState;
   elements: readonly NonDeletedExcalidrawElement[];
   isMobile: boolean;
 }
 
-const getHints = ({ appState, elements, isMobile }: Hint) => {
+const getHints = ({ appState, elements, isMobile }: HintViewerProps) => {
   const { elementType, isResizing, isRotating, lastPointerDownWith } = appState;
   const multiMode = appState.multiElement !== null;
 
@@ -84,7 +84,11 @@ const getHints = ({ appState, elements, isMobile }: Hint) => {
   return null;
 };
 
-export const HintViewer = ({ appState, elements, isMobile }: Hint) => {
+export const HintViewer = ({
+  appState,
+  elements,
+  isMobile,
+}: HintViewerProps) => {
   let hint = getHints({
     appState,
     elements,

--- a/src/components/HintViewer.tsx
+++ b/src/components/HintViewer.tsx
@@ -14,9 +14,10 @@ import { getShortcutKey } from "../utils";
 interface Hint {
   appState: AppState;
   elements: readonly NonDeletedExcalidrawElement[];
+  isMobile: boolean;
 }
 
-const getHints = ({ appState, elements }: Hint) => {
+const getHints = ({ appState, elements, isMobile }: Hint) => {
   const { elementType, isResizing, isRotating, lastPointerDownWith } = appState;
   const multiMode = appState.multiElement !== null;
 
@@ -76,17 +77,18 @@ const getHints = ({ appState, elements }: Hint) => {
     return t("hints.text_editing");
   }
 
-  if (elementType === "selection" && !selectedElements.length) {
+  if (elementType === "selection" && !selectedElements.length && !isMobile) {
     return t("hints.canvasPanning");
   }
 
   return null;
 };
 
-export const HintViewer = ({ appState, elements }: Hint) => {
+export const HintViewer = ({ appState, elements, isMobile }: Hint) => {
   let hint = getHints({
     appState,
     elements,
+    isMobile,
   });
   if (!hint) {
     return null;

--- a/src/components/HintViewer.tsx
+++ b/src/components/HintViewer.tsx
@@ -19,6 +19,7 @@ interface Hint {
 const getHints = ({ appState, elements }: Hint) => {
   const { elementType, isResizing, isRotating, lastPointerDownWith } = appState;
   const multiMode = appState.multiElement !== null;
+
   if (elementType === "arrow" || elementType === "line") {
     if (!multiMode) {
       return t("hints.linearElement");
@@ -39,14 +40,6 @@ const getHints = ({ appState, elements }: Hint) => {
   }
 
   const selectedElements = getSelectedElements(elements, appState);
-
-  if (
-    elementType === "selection" &&
-    appState.draggingElement?.type === "selection" &&
-    !selectedElements.length
-  ) {
-    return t("hints.canvasPanning");
-  }
 
   if (
     isResizing &&
@@ -81,6 +74,10 @@ const getHints = ({ appState, elements }: Hint) => {
 
   if (appState.editingElement && isTextElement(appState.editingElement)) {
     return t("hints.text_editing");
+  }
+
+  if (elementType === "selection" && !selectedElements.length) {
+    return t("hints.canvasPanning");
   }
 
   return null;

--- a/src/components/LayerUI.tsx
+++ b/src/components/LayerUI.tsx
@@ -624,7 +624,11 @@ const LayerUI = ({
                       padding={1}
                       className={clsx({ "zen-mode": zenModeEnabled })}
                     >
-                      <HintViewer appState={appState} elements={elements} />
+                      <HintViewer
+                        appState={appState}
+                        elements={elements}
+                        isMobile={isMobile}
+                      />
                       {heading}
                       <Stack.Row gap={1}>
                         <ShapesSwitcher

--- a/src/components/MobileMenu.tsx
+++ b/src/components/MobileMenu.tsx
@@ -92,7 +92,7 @@ export const MobileMenu = ({
             </Stack.Col>
           )}
         </Section>
-        <HintViewer appState={appState} elements={elements} />
+        <HintViewer appState={appState} elements={elements} isMobile={true} />
       </FixedSideContainer>
     );
   };

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -203,7 +203,7 @@
     "lineEditor_pointSelected": "Press Delete to remove point, CtrlOrCmd+D to duplicate, or drag to move",
     "lineEditor_nothingSelected": "Select a point to move or remove, or hold Alt and click to add new points",
     "placeImage": "Click to place the image, or click and drag to set its size manually",
-    "canvasPanning": "To move canvas, hold mouse wheel or spacebar while dragging."
+    "canvasPanning": "To move canvas, hold mouse wheel or spacebar while dragging"
   },
   "canvasError": {
     "cannotShowPreview": "Cannot show preview",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -202,7 +202,8 @@
     "lineEditor_info": "Double-click or press Enter to edit points",
     "lineEditor_pointSelected": "Press Delete to remove point, CtrlOrCmd+D to duplicate, or drag to move",
     "lineEditor_nothingSelected": "Select a point to move or remove, or hold Alt and click to add new points",
-    "placeImage": "Click to place the image, or click and drag to set its size manually"
+    "placeImage": "Click to place the image, or click and drag to set its size manually",
+    "canvasPanning": "To move canvas, hold mouse wheel or spacebar while dragging."
   },
   "canvasError": {
     "cannotShowPreview": "Cannot show preview",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -189,6 +189,7 @@
     "shapes": "Shapes"
   },
   "hints": {
+    "canvasPanning": "To move canvas, hold mouse wheel or spacebar while dragging",
     "linearElement": "Click to start multiple points, drag for single line",
     "freeDraw": "Click and drag, release when you're finished",
     "text": "Tip: you can also add text by double-clicking anywhere with the selection tool",
@@ -202,8 +203,7 @@
     "lineEditor_info": "Double-click or press Enter to edit points",
     "lineEditor_pointSelected": "Press Delete to remove point, CtrlOrCmd+D to duplicate, or drag to move",
     "lineEditor_nothingSelected": "Select a point to move or remove, or hold Alt and click to add new points",
-    "placeImage": "Click to place the image, or click and drag to set its size manually",
-    "canvasPanning": "To move canvas, hold mouse wheel or spacebar while dragging"
+    "placeImage": "Click to place the image, or click and drag to set its size manually"
   },
   "canvasError": {
     "cannotShowPreview": "Cannot show preview",


### PR DESCRIPTION
Many users don't know how to pan canvas. While we will add a separate pan tool shortly, we should nevertheless teach people how to move canvas in a more efficient way.

Added a hint around canvas panning, when a `selection` tool is active, but nothing is selected — the reasoning for the latter is we show specific hints when certain elements are selected (arrow, line...) or when doing some action while selection tool is active (resizing...). So it's best we don't show the canvas panning hint all the time as it'd not be consistent and to ensure the hint doesn't appear as related to selecting.

Not showing on Mobile. This will still show on tablets. We will need a better way to discern devices that don't have a keyboard or mouse attached. One way is to detect in which way the selection tool was selected (`pointerType`/keyboard) — we're already doing that for image tool, but we need to figure out a state management for this so it propagates to HintViewer.

![image](https://user-images.githubusercontent.com/5153846/139655336-e0c7b06e-c2da-441a-ba9c-42393b0b5ca0.png)
