### PR TITLE
fix: don't render library menu twice for mobile

### DIFF
--- a/src/components/LayerUI.tsx
+++ b/src/components/LayerUI.tsx
@@ -478,10 +478,10 @@ const LayerUI = ({
               {t("buttons.scrollBackToContent")}
             </button>
           )}
+          {appState.isLibraryOpen && (
+            <div className="layer-ui__sidebar">{libraryMenu}</div>
+          )}
         </div>
-      )}
-      {appState.isLibraryOpen && (
-        <div className="layer-ui__sidebar">{libraryMenu}</div>
       )}
     </>
   );


### PR DESCRIPTION
Introduced as a regression in https://github.com/excalidraw/excalidraw/pull/5611