### PR TITLE
fix: resize multiple elements from center

### DIFF
--- a/src/element/bounds.ts
+++ b/src/element/bounds.ts
@@ -18,6 +18,7 @@ import { rescalePoints } from "../points";
 
 // x and y position of top left corner, x and y position of bottom right corner
 export type Bounds = readonly [number, number, number, number];
+type MaybeQuadraticSolution = [number | null, number | null] | false;
 
 // If the element is created from right to left, the width is going to be negative
 // This set of functions retrieves the absolute position of the 4 points.
@@ -68,6 +69,89 @@ export const getCurvePathOps = (shape: Drawable): Op[] => {
   return shape.sets[0].ops;
 };
 
+// reference: https://eliot-jones.com/2019/12/cubic-bezier-curve-bounding-boxes
+const getBezierValueForT = (
+  t: number,
+  p0: number,
+  p1: number,
+  p2: number,
+  p3: number,
+) => {
+  const oneMinusT = 1 - t;
+  return (
+    Math.pow(oneMinusT, 3) * p0 +
+    3 * Math.pow(oneMinusT, 2) * t * p1 +
+    3 * oneMinusT * Math.pow(t, 2) * p2 +
+    Math.pow(t, 3) * p3
+  );
+};
+
+const solveQuadratic = (
+  p0: number,
+  p1: number,
+  p2: number,
+  p3: number,
+): MaybeQuadraticSolution => {
+  const i = p1 - p0;
+  const j = p2 - p1;
+  const k = p3 - p2;
+
+  const a = 3 * i - 6 * j + 3 * k;
+  const b = 6 * j - 6 * i;
+  const c = 3 * i;
+
+  const sqrtPart = b * b - 4 * a * c;
+  const hasSolution = sqrtPart >= 0;
+
+  if (!hasSolution) {
+    return false;
+  }
+
+  const t1 = (-b + Math.sqrt(sqrtPart)) / (2 * a);
+  const t2 = (-b - Math.sqrt(sqrtPart)) / (2 * a);
+
+  let s1 = null;
+  let s2 = null;
+
+  if (t1 >= 0 && t1 <= 1) {
+    s1 = getBezierValueForT(t1, p0, p1, p2, p3);
+  }
+
+  if (t2 >= 0 && t2 <= 1) {
+    s2 = getBezierValueForT(t2, p0, p1, p2, p3);
+  }
+
+  return [s1, s2];
+};
+
+const getCubicBezierCurveBound = (
+  p0: Point,
+  p1: Point,
+  p2: Point,
+  p3: Point,
+): Bounds => {
+  const solX = solveQuadratic(p0[0], p1[0], p2[0], p3[0]);
+  const solY = solveQuadratic(p0[1], p1[1], p2[1], p3[1]);
+
+  let minX = Math.min(p0[0], p3[0]);
+  let maxX = Math.max(p0[0], p3[0]);
+
+  if (solX) {
+    const xs = solX.filter((x) => x !== null) as number[];
+    minX = Math.min(minX, ...xs);
+    maxX = Math.max(maxX, ...xs);
+  }
+
+  let minY = Math.min(p0[1], p3[1]);
+  let maxY = Math.max(p0[1], p3[1]);
+  if (solY) {
+    const ys = solY.filter((y) => y !== null) as number[];
+    minY = Math.min(minY, ...ys);
+    maxY = Math.max(maxY, ...ys);
+  }
+  return [minX, minY, maxX, maxY];
+};
+
 const getMinMaxXYFromCurvePathOps = (
   ops: Op[],
   transformXY?: (x: number, y: number) => [number, number],
@@ -83,38 +167,29 @@ const getMinMaxXYFromCurvePathOps = (
         // move operation does not draw anything; so, it always
         // returns false
       } else if (op === "bcurveTo") {
-        // create points from bezier curve
-        // bezier curve stores data as a flattened array of three positions
-        // [x1, y1, x2, y2, x3, y3]
-        const p1 = [data[0], data[1]] as Point;
-        const p2 = [data[2], data[3]] as Point;
-        const p3 = [data[4], data[5]] as Point;
+        const _p1 = [data[0], data[1]] as Point;
+        const _p2 = [data[0], data[1]] as Point;
+        const _p3 = [data[4], data[5]] as Point;
 
-        const p0 = currentP;
-        currentP = p3;
+        const p1 = transformXY ? transformXY(..._p1) : _p1;
+        const p2 = transformXY ? transformXY(..._p2) : _p2;
+        const p3 = transformXY ? transformXY(..._p3) : _p3;
 
-        const equation = (t: number, idx: number) =>
-          Math.pow(1 - t, 3) * p3[idx] +
-          3 * t * Math.pow(1 - t, 2) * p2[idx] +
-          3 * Math.pow(t, 2) * (1 - t) * p1[idx] +
-          p0[idx] * Math.pow(t, 3);
+        const p0 = transformXY ? transformXY(...currentP) : currentP;
+        currentP = _p3;
 
-        let t = 0;
-        while (t <= 1.0) {
-          let x = equation(t, 0);
-          let y = equation(t, 1);
-          if (transformXY) {
-            [x, y] = transformXY(x, y);
-          }
+        const [minX, minY, maxX, maxY] = getCubicBezierCurveBound(
+          p0,
+          p1,
+          p2,
+          p3,
+        );
 
-          limits.minY = Math.min(limits.minY, y);
-          limits.minX = Math.min(limits.minX, x);
+        limits.minY = Math.min(limits.minY, minY);
+        limits.minX = Math.min(limits.minX, minX);
 
-          limits.maxX = Math.max(limits.maxX, x);
-          limits.maxY = Math.max(limits.maxY, y);
-
-          t += 0.1;
-        }
+        limits.maxX = Math.max(limits.maxX, maxX);
+        limits.maxY = Math.max(limits.maxY, maxY);
       } else if (op === "lineTo") {
         // TODO: Implement this
       } else if (op === "qcurveTo") {
@@ -124,7 +199,6 @@ const getMinMaxXYFromCurvePathOps = (
     },
     { minX: Infinity, minY: Infinity, maxX: -Infinity, maxY: -Infinity },
   );
-
   return [minX, minY, maxX, maxY];
 };
 

