### PR TITLE
fix: multiple elements resizing regressions

### DIFF
--- a/src/element/bounds.test.ts
+++ b/src/element/bounds.test.ts
@@ -22,7 +22,7 @@ const _ce = ({
     backgroundColor: "#000",
     fillStyle: "solid",
     strokeWidth: 1,
-    roughness: 1,
+    roughness: 0,
     opacity: 1,
     x,
     y,
@@ -106,7 +106,7 @@ describe("getElementBounds", () => {
     } as ExcalidrawLinearElement);
     expect(x1).toEqual(360.3176068760539);
     expect(y1).toEqual(185.90654264413516);
-    expect(x2).toEqual(473.8171188951176);
-    expect(y2).toEqual(320.391865303557);
+    expect(x2).toEqual(480.87005902729743);
+    expect(y2).toEqual(320.4751269334226);
   });
 });

--- a/src/element/bounds.ts
+++ b/src/element/bounds.ts
@@ -542,7 +542,18 @@ export const getResizedElementAbsoluteCoords = (
     bounds = getBoundsFromPoints(points);
   } else {
     // Line
-    const curve = generateLinearElementShape(element);
+    const gen = rough.generator();
+    const curve =
+      element.strokeSharpness === "sharp"
+        ? gen.linearPath(
+            points as [number, number][],
+            generateRoughOptions(element),
+          )
+        : gen.curve(
+            points as [number, number][],
+            generateRoughOptions(element),
+          );
+
     const ops = getCurvePathOps(curve);
     bounds = getMinMaxXYFromCurvePathOps(ops);
   }

