### PR TITLE
Add Gitpod support

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,9 @@
+# List the start up tasks. Learn more https://www.gitpod.io/docs/config-start-tasks/
+tasks:
+  - init: yarn # runs during prebuild
+    command: yarn start
+
+# List the ports to expose. Learn more https://www.gitpod.io/docs/config-ports/
+ports:
+  - port: 3000
+    onOpen: open-preview

--- a/README.md
+++ b/README.md
@@ -88,6 +88,13 @@ Try out [`@excalidraw/excalidraw`](https://www.npmjs.com/package/@excalidraw/exc
   - You may need to sign in with GitHub and reload the page
 - You can start coding instantly, and even send PRs from there!
 
+### Gitpod
+
+Open a fresh, automated dev environment using Gitpod. 
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/excalidraw/excalidraw)
+
+
 ### Local Installation
 
 These instructions will get you a copy of the project up and running on your local machine for development and testing purposes.


### PR DESCRIPTION
Hi, Pauline from [Gitpod](https://gitpod.io/) here. 👋🏼

Gitpod is an open-source developer platform automating the provisioning of ready-to-code developer environments. This will help folks wanting to contribute and fix bugs to get started instantly without the local dev! I see that you've got a similar sandbox environment which is fantastic, Gitpod does the same thing but with more features and functionality (e.g. docker support, prebuilds, a full laptop in each browser tab)

🪄 Try out the magic here to test this PR: 

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/)

Happy to answer any questions! LMK. 🧡