### PR TITLE
(chore): add .prettierrc file for those using a prettier-based formatter engine

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,19 @@
+{
+  "arrowParens": "always",
+  "bracketSameLine": false,
+  "bracketSpacing": true,
+  "embeddedLanguageFormatting": "auto",
+  "endOfLine": "lf",
+  "htmlWhitespaceSensitivity": "css",
+  "insertPragma": false,
+  "jsxSingleQuote": true,
+  "parser": "typescript",
+  "printWidth": null,
+  "quoteProps": "as-needed",
+  "semi": true,
+  "singleQuote": false,
+  "tabWidth": 2,
+  "trailingComma": "es5",
+  "useTabs": false,
+  "vueIndentScriptAndStyle": true
+}


### PR DESCRIPTION
(chore): add a .pretterrc file for those using a prettier-based formatter engine
- helps to keep code consistent across machines and easier for vscode users to format without needing to refactor their personal settings