### PR TITLE
Enhancement: Using s and g key, open color pickers in zen mode

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -497,6 +497,7 @@ class App extends React.Component<AppProps, AppState> {
             />
             <div className="excalidraw-textEditorContainer" />
             <div className="excalidraw-contextMenuContainer" />
+            <div className="excalidraw-popupContainer" />
             {this.state.showStats && (
               <Stats
                 appState={this.state}

--- a/src/components/PopoverModal.tsx
+++ b/src/components/PopoverModal.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+import { createPortal } from "react-dom";
+
+export const PopoverModal = (props: {
+  container: HTMLElement | null;
+  children: React.ReactNode;
+}) => {
+  const { container, children } = props;
+  if (!container) {
+    return null;
+  }
+  return createPortal(<>{children}</>, container);
+};


### PR DESCRIPTION
Signed-off-by: GurkiranSingh <gurkiransinghk@gmail.com>

ZenMode can allow opening color pickers via shortcuts particularly using `s` and `g`. Following suggestions from my previous [pr](https://github.com/excalidraw/excalidraw/pull/3851), I have implemented the following solution.
 - When the user is not in zen mode, then I am putting popover modal in the same [ColorPickerContainer](https://github.com/excalidraw/excalidraw/blob/631a228ca1344b4a048e1ffe7f042421e6b2a4f1/src/components/ColorPicker.tsx#L260), so that we don't face that scrolling issue.
 - When user is in zen mode, then I am putting the color pickers in the outside nodes, `<div className="excalidraw-popupContainer" />`.
 - Also, for excalidraw `package`, I am making sure, we are keeping the position in of color pickers same relative to the top of excalidraw container.

Please, feel free to point out any issues.

Resolves: #3680
 
 Testing:

https://user-images.githubusercontent.com/61521805/151901121-29cb5b88-837b-49ce-aaf7-2f63db0134e2.mp4

 