### PR TITLE
fix: bound text doesn't inherit container

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -2168,6 +2168,7 @@ class App extends React.Component<AppProps, AppState> {
             ? "middle"
             : DEFAULT_VERTICAL_ALIGN,
           containerId: container?.id ?? undefined,
+          groupIds: container?.groupIds ?? [],
         });
 
     this.setState({ editingElement: element });


### PR DESCRIPTION
Adding text inside a container who's part of a group(s) doesn't set the `groupIds` on the new text element.