### PR TITLE
feat: create and expose serializeLibraryAsJSON

### DIFF
--- a/src/data/json.ts
+++ b/src/data/json.ts
@@ -131,7 +131,7 @@ export const serializeLibraryAsJSON = (libraryItems: LibraryItems) => {
     libraryItems,
   };
   return JSON.stringify(data, null, 2);
-}
+};
 
 export const saveLibraryAsJSON = async (libraryItems: LibraryItems) => {
   const serialized = serializeLibraryAsJSON(libraryItems);

--- a/src/data/json.ts
+++ b/src/data/json.ts
@@ -123,14 +123,18 @@ export const isValidLibrary = (json: any) => {
   );
 };
 
-export const saveLibraryAsJSON = async (libraryItems: LibraryItems) => {
+export const serializeLibraryAsJSON = (libraryItems: LibraryItems) => {
   const data: ExportedLibraryData = {
     type: EXPORT_DATA_TYPES.excalidrawLibrary,
     version: VERSIONS.excalidrawLibrary,
     source: EXPORT_SOURCE,
     libraryItems,
   };
-  const serialized = JSON.stringify(data, null, 2);
+  return JSON.stringify(data, null, 2);
+}
+
+export const saveLibraryAsJSON = async (libraryItems: LibraryItems) => {
+  const serialized = serializeLibraryAsJSON(libraryItems);
   await fileSave(
     new Blob([serialized], {
       type: MIME_TYPES.excalidrawlib,

--- a/src/packages/excalidraw/CHANGELOG.md
+++ b/src/packages/excalidraw/CHANGELOG.md
@@ -18,6 +18,7 @@ Please add the latest change on the top under the correct section.
 #### Refactor
 
 - Rename `appState.elementLocked` to `appState.activeTool.locked` [#4983](https://github.com/excalidraw/excalidraw/pull/4983).
+- Expose [`serializeLibraryAsJSON`](https://github.com/excalidraw/excalidraw/blob/master/src/packages/excalidraw/README.md#serializeLibraryAsJSON) helper that we use when saving Excalidraw Library to a file.
 
 ##### BREAKING CHANGE
 

--- a/src/packages/excalidraw/README.md
+++ b/src/packages/excalidraw/README.md
@@ -900,17 +900,6 @@ serializeAsJSON({
 
 Takes the scene elements and state and returns a JSON string. Deleted `elements`as well as most properties from `AppState` are removed from the resulting JSON. (see [`serializeAsJSON()`](https://github.com/excalidraw/excalidraw/blob/master/src/data/json.ts#L16) source for details).
 
-#### `serializeLibraryAsJSON`
-
-**_Signature_**
-
-<pre>
-serializeLibraryAsJSON({
-  libraryItems: <a href="https://github.com/excalidraw/excalidraw/blob/2fa69ddc329c327458d50ce6efde65d4e247b175/src/types.ts#L191">LibraryItems[]</a>,
-</pre>
-
-Takes the library items and returns a JSON string.
-
 #### `getSceneVersion`
 
 **How to use**

--- a/src/packages/excalidraw/README.md
+++ b/src/packages/excalidraw/README.md
@@ -900,6 +900,17 @@ serializeAsJSON({
 
 Takes the scene elements and state and returns a JSON string. Deleted `elements`as well as most properties from `AppState` are removed from the resulting JSON. (see [`serializeAsJSON()`](https://github.com/excalidraw/excalidraw/blob/master/src/data/json.ts#L16) source for details).
 
+#### `serializeLibraryAsJSON`
+
+**_Signature_**
+
+<pre>
+serializeLibraryAsJSON({
+  libraryItems: <a href="https://github.com/excalidraw/excalidraw/blob/2fa69ddc329c327458d50ce6efde65d4e247b175/src/types.ts#L191">LibraryItems[]</a>,
+</pre>
+
+Takes the library items and returns a JSON string.
+
 #### `getSceneVersion`
 
 **How to use**

--- a/src/packages/excalidraw/README_NEXT.md
+++ b/src/packages/excalidraw/README_NEXT.md
@@ -906,6 +906,17 @@ serializeAsJSON({
 
 Takes the scene elements and state and returns a JSON string. Deleted `elements`as well as most properties from `AppState` are removed from the resulting JSON. (see [`serializeAsJSON()`](https://github.com/excalidraw/excalidraw/blob/master/src/data/json.ts#L16) source for details).
 
+#### `serializeLibraryAsJSON`
+
+**_Signature_**
+
+<pre>
+serializeLibraryAsJSON({
+  libraryItems: <a href="https://github.com/excalidraw/excalidraw/blob/2fa69ddc329c327458d50ce6efde65d4e247b175/src/types.ts#L191">LibraryItems[]</a>,
+</pre>
+
+Takes the library items and returns a JSON string.
+
 #### `getSceneVersion`
 
 **How to use**

--- a/src/packages/excalidraw/README_NEXT.md
+++ b/src/packages/excalidraw/README_NEXT.md
@@ -912,7 +912,7 @@ Takes the scene elements and state and returns a JSON string. Deleted `elements`
 
 <pre>
 serializeLibraryAsJSON({
-  libraryItems: <a href="https://github.com/excalidraw/excalidraw/blob/2fa69ddc329c327458d50ce6efde65d4e247b175/src/types.ts#L191">LibraryItems[]</a>,
+  libraryItems: <a href="https://github.com/excalidraw/excalidraw/blob/master/src/types.ts#L191">LibraryItems[]</a>,
 </pre>
 
 Takes the library items and returns a JSON string.

--- a/src/packages/utils.ts
+++ b/src/packages/utils.ts
@@ -139,6 +139,6 @@ export const exportToSvg = async ({
   );
 };
 
-export { serializeAsJSON } from "../data/json";
+export { serializeAsJSON, serializeLibraryAsJSON } from "../data/json";
 export { loadFromBlob, loadLibraryFromBlob } from "../data/blob";
 export { getFreeDrawSvgPath } from "../renderer/renderElement";


### PR DESCRIPTION
This PR add an `serializeLibraryAsJSON` helper.

Example usecase in the VSCode extension: https://github.com/pomdtr/vscode-excalidraw-editor/issues/16
