### PR TITLE
fix: improve solveQuadratic when a = 0

### DIFF
--- a/src/element/bounds.ts
+++ b/src/element/bounds.ts
@@ -107,11 +107,18 @@ const solveQuadratic = (
     return false;
   }
 
-  const t1 = (-b + Math.sqrt(sqrtPart)) / (2 * a);
-  const t2 = (-b - Math.sqrt(sqrtPart)) / (2 * a);
-
   let s1 = null;
   let s2 = null;
+
+  let t1 = Infinity;
+  let t2 = Infinity;
+
+  if (a === 0) {
+    t1 = t2 = -c / b;
+  } else {
+    t1 = (-b + Math.sqrt(sqrtPart)) / (2 * a);
+    t2 = (-b - Math.sqrt(sqrtPart)) / (2 * a);
+  }
 
   if (t1 >= 0 && t1 <= 1) {
     s1 = getBezierValueForT(t1, p0, p1, p2, p3);
@@ -152,11 +159,6 @@ const getCubicBezierCurveBound = (
   return [minX, minY, maxX, maxY];
 };
 
-// TODO: https://github.com/excalidraw/excalidraw/issues/5617
-const getRandomOffset = () => {
-  return Math.random() / 1000000;
-};
-
 const getMinMaxXYFromCurvePathOps = (
   ops: Op[],
   transformXY?: (x: number, y: number) => [number, number],
@@ -173,19 +175,9 @@ const getMinMaxXYFromCurvePathOps = (
         // move operation does not draw anything; so, it always
         // returns false
       } else if (op === "bcurveTo") {
-        // random offset is needed to fix https://github.com/excalidraw/excalidraw/issues/5585
-        const _p1 = [
-          data[0] + getRandomOffset(),
-          data[1] + getRandomOffset(),
-        ] as Point;
-        const _p2 = [
-          data[2] + getRandomOffset(),
-          data[3] + getRandomOffset(),
-        ] as Point;
-        const _p3 = [
-          data[4] + getRandomOffset(),
-          data[5] + getRandomOffset(),
-        ] as Point;
+        const _p1 = [data[0], data[1]] as Point;
+        const _p2 = [data[2], data[3]] as Point;
+        const _p3 = [data[4], data[5]] as Point;
 
         const p1 = transformXY ? transformXY(..._p1) : _p1;
         const p2 = transformXY ? transformXY(..._p2) : _p2;


### PR DESCRIPTION
closes #5617 

When we have two consecutive points lined up vertically, rough.js has the two control points lined up vertically as well. This means that in `solveQuadratic`, we would have `a = 0`, which makes the calculation of `t1` and `t2` undefined, leading to `[s1, s2] = [null, null]`, which then leads to `getCubicBezierCurveBound` taking the max of starting and ending points' `x` as the max `x` bound, resulting in clipping as shown in #5585. 

Since we're trying to solve the derivative of the cubic bezier curve, which is a quadratic equation, when `a = 0`, we are really just solving a linear equation. The adjustment in `solveQuadratic` does exactly this. 