### PR TITLE
fix: rotate bounded text when container is rotated before typing

### DIFF
--- a/src/element/textWysiwyg.tsx
+++ b/src/element/textWysiwyg.tsx
@@ -163,8 +163,7 @@ export const textWysiwyg = ({
         }
       }
       const [viewportX, viewportY] = getViewportCoords(coordX, coordY);
-      const { textAlign, angle } = updatedElement;
-
+      const { textAlign } = updatedElement;
       editable.value = updatedElement.originalText || updatedElement.text;
       const lines = updatedElement.originalText.split("\n");
       const lineHeight = updatedElement.containerId
@@ -194,6 +193,7 @@ export const textWysiwyg = ({
             ? ((appState.zoom.value * 100 - 100) / 10) * 14
             : 0)) /
         appState.zoom.value;
+      const angle = container ? container.angle : updatedElement.angle;
       Object.assign(editable.style, {
         font: getFontString(updatedElement),
         // must be defined *after* font ¯\_(ツ)_/¯
@@ -460,6 +460,7 @@ export const textWysiwyg = ({
               width: Number(editable.style.width.slice(0, -2)),
               // preserve padding
               x: container.x + BOUND_TEXT_PADDING,
+              angle: container.angle,
             });
             const boundTextElementId = getBoundTextElementId(container);
             if (!boundTextElementId || boundTextElementId !== element.id) {


### PR DESCRIPTION
fixes https://github.com/excalidraw/excalidraw/issues/4474
Previou
![Excalidraw (4)](https://user-images.githubusercontent.com/11256141/148032642-51b0c2a1-9e58-412d-8c53-ea1d32e39fbc.gif)


Now
![Excalidraw _ Hand-drawn look   feel • Collaborative • Secure](https://user-images.githubusercontent.com/11256141/148032746-46c079bf-8d4f-4516-b707-434bb567c114.gif)

There are still few bugs related to rotation which I will fix in future PR's
