### PR TITLE
feat: Font color picker for sticky notes (only)

### DIFF
--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -8,6 +8,7 @@ export {
 export { actionSelectAll } from "./actionSelectAll";
 export { actionDuplicateSelection } from "./actionDuplicateSelection";
 export {
+  actionChangeFontColor,
   actionChangeStrokeColor,
   actionChangeBackgroundColor,
   actionChangeStrokeWidth,

--- a/src/actions/types.ts
+++ b/src/actions/types.ts
@@ -49,6 +49,7 @@ export type ActionName =
   | "gridMode"
   | "zenMode"
   | "stats"
+  | "changeFontColor"
   | "changeStrokeColor"
   | "changeBackgroundColor"
   | "changeFillStyle"

--- a/src/components/Actions.tsx
+++ b/src/components/Actions.tsx
@@ -68,8 +68,15 @@ export const SelectedShapeActions = ({
     }
   }
 
+  const hasOnlyContainersWithBoundText =
+    targetElements.length > 1 &&
+    targetElements.every(
+      (element) => hasBoundTextElement(element) || isBoundToContainer(element),
+    );
+
   return (
     <div className="panelColumn">
+      {hasOnlyContainersWithBoundText && renderAction("changeFontColor")}
       {((hasStrokeColor(elementType) &&
         elementType !== "image" &&
         commonSelectedType !== "image") ||

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1840,7 +1840,11 @@ class App extends React.Component<AppProps, AppState> {
         event.preventDefault();
       }
 
-      if (event.key === KEYS.G || event.key === KEYS.S) {
+      if (
+        event.key === KEYS.G ||
+        event.key === KEYS.S ||
+        event.key === KEYS.C
+      ) {
         const selectedElements = getSelectedElements(
           this.scene.getElements(),
           this.state,
@@ -1861,6 +1865,9 @@ class App extends React.Component<AppProps, AppState> {
         }
         if (event.key === KEYS.S) {
           this.setState({ openPopup: "strokeColorPicker" });
+        }
+        if (event.key === KEYS.C) {
+          this.setState({ openPopup: "fontColorPicker" });
         }
       }
     },

--- a/src/components/ColorPicker.scss
+++ b/src/components/ColorPicker.scss
@@ -255,7 +255,8 @@
     color: #aaa;
   }
 
-  .color-picker-type-elementStroke .color-picker-keybinding {
+  .color-picker-type-elementStroke .color-picker-keybinding,
+  .color-picker-type-elementFontColor .color-picker-keybinding {
     color: #d4d4d4;
   }
 

--- a/src/components/ColorPicker.tsx
+++ b/src/components/ColorPicker.tsx
@@ -101,19 +101,24 @@ const Picker = ({
   onClose: () => void;
   label: string;
   showInput: boolean;
-  type: "canvasBackground" | "elementBackground" | "elementStroke";
+  type:
+    | "canvasBackground"
+    | "elementBackground"
+    | "elementStroke"
+    | "elementFontColor";
   elements: readonly ExcalidrawElement[];
 }) => {
   const firstItem = React.useRef<HTMLButtonElement>();
   const activeItem = React.useRef<HTMLButtonElement>();
   const gallery = React.useRef<HTMLDivElement>();
   const colorInput = React.useRef<HTMLInputElement>();
+  const colorType = type === "elementFontColor" ? "elementStroke" : type;
 
   const [customColors] = React.useState(() => {
-    if (type === "canvasBackground") {
+    if (colorType === "canvasBackground") {
       return [];
     }
-    return getCustomColors(elements, type);
+    return getCustomColors(elements, colorType);
   });
 
   React.useEffect(() => {
@@ -356,7 +361,11 @@ export const ColorPicker = ({
   elements,
   appState,
 }: {
-  type: "canvasBackground" | "elementBackground" | "elementStroke";
+  type:
+    | "canvasBackground"
+    | "elementBackground"
+    | "elementStroke"
+    | "elementFontColor";
   color: string | null;
   onChange: (color: string) => void;
   label: string;
@@ -366,7 +375,7 @@ export const ColorPicker = ({
   appState: AppState;
 }) => {
   const pickerButton = React.useRef<HTMLButtonElement>(null);
-
+  const colorType = type === "elementFontColor" ? "elementStroke" : type;
   return (
     <div>
       <div className="color-picker-control-container">
@@ -393,7 +402,7 @@ export const ColorPicker = ({
             }
           >
             <Picker
-              colors={colors[type]}
+              colors={colors[colorType]}
               color={color || null}
               onChange={(changedColor) => {
                 onChange(changedColor);

--- a/src/keys.ts
+++ b/src/keys.ts
@@ -47,6 +47,7 @@ export const KEYS = {
   COMMA: ",",
 
   A: "a",
+  C: "c",
   D: "d",
   E: "e",
   G: "g",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -16,6 +16,7 @@
     "delete": "Delete",
     "copyStyles": "Copy styles",
     "pasteStyles": "Paste styles",
+    "fontColor": "Font color",
     "stroke": "Stroke",
     "background": "Background",
     "fill": "Fill",

--- a/src/scene/selection.ts
+++ b/src/scene/selection.ts
@@ -4,7 +4,7 @@ import {
 } from "../element/types";
 import { getElementAbsoluteCoords, getElementBounds } from "../element";
 import { AppState } from "../types";
-import { isBoundToContainer } from "../element/typeChecks";
+import { isBoundToContainer, isTextElement } from "../element/typeChecks";
 
 export const getElementsWithinSelection = (
   elements: readonly NonDeletedExcalidrawElement[],
@@ -41,12 +41,15 @@ export const getCommonAttributeOfSelectedElements = <T>(
   elements: readonly NonDeletedExcalidrawElement[],
   appState: AppState,
   getAttribute: (element: ExcalidrawElement) => T,
+  onlyBoundTextElements: boolean = false,
 ): T | null => {
   const attributes = Array.from(
     new Set(
-      getSelectedElements(elements, appState).map((element) =>
-        getAttribute(element),
-      ),
+      getSelectedElements(elements, appState, onlyBoundTextElements)
+        .filter((element) =>
+          onlyBoundTextElements ? isTextElement(element) : true,
+        )
+        .map((element) => getAttribute(element)),
     ),
   );
   return attributes.length === 1 ? attributes[0] : null;

--- a/src/types.ts
+++ b/src/types.ts
@@ -113,6 +113,7 @@ export type AppState = {
     | "canvasColorPicker"
     | "backgroundColorPicker"
     | "strokeColorPicker"
+    | "fontColorPicker"
     | null;
   lastPointerDownWith: PointerType;
   selectedElementIds: { [id: string]: boolean };


### PR DESCRIPTION
I regularly create sticky notes that have a different border color and font color.  Achieving this in Excalidraw is a bit difficult, especially working on a mobile device.

I made multiple attempts at fixing the mobile element properties panel to allow editing the font color of a sticky note. In the end, I gave up. While my solution (#4897) worked on a desktop, on a mobile/iPad it did not. I've burnt many hours trying to debug the issue... but in the end, I gave up.

Instead, my current proposal is to add a Font color setting to the properties panel, that is only displayed when one or more sticky notes are selected, and that simply sets the stroke color of the TextElement. When a mix of elements are selected, i.e. sticky notes together with other elements, then only a common stroke color is shown (as today). 

https://user-images.githubusercontent.com/14358394/158252998-f0883c4c-12ec-4b65-a13d-81e119ea0d2b.mp4

