### PR TITLE
fix: also check overflowY: overlay in detectScroll

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -475,7 +475,7 @@ export const getNearestScrollableContainer = (
     const hasScrollableContent = parent.scrollHeight > parent.clientHeight;
     if (
       hasScrollableContent &&
-      (overflowY === "auto" || overflowY === "scroll")
+      (overflowY === "auto" || overflowY === "scroll" || overflowY === "overlay")
     ) {
       return parent;
     }


### PR DESCRIPTION
Ref: https://developer.mozilla.org/en-US/docs/Web/CSS/overflow

> Behaves the same as auto, but with the scrollbars drawn on top of content instead of taking up space. Only supported in WebKit-based (e.g., Safari) and Blink-based (e.g., Chrome or Opera) browsers.