### PR TITLE
fix: remove opacity scroll wheel interaction

### DIFF
--- a/src/actions/actionProperties.tsx
+++ b/src/actions/actionProperties.tsx
@@ -503,20 +503,6 @@ export const actionChangeOpacity = register({
         max="100"
         step="10"
         onChange={(event) => updateData(+event.target.value)}
-        onWheel={(event) => {
-          event.stopPropagation();
-          const target = event.target as HTMLInputElement;
-          const STEP = 10;
-          const MAX = 100;
-          const MIN = 0;
-          const value = +target.value;
-
-          if (event.deltaY < 0 && value < MAX) {
-            updateData(value + STEP);
-          } else if (event.deltaY > 0 && value > MIN) {
-            updateData(value - STEP);
-          }
-        }}
         value={
           getFormValue(
             elements,


### PR DESCRIPTION
So currently the scroll wheel interaction on the opacity slider can cause some really jarring stuff to happen when you need to scroll down the action bar.

You mouse over to the action bar, your mouse happens to be hovering over the opacity bar, you scroll down.. and what happens is the opacity is dropped to zero at the same time as the action panel is scrolled down.

This means you don't notice that the opacity got changed, just that your element is suddenly invisible.

The problem stems from the fact that React just doesn't handle wheel event properly, you cant just `event.stopPropagation()`. It doesn't stop the scroll behaviour from propagating to the parent element.
https://github.com/facebook/react/issues/14856

Rather than pursuing some hacky solution involving binding an event listener to the action panel that prevent's the scroll wheel behaviour only when the slider is active, it probably makes more sense to just remove the scroll wheel interaction.

https://www.loom.com/share/b94639a2f67d46438f64799ec4755551