### PR TITLE
fix: don't merge libraryItems on updateScene

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -77,7 +77,7 @@ import {
 } from "../constants";
 import { loadFromBlob } from "../data";
 import Library from "../data/library";
-import { restore, restoreElements } from "../data/restore";
+import { restore, restoreElements, restoreLibraryItems } from "../data/restore";
 import {
   dragNewElement,
   dragSelectedElements,
@@ -1692,7 +1692,20 @@ class App extends React.Component<AppProps, AppState> {
       }
 
       if (sceneData.libraryItems) {
-        this.library.importLibrary(sceneData.libraryItems, "unpublished");
+        this.library.saveLibrary(
+          new Promise<LibraryItems>(async (resolve, reject) => {
+            try {
+              resolve(
+                restoreLibraryItems(
+                  await sceneData.libraryItems,
+                  "unpublished",
+                ),
+              );
+            } catch {
+              reject(new Error(t("errors.importLibraryError")));
+            }
+          }),
+        );
       }
     },
   );


### PR DESCRIPTION
In the vscode extension, the updateScene helper is used to sync deleted items from the library between webviews.

The behavior since of the `updateScene` method since cd942c3 break this, since the deleted items from the library will still be present after the merge.
The `updateScene` method does not attempt to merge the appState or the elements, so I feel like this is not the expected behavior.