### PR TITLE
feat: embed scene support for png export in npm package

### DIFF
--- a/src/packages/excalidraw/CHANGELOG.md
+++ b/src/packages/excalidraw/CHANGELOG.md
@@ -18,7 +18,7 @@ Please add the latest change on the top under the correct section.
 #### Features
 
 - Exported [`restoreLibraryItems`](https://github.com/excalidraw/excalidraw/blob/master/src/packages/excalidraw/README.md#restoreLibraryItems) API [#4995](https://github.com/excalidraw/excalidraw/pull/4995).
-- The `exportToBlob` utility now supports the `exportEmbedScene` options when generating a png image
+- The `exportToBlob` utility now supports the `exportEmbedScene` option when generating a png image [#5047](https://github.com/excalidraw/excalidraw/pull/5047).
 
 #### Fixes
 

--- a/src/packages/excalidraw/CHANGELOG.md
+++ b/src/packages/excalidraw/CHANGELOG.md
@@ -17,8 +17,8 @@ Please add the latest change on the top under the correct section.
 
 #### Features
 
-- Exported [`restoreLibraryItems`](https://github.com/excalidraw/excalidraw/blob/master/src/packages/excalidraw/README.md#restoreLibraryItems) API [#4995](https://github.com/excalidraw/excalidraw/pull/4995).
 - The `exportToBlob` utility now supports the `exportEmbedScene` option when generating a png image [#5047](https://github.com/excalidraw/excalidraw/pull/5047).
+- Exported [`restoreLibraryItems`](https://github.com/excalidraw/excalidraw/blob/master/src/packages/excalidraw/README.md#restoreLibraryItems) API [#4995](https://github.com/excalidraw/excalidraw/pull/4995).
 
 #### Fixes
 

--- a/src/packages/excalidraw/CHANGELOG.md
+++ b/src/packages/excalidraw/CHANGELOG.md
@@ -17,7 +17,8 @@ Please add the latest change on the top under the correct section.
 
 #### Features
 
-- Exported [`restoreLibraryItems`](https://github.com/excalidraw/excalidraw/blob/master/src/packages/excalidraw/README.md#restoreLibraryItems) API useful when dealing with libraries [#4995](https://github.com/excalidraw/excalidraw/pull/4995).
+- Exported [`restoreLibraryItems`](https://github.com/excalidraw/excalidraw/blob/master/src/packages/excalidraw/README.md#restoreLibraryItems) API [#4995](https://github.com/excalidraw/excalidraw/pull/4995).
+- The `exportToBlob` utility now supports the `exportEmbedScene` options when generating a png image
 
 #### Fixes
 

--- a/src/packages/excalidraw/README_NEXT.md
+++ b/src/packages/excalidraw/README_NEXT.md
@@ -907,7 +907,7 @@ This function returns a promise which resolves to svg of the exported drawing.
 | exportBackground | boolean | true | Indicates whether background should be exported |
 | viewBackgroundColor | string | #fff | The default background color |
 | exportWithDarkMode | boolean | false | Indicates whether to export with dark mode |
-| exportEmbedScene | boolean | false | Indicates whether scene data should be embedded in svg. This will increase the svg size. |
+| exportEmbedScene | boolean | false | Indicates whether scene data should be embedded in svg/png. This will increase the image size. |
 
 ### Extra API's
 

--- a/src/packages/excalidraw/example/App.js
+++ b/src/packages/excalidraw/example/App.js
@@ -51,6 +51,7 @@ export default function App() {
   const [blobUrl, setBlobUrl] = useState(null);
   const [canvasUrl, setCanvasUrl] = useState(null);
   const [exportWithDarkMode, setExportWithDarkMode] = useState(false);
+  const [exportEmbedScene, setExportEmbedScene] = useState(false);
   const [theme, setTheme] = useState("light");
 
   const initialStatePromiseRef = useRef({ promise: null });
@@ -245,6 +246,14 @@ export default function App() {
             />
             Export with dark mode
           </label>
+          <label className="export-wrapper__checkbox">
+            <input
+              type="checkbox"
+              checked={exportEmbedScene}
+              onChange={() => setExportEmbedScene(!exportEmbedScene)}
+            />
+            Export with embed scene
+          </label>
           <button
             onClick={async () => {
               const svg = await exportToSvg({
@@ -252,6 +261,7 @@ export default function App() {
                 appState: {
                   ...initialData.appState,
                   exportWithDarkMode,
+                  exportEmbedScene,
                   width: 300,
                   height: 100,
                 },
@@ -272,6 +282,7 @@ export default function App() {
                 mimeType: "image/png",
                 appState: {
                   ...initialData.appState,
+                  exportEmbedScene,
                   exportWithDarkMode,
                 },
                 files: excalidrawRef.current.getFiles(),

--- a/src/packages/utils.ts
+++ b/src/packages/utils.ts
@@ -107,29 +107,30 @@ export const exportToBlob = async (
 
   quality = quality ? quality : /image\/jpe?g/.test(mimeType) ? 0.92 : 0.8;
 
-  let blob: Blob | null = await new Promise((resolve) => {
+  return new Promise((resolve) => {
     canvas.toBlob(
-      (blob: Blob | null) => {
+      async (blob: Blob | null) => {
+        if (
+          blob &&
+          mimeType === MIME_TYPES.png &&
+          opts.appState?.exportEmbedScene
+        ) {
+          blob = await encodePngMetadata({
+            blob,
+            metadata: serializeAsJSON(
+              opts.elements,
+              opts.appState,
+              opts.files || {},
+              "local",
+            ),
+          });
+        }
         resolve(blob);
       },
       mimeType,
       quality,
     );
   });
-
-  if (blob && mimeType === MIME_TYPES.png && opts.appState?.exportEmbedScene) {
-    blob = await encodePngMetadata({
-      blob,
-      metadata: serializeAsJSON(
-        opts.elements,
-        opts.appState,
-        opts.files || {},
-        "local",
-      ),
-    });
-  }
-
-  return blob;
 };
 
 export const exportToSvg = async ({


### PR DESCRIPTION
This will be helpful to allow users to edit png files directly in the vscode extension (https://github.com/excalidraw/excalidraw-vscode/issues/10)