### PR TITLE
fix: Skia rendering issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "react-scripts": "4.0.3",
-    "roughjs": "4.4.3",
+    "roughjs": "4.4.4",
     "sass": "1.43.4",
     "socket.io-client": "2.3.1",
     "typescript": "4.4.4"

--- a/src/renderer/renderElement.ts
+++ b/src/renderer/renderElement.ts
@@ -330,7 +330,6 @@ export const generateRoughOptions = (
   switch (element.type) {
     case "rectangle":
     case "diamond":
-    case "image":
     case "ellipse": {
       options.fillStyle = element.fillStyle;
       options.fill =

--- a/src/renderer/renderElement.ts
+++ b/src/renderer/renderElement.ts
@@ -323,6 +323,8 @@ export const generateRoughOptions = (
     roughness: element.roughness,
     stroke: element.strokeColor,
     preserveVertices: continuousPath,
+    // disable decimals to fix Skia rendering issues #4046
+    fixedDecimalPlaceDigits: 0,
   };
 
   switch (element.type) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -12797,10 +12797,10 @@ rollup@^1.31.1:
     "@types/node" "*"
     acorn "^7.1.0"
 
-roughjs@4.4.3:
-  version "4.4.3"
-  resolved "https://registry.yarnpkg.com/roughjs/-/roughjs-4.4.3.tgz#c6278e1bfe6e16bfd8470d8a835236a81df877f9"
-  integrity sha512-bfeqk/dWmQUkn6HHvKGJlENOSHxmPZ9pS33u9WtK8UeQRvqrJZ+2i7AgyOsUurEc9LqOLGHN2L6oUiaQxcdljg==
+roughjs@4.4.4:
+  version "4.4.4"
+  resolved "https://registry.yarnpkg.com/roughjs/-/roughjs-4.4.4.tgz#880e2ef0cb195f0e7e3096f0a2d474121ae874fe"
+  integrity sha512-OXoPkOIoT1vlo+kvy6JZemRxRPkWM5spWUCU+c8JI6bca95tc1Z82SBABRHH+aTpvI+ZK3STGrmvire/f56wvQ==
   dependencies:
     path-data-parser "^0.1.0"
     points-on-curve "^0.2.0"


### PR DESCRIPTION
fix https://github.com/excalidraw/excalidraw/issues/4046

Removing decimal points when rendering rough elements on Canvas seem to have fixed #4046. There's minimal difference in render output.

PR: https://excalidraw-git-fixskiarendering-excalidraw.vercel.app/#json=5629239709663232,-x6WJuEA3TsAz3vIjZmgtQ
prod: https://excalidraw.com/#json=5629239709663232,-x6WJuEA3TsAz3vIjZmgtQ

PR/prod: (or was it the other way round? :p)
![image](https://user-images.githubusercontent.com/5153846/140314214-fd7d07b3-908f-4e01-958a-1cf35f550226.png)
![image](https://user-images.githubusercontent.com/5153846/140314232-3c1df868-58fe-4aa0-b3df-4b42f61ade39.png)
