### PR TITLE
feat: Add an optional `ExcalidrawElement.subtype` attribute.

### DIFF
--- a/src/data/restore.ts
+++ b/src/data/restore.ts
@@ -28,6 +28,7 @@ import { LinearElementEditor } from "../element/linearElementEditor";
 import { bumpVersion } from "../element/mutateElement";
 import { getUpdatedTimestamp, updateActiveTool } from "../utils";
 import { arrayToMap } from "../utils";
+import { isValidSubtype } from "../subtypes";
 
 type RestoredAppState = Omit<
   AppState,
@@ -67,7 +68,8 @@ const getFontFamilyByName = (fontFamilyName: string): FontFamilyValues => {
 };
 
 const restoreElementWithProperties = <
-  T extends Required<Omit<ExcalidrawElement, "customData">> & {
+  T extends Required<Omit<ExcalidrawElement, "subtype" | "customData">> & {
+    subtype?: ExcalidrawElement["subtype"];
     customData?: ExcalidrawElement["customData"];
     /** @deprecated */
     boundElementIds?: readonly ExcalidrawElement["id"][];
@@ -116,6 +118,9 @@ const restoreElementWithProperties = <
     locked: element.locked ?? false,
   };
 
+  if ("subtype" in element && isValidSubtype(element.subtype, base.type)) {
+    base.subtype = element.subtype;
+  }
   if ("customData" in element) {
     base.customData = element.customData;
   }

--- a/src/data/restore.ts
+++ b/src/data/restore.ts
@@ -28,7 +28,7 @@ import { LinearElementEditor } from "../element/linearElementEditor";
 import { bumpVersion } from "../element/mutateElement";
 import { getUpdatedTimestamp, updateActiveTool } from "../utils";
 import { arrayToMap } from "../utils";
-import { isValidSubtype } from "../subtypes";
+import { isValidSubtypeName } from "../subtypes";
 
 type RestoredAppState = Omit<
   AppState,
@@ -118,7 +118,7 @@ const restoreElementWithProperties = <
     locked: element.locked ?? false,
   };
 
