### PR TITLE
fix: prevent duplicated point of linear element with multiple points

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -3952,15 +3952,13 @@ class App extends React.Component<AppProps, AppState> {
           draggingElement &&
           !multiElement
         ) {
-          mutateElement(draggingElement, {
-            points: [
-              ...draggingElement.points,
-              [
-                pointerCoords.x - draggingElement.x,
-                pointerCoords.y - draggingElement.y,
-              ],
-            ],
-          });
+          const dx = pointerCoords.x - draggingElement.x;
+          const dy = pointerCoords.y - draggingElement.y;
+          if (dx > 0 || dy > 0) {
+            mutateElement(draggingElement, {
+              points: [...draggingElement.points, [dx, dy]],
+            });
+          }
           this.setState({
             multiElement: draggingElement,
             editingElement: this.state.draggingElement,


### PR DESCRIPTION
Fixed adding origin twice to points.
(the cause is a touchup event that occurred before initializing MultiElement when linear elements were added.)

**current**
![current](https://user-images.githubusercontent.com/32428373/150068057-dd4447f6-b3e8-40e3-b05b-990c54e3a950.gif)

**fix**
![fix](https://user-images.githubusercontent.com/32428373/150068061-1d96ad0a-8c7d-4c60-88e6-d742f956ae4e.gif)

