### PR TITLE
fix: don't crash on drop highlighted text onto canvas

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -4932,7 +4932,7 @@ class App extends React.Component<AppProps, AppState> {
 
   private handleAppOnDrop = async (event: React.DragEvent<HTMLDivElement>) => {
     try {
-      const file = event.dataTransfer.files[0];
+      const file = event.dataTransfer.files.item(0);
 
       if (isSupportedImageFile(file)) {
         // first attempt to decode scene from the image if it's embedded
@@ -5008,7 +5008,7 @@ class App extends React.Component<AppProps, AppState> {
       return;
     }
 
-    const file = event.dataTransfer?.files[0];
+    const file = event.dataTransfer?.files.item(0);
     if (
       file?.type === MIME_TYPES.excalidrawlib ||
       file?.name?.endsWith(".excalidrawlib")
@@ -5024,7 +5024,7 @@ class App extends React.Component<AppProps, AppState> {
           this.setState({ isLoading: false, errorMessage: error.message }),
         );
       // default: assume an Excalidraw file regardless of extension/MimeType
-    } else {
+    } else if (file) {
       this.setState({ isLoading: true });
       if (nativeFileSystemSupported) {
         try {

--- a/src/tests/helpers/api.ts
+++ b/src/tests/helpers/api.ts
@@ -213,9 +213,12 @@ export class API {
       }
     });
 
+    const files = [blob] as File[] & { item: (index: number) => File };
+    files.item = (index: number) => files[index];
+
     Object.defineProperty(fileDropEvent, "dataTransfer", {
       value: {
-        files: [blob],
+        files,
         getData: (type: string) => {
           if (type === blob.type) {
             return text;


### PR DESCRIPTION
Closes #3971 

Adds a missing check for if a file is present on drop. This is required manually due a typescript `as any` cast further inside the code block. Also manually adds a couple of type annotations to make clear that file may not be provided.

The behaviour is now to take no action, if a file is not found (rather than showing an error modal).

![excalidraw-no-crash-on-drop-text](https://user-images.githubusercontent.com/12255914/157292710-313e6dac-3945-429d-9886-4575dd623702.gif)
