### PR TITLE
feat: export exportToClipboard util from package

### DIFF
--- a/src/actions/actionClipboard.tsx
+++ b/src/actions/actionClipboard.tsx
@@ -15,7 +15,9 @@ export const actionCopy = register({
   name: "copy",
   trackEvent: { category: "element" },
   perform: (elements, appState, _, app) => {
-    copyToClipboard(getNonDeletedElements(elements), appState, app.files);
+    const selectedElements = getSelectedElements(elements, appState, true);
+
+    copyToClipboard(selectedElements, appState, app.files);
 
     return {
       commitToHistory: false,

--- a/src/clipboard.ts
+++ b/src/clipboard.ts
@@ -57,19 +57,21 @@ const clipboardContainsElements = (
 export const copyToClipboard = async (
   elements: readonly NonDeletedExcalidrawElement[],
   appState: AppState,
-  files: BinaryFiles,
+  files: BinaryFiles | null,
 ) => {
   // select binded text elements when copying
   const selectedElements = getSelectedElements(elements, appState, true);
   const contents: ElementsClipboard = {
     type: EXPORT_DATA_TYPES.excalidrawClipboard,
     elements: selectedElements,
-    files: selectedElements.reduce((acc, element) => {
-      if (isInitializedImageElement(element) && files[element.fileId]) {
-        acc[element.fileId] = files[element.fileId];
-      }
-      return acc;
-    }, {} as BinaryFiles),
+    files: files
+      ? selectedElements.reduce((acc, element) => {
+          if (isInitializedImageElement(element) && files[element.fileId]) {
+            acc[element.fileId] = files[element.fileId];
+          }
+          return acc;
+        }, {} as BinaryFiles)
+      : undefined,
   };
   const json = JSON.stringify(contents);
   CLIPBOARD = json;

--- a/src/clipboard.ts
+++ b/src/clipboard.ts
@@ -2,7 +2,6 @@ import {
   ExcalidrawElement,
   NonDeletedExcalidrawElement,
 } from "./element/types";
-import { getSelectedElements } from "./scene";
 import { AppState, BinaryFiles } from "./types";
 import { SVG_EXPORT_TAG } from "./scene/export";
 import { tryParseSpreadsheet, Spreadsheet, VALID_SPREADSHEET } from "./charts";
@@ -12,7 +11,7 @@ import { isPromiseLike } from "./utils";
 
 type ElementsClipboard = {
   type: typeof EXPORT_DATA_TYPES.excalidrawClipboard;
-  elements: ExcalidrawElement[];
+  elements: readonly NonDeletedExcalidrawElement[];
   files: BinaryFiles | undefined;
 };
 
@@ -60,12 +59,11 @@ export const copyToClipboard = async (
   files: BinaryFiles | null,
 ) => {
   // select binded text elements when copying
-  const selectedElements = getSelectedElements(elements, appState, true);
   const contents: ElementsClipboard = {
     type: EXPORT_DATA_TYPES.excalidrawClipboard,
-    elements: selectedElements,
+    elements,
     files: files
-      ? selectedElements.reduce((acc, element) => {
+      ? elements.reduce((acc, element) => {
           if (isInitializedImageElement(element) && files[element.fileId]) {
             acc[element.fileId] = files[element.fileId];
           }

--- a/src/packages/excalidraw/CHANGELOG.md
+++ b/src/packages/excalidraw/CHANGELOG.md
@@ -17,6 +17,7 @@ Please add the latest change on the top under the correct section.
 
 #### Features
 
+- Expose util `exportToClipboard`[https://github.com/excalidraw/excalidraw/blob/master/src/packages/excalidraw/README.md#exportToClipboard] which allows to copy the scene contents to clipboard as `svg`, `png` or `text` [#5103](https://github.com/excalidraw/excalidraw/pull/5103).
 - Expose `window.EXCALIDRAW_EXPORT_SOURCE` which you can use to overwrite the `source` field in exported data [#5095](https://github.com/excalidraw/excalidraw/pull/5095).
 - The `exportToBlob` utility now supports the `exportEmbedScene` option when generating a png image [#5047](https://github.com/excalidraw/excalidraw/pull/5047).
 - Exported [`restoreLibraryItems`](https://github.com/excalidraw/excalidraw/blob/master/src/packages/excalidraw/README.md#restoreLibraryItems) API [#4995](https://github.com/excalidraw/excalidraw/pull/4995).

--- a/src/packages/excalidraw/CHANGELOG.md
+++ b/src/packages/excalidraw/CHANGELOG.md
@@ -17,7 +17,7 @@ Please add the latest change on the top under the correct section.
 
 #### Features
 
-- Expose util `exportToClipboard`[https://github.com/excalidraw/excalidraw/blob/master/src/packages/excalidraw/README.md#exportToClipboard] which allows to copy the scene contents to clipboard as `svg`, `png` or `text` [#5103](https://github.com/excalidraw/excalidraw/pull/5103).
+- Expose util `exportToClipboard`[https://github.com/excalidraw/excalidraw/blob/master/src/packages/excalidraw/README.md#exportToClipboard] which allows to copy the scene contents to clipboard as `svg`, `png` or `json` [#5103](https://github.com/excalidraw/excalidraw/pull/5103).
 - Expose `window.EXCALIDRAW_EXPORT_SOURCE` which you can use to overwrite the `source` field in exported data [#5095](https://github.com/excalidraw/excalidraw/pull/5095).
 - The `exportToBlob` utility now supports the `exportEmbedScene` option when generating a png image [#5047](https://github.com/excalidraw/excalidraw/pull/5047).
 - Exported [`restoreLibraryItems`](https://github.com/excalidraw/excalidraw/blob/master/src/packages/excalidraw/README.md#restoreLibraryItems) API [#4995](https://github.com/excalidraw/excalidraw/pull/4995).

--- a/src/packages/excalidraw/README_NEXT.md
+++ b/src/packages/excalidraw/README_NEXT.md
@@ -857,7 +857,7 @@ This function returns the canvas with the exported elements, appState and dimens
 
 <pre>
 exportToBlob(
-  opts: <a href="https://github.com/excalidraw/excalidraw/blob/master/src/packages/utils.ts#L10">ExportOpts</a> & {
+  opts: <a href="https://github.com/excalidraw/excalidraw/blob/master/src/packages/utils.ts#L14">ExportOpts</a> & {
   mimeType?: string,
   quality?: number;
 })
@@ -899,6 +899,34 @@ exportToSvg({
 | files | [BinaryFiles](The [`BinaryFiles`](<[BinaryFiles](https://github.com/excalidraw/excalidraw/blob/master/src/types.ts#L64)>) | undefined | The files added to the scene. |
 
 This function returns a promise which resolves to svg of the exported drawing.
+
+#### `exportToClipboard`
+
+**_Signature_**
+
+<pre>
+exportToClipboard(
+  opts: <a href="https://github.com/excalidraw/excalidraw/blob/master/src/packages/utils.ts#L14">ExportOpts</a> & {
+  mimeType?: string,
+  quality?: number;
+  type: 'png' | 'svg' |'text'
+})
+</pre>
+
+| Name | Type | Default | Description |
+| --- | --- | --- | --- | --- | --- |
+| opts |  |  | This param is same as the params passed to `exportToCanvas`. You can refer to [`exportToCanvas`](#exportToCanvas). |
+| mimeType | string | "image/png" | Indicates the image format, this will be used when exporting as `png`. |
+| quality | number | 0.92 | A value between 0 and 1 indicating the [image quality](https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/toBlob#parameters). Applies only to `image/jpeg`/`image/webp` MIME types. This will be used when exporting as `png`. |
+| type | 'png' | 'svg' | 'text' |  | This determines the format to which the scene data should be exported. |
+
+**How to use**
+
+```js
+import { exportToClipboard } from "@excalidraw/excalidraw-next";
+```
+
+Copies the scene data in the specified format (determined by `type`) to clipboard.
 
 ##### Additional attributes of appState for `export\*` APIs
 

--- a/src/packages/excalidraw/README_NEXT.md
+++ b/src/packages/excalidraw/README_NEXT.md
@@ -909,7 +909,7 @@ exportToClipboard(
   opts: <a href="https://github.com/excalidraw/excalidraw/blob/master/src/packages/utils.ts#L14">ExportOpts</a> & {
   mimeType?: string,
   quality?: number;
-  type: 'png' | 'svg' |'text'
+  type: 'png' | 'svg' |'json'
 })
 </pre>
 
@@ -918,7 +918,7 @@ exportToClipboard(
 | opts |  |  | This param is same as the params passed to `exportToCanvas`. You can refer to [`exportToCanvas`](#exportToCanvas). |
 | mimeType | string | "image/png" | Indicates the image format, this will be used when exporting as `png`. |
 | quality | number | 0.92 | A value between 0 and 1 indicating the [image quality](https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/toBlob#parameters). Applies only to `image/jpeg`/`image/webp` MIME types. This will be used when exporting as `png`. |
-| type | 'png' | 'svg' | 'text' |  | This determines the format to which the scene data should be exported. |
+| type | 'png' | 'svg' | 'json' |  | This determines the format to which the scene data should be exported. |
 
 **How to use**
 

--- a/src/packages/excalidraw/example/App.js
+++ b/src/packages/excalidraw/example/App.js
@@ -150,7 +150,7 @@ export default function App() {
     await exportToClipboard({
       elements: excalidrawRef.current.getSceneElements(),
       appState: excalidrawRef.current.getAppState(),
-      files: excalidrawRef.getFiles(),
+      files: excalidrawRef.current.getFiles(),
       type,
     });
     window.alert(`Copied to clipboard as ${type} sucessfully`);

--- a/src/packages/excalidraw/example/App.js
+++ b/src/packages/excalidraw/example/App.js
@@ -10,8 +10,13 @@ import { MIME_TYPES } from "../../../constants";
 // This is so that we use the bundled excalidraw.development.js file instead
 // of the actual source code
 
-const { exportToCanvas, exportToSvg, exportToBlob, Excalidraw } =
-  window.ExcalidrawLib;
+const {
+  exportToCanvas,
+  exportToSvg,
+  exportToBlob,
+  exportToClipboard,
+  Excalidraw,
+} = window.ExcalidrawLib;
 const resolvablePromise = () => {
   let resolve;
   let reject;
@@ -174,6 +179,20 @@ export default function App() {
             }}
           >
             Update Library
+          </button>
+          <button
+            onClick={async () => {
+              await exportToClipboard({
+                elements: excalidrawRef.current.getSceneElements(),
+                appState: {
+                  ...initialData.appState,
+                  exportWithDarkMode,
+                },
+              });
+              window.alert("Copied");
+            }}
+          >
+            Copy to Clipboard
           </button>
           <label>
             <input

--- a/src/packages/excalidraw/example/App.js
+++ b/src/packages/excalidraw/example/App.js
@@ -150,6 +150,7 @@ export default function App() {
     await exportToClipboard({
       elements: excalidrawRef.current.getSceneElements(),
       appState: excalidrawRef.current.getAppState(),
+      files: excalidrawRef.getFiles(),
       type,
     });
     window.alert(`Copied to clipboard as ${type} sucessfully`);

--- a/src/packages/excalidraw/example/App.js
+++ b/src/packages/excalidraw/example/App.js
@@ -146,6 +146,14 @@ export default function App() {
     }
   }, []);
 
+  const onCopy = async (type) => {
+    await exportToClipboard({
+      elements: excalidrawRef.current.getSceneElements(),
+      appState: excalidrawRef.current.getAppState(),
+      type,
+    });
+    window.alert(`Copied to clipboard as ${type} sucessfully`);
+  };
   return (
     <div className="App">
       <h1> Excalidraw Example</h1>
@@ -180,20 +188,7 @@ export default function App() {
           >
             Update Library
           </button>
-          <button
-            onClick={async () => {
-              await exportToClipboard({
-                elements: excalidrawRef.current.getSceneElements(),
-                appState: {
-                  ...initialData.appState,
-                  exportWithDarkMode,
-                },
-              });
-              window.alert("Copied");
-            }}
-          >
-            Copy to Clipboard
-          </button>
+
           <label>
             <input
               type="checkbox"
@@ -232,6 +227,17 @@ export default function App() {
             />
             Switch to Dark Theme
           </label>
+          <div>
+            <button onClick={onCopy.bind(null, "png")}>
+              Copy to Clipboard as PNG
+            </button>
+            <button onClick={onCopy.bind(null, "svg")}>
+              Copy to Clipboard as SVG
+            </button>
+            <button onClick={onCopy.bind(null, "text")}>
+              Copy to Clipboard as Text
+            </button>
+          </div>
         </div>
         <div className="excalidraw-wrapper">
           <Excalidraw

--- a/src/packages/excalidraw/example/App.js
+++ b/src/packages/excalidraw/example/App.js
@@ -234,8 +234,8 @@ export default function App() {
             <button onClick={onCopy.bind(null, "svg")}>
               Copy to Clipboard as SVG
             </button>
-            <button onClick={onCopy.bind(null, "text")}>
-              Copy to Clipboard as Text
+            <button onClick={onCopy.bind(null, "json")}>
+              Copy to Clipboard as JSON
             </button>
           </div>
         </div>

--- a/src/packages/excalidraw/index.tsx
+++ b/src/packages/excalidraw/index.tsx
@@ -197,6 +197,7 @@ export {
   loadLibraryFromBlob,
   loadFromBlob,
   getFreeDrawSvgPath,
+  exportToClipboard,
 } from "../../packages/utils";
 export { isLinearElement } from "../../element/typeChecks";
 

--- a/src/packages/utils.ts
+++ b/src/packages/utils.ts
@@ -10,6 +10,7 @@ import { restore } from "../data/restore";
 import { MIME_TYPES } from "../constants";
 import { encodePngMetadata } from "../data/image";
 import { serializeAsJSON } from "../data/json";
+import { copyBlobToClipboardAsPng } from "../clipboard";
 
 type ExportOpts = {
   elements: readonly NonDeleted<ExcalidrawElement>[];
@@ -154,6 +155,16 @@ export const exportToSvg = async ({
     },
     files,
   );
+};
+
+export const exportToClipboard = async (
+  opts: ExportOpts & { mimeType?: string; quality?: number },
+) => {
+  const blob = await exportToBlob(opts);
+  if (!blob) {
+    throw new Error("couldn't export to blob");
+  }
+  await copyBlobToClipboardAsPng(blob);
 };
 
 export { serializeAsJSON, serializeLibraryAsJSON } from "../data/json";

--- a/src/packages/utils.ts
+++ b/src/packages/utils.ts
@@ -168,7 +168,7 @@ export const exportToClipboard = async (
   opts: ExportOpts & {
     mimeType?: string;
     quality?: number;
-    type: "png" | "svg" | "text";
+    type: "png" | "svg" | "json";
   },
 ) => {
   if (opts.type === "svg") {
@@ -176,7 +176,7 @@ export const exportToClipboard = async (
     await copyTextToSystemClipboard(svg.outerHTML);
   } else if (opts.type === "png") {
     await copyBlobToClipboardAsPng(exportToBlob(opts));
-  } else if (opts.type === "text") {
+  } else if (opts.type === "json") {
     const appState = {
       offsetTop: 0,
       offsetLeft: 0,

--- a/src/packages/utils.ts
+++ b/src/packages/utils.ts
@@ -82,7 +82,7 @@ export const exportToBlob = async (
     mimeType?: string;
     quality?: number;
   },
-): Promise<Blob | null> => {
+): Promise<Blob> => {
   let { mimeType = MIME_TYPES.png, quality } = opts;
 
   if (mimeType === MIME_TYPES.png && typeof quality === "number") {
@@ -108,9 +108,12 @@ export const exportToBlob = async (
 
   quality = quality ? quality : /image\/jpe?g/.test(mimeType) ? 0.92 : 0.8;
 
-  return new Promise((resolve) => {
+  return new Promise((resolve, reject) => {
     canvas.toBlob(
-      async (blob: Blob | null) => {
+      async (blob) => {
+        if (!blob) {
+          return reject(new Error("couldn't export to blob"));
+        }
         if (
           blob &&
           mimeType === MIME_TYPES.png &&
@@ -160,11 +163,7 @@ export const exportToSvg = async ({
 export const exportToClipboard = async (
   opts: ExportOpts & { mimeType?: string; quality?: number },
 ) => {
-  const blob = await exportToBlob(opts);
-  if (!blob) {
-    throw new Error("couldn't export to blob");
-  }
-  await copyBlobToClipboardAsPng(blob);
+  await copyBlobToClipboardAsPng(exportToBlob(opts));
 };
 
 export { serializeAsJSON, serializeLibraryAsJSON } from "../data/json";


### PR DESCRIPTION
https://user-images.githubusercontent.com/11256141/165487436-7f7a1fc3-9746-4c3f-9f38-a1d63ed82df3.mp4

~Do we want to introduce `type`  (svg, png, text) ?~ done

- [x] update docs
- [x] Added type (`png` | `svg` |`text`) and updated the example