### PR TITLE
fix: align library item previews to center

### DIFF
--- a/src/components/LibraryUnit.scss
+++ b/src/components/LibraryUnit.scss
@@ -27,6 +27,8 @@
 
   .library-unit__dragger {
     display: flex;
+    align-items: center;
+    justify-content: center;
     height: 100%;
     width: 100%;
   }


### PR DESCRIPTION
before: 

![image](https://user-images.githubusercontent.com/5153846/146765995-2c9c88ee-0efb-47a1-bad0-2b739d14197b.png)

after: 

![image](https://user-images.githubusercontent.com/5153846/146766002-9b4df524-4f9b-4eb5-8b71-ca79b3691696.png)
