### PR TITLE
fix: useLayout effect cleanup in dev mode for charts

### DIFF
--- a/src/components/PasteChartDialog.tsx
+++ b/src/components/PasteChartDialog.tsx
@@ -46,7 +46,7 @@ const ChartPreviewBtn = (props: {
         },
         null, // files
       );
-
+      previewNode.replaceChildren();
       previewNode.appendChild(svg);
 
       if (props.selected) {
@@ -55,7 +55,7 @@ const ChartPreviewBtn = (props: {
     })();
 
     return () => {
-      previewNode.removeChild(svg);
+      previewNode.replaceChildren();
     };
   }, [props.spreadsheet, props.chartType, props.selected]);
 


### PR DESCRIPTION
In React 18 the effects run twice mount -> unmount -> mount in strict mode (only for dev to cleanup any unsafe side effects and ensure [reusable state](https://github.com/reactwg/react-18/discussions/19) for future API's) hence due to this the charts was broken as mentioned in https://github.com/excalidraw/excalidraw/issues/5503 in dev mode only

Due to this the component was being unmounted even before `svg` generate leading to the error in dev mode. So I am cleaning up the children of the DOM node before appending the new child.

