### PR TITLE
fix: unable to use cmd/ctrl-delete/backspace in inputs

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1731,11 +1731,18 @@ class App extends React.Component<AppProps, AppState> {
         });
       }
 
+      // bail if
       if (
+        // inside an input
         (isWritableElement(event.target) &&
-          !event[KEYS.CTRL_OR_CMD] &&
+          // unless pressing cmd/ctrl, except when using in conjunction of
+          // backspace/delete (we want to allow word-deleting)
+          (!event[KEYS.CTRL_OR_CMD] ||
+            event.key === KEYS.BACKSPACE ||
+            event.key === KEYS.DELETE) &&
+          // unless pressing escape (finalize action)
           event.key !== KEYS.ESCAPE) ||
-        // case: using arrows to move between buttons
+        // or unless using arrows (to move between buttons)
         (isArrowKey(event.key) && isInputLike(event.target))
       ) {
         return;

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1735,11 +1735,6 @@ class App extends React.Component<AppProps, AppState> {
       if (
         // inside an input
         (isWritableElement(event.target) &&
-          // unless pressing cmd/ctrl, except when using in conjunction of
-          // backspace/delete (we want to allow word-deleting)
-          (!event[KEYS.CTRL_OR_CMD] ||
-            event.key === KEYS.BACKSPACE ||
-            event.key === KEYS.DELETE) &&
           // unless pressing escape (finalize action)
           event.key !== KEYS.ESCAPE) ||
         // or unless using arrows (to move between buttons)


### PR DESCRIPTION
fixes regression from https://github.com/excalidraw/excalidraw/pull/5316

turns out (again?) that not bailing on using `cmd/ctrl`-modified keypresses within inputs is breaking too many things to easily catch. So let's go the other way and fix cases where specific app shortcuts don't work (and should) in inputs.

Later we'll move to a different way to handle shortcuts altogether.