### PR TITLE
[Not For Merge]: Make text labels for `ButtonSelect`s follow the icon style.

### DIFF
--- a/src/components/ButtonSelect.tsx
+++ b/src/components/ButtonSelect.tsx
@@ -1,21 +1,26 @@
 import clsx from "clsx";
+import { iconFillColor } from "../components/icons";
+import { Theme } from "../element/types";
 
 export const ButtonSelect = <T extends Object>({
   options,
   value,
   onChange,
   group,
+  theme,
 }: {
   options: { value: T; text: string }[];
   value: T | null;
   onChange: (value: T) => void;
   group: string;
+  theme: Theme;
 }) => (
   <div className="buttonList">
     {options.map((option) => (
       <label
         key={option.text}
         className={clsx({ active: value === option.value })}
+        style={{ color: iconFillColor(theme), fontWeight: "bold" }}
       >
         <input
           type="radio"

--- a/src/components/icons.tsx
+++ b/src/components/icons.tsx
@@ -16,7 +16,7 @@ import { THEME } from "../constants";
 const activeElementColor = (theme: Theme) =>
   theme === THEME.LIGHT ? oc.orange[4] : oc.orange[9];
 
-const iconFillColor = (theme: Theme) => "var(--icon-fill-color)";
+export const iconFillColor = (theme: Theme) => "var(--icon-fill-color)";
 
 const handlerColor = (theme: Theme) =>
   theme === THEME.LIGHT ? oc.white : "#1e1e1e";

--- a/src/css/styles.scss
+++ b/src/css/styles.scss
@@ -195,6 +195,8 @@
     padding: 0.25rem;
     white-space: nowrap;
 
+    --icon-fill-color: #{$oc-gray-6};
+
     cursor: pointer;
 
     &:focus-visible {


### PR DESCRIPTION
(This is not the PR you are looking for.)  #2993 uses #5289 to select between standard and simplified math input (Latex/AsciiMath) and mixed-text/math-only modes.