### PR TITLE
feat: throttle scene rendering to animation framerate

### DIFF
--- a/src/renderer/index.ts
+++ b/src/renderer/index.ts
@@ -1,1 +1,0 @@
-export { renderScene } from "./renderScene";

--- a/src/renderer/renderScene.ts
+++ b/src/renderer/renderScene.ts
@@ -47,7 +47,11 @@ import {
   TransformHandles,
   TransformHandleType,
 } from "../element/transformHandles";
-import { viewportCoordsToSceneCoords, supportsEmoji } from "../utils";
+import {
+  viewportCoordsToSceneCoords,
+  supportsEmoji,
+  throttleRAF,
+} from "../utils";
 import { UserIdleState } from "../types";
 import { THEME_FILTER } from "../constants";
 import {
@@ -567,6 +571,32 @@ export const renderScene = (
   context.restore();
   return { atLeastOneVisibleElement: visibleElements.length > 0, scrollBars };
 };
+
+/** renderScene throttled to animation framerate */
+export const renderSceneThrottled = throttleRAF(
+  (
+    elements: readonly NonDeletedExcalidrawElement[],
+    appState: AppState,
+    selectionElement: NonDeletedExcalidrawElement | null,
+    scale: number,
+    rc: RoughCanvas,
+    canvas: HTMLCanvasElement,
+    renderConfig: RenderConfig,
+    callback?: (data: ReturnType<typeof renderScene>) => void,
+  ) => {
+    const ret = renderScene(
+      elements,
+      appState,
+      selectionElement,
+      scale,
+      rc,
+      canvas,
+      renderConfig,
+    );
+    callback?.(ret);
+  },
+  { trailing: true },
+);
 
 const renderTransformHandles = (
   context: CanvasRenderingContext2D,

--- a/src/tests/contextmenu.test.tsx
+++ b/src/tests/contextmenu.test.tsx
@@ -39,7 +39,7 @@ const mouse = new Pointer("mouse");
 // Unmount ReactDOM from root
 ReactDOM.unmountComponentAtNode(document.getElementById("root")!);
 
-const renderScene = jest.spyOn(Renderer, "renderScene");
+const renderScene = jest.spyOn(Renderer, "renderSceneThrottled");
 beforeEach(() => {
   localStorage.clear();
   renderScene.mockClear();

--- a/src/tests/dragCreate.test.tsx
+++ b/src/tests/dragCreate.test.tsx
@@ -14,7 +14,7 @@ import { reseed } from "../random";
 // Unmount ReactDOM from root
 ReactDOM.unmountComponentAtNode(document.getElementById("root")!);
 
-const renderScene = jest.spyOn(Renderer, "renderScene");
+const renderScene = jest.spyOn(Renderer, "renderSceneThrottled");
 beforeEach(() => {
   localStorage.clear();
   renderScene.mockClear();

--- a/src/tests/move.test.tsx
+++ b/src/tests/move.test.tsx
@@ -16,7 +16,7 @@ import { KEYS } from "../keys";
 // Unmount ReactDOM from root
 ReactDOM.unmountComponentAtNode(document.getElementById("root")!);
 
-const renderScene = jest.spyOn(Renderer, "renderScene");
+const renderScene = jest.spyOn(Renderer, "renderSceneThrottled");
 beforeEach(() => {
   localStorage.clear();
   renderScene.mockClear();

--- a/src/tests/multiPointCreate.test.tsx
+++ b/src/tests/multiPointCreate.test.tsx
@@ -14,7 +14,7 @@ import { reseed } from "../random";
 // Unmount ReactDOM from root
 ReactDOM.unmountComponentAtNode(document.getElementById("root")!);
 
-const renderScene = jest.spyOn(Renderer, "renderScene");
+const renderScene = jest.spyOn(Renderer, "renderSceneThrottled");
 beforeEach(() => {
   localStorage.clear();
   renderScene.mockClear();

--- a/src/tests/regressionTests.test.tsx
+++ b/src/tests/regressionTests.test.tsx
@@ -20,7 +20,7 @@ import { t } from "../i18n";
 
 const { h } = window;
 
-const renderScene = jest.spyOn(Renderer, "renderScene");
+const renderScene = jest.spyOn(Renderer, "renderSceneThrottled");
 
 const mouse = new Pointer("mouse");
 const finger1 = new Pointer("touch", 1);

--- a/src/tests/resize.test.tsx
+++ b/src/tests/resize.test.tsx
@@ -18,7 +18,7 @@ const mouse = new Pointer("mouse");
 // Unmount ReactDOM from root
 ReactDOM.unmountComponentAtNode(document.getElementById("root")!);
 
-const renderScene = jest.spyOn(Renderer, "renderScene");
+const renderScene = jest.spyOn(Renderer, "renderSceneThrottled");
 beforeEach(() => {
   localStorage.clear();
   renderScene.mockClear();

--- a/src/tests/selection.test.tsx
+++ b/src/tests/selection.test.tsx
@@ -16,7 +16,7 @@ import { Keyboard, Pointer } from "./helpers/ui";
 // Unmount ReactDOM from root
 ReactDOM.unmountComponentAtNode(document.getElementById("root")!);
 
-const renderScene = jest.spyOn(Renderer, "renderScene");
+const renderScene = jest.spyOn(Renderer, "renderSceneThrottled");
 beforeEach(() => {
   localStorage.clear();
   renderScene.mockClear();

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -134,16 +134,15 @@ export const throttleRAF = <T extends any[]>(
   let lastArgs: T | null = null;
   let lastArgsTrailing: T | null = null;
 
-  const scheduleFunc = (args: T, trailing = false) => {
+  const scheduleFunc = (args: T) => {
     timerId = window.requestAnimationFrame(() => {
       timerId = null;
-      // @ts-ignore
-      fn(...[...args, trailing]);
+      fn(...args);
       lastArgs = null;
       if (lastArgsTrailing) {
         lastArgs = lastArgsTrailing;
         lastArgsTrailing = null;
-        scheduleFunc(lastArgs, true);
+        scheduleFunc(lastArgs);
       }
     });
   };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -126,47 +126,55 @@ export const debounce = <T extends any[]>(
 };
 
 // throttle callback to execute once per animation frame
-export const throttleRAF = <T extends any[]>(fn: (...args: T) => void) => {
-  let handle: number | null = null;
+export const throttleRAF = <T extends any[]>(
+  fn: (...args: T) => void,
+  opts?: { trailing?: boolean },
+) => {
+  let timerId: number | null = null;
   let lastArgs: T | null = null;
-  let callback: ((...args: T) => void) | null = null;
+  let lastArgsTrailing: T | null = null;
+
+  const scheduleFunc = (args: T, trailing = false) => {
+    timerId = window.requestAnimationFrame(() => {
+      timerId = null;
+      // @ts-ignore
+      fn(...[...args, trailing]);
+      lastArgs = null;
+      if (lastArgsTrailing) {
+        lastArgs = lastArgsTrailing;
+        lastArgsTrailing = null;
+        scheduleFunc(lastArgs, true);
+      }
+    });
+  };
+
   const ret = (...args: T) => {
     if (process.env.NODE_ENV === "test") {
       fn(...args);
       return;
     }
     lastArgs = args;
-    callback = fn;
-    if (handle === null) {
-      handle = window.requestAnimationFrame(() => {
-        handle = null;
-        lastArgs = null;
-        callback = null;
-        fn(...args);
-      });
+    if (timerId === null) {
+      scheduleFunc(lastArgs);
+    } else if (opts?.trailing) {
+      lastArgsTrailing = args;
     }
   };
   ret.flush = () => {
-    if (handle !== null) {
-      cancelAnimationFrame(handle);
-      handle = null;
+    if (timerId !== null) {
+      cancelAnimationFrame(timerId);
+      timerId = null;
     }
     if (lastArgs) {
-      const _lastArgs = lastArgs;
-      const _callback = callback;
-      lastArgs = null;
-      callback = null;
-      if (_callback !== null) {
-        _callback(..._lastArgs);
-      }
+      fn(...(lastArgsTrailing || lastArgs));
+      lastArgs = lastArgsTrailing = null;
     }
   };
   ret.cancel = () => {
-    lastArgs = null;
-    callback = null;
-    if (handle !== null) {
-      cancelAnimationFrame(handle);
-      handle = null;
+    lastArgs = lastArgsTrailing = null;
+    if (timerId !== null) {
+      cancelAnimationFrame(timerId);
+      timerId = null;
     }
   };
   return ret;


### PR DESCRIPTION
fix https://github.com/excalidraw/excalidraw/issues/5385

The main scene render loop is now throttled to animation framerate. Trailing invocation is enabled to ensure that potentially significant calls are not lost, such as when selecting where we need to ensure the last render removing the box-selection is made.

May break things. I suppose we'll find out once we ship.