### PR TITLE
fix: pasted elements except binded text once paste action is complete

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -123,6 +123,7 @@ import {
   hasBoundTextElement,
   isBindingElement,
   isBindingElementType,
+  isBoundToContainer,
   isImageElement,
   isInitializedImageElement,
   isLinearElement,
@@ -1419,7 +1420,7 @@ class App extends React.Component<AppProps, AppState> {
           ...this.state,
           isLibraryOpen: false,
           selectedElementIds: newElements.reduce((map, element) => {
-            if (isTextElement(element) && !element.containerId) {
+            if (!isBoundToContainer(element)) {
               map[element.id] = true;
             }
             return map;


### PR DESCRIPTION
Previous
![Excalidraw (42)](https://user-images.githubusercontent.com/11256141/147268191-d360c664-02de-433a-841f-f19a727eaced.gif)
Now
![Excalidraw (43)](https://user-images.githubusercontent.com/11256141/147268257-068dae0a-a440-4446-a929-3ab2da18069d.gif)
fixes https://github.com/excalidraw/excalidraw/issues/4471
