### PR TITLE
feat: hide penMode button on reload if not enabled

### DIFF
--- a/src/data/restore.ts
+++ b/src/data/restore.ts
@@ -252,6 +252,10 @@ export const restoreAppState = (
   }
   return {
     ...nextAppState,
+    // reset on fresh restore so as to hide the UI button if penMode not active
+    penDetected:
+      localAppState?.penDetected ??
+      (appState.penMode ? appState.penDetected ?? false : false),
     activeTool: {
       lastActiveToolBeforeEraser: null,
       locked: nextAppState.activeTool.locked ?? false,


### PR DESCRIPTION
Resetting `penDetected` on reload if penMode isn't active. Currently, the button is never hidden if you ever enter penMode.

If `localAppState` passed to restore, we don't reset. This accounts for a case where you restore the appState during the same session for some reason.