### PR TITLE
build: remove file loader and migrate to asset modules webpack for font assets

### DIFF
--- a/src/packages/excalidraw/CHANGELOG.md
+++ b/src/packages/excalidraw/CHANGELOG.md
@@ -52,10 +52,6 @@ Please add the latest change on the top under the correct section.
   - `.excalidraw` files may now contain top-level `files` key in format of `Record<FileId, BinaryFileData>` when exporting any (image) elements.
   - Changes were made to various export utilityies exported from the package so that they take `files`. For now, TypeScript should help you figure the changes out.
 
-## Excalidraw API
-
-### Features
-
 - Export [`isLinearElement`](https://github.com/excalidraw/excalidraw/blob/master/src/packages/excalidraw/README.md#isLinearElement) and [`getNonDeletedElements`](https://github.com/excalidraw/excalidraw/blob/master/src/packages/excalidraw/README.md#getNonDeletedElements).
 
 - Support [`renderTopRightUI`](https://github.com/excalidraw/excalidraw/blob/master/src/packages/excalidraw/README.md#renderTopRightUI) in mobile UI.
@@ -67,6 +63,8 @@ Please add the latest change on the top under the correct section.
   The `Appearance` type is now removed and renamed to `Theme` so `Theme` type needs to be used.
 
 ### Build
+
+- Use `type: javascript/auto` for `file-loader` so font assets are not duplicated by webpack [#4380](https://github.com/excalidraw/excalidraw/pull/4380)
 
 - We're now compiling to `es2017` target. Notably, `async/await` is not compiled down to generators. [#4341](https://github.com/excalidraw/excalidraw/pull/4341)
 

--- a/src/packages/excalidraw/CHANGELOG.md
+++ b/src/packages/excalidraw/CHANGELOG.md
@@ -64,7 +64,7 @@ Please add the latest change on the top under the correct section.
 
 ### Build
 
-- Use `type: javascript/auto` for `file-loader` so font assets are not duplicated by webpack [#4380](https://github.com/excalidraw/excalidraw/pull/4380)
+- Remove `file-loader` so font assets are not duplicated by webpack and use webpack asset modules for font generation [#4380](https://github.com/excalidraw/excalidraw/pull/4380)
 
 - We're now compiling to `es2017` target. Notably, `async/await` is not compiled down to generators. [#4341](https://github.com/excalidraw/excalidraw/pull/4341)
 

--- a/src/packages/excalidraw/package.json
+++ b/src/packages/excalidraw/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@excalidraw/excalidraw",
-  "version": "0.10.0",
+  "name": "aakansha-excalidraw",
+  "version": "0.10.0-build",
   "main": "main.js",
   "types": "types/packages/excalidraw/index.d.ts",
   "files": [
@@ -57,7 +57,6 @@
     "babel-plugin-transform-class-properties": "6.24.1",
     "cross-env": "7.0.3",
     "css-loader": "6.5.1",
-    "file-loader": "6.2.0",
     "mini-css-extract-plugin": "2.4.5",
     "postcss-loader": "6.2.1",
     "sass-loader": "12.3.0",

--- a/src/packages/excalidraw/package.json
+++ b/src/packages/excalidraw/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "aakansha-excalidraw",
-  "version": "0.10.0-build",
+  "name": "@excalidraw/excalidraw",
+  "version": "0.10.0",
   "main": "main.js",
   "types": "types/packages/excalidraw/index.d.ts",
   "files": [

--- a/src/packages/excalidraw/webpack.dev.config.js
+++ b/src/packages/excalidraw/webpack.dev.config.js
@@ -15,6 +15,8 @@ module.exports = {
     libraryTarget: "umd",
     filename: "[name].js",
     chunkFilename: "excalidraw-assets-dev/[name]-[contenthash].js",
+    assetModuleFilename: "excalidraw-assets-dev/[name][ext]",
+
     publicPath: "",
   },
   resolve: {
@@ -54,16 +56,7 @@ module.exports = {
       },
       {
         test: /\.(woff|woff2|eot|ttf|otf)$/,
-        use: [
-          {
-            loader: "file-loader",
-            options: {
-              name: "[name].[ext]",
-              outputPath: "excalidraw-assets-dev",
-            },
-          },
-        ],
-        type: "javascript/auto",
+        type: "asset/resource",
       },
     ],
   },

--- a/src/packages/excalidraw/webpack.dev.config.js
+++ b/src/packages/excalidraw/webpack.dev.config.js
@@ -63,6 +63,7 @@ module.exports = {
             },
           },
         ],
+        type: "javascript/auto",
       },
     ],
   },

--- a/src/packages/excalidraw/webpack.prod.config.js
+++ b/src/packages/excalidraw/webpack.prod.config.js
@@ -17,6 +17,7 @@ module.exports = {
     libraryTarget: "umd",
     filename: "[name].js",
     chunkFilename: "excalidraw-assets/[name]-[contenthash].js",
+    assetModuleFilename: "excalidraw-assets/[name][ext]",
     publicPath: "",
   },
   resolve: {
@@ -72,16 +73,7 @@ module.exports = {
       },
       {
         test: /\.(woff|woff2|eot|ttf|otf)$/,
-        use: [
-          {
-            loader: "file-loader",
-            options: {
-              name: "[name].[ext]",
-              outputPath: "excalidraw-assets",
-            },
-          },
-        ],
-        type: "javascript/auto",
+        type: "asset/resource",
       },
     ],
   },

