### PR TITLE
fix: adding check for link length to prevent early return 

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -3415,7 +3415,8 @@ class App extends React.Component<AppProps, AppState> {
               this.state,
               [pointerDownState.origin.x, pointerDownState.origin.y],
               this.deviceType.isMobile,
-            )
+            ) &&
+            pointerDownState.hit.element.link!.length > 0
           ) {
             return false;
           }

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -2409,13 +2409,13 @@ class App extends React.Component<AppProps, AppState> {
       }
       return (
         element.link &&
+        index <= hitElementIndex &&
         isPointHittingLinkIcon(
           element,
           this.state,
           [scenePointer.x, scenePointer.y],
           this.deviceType.isMobile,
-        ) &&
-        index <= hitElementIndex
+        )
       );
     });
   };

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -2443,7 +2443,7 @@ class App extends React.Component<AppProps, AppState> {
       this.state,
     );
     const lastPointerDownHittingLinkIcon = isPointHittingLinkIcon(
-      this.hitLinkElement!,
+      this.hitLinkElement,
       this.state,
       [lastPointerDownCoords.x, lastPointerDownCoords.y],
       this.deviceType.isMobile,
@@ -2453,7 +2453,7 @@ class App extends React.Component<AppProps, AppState> {
       this.state,
     );
     const lastPointerUpHittingLinkIcon = isPointHittingLinkIcon(
-      this.hitLinkElement!,
+      this.hitLinkElement,
       this.state,
       [lastPointerUpCoords.x, lastPointerUpCoords.y],
       this.deviceType.isMobile,
@@ -3415,8 +3415,7 @@ class App extends React.Component<AppProps, AppState> {
               this.state,
               [pointerDownState.origin.x, pointerDownState.origin.y],
               this.deviceType.isMobile,
-            ) &&
-            pointerDownState.hit.element.link!.length > 0
+            )
           ) {
             return false;
           }

--- a/src/element/Hyperlink.tsx
+++ b/src/element/Hyperlink.tsx
@@ -337,6 +337,9 @@ export const isPointHittingLinkIcon = (
   [x, y]: Point,
   isMobile: boolean,
 ) => {
+  if (!element.link || appState.selectedElementIds[element.id]) {
+    return false;
+  }
   const threshold = 4 / appState.zoom.value;
   if (
     !isMobile &&


### PR DESCRIPTION
this is for _top-right corner hitbox issue #4966_

I've added a check to ensure there's actually a link for the element to do the early return. From what I can tell there's no need to return early if there's no link to actually go to. 

I'm checking for `length > 0` instead of just checking `not equals null ` because as soon as you open the hyperlink box, `link` is not null (even after closing hyperlink box).

_edge case this fix doesn't handle_ – if you open up the hyperlink box and start typing in a link, we don't satisfy this check anymore, so you'd not be able to drag the element from the top right corner with an open hyperlink editor with some contents for the link