### PR TITLE
fix: disable locking aspect ratio for box-selection

### DIFF
--- a/src/element/dragElements.ts
+++ b/src/element/dragElements.ts
@@ -105,7 +105,7 @@ export const dragNewElement = (
       true */
   widthAspectRatio?: number | null,
 ) => {
-  if (shouldMaintainAspectRatio) {
+  if (shouldMaintainAspectRatio && draggingElement.type !== "selection") {
     if (widthAspectRatio) {
       height = width / widthAspectRatio;
     } else {


### PR DESCRIPTION
Disabled aspect ration locking for box-selection. Other apps don't do it, and it fixes this regression we shipped recently:

![excal-box-selection-ar-bug](https://user-images.githubusercontent.com/5153846/182388601-559a78ab-e7be-4c80-b1b6-e4197d1f239b.gif)
