### PR TITLE
feat: Expose `window.EXCALIDRAW_EXPORT_SOURCE` which host can use to overwrite the source field in exports

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -81,7 +81,6 @@
     <link rel="stylesheet" href="fonts.css" type="text/css" />
     <script>
       window.EXCALIDRAW_ASSET_PATH = "/";
-      window.EXCALIDRAW_EXPORT_SOURCE = window.location.origin;
       // setting this so that libraries installation reuses this window tab.
       window.name = "_excalidraw";
     </script>

--- a/public/index.html
+++ b/public/index.html
@@ -81,6 +81,7 @@
     <link rel="stylesheet" href="fonts.css" type="text/css" />
     <script>
       window.EXCALIDRAW_ASSET_PATH = "/";
+      window.EXCALIDRAW_EXPORT_SOURCE = window.location.origin;
       // setting this so that libraries installation reuses this window tab.
       window.name = "_excalidraw";
     </script>

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -109,7 +109,7 @@ export const EXPORT_DATA_TYPES = {
 } as const;
 
 export const EXPORT_SOURCE =
-  window.EXCALIDRAW_EXPORT_SOURCE || window.location.origin;
+  window.EXCALIDRAW_EXPORT_SOURCE_PATH || window.location.origin;
 
 // time in milliseconds
 export const IMAGE_RENDER_TIMEOUT = 500;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -108,7 +108,8 @@ export const EXPORT_DATA_TYPES = {
   excalidrawLibrary: "excalidrawlib",
 } as const;
 
-export const EXPORT_SOURCE = window.location.origin;
+export const EXPORT_SOURCE =
+  window.EXCALIDRAW_EXPORT_SOURCE || window.location.origin;
 
 // time in milliseconds
 export const IMAGE_RENDER_TIMEOUT = 500;

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -13,6 +13,7 @@ interface Window {
   ClipboardItem: any;
   __EXCALIDRAW_SHA__: string | undefined;
   EXCALIDRAW_ASSET_PATH: string | undefined;
+  EXCALIDRAW_EXPORT_SOURCE: string;
   gtag: Function;
 }
 

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -13,7 +13,7 @@ interface Window {
   ClipboardItem: any;
   __EXCALIDRAW_SHA__: string | undefined;
   EXCALIDRAW_ASSET_PATH: string | undefined;
-  EXCALIDRAW_EXPORT_SOURCE: string;
+  EXCALIDRAW_EXPORT_SOURCE_PATH: string;
   gtag: Function;
 }
 

--- a/src/packages/excalidraw/CHANGELOG.md
+++ b/src/packages/excalidraw/CHANGELOG.md
@@ -17,6 +17,7 @@ Please add the latest change on the top under the correct section.
 
 #### Features
 
