### PR TITLE
fix: toolIcon height not using rem

### DIFF
--- a/src/components/ToolIcon.scss
+++ b/src/components/ToolIcon.scss
@@ -155,7 +155,7 @@
       }
 
       width: 2rem;
-      height: 2em;
+      height: 2rem;
     }
   }
 


### PR DESCRIPTION
fixes vscode extension floating buttons not being round