### PR TITLE
fix: show text properties button states correctly for bounded text

### DIFF
--- a/src/actions/actionProperties.tsx
+++ b/src/actions/actionProperties.tsx
@@ -42,6 +42,7 @@ import {
   redrawTextBoundingBox,
 } from "../element";
 import { newElementWith } from "../element/mutateElement";
+import { getBoundedTextElement } from "../element/textElement";
 import { isLinearElement, isLinearElementType } from "../element/typeChecks";
 import {
   Arrowhead,
@@ -490,7 +491,16 @@ export const actionChangeFontSize = register({
         value={getFormValue(
           elements,
           appState,
-          (element) => isTextElement(element) && element.fontSize,
+          (element) => {
+            if (isTextElement(element)) {
+              return element.fontSize;
+            }
+            const boundedTextElement = getBoundedTextElement(element);
+            if (boundedTextElement) {
+              return boundedTextElement.fontSize;
+            }
+            return null;
+          },
           appState.currentItemFontSize || DEFAULT_FONT_SIZE,
         )}
         onChange={(value) => updateData(value)}
@@ -562,7 +572,16 @@ export const actionChangeFontFamily = register({
           value={getFormValue(
             elements,
             appState,
-            (element) => isTextElement(element) && element.fontFamily,
+            (element) => {
+              if (isTextElement(element)) {
+                return element.fontFamily;
+              }
+              const boundedTextElement = getBoundedTextElement(element);
+              if (boundedTextElement) {
+                return boundedTextElement.fontFamily;
+              }
+              return null;
+            },
             appState.currentItemFontFamily || DEFAULT_FONT_FAMILY,
           )}
           onChange={(value) => updateData(value)}
@@ -628,7 +647,16 @@ export const actionChangeTextAlign = register({
         value={getFormValue(
           elements,
           appState,
-          (element) => isTextElement(element) && element.textAlign,
+          (element) => {
+            if (isTextElement(element)) {
+              return element.textAlign;
+            }
+            const boundedTextElement = getBoundedTextElement(element);
+            if (boundedTextElement) {
+              return boundedTextElement.textAlign;
+            }
+            return null;
+          },
           appState.currentItemTextAlign,
         )}
         onChange={(value) => updateData(value)}

--- a/src/actions/actionProperties.tsx
+++ b/src/actions/actionProperties.tsx
@@ -42,7 +42,7 @@ import {
   redrawTextBoundingBox,
 } from "../element";
 import { newElementWith } from "../element/mutateElement";
-import { getBoundedTextElement } from "../element/textElement";
+import { getBoundTextElement } from "../element/textElement";
 import { isLinearElement, isLinearElementType } from "../element/typeChecks";
 import {
   Arrowhead,
@@ -495,9 +495,9 @@ export const actionChangeFontSize = register({
             if (isTextElement(element)) {
               return element.fontSize;
             }
-            const boundedTextElement = getBoundedTextElement(element);
-            if (boundedTextElement) {
-              return boundedTextElement.fontSize;
+            const boundTextElement = getBoundTextElement(element);
+            if (boundTextElement) {
+              return boundTextElement.fontSize;
             }
             return null;
           },
@@ -576,9 +576,9 @@ export const actionChangeFontFamily = register({
               if (isTextElement(element)) {
                 return element.fontFamily;
               }
-              const boundedTextElement = getBoundedTextElement(element);
-              if (boundedTextElement) {
-                return boundedTextElement.fontFamily;
+              const boundTextElement = getBoundTextElement(element);
+              if (boundTextElement) {
+                return boundTextElement.fontFamily;
               }
               return null;
             },
@@ -651,9 +651,9 @@ export const actionChangeTextAlign = register({
             if (isTextElement(element)) {
               return element.textAlign;
             }
-            const boundedTextElement = getBoundedTextElement(element);
-            if (boundedTextElement) {
-              return boundedTextElement.textAlign;
+            const boundTextElement = getBoundTextElement(element);
+            if (boundTextElement) {
+              return boundTextElement.textAlign;
             }
             return null;
           },

--- a/src/element/textElement.ts
+++ b/src/element/textElement.ts
@@ -410,7 +410,7 @@ export const getBoundTextElementId = (container: ExcalidrawElement | null) => {
   return container?.boundElements?.filter((ele) => ele.type === "text")[0]?.id;
 };
 
-export const getBoundedTextElement = (element: ExcalidrawElement | null) => {
+export const getBoundTextElement = (element: ExcalidrawElement | null) => {
   if (!element) {
     return null;
   }

--- a/src/element/textElement.ts
+++ b/src/element/textElement.ts
@@ -3,6 +3,7 @@ import {
   ExcalidrawBindableElement,
   ExcalidrawElement,
   ExcalidrawTextElement,
+  ExcalidrawTextElementWithContainer,
   FontString,
   NonDeletedExcalidrawElement,
 } from "./types";
@@ -407,4 +408,17 @@ export const getApproxCharsToFitInWidth = (font: FontString, width: number) => {
 
 export const getBoundTextElementId = (container: ExcalidrawElement | null) => {
   return container?.boundElements?.filter((ele) => ele.type === "text")[0]?.id;
+};
+
+export const getBoundedTextElement = (element: ExcalidrawElement | null) => {
+  if (!element) {
+    return null;
+  }
+  const boundTextElementId = getBoundTextElementId(element);
+  if (boundTextElementId) {
+    return Scene.getScene(element)!.getElement(
+      boundTextElementId,
+    ) as ExcalidrawTextElementWithContainer;
+  }
+  return null;
 };


### PR DESCRIPTION
Previous
![Excalidraw (10)](https://user-images.githubusercontent.com/11256141/148195566-ac073419-a97a-4de6-be4a-d21d4c1c2fac.gif)

Now
![Excalidraw (11)](https://user-images.githubusercontent.com/11256141/148195755-e894684c-2cf9-40a1-a57f-e5b7c4af3d23.gif)

