### PR TITLE
refactor: Deduplicate color translation strings

### DIFF
--- a/src/components/ColorPicker.tsx
+++ b/src/components/ColorPicker.tsx
@@ -7,6 +7,7 @@ import { isArrowKey, KEYS } from "../keys";
 import { t, getLanguage } from "../i18n";
 import { isWritableElement } from "../utils";
 import colors from "../colors";
+import { colorNumberByHex, localeIdByHex } from "./colorPickerHelpers";
 
 const isValidColor = (color: string) => {
   const style = new Option().style;
@@ -34,7 +35,7 @@ const getColor = (color: string): string | null => {
 const keyBindings = [
   ["1", "2", "3", "4", "5"],
   ["q", "w", "e", "r", "t"],
-  ["a", "s", "d", "f", "g"],
+  ["a", "s", "d", "f", "g"]
 ].flat();
 
 const Picker = ({
@@ -44,7 +45,7 @@ const Picker = ({
   onClose,
   label,
   showInput = true,
-  type,
+  type
 }: {
   colors: string[];
   color: string | null;
@@ -87,7 +88,7 @@ const Picker = ({
       const isRTL = getLanguage().rtl;
       const index = Array.prototype.indexOf.call(
         gallery!.current!.children,
-        activeElement,
+        activeElement
       );
       if (index !== -1) {
         const length = gallery!.current!.children.length - (showInput ? 1 : 0);
@@ -139,7 +140,13 @@ const Picker = ({
         tabIndex={0}
       >
         {colors.map((_color, i) => {
-          const _colorWithoutHash = _color.replace("#", "");
+          const numToAppend = colorNumberByHex[_color];
+          const localeId = localeIdByHex[_color];
+          const translatedColorStr = `${t(`colors.${localeId}`, {
+            number: numToAppend
+          })}${!isTransparent(_color) ? ` (${_color})` : ""} — ${keyBindings[
+            i
+          ].toUpperCase()}`;
           return (
             <button
               className="color-picker-swatch"
@@ -147,10 +154,10 @@ const Picker = ({
                 (event.currentTarget as HTMLButtonElement).focus();
                 onChange(_color);
               }}
-              title={`${t(`colors.${_colorWithoutHash}`)}${
-                !isTransparent(_color) ? ` (${_color})` : ""
-              } — ${keyBindings[i].toUpperCase()}`}
-              aria-label={t(`colors.${_colorWithoutHash}`)}
+              title={translatedColorStr}
+              aria-label={t(`colors.${localeId}`, {
+                number: numToAppend
+              })}
               aria-keyshortcuts={keyBindings[i]}
               style={{ color: _color }}
               key={_color}
@@ -193,13 +200,13 @@ const ColorInput = React.forwardRef(
     {
       color,
       onChange,
-      label,
+      label
     }: {
       color: string | null;
       onChange: (color: string) => void;
       label: string;
     },
-    ref,
+    ref
   ) => {
     const [innerValue, setInnerValue] = React.useState(color);
     const inputRef = React.useRef(null);
@@ -219,7 +226,7 @@ const ColorInput = React.forwardRef(
         }
         setInnerValue(value);
       },
-      [onChange],
+      [onChange]
     );
 
     return (
@@ -236,7 +243,7 @@ const ColorInput = React.forwardRef(
         />
       </label>
     );
-  },
+  }
 );
 
 export const ColorPicker = ({
@@ -245,7 +252,7 @@ export const ColorPicker = ({
   onChange,
   label,
   isActive,
-  setActive,
+  setActive
 }: {
   type: "canvasBackground" | "elementBackground" | "elementStroke";
   color: string | null;

--- a/src/components/colorPickerHelpers.ts
+++ b/src/components/colorPickerHelpers.ts
@@ -1,0 +1,157 @@
+export const colorNumberByHex: Record<string, string> = {
+  // White
+  "#ffffff": "",
+
+  // Black
+  "#000000": "",
+
+  // Gray
+  "#f8f9fa": "0",
+  "#f1f3f5": "1",
+  "#ced4da": "4",
+  "#868e96": "6",
+  "#343a40": "8",
+  "#495057": "7",
+
+  // Red
+  "#fff5f5": "0",
+  "#fa5252": "6",
+  "#c92a2a": "9",
+
+  // Pink
+  "#fff0f6": "0",
+  "#e64980": "6",
+  "#a61e4d": "9",
+
+  // Grape
+  "#f8f0fc": "0",
+  "#be4bdb": "6",
+  "#862e9c": "9",
+
+  // Violet
+  "#f3f0ff": "0",
+  "#7950f2": "6",
+  "#5f3dc4": "9",
+
+  // Indigo
+  "#edf2ff": "0",
+  "#4c6ef5": "6",
+  "#364fc7": "9",
+
+  // Blue
+  "#e7f5ff": "0",
+  "#228be6": "6",
+  "#1864ab": "9",
+
+  // Cyan
+  "#e3fafc": "0",
+  "#15aabf": "6",
+  "#0b7285": "9",
+
+  // Teal
+  "#e6fcf5": "0",
+  "#12b886": "6",
+  "#087f5b": "9",
+
+  // Green
+  "#ebfbee": "0",
+  "#40c057": "6",
+  "#2b8a3e": "9",
+
+  // Lime
+  "#f4fce3": "0",
+  "#82c91e": "6",
+  "#5c940d": "9",
+
+  // Yellow
+  "#fff9db": "0",
+  "#fab005": "6",
+  "#e67700": "9",
+
+  // Orange
+  "#fff4e6": "0",
+  "#fd7e14": "6",
+  "#d9480f": "9",
+
+  // Transparent
+  "#transparent": ""
+};
+
+export const localeIdByHex: Record<string, string> = {
+  // White
+  "#ffffff": "white",
+
+  // Black
+  "#000000": "black",
+
+  // Gray
+  "#f8f9fa": "gray",
+  "#f1f3f5": "gray",
+  "#ced4da": "gray",
+  "#868e96": "gray",
+  "#343a40": "gray",
+  "#495057": "gray",
+
+  // Red
+  "#fff5f5": "red",
+  "#fa5252": "red",
+  "#c92a2a": "red",
+
+  // Pink
+  "#fff0f6": "pink",
+  "#e64980": "pink",
+  "#a61e4d": "pink",
+
+  // Grape
+  "#f8f0fc": "grape",
+  "#be4bdb": "grape",
+  "#862e9c": "grape",
+
+  // Violet
+  "#f3f0ff": "violet",
+  "#7950f2": "violet",
+  "#5f3dc4": "violet",
+
+  // Indigo
+  "#edf2ff": "indigo",
+  "#4c6ef5": "indigo",
+  "#364fc7": "indigo",
+
+  // Blue
+  "#e7f5ff": "blue",
+  "#228be6": "blue",
+  "#1864ab": "blue",
+
+  // Cyan
+  "#e3fafc": "cyan",
+  "#15aabf": "cyan",
+  "#0b7285": "cyan",
+
+  // Teal
+  "#e6fcf5": "teal",
+  "#12b886": "teal",
+  "#087f5b": "teal",
+
+  // Green
+  "#ebfbee": "green",
+  "#40c057": "green",
+  "#2b8a3e": "green",
+
+  // Lime
+  "#f4fce3": "lime",
+  "#82c91e": "lime",
+  "#5c940d": "lime",
+
+  // Yellow
+  "#fff9db": "yellow",
+  "#fab005": "yellow",
+  "#e67700": "yellow",
+
+  // Orange
+  "#fff4e6": "orange",
+  "#fd7e14": "orange",
+  "#d9480f": "orange",
+
+  // Transparent
+  "#transparent": "transparent"
+};


### PR DESCRIPTION
This was in response to this issue: https://github.com/excalidraw/excalidraw/issues/3887

Context: Translation strings are being repeated when the only thing that is changing is the hex code and the associated number. The end result is many duplicate translations.

This worked for me locally but I was iffy on messing with the crowdin translations since I'm not familiar with how that works and wouldn't want to accidentally mess up translations in production. But the next step to merge this would be to either add or edit the current translations in crowdin so instead of "gray 0", "gray 6", etc. there should only be one string "gray" for each color. 

I didn't see any other kind of helper file pattern in the components dir so also welcome to feedback if I should throw those big hashes elsewhere.

Sidenote: I made this pr using the code sandbox and even though I gave it a real name, it still called it 'initial commit' 🤦 