### PR TITLE
fix: support updating stroke color for text by typing in color picker input

### DIFF
--- a/src/element/textWysiwyg.tsx
+++ b/src/element/textWysiwyg.tsx
@@ -486,17 +486,20 @@ export const textWysiwyg = ({
     // trigger the blur on ensuing pointerup.
     // Also to handle cases such as picking a color which would trigger a blur
     // in that same tick.
+    const target = event?.target;
 
     const isTargetColorPicker =
-      event?.target instanceof HTMLInputElement &&
-      event.target.closest(".color-picker-input") &&
-      isWritableElement(event.target);
-    if (isTargetColorPicker) {
-      event.target.onblur = handleSubmit;
-    }
+      target instanceof HTMLInputElement &&
+      target.closest(".color-picker-input") &&
+      isWritableElement(target);
+
     setTimeout(() => {
       editable.onblur = handleSubmit;
-
+      if (target && isTargetColorPicker) {
+        target.onblur = () => {
+          editable.focus();
+        };
+      }
       // case: clicking on the same property → no change → no update → no focus
       if (!isTargetColorPicker) {
         editable.focus();

--- a/src/element/textWysiwyg.tsx
+++ b/src/element/textWysiwyg.tsx
@@ -531,7 +531,12 @@ export const textWysiwyg = ({
   // handle updates of textElement properties of editing element
   const unbindUpdate = Scene.getScene(element)!.addCallback(() => {
     updateWysiwygStyle();
-    editable.focus();
+    const isColorPickerActive = !!document.activeElement?.closest(
+      ".color-picker-input",
+    );
+    if (!isColorPickerActive) {
+      editable.focus();
+    }
   });
 
   // ---------------------------------------------------------------------------

--- a/src/element/textWysiwyg.tsx
+++ b/src/element/textWysiwyg.tsx
@@ -480,14 +480,27 @@ export const textWysiwyg = ({
     editable.remove();
   };
 
-  const bindBlurEvent = () => {
+  const bindBlurEvent = (event?: MouseEvent) => {
     window.removeEventListener("pointerup", bindBlurEvent);
     // Deferred so that the pointerdown that initiates the wysiwyg doesn't
     // trigger the blur on ensuing pointerup.
     // Also to handle cases such as picking a color which would trigger a blur
     // in that same tick.
+
+    const isTargetColorPicker =
+      event?.target instanceof HTMLInputElement &&
+      event.target.closest(".color-picker-input") &&
+      isWritableElement(event.target);
+    if (isTargetColorPicker) {
+      event.target.onblur = handleSubmit;
+    }
     setTimeout(() => {
       editable.onblur = handleSubmit;
+
+      // case: clicking on the same property → no change → no update → no focus
+      if (!isTargetColorPicker) {
+        editable.focus();
+      }
     });
   };
 

--- a/src/element/textWysiwyg.tsx
+++ b/src/element/textWysiwyg.tsx
@@ -488,18 +488,21 @@ export const textWysiwyg = ({
     // in that same tick.
     setTimeout(() => {
       editable.onblur = handleSubmit;
-      // case: clicking on the same property → no change → no update → no focus
-      editable.focus();
     });
   };
 
   // prevent blur when changing properties from the menu
   const onPointerDown = (event: MouseEvent) => {
+    const isTargetColorPicker =
+      event.target instanceof HTMLInputElement &&
+      event.target.closest(".color-picker-input") &&
+      isWritableElement(event.target);
     if (
-      (event.target instanceof HTMLElement ||
+      ((event.target instanceof HTMLElement ||
         event.target instanceof SVGElement) &&
-      event.target.closest(`.${CLASSES.SHAPE_ACTIONS_MENU}`) &&
-      !isWritableElement(event.target)
+        event.target.closest(`.${CLASSES.SHAPE_ACTIONS_MENU}`) &&
+        !isWritableElement(event.target)) ||
+      isTargetColorPicker
     ) {
       editable.onblur = null;
       window.addEventListener("pointerup", bindBlurEvent);


### PR DESCRIPTION
This has been an existing issue for text editor 
Before
![Excalidraw (20)](https://user-images.githubusercontent.com/11256141/146504105-e169c9a8-cb13-4f16-aad3-f88ced0a5359.gif)
Now
![Excalidraw (21)](https://user-images.githubusercontent.com/11256141/146504322-215d1a05-ae8e-4b33-acd3-e90a59f58a87.gif)

