### PR TITLE
fix: Don't save deleted ExcalidrawElements to Firebase

### DIFF
--- a/src/excalidraw-app/data/firebase.ts
+++ b/src/excalidraw-app/data/firebase.ts
@@ -106,7 +106,7 @@ const encryptElements = async (
   key: string,
   elements: readonly ExcalidrawElement[],
 ): Promise<{ ciphertext: ArrayBuffer; iv: Uint8Array }> => {
-  const json = JSON.stringify(elements);
+  const json = JSON.stringify(elements.filter((el) => !el.isDeleted));
   const encoded = new TextEncoder().encode(json);
   const { encryptedBuffer, iv } = await encryptData(key, encoded);
 


### PR DESCRIPTION
**Background:**
Using #2993 in my teaching over the course of a semester, I eventually found contents would no longer save to the cloud.  In the browser console, I observed error messages about the ciphertext being longer than 1MB.  Digging beneath the surface, I discovered that deleted `ExcalidrawElements` were being stored persistently in Firebase.  This even included equations which I had lectured on all the way back at the start of the semester.

**Solution proposed:**
When creating the ciphertext for storage in Firebase, only include non-deleted `ExcalidrawElements` in the ciphertext.  This just requires changing one line of code.