--- a/src/element/bounds.ts
+++ b/src/element/bounds.ts
@@ -18,7 +18,6 @@ import { rescalePoints } from "../points";
 
 // x and y position of top left corner, x and y position of bottom right corner
 export type Bounds = readonly [number, number, number, number];
-type MaybeQuadraticSolution = [number | null, number | null] | false;
 
 // If the element is created from right to left, the width is going to be negative
 // This set of functions retrieves the absolute position of the 4 points.
@@ -69,89 +68,6 @@ export const getCurvePathOps = (shape: Drawable): Op[] => {
   return shape.sets[0].ops;
 };
 
-// reference: https://eliot-jones.com/2019/12/cubic-bezier-curve-bounding-boxes
-const getBezierValueForT = (
-  t: number,
-  p0: number,
-  p1: number,
-  p2: number,
-  p3: number,
-) => {
-  const oneMinusT = 1 - t;
-  return (
-    Math.pow(oneMinusT, 3) * p0 +
-    3 * Math.pow(oneMinusT, 2) * t * p1 +
-    3 * oneMinusT * Math.pow(t, 2) * p2 +
-    Math.pow(t, 3) * p3
-  );
-};
-
-const solveQuadratic = (
-  p0: number,
-  p1: number,
-  p2: number,
-  p3: number,
-): MaybeQuadraticSolution => {
-  const i = p1 - p0;
-  const j = p2 - p1;
-  const k = p3 - p2;
-
-  const a = 3 * i - 6 * j + 3 * k;
-  const b = 6 * j - 6 * i;
-  const c = 3 * i;
-
-  const sqrtPart = b * b - 4 * a * c;
-  const hasSolution = sqrtPart >= 0;
-
-  if (!hasSolution) {
-    return false;
-  }
-
-  const t1 = (-b + Math.sqrt(sqrtPart)) / (2 * a);
-  const t2 = (-b - Math.sqrt(sqrtPart)) / (2 * a);
-
-  let s1 = null;
-  let s2 = null;
-
-  if (t1 >= 0 && t1 <= 1) {
-    s1 = getBezierValueForT(t1, p0, p1, p2, p3);
-  }
-
-  if (t2 >= 0 && t2 <= 1) {
-    s2 = getBezierValueForT(t2, p0, p1, p2, p3);
-  }
-
-  return [s1, s2];
-};
-
-const getCubicBezierCurveBound = (
-  p0: Point,
-  p1: Point,
-  p2: Point,
-  p3: Point,
-): Bounds => {
-  const solX = solveQuadratic(p0[0], p1[0], p2[0], p3[0]);
-  const solY = solveQuadratic(p0[1], p1[1], p2[1], p3[1]);
-
-  let minX = Math.min(p0[0], p3[0]);
-  let maxX = Math.max(p0[0], p3[0]);
-
-  if (solX) {
-    const xs = solX.filter((x) => x !== null) as number[];
-    minX = Math.min(minX, ...xs);
-    maxX = Math.max(maxX, ...xs);
-  }
-
-  let minY = Math.min(p0[1], p3[1]);
-  let maxY = Math.max(p0[1], p3[1]);
-  if (solY) {
-    const ys = solY.filter((y) => y !== null) as number[];
-    minY = Math.min(minY, ...ys);
-    maxY = Math.max(maxY, ...ys);
-  }
-  return [minX, minY, maxX, maxY];
-};
-
 const getMinMaxXYFromCurvePathOps = (
   ops: Op[],
   transformXY?: (x: number, y: number) => [number, number],
@@ -167,29 +83,38 @@ const getMinMaxXYFromCurvePathOps = (
         // move operation does not draw anything; so, it always
         // returns false
       } else if (op === "bcurveTo") {
-        const _p1 = [data[0], data[1]] as Point;
-        const _p2 = [data[0], data[1]] as Point;
-        const _p3 = [data[4], data[5]] as Point;
+        // create points from bezier curve
+        // bezier curve stores data as a flattened array of three positions
+        // [x1, y1, x2, y2, x3, y3]
+        const p1 = [data[0], data[1]] as Point;
+        const p2 = [data[2], data[3]] as Point;
+        const p3 = [data[4], data[5]] as Point;
 
-        const p1 = transformXY ? transformXY(..._p1) : _p1;
-        const p2 = transformXY ? transformXY(..._p2) : _p2;
-        const p3 = transformXY ? transformXY(..._p3) : _p3;
+        const p0 = currentP;
+        currentP = p3;
 
-        const p0 = transformXY ? transformXY(...currentP) : currentP;
-        currentP = _p3;
+        const equation = (t: number, idx: number) =>
+          Math.pow(1 - t, 3) * p3[idx] +
+          3 * t * Math.pow(1 - t, 2) * p2[idx] +
+          3 * Math.pow(t, 2) * (1 - t) * p1[idx] +
+          p0[idx] * Math.pow(t, 3);
 
-        const [minX, minY, maxX, maxY] = getCubicBezierCurveBound(
-          p0,
-          p1,
-          p2,
-          p3,
-        );
+        let t = 0;
+        while (t <= 1.0) {
+          let x = equation(t, 0);
+          let y = equation(t, 1);
+          if (transformXY) {
+            [x, y] = transformXY(x, y);
+          }
 
-        limits.minY = Math.min(limits.minY, minY);
-        limits.minX = Math.min(limits.minX, minX);
+          limits.minY = Math.min(limits.minY, y);
+          limits.minX = Math.min(limits.minX, x);
 
-        limits.maxX = Math.max(limits.maxX, maxX);
-        limits.maxY = Math.max(limits.maxY, maxY);
+          limits.maxX = Math.max(limits.maxX, x);
+          limits.maxY = Math.max(limits.maxY, y);
+
+          t += 0.1;
+        }
       } else if (op === "lineTo") {
         // TODO: Implement this
       } else if (op === "qcurveTo") {
@@ -199,6 +124,7 @@ const getMinMaxXYFromCurvePathOps = (
     },
     { minX: Infinity, minY: Infinity, maxX: -Infinity, maxY: -Infinity },
   );
+
   return [minX, minY, maxX, maxY];
 };
 

