### PR TITLE
feat: Adaptive link handle sizing

### DIFF
--- a/src/element/Hyperlink.tsx
+++ b/src/element/Hyperlink.tsx
@@ -290,12 +290,16 @@ export const getLinkHandleFromCoords = (
   appState: AppState,
 ): [x: number, y: number, width: number, height: number] => {
   const size = DEFAULT_LINK_SIZE;
-  const linkWidth = size; // / appState.zoom.value;
-  const linkHeight = size; // / appState.zoom.value;
+  const sizeZoom = appState.zoom.value > 1 ? appState.zoom.value : 1;
+  const linkWidth = size / sizeZoom;
+  const linkHeight = size / sizeZoom;
   const linkMarginY = size / appState.zoom.value;
   const centerX = (x1 + x2) / 2;
   const centerY = (y1 + y2) / 2;
-  const centeringOffset = (size - 8) / (2 * appState.zoom.value);
+  const centeringOffset =
+    (size - 8) / (2 * appState.zoom.value) +
+    size / appState.zoom.value -
+    linkWidth;
   const dashedLineMargin = 4 / appState.zoom.value;
 
   // Same as `ne` resize handle

--- a/src/element/Hyperlink.tsx
+++ b/src/element/Hyperlink.tsx
@@ -290,8 +290,8 @@ export const getLinkHandleFromCoords = (
   appState: AppState,
 ): [x: number, y: number, width: number, height: number] => {
   const size = DEFAULT_LINK_SIZE;
-  const linkWidth = size / appState.zoom.value;
-  const linkHeight = size / appState.zoom.value;
+  const linkWidth = size;// / appState.zoom.value;
+  const linkHeight = size;// / appState.zoom.value;
   const linkMarginY = size / appState.zoom.value;
   const centerX = (x1 + x2) / 2;
   const centerY = (y1 + y2) / 2;

--- a/src/element/Hyperlink.tsx
+++ b/src/element/Hyperlink.tsx
@@ -296,11 +296,8 @@ export const getLinkHandleFromCoords = (
   const linkMarginY = size / appState.zoom.value;
   const centerX = (x1 + x2) / 2;
   const centerY = (y1 + y2) / 2;
-  const centeringOffset =
-    (size - 8) / (2 * appState.zoom.value) +
-    size / appState.zoom.value -
-    linkWidth;
-  const dashedLineMargin = 4 / appState.zoom.value;
+  const centeringOffset = (size - 8) / (2 * sizeZoom);
+  const dashedLineMargin = 4 / sizeZoom;
 
   // Same as `ne` resize handle
   const x = x2 + dashedLineMargin - centeringOffset;

--- a/src/element/Hyperlink.tsx
+++ b/src/element/Hyperlink.tsx
@@ -290,14 +290,14 @@ export const getLinkHandleFromCoords = (
   appState: AppState,
 ): [x: number, y: number, width: number, height: number] => {
   const size = DEFAULT_LINK_SIZE;
-  const sizeZoom = appState.zoom.value > 1 ? appState.zoom.value : 1;
-  const linkWidth = size / sizeZoom;
-  const linkHeight = size / sizeZoom;
-  const linkMarginY = size / appState.zoom.value;
+  const zoom = appState.zoom.value > 1 ? appState.zoom.value : 1;
+  const linkWidth = size / zoom;
+  const linkHeight = size / zoom;
+  const linkMarginY = size / zoom;
   const centerX = (x1 + x2) / 2;
   const centerY = (y1 + y2) / 2;
-  const centeringOffset = (size - 8) / (2 * sizeZoom);
-  const dashedLineMargin = 4 / sizeZoom;
+  const centeringOffset = (size - 8) / (2 * zoom);
+  const dashedLineMargin = 4 / zoom;
 
   // Same as `ne` resize handle
   const x = x2 + dashedLineMargin - centeringOffset;

--- a/src/element/Hyperlink.tsx
+++ b/src/element/Hyperlink.tsx
@@ -290,8 +290,8 @@ export const getLinkHandleFromCoords = (
   appState: AppState,
 ): [x: number, y: number, width: number, height: number] => {
   const size = DEFAULT_LINK_SIZE;
-  const linkWidth = size;// / appState.zoom.value;
-  const linkHeight = size;// / appState.zoom.value;
+  const linkWidth = size; // / appState.zoom.value;
+  const linkHeight = size; // / appState.zoom.value;
   const linkMarginY = size / appState.zoom.value;
   const centerX = (x1 + x2) / 2;
   const centerY = (y1 + y2) / 2;


### PR DESCRIPTION
In response to #4761
See the difference at 50% & 20% zoom.

## Before
### 100%
![image](https://user-images.githubusercontent.com/14358394/153198820-8204b06c-12b0-445b-819f-5af4d546221f.png)

### 250%
![image](https://user-images.githubusercontent.com/14358394/153198867-ead26e38-7ae0-4dd2-8a92-7c84f3603da2.png)

### 50%
![image](https://user-images.githubusercontent.com/14358394/153198928-297933a3-866f-4a05-abbf-a7e0fc73233d.png)

### 20%
![image](https://user-images.githubusercontent.com/14358394/153200055-e83d3c89-d086-49da-88ba-afc7511ae5d0.png)


## After
### 100%
![image](https://user-images.githubusercontent.com/14358394/153198462-e3585bf9-5e87-4c36-aa6b-6a25ba8f873d.png)

### 250%
![image](https://user-images.githubusercontent.com/14358394/153198588-e5200c12-6849-4957-8e8f-6b9a89545b68.png)

### 50%
![image](https://user-images.githubusercontent.com/14358394/153198677-2234718e-8cf2-4b83-88ea-dbacdeaa89c1.png)

### 20%
![image](https://user-images.githubusercontent.com/14358394/153199970-82a78073-4291-48cc-bf75-efaf1e25b5bc.png)
