### PR TITLE
fix: SVG metadata extraction regex on multiline elements

### DIFF
--- a/src/data/image.ts
+++ b/src/data/image.ts
@@ -105,7 +105,9 @@ export const encodeSvgMetadata = async ({ text }: { text: string }) => {
 
 export const decodeSvgMetadata = async ({ svg }: { svg: string }) => {
   if (svg.includes(`payload-type:${MIME_TYPES.excalidraw}`)) {
-    const match = svg.match(/<!-- payload-start -->\s*(.+?)\s*<!-- payload-end -->/m);
+    const match = svg.match(
+      /<!-- payload-start -->\s*(.+?)\s*<!-- payload-end -->/,
+    );
     if (!match) {
       throw new Error("INVALID");
     }

--- a/src/data/image.ts
+++ b/src/data/image.ts
@@ -105,7 +105,7 @@ export const encodeSvgMetadata = async ({ text }: { text: string }) => {
 
 export const decodeSvgMetadata = async ({ svg }: { svg: string }) => {
   if (svg.includes(`payload-type:${MIME_TYPES.excalidraw}`)) {
-    const match = svg.match(/<!-- payload-start -->(.+?)<!-- payload-end -->/);
+    const match = svg.match(/<!-- payload-start -->\s*(.+?)\s*<!-- payload-end -->/m);
     if (!match) {
       throw new Error("INVALID");
     }


### PR DESCRIPTION
Example file triggering an error: https://gist.github.com/pomdtr/53af6d4170a8682b7f944e32c8ca499b which can be reproduced when prettifying the SVG file