+- Expose `window.EXCALIDRAW_EXPORT_SOURCE` which host can use to overwrite the source field in exports
 - The `exportToBlob` utility now supports the `exportEmbedScene` option when generating a png image [#5047](https://github.com/excalidraw/excalidraw/pull/5047).
 - Exported [`restoreLibraryItems`](https://github.com/excalidraw/excalidraw/blob/master/src/packages/excalidraw/README.md#restoreLibraryItems) API [#4995](https://github.com/excalidraw/excalidraw/pull/4995).
 

--- a/src/packages/excalidraw/CHANGELOG.md
+++ b/src/packages/excalidraw/CHANGELOG.md
@@ -17,7 +17,7 @@ Please add the latest change on the top under the correct section.
 
 #### Features
 
-- Expose `window.EXCALIDRAW_EXPORT_SOURCE` which you can use to overwrite the `source` field in exported data [#5095](https://github.com/excalidraw/excalidraw/pull/5095).
+- Expose `window.EXCALIDRAW_EXPORT_SOURCE_PATH` which you can use to overwrite the `source` field in exported data [#5095](https://github.com/excalidraw/excalidraw/pull/5095).
 - The `exportToBlob` utility now supports the `exportEmbedScene` option when generating a png image [#5047](https://github.com/excalidraw/excalidraw/pull/5047).
 - Exported [`restoreLibraryItems`](https://github.com/excalidraw/excalidraw/blob/master/src/packages/excalidraw/README.md#restoreLibraryItems) API [#4995](https://github.com/excalidraw/excalidraw/pull/4995).
 

--- a/src/packages/excalidraw/CHANGELOG.md
+++ b/src/packages/excalidraw/CHANGELOG.md
@@ -17,7 +17,7 @@ Please add the latest change on the top under the correct section.
 
 #### Features
 
-- Expose `window.EXCALIDRAW_EXPORT_SOURCE` which host can use to overwrite the source field in exports
+- Expose `window.EXCALIDRAW_EXPORT_SOURCE` which you can use to overwrite the `source` field in exported data [#5095](https://github.com/excalidraw/excalidraw/pull/5095).
 - The `exportToBlob` utility now supports the `exportEmbedScene` option when generating a png image [#5047](https://github.com/excalidraw/excalidraw/pull/5047).
 - Exported [`restoreLibraryItems`](https://github.com/excalidraw/excalidraw/blob/master/src/packages/excalidraw/README.md#restoreLibraryItems) API [#4995](https://github.com/excalidraw/excalidraw/pull/4995).
 

--- a/src/packages/excalidraw/README_NEXT.md
+++ b/src/packages/excalidraw/README_NEXT.md
@@ -937,7 +937,7 @@ serializeLibraryAsJSON({
 
 Takes the library items and returns a JSON string.
 
-If you want to overwrite the source field in the JSON string, you can set a variable `window.EXCALIDRAW_EXPORT_SOURCE` to the desired value.
+If you want to overwrite the source field in the JSON string, you can set  `window.EXCALIDRAW_EXPORT_SOURCE` to the desired value.
 
 #### `getSceneVersion`
 

--- a/src/packages/excalidraw/README_NEXT.md
+++ b/src/packages/excalidraw/README_NEXT.md
@@ -924,6 +924,8 @@ serializeAsJSON({
 
 Takes the scene elements and state and returns a JSON string. Deleted `elements`as well as most properties from `AppState` are removed from the resulting JSON. (see [`serializeAsJSON()`](https://github.com/excalidraw/excalidraw/blob/master/src/data/json.ts#L16) source for details).
 
+If you want to overwrite the source field in the JSON string, you can set a variable `window.EXCALIDRAW_EXPORT_SOURCE` to the desired value.
+
 #### `serializeLibraryAsJSON`
 
 **_Signature_**

--- a/src/packages/excalidraw/README_NEXT.md
+++ b/src/packages/excalidraw/README_NEXT.md
@@ -924,7 +924,7 @@ serializeAsJSON({
 
 Takes the scene elements and state and returns a JSON string. Deleted `elements`as well as most properties from `AppState` are removed from the resulting JSON. (see [`serializeAsJSON()`](https://github.com/excalidraw/excalidraw/blob/master/src/data/json.ts#L16) source for details).
 
-If you want to overwrite the source field in the JSON string, you can set a variable `window.EXCALIDRAW_EXPORT_SOURCE` to the desired value.
+If you want to overwrite the source field in the JSON string, you can set  `window.EXCALIDRAW_EXPORT_SOURCE` to the desired value.
 
 #### `serializeLibraryAsJSON`
 

--- a/src/packages/excalidraw/README_NEXT.md
+++ b/src/packages/excalidraw/README_NEXT.md
@@ -937,6 +937,8 @@ serializeLibraryAsJSON({
 
 Takes the library items and returns a JSON string.
 
+If you want to overwrite the source field in the JSON string, you can set a variable `window.EXCALIDRAW_EXPORT_SOURCE` to the desired value.
+
 #### `getSceneVersion`
 
 **How to use**

--- a/src/packages/excalidraw/README_NEXT.md
+++ b/src/packages/excalidraw/README_NEXT.md
@@ -924,7 +924,7 @@ serializeAsJSON({
 
 Takes the scene elements and state and returns a JSON string. Deleted `elements`as well as most properties from `AppState` are removed from the resulting JSON. (see [`serializeAsJSON()`](https://github.com/excalidraw/excalidraw/blob/master/src/data/json.ts#L16) source for details).
 
-If you want to overwrite the source field in the JSON string, you can set  `window.EXCALIDRAW_EXPORT_SOURCE` to the desired value.
+If you want to overwrite the source field in the JSON string, you can set `window.EXCALIDRAW_EXPORT_SOURCE_PATH` to the desired value.
 
 #### `serializeLibraryAsJSON`
 
@@ -937,7 +937,7 @@ serializeLibraryAsJSON({
 
 Takes the library items and returns a JSON string.
 
-If you want to overwrite the source field in the JSON string, you can set  `window.EXCALIDRAW_EXPORT_SOURCE` to the desired value.
+If you want to overwrite the source field in the JSON string, you can set `window.EXCALIDRAW_EXPORT_SOURCE_PATH` to the desired value.
 
 #### `getSceneVersion`
 


### PR DESCRIPTION
fix #5085 