### PR TITLE
fix: update `storage.rules`

### DIFF
--- a/firebase-project/storage.rules
+++ b/firebase-project/storage.rules
@@ -1,12 +1,11 @@
 rules_version = '2';
 service firebase.storage {
   match /b/{bucket}/o {
-    match /{migrations} {
-      match /{scenes}/{scene} {
-      	allow get, write: if true;
-        // redundant, but let's be explicit'
-        allow list: if false;
-      }
+    match /{files}/rooms/{room}/{file} {
+    	allow get, write: if true;
+    }
+    match /{files}/shareLinks/{shareLink}/{file} {
+    	allow get, write: if true;
     }
   }
 }


### PR DESCRIPTION
Updates our Firebase storage rules. This is just for docs for self-hosting purposes. The Storage rules aren't deployed from source, and our actual rules differ slightly. For example, this PR removes the `match /{migrations}` rule as it's excalidraw.com/E+ specific and doesn't serve any purpose for host apps.