### PR TITLE
chore: update CodeSandbox links and add a config

### DIFF
--- a/.codesandbox/tasks.json
+++ b/.codesandbox/tasks.json
@@ -33,6 +33,11 @@
       "name": "Run Tests",
       "command": "yarn test",
       "runAtStart": false
+    },
+    "install-deps": {
+      "name": "Install Dependencies",
+      "command": "yarn install",
+      "restartOn": { "files": ["yarn.lock"] }
     }
   }
 }

--- a/.codesandbox/tasks.json
+++ b/.codesandbox/tasks.json
@@ -1,0 +1,38 @@
+{
+  // These tasks will run in order when initializing your CodeSandbox project.
+  "setupTasks": [
+    {
+      "name": "Install Dependencies",
+      "command": "yarn install"
+    }
+  ],
+
+  // These tasks can be run from CodeSandbox. Running one will open a log in the app.
+  "tasks": {
+    "build": {
+      "name": "Build",
+      "command": "yarn build",
+      "runAtStart": false
+    },
+    "fix": {
+      "name": "Fix",
+      "command": "yarn fix",
+      "runAtStart": false
+    },
+    "prettier": {
+      "name": "Prettify",
+      "command": "yarn prettier",
+      "runAtStart": false
+    },
+    "start": {
+      "name": "Start Excalidraw",
+      "command": "yarn start",
+      "runAtStart": true
+    },
+    "test": {
+      "name": "Run Tests",
+      "command": "yarn test",
+      "runAtStart": false
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Try out [`@excalidraw/excalidraw`](https://www.npmjs.com/package/@excalidraw/exc
 
 ### Code Sandbox
 
-- Go to https://codesandbox.io/s/github/excalidraw/excalidraw
+- Go to https://codesandbox.io/p/github/excalidraw/excalidraw
   - You may need to sign in with GitHub and reload the page
 - You can start coding instantly, and even send PRs from there!
 


### PR DESCRIPTION
Hello team!

In this PR I update the link for contributing to CodeSandbox to the new version of CodeSandbox. This is a more smooth experience, and should also work faster and more consistently with the local environment. I've also added a configuration so it works more smooth when you link to https://codesandbox.io/p/github/excalidraw/excalidraw/master.

Also, if you're interested you could install the GitHub App, this would ensure that every PR also has a running dev environment you can open to review like we have here:

<img width="970" alt="image" src="https://user-images.githubusercontent.com/587016/186698945-7a9c47d2-2840-4b41-b840-39ce1c881a6d.png">

(For this PR for instance, it would link to https://codesandbox.io/p/github/excalidraw/excalidraw/csb-1zdutz/draft/cold-sun)