### PR TITLE
fix: undo should work when selecting bounded text

### DIFF
--- a/src/element/textElement.ts
+++ b/src/element/textElement.ts
@@ -11,7 +11,6 @@ import { BOUND_TEXT_PADDING } from "../constants";
 import { MaybeTransformHandleType } from "./transformHandles";
 import Scene from "../scene/Scene";
 import { AppState } from "../types";
-import { isTextElement } from ".";
 
 export const redrawTextBoundingBox = (
   element: ExcalidrawTextElement,
@@ -21,10 +20,9 @@ export const redrawTextBoundingBox = (
   const maxWidth = container
     ? container.width - BOUND_TEXT_PADDING * 2
     : undefined;
-  let text = element.originalText;
-  // Call wrapText only when updating text properties
-  // By clicking on the container
-  if (container && !isTextElement(appState.editingElement)) {
+  let text = element.text;
+
+  if (container) {
     text = wrapText(
       element.originalText,
       getFontString(element),


### PR DESCRIPTION
fixes https://github.com/excalidraw/excalidraw/issues/4500

Previous
![Excalidraw (7)](https://user-images.githubusercontent.com/11256141/148033990-a072e1c3-8780-4c68-9da0-2daba7901900.gif)

Now

![Excalidraw (8)](https://user-images.githubusercontent.com/11256141/148038514-eb48763f-b895-43b8-ad55-f36f2aefc214.gif)

There is still one issue, you need to undo twice  for first time, and thats coz the data gets pushed twice to the stack when editing in https://github.com/excalidraw/excalidraw/blob/master/src/components/App.tsx#L1970
