### PR TITLE
feat: cursor alignment when creating generic elements

### DIFF
--- a/src/element/dragElements.ts
+++ b/src/element/dragElements.ts
@@ -109,11 +109,22 @@ export const dragNewElement = (
     if (widthAspectRatio) {
       height = width / widthAspectRatio;
     } else {
-      ({ width, height } = getPerfectElementSize(
-        elementType,
-        width,
-        y < originY ? -height : height,
-      ));
+      // Depending on where the cursor is at (x, y) relative to where the starting point is
+      // (originX, originY), we use ONLY width or height to control size increase.
+      // This allows the cursor to always "stick" to one of the sides of the bounding box.
+      if (Math.abs(y - originY) > Math.abs(x - originX)) {
+        ({ width, height } = getPerfectElementSize(
+          elementType,
+          height,
+          x < originX ? -width : width,
+        ));
+      } else {
+        ({ width, height } = getPerfectElementSize(
+          elementType,
+          width,
+          y < originY ? -height : height,
+        ));
+      }
 
       if (height < 0) {
         height = -height;


### PR DESCRIPTION
![generic-shift](https://user-images.githubusercontent.com/47294779/182067557-c8a0ce84-b30f-4965-b8af-a8887eb91c3a.png)

fixes https://github.com/excalidraw/excalidraw/issues/5513