### PR TITLE
fix: prefer spreadsheet data over image

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1306,7 +1306,8 @@ class App extends React.Component<AppProps, AppState> {
         }
       }
 
-      if (isSupportedImageFile(file)) {
+      // prefer spreadsheet data over image file (MS Office/Libre Office)
+      if (isSupportedImageFile(file) && !data.spreadsheet) {
         const { x: sceneX, y: sceneY } = viewportCoordsToSceneCoords(
           { clientX: cursorX, clientY: cursorY },
           this.state,


### PR DESCRIPTION
Pasting spreadsheet data from MS Office/Libre Office also puts an image fine into the clipboard, which is currently preferred. This PR makes sure the spreadsheet data takes priority.