### PR TITLE
chore: Remove outdated origin trial info

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -13,18 +13,6 @@
 
     <meta name="theme-color" content="#000" />
 
-    <!-- Declarative Link Capturing (https://web.dev/declarative-link-capturing/) -->
-    <meta
-      http-equiv="origin-trial"
-      content="Ak3VyzTheARtX2CnxBZ3ZKxImB0mNyvDakmMxeAChgxrWFMZ3IGN64VP+uj36VxM5OegsbLmrP258b1xvqp7+Q8AAABbeyJvcmlnaW4iOiJodHRwczovL2V4Y2FsaWRyYXcuY29tOjQ0MyIsImZlYXR1cmUiOiJXZWJBcHBMaW5rQ2FwdHVyaW5nIiwiZXhwaXJ5IjoxNjM0MDgzMTk5fQ=="
-    />
-
-    <!-- File Handling (https://web.dev/file-handling/) -->
-    <meta
-      http-equiv="origin-trial"
-      content="AkMQsAnFmKfRfPKQHNCv2WmZREqgwkqhyt2M7aOwQiCStB+hPYnGnv+mNbkPDAsGXrwsj/waFi76wPzTDUaEeQ0AAABUeyJvcmlnaW4iOiJodHRwczovL2V4Y2FsaWRyYXcuY29tOjQ0MyIsImZlYXR1cmUiOiJGaWxlSGFuZGxpbmciLCJleHBpcnkiOjE2MzQwODMxOTl9"
-    />
-
     <!-- General tags -->
     <meta
       name="description"

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -26,7 +26,6 @@
       }
     }
   ],
-  "capture_links": "new-client",
   "share_target": {
     "action": "/web-share-target",
     "method": "POST",


### PR DESCRIPTION
- The origin trial for File Handling is over.
- The declarative link capturing feature will launch in a different shape.