### PR TITLE
fix: Scene lookup failing when looking up by id

### DIFF
--- a/src/scene/Scene.ts
+++ b/src/scene/Scene.ts
@@ -29,9 +29,14 @@ class Scene {
 
   static mapElementToScene(elementKey: ElementKey, scene: Scene) {
     if (isIdKey(elementKey)) {
+      // for cases where we don't have access to the element object
+      // (e.g. restore serialized appState with id references)
       this.sceneMapById.set(elementKey, scene);
     } else {
       this.sceneMapByElement.set(elementKey, scene);
+      // if mapping element objects, also cache the id string when later
+      // looking up by id alone
+      this.sceneMapById.set(elementKey.id, scene);
     }
   }
 


### PR DESCRIPTION
fix https://github.com/excalidraw/excalidraw/issues/5541

When caching elements for later Scene lookup, we were mapping `Scene -> ExcalidrawElement` only, but we also have `Scene -> ExcalidrawElementId` when we need to lookup by id alone.

This PR makes sure we populate both maps when caching.

- [ ] this won't fix a case where we cache by `id` alone, look up by element object. Should we check both maps when looking up by element object? The worry here is that in multi-instance scenarios it may retrieve the wrong Scene (from another instance). This can already happen when looking up by id alone, though.