### PR TITLE
fix: export serializeLibraryAsJSON in the excalidraw package

### DIFF
--- a/src/packages/excalidraw/index.tsx
+++ b/src/packages/excalidraw/index.tsx
@@ -183,6 +183,7 @@ export {
   exportToBlob,
   exportToSvg,
   serializeAsJSON,
+  serializeLibraryAsJSON,
   loadLibraryFromBlob,
   loadFromBlob,
   getFreeDrawSvgPath,


### PR DESCRIPTION
this is a followup to #5009 