### PR TITLE
fix: don't bump element version when adding files data

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1620,9 +1620,6 @@ class App extends React.Component<AppProps, AppState> {
 
       this.files = { ...this.files, ...Object.fromEntries(filesMap) };
 
-      // bump versions for elements that reference added files so that
-      // we/host apps can detect the change, and invalidate the image & shape
-      // cache
       this.scene.getElements().forEach((element) => {
         if (
           isInitializedImageElement(element) &&
@@ -1630,7 +1627,6 @@ class App extends React.Component<AppProps, AppState> {
         ) {
           this.imageCache.delete(element.fileId);
           invalidateShapeForElement(element);
-          bumpVersion(element);
         }
       });
       this.scene.informMutation();

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -115,11 +115,7 @@ import {
   updateBoundElements,
 } from "../element/binding";
 import { LinearElementEditor } from "../element/linearElementEditor";
-import {
-  bumpVersion,
-  mutateElement,
-  newElementWith,
-} from "../element/mutateElement";
+import { mutateElement, newElementWith } from "../element/mutateElement";
 import { deepCopyElement, newFreeDrawElement } from "../element/newElement";
 import {
   hasBoundTextElement,


### PR DESCRIPTION
I no longer think it is either necessary (https://github.com/excalidraw/excalidraw/pull/4089/files) or desired to bump element versions when you're simply updating `app.files`.

For excalidraw.com it makes it hard to figure out what constitutes an actual change (for collaboration versioning purposes).

@zsviczian 