### PR TITLE
fix: remove unnecessary options passed to language detector

### DIFF
--- a/src/excalidraw-app/index.tsx
+++ b/src/excalidraw-app/index.tsx
@@ -18,7 +18,7 @@ import {
   NonDeletedExcalidrawElement,
 } from "../element/types";
 import { useCallbackRefState } from "../hooks/useCallbackRefState";
-import { Language, t } from "../i18n";
+import { t } from "../i18n";
 import {
   Excalidraw,
   defaultLang,
@@ -80,11 +80,7 @@ const isExcalidrawPlusSignedUser = document.cookie.includes(
 
 const languageDetector = new LanguageDetector();
 languageDetector.init({
-  languageUtils: {
-    formatLanguageCode: (langCode: Language["code"]) => langCode,
-    isWhitelisted: () => true,
-  },
-  checkWhitelist: false,
+  languageUtils: {},
 });
 
 const initializeScene = async (opts: {


### PR DESCRIPTION
Looks like these params are not needed any more and some of it is deprecated as well eg `isWhitelisted` has been renamed to `isSupportedCode` https://github.com/i18next/i18next/blob/master/CHANGELOG.md#1950 and I wasn't able to find the use of `formatLanguageCode`
This change was introduced in https://github.com/excalidraw/excalidraw/pull/638/files and that time probably it was needed.

As per my understanding we are just passing it since we don't use `i18next` which we used to earlier and the library expects `i18next` params else code breaks hence we need to pass `languageUtils` as empty.

When testing it looks fine, lemme know if you find any issue