### PR TITLE
fix: non-letter shortcuts being swallowed by color picker

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1694,7 +1694,9 @@ class App extends React.Component<AppProps, AppState> {
       }
 
       if (
-        (isWritableElement(event.target) && event.key !== KEYS.ESCAPE) ||
+        (isWritableElement(event.target) &&
+          !event[KEYS.CTRL_OR_CMD] &&
+          event.key !== KEYS.ESCAPE) ||
         // case: using arrows to move between buttons
         (isArrowKey(event.key) && isInputLike(event.target))
       ) {

--- a/src/components/ColorPicker.tsx
+++ b/src/components/ColorPicker.tsx
@@ -147,15 +147,14 @@ const Picker = ({
       const isRTL = getLanguage().rtl;
       let isCustom = false;
       let index = Array.prototype.indexOf.call(
-        gallery.current!.querySelector(".color-picker-content--default")!
-          .children,
+        gallery.current!.querySelector(".color-picker-content--default")
+          ?.children,
         activeElement,
       );
       if (index === -1) {
         index = Array.prototype.indexOf.call(
-          gallery.current!.querySelector(
-            ".color-picker-content--canvas-colors",
-          )!.children,
+          gallery.current!.querySelector(".color-picker-content--canvas-colors")
+            ?.children,
           activeElement,
         );
         if (index !== -1) {

--- a/src/components/ColorPicker.tsx
+++ b/src/components/ColorPicker.tsx
@@ -128,7 +128,9 @@ const Picker = ({
   }, []);
 
   const handleKeyDown = (event: React.KeyboardEvent) => {
+    let handled = false;
     if (event.key === KEYS.TAB) {
+      handled = true;
       const { activeElement } = document;
       if (event.shiftKey) {
         if (activeElement === firstItem.current) {
@@ -140,6 +142,7 @@ const Picker = ({
         event.preventDefault();
       }
     } else if (isArrowKey(event.key)) {
+      handled = true;
       const { activeElement } = document;
       const isRTL = getLanguage().rtl;
       let isCustom = false;
@@ -184,6 +187,7 @@ const Picker = ({
       !event.altKey &&
       !isWritableElement(event.target)
     ) {
+      handled = true;
       const index = keyBindings.indexOf(event.key.toLowerCase());
       const isCustom = index >= MAX_DEFAULT_COLORS;
       const parentElement = isCustom
@@ -198,11 +202,14 @@ const Picker = ({
 
       event.preventDefault();
     } else if (event.key === KEYS.ESCAPE || event.key === KEYS.ENTER) {
+      handled = true;
       event.preventDefault();
       onClose();
     }
-    event.nativeEvent.stopImmediatePropagation();
-    event.stopPropagation();
+    if (handled) {
+      event.nativeEvent.stopImmediatePropagation();
+      event.stopPropagation();
+    }
   };
 
   const renderColors = (colors: Array<string>, custom: boolean = false) => {

--- a/src/components/ColorPicker.tsx
+++ b/src/components/ColorPicker.tsx
@@ -180,6 +180,8 @@ const Picker = ({
       event.preventDefault();
     } else if (
       keyBindings.includes(event.key.toLowerCase()) &&
+      !event[KEYS.CTRL_OR_CMD] &&
+      !event.altKey &&
       !isWritableElement(event.target)
     ) {
       const index = keyBindings.indexOf(event.key.toLowerCase());


### PR DESCRIPTION
fix https://github.com/excalidraw/excalidraw/issues/5314 

Stopped preventing cmd/ctrl-modified keydown events even in inputs, if they're not arrow keys. Not really a general fix (and who knows if it doesn't break some cases), for that we'll need to rewrite the keyboard handling.

An unrelated fix https://github.com/excalidraw/excalidraw/pull/5316/commits/68c7d789e6d0394eb4999f9afd344ad00dbcb865 for unsafe children access.