### PR TITLE
fix: reset unmounted state for the component

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -809,6 +809,7 @@ class App extends React.Component<AppProps, AppState> {
   };
 
   public async componentDidMount() {
+    this.unmounted = false;
     this.excalidrawContainerValue.container =
       this.excalidrawContainerRef.current;
 

--- a/src/packages/excalidraw/CHANGELOG.md
+++ b/src/packages/excalidraw/CHANGELOG.md
@@ -68,6 +68,7 @@ Please add the latest change on the top under the correct section.
 
 ### Fixes
 
+- Reset `unmounted` state on the component once component mounts to fix the mounting/unmounting repeatedly when used with `useEffect` [#4682](https://github.com/excalidraw/excalidraw/pull/4682).
 - Panning the canvas using `mousewheel-drag` and `space-drag` now prevents the browser from scrolling the container/page [#4489](https://github.com/excalidraw/excalidraw/pull/4489).
 - Scope drag and drop events to Excalidraw container to prevent overriding host application drag and drop events.
 


### PR DESCRIPTION
When Excalidraw is used as a dynamic component with useEffects it gets unmounted and mounted back multiple times. `componentWillUnmount` sets `this.unmounted` to `true` which breaks the functionality because it blocks `syncActionResult`. This fix ensures that `this.unmounted` is reseted to false