### PR TITLE
feat: keep selected tool on canvas reset

### DIFF
--- a/src/actions/actionCanvas.tsx
+++ b/src/actions/actionCanvas.tsx
@@ -65,6 +65,8 @@ export const actionClearCanvas = register({
         gridSize: appState.gridSize,
         showStats: appState.showStats,
         pasteDialog: appState.pasteDialog,
+        elementType:
+          appState.elementType === "image" ? "selection" : appState.elementType,
       },
       commitToHistory: true,
     };


### PR DESCRIPTION
Something that annoyed me is when you're drawing and want to clear canvas, it resets the selected tool.