### PR TITLE
fix: freedraw element's background fill color missing from SVG when exporting with package API exportToSvg()

### DIFF
--- a/src/renderer/renderElement.ts
+++ b/src/renderer/renderElement.ts
@@ -924,6 +924,7 @@ export const renderElementToSvg = (
       break;
     }
     case "freedraw": {
+      generateElementShape(element, generator);
       generateFreeDrawShape(element);
       const opacity = element.opacity / 100;
       const shape = getShapeForElement(element);


### PR DESCRIPTION
The drawing:
![image](https://user-images.githubusercontent.com/14358394/156900509-1e2e92d8-97cd-4ce8-a7ae-d39c263c5f7d.png)

export using [exportToSvg](https://github.com/excalidraw/excalidraw/tree/master/src/packages/excalidraw#exporttosvg) before the fix:
![image](https://user-images.githubusercontent.com/14358394/156900490-eca58266-055e-4d9a-9daf-975c731c823b.png)

export using [exportToSvg](https://github.com/excalidraw/excalidraw/tree/master/src/packages/excalidraw#exporttosvg) after the fix:
![image](https://user-images.githubusercontent.com/14358394/156900520-543c2ebc-d2dd-47a6-ac92-46c1d8670586.png)

Zip file with the two sample SVG files:
[sample.svg.zip](https://github.com/excalidraw/excalidraw/files/8191516/sample.svg.zip)

