### PR TITLE
fix: Don't show align icons for single bound container element

### DIFF
--- a/src/components/Actions.tsx
+++ b/src/components/Actions.tsx
@@ -38,7 +38,11 @@ export const SelectedShapeActions = ({
   );
 
   let isSingleElementBoundContainer = false;
-  if (targetElements.length === 2 && hasBoundTextElement(targetElements[0])) {
+  if (
+    targetElements.length === 2 &&
+    (hasBoundTextElement(targetElements[0]) ||
+      hasBoundTextElement(targetElements[1]))
+  ) {
     isSingleElementBoundContainer = true;
   }
   const isEditing = Boolean(appState.editingElement);

--- a/src/components/Actions.tsx
+++ b/src/components/Actions.tsx
@@ -19,6 +19,7 @@ import { capitalizeString, isTransparent, setCursorForShape } from "../utils";
 import Stack from "./Stack";
 import { ToolButton } from "./ToolButton";
 import { hasStrokeColor } from "../scene/comparisons";
+import { hasBoundTextElement } from "../element/typeChecks";
 
 export const SelectedShapeActions = ({
   appState,
@@ -35,6 +36,11 @@ export const SelectedShapeActions = ({
     getNonDeletedElements(elements),
     appState,
   );
+
+  let isSingleElementBoundContainer = false;
+  if (targetElements.length === 2 && hasBoundTextElement(targetElements[0])) {
+    isSingleElementBoundContainer = true;
+  }
   const isEditing = Boolean(appState.editingElement);
   const isMobile = useIsMobile();
   const isRTL = document.documentElement.getAttribute("dir") === "rtl";
@@ -117,7 +123,7 @@ export const SelectedShapeActions = ({
         </div>
       </fieldset>
 
-      {targetElements.length > 1 && (
+      {targetElements.length > 1 && !isSingleElementBoundContainer && (
         <fieldset>
           <legend>{t("labels.align")}</legend>
           <div className="buttonList">


### PR DESCRIPTION
Before
![image](https://user-images.githubusercontent.com/11256141/155717917-edac59cc-5012-4dab-beba-9ac0756fc95a.png)

Now
![image](https://user-images.githubusercontent.com/11256141/155718048-d0192da5-e4b1-48ad-a51c-d7967d65e339.png)