### PR TITLE
fix: move binded text when moving container using keyboard

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1679,9 +1679,11 @@ class App extends React.Component<AppProps, AppState> {
             ? ELEMENT_SHIFT_TRANSLATE_AMOUNT
             : ELEMENT_TRANSLATE_AMOUNT);
 
-        const selectedElements = this.scene
-          .getElements()
-          .filter((element) => this.state.selectedElementIds[element.id]);
+        const selectedElements = getSelectedElements(
+          this.scene.getElements(),
+          this.state,
+          true,
+        );
 
         let offsetX = 0;
         let offsetY = 0;


### PR DESCRIPTION
Previous
![Excalidraw (34)](https://user-images.githubusercontent.com/11256141/147150032-963776e0-1398-47ab-bc33-3bd71b70b557.gif)
Now
![Excalidraw (35)](https://user-images.githubusercontent.com/11256141/147150068-265fcced-4dcb-4836-823d-9b2e78e57da4.gif)

