### PR TITLE
feat: rewrite collab server connecting 

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -4,5 +4,5 @@ REACT_APP_BACKEND_V2_POST_URL=https://json-dev.excalidraw.com/api/v2/post/
 REACT_APP_LIBRARY_URL=https://libraries.excalidraw.com
 REACT_APP_LIBRARY_BACKEND=https://us-central1-excalidraw-room-persistence.cloudfunctions.net/libraries
 
-REACT_APP_SOCKET_SERVER_URL=http://localhost:3002
+REACT_APP_SOCKET_SERVER_RESOLVER_URL=http://localhost:3002
 REACT_APP_FIREBASE_CONFIG='{"apiKey":"AIzaSyCMkxA60XIW8KbqMYL7edC4qT5l4qHX2h8","authDomain":"excalidraw-oss-dev.firebaseapp.com","projectId":"excalidraw-oss-dev","storageBucket":"excalidraw-oss-dev.appspot.com","messagingSenderId":"664559512677","appId":"1:664559512677:web:a385181f2928d328a7aa8c"}'

--- a/.env.development
+++ b/.env.development
@@ -4,5 +4,5 @@ REACT_APP_BACKEND_V2_POST_URL=https://json-dev.excalidraw.com/api/v2/post/
 REACT_APP_LIBRARY_URL=https://libraries.excalidraw.com
 REACT_APP_LIBRARY_BACKEND=https://us-central1-excalidraw-room-persistence.cloudfunctions.net/libraries
 
-REACT_APP_SOCKET_SERVER_RESOLVER_URL=http://localhost:3002
+REACT_APP_PORTAL_URL=http://localhost:3002
 REACT_APP_FIREBASE_CONFIG='{"apiKey":"AIzaSyCMkxA60XIW8KbqMYL7edC4qT5l4qHX2h8","authDomain":"excalidraw-oss-dev.firebaseapp.com","projectId":"excalidraw-oss-dev","storageBucket":"excalidraw-oss-dev.appspot.com","messagingSenderId":"664559512677","appId":"1:664559512677:web:a385181f2928d328a7aa8c"}'

--- a/.env.production
+++ b/.env.production
@@ -4,7 +4,7 @@ REACT_APP_BACKEND_V2_POST_URL=https://json.excalidraw.com/api/v2/post/
 REACT_APP_LIBRARY_URL=https://libraries.excalidraw.com
 REACT_APP_LIBRARY_BACKEND=https://us-central1-excalidraw-room-persistence.cloudfunctions.net/libraries
 
-REACT_APP_SOCKET_SERVER_URL=https://oss-collab-us1.excalidraw.com
+REACT_APP_SOCKET_SERVER_RESOLVER_URL=https://portal.excalidraw.com
 REACT_APP_FIREBASE_CONFIG='{"apiKey":"AIzaSyAd15pYlMci_xIp9ko6wkEsDzAAA0Dn0RU","authDomain":"excalidraw-room-persistence.firebaseapp.com","databaseURL":"https://excalidraw-room-persistence.firebaseio.com","projectId":"excalidraw-room-persistence","storageBucket":"excalidraw-room-persistence.appspot.com","messagingSenderId":"654800341332","appId":"1:654800341332:web:4a692de832b55bd57ce0c1"}'
 
 # production-only vars

--- a/.env.production
+++ b/.env.production
@@ -4,7 +4,7 @@ REACT_APP_BACKEND_V2_POST_URL=https://json.excalidraw.com/api/v2/post/
 REACT_APP_LIBRARY_URL=https://libraries.excalidraw.com
 REACT_APP_LIBRARY_BACKEND=https://us-central1-excalidraw-room-persistence.cloudfunctions.net/libraries
 
-REACT_APP_SOCKET_SERVER_RESOLVER_URL=https://portal.excalidraw.com
+REACT_APP_PORTAL_URL=https://portal.excalidraw.com
 REACT_APP_FIREBASE_CONFIG='{"apiKey":"AIzaSyAd15pYlMci_xIp9ko6wkEsDzAAA0Dn0RU","authDomain":"excalidraw-room-persistence.firebaseapp.com","databaseURL":"https://excalidraw-room-persistence.firebaseio.com","projectId":"excalidraw-room-persistence","storageBucket":"excalidraw-room-persistence.appspot.com","messagingSenderId":"654800341332","appId":"1:654800341332:web:4a692de832b55bd57ce0c1"}'
 
 # production-only vars

--- a/public/index.html
+++ b/public/index.html
@@ -73,12 +73,6 @@
     />
 
     <link
-      href="%REACT_APP_SOCKET_SERVER_URL%/socket.io"
-      rel="preconnect"
-      crossorigin="anonymous"
-    />
-
-    <link
       rel="manifest"
       href="manifest.json"
       style="--pwacompat-splash-font: 24px Virgil"

