### PR TITLE
fix: missing translation for "Scale" to Export Dialog

### DIFF
--- a/src/components/ImageExportDialog.tsx
+++ b/src/components/ImageExportDialog.tsx
@@ -170,7 +170,9 @@ const ImageExportModal = ({
         <Stack.Row gap={2}>
           {actionManager.renderAction("changeExportScale")}
         </Stack.Row>
-        <p style={{ marginLeft: "1em", userSelect: "none" }}>Scale</p>
+        <p style={{ marginLeft: "1em", userSelect: "none" }}>
+          {t("buttons.scale")}
+        </p>
       </div>
       <div
         style={{


### PR DESCRIPTION
Hi,
I found a missing translation for the word "Scale" in the export dialog.
I have reused the "button.scale" entry. Is it right for you?
Or it's better to create a new entry?
