### PR TITLE
chore: normalize package.json order

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,22 +1,30 @@
 {
-  "browserslist": {
-    "production": [
-      ">0.2%",
-      "not dead",
-      "not ie <= 11",
-      "not op_mini all",
-      "not safari < 12",
-      "not kaios <= 2.5",
-      "not edge < 79",
-      "not chrome < 70",
-      "not and_uc < 13",
-      "not samsung < 10"
-    ],
-    "development": [
-      "last 1 chrome version",
-      "last 1 firefox version",
-      "last 1 safari version"
-    ]
+  "name": "excalidraw",
+  "private": true,
+  "scripts": {
+    "build-node": "node ./scripts/build-node.js",
+    "build:app:docker": "REACT_APP_DISABLE_SENTRY=true react-scripts build",
+    "build:app": "REACT_APP_GIT_SHA=$VERCEL_GIT_COMMIT_SHA react-scripts build",
+    "build:version": "node ./scripts/build-version.js",
+    "build": "yarn build:app && yarn build:version",
+    "eject": "react-scripts eject",
+    "fix:code": "yarn test:code --fix",
+    "fix:other": "yarn prettier --write",
+    "fix": "yarn fix:other && yarn fix:code",
+    "locales-coverage": "node scripts/build-locales-coverage.js",
+    "locales-coverage:description": "node scripts/locales-coverage-description.js",
+    "prepare": "husky install",
+    "prettier": "prettier \"**/*.{css,scss,json,md,html,yml}\" --ignore-path=.eslintignore",
+    "start": "react-scripts start",
+    "test:all": "yarn test:typecheck && yarn test:code && yarn test:other && yarn test:app --watchAll=false",
+    "test:app": "react-scripts test --passWithNoTests",
+    "test:code": "eslint --max-warnings=0 --ext .js,.ts,.tsx .",
+    "test:debug": "react-scripts --inspect-brk test --runInBand --no-cache",
+    "test:other": "yarn prettier --list-different",
+    "test:typecheck": "tsc",
+    "test:update": "yarn test:app --updateSnapshot --watchAll=false",
+    "test": "yarn test:app",
+    "autorelease": "node scripts/autorelease.js"
   },
   "dependencies": {
     "@sentry/browser": "6.2.5",
@@ -86,32 +94,24 @@
     ],
     "resetMocks": false
   },
-  "name": "excalidraw",
   "prettier": "@excalidraw/prettier-config",
-  "private": true,
-  "scripts": {
-    "build-node": "node ./scripts/build-node.js",
-    "build:app:docker": "REACT_APP_DISABLE_SENTRY=true react-scripts build",
-    "build:app": "REACT_APP_GIT_SHA=$VERCEL_GIT_COMMIT_SHA react-scripts build",
-    "build:version": "node ./scripts/build-version.js",
-    "build": "yarn build:app && yarn build:version",
-    "eject": "react-scripts eject",
-    "fix:code": "yarn test:code --fix",
-    "fix:other": "yarn prettier --write",
-    "fix": "yarn fix:other && yarn fix:code",
-    "locales-coverage": "node scripts/build-locales-coverage.js",
-    "locales-coverage:description": "node scripts/locales-coverage-description.js",
-    "prepare": "husky install",
-    "prettier": "prettier \"**/*.{css,scss,json,md,html,yml}\" --ignore-path=.eslintignore",
-    "start": "react-scripts start",
-    "test:all": "yarn test:typecheck && yarn test:code && yarn test:other && yarn test:app --watchAll=false",
-    "test:app": "react-scripts test --passWithNoTests",
-    "test:code": "eslint --max-warnings=0 --ext .js,.ts,.tsx .",
-    "test:debug": "react-scripts --inspect-brk test --runInBand --no-cache",
-    "test:other": "yarn prettier --list-different",
-    "test:typecheck": "tsc",
-    "test:update": "yarn test:app --updateSnapshot --watchAll=false",
-    "test": "yarn test:app",
-    "autorelease": "node scripts/autorelease.js"
+  "browserslist": {
+    "production": [
+      ">0.2%",
+      "not dead",
+      "not ie <= 11",
+      "not op_mini all",
+      "not safari < 12",
+      "not kaios <= 2.5",
+      "not edge < 79",
+      "not chrome < 70",
+      "not and_uc < 13",
+      "not samsung < 10"
+    ],
+    "development": [
+      "last 1 chrome version",
+      "last 1 firefox version",
+      "last 1 safari version"
+    ]
   }
 }


### PR DESCRIPTION
This PR rearranges the contents of `package.json` to display the information most relevant to contributors first.

---

As a maintainer, one of the first things I do when I familiarize myself with a new repo is to read through `package.json`. I do this because `package.json` often contains a lot of context that helps me understand the repo's setup, structure, and tooling:

- the `name` of the package (sometimes differs from repo name)
- presence of `private`/`version` in the root `package.json` signals whether the repo is a single published package, a monorepo, etc.
- `scripts` gives me an idea of the tooling that the project uses to develop/manage itself
- `dependencies`/`devDependencies` allows me to understand the external libraries that the project relies on to get things done

When I first read through this repo's `package.json`, I felt a little disoriented because the order of the contents doesn't seem to follow any rhyme or reason. 

To help avoid that feeling for future newcomers, I've rearranged the contents of `package.json` to give it some order:

1. config directly relevant to contributors (the fields mentioned above)
2. config for language/package manager (`engines`, `resolutions`)
3. config for third-party libraries (`homepage`, `jest`, `prettier`, `browserslist`)

After the change, opening `package.json` immediately displays some of the most important information about the repo. Less important information is just a scroll away.

---

I know this isn't a major contribution and on its own it accomplishes very little. But lots of little changes like this that elevate _contributor accessibility_ can make a big difference in how approachable a project is for newcomers.

I think a lot about this and hope this is the first of many of this type of contribution that I can make around here! ❤️ 