### PR TITLE
fix: vertically center the first line as user starts typing in container

### DIFF
--- a/src/element/textWysiwyg.tsx
+++ b/src/element/textWysiwyg.tsx
@@ -270,6 +270,15 @@ export const textWysiwyg = ({
 
   if (onChange) {
     editable.oninput = () => {
+      const lines = editable.scrollHeight / approxLineHeight;
+      // auto increase height only when lines  > 1 so its
+      // measured correctly and vertically alignes for
+      // first line as well as setting height to "auto"
+      // doubles the height as soon as user starts typing
+      if (isBoundToContainer(element) && lines > 1) {
+        editable.style.height = "auto";
+        editable.style.height = `${editable.scrollHeight}px`;
+      }
       onChange(normalizeText(editable.value));
     };
   }

--- a/src/element/textWysiwyg.tsx
+++ b/src/element/textWysiwyg.tsx
@@ -165,10 +165,8 @@ export const textWysiwyg = ({
         // is reached
         else {
           const lines = editable.scrollHeight / approxLineHeight;
-          // For some reason the scrollHeight gets set to twice the lineHeight
-          // when you start typing for first time  and thus line count is 2
-          // hence this check
-          if (lines > 2 || propertiesUpdated) {
+
+          if (lines > 1 || propertiesUpdated) {
             // vertically center align the text
             coordY =
               container.y + container.height / 2 - editable.scrollHeight / 2;
@@ -272,10 +270,6 @@ export const textWysiwyg = ({
 
   if (onChange) {
     editable.oninput = () => {
-      if (isBoundToContainer(element)) {
-        editable.style.height = "auto";
-        editable.style.height = `${editable.scrollHeight}px`;
-      }
       onChange(normalizeText(editable.value));
     };
   }


### PR DESCRIPTION
Earlier
![Excalidraw (29)](https://user-images.githubusercontent.com/11256141/146950970-61a6fdc9-dacc-44e4-bc5f-962368b2d0b2.gif)
Now

![Excalidraw (30)](https://user-images.githubusercontent.com/11256141/146951163-0f53c1d5-134b-4724-92ce-b430ee925c4b.gif)



