### PR TITLE
fix: disable contextmenu on non-secondary `pen` events or `touch`

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -4802,6 +4802,15 @@ class App extends React.Component<AppProps, AppState> {
   ) => {
     event.preventDefault();
 
+    if (
+      (event.nativeEvent.pointerType === "touch" ||
+        (event.nativeEvent.pointerType === "pen" &&
+          event.button !== POINTER_BUTTON.SECONDARY)) &&
+      this.state.elementType !== "selection"
+    ) {
+      return;
+    }
+
     const { x, y } = viewportCoordsToSceneCoords(event, this.state);
     const element = this.getElementAtPosition(x, y, { preferSelected: true });
 

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -4805,6 +4805,7 @@ class App extends React.Component<AppProps, AppState> {
     if (
       (event.nativeEvent.pointerType === "touch" ||
         (event.nativeEvent.pointerType === "pen" &&
+          // always allow if user uses a pen secondary button
           event.button !== POINTER_BUTTON.SECONDARY)) &&
       this.state.elementType !== "selection"
     ) {

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -2701,7 +2701,7 @@ class App extends React.Component<AppProps, AppState> {
     event: React.PointerEvent<HTMLCanvasElement>,
   ): void => {
     // deal with opening context menu on touch devices
-    if (event.pointerType === "touch") {
+    if (event.pointerType === "touch" || event.pointerType === "pen") {
       invalidateContextMenu = false;
 
       if (touchTimeout) {

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -2701,7 +2701,7 @@ class App extends React.Component<AppProps, AppState> {
     event: React.PointerEvent<HTMLCanvasElement>,
   ): void => {
     // deal with opening context menu on touch devices
-    if (event.pointerType === "touch" || event.pointerType === "pen") {
+    if (event.pointerType === "touch") {
       invalidateContextMenu = false;
 
       if (touchTimeout) {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -24,7 +24,7 @@ export const POINTER_BUTTON = {
   WHEEL: 1,
   SECONDARY: 2,
   TOUCH: -1,
-};
+} as const;
 
 export enum EVENT {
   COPY = "copy",


### PR DESCRIPTION
fix https://github.com/excalidraw/excalidraw/issues/4674