--- a/src/packages/excalidraw/webpack.prod.config.js
+++ b/src/packages/excalidraw/webpack.prod.config.js
@@ -81,6 +81,7 @@ module.exports = {
             },
           },
         ],
+        type: "javascript/auto",
       },
     ],
   },

--- a/src/packages/excalidraw/yarn.lock
+++ b/src/packages/excalidraw/yarn.lock
@@ -1759,14 +1759,6 @@ fastest-levenshtein@^1.0.12:
   resolved "https://registry.yarnpkg.com/fastest-levenshtein/-/fastest-levenshtein-1.0.12.tgz#9990f7d3a88cc5a9ffd1f1745745251700d497e2"
   integrity sha512-On2N+BpYJ15xIC974QNVuYGMOlEVt4s0EOI3wwMqOmK1fdDY+FN/zltPV8vosq4ad4c/gJ1KHScUn/6AWIgiow==
 
-file-loader@6.2.0:
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/file-loader/-/file-loader-6.2.0.tgz#baef7cf8e1840df325e4390b4484879480eebe4d"
-  integrity sha512-qo3glqyTa61Ytg4u73GultjHGjdRyig3tG6lPtyX/jOEJvHif9uB0/OCI2Kif6ctF3caQTW2G5gym21oAsI4pw==
-  dependencies:
-    loader-utils "^2.0.0"
-    schema-utils "^3.0.0"
-
 fill-range@^7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-7.0.1.tgz#1919a6a7c75fe38b2c7c77e5198535da9acdda40"
@@ -2049,15 +2041,6 @@ loader-utils@^1.4.0:
     big.js "^5.2.2"
     emojis-list "^3.0.0"
     json5 "^1.0.1"
-
-loader-utils@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-2.0.0.tgz#e4cace5b816d425a166b5f097e10cd12b36064b0"
-  integrity sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==
-  dependencies:
-    big.js "^5.2.2"
-    emojis-list "^3.0.0"
-    json5 "^2.1.2"
 
 locate-path@^5.0.0:
   version "5.0.0"
@@ -2471,7 +2454,7 @@ schema-utils@^2.6.5:
     ajv "^6.12.4"
     ajv-keywords "^3.5.2"
 
-schema-utils@^3.0.0, schema-utils@^3.1.0, schema-utils@^3.1.1:
+schema-utils@^3.1.0, schema-utils@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-3.1.1.tgz#bc74c4b6b6995c1d88f76a8b77bea7219e0c8281"
   integrity sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==


### PR DESCRIPTION
fixes  https://github.com/excalidraw/excalidraw/issues/4313
This started happening since https://github.com/excalidraw/excalidraw/pull/4122 was merged as `css-loader` was compatible with webpack 5 which led to duplication of assets and started pointing to the new urls due to which fonts stopped working
![css-loader](https://user-images.githubusercontent.com/11256141/145158510-b8a9be46-b78f-4ea4-9dc7-0d701879b660.png)

Using asset modules as suggested in [webpack docs](https://webpack.js.org/guides/asset-modules/)

Try [here](https://1m7pt.csb.app/)

 