### PR TITLE
fix: check for ctrl key when wheel event triggered to only disable zooming

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -955,7 +955,6 @@ class App extends React.Component<AppProps, AppState> {
       EVENT.WHEEL,
       this.onWheel,
     );
-
     this.nearestScrollableContainer?.removeEventListener(
       EVENT.SCROLL,
       this.onScroll,

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -955,6 +955,7 @@ class App extends React.Component<AppProps, AppState> {
       EVENT.WHEEL,
       this.onWheel,
     );
+
     this.nearestScrollableContainer?.removeEventListener(
       EVENT.SCROLL,
       this.onScroll,
@@ -1959,9 +1960,9 @@ class App extends React.Component<AppProps, AppState> {
     },
   );
 
-  private onWheel = withBatchedUpdates((event: MouseEvent) => {
+  private onWheel = withBatchedUpdates((event: WheelEvent) => {
     // prevent browser pinch zoom on DOM elements
-    if (!(event.target instanceof HTMLCanvasElement)) {
+    if (!(event.target instanceof HTMLCanvasElement) && event.ctrlKey) {
       event.preventDefault();
     }
   });


### PR DESCRIPTION
fixes https://github.com/excalidraw/excalidraw/issues/5458

https://user-images.githubusercontent.com/11256141/179467759-bfd03de4-a3b2-4e97-84bf-56d79f7962c3.mp4



Looked into different heuristics eg checking `event.deltaY` to fix this but `browser` setting `ctrl` event to true when pinch zooming is interesting, got to know about this when looking into how Miro code of preventing pinch zoom but still allow scrolling :p.

This works well, lemme know if you find any issues when testing it out.