### PR TITLE
fix: setting webpack public path

### DIFF
--- a/src/packages/excalidraw/entry.js
+++ b/src/packages/excalidraw/entry.js
@@ -1,3 +1,5 @@
+import "./publicPath";
+
 import "../../../public/fonts.css";
 
 export * from "./index";

--- a/src/packages/excalidraw/index.tsx
+++ b/src/packages/excalidraw/index.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, forwardRef } from "react";
-import "./publicPath";
 
 import { InitializeApp } from "../../components/InitializeApp";
 import App from "../../components/App";


### PR DESCRIPTION
fixes https://github.com/excalidraw/excalidraw/issues/5080
check [preview](https://excalidraw-package-example-git-aakansha-fix-webpack-excalidraw.vercel.app/)