### PR TITLE
fix: check if process is defined before using so it works in browser

### DIFF
--- a/src/element/newElement.ts
+++ b/src/element/newElement.ts
@@ -13,7 +13,7 @@ import {
   FontFamilyValues,
   ExcalidrawRectangleElement,
 } from "../element/types";
-import { getFontString, getUpdatedTimestamp } from "../utils";
+import { getFontString, getUpdatedTimestamp, isTestEnv } from "../utils";
 import { randomInteger, randomId } from "../random";
 import { mutateElement, newElementWith } from "./mutateElement";
 import { getNewGroupIdsForDuplication } from "../groups";
@@ -369,7 +369,7 @@ export const duplicateElement = <TElement extends Mutable<ExcalidrawElement>>(
   overrides?: Partial<TElement>,
 ): TElement => {
   let copy: TElement = deepCopyElement(element);
-  if (process.env.NODE_ENV === "test") {
+  if (isTestEnv()) {
     copy.id = `${copy.id}_copy`;
     // `window.h` may not be defined in some unit tests
     if (

--- a/src/random.ts
+++ b/src/random.ts
@@ -1,5 +1,6 @@
 import { Random } from "roughjs/bin/math";
 import { nanoid } from "nanoid";
+import { isTestEnv } from "./utils";
 
 let random = new Random(Date.now());
 let testIdBase = 0;
@@ -11,5 +12,4 @@ export const reseed = (seed: number) => {
   testIdBase = 0;
 };
 
-export const randomId = () =>
-  process.env.NODE_ENV === "test" ? `id${testIdBase++}` : nanoid();
+export const randomId = () => (isTestEnv() ? `id${testIdBase++}` : nanoid());

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -443,8 +443,7 @@ export const bytesToHexString = (bytes: Uint8Array) => {
     .join("");
 };
 
-export const getUpdatedTimestamp = () =>
-  process.env.NODE_ENV === "test" ? 1 : Date.now();
+export const getUpdatedTimestamp = () => (isTestEnv() ? 1 : Date.now());
 
 /**
  * Transforms array of objects containing `id` attribute,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -458,4 +458,5 @@ export const arrayToMap = <T extends { id: string } | string>(
   }, new Map());
 };
 
-export const isTestEnv = () => process?.env?.NODE_ENV === "test";
+export const isTestEnv = () =>
+  typeof process !== "undefined" && process.env?.NODE_ENV === "test";


### PR DESCRIPTION
Introduced in https://github.com/excalidraw/excalidraw/pull/4495, since `process?.env?.NODE_ENV` breaks in browser as `process` is not defined hence package breaks hence adding a safe check to make sure its defined before using it