### PR TITLE
fix: bind text to correct container when nested

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -2227,6 +2227,8 @@ class App extends React.Component<AppProps, AppState> {
       } else {
         existingTextElement = this.getTextElementAtPosition(sceneX, sceneY);
       }
+    } else {
+      existingTextElement = this.getTextElementAtPosition(sceneX, sceneY);
     }
 
     // bind to container when shouldBind is true or

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -2224,11 +2224,10 @@ class App extends React.Component<AppProps, AppState> {
         existingTextElement = selectedElements[0];
       } else if (isTextBindableContainer(selectedElements[0], false)) {
         existingTextElement = getBoundTextElement(selectedElements[0]);
+      } else {
+        existingTextElement = this.getTextElementAtPosition(sceneX, sceneY);
       }
     }
-
-    existingTextElement =
-      existingTextElement ?? this.getTextElementAtPosition(sceneX, sceneY);
 
     // bind to container when shouldBind is true or
     // clicked on center of container

--- a/src/element/textWysiwyg.test.tsx
+++ b/src/element/textWysiwyg.test.tsx
@@ -115,6 +115,9 @@ describe("textWysiwyg", () => {
         height: textSize,
         containerId: container.id,
       });
+      mutateElement(container, {
+        boundElements: [{ type: "text", id: text.id }],
+      });
 
       h.elements = [container, text];
 


### PR DESCRIPTION
fixes https://github.com/excalidraw/excalidraw/issues/5300

https://user-images.githubusercontent.com/11256141/173784757-a59d6e42-f87d-46a6-aab6-b618c9b55afe.mp4


