### PR TITLE
Added trilium as an application that integrates excalidraw

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Last but not least, we're thankful to these companies for offering their service
 
 ## Who's integrating Excalidraw
 
-[Google Cloud](https://googlecloudcheatsheet.withgoogle.com/architecture) • [Meta](https://meta.com/) • [CodeSandbox](https://codesandbox.io/) • [Obsidian Excalidraw](https://github.com/zsviczian/obsidian-excalidraw-plugin) • [Replit](https://replit.com/) • [Slite](https://slite.com/) • [Notion](https://notion.so/) • [HackerRank](https://www.hackerrank.com/) •
+[Google Cloud](https://googlecloudcheatsheet.withgoogle.com/architecture) • [Meta](https://meta.com/) • [CodeSandbox](https://codesandbox.io/) • [Obsidian Excalidraw](https://github.com/zsviczian/obsidian-excalidraw-plugin) • [Replit](https://replit.com/) • [Slite](https://slite.com/) • [Notion](https://notion.so/) • [HackerRank](https://www.hackerrank.com/) • [Trilium](https://github.com/zadam/trilium) •
 
 ## Documentation
 


### PR DESCRIPTION
Since its newest release, trilium is integrating excalidraw. Trilium is a personal, self-hosted note taking application which can be hugely customized. Even more so than notion.