### PR TITLE
feat: better default radius size for squares and diamonds

### DIFF
--- a/src/math.ts
+++ b/src/math.ts
@@ -263,3 +263,14 @@ export const getGridPoint = (
   }
   return [x, y];
 };
+
+/**
+ * @param x
+ * @param scale used to "speed up" or "slow down" mono decrease amount
+ * @returns monotonically decreasingly scaled version of x
+ */
+export const getMonoDecreasedValue = (x: number, scale = 0.005) => {
+  // take f(x) = 1 - ((1-e^(-x)) / 2)
+  // for x >= 0, f(x) is in the range of [0, 1] monotonically decreasing
+  return (1 - (1 - Math.exp(-x * scale)) / 2) * x;
+};

--- a/src/math.ts
+++ b/src/math.ts
@@ -269,8 +269,10 @@ export const getGridPoint = (
  * @param scale used to "speed up" or "slow down" mono decrease amount
  * @returns monotonically decreasingly scaled version of x
  */
-export const getMonoDecreasedValue = (x: number, scale = 0.005) => {
-  // take f(x) = 1 - ((1-e^(-x)) / 2)
-  // for x >= 0, f(x) is in the range of [0, 1] monotonically decreasing
-  return (1 - (1 - Math.exp(-x * scale)) / 2) * x;
+export const getMonoDecreasedValue = (x: number, scale = 0.0035) => {
+  // Take f(x) = e^(-x), a monotonically decreasing function.
+  // For x >= 0, f(x) is in the range of [0.5, 1], which provides a
+  // gradual scale down as x increases.
+  // As f(x) is really meant for x >= 0, for x < 0, we return it as is
+  return x < 0 ? x : (1 - (1 - Math.exp(-x * scale)) / 2) * x;
 };

--- a/src/renderer/renderElement.ts
+++ b/src/renderer/renderElement.ts
@@ -443,30 +443,32 @@ const generateElementShape = (
           getDiamondPoints(element);
         if (element.strokeSharpness === "round") {
           shape = generator.path(
-            `M ${topX + (rightX - topX) * 0.25} ${
-              topY + (rightY - topY) * 0.25
-            } L ${rightX - (rightX - topX) * 0.25} ${
-              rightY - (rightY - topY) * 0.25
+            `M ${topX + getMonoDecreasedValue(rightX - topX) * 0.25} ${
+              topY + getMonoDecreasedValue(rightY - topY) * 0.25
+            } L ${rightX - getMonoDecreasedValue(rightX - topX) * 0.25} ${
+              rightY - getMonoDecreasedValue(rightY - topY) * 0.25
             }
             C ${rightX} ${rightY}, ${rightX} ${rightY}, ${
-              rightX - (rightX - bottomX) * 0.25
-            } ${rightY + (bottomY - rightY) * 0.25}
-            L ${bottomX + (rightX - bottomX) * 0.25} ${
-              bottomY - (bottomY - rightY) * 0.25
+              rightX - getMonoDecreasedValue(rightX - bottomX) * 0.25
+            } ${rightY + getMonoDecreasedValue(bottomY - rightY) * 0.25}
+            L ${bottomX + getMonoDecreasedValue(rightX - bottomX) * 0.25} ${
+              bottomY - getMonoDecreasedValue(bottomY - rightY) * 0.25
             }
             C ${bottomX} ${bottomY}, ${bottomX} ${bottomY}, ${
-              bottomX - (bottomX - leftX) * 0.25
-            } ${bottomY - (bottomY - leftY) * 0.25}
-            L ${leftX + (bottomX - leftX) * 0.25} ${
-              leftY + (bottomY - leftY) * 0.25
+              bottomX - getMonoDecreasedValue(bottomX - leftX) * 0.25
+            } ${bottomY - getMonoDecreasedValue(bottomY - leftY) * 0.25}
+            L ${leftX + getMonoDecreasedValue(bottomX - leftX) * 0.25} ${
+              leftY + getMonoDecreasedValue(bottomY - leftY) * 0.25
             }
             C ${leftX} ${leftY}, ${leftX} ${leftY}, ${
-              leftX + (topX - leftX) * 0.25
-            } ${leftY - (leftY - topY) * 0.25}
-            L ${topX - (topX - leftX) * 0.25} ${topY + (leftY - topY) * 0.25}
+              leftX + getMonoDecreasedValue(topX - leftX) * 0.25
+            } ${leftY - getMonoDecreasedValue(leftY - topY) * 0.25}
+            L ${topX - getMonoDecreasedValue(topX - leftX) * 0.25} ${
+              topY + getMonoDecreasedValue(leftY - topY) * 0.25
+            }
             C ${topX} ${topY}, ${topX} ${topY}, ${
-              topX + (rightX - topX) * 0.25
-            } ${topY + (rightY - topY) * 0.25}`,
+              topX + getMonoDecreasedValue(rightX - topX) * 0.25
+            } ${topY + getMonoDecreasedValue(rightY - topY) * 0.25}`,
             generateRoughOptions(element, true),
           );
         } else {

--- a/src/renderer/renderElement.ts
+++ b/src/renderer/renderElement.ts
@@ -25,7 +25,7 @@ import { RoughGenerator } from "roughjs/bin/generator";
 
 import { RenderConfig } from "../scene/types";
 import { distance, getFontString, getFontFamilyString, isRTL } from "../utils";
-import { isPathALoop } from "../math";
+import { getMonoDecreasedValue, isPathALoop } from "../math";
 import rough from "roughjs/bin/rough";
 import { AppState, BinaryFiles, Zoom } from "../types";
 import { getDefaultAppState } from "../appState";
@@ -417,7 +417,7 @@ const generateElementShape = (
         if (element.strokeSharpness === "round") {
           const w = element.width;
           const h = element.height;
-          const r = Math.min(w, h) * 0.25;
+          const r = getMonoDecreasedValue(Math.min(w, h)) * 0.25;
           shape = generator.path(
             `M ${r} 0 L ${w - r} 0 Q ${w} 0, ${w} ${r} L ${w} ${
               h - r


### PR DESCRIPTION
Using a monotonically decreasing function to take the size of the squares and diamonds into consideration when deciding the corner radius. 

![image](https://user-images.githubusercontent.com/47294779/183559857-7ccfd8bf-18b8-44ac-8c7c-21a4c3c804da.png)

The smaller the size of the square, the closer the radius is to the current production fixed radius.
![image](https://user-images.githubusercontent.com/47294779/183560037-bcb46e2c-e831-4011-8e8d-a1843d1549cc.png)

We can play around with the default scale, 0.0035, for a bit. 

