### PR TITLE
fix: #5622 - prevent session theme reset during collaboration

### DIFF
--- a/src/excalidraw-app/index.tsx
+++ b/src/excalidraw-app/index.tsx
@@ -197,9 +197,7 @@ const initializeScene = async (opts: {
           ...restoreAppState(
             {
               ...scene?.appState,
-              ...(localDataState.appState?.theme && {
-                theme: localDataState.appState.theme,
-              }),
+              theme: localDataState?.appState?.theme || scene?.appState?.theme,
             },
             excalidrawAPI.getAppState(),
           ),

--- a/src/excalidraw-app/index.tsx
+++ b/src/excalidraw-app/index.tsx
@@ -194,7 +194,15 @@ const initializeScene = async (opts: {
       scene: {
         ...scene,
         appState: {
-          ...restoreAppState(scene?.appState, excalidrawAPI.getAppState()),
+          ...restoreAppState(
+            {
+              ...scene?.appState,
+              ...(localDataState.appState?.theme && {
+                theme: localDataState.appState.theme,
+              }),
+            },
+            excalidrawAPI.getAppState(),
+          ),
           // necessary if we're invoking from a hashchange handler which doesn't
           // go through App.initializeScene() that resets this flag
           isLoading: false,


### PR DESCRIPTION
 - ❌ prevent newly initialized state to override theme preferences.
 - 🔧 fix for [#5622](https://github.com/excalidraw/excalidraw/issues/5622)