--- a/src/excalidraw-app/collab/CollabWrapper.tsx
+++ b/src/excalidraw-app/collab/CollabWrapper.tsx
@@ -27,7 +27,7 @@ import {
 import {
   generateCollaborationLinkData,
   getCollaborationLink,
-  getSocketServer,
+  getCollabServer,
   SocketUpdateDataSource,
 } from "../data";
 import {
@@ -359,9 +359,9 @@ class CollabWrapper extends PureComponent<Props, CollabState> {
 
     try {
       // Returns from the server URL where to connect sockets
-      const socketServerData = await getSocketServer();
+      const socketServerData = await getCollabServer();
       this.portal.socket = this.portal.open(
-        socketIOClient(socketServerData.socket_server_url),
+        socketIOClient(socketServerData.url),
         roomId,
         roomKey,
       );

--- a/src/excalidraw-app/collab/CollabWrapper.tsx
+++ b/src/excalidraw-app/collab/CollabWrapper.tsx
@@ -27,8 +27,8 @@ import {
 import {
   generateCollaborationLinkData,
   getCollaborationLink,
+  getSocketServer,
   SocketUpdateDataSource,
-  SOCKET_SERVER,
 } from "../data";
 import {
   isSavedToFirebase,
@@ -357,7 +357,19 @@ class CollabWrapper extends PureComponent<Props, CollabState> {
       /* webpackChunkName: "socketIoClient" */ "socket.io-client"
     );
 
-    this.portal.open(socketIOClient(SOCKET_SERVER), roomId, roomKey);
+    try {
+      // Returns from the server URL where to connect sockets
+      const socketServerData = await getSocketServer();
+      this.portal.open(
+        socketIOClient(socketServerData.socket_server_url),
+        roomId,
+        roomKey,
+      );
+    } catch (error: any) {
+      console.error(error);
+      this.setState({ errorMessage: error.message });
+      return null;
+    }
 
     if (existingRoomLinkData) {
       this.excalidrawAPI.resetScene();

--- a/src/excalidraw-app/collab/CollabWrapper.tsx
+++ b/src/excalidraw-app/collab/CollabWrapper.tsx
@@ -358,14 +358,9 @@ class CollabWrapper extends PureComponent<Props, CollabState> {
     );
 
     try {
-      // Returns from the server URL where to connect sockets
       const socketServerData = await getCollabServer();
       this.portal.socket = this.portal.open(
         socketIOClient(socketServerData.url, {
-          // only reason why we conrol polling from upstream is to allow
-          // switching it on/off immediately when needed without having to
-          // wait for clients to update the SW
-          // (likely we'll switch to websockets completely soon)
           transports: socketServerData.polling
             ? ["websocket", "polling"]
             : ["websocket"],

--- a/src/excalidraw-app/collab/CollabWrapper.tsx
+++ b/src/excalidraw-app/collab/CollabWrapper.tsx
@@ -361,7 +361,15 @@ class CollabWrapper extends PureComponent<Props, CollabState> {
       // Returns from the server URL where to connect sockets
       const socketServerData = await getCollabServer();
       this.portal.socket = this.portal.open(
-        socketIOClient(socketServerData.url),
+        socketIOClient(socketServerData.url, {
+          // only reason why we conrol polling from upstream is to allow
+          // switching it on/off immediately when needed without having to
+          // wait for clients to update the SW
+          // (likely we'll switch to websockets completely soon)
+          transports: socketServerData.polling
+            ? ["websocket", "polling"]
+            : ["websocket"],
+        }),
         roomId,
         roomKey,
       );

--- a/src/excalidraw-app/data/index.ts
+++ b/src/excalidraw-app/data/index.ts
@@ -23,7 +23,6 @@ import { saveFilesToFirebase } from "./firebase";
 
 const BACKEND_V2_GET = process.env.REACT_APP_BACKEND_V2_GET_URL;
 const BACKEND_V2_POST = process.env.REACT_APP_BACKEND_V2_POST_URL;
-const SOCKET_SERVER_RESOLVER = process.env.REACT_APP_SOCKET_SERVER_RESOLVER_URL;
 
 const generateRoomId = async () => {
   const buffer = new Uint8Array(ROOM_ID_BYTES);
@@ -31,17 +30,18 @@ const generateRoomId = async () => {
   return bytesToHexString(buffer);
 };
 
-export const getSocketServer = async () => {
+export const getCollabServer = async (): Promise<{
+  url: string;
+  polling: boolean;
+}> => {
   try {
-    const resp = await fetch(`${SOCKET_SERVER_RESOLVER}/socket-server`, {
-      mode: "cors",
-    });
-    const data = await resp.json();
-
-    return data;
+    const resp = await fetch(
+      `${process.env.REACT_APP_PORTAL_URL}/collab-server`,
+    );
+    return await resp.json();
   } catch (error) {
     console.error(error);
-    throw new Error(t("errors.cannotGetSocketServer"));
+    throw new Error(t("errors.cannotResolveCollabServer"));
   }
 };
 

--- a/src/excalidraw-app/data/index.ts
+++ b/src/excalidraw-app/data/index.ts
@@ -23,6 +23,7 @@ import { saveFilesToFirebase } from "./firebase";
 
 const BACKEND_V2_GET = process.env.REACT_APP_BACKEND_V2_GET_URL;
 const BACKEND_V2_POST = process.env.REACT_APP_BACKEND_V2_POST_URL;
+const SOCKET_SERVER_RESOLVER = process.env.REACT_APP_SOCKET_SERVER_RESOLVER_URL;
 
 const generateRoomId = async () => {
   const buffer = new Uint8Array(ROOM_ID_BYTES);
@@ -30,7 +31,19 @@ const generateRoomId = async () => {
   return bytesToHexString(buffer);
 };
 
-export const SOCKET_SERVER = process.env.REACT_APP_SOCKET_SERVER_URL;
+export const getSocketServer = async () => {
+  try {
+    const resp = await fetch(`${SOCKET_SERVER_RESOLVER}/socket-server`, {
+      mode: "cors",
+    });
+    const data = await resp.json();
+
+    return data;
+  } catch (error) {
+    console.error(error);
+    throw new Error(t("errors.cannotGetSocketServer"));
+  }
+};
 
 export type EncryptedData = {
   data: ArrayBuffer;

--- a/src/excalidraw-app/data/index.ts
+++ b/src/excalidraw-app/data/index.ts
@@ -30,6 +30,11 @@ const generateRoomId = async () => {
   return bytesToHexString(buffer);
 };
 
+/**
+ * Right now the reason why we resolve connection params (url, polling...)
+ * from upstream is to allow changing the params immediately when needed without
+ * having to wait for clients to update the SW.
+ */
 export const getCollabServer = async (): Promise<{
   url: string;
   polling: boolean;

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -21,7 +21,7 @@ declare namespace NodeJS {
   interface ProcessEnv {
     readonly REACT_APP_BACKEND_V2_GET_URL: string;
     readonly REACT_APP_BACKEND_V2_POST_URL: string;
-    readonly REACT_APP_SOCKET_SERVER_URL: string;
+    readonly REACT_APP_PORTAL_URL: string;
     readonly REACT_APP_FIREBASE_CONFIG: string;
   }
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -181,7 +181,7 @@
     "fileTooBig": "File is too big. Maximum allowed size is {{maxSize}}.",
     "svgImageInsertError": "Couldn't insert SVG image. The SVG markup looks invalid.",
     "invalidSVGString": "Invalid SVG.",
-    "cannotGetSocketServer": "Couldn't get socket server. Please refresh page and try again"
+    "cannotResolveCollabServer": "Couldn't connect to the collab server. Please reload the page and try again."
   },
   "toolBar": {
     "selection": "Selection",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -180,7 +180,8 @@
     "imageInsertError": "Couldn't insert image. Try again later...",
     "fileTooBig": "File is too big. Maximum allowed size is {{maxSize}}.",
     "svgImageInsertError": "Couldn't insert SVG image. The SVG markup looks invalid.",
-    "invalidSVGString": "Invalid SVG."
+    "invalidSVGString": "Invalid SVG.",
+    "cannotGetSocketServer": "Couldn't get socket server. Please refresh page and try again"
   },
   "toolBar": {
     "selection": "Selection",

--- a/src/tests/collab.test.tsx
+++ b/src/tests/collab.test.tsx
@@ -18,9 +18,9 @@ Object.defineProperty(window, "crypto", {
 jest.mock("../excalidraw-app/data/index.ts", () => ({
   __esmodule: true,
   ...jest.requireActual("../excalidraw-app/data/index.ts"),
-  getSocketServer: jest.fn(
-    () => /* doesn't really matter */ "http://localhost:3002",
-  ),
+  getCollabServer: jest.fn(() => ({
+    url: /* doesn't really matter */ "http://localhost:3002",
+  })),
 }));
 
 jest.mock("../excalidraw-app/data/firebase.ts", () => {

--- a/src/tests/collab.test.tsx
+++ b/src/tests/collab.test.tsx
@@ -15,6 +15,14 @@ Object.defineProperty(window, "crypto", {
   },
 });
 
+jest.mock("../excalidraw-app/data/index.ts", () => ({
+  __esmodule: true,
+  ...jest.requireActual("../excalidraw-app/data/index.ts"),
+  getSocketServer: jest.fn(
+    () => /* doesn't really matter */ "http://localhost:3002",
+  ),
+}));
+
 jest.mock("../excalidraw-app/data/firebase.ts", () => {
   const loadFromFirebase = async () => null;
   const saveToFirebase = () => {};


### PR DESCRIPTION
- Switched to a new collab server
- Connecting to a collab server is done in two steps now:
	1. get collab server connection details by querying `portal.excalidraw.com`
	2. connect to the server using the data from step (1) 
	
	This allows us to switch servers etc. more-or-less immediately without having to push things and waiting for all clients to update to latest ServiceWorker (which in many cases takes months or even more).
- disabled `polling` socketIO transport (all the browser we support have support for WS)
- removed preconnecting to our WS server. The optim is not worth the downsides (increasing load on our servers). If needed, we can optimize differently.