### PR TITLE
feat: simple impl of multi font support, for chinese font

### DIFF
--- a/src/actions/actionProperties.tsx
+++ b/src/actions/actionProperties.tsx
@@ -661,7 +661,7 @@ export const actionChangeFontFamily = register({
       icon: JSX.Element;
     }[] = [
       {
-        value: FONT_FAMILY.Virgil,
+        value: FONT_FAMILY['Virgil, HanziPen SC, Kai'],
         text: t("labels.handDrawn"),
         icon: FreedrawIcon,
       },

--- a/src/actions/actionProperties.tsx
+++ b/src/actions/actionProperties.tsx
@@ -661,7 +661,7 @@ export const actionChangeFontFamily = register({
       icon: JSX.Element;
     }[] = [
       {
-        value: FONT_FAMILY['Virgil, HanziPen SC, Kai'],
+        value: FONT_FAMILY['Virgil, HanziPen SC, KaiTi'],
         text: t("labels.handDrawn"),
         icon: FreedrawIcon,
       },

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -76,7 +76,7 @@ export const CLASSES = {
 
 // 1-based in case we ever do `if(element.fontFamily)`
 export const FONT_FAMILY = {
-  Virgil: 1,
+  'Virgil, HanziPen SC, Kai': 1,
   Helvetica: 2,
   Cascadia: 3,
 };
@@ -89,7 +89,7 @@ export const THEME = {
 export const WINDOWS_EMOJI_FALLBACK_FONT = "Segoe UI Emoji";
 
 export const DEFAULT_FONT_SIZE = 20;
-export const DEFAULT_FONT_FAMILY: FontFamilyValues = FONT_FAMILY.Virgil;
+export const DEFAULT_FONT_FAMILY: FontFamilyValues = FONT_FAMILY['Virgil, HanziPen SC, Kai'];
 export const DEFAULT_TEXT_ALIGN = "left";
 export const DEFAULT_VERTICAL_ALIGN = "top";
 export const DEFAULT_VERSION = "{version}";

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -76,7 +76,7 @@ export const CLASSES = {
 
 // 1-based in case we ever do `if(element.fontFamily)`
 export const FONT_FAMILY = {
-  'Virgil, HanziPen SC, Kai': 1,
+  'Virgil, HanziPen SC, KaiTi': 1,
   Helvetica: 2,
   Cascadia: 3,
 };
@@ -89,7 +89,7 @@ export const THEME = {
 export const WINDOWS_EMOJI_FALLBACK_FONT = "Segoe UI Emoji";
 
 export const DEFAULT_FONT_SIZE = 20;
-export const DEFAULT_FONT_FAMILY: FontFamilyValues = FONT_FAMILY['Virgil, HanziPen SC, Kai'];
+export const DEFAULT_FONT_FAMILY: FontFamilyValues = FONT_FAMILY['Virgil, HanziPen SC, KaiTi'];
 export const DEFAULT_TEXT_ALIGN = "left";
 export const DEFAULT_VERTICAL_ALIGN = "top";
 export const DEFAULT_VERSION = "{version}";

--- a/src/element/newElement.test.ts
+++ b/src/element/newElement.test.ts
@@ -76,7 +76,7 @@ it("clones text element", () => {
     opacity: 100,
     text: "hello",
     fontSize: 20,
-    fontFamily: FONT_FAMILY.Virgil,
+    fontFamily: FONT_FAMILY['Virgil, HanziPen SC, Kai'],
     textAlign: "left",
     verticalAlign: "top",
   });

--- a/src/element/newElement.test.ts
+++ b/src/element/newElement.test.ts
@@ -76,7 +76,7 @@ it("clones text element", () => {
     opacity: 100,
     text: "hello",
     fontSize: 20,
-    fontFamily: FONT_FAMILY['Virgil, HanziPen SC, Kai'],
+    fontFamily: FONT_FAMILY['Virgil, HanziPen SC, KaiTi'],
     textAlign: "left",
     verticalAlign: "top",
   });

--- a/src/element/textWysiwyg.test.tsx
+++ b/src/element/textWysiwyg.test.tsx
@@ -636,7 +636,7 @@ describe("textWysiwyg", () => {
       await new Promise((r) => setTimeout(r, 0));
       fireEvent.change(editor, { target: { value: "Hello World!" } });
       editor.blur();
-      expect(text.fontFamily).toEqual(FONT_FAMILY.Virgil);
+      expect(text.fontFamily).toEqual(FONT_FAMILY['Virgil, HanziPen SC, Kai']);
       UI.clickTool("text");
 
       mouse.clickAt(
@@ -663,7 +663,7 @@ describe("textWysiwyg", () => {
       });
       expect(
         (h.elements[1] as ExcalidrawTextElementWithContainer).fontFamily,
-      ).toEqual(FONT_FAMILY.Virgil);
+      ).toEqual(FONT_FAMILY['Virgil, HanziPen SC, Kai']);
 
       //redo
       Keyboard.withModifierKeys({ ctrl: true, shift: true }, () => {

--- a/src/element/textWysiwyg.test.tsx
+++ b/src/element/textWysiwyg.test.tsx
@@ -636,7 +636,7 @@ describe("textWysiwyg", () => {
       await new Promise((r) => setTimeout(r, 0));
       fireEvent.change(editor, { target: { value: "Hello World!" } });
       editor.blur();
-      expect(text.fontFamily).toEqual(FONT_FAMILY['Virgil, HanziPen SC, Kai']);
+      expect(text.fontFamily).toEqual(FONT_FAMILY['Virgil, HanziPen SC, KaiTi']);
       UI.clickTool("text");
 
       mouse.clickAt(
@@ -663,7 +663,7 @@ describe("textWysiwyg", () => {
       });
       expect(
         (h.elements[1] as ExcalidrawTextElementWithContainer).fontFamily,
-      ).toEqual(FONT_FAMILY['Virgil, HanziPen SC, Kai']);
+      ).toEqual(FONT_FAMILY['Virgil, HanziPen SC, KaiTi']);
 
       //redo
       Keyboard.withModifierKeys({ ctrl: true, shift: true }, () => {

--- a/src/tests/data/restore.test.ts
+++ b/src/tests/data/restore.test.ts
@@ -57,7 +57,7 @@ describe("restoreElements", () => {
     const textElement = API.createElement({
       type: "text",
       fontSize: 14,
-      fontFamily: FONT_FAMILY.Virgil,
+      fontFamily: FONT_FAMILY['Virgil, HanziPen SC, Kai'],
       text: "text",
       textAlign: "center",
       verticalAlign: "middle",

--- a/src/tests/data/restore.test.ts
+++ b/src/tests/data/restore.test.ts
@@ -57,7 +57,7 @@ describe("restoreElements", () => {
     const textElement = API.createElement({
       type: "text",
       fontSize: 14,
-      fontFamily: FONT_FAMILY['Virgil, HanziPen SC, Kai'],
+      fontFamily: FONT_FAMILY['Virgil, HanziPen SC, KaiTi'],
       text: "text",
       textAlign: "center",
       verticalAlign: "middle",

--- a/src/tests/regressionTests.test.tsx
+++ b/src/tests/regressionTests.test.tsx
@@ -664,7 +664,7 @@ describe("regression tests", () => {
 
   it("updates fontSize & fontFamily appState", () => {
     UI.clickTool("text");
-    expect(h.state.currentItemFontFamily).toEqual(FONT_FAMILY.Virgil);
+    expect(h.state.currentItemFontFamily).toEqual(FONT_FAMILY['Virgil, HanziPen SC, Kai']);
     fireEvent.click(screen.getByTitle(/code/i));
     expect(h.state.currentItemFontFamily).toEqual(FONT_FAMILY.Cascadia);
   });

--- a/src/tests/regressionTests.test.tsx
+++ b/src/tests/regressionTests.test.tsx
@@ -664,7 +664,7 @@ describe("regression tests", () => {
 
   it("updates fontSize & fontFamily appState", () => {
     UI.clickTool("text");
-    expect(h.state.currentItemFontFamily).toEqual(FONT_FAMILY['Virgil, HanziPen SC, Kai']);
+    expect(h.state.currentItemFontFamily).toEqual(FONT_FAMILY['Virgil, HanziPen SC, KaiTi']);
     fireEvent.click(screen.getByTitle(/code/i));
     expect(h.state.currentItemFontFamily).toEqual(FONT_FAMILY.Cascadia);
   });


### PR DESCRIPTION
This is a feature of multi font support, and especially for Chinese font.

There are three solution for CJK hand writing style font:

1. add a new font(eg. HandWritingCN) after Hand-Drawn, Normal, Code.
    - https://github.com/excalidraw/excalidraw/pull/2429 (This is full solution)
    - https://github.com/excalidraw/excalidraw/pull/3409 (This is full solution)
    - https://github.com/excalidraw/excalidraw/issues/5259
    - https://github.com/excalidraw/excalidraw/issues/1290
2. Using multi font for font-family, Virgil is first font, and if Virgil missing, the second(eg. HanziPen SC) will be enabled
3. Patching Virgil font file, add CJK(more then thousands unicode) 
    - https://github.com/excalidraw/excalidraw/issues/5370 imp

In my solution, I choose 2.

By using system including fonts(macOS HanziPen SC, Windows Kai), I do not add any external fonts.

Demo:

<img width="1224" alt="image" src="https://user-images.githubusercontent.com/227562/185801204-8296ce8e-d3e8-487b-9016-a32dfb7e35b5.png">
