### PR TITLE
fix: wheel zoom normalization

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -71,7 +71,6 @@ import {
   THEME,
   TOUCH_CTX_MENU_TIMEOUT,
   VERTICAL_ALIGN,
-  ZOOM_STEP,
 } from "../constants";
 import { loadFromBlob } from "../data";
 import Library, { distributeLibraryItemsOnSquareGrid } from "../data/library";
@@ -5659,8 +5658,6 @@ class App extends React.Component<AppProps, AppState> {
       let newZoom = this.state.zoom.value - delta / 100;
       // increase zoom steps the more zoomed-in we are (applies to >100% only)
       newZoom += Math.log10(Math.max(1, this.state.zoom.value)) * -sign;
-      // round to nearest step
-      newZoom = Math.round(newZoom * ZOOM_STEP * 100) / (ZOOM_STEP * 100);
 
       this.setState((state) => ({
         ...getStateForZoom(

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -5641,11 +5641,11 @@ class App extends React.Component<AppProps, AppState> {
     if (event.metaKey || event.ctrlKey) {
       const sign = Math.sign(deltaY);
       const MAX_STEP = 10;
-      let delta = Math.abs(deltaY);
-      if (delta > MAX_STEP) {
-        delta = MAX_STEP;
+      const absDelta = Math.abs(deltaY);
+      let delta = deltaY;
+      if (absDelta > MAX_STEP) {
+        delta = MAX_STEP * sign;
       }
-      delta *= sign;
       if (Object.keys(previousSelectedElementIds).length !== 0) {
         setTimeout(() => {
           this.setState({
@@ -5657,10 +5657,12 @@ class App extends React.Component<AppProps, AppState> {
 
       let newZoom = this.state.zoom.value - delta / 100;
       // increase zoom steps the more zoomed-in we are (applies to >100% only)
-      // do not amplify zoom steps for small deltas (small movements on a trackpad)
-      if (Math.abs(deltaY) > 10) {
-        newZoom += Math.log10(Math.max(1, this.state.zoom.value)) * -sign;
-      }
+      // reduced amplification for small deltas (small movements on a trackpad)
+      const smallDeltaAdjustment = Math.min(1, absDelta / 20);
+      newZoom +=
+        Math.log10(Math.max(1, this.state.zoom.value)) *
+        -sign *
+        smallDeltaAdjustment;
 
       this.setState((state) => ({
         ...getStateForZoom(

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -5657,12 +5657,11 @@ class App extends React.Component<AppProps, AppState> {
 
       let newZoom = this.state.zoom.value - delta / 100;
       // increase zoom steps the more zoomed-in we are (applies to >100% only)
-      // reduced amplification for small deltas (small movements on a trackpad)
-      const smallDeltaAdjustment = Math.min(1, absDelta / 20);
       newZoom +=
         Math.log10(Math.max(1, this.state.zoom.value)) *
         -sign *
-        smallDeltaAdjustment;
+         // reduced amplification for small deltas (small movements on a trackpad)
+         Math.min(1, absDelta / 20)
 
       this.setState((state) => ({
         ...getStateForZoom(

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -5657,7 +5657,10 @@ class App extends React.Component<AppProps, AppState> {
 
       let newZoom = this.state.zoom.value - delta / 100;
       // increase zoom steps the more zoomed-in we are (applies to >100% only)
-      newZoom += Math.log10(Math.max(1, this.state.zoom.value)) * -sign;
+      // do not amplify zoom steps for small deltas (small movements on a trackpad)
+      if (Math.abs(deltaY) > 10) {
+        newZoom += Math.log10(Math.max(1, this.state.zoom.value)) * -sign;
+      }
 
       this.setState((state) => ({
         ...getStateForZoom(

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -5660,8 +5660,8 @@ class App extends React.Component<AppProps, AppState> {
       newZoom +=
         Math.log10(Math.max(1, this.state.zoom.value)) *
         -sign *
-         // reduced amplification for small deltas (small movements on a trackpad)
-         Math.min(1, absDelta / 20)
+        // reduced amplification for small deltas (small movements on a trackpad)
+        Math.min(1, absDelta / 20);
 
       this.setState((state) => ({
         ...getStateForZoom(


### PR DESCRIPTION
Playing around with the wheel zoom normalization to try and get it to behave nicely on trackpads.

It seems the go-to logic for getting some kinds of normalization between different browsers / devices is some hand-me-down facebook code. https://github.com/basilfx/normalize-wheel

I've tried this in firefox and chrome with both a mouse wheel and trackpad, and it seems to behave fine.

The only thing that could be slightly better is the velocity when very zoomed in, currently it moves at bit fast. Would just be a question of tweaking the maths a little..

https://www.loom.com/share/dff08cfe53d04719bcf7da624b4d6149

Fixes #4385

I think the normalize-wheel repo is just a copy of what's on npm with types added? In that case it might be better to use the NPM version and just add the types locally?