-  if ("subtype" in element && isValidSubtype(element.subtype, base.type)) {
+  if ("subtype" in element && isValidSubtypeName(element.subtype, base.type)) {
     base.subtype = element.subtype;
   }
   if ("customData" in element) {

--- a/src/data/restore.ts
+++ b/src/data/restore.ts
@@ -28,7 +28,7 @@ import { LinearElementEditor } from "../element/linearElementEditor";
 import { bumpVersion } from "../element/mutateElement";
 import { getUpdatedTimestamp, updateActiveTool } from "../utils";
 import { arrayToMap } from "../utils";
-import { isValidSubtypeName } from "../subtypes";
+import { isValidSubtype } from "../subtypes";
 
 type RestoredAppState = Omit<
   AppState,
@@ -118,7 +118,7 @@ const restoreElementWithProperties = <
     locked: element.locked ?? false,
   };
 
-  if ("subtype" in element && isValidSubtypeName(element.subtype, base.type)) {
+  if ("subtype" in element && isValidSubtype(element.subtype, base.type)) {
     base.subtype = element.subtype;
   }
   if ("customData" in element) {

--- a/src/element/types.ts
+++ b/src/element/types.ts
@@ -1,4 +1,4 @@
-import { CustomSubtype } from "../subtypes";
+import { SubtypeName } from "../subtypes";
 import { Point } from "../types";
 import { FONT_FAMILY, THEME, VERTICAL_ALIGN } from "../constants";
 
@@ -57,7 +57,7 @@ type _ExcalidrawElementBase = Readonly<{
   updated: number;
   link: string | null;
   locked: boolean;
-  subtype?: CustomSubtype;
+  subtype?: SubtypeName;
   customData?: Record<string, any>;
 }>;
 

--- a/src/element/types.ts
+++ b/src/element/types.ts
@@ -1,3 +1,4 @@
+import { CustomSubtype } from "../subtypes";
 import { Point } from "../types";
 import { FONT_FAMILY, THEME, VERTICAL_ALIGN } from "../constants";
 
@@ -56,6 +57,7 @@ type _ExcalidrawElementBase = Readonly<{
   updated: number;
   link: string | null;
   locked: boolean;
+  subtype?: CustomSubtype;
   customData?: Record<string, any>;
 }>;
 

--- a/src/element/types.ts
+++ b/src/element/types.ts
@@ -1,4 +1,4 @@
-import { SubtypeName } from "../subtypes";
+import { SubtypeRecord } from "../subtypes";
 import { Point } from "../types";
 import { FONT_FAMILY, THEME, VERTICAL_ALIGN } from "../constants";
 
@@ -57,7 +57,7 @@ type _ExcalidrawElementBase = Readonly<{
   updated: number;
   link: string | null;
   locked: boolean;
-  subtype?: SubtypeName;
+  subtype?: SubtypeRecord;
   customData?: Record<string, any>;
 }>;
 

--- a/src/subtypes.ts
+++ b/src/subtypes.ts
@@ -1,2 +1,2 @@
-export type CustomSubtype = string;
-export const isValidSubtype = (s: any, t: any): s is CustomSubtype => true; // Placeholder before further commits
+export type SubtypeName = string;
+export const isValidSubtypeName = (s: any, t: any): s is SubtypeName => true; // Placeholder before further commits

--- a/src/subtypes.ts
+++ b/src/subtypes.ts
@@ -1,42 +1,42 @@
 import { ExcalidrawElement } from "./element/types";
 
 // Use "let" instead of "const" so we can dynamically add subtypes
-let subtypeNames: readonly SubtypeName[] = [];
+let subtypeNames: readonly Subtype[] = [];
 let parentTypeMap: readonly {
-  subtype: SubtypeName;
+  subtype: Subtype;
   parentType: ExcalidrawElement["type"];
 }[] = [];
 
-export type Subtype = Readonly<{
-  name: SubtypeName;
+export type SubtypeRecord = Readonly<{
+  subtype: Subtype;
   parents: readonly ExcalidrawElement["type"][];
 }>;
 
 // Subtype Names
-export type SubtypeName = string;
-export const isValidSubtypeName = (s: any, t: any): s is SubtypeName =>
+export type Subtype = string;
+export const isValidSubtype = (s: any, t: any): s is Subtype =>
   parentTypeMap.find(
     (val) => val.subtype === (s as string) && val.parentType === (t as string),
   ) !== undefined;
 
 // This is the main method to set up the subtype.
 // The signature of `prepareSubtype` will change in further commits.
-export const prepareSubtype = (subtype: Subtype): {} => {
+export const prepareSubtype = (record: SubtypeRecord): {} => {
   // Check for undefined/null subtypes and parentTypes
   if (
-    subtype.name === undefined ||
-    subtype.name === "" ||
-    subtype.parents === undefined ||
-    subtype.parents.length === 0
+    record.subtype === undefined ||
+    record.subtype === "" ||
+    record.parents === undefined ||
+    record.parents.length === 0
   ) {
     return {};
   }
 
   // Register the types
-  const name = subtype.name;
-  subtypeNames = [...subtypeNames, name];
-  subtype.parents.forEach((parentType) => {
-    parentTypeMap = [...parentTypeMap, { subtype: name, parentType }];
+  const subtype = record.subtype;
+  subtypeNames = [...subtypeNames, subtype];
+  record.parents.forEach((parentType) => {
+    parentTypeMap = [...parentTypeMap, { subtype, parentType }];
   });
   return {};
 };

--- a/src/subtypes.ts
+++ b/src/subtypes.ts
@@ -1,0 +1,2 @@
+export type CustomSubtype = string;
+export const isValidSubtype = (s: any, t: any): s is CustomSubtype => true; // Placeholder before further commits

--- a/src/subtypes.ts
+++ b/src/subtypes.ts
@@ -1,2 +1,42 @@
+import { ExcalidrawElement } from "./element/types";
+
+// Use "let" instead of "const" so we can dynamically add subtypes
+let subtypeNames: readonly SubtypeName[] = [];
+let parentTypeMap: readonly {
+  subtype: SubtypeName;
+  parentType: ExcalidrawElement["type"];
+}[] = [];
+
+export type Subtype = Readonly<{
+  name: SubtypeName;
+  parents: readonly ExcalidrawElement["type"][];
+}>;
+
+// Subtype Names
 export type SubtypeName = string;
-export const isValidSubtypeName = (s: any, t: any): s is SubtypeName => true; // Placeholder before further commits
+export const isValidSubtypeName = (s: any, t: any): s is SubtypeName =>
+  parentTypeMap.find(
+    (val) => val.subtype === (s as string) && val.parentType === (t as string),
+  ) !== undefined;
+
+// This is the main method to set up the subtype.
+// The signature of `prepareSubtype` will change in further commits.
+export const prepareSubtype = (subtype: Subtype): {} => {
+  // Check for undefined/null subtypes and parentTypes
+  if (
+    subtype.name === undefined ||
+    subtype.name === "" ||
+    subtype.parents === undefined ||
+    subtype.parents.length === 0
+  ) {
+    return {};
+  }
+
+  // Register the types
+  const name = subtype.name;
+  subtypeNames = [...subtypeNames, name];
+  subtype.parents.forEach((parentType) => {
+    parentTypeMap = [...parentTypeMap, { subtype: name, parentType }];
+  });
+  return {};
+};

--- a/src/tests/subtypes.test.tsx
+++ b/src/tests/subtypes.test.tsx
@@ -1,7 +1,7 @@
-import { Subtype, isValidSubtypeName, prepareSubtype } from "../subtypes";
+import { SubtypeRecord, isValidSubtype, prepareSubtype } from "../subtypes";
 
-const test1: Subtype = {
-  name: "test",
+const test1: SubtypeRecord = {
+  subtype: "test",
   parents: ["line", "arrow", "rectangle", "diamond", "ellipse"],
 };
 
@@ -12,11 +12,11 @@ prepareSubtype(test1);
 describe("subtypes", () => {
   it("should correctly validate", async () => {
     test1.parents.forEach((p) => {
-      expect(isValidSubtypeName(test1.name, p)).toBe(true);
-      expect(isValidSubtypeName(undefined, p)).toBe(false);
+      expect(isValidSubtype(test1.subtype, p)).toBe(true);
+      expect(isValidSubtype(undefined, p)).toBe(false);
     });
-    expect(isValidSubtypeName(test1.name, test1NonParent)).toBe(false);
-    expect(isValidSubtypeName(test1.name, undefined)).toBe(false);
-    expect(isValidSubtypeName(undefined, undefined)).toBe(false);
+    expect(isValidSubtype(test1.subtype, test1NonParent)).toBe(false);
+    expect(isValidSubtype(test1.subtype, undefined)).toBe(false);
+    expect(isValidSubtype(undefined, undefined)).toBe(false);
   });
 });

--- a/src/tests/subtypes.test.tsx
+++ b/src/tests/subtypes.test.tsx
@@ -1,0 +1,22 @@
+import { Subtype, isValidSubtypeName, prepareSubtype } from "../subtypes";
+
+const test1: Subtype = {
+  name: "test",
+  parents: ["line", "arrow", "rectangle", "diamond", "ellipse"],
+};
+
+const test1NonParent = "text" as const;
+
+prepareSubtype(test1);
+
+describe("subtypes", () => {
+  it("should correctly validate", async () => {
+    test1.parents.forEach((p) => {
+      expect(isValidSubtypeName(test1.name, p)).toBe(true);
+      expect(isValidSubtypeName(undefined, p)).toBe(false);
+    });
+    expect(isValidSubtypeName(test1.name, test1NonParent)).toBe(false);
+    expect(isValidSubtypeName(test1.name, undefined)).toBe(false);
+    expect(isValidSubtypeName(undefined, undefined)).toBe(false);
+  });
+});


### PR DESCRIPTION
This is intended to be used in further PRs for incremental merging of #3915.

- Subtypes are meant to support dynamic registration.  Thus, we use `isValidSubtype()` instead of something like `type: ExcalidrawElement["type"]`.
- The type alias `Subtype` for `string` emphasizes that `ExcalidrawElement.subtype` may only store registered subtype names.
- If a `"math"` subtype was registered with sole parent type `"text"`, then `isValidSubtype("math", t)` will evaluate `true` if and only if `t === "text"`.