### PR TITLE
feat: cursor alignment when creating linear elements with shift pressed

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -89,7 +89,7 @@ import {
   getNormalizedDimensions,
   getResizeArrowDirection,
   getResizeOffsetXY,
-  getPerfectLinearSize,
+  getLockedLinearCursorAlignSize,
   getTransformHandleTypeFromCoords,
   hitTest,
   isHittingElementBoundingBoxWithoutHittingElement,
@@ -2768,7 +2768,7 @@ class App extends React.Component<AppProps, AppState> {
 
         if (shouldRotateWithDiscreteAngle(event)) {
           ({ width: dxFromLastCommitted, height: dyFromLastCommitted } =
-            getPerfectLinearSize(
+            getLockedLinearCursorAlignSize(
               // actual coordinate of the last committed point
               lastCommittedX + rx,
               lastCommittedY + ry,
@@ -4244,7 +4244,7 @@ class App extends React.Component<AppProps, AppState> {
         let dy = gridY - draggingElement.y;
 
         if (shouldRotateWithDiscreteAngle(event) && points.length === 2) {
-          ({ width: dx, height: dy } = getPerfectLinearSize(
+          ({ width: dx, height: dy } = getLockedLinearCursorAlignSize(
             draggingElement.x,
             draggingElement.y,
             pointerCoords.x,

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -89,6 +89,7 @@ import {
   getNormalizedDimensions,
   getResizeArrowDirection,
   getResizeOffsetXY,
+  getPerfectLinearSize,
   getTransformHandleTypeFromCoords,
   hitTest,
   isHittingElementBoundingBoxWithoutHittingElement,
@@ -259,7 +260,6 @@ import {
   isPointHittingLinkIcon,
   isLocalLink,
 } from "../element/Hyperlink";
-import { getPerfectLinearSize } from "../element/sizeHelpers";
 
 const deviceContextInitialValue = {
   isSmScreen: false,
@@ -2768,10 +2768,13 @@ class App extends React.Component<AppProps, AppState> {
 
         if (shouldRotateWithDiscreteAngle(event)) {
           ({ width: dxFromLastCommitted, height: dyFromLastCommitted } =
-            getPerfectElementSize(
-              this.state.activeTool.type,
-              dxFromLastCommitted,
-              dyFromLastCommitted,
+            getPerfectLinearSize(
+              // actual coordinate of the last committed point
+              lastCommittedX + rx,
+              lastCommittedY + ry,
+              // cursor-grid coordinate
+              gridX,
+              gridY,
             ));
         }
 

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -87,7 +87,6 @@ import {
   getDragOffsetXY,
   getElementWithTransformHandleType,
   getNormalizedDimensions,
-  getPerfectElementSize,
   getResizeArrowDirection,
   getResizeOffsetXY,
   getTransformHandleTypeFromCoords,
@@ -260,6 +259,7 @@ import {
   isPointHittingLinkIcon,
   isLocalLink,
 } from "../element/Hyperlink";
+import { getPerfectLinearSize } from "../element/sizeHelpers";
 
 const deviceContextInitialValue = {
   isSmScreen: false,
@@ -4241,10 +4241,11 @@ class App extends React.Component<AppProps, AppState> {
         let dy = gridY - draggingElement.y;
 
         if (shouldRotateWithDiscreteAngle(event) && points.length === 2) {
-          ({ width: dx, height: dy } = getPerfectElementSize(
-            this.state.activeTool.type,
-            dx,
-            dy,
+          ({ width: dx, height: dy } = getPerfectLinearSize(
+            draggingElement.x,
+            draggingElement.y,
+            pointerCoords.x,
+            pointerCoords.y,
           ));
         }
 

--- a/src/element/index.ts
+++ b/src/element/index.ts
@@ -53,6 +53,7 @@ export { textWysiwyg } from "./textWysiwyg";
 export { redrawTextBoundingBox } from "./textElement";
 export {
   getPerfectElementSize,
+  getPerfectLinearSize,
   isInvisiblySmallElement,
   resizePerfectLineForNWHandler,
   getNormalizedDimensions,

--- a/src/element/index.ts
+++ b/src/element/index.ts
@@ -53,7 +53,7 @@ export { textWysiwyg } from "./textWysiwyg";
 export { redrawTextBoundingBox } from "./textElement";
 export {
   getPerfectElementSize,
-  getPerfectLinearSize,
+  getLockedLinearCursorAlignSize,
   isInvisiblySmallElement,
   resizePerfectLineForNWHandler,
   getNormalizedDimensions,

--- a/src/element/sizeHelpers.ts
+++ b/src/element/sizeHelpers.ts
@@ -47,6 +47,46 @@ export const getPerfectElementSize = (
   return { width, height };
 };
 
+export const getPerfectLinearSize = (
+  originX: number,
+  originY: number,
+  x: number,
+  y: number,
+) => {
+  let width = x - originX;
+  let height = y - originY;
+
+  const lockedAngle =
+    Math.round(Math.atan(height / width) / SHIFT_LOCKING_ANGLE) *
+    SHIFT_LOCKING_ANGLE;
+
+  if (lockedAngle === 0) {
+    height = 0;
+  } else if (lockedAngle === Math.PI / 2) {
+    width = 0;
+  } else {
+    // locked angle line, y = mx + b => mx - y + b = 0
+    const a1 = Math.tan(lockedAngle);
+    const b1 = -1;
+    const c1 = originY - a1 * originX;
+
+    // line through cursor, perpendicular to locked angle line
+    const a2 = -1 / a1;
+    const b2 = -1;
+    const c2 = y - a2 * x;
+
+    // intersection of the two lines above
+    const intersectX = Math.round((b1 * c2 - b2 * c1) / (a1 * b2 - a2 * b1));
+    const intersectY = Math.round((c1 * a2 - c2 * a1) / (a1 * b2 - a2 * b1));
+
+    // delta
+    width = intersectX - originX;
+    height = intersectY - originY;
+  }
+
+  return { width, height };
+};
+
 export const resizePerfectLineForNWHandler = (
   element: ExcalidrawElement,
   x: number,

--- a/src/element/sizeHelpers.ts
+++ b/src/element/sizeHelpers.ts
@@ -47,7 +47,7 @@ export const getPerfectElementSize = (
   return { width, height };
 };
 
-export const getPerfectLinearSize = (
+export const getLockedLinearCursorAlignSize = (
   originX: number,
   originY: number,
   x: number,


### PR DESCRIPTION
1. work out the angle θ
2. find out which locked angle θ is closet to
3. express the locked angle line and the line through the point at cursor that is also perpendicular to the locked angle line
4. find out the perpendicular intersection
![shift-linear-alignment](https://user-images.githubusercontent.com/47294779/182142479-78ef332d-84b2-4d91-9ab9-a32779ebcf24.png)

