### PR TITLE
[Not For Merge]: Plugins API for `@excalidraw/excalidraw`

### DIFF
--- a/src/actions/actionBoundText.tsx
+++ b/src/actions/actionBoundText.tsx
@@ -3,9 +3,9 @@ import { getNonDeletedElements, isTextElement } from "../element";
 import { mutateElement } from "../element/mutateElement";
 import {
   getBoundTextElement,
-  measureText,
   redrawTextBoundingBox,
 } from "../element/textElement";
+import { measureTextElement } from "../element/textWysiwyg";
 import {
   hasBoundTextElement,
   isTextBindableContainer,
@@ -15,7 +15,6 @@ import {
   ExcalidrawTextElement,
 } from "../element/types";
 import { getSelectedElements } from "../scene";
-import { getFontString } from "../utils";
 import { register } from "./register";
 
 export const actionUnbindText = register({
@@ -34,10 +33,8 @@ export const actionUnbindText = register({
     selectedElements.forEach((element) => {
       const boundTextElement = getBoundTextElement(element);
       if (boundTextElement) {
-        const { width, height, baseline } = measureText(
-          boundTextElement.originalText,
-          getFontString(boundTextElement),
-        );
+        const { width, height, baseline } =
+          measureTextElement(boundTextElement);
         mutateElement(boundTextElement as ExcalidrawTextElement, {
           containerId: null,
           width,

--- a/src/actions/actionProperties.tsx
+++ b/src/actions/actionProperties.tsx
@@ -81,7 +81,7 @@ import { register } from "./register";
 
 const FONT_SIZE_RELATIVE_INCREASE_STEP = 0.1;
 
-const changeProperty = (
+export const changeProperty = (
   elements: readonly ExcalidrawElement[],
   appState: AppState,
   callback: (element: ExcalidrawElement) => ExcalidrawElement,
@@ -101,7 +101,7 @@ const changeProperty = (
   });
 };
 
-const getFormValue = function <T>(
+export const getFormValue = function <T>(
   elements: readonly ExcalidrawElement[],
   appState: AppState,
   getAttribute: (element: ExcalidrawElement) => T,

--- a/src/actions/manager.tsx
+++ b/src/actions/manager.tsx
@@ -10,6 +10,7 @@ import {
 import { ExcalidrawElement } from "../element/types";
 import { AppClassProperties, AppState } from "../types";
 import { MODES } from "../constants";
+import { isActionEnabled } from "../subtypes";
 import { trackEvent } from "../analytics";
 
 const trackAction = (
@@ -85,7 +86,11 @@ export class ActionManager {
         (action) =>
           (action.name in canvasActions
             ? canvasActions[action.name as keyof typeof canvasActions]
-            : true) &&
+            : isActionEnabled(
+                this.getElementsIncludingDeleted(),
+                this.getAppState(),
+                action.name,
+              )) &&
           action.keyTest &&
           action.keyTest(
             event,
@@ -138,13 +143,19 @@ export class ActionManager {
   renderAction = (name: ActionName, data?: PanelComponentProps["data"]) => {
     const canvasActions = this.app.props.UIOptions.canvasActions;
 
+    let key: string;
     if (
       this.actions[name] &&
       "PanelComponent" in this.actions[name] &&
       (name in canvasActions
         ? canvasActions[name as keyof typeof canvasActions]
-        : true)
+        : isActionEnabled(
+            this.getElementsIncludingDeleted(),
+            this.getAppState(),
+            name,
+          ))
     ) {
+      key = name;
       const action = this.actions[name];
       const PanelComponent = action.PanelComponent!;
       const elements = this.getElementsIncludingDeleted();
@@ -164,6 +175,7 @@ export class ActionManager {
 
       return (
         <PanelComponent
+          key={key}
           elements={this.getElementsIncludingDeleted()}
           appState={this.getAppState()}
           updateData={updateData}

--- a/src/actions/shortcuts.ts
+++ b/src/actions/shortcuts.ts
@@ -1,6 +1,11 @@
 import { t } from "../i18n";
 import { isDarwin } from "../keys";
 import { getShortcutKey } from "../utils";
+import {
+  getCustomShortcutKey,
+  isCustomShortcutName,
+  CustomShortcutName,
+} from "../subtypes";
 import { ActionName } from "./types";
 
 export type ShortcutName = SubtypeOf<
@@ -71,8 +76,12 @@ const shortcutMap: Record<ShortcutName, string[]> = {
   toggleLock: [getShortcutKey("CtrlOrCmd+Shift+L")],
 };
 
-export const getShortcutFromShortcutName = (name: ShortcutName) => {
-  const shortcuts = shortcutMap[name];
+export const getShortcutFromShortcutName = (
+  name: ShortcutName | CustomShortcutName,
+) => {
+  const shortcuts = isCustomShortcutName(name)
+    ? getCustomShortcutKey(name)
+    : shortcutMap[name as ShortcutName];
   // if multiple shortcuts available, take the first one
   return shortcuts && shortcuts.length > 0 ? shortcuts[0] : "";
 };

--- a/src/actions/types.ts
+++ b/src/actions/types.ts
@@ -6,6 +6,7 @@ import {
   ExcalidrawProps,
   BinaryFiles,
 } from "../types";
+import { CustomActionName } from "../subtypes";
 
 export type ActionSource = "ui" | "keyboard" | "contextMenu" | "api";
 
@@ -35,6 +36,7 @@ export type UpdaterFn = (res: ActionResult) => void;
 export type ActionFilterFn = (action: Action) => void;
 
 export type ActionName =
+  | CustomActionName
   | "copy"
   | "cut"
   | "paste"

--- a/src/appState.ts
+++ b/src/appState.ts
@@ -136,6 +136,8 @@ const APP_STATE_STORAGE_CONF = (<
   editingGroupId: { browser: true, export: false, server: false },
   editingLinearElement: { browser: false, export: false, server: false },
   activeTool: { browser: true, export: false, server: false },
+  activeSubtype: { browser: true, export: false, server: false },
+  customProps: { browser: true, export: false, server: false },
   penMode: { browser: true, export: false, server: false },
   penDetected: { browser: true, export: false, server: false },
   errorMessage: { browser: false, export: false, server: false },

--- a/src/charts.ts
+++ b/src/charts.ts
@@ -6,6 +6,7 @@ import {
   VERTICAL_ALIGN,
 } from "./constants";
 import { newElement, newLinearElement, newTextElement } from "./element";
+import { maybeGetCustom } from "./element/newElement";
 import { NonDeletedExcalidrawElement } from "./element/types";
 import { randomId } from "./random";
 
@@ -20,6 +21,8 @@ export interface Spreadsheet {
   title: string | null;
   labels: string[] | null;
   values: number[];
+  subtype?: NonDeletedExcalidrawElement["subtype"];
+  customProps?: NonDeletedExcalidrawElement["customProps"];
 }
 
 export const NOT_SPREADSHEET = "NOT_SPREADSHEET";
@@ -207,6 +210,7 @@ const chartXLabels = (
         fontSize: 16,
         textAlign: "center",
         verticalAlign: "top",
+        ...maybeGetCustom(spreadsheet, "text"),
       });
     }) || []
   );
@@ -227,6 +231,7 @@ const chartYLabels = (
     y: y - BAR_GAP,
     text: "0",
     textAlign: "right",
+    ...maybeGetCustom(spreadsheet, "text"),
   });
 
   const maxYLabel = newTextElement({
@@ -237,6 +242,7 @@ const chartYLabels = (
     y: y - BAR_HEIGHT - minYLabel.height / 2,
     text: Math.max(...spreadsheet.values).toLocaleString(),
     textAlign: "right",
+    ...maybeGetCustom(spreadsheet, "text"),
   });
 
   return [minYLabel, maxYLabel];
@@ -264,6 +270,7 @@ const chartLines = (
       [0, 0],
       [chartWidth, 0],
     ],
+    ...maybeGetCustom(spreadsheet, "line"),
   });
 
   const yLine = newLinearElement({
@@ -280,6 +287,7 @@ const chartLines = (
       [0, 0],
       [0, -chartHeight],
     ],
+    ...maybeGetCustom(spreadsheet, "line"),
   });
 
   const maxLine = newLinearElement({
@@ -298,6 +306,7 @@ const chartLines = (
       [0, 0],
       [chartWidth, 0],
     ],
+    ...maybeGetCustom(spreadsheet, "line"),
   });
 
   return [xLine, yLine, maxLine];
@@ -325,6 +334,7 @@ const chartBaseElements = (
         strokeSharpness: "sharp",
         strokeStyle: "solid",
         textAlign: "center",
+        ...maybeGetCustom(spreadsheet, "text"),
       })
     : null;
 
@@ -341,6 +351,7 @@ const chartBaseElements = (
         strokeColor: colors.elementStroke[0],
         fillStyle: "solid",
         opacity: 6,
+        ...maybeGetCustom(spreadsheet, "rectangle"),
       })
     : null;
 
@@ -373,6 +384,7 @@ const chartTypeBar = (
       y: y - barHeight - BAR_GAP,
       width: BAR_WIDTH,
       height: barHeight,
+      ...maybeGetCustom(spreadsheet, "rectangle"),
     });
   });
 
@@ -425,6 +437,7 @@ const chartTypeLine = (
     width: maxX - minX,
     strokeWidth: 2,
     points: points as any,
+    ...maybeGetCustom(spreadsheet, "line"),
   });
 
   const dots = spreadsheet.values.map((value, index) => {
@@ -441,6 +454,7 @@ const chartTypeLine = (
       y: y + cy - BAR_GAP * 2,
       width: BAR_GAP,
       height: BAR_GAP,
+      ...maybeGetCustom(spreadsheet, "ellipse"),
     });
   });
 
@@ -463,6 +477,7 @@ const chartTypeLine = (
         [0, 0],
         [0, cy],
       ],
+      ...maybeGetCustom(spreadsheet, "line"),
     });
   });
 

--- a/src/clipboard.ts
+++ b/src/clipboard.ts
@@ -129,6 +129,7 @@ const getSystemClipboard = async (
  */
 export const parseClipboard = async (
   event: ClipboardEvent | null,
+  appState?: AppState,
 ): Promise<ClipboardData> => {
   const systemClipboard = await getSystemClipboard(event);
 
@@ -143,6 +144,10 @@ export const parseClipboard = async (
   // technically possible it's staler than in-app clipboard
   const spreadsheetResult = parsePotentialSpreadsheet(systemClipboard);
   if (spreadsheetResult) {
+    if ("spreadsheet" in spreadsheetResult) {
+      spreadsheetResult.spreadsheet.subtype = appState?.activeSubtype;
+      spreadsheetResult.spreadsheet.customProps = appState?.customProps;
+    }
     return spreadsheetResult;
   }
 

--- a/src/components/Actions.tsx
+++ b/src/components/Actions.tsx
@@ -23,9 +23,15 @@ import {
 } from "../utils";
 import Stack from "./Stack";
 import { ToolButton } from "./ToolButton";
+import {
+  getCustomActions,
+  getCustomSubtypes,
+  CustomSubtype,
+} from "../subtypes";
 import { hasStrokeColor } from "../scene/comparisons";
 import { trackEvent } from "../analytics";
 import { hasBoundTextElement, isBoundToContainer } from "../element/typeChecks";
+import { delUndefinedProps } from "../element/newElement";
 
 export const SelectedShapeActions = ({
   appState,
@@ -123,6 +129,17 @@ export const SelectedShapeActions = ({
         (element) =>
           hasBoundTextElement(element) || isBoundToContainer(element),
       ) && renderAction("changeVerticalAlign")}
+      {(appState.activeSubtype ||
+        targetElements.some((element) => element.subtype)) && (
+        <>
+          {getCustomActions().map((action) => {
+            if (!getCustomSubtypes().includes(action.name as CustomSubtype)) {
+              return renderAction(action.name);
+            }
+            return null;
+          })}
+        </>
+      )}
       {(canHaveArrowheads(activeTool) ||
         targetElements.some((element) => canHaveArrowheads(element.type))) && (
         <>{renderAction("changeArrowhead")}</>
@@ -237,11 +254,17 @@ export const ShapesSwitcher = ({
             const nextActiveTool = updateActiveTool(appState, {
               type: value,
             });
-            setAppState({
-              activeTool: nextActiveTool,
-              multiElement: null,
-              selectedElementIds: {},
-            });
+            setAppState(
+              delUndefinedProps(
+                {
+                  activeTool: nextActiveTool,
+                  multiElement: null,
+                  selectedElementIds: {},
+                  customSubtype: undefined,
+                },
+                ["customSubtype"],
+              ),
+            );
             setCursorForShape(canvas, {
               ...appState,
               activeTool: nextActiveTool,

--- a/src/components/ButtonSelect.tsx
+++ b/src/components/ButtonSelect.tsx
@@ -23,7 +23,15 @@ export const ButtonSelect = <T extends Object>({
           onChange={() => onChange(option.value)}
           checked={value === option.value}
         />
-        {option.text}
+        <span
+          style={{
+            color: "var(--icon-fill-color)",
+            fontWeight: "bold",
+            opacity: value === option.value ? 1.0 : 0.6,
+          }}
+        >
+          {option.text}
+        </span>
       </label>
     ))}
   </div>

--- a/src/components/ContextMenu.tsx
+++ b/src/components/ContextMenu.tsx
@@ -11,6 +11,7 @@ import {
 import { Action } from "../actions/types";
 import { ActionManager } from "../actions/manager";
 import { AppState } from "../types";
+import { CustomShortcutName } from "../subtypes";
 import { NonDeletedExcalidrawElement } from "../element/types";
 
 export type ContextMenuOption = "separator" | Action;
@@ -77,7 +78,9 @@ const ContextMenu = ({
                 <div className="context-menu-option__label">{label}</div>
                 <kbd className="context-menu-option__shortcut">
                   {actionName
-                    ? getShortcutFromShortcutName(actionName as ShortcutName)
+                    ? getShortcutFromShortcutName(
+                        actionName as ShortcutName | CustomShortcutName,
+                      )
                     : ""}
                 </kbd>
               </button>

--- a/src/components/LayerUI.tsx
+++ b/src/components/LayerUI.tsx
@@ -1,5 +1,6 @@
 import clsx from "clsx";
 import React, { useCallback } from "react";
+import { getCustomSubtypes } from "../subtypes";
 import { ActionManager } from "../actions/manager";
 import { CLASSES, LIBRARY_SIDEBAR_WIDTH } from "../constants";
 import { exportCanvas } from "../data";
@@ -356,6 +357,9 @@ const LayerUI = ({
                             });
                           }}
                         />
+                        {getCustomSubtypes().map((subtype) =>
+                          actionManager.renderAction(subtype),
+                        )}
                       </Stack.Row>
                     </Island>
                     <LibraryButton

--- a/src/components/MobileMenu.tsx
+++ b/src/components/MobileMenu.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { getCustomSubtypes } from "../subtypes";
 import { AppState } from "../types";
 import { ActionManager } from "../actions/manager";
 import { t } from "../i18n";
@@ -87,6 +88,9 @@ export const MobileMenu = ({
                         });
                       }}
                     />
+                    {getCustomSubtypes().map((subtype) =>
+                      actionManager.renderAction(subtype),
+                    )}
                   </Stack.Row>
                 </Island>
                 {renderTopRightUI && renderTopRightUI(true, appState)}

--- a/src/components/PasteChartDialog.tsx
+++ b/src/components/PasteChartDialog.tsx
@@ -8,6 +8,12 @@ import { exportToSvg } from "../scene/export";
 import { AppState, LibraryItem } from "../types";
 import { Dialog } from "./Dialog";
 import "./PasteChartDialog.scss";
+import { ensureSubtypesLoaded } from "../subtypes";
+import { isTextElement } from "../element";
+import {
+  getContainerElement,
+  redrawTextBoundingBox,
+} from "../element/textElement";
 
 type OnInsertChart = (chartType: ChartType, elements: ChartElements) => void;
 
@@ -33,7 +39,16 @@ const ChartPreviewBtn = (props: {
       0,
       0,
     );
-    setChartElements(elements);
+    (async () => {
+      await ensureSubtypesLoaded(elements, () => {
+        elements.forEach(
+          (el) =>
+            isTextElement(el) &&
+            redrawTextBoundingBox(el, getContainerElement(el)),
+        );
+        setChartElements(elements);
+      });
+    })();
     let svg: SVGSVGElement;
     const previewNode = previewRef.current!;
 

--- a/src/components/icons.tsx
+++ b/src/components/icons.tsx
@@ -16,7 +16,7 @@ import { THEME } from "../constants";
 const activeElementColor = (theme: Theme) =>
   theme === THEME.LIGHT ? oc.orange[4] : oc.orange[9];
 
-const iconFillColor = (theme: Theme) => "var(--icon-fill-color)";
+export const iconFillColor = (theme: Theme) => "var(--icon-fill-color)";
 
 const handlerColor = (theme: Theme) =>
   theme === THEME.LIGHT ? oc.white : "#1e1e1e";

--- a/src/element/resizeElements.ts
+++ b/src/element/resizeElements.ts
@@ -41,8 +41,8 @@ import {
   getBoundTextElement,
   getBoundTextElementId,
   handleBindTextResize,
-  measureText,
 } from "./textElement";
+import { measureTextElement } from "./textWysiwyg";
 
 export const normalizeAngle = (angle: number): number => {
   if (angle >= 2 * Math.PI) {
@@ -284,9 +284,9 @@ const measureFontSizeFromWH = (
   if (nextFontSize < MIN_FONT_SIZE) {
     return null;
   }
-  const metrics = measureText(
-    element.text,
-    getFontString({ fontSize: nextFontSize, fontFamily: element.fontFamily }),
+  const metrics = measureTextElement(
+    element,
+    { fontSize: nextFontSize },
     element.containerId ? element.width : null,
   );
   return {

--- a/src/element/types.ts
+++ b/src/element/types.ts
@@ -1,3 +1,4 @@
+import { CustomProps, CustomSubtype } from "../subtypes";
 import { Point } from "../types";
 import { FONT_FAMILY, THEME, VERTICAL_ALIGN } from "../constants";
 
@@ -56,6 +57,8 @@ type _ExcalidrawElementBase = Readonly<{
   updated: number;
   link: string | null;
   locked: boolean;
+  subtype?: CustomSubtype;
+  customProps?: CustomProps;
 }>;
 
 export type ExcalidrawSelectionElement = _ExcalidrawElementBase & {

--- a/src/renderer/renderElement.ts
+++ b/src/renderer/renderElement.ts
@@ -29,6 +29,7 @@ import { isPathALoop } from "../math";
 import rough from "roughjs/bin/rough";
 import { AppState, BinaryFiles, Zoom } from "../types";
 import { getDefaultAppState } from "../appState";
+import { getCustomMethods } from "../subtypes";
 import {
   BOUND_TEXT_PADDING,
   MAX_DECIMALS_FOR_SVG_EXPORT,
@@ -196,6 +197,12 @@ const drawElementOnCanvas = (
   renderConfig: RenderConfig,
 ) => {
   context.globalAlpha = element.opacity / 100;
+  const map = getCustomMethods(element.subtype);
+  if (map) {
+    map.render(element, context, renderConfig.renderCb);
+    context.globalAlpha = 1;
+    return;
+  }
   switch (element.type) {
     case "rectangle":
     case "diamond":
@@ -858,6 +865,11 @@ export const renderElementToSvg = (
     root = anchorTag;
   }
 
+  const map = getCustomMethods(element.subtype);
+  if (map) {
+    map.renderSvg(svgRoot, root, element, { offsetX, offsetY });
+    return;
+  }
   switch (element.type) {
     case "selection": {
       // Since this is used only during editing experience, which is canvas based,

--- a/src/scene/export.ts
+++ b/src/scene/export.ts
@@ -11,6 +11,7 @@ import {
   getInitializedImageElements,
   updateImageCache,
 } from "../element/image";
+import { ensureSubtypesLoaded } from "../subtypes";
 
 export const SVG_EXPORT_TAG = `<!-- svg-source:excalidraw -->`;
 
@@ -51,7 +52,9 @@ export const exportToCanvas = async (
     files,
   });
 
-  renderScene(elements, appState, null, scale, rough.canvas(canvas), canvas, {
+  let refreshTimer = 0;
+
+  const renderConfig = {
     viewBackgroundColor: exportBackground ? viewBackgroundColor : null,
     scrollX: -minX + exportPadding,
     scrollY: -minY + exportPadding,
@@ -67,7 +70,31 @@ export const exportToCanvas = async (
     renderSelection: false,
     renderGrid: false,
     isExporting: true,
-  });
+    renderCb: () => {
+      if (refreshTimer !== 0) {
+        window.clearTimeout(refreshTimer);
+      }
+      refreshTimer = window.setTimeout(() => {
+        renderConfig.renderCb = () => {};
+        window.clearTimeout(refreshTimer);
+        // Here instead of setState({}), call renderScene() again
+        render();
+      }, 50);
+    },
+  };
+
+  const render = () => {
+    renderScene(
+      elements,
+      appState,
+      null,
+      scale,
+      rough.canvas(canvas),
+      canvas,
+      renderConfig,
+    );
+  };
+  render();
 
   return canvas;
 };
@@ -156,10 +183,12 @@ export const exportToSvg = async (
   }
 
   const rsvg = rough.svg(svgRoot);
-  renderSceneToSvg(elements, rsvg, svgRoot, files || {}, {
-    offsetX: -minX + exportPadding,
-    offsetY: -minY + exportPadding,
-    exportWithDarkMode: appState.exportWithDarkMode,
+  await ensureSubtypesLoaded(elements, () => {
+    renderSceneToSvg(elements, rsvg, svgRoot, files || {}, {
+      offsetX: -minX + exportPadding,
+      offsetY: -minY + exportPadding,
+      exportWithDarkMode: appState.exportWithDarkMode,
+    });
   });
 
   return svgRoot;

--- a/src/scene/types.ts
+++ b/src/scene/types.ts
@@ -24,6 +24,7 @@ export type RenderConfig = {
   renderScrollbars?: boolean;
   renderSelection?: boolean;
   renderGrid?: boolean;
+  renderCb?: () => void;
   /** when exporting the behavior is slightly different (e.g. we can't use
     CSS filters), and we disable render optimizations for best output */
   isExporting: boolean;

--- a/src/subtypes/index.ts
+++ b/src/subtypes/index.ts
@@ -1,0 +1,264 @@
+import {
+  ExcalidrawElement,
+  ExcalidrawTextElement,
+  NonDeleted,
+} from "../element/types";
+import { getNonDeletedElements } from "../element";
+import { getSelectedElements } from "../scene";
+import { AppState } from "../types";
+
+import { Action, ActionName } from "../actions/types";
+import { register } from "../actions/register";
+import { hasBoundTextElement } from "../element/typeChecks";
+import { getBoundTextElement } from "../element/textElement";
+
+// Start adding subtype imports here
+
+const customSubtypes = [...[]] as const;
+const customParents = [...[]] as readonly {
+  subtype: CustomSubtype;
+  parentType: ExcalidrawElement["type"];
+}[];
+const customProps = [...[]] as const;
+const customActionNames = [...[]] as const;
+const customActions = [...[]] as readonly {
+  subtype: CustomSubtype;
+  actions: CustomActionName[];
+}[];
+const disabledActionNames = [...[]] as readonly ActionName[];
+const disabledActions = [...[]] as readonly {
+  subtype: CustomSubtype;
+  actions: DisabledActionName[];
+}[];
+const customShortcutNames = [...[]] as const;
+
+// Custom Shortcuts
+export const customShortcutMap = { ...{} } as Record<
+  CustomShortcutName,
+  string[]
+>;
+
+// End adding subtype imports here
+
+// Types to export, union over all ExcalidrawElement subtypes
+
+// Custom Subtypes
+export type CustomSubtype = typeof customSubtypes[number];
+export const getCustomSubtypes = (): readonly CustomSubtype[] => {
+  return customSubtypes;
+};
+export const isValidSubtype = (s: any, t: any): s is CustomSubtype =>
+  customParents.find(
+    (val) => val.subtype === (s as string) && val.parentType === (t as string),
+  ) !== undefined;
+
+// Custom Properties
+export type CustomProps = typeof customProps[number];
+
+// Custom Actions
+export type CustomActionName = typeof customActionNames[number];
+
+const customActionMap: Action[] = [];
+export const getCustomActions = (): readonly Action[] => {
+  return customActionMap;
+};
+
+const addCustomAction = (action: Action) => {
+  if (customActionMap.every((value) => value.name !== action.name)) {
+    const customName = action.name as CustomActionName;
+    if (customActionNames.includes(customName)) {
+      customActionMap.push(action);
+      register(action);
+    }
+  }
+};
+
+// Standard actions disabled by subtypes
+type DisabledActionName = typeof disabledActionNames[number];
+
+export const isActionEnabled = (
+  elements: readonly ExcalidrawElement[],
+  appState: AppState,
+  actionName: ActionName | CustomActionName,
+) => {
+  const selectedElements = getSelectedElements(
+    getNonDeletedElements(elements),
+    appState,
+  );
+  const chosen = appState.editingElement
+    ? [appState.editingElement, ...selectedElements]
+    : selectedElements;
+  let enabled = chosen.some((el) =>
+    customParents.some((parent) => {
+      const e = hasBoundTextElement(el) ? getBoundTextElement(el)! : el;
+      return (
+        ((el.type === parent.parentType && el.subtype === undefined) ||
+          (e.type === parent.parentType && e.subtype === undefined)) &&
+        !customActionNames.includes(actionName as CustomActionName)
+      );
+    }),
+  );
+  enabled =
+    enabled ||
+    (chosen.length === 0 &&
+      (appState.activeSubtype === undefined ||
+        isActionForSubtype(appState.activeSubtype, actionName)));
+  !enabled &&
+    chosen.forEach((el) => {
+      const subtype = hasBoundTextElement(el)
+        ? getBoundTextElement(el)!.subtype
+        : el.subtype;
+      if (!enabled && isActionForSubtype(subtype, actionName)) {
+        enabled = true;
+      }
+    });
+  if (customSubtypes.includes(actionName as CustomSubtype)) {
+    enabled = true;
+  }
+  return enabled;
+};
+
+const isActionForSubtype = (
+  subtype: CustomSubtype | undefined,
+  action: ActionName | CustomActionName,
+) => {
+  const name = action as DisabledActionName;
+  const customName = action as CustomActionName;
+  if (subtype && customSubtypes.includes(subtype)) {
+    return (
+      !disabledActions // Not disabled by subtype
+        .find((value) => value.subtype === subtype)!
+        .actions.includes(name) ||
+      customActions // Added by subtype
+        .find((value) => value.subtype === subtype)!
+        .actions.includes(customName)
+    );
+  }
+  return (
+    !customActionNames.includes(customName) &&
+    !disabledActions.some((disabled) => disabled.actions.includes(name))
+  );
+};
+
+// Custom Shortcuts (for custom actions)
+export type CustomShortcutName = typeof customShortcutNames[number];
+export const isCustomShortcutName = (s: any): s is CustomShortcutName =>
+  customShortcutNames.includes(s as CustomShortcutName);
+
+// Return the shortcut by CustomShortcutName
+export const getCustomShortcutKey = (name: CustomShortcutName) => {
+  let shortcuts: string[] = [];
+  if (isCustomShortcutName(name)) {
+    shortcuts = customShortcutMap[name];
+  }
+  return shortcuts;
+};
+
+// Custom Methods
+export type CustomMethods = {
+  clean: (
+    updates: Omit<
+      Partial<ExcalidrawElement>,
+      "id" | "version" | "versionNonce"
+    >,
+  ) => Omit<Partial<ExcalidrawElement>, "id" | "version" | "versionNonce">;
+  ensureLoaded: (callback?: () => void) => Promise<void>;
+  measureText: (
+    element: Pick<
+      ExcalidrawTextElement,
+      "subtype" | "customProps" | "fontSize" | "fontFamily" | "text"
+    >,
+    next?: {
+      fontSize?: number;
+      text?: string;
+      customProps?: CustomProps;
+    },
+    maxWidth?: number | null,
+  ) => { width: number; height: number; baseline: number };
+  render: (
+    element: NonDeleted<ExcalidrawElement>,
+    context: CanvasRenderingContext2D,
+    renderCb?: () => void,
+  ) => void;
+  renderSvg: (
+    svgRoot: SVGElement,
+    root: SVGElement,
+    element: NonDeleted<ExcalidrawElement>,
+    opt?: { offsetX?: number; offsetY?: number },
+  ) => void;
+  wrapText: (
+    element: Pick<
+      ExcalidrawTextElement,
+      "subtype" | "customProps" | "fontSize" | "fontFamily" | "originalText"
+    >,
+    containerWidth: number,
+    next?: {
+      fontSize?: number;
+      text?: string;
+      customProps?: CustomProps;
+    },
+  ) => string;
+};
+
+type MethodMap = { subtype: CustomSubtype; methods: CustomMethods };
+const methodMaps = [] as Array<MethodMap>;
+
+// Assumption: registerCustomSubtypes() has run first or is the caller.
+// Use `getCustomMethods` to call subtype-specialized methods, like `render`.
+export const getCustomMethods = (subtype: CustomSubtype | undefined) => {
+  const map = methodMaps.find((method) => method.subtype === subtype);
+  return map?.methods;
+};
+
+// Register all custom subtypes.  Each subtype must provide a
+// `registerCustomSubtype` method, which should have these params:
+// - methods: CustomMethods
+// - addCustomAction: (action: Action) => void
+// - onSubtypeLoaded?: (hasSubtype: (element: ExcalidrawElement) => boolean) => void
+export const registerCustomSubtypes = (
+  onSubtypeLoaded?: (
+    hasSubtype: (element: ExcalidrawElement) => boolean,
+  ) => void,
+) => {
+  const subtypes = customSubtypes;
+  for (let index = 0; index < subtypes.length; index++) {
+    const subtype = subtypes[index];
+    if (!methodMaps.find((method) => method.subtype === subtype)) {
+      const methods = {} as CustomMethods;
+      methodMaps.push({ subtype, methods });
+      require(`./${subtypes[index]}/index`).registerCustomSubtype(
+        methods,
+        addCustomAction,
+        onSubtypeLoaded,
+      );
+    }
+  }
+};
+
+export const ensureSubtypesLoaded = async (
+  elements: readonly ExcalidrawElement[],
+  callback?: () => void,
+) => {
+  // Only ensure the loading of subtypes which are actually needed.
+  // We don't want to be held up by eg downloading the MathJax SVG fonts
+  // if we don't actually need them yet.
+  const subtypesUsed = [] as CustomSubtype[];
+  elements.forEach((el) => {
+    if (
+      "subtype" in el &&
+      isValidSubtype(el.subtype, el.type) &&
+      !subtypesUsed.includes(el.subtype)
+    ) {
+      subtypesUsed.push(el.subtype);
+    }
+  });
+  for (let i = 0; i < subtypesUsed.length; i++) {
+    const subtype = subtypesUsed[i];
+    // Should be defined if registerCustomSubtypes() has run
+    const map = getCustomMethods(subtype)!;
+    await map.ensureLoaded();
+  }
+  if (callback) {
+    callback();
+  }
+};

--- a/src/tests/helpers/api.ts
+++ b/src/tests/helpers/api.ts
@@ -13,15 +13,20 @@ import fs from "fs";
 import util from "util";
 import path from "path";
 import { getMimeType } from "../../data/blob";
-import { newFreeDrawElement } from "../../element/newElement";
+import { maybeGetCustom, newFreeDrawElement } from "../../element/newElement";
 import { Point } from "../../types";
 import { getSelectedElements } from "../../scene/selection";
+import { registerCustomSubtypes } from "../../subtypes";
 
 const readFile = util.promisify(fs.readFile);
 
 const { h } = window;
 
 export class API {
+  constructor() {
+    registerCustomSubtypes();
+  }
+
   static setSelectedElements = (elements: ExcalidrawElement[]) => {
     h.setState({
       selectedElementIds: elements.reduce((acc, element) => {
@@ -97,6 +102,8 @@ export class API {
     verticalAlign?: T extends "text"
       ? ExcalidrawTextElement["verticalAlign"]
       : never;
+    subtype?: ExcalidrawElement["subtype"];
+    customProps?: ExcalidrawElement["customProps"];
     boundElements?: ExcalidrawGenericElement["boundElements"];
     containerId?: T extends "text"
       ? ExcalidrawTextElement["containerId"]
@@ -114,7 +121,15 @@ export class API {
 
     const appState = h?.state || getDefaultAppState();
 
+    const custom = maybeGetCustom(
+      {
+        subtype: rest.subtype ?? appState.activeSubtype,
+        customProps: rest.customProps ?? appState.customProps,
+      },
+      type,
+    );
     const base = {
+      ...custom,
       x,
       y,
       strokeColor: rest.strokeColor ?? appState.currentItemStrokeColor,

--- a/src/types.ts
+++ b/src/types.ts
@@ -92,6 +92,8 @@ export type AppState = {
   // (e.g. text element when typing into the input)
   editingElement: NonDeletedExcalidrawElement | null;
   editingLinearElement: LinearElementEditor | null;
+  activeSubtype?: ExcalidrawElement["subtype"];
+  customProps?: ExcalidrawElement["customProps"];
   activeTool:
     | {
         type: typeof SHAPES[number]["value"] | "eraser";


### PR DESCRIPTION
(This might not be the PR you are looking for.  #5349 duplicates #3915, and #5429 provides an actual `@excalidraw/plugins` stub package.)

#5349 is a rollup subset of #2993.  (#2993 contributes three features: an initial `@excalidraw/plugins` package; custom `ExcalidrawElement` subtype extensions; and MathJax support as a plugin.)

**Overview of #5349**
This PR is to start the creation of a plugins API for `@excalidraw/excalidraw`.  The description of #3915 provides an overview of the first commit here (essentially the second feature of #2993).  The first commit provides a mechanism to decouple custom extensions of `ExcalidrawElement` from the Excalidraw codebase.  This mechanism is used in the MathJax plugin of #2993, and can also be used for Kroki, Mermaid, and the like.

cc @dwelle @ad1992 