### PR TITLE
fix: export to svg 'line' and 'arrow' issue

### DIFF
--- a/src/renderer/renderElement.ts
+++ b/src/renderer/renderElement.ts
@@ -401,7 +401,7 @@ export const generateRoughOptions = (
  * @param element
  * @param generator
  */
-const generateElementShape = (
+export const generateElementShape = (
   element: NonDeletedExcalidrawElement,
   generator: RoughGenerator,
 ) => {
@@ -845,7 +845,6 @@ export const renderElementToSvg = (
   const cx = (x2 - x1) / 2 - (element.x - x1);
   const cy = (y2 - y1) / 2 - (element.y - y1);
   const degree = (180 * element.angle) / Math.PI;
-  const generator = rsvg.generator;
 
   // element to append node to, most of the time svgRoot
   let root = svgRoot;
@@ -867,7 +866,6 @@ export const renderElementToSvg = (
     case "rectangle":
     case "diamond":
     case "ellipse": {
-      generateElementShape(element, generator);
       const node = roughSVGDrawWithPrecision(
         rsvg,
         getShapeForElement(element)!,
@@ -890,7 +888,6 @@ export const renderElementToSvg = (
     }
     case "line":
     case "arrow": {
-      generateElementShape(element, generator);
       const group = svgRoot.ownerDocument!.createElementNS(SVG_NS, "g");
       const opacity = element.opacity / 100;
       group.setAttribute("stroke-linecap", "round");
@@ -924,8 +921,6 @@ export const renderElementToSvg = (
       break;
     }
     case "freedraw": {
-      generateElementShape(element, generator);
-      generateFreeDrawShape(element);
       const opacity = element.opacity / 100;
       const shape = getShapeForElement(element);
       const node = shape

--- a/src/scene/export.ts
+++ b/src/scene/export.ts
@@ -2,6 +2,7 @@ import rough from "roughjs/bin/rough";
 import { NonDeletedExcalidrawElement } from "../element/types";
 import { getCommonBounds } from "../element/bounds";
 import { renderScene, renderSceneToSvg } from "../renderer/renderScene";
+import { generateElementShape } from "../renderer/renderElement";
 import { distance } from "../utils";
 import { AppState, BinaryFiles } from "../types";
 import { DEFAULT_EXPORT_PADDING, SVG_NS, THEME_FILTER } from "../constants";
@@ -102,6 +103,19 @@ export const exportToSvg = async (
       console.error(error);
     }
   }
+
+  const dummySvg = document.createElementNS(SVG_NS, "svg");
+  const rsvg = rough.svg(dummySvg);
+  elements
+    .filter((el) => !el.isDeleted)
+    .forEach((element) => {
+      try {
+        generateElementShape(element, rsvg.generator);
+      } catch (err) {
+        console.error(err);
+      }
+    });
+
   const [minX, minY, width, height] = getCanvasSize(elements, exportPadding);
 
   // initialize SVG root
@@ -155,7 +169,6 @@ export const exportToSvg = async (
     svgRoot.appendChild(rect);
   }
 
-  const rsvg = rough.svg(svgRoot);
   renderSceneToSvg(elements, rsvg, svgRoot, files || {}, {
     offsetX: -minX + exportPadding,
     offsetY: -minY + exportPadding,


### PR DESCRIPTION
Hello, first of all I love your project. Secondly, I think I found a slight issue in the `exportToSvg` function. When this function is used while there is an active Excalidraw component, it works just fine. However, if this function is used without initiating an Excalidraw instance (for example generating an SVG on the server from an 'Excalidraw' file), it does not work for two shapes (`line` and `arrow`). That happens because if we have an Excalidraw instance, the element shapes are already generated. If we don't then the SVG size is first calculated without generating element shapes, and for `line` and `arrow` shapes the bounds are just a poor estimate. So when there is an `arrow` or `line` on the edge of a drawing, they are cut out from the resulting SVG. Here I suggested a fix to this issue. Hoping to get your feedback!

### Bug preview

You can check out the issue here on this awesome tool [https://kroki.io/](url). Just select the 'Excalidraw' option from the select component and add the content below. As you can see the arrow is clearly cut out on the left side.

`{
  "type": "excalidraw",
  "version": 2,
  "source": "http://localhost:3000",
  "elements": [
    {
      "type": "diamond",
      "version": 32,
      "versionNonce": 1361277945,
      "isDeleted": false,
      "id": "0GyZ9vrB_J6rrkRM7sYOE",
      "fillStyle": "hachure",
      "strokeWidth": 1,
      "strokeStyle": "solid",
      "roughness": 1,
      "opacity": 100,
      "angle": 0,
      "x": 989.3334350585938,
      "y": 441,
      "strokeColor": "#000000",
      "backgroundColor": "#fa5252",
      "width": 352.00006103515625,
      "height": 349.3333740234375,
      "seed": 40568313,
      "groupIds": [],
      "strokeSharpness": "sharp",
      "boundElements": [],
      "updated": 1652991405009,
      "link": null,
      "locked": false
    },
    {
      "type": "ellipse",
      "version": 122,
      "versionNonce": 1401635257,
      "isDeleted": false,
      "id": "bCIC3CV-OpV0hdHF7ahWf",
      "fillStyle": "cross-hatch",
      "strokeWidth": 1,
      "strokeStyle": "solid",
      "roughness": 1,
      "opacity": 100,
      "angle": 0,
      "x": 1265.416625215918,
      "y": 487.04859677981204,
      "strokeColor": "#000000",
      "backgroundColor": "#15aabf",
      "width": 285.0434759466907,
      "height": 271.6821107958371,
      "seed": 1305446841,
      "groupIds": [],
      "strokeSharpness": "sharp",
      "boundElements": [],
      "updated": 1652991491793,
      "link": null,
      "locked": false
    },
    {
      "id": "NSxcJ1K4egnawTUV2ono0",
      "type": "arrow",
      "x": 1137.9264803782598,
      "y": 246.5431575785723,
      "width": 1028.8290412870438,
      "height": 266.1148880587542,
      "angle": 0,
      "strokeColor": "#000000",
      "backgroundColor": "#15aabf",
      "fillStyle": "cross-hatch",
      "strokeWidth": 1,
      "strokeStyle": "solid",
      "roughness": 1,
      "opacity": 100,
      "groupIds": [],
      "strokeSharpness": "round",
      "seed": 207168439,
      "version": 280,
      "versionNonce": 51698905,
      "isDeleted": false,
      "boundElements": null,
      "updated": 1652992286343,
      "link": null,
      "locked": false,
      "points": [
        [
          0,
          0
        ],
        [
          -541.6941465161127,
          91.85973582920039
        ],
        [
          -524.992376365349,
          266.1148880587542
        ],
        [
          487.13489477093117,
          8.907602252114373
        ]
      ],
      "lastCommittedPoint": null,
      "startBinding": null,
      "endBinding": null,
      "startArrowhead": null,
      "endArrowhead": "arrow"
    }
  ],
  "appState": {
    "gridSize": null,
    "viewBackgroundColor": "#ffffff"
  },
  "files": {}
}`