### PR TITLE
fix: restore cursor position after bound text container value updated

### DIFF
--- a/src/element/textWysiwyg.tsx
+++ b/src/element/textWysiwyg.tsx
@@ -169,14 +169,18 @@ export const textWysiwyg = ({
       const initialSelectionEnd = editable.selectionEnd;
       const initialLength = editable.value.length;
       editable.value = updatedElement.originalText;
+
       // restore cursor positon after value updated so it doesn't
       // go to the end of text when container auto expanded
       if (
         initialSelectionStart === initialSelectionEnd &&
         initialSelectionEnd !== initialLength
       ) {
-        editable.selectionStart = initialSelectionStart;
-        editable.selectionEnd = initialSelectionEnd;
+        // get diff between length and selection end and shift
+        // the cursor by "diff" times to position correctly
+        const diff = initialLength - initialSelectionEnd;
+        editable.selectionStart = editable.value.length - diff;
+        editable.selectionEnd = editable.value.length - diff;
       }
 
       const lines = updatedElement.originalText.split("\n");

--- a/src/element/textWysiwyg.tsx
+++ b/src/element/textWysiwyg.tsx
@@ -167,11 +167,17 @@ export const textWysiwyg = ({
       const { textAlign } = updatedElement;
       const initialSelectionStart = editable.selectionStart;
       const initialSelectionEnd = editable.selectionEnd;
+      const initialLength = editable.value.length;
       editable.value = updatedElement.originalText;
       // restore cursor positon after value updated so it doesn't
       // go to the end of text when container auto expanded
-      editable.selectionStart = initialSelectionStart;
-      editable.selectionEnd = initialSelectionEnd;
+      if (
+        initialSelectionStart === initialSelectionEnd &&
+        initialSelectionEnd !== initialLength
+      ) {
+        editable.selectionStart = initialSelectionStart;
+        editable.selectionEnd = initialSelectionEnd;
+      }
 
       const lines = updatedElement.originalText.split("\n");
       const lineHeight = updatedElement.containerId

--- a/src/element/textWysiwyg.tsx
+++ b/src/element/textWysiwyg.tsx
@@ -165,7 +165,14 @@ export const textWysiwyg = ({
       }
       const [viewportX, viewportY] = getViewportCoords(coordX, coordY);
       const { textAlign } = updatedElement;
+      const initialSelectionStart = editable.selectionStart;
+      const initialSelectionEnd = editable.selectionEnd;
       editable.value = updatedElement.originalText;
+      // restore cursor positon after value updated so it doesn't
+      // go to the end of text when container auto expanded
+      editable.selectionStart = initialSelectionStart;
+      editable.selectionEnd = initialSelectionEnd;
+
       const lines = updatedElement.originalText.split("\n");
       const lineHeight = updatedElement.containerId
         ? approxLineHeight


### PR DESCRIPTION
Attempt to fix https://github.com/excalidraw/excalidraw/issues/4617

https://user-images.githubusercontent.com/11256141/155104144-e86301af-b27a-4735-9264-d657a4c931b8.mp4


