### PR TITLE
fix: using stale state when switching tools

### DIFF
--- a/src/components/Actions.tsx
+++ b/src/components/Actions.tsx
@@ -219,13 +219,17 @@ export const ShapesSwitcher = ({
           penMode: true,
         });
       }
+      const nextActiveTool = { ...activeTool, type: activeToolType };
       setAppState({
-        activeTool: { ...activeTool, type: activeToolType },
+        activeTool: nextActiveTool,
         multiElement: null,
         selectedElementIds: {},
       });
-      setCursorForShape(canvas, { ...appState, activeTool });
-      if (activeTool.type === "image") {
+      setCursorForShape(canvas, {
+        ...appState,
+        activeTool: nextActiveTool,
+      });
+      if (activeToolType === "image") {
         onImageAction({ pointerType });
       }
     },


### PR DESCRIPTION
we were passing stale state when switching shapes, which resulted in image tool not working