### PR TITLE
fix: deselect linear element when clicked inside bounding box outside editor

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -4179,6 +4179,7 @@ class App extends React.Component<AppProps, AppState> {
         if (didDrag) {
           pointerDownState.lastCoords.x = pointerCoords.x;
           pointerDownState.lastCoords.y = pointerCoords.y;
+          pointerDownState.drag.hasOccurred = true;
           if (
             this.state.editingLinearElement &&
             !this.state.editingLinearElement.isDragging
@@ -4936,7 +4937,6 @@ class App extends React.Component<AppProps, AppState> {
       }
 
       if (
-        !this.state.selectedLinearElement &&
         !this.state.editingLinearElement &&
         !pointerDownState.drag.hasOccurred &&
         !this.state.isResizing &&


### PR DESCRIPTION
fixes https://github.com/excalidraw/excalidraw/issues/5577