### PR TITLE
Feat: UI Moved Dialog title to the bottom to support mobile users

### DIFF
--- a/src/components/Dialog.scss
+++ b/src/components/Dialog.scss
@@ -38,18 +38,22 @@
       --inset-right: #{"max(var(--metric), var(--sar))"};
     }
 
+    .Dialog__content {
+      margin-bottom: 16px;
+    }
+
     .Dialog__title {
       grid-template-columns: calc(var(--space-factor) * 7) 1fr calc(
           var(--space-factor) * 7
         );
-      position: sticky;
-      top: 0;
+      position: fixed;
+      bottom: 0;
       padding: calc(var(--space-factor) * 2);
       background: var(--island-bg-color);
       font-size: 1.25em;
-
+      margin: 0;
       box-sizing: border-box;
-      border-bottom: 1px solid var(--button-gray-2);
+      border-top: 1px solid var(--button-gray-2);
       z-index: 1;
     }
 

--- a/src/components/Dialog.scss
+++ b/src/components/Dialog.scss
@@ -43,6 +43,7 @@
     }
 
     .Dialog__title {
+      width:100%;
       grid-template-columns: calc(var(--space-factor) * 7) 1fr calc(
           var(--space-factor) * 7
         );


### PR DESCRIPTION
#4833 
The notch on some mobiles blocks the navigation and Dialog at the top of the export page. This change moves the Dialog title and back button to the bottom of the screen.