### PR TITLE
fix: points not being normalized on single-elem resize

### DIFF
--- a/src/element/bounds.ts
+++ b/src/element/bounds.ts
@@ -495,6 +495,7 @@ export const getResizedElementAbsoluteCoords = (
   element: ExcalidrawElement,
   nextWidth: number,
   nextHeight: number,
+  normalizePoints: boolean,
 ): [number, number, number, number] => {
   if (!(isLinearElement(element) || isFreeDrawElement(element))) {
     return [
@@ -508,7 +509,8 @@ export const getResizedElementAbsoluteCoords = (
   const points = rescalePoints(
     0,
     nextWidth,
-    rescalePoints(1, nextHeight, element.points),
+    rescalePoints(1, nextHeight, element.points, normalizePoints),
+    normalizePoints,
   );
 
   let bounds: [number, number, number, number];

--- a/src/element/newElement.ts
+++ b/src/element/newElement.ts
@@ -198,6 +198,7 @@ const getAdjustedDimensions = (
       element,
       nextWidth,
       nextHeight,
+      false,
     );
     const deltaX1 = (x1 - nextX1) / 2;
     const deltaY1 = (y1 - nextY1) / 2;

--- a/src/element/resizeElements.ts
+++ b/src/element/resizeElements.ts
@@ -264,13 +264,15 @@ const rescalePointsInElement = (
   element: NonDeletedExcalidrawElement,
   width: number,
   height: number,
+  normalizePoints: boolean,
 ) =>
   isLinearElement(element) || isFreeDrawElement(element)
     ? {
         points: rescalePoints(
           0,
           width,
-          rescalePoints(1, height, element.points),
+          rescalePoints(1, height, element.points, normalizePoints),
+          normalizePoints,
         ),
       }
     : {};
@@ -374,6 +376,7 @@ const resizeSingleTextElement = (
       element,
       nextWidth,
       nextHeight,
+      false,
     );
     const deltaX1 = (x1 - nextX1) / 2;
     const deltaY1 = (y1 - nextY1) / 2;
@@ -415,6 +418,7 @@ export const resizeSingleElement = (
     stateAtResizeStart,
     stateAtResizeStart.width,
     stateAtResizeStart.height,
+    true,
   );
   const startTopLeft: Point = [x1, y1];
   const startBottomRight: Point = [x2, y2];
@@ -432,6 +436,7 @@ export const resizeSingleElement = (
     element,
     element.width,
     element.height,
+    true,
   );
 
   const boundsCurrentWidth = esx2 - esx1;
@@ -525,6 +530,7 @@ export const resizeSingleElement = (
       stateAtResizeStart,
       eleNewWidth,
       eleNewHeight,
+      true,
     );
   const newBoundsWidth = newBoundsX2 - newBoundsX1;
   const newBoundsHeight = newBoundsY2 - newBoundsY1;
@@ -595,6 +601,7 @@ export const resizeSingleElement = (
     stateAtResizeStart,
     eleNewWidth,
     eleNewHeight,
+    true,
   );
   // For linear elements (x,y) are the coordinates of the first drawn point not the top-left corner
   // So we need to readjust (x,y) to be where the first point should be
@@ -725,7 +732,12 @@ const resizeMultipleElements = (
     const y = anchorY + (element.orig.y - anchorY) * scale;
 
     // readjust points for linear & free draw elements
-    const rescaledPoints = rescalePointsInElement(element.orig, width, height);
+    const rescaledPoints = rescalePointsInElement(
+      element.orig,
+      width,
+      height,
+      false,
+    );
 
     const update: {
       width: number;

--- a/src/points.ts
+++ b/src/points.ts
@@ -14,6 +14,7 @@ export const rescalePoints = (
   dimension: 0 | 1,
   newSize: number,
   points: readonly Point[],
+  normalize: boolean,
 ): Point[] => {
   const coordinates = points.map((point) => point[dimension]);
   const maxCoordinate = Math.max(...coordinates);
@@ -21,10 +22,35 @@ export const rescalePoints = (
   const size = maxCoordinate - minCoordinate;
   const scale = size === 0 ? 1 : newSize / size;
 
-  return points.map((point): Point => {
+  let nextMinCoordinate = Infinity;
+
+  const scaledPoints = points.map((point): Point => {
     const newCoordinate = point[dimension] * scale;
     const newPoint = [...point];
     newPoint[dimension] = newCoordinate;
+    if (newCoordinate < nextMinCoordinate) {
+      nextMinCoordinate = newCoordinate;
+    }
     return newPoint as unknown as Point;
   });
+
+  if (!normalize) {
+    return scaledPoints;
+  }
+
+  if (scaledPoints.length === 2) {
+    // we don't translate two-point lines
+    return scaledPoints;
+  }
+
+  const translation = minCoordinate - nextMinCoordinate;
+
+  const nextPoints = scaledPoints.map(
+    (scaledPoint) =>
+      scaledPoint.map((value, currentDimension) => {
+        return currentDimension === dimension ? value + translation : value;
+      }) as [number, number],
+  );
+
+  return nextPoints;
 };


### PR DESCRIPTION
#5560 stopped normalizing points on resize which introduced a buggy behavior such as the one shown below. This PR "fixes" it by reintroducing the normalization when resizing single elements. For multiple elements it shouldn't be needed as we don't yet allow resizing to the negative.

/cc @alex-kim-dev 

![excal-negative-resize-bug](https://user-images.githubusercontent.com/5153846/184963659-d2aa0c4e-b726-4a53-9a9b-508d361d1868.gif)

```
{"type":"excalidraw/clipboard","elements":[{"type":"freedraw","version":2875,"versionNonce":879128633,"isDeleted":false,"id":"Pjd86HppQGL0FhjcFqNPl","fillStyle":"hachure","strokeWidth":1,"strokeStyle":"solid","roughness":1,"opacity":100,"angle":0,"x":921.6778895758034,"y":476.80697591987155,"strokeColor":"#5c940d","backgroundColor":"#fa5252","width":45.86902273164816,"height":46.94255062652051,"seed":146528458,"groupIds":[],"strokeSharpness":"round","boundElements":[],"updated":1660677471800,"link":null,"locked":false,"points":[[0,-168.62724083598448],[0,-168.6685003385987],[0.4432438507011683,-168.60930192180436],[0.9323441319791236,-168.34799641017298],[4.103363526945416,-166.5576927749977],[9.041691855034111,-162.34144530727286],[13.47638645645598,-158.06660205815177],[16.951821194908117,-154.46207156396886],[18.161769874006048,-152.67714960304752],[18.771807309150603,-151.76226497986175],[18.95759406049213,-151.46927205810442],[18.95759406049213,-151.29466195515903],[18.95759406049213,-151.33592145777328],[18.88036217741545,-151.4184404630018],[18.80313029433865,-151.50095946823032],[18.64866652818528,-151.54221897084466],[18.494202762031797,-151.58347847345888],[18.494202762031797,-151.7598824678222],[18.405795341526236,-152.04152342044995],[18.30615991627982,-152.52049242905895],[18.30615991627982,-153.4622854235149],[18.30615991627982,-157.43335838759384],[19.71091972436129,-164.8857859734111],[21.996500764162818,-170.68961333129928],[27.364693778424968,-180.07825239254905],[34.19803647673423,-189.1547403322881],[37.45856510575549,-192.55715672424577],[41.86188425467748,-196.28426746286343],[44.091535140022614,-197.50171710029488],[45.36754016476837,-198.05483829244065],[45.79289266212081,-198.19595307906533],[45.86902273164816,-198.23721258167953],[45.7917908485715,-198.23721258167953],[45.63732708241816,-198.23721258167953],[45.560095199341326,-198.19655571446344],[45.560095199341326,-198.19655571446344]],"lastCommittedPoint":null,"simulatePressure":true,"pressures":[]}],"files":{}}
```