### PR TITLE
fix: Use React.FC as react-dom is not able to infer types of Modal

### DIFF
--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -8,7 +8,7 @@ import { useExcalidrawContainer, useDevice } from "./App";
 import { AppState } from "../types";
 import { THEME } from "../constants";
 
-export const Modal = (props: {
+export const Modal: React.FC<{
   className?: string;
   children: React.ReactNode;
   maxWidth?: number;
@@ -16,7 +16,7 @@ export const Modal = (props: {
   labelledBy: string;
   theme?: AppState["theme"];
   closeOnClickOutside?: boolean;
-}) => {
+}> = (props) => {
   const { theme = THEME.LIGHT, closeOnClickOutside = true } = props;
   const modalRoot = useBodyRoot(theme);
 


### PR DESCRIPTION
Error
<img width="458" alt="Screenshot 2022-07-22 at 12 45 53 PM" src="https://user-images.githubusercontent.com/11256141/180384848-063df368-d2e7-487f-b49f-ac269df5e658.png">

Due to this types couldn't be generated and hence package couldn't be [released](https://github.com/excalidraw/excalidraw/runs/7462925431?check_suite_focus=true) 