### PR TITLE
feat: log FS abortError to console

### DIFF
--- a/src/actions/actionExport.tsx
+++ b/src/actions/actionExport.tsx
@@ -154,6 +154,8 @@ export const actionSaveToActiveFile = register({
     } catch (error: any) {
       if (error?.name !== "AbortError") {
         console.error(error);
+      } else {
+        console.warn(error);
       }
       return { commitToHistory: false };
     }
@@ -184,6 +186,8 @@ export const actionSaveFileToDisk = register({
     } catch (error: any) {
       if (error?.name !== "AbortError") {
         console.error(error);
+      } else {
+        console.warn(error);
       }
       return { commitToHistory: false };
     }
@@ -221,6 +225,7 @@ export const actionLoadScene = register({
       };
     } catch (error: any) {
       if (error?.name === "AbortError") {
+        console.warn(error);
         return false;
       }
       return {

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -4195,6 +4195,8 @@ class App extends React.Component<AppProps, AppState> {
     } catch (error: any) {
       if (error.name !== "AbortError") {
         console.error(error);
+      } else {
+        console.warn(error);
       }
       this.setState(
         {

--- a/src/components/ToolButton.tsx
+++ b/src/components/ToolButton.tsx
@@ -70,6 +70,8 @@ export const ToolButton = React.forwardRef((props: ToolButtonProps, ref) => {
       } catch (error: any) {
         if (!(error instanceof AbortError)) {
           throw error;
+        } else {
+          console.warn(error);
         }
       } finally {
         if (isMountedRef.current) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -303,6 +303,7 @@ export const tupleToCoors = (
 /** use as a rejectionHandler to mute filesystem Abort errors */
 export const muteFSAbortError = (error?: Error) => {
   if (error?.name === "AbortError") {
+    console.warn(error);
     return;
   }
   throw error;


### PR DESCRIPTION
We tend to get a lot of bugs related to FS abort errors. To make debugging easier, let's always log them to the console (`console.warn` to not log to Sentry).