### PR TITLE
docs: Add VS Code mention to the integration section

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Last but not least, we're thankful to these companies for offering their service
 
 ## Who's integrating Excalidraw
 
-[Google Cloud](https://googlecloudcheatsheet.withgoogle.com/architecture) • [Meta](https://meta.com/) • [CodeSandbox](https://codesandbox.io/) • [Obsidian Excalidraw](https://github.com/zsviczian/obsidian-excalidraw-plugin) • [Replit](https://replit.com/) • [Slite](https://slite.com/) • [Notion](https://notion.so/) • [HackerRank](https://www.hackerrank.com/) •
+[Google Cloud](https://googlecloudcheatsheet.withgoogle.com/architecture) • [Meta](https://meta.com/) • [CodeSandbox](https://codesandbox.io/) • [Obsidian Excalidraw](https://github.com/zsviczian/obsidian-excalidraw-plugin) • [Replit](https://replit.com/) • [Slite](https://slite.com/) • [Notion](https://notion.so/) • [HackerRank](https://www.hackerrank.com/) • [VS Code](https://marketplace.visualstudio.com/items?itemName=pomdtr.excalidraw-editor)
 
 ## Documentation
 


### PR DESCRIPTION
Since the obsidian plugin is mentionned there, I think it makes sense.

Alternatively, we could have a whole section with a demo image.