### PR TITLE
feat: set package build target to `es2017`

### DIFF
--- a/src/packages/excalidraw/CHANGELOG.md
+++ b/src/packages/excalidraw/CHANGELOG.md
@@ -62,6 +62,10 @@ Please add the latest change on the top under the correct section.
 
   The `Appearance` type is now removed and renamed to `Theme` so `Theme` type needs to be used.
 
+### Build
+
+- We're now compiling to `es2017` target. Notably, `async/await` is not compiled down to generators. [#4341](https://github.com/excalidraw/excalidraw/pull/4341)
+
 ---
 
 ## 0.10.0 (2021-10-13)

--- a/src/packages/excalidraw/package.json
+++ b/src/packages/excalidraw/package.json
@@ -72,7 +72,7 @@
   "homepage": "https://github.com/excalidraw/excalidraw/tree/master/src/packages/excalidraw",
   "scripts": {
     "gen:types": "tsc --project ../../../tsconfig-types.json",
-    "build:umd": "cross-env NODE_ENV=production webpack --config webpack.prod.config.js && cross-env NODE_ENV=development webpack --config webpack.dev.config.js && yarn gen:types",
+    "build:umd": "rm -rf dist && cross-env NODE_ENV=production webpack --config webpack.prod.config.js && cross-env NODE_ENV=development webpack --config webpack.dev.config.js && yarn gen:types",
     "build:umd:withAnalyzer": "cross-env NODE_ENV=production ANALYZER=true webpack --config webpack.prod.config.js",
     "pack": "yarn build:umd && yarn pack"
   },

--- a/src/packages/excalidraw/webpack.prod.config.js
+++ b/src/packages/excalidraw/webpack.prod.config.js
@@ -63,10 +63,7 @@ module.exports = {
                 "@babel/preset-typescript",
               ],
               plugins: [
-                "@babel/plugin-proposal-object-rest-spread",
-                "@babel/plugin-transform-arrow-functions",
                 "transform-class-properties",
-                "@babel/plugin-transform-async-to-generator",
                 "@babel/plugin-transform-runtime",
               ],
             },

--- a/src/packages/tsconfig.prod.json
+++ b/src/packages/tsconfig.prod.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2017",
     "module": "es2015",
     "moduleResolution": "node",
     "resolveJsonModule": true,


### PR DESCRIPTION
- remove `dist/` before build because it seems webpack simply merges the build output, not removing the old chunks/assets generated from previous builds
- move to `es2017` build target. We don't support browsers that don't support it anyway. Solves a recent regression where transpiling async/wait to regenerators was causing typeError issues. Haven't dug super deep to figure out what was the exact cause, but it just seems a compiler issue.

- [ ] add to changelog?