--- a/src/element/bounds.ts
+++ b/src/element/bounds.ts
@@ -573,7 +573,14 @@ export const getElementPointsCoords = (
   sharpness: ExcalidrawElement["strokeSharpness"],
 ): [number, number, number, number] => {
   // This might be computationally heavey
-  const curve = generateLinearElementShape(element);
+  const gen = rough.generator();
+  const curve =
+    sharpness === "sharp"
+      ? gen.linearPath(
+          points as [number, number][],
+          generateRoughOptions(element),
+        )
+      : gen.curve(points as [number, number][], generateRoughOptions(element));
   const ops = getCurvePathOps(curve);
   const [minX, minY, maxX, maxY] = getMinMaxXYFromCurvePathOps(ops);
   return [

--- a/src/element/bounds.ts
+++ b/src/element/bounds.ts
@@ -387,34 +387,49 @@ export const getArrowheadPoints = (
   return [x2, y2, x3, y3, x4, y4];
 };
 
+const generateLinearElementShape = (
+  element: ExcalidrawLinearElement,
+): Drawable => {
+  const generator = rough.generator();
+  const options = generateRoughOptions(element);
+
+  const method = (() => {
+    if (element.strokeSharpness !== "sharp") {
+      return "curve";
+    }
+    if (options.fill) {
+      return "polygon";
+    }
+    return "linearPath";
+  })();
+
+  return generator[method](element.points as Mutable<Point>[], options);
+};
+
 const getLinearElementRotatedBounds = (
   element: ExcalidrawLinearElement,
   cx: number,
   cy: number,
 ): [number, number, number, number] => {
-  if (element.points.length < 2 || !getShapeForElement(element)) {
-    // XXX this is just a poor estimate and not very useful
-    const { minX, minY, maxX, maxY } = element.points.reduce(
-      (limits, [x, y]) => {
-        [x, y] = rotate(element.x + x, element.y + y, cx, cy, element.angle);
-        limits.minY = Math.min(limits.minY, y);
-        limits.minX = Math.min(limits.minX, x);
-        limits.maxX = Math.max(limits.maxX, x);
-        limits.maxY = Math.max(limits.maxY, y);
-        return limits;
-      },
-      { minX: Infinity, minY: Infinity, maxX: -Infinity, maxY: -Infinity },
+  if (element.points.length < 2) {
+    const [pointX, pointY] = element.points[0];
+    const [x, y] = rotate(
+      element.x + pointX,
+      element.y + pointY,
+      cx,
+      cy,
+      element.angle,
     );
-    return [minX, minY, maxX, maxY];
+    return [x, y, x, y];
   }
 
-  const shape = getShapeForElement(element)!;
-
   // first element is always the curve
-  const ops = getCurvePathOps(shape[0]);
-
+  const cachedShape = getShapeForElement(element)?.[0];
+  const shape = cachedShape ?? generateLinearElementShape(element);
+  const ops = getCurvePathOps(shape);
   const transformXY = (x: number, y: number) =>
     rotate(element.x + x, element.y + y, cx, cy, element.angle);
+
   return getMinMaxXYFromCurvePathOps(ops, transformXY);
 };
 
@@ -527,17 +542,7 @@ export const getResizedElementAbsoluteCoords = (
     bounds = getBoundsFromPoints(points);
   } else {
     // Line
-    const gen = rough.generator();
-    const curve =
-      element.strokeSharpness === "sharp"
-        ? gen.linearPath(
-            points as [number, number][],
-            generateRoughOptions(element),
-          )
-        : gen.curve(
-            points as [number, number][],
-            generateRoughOptions(element),
-          );
+    const curve = generateLinearElementShape(element);
     const ops = getCurvePathOps(curve);
     bounds = getMinMaxXYFromCurvePathOps(ops);
   }
@@ -557,14 +562,7 @@ export const getElementPointsCoords = (
   sharpness: ExcalidrawElement["strokeSharpness"],
 ): [number, number, number, number] => {
   // This might be computationally heavey
-  const gen = rough.generator();
-  const curve =
-    sharpness === "sharp"
-      ? gen.linearPath(
-          points as [number, number][],
-          generateRoughOptions(element),
-        )
-      : gen.curve(points as [number, number][], generateRoughOptions(element));
+  const curve = generateLinearElementShape(element);
   const ops = getCurvePathOps(curve);
   const [minX, minY, maxX, maxY] = getMinMaxXYFromCurvePathOps(ops);
   return [

--- a/src/element/resizeElements.ts
+++ b/src/element/resizeElements.ts
@@ -784,6 +784,8 @@ const resizeMultipleElements = (
       }
     }
 
+    updateBoundElements(element.latest, { newSize: { width, height } });
+
     mutateElement(element.latest, update);
 
     if (boundTextElement && boundTextUpdates) {

--- a/src/element/resizeElements.ts
+++ b/src/element/resizeElements.ts
@@ -766,18 +766,21 @@ const resizeMultipleElements = (
         width - optionalPadding,
         height - optionalPadding,
       );
-      if (textMeasurements) {
-        if (isTextElement(element.orig)) {
-          update.fontSize = textMeasurements.size;
-          update.baseline = textMeasurements.baseline;
-        }
 
-        if (boundTextElement) {
-          boundTextUpdates = {
-            fontSize: textMeasurements.size,
-            baseline: textMeasurements.baseline,
-          };
-        }
+      if (!textMeasurements) {
+        return;
+      }
+
+      if (isTextElement(element.orig)) {
+        update.fontSize = textMeasurements.size;
+        update.baseline = textMeasurements.baseline;
+      }
+
+      if (boundTextElement) {
+        boundTextUpdates = {
+          fontSize: textMeasurements.size,
+          baseline: textMeasurements.baseline,
+        };
       }
     }
 

--- a/src/element/resizeElements.ts
+++ b/src/element/resizeElements.ts
@@ -721,7 +721,7 @@ const resizeMultipleElements = (
       (pointerSideY * Math.abs(pointerY - anchorY)) / (maxY - minY),
     ) * (shouldResizeFromCenter ? 2 : 1);
 
-  if (scale === 0) {
+  if (scale === 1) {
     return;
   }
 
@@ -786,7 +786,7 @@ const resizeMultipleElements = (
 
     updateBoundElements(element.latest, { newSize: { width, height } });
 
-    mutateElement(element.latest, { ...update, width: 0, height: 0 });
+    mutateElement(element.latest, update);
 
     if (boundTextElement && boundTextUpdates) {
       mutateElement(boundTextElement, boundTextUpdates);

--- a/src/element/resizeElements.ts
+++ b/src/element/resizeElements.ts
@@ -721,7 +721,7 @@ const resizeMultipleElements = (
       (pointerSideY * Math.abs(pointerY - anchorY)) / (maxY - minY),
     ) * (shouldResizeFromCenter ? 2 : 1);
 
-  if (scale === 1) {
+  if (scale === 0) {
     return;
   }
 

--- a/src/element/resizeElements.ts
+++ b/src/element/resizeElements.ts
@@ -721,7 +721,7 @@ const resizeMultipleElements = (
       (pointerSideY * Math.abs(pointerY - anchorY)) / (maxY - minY),
     ) * (shouldResizeFromCenter ? 2 : 1);
 
-  if (scale === 1) {
+  if (scale === 0) {
     return;
   }
 
@@ -786,7 +786,7 @@ const resizeMultipleElements = (
 
     updateBoundElements(element.latest, { newSize: { width, height } });
 
-    mutateElement(element.latest, update);
+    mutateElement(element.latest, { ...update, width: 0, height: 0 });
 
     if (boundTextElement && boundTextUpdates) {
       mutateElement(boundTextElement, boundTextUpdates);


### PR DESCRIPTION
- [x] If the text size is getting less than `MIN_FONT_SIZE` it stops updating and gets out of an element's bounds. It's hard to spot this issue because the last updated font size will be close to 1, unless the pointer is near the center of a selection while pressing `alt`:
  ![Peek 2022-08-17 21-06](https://user-images.githubusercontent.com/45559664/185191718-04c1bc91-7789-4866-8799-f1563892d0a9.gif)
- [x] bound arrows not moving
- [x] element's width or height of zero
- [x] incorrect bounds for uncached linear elements