### PR TITLE
fix: buttons jump around on the mobile menu

### DIFF
--- a/src/components/MobileMenu.tsx
+++ b/src/components/MobileMenu.tsx
@@ -121,7 +121,6 @@ export const MobileMenu = ({
   const renderAppToolbar = () => {
     // Render eraser conditionally in mobile
     const showEraser =
-      !appState.viewModeEnabled &&
       !appState.editingElement &&
       getSelectedElements(elements, appState).length === 0;
 
@@ -140,11 +139,11 @@ export const MobileMenu = ({
 
         {actionManager.renderAction("undo")}
         {actionManager.renderAction("redo")}
-        {showEraser && actionManager.renderAction("eraser")}
-
-        {actionManager.renderAction(
-          appState.multiElement ? "finalize" : "duplicateSelection",
-        )}
+        {showEraser
+          ? actionManager.renderAction("eraser")
+          : actionManager.renderAction(
+              appState.multiElement ? "finalize" : "duplicateSelection",
+            )}
         {actionManager.renderAction("deleteSelectedElements")}
       </div>
     );


### PR DESCRIPTION
Buttons jump around because the eraser is rendered as an extra button if no element is selected. When elements are selected 6 buttons are rendered (no eraser), but when no element is selected, then 7 buttons (or their empty place) are rendered, resulting in the jumping.

The eraser is mutually exclusive with the finalize or duplicateSelection button. If these 3 buttons are displayed in the same spot depending on scene state, then buttons will stay in place.

Checking viewModeEnabled for the eraser is superfluous because a different app-toolbar-content is returned by renderAppToolbar if viewModeEnabled. Thus I recommend removing this condition from showEraser. 

Before the fix:

https://user-images.githubusercontent.com/14358394/188264037-35217cf3-2644-4aa6-b5c4-152df0e5d3ae.mp4

After the fix:

https://user-images.githubusercontent.com/14358394/188264242-5625593d-6a54-42f0-892e-13535ff8a0b5.mp4

