### PR TITLE
feat: stop discarding precision when rendering

### DIFF
--- a/src/renderer/renderElement.ts
+++ b/src/renderer/renderElement.ts
@@ -87,12 +87,7 @@ const generateElementCanvas = (
   let canvasOffsetY = 0;
 
   if (isLinearElement(element) || isFreeDrawElement(element)) {
-    let [x1, y1, x2, y2] = getElementAbsoluteCoords(element);
-
-    x1 = Math.floor(x1);
-    x2 = Math.ceil(x2);
-    y1 = Math.floor(y1);
-    y2 = Math.ceil(y2);
+    const [x1, y1, x2, y2] = getElementAbsoluteCoords(element);
 
     canvas.width =
       distance(x1, x2) * window.devicePixelRatio * zoom.value +
@@ -103,16 +98,12 @@ const generateElementCanvas = (
 
     canvasOffsetX =
       element.x > x1
-        ? Math.floor(distance(element.x, x1)) *
-          window.devicePixelRatio *
-          zoom.value
+        ? distance(element.x, x1) * window.devicePixelRatio * zoom.value
         : 0;
 
     canvasOffsetY =
       element.y > y1
-        ? Math.floor(distance(element.y, y1)) *
-          window.devicePixelRatio *
-          zoom.value
+        ? distance(element.y, y1) * window.devicePixelRatio * zoom.value
         : 0;
 
     context.translate(canvasOffsetX, canvasOffsetY);
@@ -333,8 +324,6 @@ export const generateRoughOptions = (
     roughness: element.roughness,
     stroke: element.strokeColor,
     preserveVertices: continuousPath,
-    // disable decimals to fix Skia rendering issues #4046
-    fixedDecimalPlaceDigits: 0,
   };
 
   switch (element.type) {


### PR DESCRIPTION
Previously, we've been dropping floating points to improve render output (make sharper), but it didn't really improve much on average (if at all), and on large zoom levels (and small elements) it drastically worsened UX & rendering precision.

before/after:

![image](https://user-images.githubusercontent.com/5153846/144711600-06f85525-16ab-4517-afea-daaa8a5cc327.png) ![image](https://user-images.githubusercontent.com/5153846/144711613-3539df8c-c607-443a-807f-897165d7e7c2.png)

before:

![excal_precision_loss](https://user-images.githubusercontent.com/5153846/144711721-9123c09b-ebf0-4700-ace7-fcbfef7335d0.gif)

