### PR TITLE
fix: freedraw slow movement jittery lines

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -3852,11 +3852,12 @@ class App extends React.Component<AppProps, AppState> {
         const dx = pointerCoords.x - draggingElement.x;
         const dy = pointerCoords.y - draggingElement.y;
 
-        const discardPoint = points.length > 0 &&
-          points[points.length-1][0] === dx &&
-          points[points.length-1][1] === dy;
+        const discardPoint =
+          points.length > 0 &&
+          points[points.length - 1][0] === dx &&
+          points[points.length - 1][1] === dy;
 
-        if(!discardPoint) {
+        if (!discardPoint) {
           const pressures = draggingElement.simulatePressure
             ? draggingElement.pressures
             : [...draggingElement.pressures, event.pressure];

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -3852,10 +3852,9 @@ class App extends React.Component<AppProps, AppState> {
         const dx = pointerCoords.x - draggingElement.x;
         const dy = pointerCoords.y - draggingElement.y;
 
+        const lastPoint = points.length > 0 && points[points.length - 1];
         const discardPoint =
-          points.length > 0 &&
-          points[points.length - 1][0] === dx &&
-          points[points.length - 1][1] === dy;
+          lastPoint && lastPoint[0] === dx && lastPoint[1] === dy;
 
         if (!discardPoint) {
           const pressures = draggingElement.simulatePressure

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -3852,14 +3852,20 @@ class App extends React.Component<AppProps, AppState> {
         const dx = pointerCoords.x - draggingElement.x;
         const dy = pointerCoords.y - draggingElement.y;
 
-        const pressures = draggingElement.simulatePressure
-          ? draggingElement.pressures
-          : [...draggingElement.pressures, event.pressure];
+        const discardPoint = points.length > 0 &&
+          points[points.length-1][0] === dx &&
+          points[points.length-1][1] === dy;
 
-        mutateElement(draggingElement, {
-          points: [...points, [dx, dy]],
-          pressures,
-        });
+        if(!discardPoint) {
+          const pressures = draggingElement.simulatePressure
+            ? draggingElement.pressures
+            : [...draggingElement.pressures, event.pressure];
+
+          mutateElement(draggingElement, {
+            points: [...points, [dx, dy]],
+            pressures,
+          });
+        }
       } else if (isLinearElement(draggingElement)) {
         pointerDownState.drag.hasOccurred = true;
         const points = draggingElement.points;


### PR DESCRIPTION
Freedraw, when drawing with a pen slowly (aiming for precision) generates a jittery line. Performance of freedraw also degrades after a long stretch of "precision" drawing.
This is because freedraw captures every point, even if it has the exact same coordinates. True, these points might have different pressures, however this additional pressure information, since all the points are on top of one another, is anyway wasteful.
![IMG_0134](https://user-images.githubusercontent.com/14358394/152687341-a1b2c57c-9538-4586-abf1-f8ae6f019cb4.jpg)
![IMG_0135](https://user-images.githubusercontent.com/14358394/152687343-7ac4e5ff-8a41-4b97-813a-ca14ffdfa3e2.jpg)

The change will only add the next point to the points array if it has at least one different coordinate. This drastically reduces the size of freedraw objects and decreases the jitter on the line. 

The noise could be further decreased by increasing the minimum distance between points.

After applying the fix:
![IMG_0136](https://user-images.githubusercontent.com/14358394/152687808-4b8deec6-1402-43a1-ac3b-06f75de26b57.jpg)
![IMG_0137](https://user-images.githubusercontent.com/14358394/152687809-44102a43-89a6-47bc-aa33-d80a47599723.jpg)

