### PR TITLE
fix: switch cursor to center of container when adding text when dimensions are too small

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -2066,7 +2066,7 @@ class App extends React.Component<AppProps, AppState> {
     /** whether to attempt to insert at element center if applicable */
     insertAtParentCenter?: boolean;
   }) => {
-    const parentCenterPosition =
+    let parentCenterPosition =
       insertAtParentCenter &&
       this.getTextWysiwygSnappedToCenterPosition(
         sceneX,
@@ -2111,6 +2111,15 @@ class App extends React.Component<AppProps, AppState> {
       mutateElement(container, { height: newHeight, width: newWidth });
       sceneX = container.x + newWidth / 2;
       sceneY = container.y + newHeight / 2;
+      if (parentCenterPosition) {
+        parentCenterPosition = this.getTextWysiwygSnappedToCenterPosition(
+          sceneX,
+          sceneY,
+          this.state,
+          this.canvas,
+          window.devicePixelRatio,
+        );
+      }
     }
 
     const element = existingTextElement


### PR DESCRIPTION
previous
![Excalidraw _ Hand-drawn look   feel • Collaborative • Secure (2)](https://user-images.githubusercontent.com/11256141/146937470-6c209859-19fb-495e-b3b8-7628900ee5af.gif)
Now
![Excalidraw _ Hand-drawn look   feel • Collaborative • Secure (3)](https://user-images.githubusercontent.com/11256141/146937536-3ff73576-8fba-4ccb-8359-8d2e617ec758.gif)

