### PR TITLE
fix: Prevent local AppState reset during collaboration

### DIFF
--- a/src/excalidraw-app/data/LocalData.ts
+++ b/src/excalidraw-app/data/LocalData.ts
@@ -37,12 +37,15 @@ class LocalFileManager extends FileManager {
 const saveDataStateToLocalStorage = (
   elements: readonly ExcalidrawElement[],
   appState: AppState,
+  appStateOnly = false,
 ) => {
   try {
-    localStorage.setItem(
-      STORAGE_KEYS.LOCAL_STORAGE_ELEMENTS,
-      JSON.stringify(clearElementsForLocalStorage(elements)),
-    );
+    if (!appStateOnly) {
+      localStorage.setItem(
+        STORAGE_KEYS.LOCAL_STORAGE_ELEMENTS,
+        JSON.stringify(clearElementsForLocalStorage(elements)),
+      );
+    }
     localStorage.setItem(
       STORAGE_KEYS.LOCAL_STORAGE_APP_STATE,
       JSON.stringify(clearAppStateForLocalStorage(appState)),
@@ -63,8 +66,12 @@ export class LocalData {
       appState: AppState,
       files: BinaryFiles,
       onFilesSaved: () => void,
+      appStateOnly = false,
     ) => {
-      saveDataStateToLocalStorage(elements, appState);
+      saveDataStateToLocalStorage(elements, appState, appStateOnly);
+      if (appStateOnly) {
+        return;
+      }
 
       await this.fileStorage.saveFiles({
         elements,
@@ -85,6 +92,14 @@ export class LocalData {
     // we need to make the `isSavePaused` check synchronously (undebounced)
     if (!this.isSavePaused()) {
       this._save(elements, appState, files, onFilesSaved);
+    }
+  };
+
+  /** Saves the AppState, only if saving is paused. */
+  static saveAppState = (appState: AppState) => {
+    // we need to make the `isSavePaused` check synchronously (undebounced)
+    if (this.isSavePaused()) {
+      this._save([], appState, {}, () => {}, true);
     }
   };
 

--- a/src/excalidraw-app/data/LocalData.ts
+++ b/src/excalidraw-app/data/LocalData.ts
@@ -98,7 +98,7 @@ export class LocalData {
   /** Saves the AppState, only if saving is paused. */
   static saveAppState = (appState: AppState) => {
     // we need to make the `isSavePaused` check synchronously (undebounced)
-    if (this.isSavePaused()) {
+    if (LocalData.isSavePaused()) {
       this._save([], appState, {}, () => {}, true);
     }
   };

--- a/src/excalidraw-app/index.tsx
+++ b/src/excalidraw-app/index.tsx
@@ -197,7 +197,7 @@ const initializeScene = async (opts: {
           ...restoreAppState(
             {
               ...scene?.appState,
-              theme: localDataState?.appState?.theme || scene?.appState?.theme,
+              ...localDataState?.appState,
             },
             excalidrawAPI.getAppState(),
           ),
@@ -550,6 +550,8 @@ const ExcalidrawWrapper = () => {
           }
         }
       });
+    } else {
+      LocalData.saveAppState(appState);
     }
   };
 


### PR DESCRIPTION
Related to #5622, I noticed local AppState changes were being reset upon page reloads during collaboration sessions.  This PR saves the AppState to local storage during a collaboration session.  All locally stored AppState changes (including the theme) are applied in `initializeScene`, thus building upon #5640.