### PR TITLE
fix: vertically center align text when text deleted

### DIFF
--- a/src/element/textWysiwyg.tsx
+++ b/src/element/textWysiwyg.tsx
@@ -109,7 +109,10 @@ export const textWysiwyg = ({
 
       let maxHeight = updatedElement.height;
       let width = updatedElement.width;
-      const height = Math.max(editable.scrollHeight, updatedElement.height);
+      const height =
+        editable.scrollHeight === 0
+          ? updatedElement.height
+          : editable.scrollHeight;
       if (container && updatedElement.containerId) {
         const propertiesUpdated = textPropertiesUpdated(
           updatedElement,


### PR DESCRIPTION
Previous
![Excalidraw (31)](https://user-images.githubusercontent.com/11256141/146979258-313fd6cb-71f8-4fd8-bfa5-727153e2430c.gif)
Now
![Excalidraw (32)](https://user-images.githubusercontent.com/11256141/146979284-6637b88e-b3ea-4346-983f-4ff32dc8f563.gif)

introduced as regression in https://github.com/excalidraw/excalidraw/pull/4444 

