### PR TITLE
feat: expose debounce util in the excalidraw package

### DIFF
--- a/src/packages/excalidraw/index.tsx
+++ b/src/packages/excalidraw/index.tsx
@@ -199,6 +199,7 @@ export {
   getFreeDrawSvgPath,
 } from "../../packages/utils";
 export { isLinearElement } from "../../element/typeChecks";
+export { debounce } from "../../utils";
 
 export { FONT_FAMILY, THEME } from "../../constants";
 


### PR DESCRIPTION
I feel like the debounce logic will be useful to a lot of usecases, so it would make sense to expose it.