### PR TITLE
fix: ensure verticalAlign properties not shown when no element selected

### DIFF
--- a/src/components/Actions.tsx
+++ b/src/components/Actions.tsx
@@ -110,12 +110,10 @@ export const SelectedShapeActions = ({
         </>
       )}
 
-      {targetElements.length > 0 &&
-        targetElements.some(
-          (element) =>
-            hasBoundTextElement(element) || isBoundToContainer(element),
-        ) &&
-        renderAction("changeVerticalAlign")}
+      {targetElements.some(
+        (element) =>
+          hasBoundTextElement(element) || isBoundToContainer(element),
+      ) && renderAction("changeVerticalAlign")}
       {(canHaveArrowheads(elementType) ||
         targetElements.some((element) => canHaveArrowheads(element.type))) && (
         <>{renderAction("changeArrowhead")}</>

--- a/src/components/Actions.tsx
+++ b/src/components/Actions.tsx
@@ -110,10 +110,12 @@ export const SelectedShapeActions = ({
         </>
       )}
 
-      {targetElements.every(
-        (element) =>
-          hasBoundTextElement(element) || isBoundToContainer(element),
-      ) && <>{renderAction("changeVerticalAlign")}</>}
+      {targetElements.length > 0 &&
+        targetElements.every(
+          (element) =>
+            hasBoundTextElement(element) || isBoundToContainer(element),
+        ) &&
+        renderAction("changeVerticalAlign")}
       {(canHaveArrowheads(elementType) ||
         targetElements.some((element) => canHaveArrowheads(element.type))) && (
         <>{renderAction("changeArrowhead")}</>

--- a/src/components/Actions.tsx
+++ b/src/components/Actions.tsx
@@ -111,7 +111,7 @@ export const SelectedShapeActions = ({
       )}
 
       {targetElements.length > 0 &&
-        targetElements.every(
+        targetElements.some(
           (element) =>
             hasBoundTextElement(element) || isBoundToContainer(element),
         ) &&


### PR DESCRIPTION
fix https://github.com/excalidraw/excalidraw/issues/4859

I've also changed this from `every` to `some` to align with what we do with other props.