### PR TITLE
fix: use flushSync when moving line editor since we need to read previous value after setting state

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -2682,6 +2682,9 @@ class App extends React.Component<AppProps, AppState> {
         this.state.gridSize,
       );
       if (editingLinearElement !== this.state.editingLinearElement) {
+        // Since we are reading from previous state which is not possible with
+        // automatic batching in React 18 hence using flush sync to synchronously
+        // update the state. Check https://github.com/excalidraw/excalidraw/pull/5508 for more details.
         flushSync(() => {
           this.setState({ editingLinearElement });
         });

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,4 +1,5 @@
 import React, { useContext } from "react";
+import { flushSync } from "react-dom";
 import { RoughCanvas } from "roughjs/bin/canvas";
 import rough from "roughjs/bin/rough";
 import clsx from "clsx";
@@ -2681,7 +2682,9 @@ class App extends React.Component<AppProps, AppState> {
         this.state.gridSize,
       );
       if (editingLinearElement !== this.state.editingLinearElement) {
-        this.setState({ editingLinearElement });
+        flushSync(() => {
+          this.setState({ editingLinearElement });
+        });
       }
       if (editingLinearElement.lastUncommittedPoint != null) {
         this.maybeSuggestBindingAtCursor(scenePointer);


### PR DESCRIPTION
Since React 18 batches the states between event handlers - This was happening before as well but there was a minor difference for class Components -> You still can read values of previous state in class components as it use to render the updates synchronously which is not possible now with React 18 where it doesn't render until the next browser tick.

Due to this the line editor behaviour was breaking once you start adding points as we compare the current and previous values and in React 18 this comparison is not working as its not synchronous anymore and hence leads to continuously adding points once alt is pressed and excessive state updates of course as points get added (notice the logs in video)



https://user-images.githubusercontent.com/11256141/181766843-c56c85ba-af29-461d-b6f4-6f326a20f1b4.mp4



To solve this I am using `flushSync` to revert to previous behaviour as mentioned in [docs](https://github.com/reactwg/react-18/discussions/21)


Will come up with better approach to solve this so we can move away from flush sync

https://user-images.githubusercontent.com/11256141/181766858-e79ebf93-5cff-4e2e-a653-8f4348060f75.mp4