--- a/src/element/bounds.ts
+++ b/src/element/bounds.ts
@@ -18,6 +18,7 @@ import { rescalePoints } from "../points";
 
 // x and y position of top left corner, x and y position of bottom right corner
 export type Bounds = readonly [number, number, number, number];
+type MaybeQuadraticSolution = [number | null, number | null] | false;
 
 // If the element is created from right to left, the width is going to be negative
 // This set of functions retrieves the absolute position of the 4 points.
@@ -68,11 +69,95 @@ export const getCurvePathOps = (shape: Drawable): Op[] => {
   return shape.sets[0].ops;
 };
 
+// reference: https://eliot-jones.com/2019/12/cubic-bezier-curve-bounding-boxes
+const getBezierValueForT = (
+  t: number,
+  p0: number,
+  p1: number,
+  p2: number,
+  p3: number,
+) => {
+  const oneMinusT = 1 - t;
+  return (
+    Math.pow(oneMinusT, 3) * p0 +
+    3 * Math.pow(oneMinusT, 2) * t * p1 +
+    3 * oneMinusT * Math.pow(t, 2) * p2 +
+    Math.pow(t, 3) * p3
+  );
+};
+
+const solveQuadratic = (
+  p0: number,
+  p1: number,
+  p2: number,
+  p3: number,
+): MaybeQuadraticSolution => {
+  const i = p1 - p0;
+  const j = p2 - p1;
+  const k = p3 - p2;
+
+  const a = 3 * i - 6 * j + 3 * k;
+  const b = 6 * j - 6 * i;
+  const c = 3 * i;
+
+  const sqrtPart = b * b - 4 * a * c;
+  const hasSolution = sqrtPart >= 0;
+
+  if (!hasSolution) {
+    return false;
+  }
+
+  const t1 = (-b + Math.sqrt(sqrtPart)) / (2 * a);
+  const t2 = (-b - Math.sqrt(sqrtPart)) / (2 * a);
+
+  let s1 = null;
+  let s2 = null;
+
+  if (t1 >= 0 && t1 <= 1) {
+    s1 = getBezierValueForT(t1, p0, p1, p2, p3);
+  }
+
+  if (t2 >= 0 && t2 <= 1) {
+    s2 = getBezierValueForT(t2, p0, p1, p2, p3);
+  }
+
+  return [s1, s2];
+};
+
+const getCubicBezierCurveBound = (
+  p0: Point,
+  p1: Point,
+  p2: Point,
+  p3: Point,
+): Bounds => {
+  const solX = solveQuadratic(p0[0], p1[0], p2[0], p3[0]);
+  const solY = solveQuadratic(p0[1], p1[1], p2[1], p3[1]);
+
+  let minX = Math.min(p0[0], p3[0]);
+  let maxX = Math.max(p0[0], p3[0]);
+
+  if (solX) {
+    const xs = solX.filter((x) => x !== null) as number[];
+    minX = Math.min(minX, ...xs);
+    maxX = Math.max(maxX, ...xs);
+  }
+
+  let minY = Math.min(p0[1], p3[1]);
+  let maxY = Math.max(p0[1], p3[1]);
+  if (solY) {
+    const ys = solY.filter((y) => y !== null) as number[];
+    minY = Math.min(minY, ...ys);
+    maxY = Math.max(maxY, ...ys);
+  }
+  return [minX, minY, maxX, maxY];
+};
+
 const getMinMaxXYFromCurvePathOps = (
   ops: Op[],
   transformXY?: (x: number, y: number) => [number, number],
 ): [number, number, number, number] => {
   let currentP: Point = [0, 0];
+
   const { minX, minY, maxX, maxY } = ops.reduce(
     (limits, { op, data }) => {
       // There are only four operation types:
@@ -83,38 +168,29 @@ const getMinMaxXYFromCurvePathOps = (
         // move operation does not draw anything; so, it always
         // returns false
       } else if (op === "bcurveTo") {
-        // create points from bezier curve
-        // bezier curve stores data as a flattened array of three positions
-        // [x1, y1, x2, y2, x3, y3]
-        const p1 = [data[0], data[1]] as Point;
-        const p2 = [data[2], data[3]] as Point;
-        const p3 = [data[4], data[5]] as Point;
+        const _p1 = [data[0], data[1]] as Point;
+        const _p2 = [data[2], data[3]] as Point;
+        const _p3 = [data[4], data[5]] as Point;
 
-        const p0 = currentP;
-        currentP = p3;
+        const p1 = transformXY ? transformXY(..._p1) : _p1;
+        const p2 = transformXY ? transformXY(..._p2) : _p2;
+        const p3 = transformXY ? transformXY(..._p3) : _p3;
 
-        const equation = (t: number, idx: number) =>
-          Math.pow(1 - t, 3) * p3[idx] +
-          3 * t * Math.pow(1 - t, 2) * p2[idx] +
-          3 * Math.pow(t, 2) * (1 - t) * p1[idx] +
-          p0[idx] * Math.pow(t, 3);
+        const p0 = transformXY ? transformXY(...currentP) : currentP;
+        currentP = _p3;
 
-        let t = 0;
-        while (t <= 1.0) {
-          let x = equation(t, 0);
-          let y = equation(t, 1);
-          if (transformXY) {
-            [x, y] = transformXY(x, y);
-          }
+        const [minX, minY, maxX, maxY] = getCubicBezierCurveBound(
+          p0,
+          p1,
+          p2,
+          p3,
+        );
 
-          limits.minY = Math.min(limits.minY, y);
-          limits.minX = Math.min(limits.minX, x);
+        limits.minX = Math.min(limits.minX, minX);
+        limits.minY = Math.min(limits.minY, minY);
 
-          limits.maxX = Math.max(limits.maxX, x);
-          limits.maxY = Math.max(limits.maxY, y);
-
-          t += 0.1;
-        }
+        limits.maxX = Math.max(limits.maxX, maxX);
+        limits.maxY = Math.max(limits.maxY, maxY);
       } else if (op === "lineTo") {
         // TODO: Implement this
       } else if (op === "qcurveTo") {
@@ -124,7 +200,6 @@ const getMinMaxXYFromCurvePathOps = (
     },
     { minX: Infinity, minY: Infinity, maxX: -Infinity, maxY: -Infinity },
   );
-
   return [minX, minY, maxX, maxY];
 };
 

--- a/src/element/resizeElements.ts
+++ b/src/element/resizeElements.ts
@@ -653,11 +653,11 @@ const resizeMultipleElements = (
   const [cx, cy] = centerPoint([x1, y1], [x2, y2]);
   const direction = transformHandleType;
 
-  const mapDirectionsToAnchors = {
-    ne: [x1, y2] as Point,
-    se: [x1, y1] as Point,
-    sw: [x2, y1] as Point,
-    nw: [x2, y2] as Point,
+  const mapDirectionsToAnchors: Record<typeof direction, Point> = {
+    ne: [x1, y2],
+    se: [x1, y1],
+    sw: [x2, y1],
+    nw: [x2, y2],
   };
 
   // anchor point must be on the opposite side of the dragged selection handle
@@ -696,7 +696,7 @@ const resizeMultipleElements = (
     const textSize: Pick<Update, "fontSize" | "baseline"> = {};
     const boundTextElement = getBoundTextElement(element);
     const optionalPadding = boundTextElement ? BOUND_TEXT_PADDING * 2 : 0;
-    if (boundTextElement || element.type === "text") {
+    if (boundTextElement || isTextElement(element)) {
       const text = measureFontSizeFromWH(
         boundTextElement ?? (element as ExcalidrawTextElement),
         width - optionalPadding,

--- a/src/element/resizeElements.ts
+++ b/src/element/resizeElements.ts
@@ -668,10 +668,30 @@ const resizeMultipleElements = (
     ? [midX, midY]
     : mapDirectionsToAnchors[direction];
 
+  const mapDirectionsToPointerSides: Record<
+    typeof direction,
+    [x: boolean, y: boolean]
+  > = {
+    ne: [pointerX >= anchorX, pointerY <= anchorY],
+    se: [pointerX >= anchorX, pointerY >= anchorY],
+    sw: [pointerX <= anchorX, pointerY >= anchorY],
+    nw: [pointerX <= anchorX, pointerY <= anchorY],
+  };
+
+  // pointer side relative to anchor
+  const [pointerSideX, pointerSideY] = mapDirectionsToPointerSides[
+    direction
+  ].map((condition) => (condition ? 1 : -1));
+
+  // stop resizing if a pointer is on the other side of selection
+  if (pointerSideX < 0 && pointerSideY < 0) {
+    return;
+  }
+
   const scale =
     Math.max(
-      Math.abs(pointerX - anchorX) / (maxX - minX),
-      Math.abs(pointerY - anchorY) / (maxY - minY),
+      (pointerSideX * Math.abs(pointerX - anchorX)) / (maxX - minX),
+      (pointerSideY * Math.abs(pointerY - anchorY)) / (maxY - minY),
     ) * (shouldResizeFromCenter ? 2 : 1);
 
   if (scale === 1) {

--- a/src/packages/excalidraw/CHANGELOG.md
+++ b/src/packages/excalidraw/CHANGELOG.md
@@ -19,6 +19,14 @@ Please add the latest change on the top under the correct section.
 
 - `setToastMessage` API is now renamed to `setToast` API and the function signature is also updated [#5427](https://github.com/excalidraw/excalidraw/pull/5427). You can also pass `duration` and `closable` attributes along with `message`.
 
+### Excalidraw Library
+
+#### Fixes
+
+- Fix shifting of a multiple linear or free draw elements when resizing [#5560](https://github.com/excalidraw/excalidraw/pull/5560)
+
+- Resize multiple elements from center [#5560](https://github.com/excalidraw/excalidraw/pull/5560)
+
 ## 0.12.0 (2022-07-07)
 
 ### Excalidraw API

--- a/src/packages/excalidraw/CHANGELOG.md
+++ b/src/packages/excalidraw/CHANGELOG.md
@@ -19,14 +19,6 @@ Please add the latest change on the top under the correct section.
 
 - `setToastMessage` API is now renamed to `setToast` API and the function signature is also updated [#5427](https://github.com/excalidraw/excalidraw/pull/5427). You can also pass `duration` and `closable` attributes along with `message`.
 
-### Excalidraw Library
-
-#### Fixes
-
-- Fix shifting of a multiple linear or free draw elements when resizing [#5560](https://github.com/excalidraw/excalidraw/pull/5560)
-
-- Resize multiple elements from center [#5560](https://github.com/excalidraw/excalidraw/pull/5560)
-
 ## 0.12.0 (2022-07-07)
 
 ### Excalidraw API

--- a/src/points.ts
+++ b/src/points.ts
@@ -16,9 +16,9 @@ export const rescalePoints = (
   points: readonly Point[],
 ): Point[] => {
   const coordinates = points.map((point) => point[dimension]);
-  const minCoordinate = Math.max(...coordinates);
-  const maxCoordinate = Math.min(...coordinates);
-  const size = minCoordinate - maxCoordinate;
+  const maxCoordinate = Math.max(...coordinates);
+  const minCoordinate = Math.min(...coordinates);
+  const size = maxCoordinate - minCoordinate;
   const scale = size === 0 ? 1 : newSize / size;
 
   return points.map((point): Point => {

--- a/src/points.ts
+++ b/src/points.ts
@@ -19,14 +19,12 @@ export const rescalePoints = (
   const minCoordinate = Math.max(...coordinates);
   const maxCoordinate = Math.min(...coordinates);
   const size = minCoordinate - maxCoordinate;
-  const firstPoint = points[0];
   const scale = size === 0 ? 1 : newSize / size;
-  const d = dimension;
 
   return points.map((point): Point => {
-    const newCoordinate = (point[d] - firstPoint[d]) * scale + firstPoint[d];
+    const newCoordinate = point[dimension] * scale;
     const newPoint = [...point];
-    newPoint[d] = newCoordinate;
+    newPoint[dimension] = newCoordinate;
     return newPoint as unknown as Point;
   });
 };

--- a/src/points.ts
+++ b/src/points.ts
@@ -9,46 +9,24 @@ export const getSizeFromPoints = (points: readonly Point[]) => {
   };
 };
 
+/** @arg dimension, 0 for rescaling only x, 1 for y */
 export const rescalePoints = (
   dimension: 0 | 1,
-  nextDimensionSize: number,
-  prevPoints: readonly Point[],
+  newSize: number,
+  points: readonly Point[],
 ): Point[] => {
-  const prevDimValues = prevPoints.map((point) => point[dimension]);
-  const prevMaxDimension = Math.max(...prevDimValues);
-  const prevMinDimension = Math.min(...prevDimValues);
-  const prevDimensionSize = prevMaxDimension - prevMinDimension;
+  const coordinates = points.map((point) => point[dimension]);
+  const minCoordinate = Math.max(...coordinates);
+  const maxCoordinate = Math.min(...coordinates);
+  const size = minCoordinate - maxCoordinate;
+  const firstPoint = points[0];
+  const scale = size === 0 ? 1 : newSize / size;
+  const d = dimension;
 
-  const dimensionScaleFactor =
-    prevDimensionSize === 0 ? 1 : nextDimensionSize / prevDimensionSize;
-
-  let nextMinDimension = Infinity;
-
-  const scaledPoints = prevPoints.map(
-    (prevPoint) =>
-      prevPoint.map((value, currentDimension) => {
-        if (currentDimension !== dimension) {
-          return value;
-        }
-        const scaledValue = value * dimensionScaleFactor;
-        nextMinDimension = Math.min(scaledValue, nextMinDimension);
-        return scaledValue;
-      }) as [number, number],
-  );
-
-  if (scaledPoints.length === 2) {
-    // we don't translate two-point lines
-    return scaledPoints;
-  }
-
-  const translation = prevMinDimension - nextMinDimension;
-
-  const nextPoints = scaledPoints.map(
-    (scaledPoint) =>
-      scaledPoint.map((value, currentDimension) => {
-        return currentDimension === dimension ? value + translation : value;
-      }) as [number, number],
-  );
-
-  return nextPoints;
+  return points.map((point): Point => {
+    const newCoordinate = (point[d] - firstPoint[d]) * scale + firstPoint[d];
+    const newPoint = [...point];
+    newPoint[d] = newCoordinate;
+    return newPoint as unknown as Point;
+  });
 };


### PR DESCRIPTION
fix https://github.com/excalidraw/excalidraw/issues/3989 fix https://github.com/excalidraw/excalidraw/issues/4001 fix https://github.com/excalidraw/excalidraw/issues/2896

Hi! This is my first attempt making a meaningful oss contribution, feedback would be appreciated.

I was trying to fix #4009 and ended up rewriting the whole `resizeMultipleElements` function 😅. Now it updates selected elements based on their state at resize start. I manually tested it with:

- generic & text elements
- attached linear elements
- rotated
- with bound text inside

There's an issue with resizing multiple linear & free draw elements, but I think this is existing problem and I didn't cause it:

<details><summary>gif</summary>

![Peek 2022-08-11 17-12](https://user-images.githubusercontent.com/45559664/184130721-4ed71ddb-747e-45ee-9fd2-d844735a150a.gif)
</details>

Currently a selection doesn't flip, maybe will add this in the futute.

So how does it look?