### PR TITLE
feat: redirect vscode.excalidraw.com to vscode marketplace

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -27,6 +27,16 @@
     {
       "source": "/webex/:match*",
       "destination": "https://for-webex.excalidraw.com"
+    },
+    {
+      "source": "/:path*",
+      "has": [
+        {
+          "type": "host",
+          "value": "vscode.excalidraw.com"
+        }
+      ],
+      "destination": "https://marketplace.visualstudio.com/items?itemName=pomdtr.excalidraw-editor"
     }
   ]
 }


### PR DESCRIPTION
this might not work without setting up a dns redirect first (though I'm not sure how that would work either). Also don't think we can test this without deploying to prod first.

https://vercel.com/docs/project-configuration#project-configuration/redirects
https://vercel.com/support/articles/can-i-redirect-from-a-subdomain-to-a-subpath