### PR TITLE
fix: default light theme splash 🔧

### DIFF
--- a/src/actions/manager.tsx
+++ b/src/actions/manager.tsx
@@ -137,7 +137,6 @@ export class ActionManager {
    */
   renderAction = (name: ActionName, data?: PanelComponentProps["data"]) => {
     const canvasActions = this.app.props.UIOptions.canvasActions;
-
     if (
       this.actions[name] &&
       "PanelComponent" in this.actions[name] &&

--- a/src/actions/manager.tsx
+++ b/src/actions/manager.tsx
@@ -137,6 +137,7 @@ export class ActionManager {
    */
   renderAction = (name: ActionName, data?: PanelComponentProps["data"]) => {
     const canvasActions = this.app.props.UIOptions.canvasActions;
+    
     if (
       this.actions[name] &&
       "PanelComponent" in this.actions[name] &&

--- a/src/actions/manager.tsx
+++ b/src/actions/manager.tsx
@@ -137,7 +137,6 @@ export class ActionManager {
    */
   renderAction = (name: ActionName, data?: PanelComponentProps["data"]) => {
     const canvasActions = this.app.props.UIOptions.canvasActions;
-    
     if (
       this.actions[name] &&
       "PanelComponent" in this.actions[name] &&

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -552,11 +552,6 @@ class App extends React.Component<AppProps, AppState> {
                     typeof this.props?.zenModeEnabled === "undefined" &&
                     this.state.zenModeEnabled
                   }
-                  showThemeBtn={
-                    this.props.UIOptions.canvasActions.toggleTheme !== false &&
-                    (typeof this.props?.theme === "undefined" ||
-                      this.props.UIOptions.canvasActions.toggleTheme === true)
-                  }
                   libraryReturnUrl={this.props.libraryReturnUrl}
                   UIOptions={this.props.UIOptions}
                   focusContainer={this.focusContainer}

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -553,8 +553,8 @@ class App extends React.Component<AppProps, AppState> {
                     this.state.zenModeEnabled
                   }
                   showThemeBtn={
-                    typeof this.props?.theme === "undefined" &&
-                    this.props.UIOptions.canvasActions.theme
+                    this.props.UIOptions.canvasActions.theme ??
+                    !(typeof this.props?.theme === "undefined")
                   }
                   libraryReturnUrl={this.props.libraryReturnUrl}
                   UIOptions={this.props.UIOptions}
@@ -659,7 +659,10 @@ class App extends React.Component<AppProps, AppState> {
           gridSize = this.props.gridModeEnabled ? GRID_SIZE : null;
         }
 
-        if (typeof this.props.theme !== "undefined") {
+        if (
+          typeof this.props.theme !== "undefined" &&
+          !this.props.UIOptions.canvasActions.theme
+        ) {
           theme = this.props.theme;
         }
 
@@ -755,8 +758,8 @@ class App extends React.Component<AppProps, AppState> {
       );
     }
 
-    if (this.props.defaultTheme) {
-      this.setState({ theme: this.props.defaultTheme });
+    if (this.props.theme) {
+      this.setState({ theme: this.props.theme });
     }
     if (!this.state.isLoading) {
       this.setState({ isLoading: true });

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -755,6 +755,9 @@ class App extends React.Component<AppProps, AppState> {
       );
     }
 
+    if (this.props.defaultTheme) {
+      this.setState({ theme: this.props.defaultTheme });
+    }
     if (!this.state.isLoading) {
       this.setState({ isLoading: true });
     }

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -553,9 +553,9 @@ class App extends React.Component<AppProps, AppState> {
                     this.state.zenModeEnabled
                   }
                   showThemeBtn={
-                    this.props.UIOptions.canvasActions.theme !== false &&
+                    this.props.UIOptions.canvasActions.toggleTheme !== false &&
                     (typeof this.props?.theme === "undefined" ||
-                      this.props.UIOptions.canvasActions.theme === true)
+                      this.props.UIOptions.canvasActions.toggleTheme === true)
                   }
                   libraryReturnUrl={this.props.libraryReturnUrl}
                   UIOptions={this.props.UIOptions}

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -553,8 +553,9 @@ class App extends React.Component<AppProps, AppState> {
                     this.state.zenModeEnabled
                   }
                   showThemeBtn={
-                    this.props.UIOptions.canvasActions.theme ??
-                    !(typeof this.props?.theme === "undefined")
+                    this.props.UIOptions.canvasActions.theme !== false &&
+                    (typeof this.props?.theme === "undefined" ||
+                      this.props.UIOptions.canvasActions.theme === true)
                   }
                   libraryReturnUrl={this.props.libraryReturnUrl}
                   UIOptions={this.props.UIOptions}
@@ -645,7 +646,8 @@ class App extends React.Component<AppProps, AppState> {
         let viewModeEnabled = actionResult?.appState?.viewModeEnabled || false;
         let zenModeEnabled = actionResult?.appState?.zenModeEnabled || false;
         let gridSize = actionResult?.appState?.gridSize || null;
-        let theme = actionResult?.appState?.theme || THEME.LIGHT;
+        const theme =
+          actionResult?.appState?.theme || this.props.theme || THEME.LIGHT;
         let name = actionResult?.appState?.name ?? this.state.name;
         if (typeof this.props.viewModeEnabled !== "undefined") {
           viewModeEnabled = this.props.viewModeEnabled;
@@ -657,13 +659,6 @@ class App extends React.Component<AppProps, AppState> {
 
         if (typeof this.props.gridModeEnabled !== "undefined") {
           gridSize = this.props.gridModeEnabled ? GRID_SIZE : null;
-        }
-
-        if (
-          typeof this.props.theme !== "undefined" &&
-          !this.props.UIOptions.canvasActions.theme
-        ) {
-          theme = this.props.theme;
         }
 
         if (typeof this.props.name !== "undefined") {
@@ -790,6 +785,7 @@ class App extends React.Component<AppProps, AppState> {
     const scene = restore(initialData, null, null);
     scene.appState = {
       ...scene.appState,
+      theme: this.props.theme || scene.appState.theme,
       // we're falling back to current (pre-init) state when deciding
       // whether to open the library, to handle a case where we
       // update the state outside of initialData (e.g. when loading the app

--- a/src/components/BackgroundPickerAndDarkModeToggle.tsx
+++ b/src/components/BackgroundPickerAndDarkModeToggle.tsx
@@ -1,20 +1,12 @@
-import React from "react";
 import { ActionManager } from "../actions/manager";
-import { AppState } from "../types";
 
 export const BackgroundPickerAndDarkModeToggle = ({
-  appState,
-  setAppState,
   actionManager,
-  showThemeBtn,
 }: {
   actionManager: ActionManager;
-  appState: AppState;
-  setAppState: React.Component<any, AppState>["setState"];
-  showThemeBtn: boolean;
 }) => (
   <div style={{ display: "flex" }}>
     {actionManager.renderAction("changeViewBackgroundColor")}
-    {showThemeBtn && actionManager.renderAction("toggleTheme")}
+    {actionManager.renderAction("toggleTheme")}
   </div>
 );

--- a/src/components/InitializeApp.tsx
+++ b/src/components/InitializeApp.tsx
@@ -2,10 +2,12 @@ import React, { useEffect, useState } from "react";
 
 import { LoadingMessage } from "./LoadingMessage";
 import { defaultLang, Language, languages, setLanguage } from "../i18n";
+import { Theme } from "../element/types";
 
 interface Props {
   langCode: Language["code"];
   children: React.ReactElement;
+  theme?: Theme;
 }
 
 export const InitializeApp = (props: Props) => {
@@ -21,5 +23,5 @@ export const InitializeApp = (props: Props) => {
     updateLang();
   }, [props.langCode]);
 
-  return loading ? <LoadingMessage /> : props.children;
+  return loading ? <LoadingMessage theme={props.theme} /> : props.children;
 };

--- a/src/components/LayerUI.tsx
+++ b/src/components/LayerUI.tsx
@@ -53,7 +53,6 @@ interface LayerUIProps {
   onPenModeToggle: () => void;
   onInsertElements: (elements: readonly NonDeletedExcalidrawElement[]) => void;
   showExitZenModeBtn: boolean;
-  showThemeBtn: boolean;
   langCode: Language["code"];
   isCollaborating: boolean;
   renderTopRightUI?: ExcalidrawProps["renderTopRightUI"];
@@ -78,7 +77,6 @@ const LayerUI = ({
   onPenModeToggle,
   onInsertElements,
   showExitZenModeBtn,
-  showThemeBtn,
   isCollaborating,
   renderTopRightUI,
   renderCustomFooter,
@@ -209,12 +207,7 @@ const LayerUI = ({
               />
             )}
           </Stack.Row>
-          <BackgroundPickerAndDarkModeToggle
-            appState={appState}
-            actionManager={actionManager}
-            setAppState={setAppState}
-            showThemeBtn={showThemeBtn}
-          />
+          <BackgroundPickerAndDarkModeToggle actionManager={actionManager} />
           {appState.fileHandle && (
             <>{actionManager.renderAction("saveToActiveFile")}</>
           )}
@@ -424,7 +417,6 @@ const LayerUI = ({
           canvas={canvas}
           isCollaborating={isCollaborating}
           renderCustomFooter={renderCustomFooter}
-          showThemeBtn={showThemeBtn}
           onImageAction={onImageAction}
           renderTopRightUI={renderTopRightUI}
           renderCustomStats={renderCustomStats}

--- a/src/components/LoadingMessage.tsx
+++ b/src/components/LoadingMessage.tsx
@@ -1,8 +1,14 @@
 import { t } from "../i18n";
 import { useState, useEffect } from "react";
 import Spinner from "./Spinner";
+import clsx from "clsx";
+import { THEME } from "../constants";
+import { Theme } from "../element/types";
 
-export const LoadingMessage: React.FC<{ delay?: number }> = ({ delay }) => {
+export const LoadingMessage: React.FC<{ delay?: number; theme?: Theme }> = ({
+  delay,
+  theme,
+}) => {
   const [isWaiting, setIsWaiting] = useState(!!delay);
 
   useEffect(() => {
@@ -20,7 +26,11 @@ export const LoadingMessage: React.FC<{ delay?: number }> = ({ delay }) => {
   }
 
   return (
-    <div className="LoadingMessage">
+    <div
+      className={clsx("LoadingMessage", {
+        "LoadingMessage--dark": theme === THEME.DARK,
+      })}
+    >
       <div>
         <Spinner />
       </div>

--- a/src/components/MobileMenu.tsx
+++ b/src/components/MobileMenu.tsx
@@ -38,7 +38,6 @@ type MobileMenuProps = {
     isMobile: boolean,
     appState: AppState,
   ) => JSX.Element | null;
-  showThemeBtn: boolean;
   onImageAction: (data: { insertOnCanvasDirectly: boolean }) => void;
   renderTopRightUI?: (
     isMobile: boolean,
@@ -61,7 +60,6 @@ export const MobileMenu = ({
   canvas,
   isCollaborating,
   renderCustomFooter,
-  showThemeBtn,
   onImageAction,
   renderTopRightUI,
   renderCustomStats,
@@ -172,14 +170,7 @@ export const MobileMenu = ({
             onClick={onCollabButtonClick}
           />
         )}
-        {
-          <BackgroundPickerAndDarkModeToggle
-            actionManager={actionManager}
-            appState={appState}
-            setAppState={setAppState}
-            showThemeBtn={showThemeBtn}
-          />
-        }
+        {<BackgroundPickerAndDarkModeToggle actionManager={actionManager} />}
       </>
     );
   };

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -149,7 +149,7 @@ export const DEFAULT_UI_OPTIONS: AppProps["UIOptions"] = {
     export: { saveFileToDisk: true },
     loadScene: true,
     saveToActiveFile: true,
-    theme: true,
+    theme: null,
     saveAsImage: true,
   },
 };

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -149,7 +149,7 @@ export const DEFAULT_UI_OPTIONS: AppProps["UIOptions"] = {
     export: { saveFileToDisk: true },
     loadScene: true,
     saveToActiveFile: true,
-    theme: null,
+    toggleTheme: null,
     saveAsImage: true,
   },
 };

--- a/src/css/app.scss
+++ b/src/css/app.scss
@@ -1,3 +1,5 @@
+@import "open-color/open-color.scss";
+
 .visually-hidden {
   position: absolute !important;
   height: 1px;
@@ -29,4 +31,9 @@
     margin-top: 1em;
     font-size: 0.8em;
   }
+}
+
+.LoadingMessage--dark {
+  background-color: $oc-black;
+  color: $oc-white;
 }

--- a/src/excalidraw-app/app_constants.ts
+++ b/src/excalidraw-app/app_constants.ts
@@ -35,6 +35,7 @@ export const STORAGE_KEYS = {
   LOCAL_STORAGE_COLLAB: "excalidraw-collab",
   LOCAL_STORAGE_KEY_COLLAB_FORCE_FLAG: "collabLinkForceLoadFlag",
   LOCAL_STORAGE_LIBRARY: "excalidraw-library",
+  LOCAL_STORAGE_THEME: "excalidraw-theme",
   VERSION_DATA_STATE: "version-dataState",
   VERSION_FILES: "version-files",
 } as const;

--- a/src/excalidraw-app/index.tsx
+++ b/src/excalidraw-app/index.tsx
@@ -739,6 +739,7 @@ const ExcalidrawWrapper = () => {
         handleKeyboardGlobally={true}
         onLibraryChange={onLibraryChange}
         autoFocus={true}
+        defaultTheme={importFromLocalStorage().appState?.theme}
       />
       {excalidrawAPI && <Collab excalidrawAPI={excalidrawAPI} />}
       {errorMessage && (

--- a/src/excalidraw-app/index.tsx
+++ b/src/excalidraw-app/index.tsx
@@ -710,6 +710,7 @@ const ExcalidrawWrapper = () => {
         onPointerUpdate={collabAPI?.onPointerUpdate}
         UIOptions={{
           canvasActions: {
+            theme: true,
             export: {
               onExportToBackend,
               renderCustomUI: (elements, appState, files) => {
@@ -739,7 +740,7 @@ const ExcalidrawWrapper = () => {
         handleKeyboardGlobally={true}
         onLibraryChange={onLibraryChange}
         autoFocus={true}
-        defaultTheme={importFromLocalStorage().appState?.theme}
+        theme={importFromLocalStorage().appState?.theme}
       />
       {excalidrawAPI && <Collab excalidrawAPI={excalidrawAPI} />}
       {errorMessage && (

--- a/src/excalidraw-app/index.tsx
+++ b/src/excalidraw-app/index.tsx
@@ -9,6 +9,7 @@ import {
   APP_NAME,
   COOKIES,
   EVENT,
+  THEME,
   TITLE_TIMEOUT,
   VERSION_TIMEOUT,
 } from "../constants";
@@ -17,6 +18,7 @@ import {
   ExcalidrawElement,
   FileId,
   NonDeletedExcalidrawElement,
+  Theme,
 } from "../element/types";
 import { useCallbackRefState } from "../hooks/useCallbackRefState";
 import { t } from "../i18n";
@@ -512,6 +514,18 @@ const ExcalidrawWrapper = () => {
     languageDetector.cacheUserLanguage(langCode);
   }, [langCode]);
 
+  const [theme, setTheme] = useState<Theme>(
+    () =>
+      localStorage.getItem(STORAGE_KEYS.LOCAL_STORAGE_THEME) ||
+      // FIXME migration from old LS scheme. Can be removed later. #5660
+      importFromLocalStorage().appState?.theme ||
+      THEME.LIGHT,
+  );
+
+  useEffect(() => {
+    localStorage.setItem(STORAGE_KEYS.LOCAL_STORAGE_THEME, theme);
+  }, [theme]);
+
   const onChange = (
     elements: readonly ExcalidrawElement[],
     appState: AppState,
@@ -520,6 +534,8 @@ const ExcalidrawWrapper = () => {
     if (collabAPI?.isCollaborating()) {
       collabAPI.syncElements(elements);
     }
+
+    setTheme(appState.theme);
 
     // this check is redundant, but since this is a hot path, it's best
     // not to evaludate the nested expression every time
@@ -740,7 +756,7 @@ const ExcalidrawWrapper = () => {
         handleKeyboardGlobally={true}
         onLibraryChange={onLibraryChange}
         autoFocus={true}
-        theme={importFromLocalStorage().appState?.theme}
+        theme={theme}
       />
       {excalidrawAPI && <Collab excalidrawAPI={excalidrawAPI} />}
       {errorMessage && (

--- a/src/excalidraw-app/index.tsx
+++ b/src/excalidraw-app/index.tsx
@@ -726,7 +726,7 @@ const ExcalidrawWrapper = () => {
         onPointerUpdate={collabAPI?.onPointerUpdate}
         UIOptions={{
           canvasActions: {
-            theme: true,
+            toggleTheme: true,
             export: {
               onExportToBackend,
               renderCustomUI: (elements, appState, files) => {

--- a/src/packages/excalidraw/CHANGELOG.md
+++ b/src/packages/excalidraw/CHANGELOG.md
@@ -20,6 +20,10 @@ Please add the latest change on the top under the correct section.
 - Added support for storing [`customData`](https://github.com/excalidraw/excalidraw/blob/master/src/packages/excalidraw/README.md#storing-custom-data-to-excalidraw-elements) on Excalidraw elements [#5592].
 - Added `exportPadding?: number;` to [exportToCanvas](https://github.com/excalidraw/excalidraw/blob/master/src/packages/excalidraw/README.md#exporttocanvas) and [exportToBlob](https://github.com/excalidraw/excalidraw/blob/master/src/packages/excalidraw/README.md#exporttoblob). The default value of the padding is 10.
 
+#### Fixes
+
+- Fixed light theme splash on load [#5660](https://github.com/excalidraw/excalidraw/pull/5660)
+
 #### Breaking Changes
 
 - `setToastMessage` API is now renamed to `setToast` API and the function signature is also updated [#5427](https://github.com/excalidraw/excalidraw/pull/5427). You can also pass `duration` and `closable` attributes along with `message`.

--- a/src/packages/excalidraw/CHANGELOG.md
+++ b/src/packages/excalidraw/CHANGELOG.md
@@ -23,6 +23,7 @@ Please add the latest change on the top under the correct section.
 
 #### Breaking Changes
 
+- `props.UIOptions.canvasActions.theme` is now renamed to `props.UIOptions.canvasActions.toggleTheme` [#5660](https://github.com/excalidraw/excalidraw/pull/5660).
 - `setToastMessage` API is now renamed to `setToast` API and the function signature is also updated [#5427](https://github.com/excalidraw/excalidraw/pull/5427). You can also pass `duration` and `closable` attributes along with `message`.
 
 ## 0.12.0 (2022-07-07)

--- a/src/packages/excalidraw/CHANGELOG.md
+++ b/src/packages/excalidraw/CHANGELOG.md
@@ -17,12 +17,9 @@ Please add the latest change on the top under the correct section.
 
 #### Features
 
+- Support [theme](https://github.com/excalidraw/excalidraw/blob/master/src/packages/excalidraw/README.md#theme) to be semi-controlled [#5660](https://github.com/excalidraw/excalidraw/pull/5660).
 - Added support for storing [`customData`](https://github.com/excalidraw/excalidraw/blob/master/src/packages/excalidraw/README.md#storing-custom-data-to-excalidraw-elements) on Excalidraw elements [#5592].
 - Added `exportPadding?: number;` to [exportToCanvas](https://github.com/excalidraw/excalidraw/blob/master/src/packages/excalidraw/README.md#exporttocanvas) and [exportToBlob](https://github.com/excalidraw/excalidraw/blob/master/src/packages/excalidraw/README.md#exporttoblob). The default value of the padding is 10.
-
-#### Fixes
-
-- Fixed light theme splash on load [#5660](https://github.com/excalidraw/excalidraw/pull/5660)
 
 #### Breaking Changes
 

--- a/src/packages/excalidraw/README.md
+++ b/src/packages/excalidraw/README.md
@@ -637,7 +637,9 @@ If supplied, this URL will be used when user tries to install a library from [li
 
 #### `theme`
 
-This prop controls Excalidraw's theme. When supplied, the value takes precedence over `intialData.appState.theme`, the theme will be fully controlled by the host app, and users won't be able to toggle it from within the app unless specified by `UIOptions.canvasActions.theme` in which case, this prop will control Excalidraw's default theme with ability to allow theme switching handed over to `UIOptions.canvasActions.theme`.You can use [`THEME`](#THEME-1) to specify the theme.
+This prop controls Excalidraw's theme. When supplied, the value takes precedence over `intialData.appState.theme`, the theme will be fully controlled by the host app, and users won't be able to toggle it from within the app unless `UIOptions.canvasActions.theme` is set to `true`, in which case the `theme` prop will control Excalidraw's default theme with ability to allow theme switching (you must take care of updating the `theme` prop when you detect a change to `appState.theme` from the [onChange](#onChange) callback).
+
+You can use [`THEME`](#THEME-1) to specify the theme.
 
 #### `name`
 

--- a/src/packages/excalidraw/README.md
+++ b/src/packages/excalidraw/README.md
@@ -637,7 +637,7 @@ If supplied, this URL will be used when user tries to install a library from [li
 
 #### `theme`
 
-This prop controls Excalidraw's theme. When supplied, the value takes precedence over `intialData.appState.theme`, the theme will be fully controlled by the host app, and users won't be able to toggle it from within the app. You can use [`THEME`](#THEME-1) to specify the theme.
+This prop controls Excalidraw's theme. When supplied, the value takes precedence over `intialData.appState.theme`, the theme will be fully controlled by the host app, and users won't be able to toggle it from within the app unless specified by `UIOptions.canvasActions.theme` in which case, this prop will control Excalidraw's default theme with ability to allow theme switching handed over to `UIOptions.canvasActions.theme`.You can use [`THEME`](#THEME-1) to specify the theme.
 
 #### `name`
 
@@ -660,7 +660,7 @@ This prop can be used to customise UI of Excalidraw. Currently we support custom
 | `export` | false &#124; [exportOpts](#exportOpts) | <pre>{ saveFileToDisk: true }</pre> | This prop allows to customize the UI inside the export dialog. By default it shows the "saveFileToDisk". If this prop is `false` the export button will not be rendered. For more details visit [`exportOpts`](#exportOpts). |
 | `loadScene` | boolean | true | Implies whether to show `Load button` |
 | `saveToActiveFile` | boolean | true | Implies whether to show `Save button` to save to current file |
-| `theme` | boolean | true | Implies whether to show `Theme toggle` |
+| `theme` | boolean &#124; null | null | Implies whether to show `Theme toggle`. When defined as `boolean`, takes precedence over `props.theme` to show `Theme toggle` |
 | `saveAsImage` | boolean | true | Implies whether to show `Save as image button` |
 
 ##### `dockedSidebarBreakpoint`

--- a/src/packages/excalidraw/README.md
+++ b/src/packages/excalidraw/README.md
@@ -637,7 +637,7 @@ If supplied, this URL will be used when user tries to install a library from [li
 
 #### `theme`
 
-This prop controls Excalidraw's theme. When supplied, the value takes precedence over `intialData.appState.theme`, the theme will be fully controlled by the host app, and users won't be able to toggle it from within the app unless `UIOptions.canvasActions.theme` is set to `true`, in which case the `theme` prop will control Excalidraw's default theme with ability to allow theme switching (you must take care of updating the `theme` prop when you detect a change to `appState.theme` from the [onChange](#onChange) callback).
+This prop controls Excalidraw's theme. When supplied, the value takes precedence over `intialData.appState.theme`, the theme will be fully controlled by the host app, and users won't be able to toggle it from within the app unless `UIOptions.canvasActions.toggleTheme` is set to `true`, in which case the `theme` prop will control Excalidraw's default theme with ability to allow theme switching (you must take care of updating the `theme` prop when you detect a change to `appState.theme` from the [onChange](#onChange) callback).
 
 You can use [`THEME`](#THEME-1) to specify the theme.
 
@@ -662,7 +662,7 @@ This prop can be used to customise UI of Excalidraw. Currently we support custom
 | `export` | false &#124; [exportOpts](#exportOpts) | <pre>{ saveFileToDisk: true }</pre> | This prop allows to customize the UI inside the export dialog. By default it shows the "saveFileToDisk". If this prop is `false` the export button will not be rendered. For more details visit [`exportOpts`](#exportOpts). |
 | `loadScene` | boolean | true | Implies whether to show `Load button` |
 | `saveToActiveFile` | boolean | true | Implies whether to show `Save button` to save to current file |
-| `theme` | boolean &#124; null | null | Implies whether to show `Theme toggle`. When defined as `boolean`, takes precedence over [`props.theme`](#theme) to show `Theme toggle` |
+| `toggleTheme` | boolean &#124; null | null | Implies whether to show `Theme toggle`. When defined as `boolean`, takes precedence over [`props.theme`](#theme) to show `Theme toggle` |
 | `saveAsImage` | boolean | true | Implies whether to show `Save as image button` |
 
 ##### `dockedSidebarBreakpoint`

--- a/src/packages/excalidraw/README.md
+++ b/src/packages/excalidraw/README.md
@@ -660,7 +660,7 @@ This prop can be used to customise UI of Excalidraw. Currently we support custom
 | `export` | false &#124; [exportOpts](#exportOpts) | <pre>{ saveFileToDisk: true }</pre> | This prop allows to customize the UI inside the export dialog. By default it shows the "saveFileToDisk". If this prop is `false` the export button will not be rendered. For more details visit [`exportOpts`](#exportOpts). |
 | `loadScene` | boolean | true | Implies whether to show `Load button` |
 | `saveToActiveFile` | boolean | true | Implies whether to show `Save button` to save to current file |
-| `theme` | boolean &#124; null | null | Implies whether to show `Theme toggle`. When defined as `boolean`, takes precedence over `props.theme` to show `Theme toggle` |
+| `theme` | boolean &#124; null | null | Implies whether to show `Theme toggle`. When defined as `boolean`, takes precedence over [`props.theme`](#theme) to show `Theme toggle` |
 | `saveAsImage` | boolean | true | Implies whether to show `Save as image button` |
 
 ##### `dockedSidebarBreakpoint`

--- a/src/packages/excalidraw/index.tsx
+++ b/src/packages/excalidraw/index.tsx
@@ -56,6 +56,12 @@ const ExcalidrawBase = (props: ExcalidrawProps) => {
       DEFAULT_UI_OPTIONS.canvasActions.export.saveFileToDisk;
   }
 
+  if (
+    UIOptions.canvasActions.toggleTheme === null &&
+    typeof theme === "undefined"
+  ) {
+    UIOptions.canvasActions.toggleTheme = true;
+  }
   useEffect(() => {
     // Block pinch-zooming on iOS outside of the content area
     const handleTouchMove = (event: TouchEvent) => {

--- a/src/packages/excalidraw/index.tsx
+++ b/src/packages/excalidraw/index.tsx
@@ -38,7 +38,6 @@ const ExcalidrawBase = (props: ExcalidrawProps) => {
     onLinkOpen,
     onPointerDown,
     onScrollChange,
-    defaultTheme,
   } = props;
 
   const canvasActions = props.UIOptions?.canvasActions;
@@ -76,7 +75,7 @@ const ExcalidrawBase = (props: ExcalidrawProps) => {
   }, []);
 
   return (
-    <InitializeApp langCode={langCode} theme={theme || defaultTheme}>
+    <InitializeApp langCode={langCode} theme={theme}>
       <Provider unstable_createStore={() => jotaiStore} scope={jotaiScope}>
         <App
           onChange={onChange}
@@ -105,7 +104,6 @@ const ExcalidrawBase = (props: ExcalidrawProps) => {
           onLinkOpen={onLinkOpen}
           onPointerDown={onPointerDown}
           onScrollChange={onScrollChange}
-          defaultTheme={defaultTheme}
         />
       </Provider>
     </InitializeApp>

--- a/src/packages/excalidraw/index.tsx
+++ b/src/packages/excalidraw/index.tsx
@@ -38,6 +38,7 @@ const ExcalidrawBase = (props: ExcalidrawProps) => {
     onLinkOpen,
     onPointerDown,
     onScrollChange,
+    defaultTheme,
   } = props;
 
   const canvasActions = props.UIOptions?.canvasActions;
@@ -75,7 +76,7 @@ const ExcalidrawBase = (props: ExcalidrawProps) => {
   }, []);
 
   return (
-    <InitializeApp langCode={langCode}>
+    <InitializeApp langCode={langCode} theme={theme || defaultTheme}>
       <Provider unstable_createStore={() => jotaiStore} scope={jotaiScope}>
         <App
           onChange={onChange}
@@ -104,6 +105,7 @@ const ExcalidrawBase = (props: ExcalidrawProps) => {
           onLinkOpen={onLinkOpen}
           onPointerDown={onPointerDown}
           onScrollChange={onScrollChange}
+          defaultTheme={defaultTheme}
         />
       </Provider>
     </InitializeApp>

--- a/src/packages/excalidraw/index.tsx
+++ b/src/packages/excalidraw/index.tsx
@@ -62,6 +62,7 @@ const ExcalidrawBase = (props: ExcalidrawProps) => {
   ) {
     UIOptions.canvasActions.toggleTheme = true;
   }
+
   useEffect(() => {
     // Block pinch-zooming on iOS outside of the content area
     const handleTouchMove = (event: TouchEvent) => {

--- a/src/tests/packages/excalidraw.test.tsx
+++ b/src/tests/packages/excalidraw.test.tsx
@@ -88,53 +88,41 @@ describe("<Excalidraw/>", () => {
   });
 
   describe("Test theme prop", () => {
-    it("should show the dark mode toggle by default", async () => {
+    it("should show the theme toggle by default", async () => {
       const { container } = await render(<Excalidraw />);
       expect(h.state.theme).toBe(THEME.LIGHT);
       const darkModeToggle = queryByTestId(container, "toggle-dark-mode");
       expect(darkModeToggle).toBeTruthy();
     });
 
-    it("should always show dark mode toggle when `UIOptions.canvasActions.theme` is true", async () => {
+    it("should not show theme toggle when the theme prop is defined", async () => {
+      const { container } = await render(<Excalidraw theme="dark" />);
+      expect(h.state.theme).toBe(THEME.DARK);
+      expect(queryByTestId(container, "toggle-dark-mode")).toBe(null);
+    });
+
+    it("should theme mode toggle when `UIOptions.canvasActions.theme` is true", async () => {
       const { container } = await render(
-        <Excalidraw UIOptions={{ canvasActions: { theme: true } }} />,
+        <Excalidraw
+          theme={THEME.DARK}
+          UIOptions={{ canvasActions: { theme: true } }}
+        />,
       );
-      expect(h.state.theme).toBe(THEME.LIGHT);
+      expect(h.state.theme).toBe(THEME.DARK);
       const darkModeToggle = queryByTestId(container, "toggle-dark-mode");
       expect(darkModeToggle).toBeTruthy();
     });
 
-    describe("should never show dark mode toggle when `UIOptions.canvasActions.theme` is false", () => {
-      it("should not show when theme is not defined", async () => {
-        const { container } = await render(
-          <Excalidraw UIOptions={{ canvasActions: { theme: false } }} />,
-        );
-        expect(h.state.theme).toBe(THEME.LIGHT);
-        const darkModeToggle = queryByTestId(container, "toggle-dark-mode");
-        expect(darkModeToggle).toBeFalsy();
-      });
-
-      it("should not show when theme is defined", async () => {
-        const { container } = await render(
-          <Excalidraw
-            UIOptions={{ canvasActions: { theme: false } }}
-            theme={THEME.DARK}
-          />,
-        );
-        expect(h.state.theme).toBe(THEME.DARK);
-        const darkModeToggle = queryByTestId(container, "toggle-dark-mode");
-        expect(darkModeToggle).toBeFalsy();
-      });
-    });
-
-    it("should render dark theme when specified by `theme` prop", async () => {
-      await render(
+    it("should not show theme toggle when disabled", async () => {
+      const { container } = await render(
         <Excalidraw
-          theme={THEME.DARK}
           UIOptions={{ canvasActions: { theme: false } }}
+          theme={THEME.DARK}
         />,
       );
       expect(h.state.theme).toBe(THEME.DARK);
+      const darkModeToggle = queryByTestId(container, "toggle-dark-mode");
+      expect(darkModeToggle).toBeFalsy();
     });
   });
 

--- a/src/tests/packages/excalidraw.test.tsx
+++ b/src/tests/packages/excalidraw.test.tsx
@@ -101,7 +101,7 @@ describe("<Excalidraw/>", () => {
       expect(queryByTestId(container, "toggle-dark-mode")).toBe(null);
     });
 
-    it("should theme mode toggle when `UIOptions.canvasActions.theme` is true", async () => {
+    it("should show theme mode toggle when `UIOptions.canvasActions.theme` is true", async () => {
       const { container } = await render(
         <Excalidraw
           theme={THEME.DARK}
@@ -113,7 +113,7 @@ describe("<Excalidraw/>", () => {
       expect(darkModeToggle).toBeTruthy();
     });
 
-    it("should not show theme toggle when disabled", async () => {
+    it("should not show theme toggle when `UIOptions.canvasActions.theme` is false", async () => {
       const { container } = await render(
         <Excalidraw
           UIOptions={{ canvasActions: { theme: false } }}

--- a/src/tests/packages/excalidraw.test.tsx
+++ b/src/tests/packages/excalidraw.test.tsx
@@ -88,20 +88,53 @@ describe("<Excalidraw/>", () => {
   });
 
   describe("Test theme prop", () => {
-    it('should show the dark mode toggle when the theme prop is "undefined"', async () => {
+    it("should show the dark mode toggle by default", async () => {
       const { container } = await render(<Excalidraw />);
       expect(h.state.theme).toBe(THEME.LIGHT);
-
       const darkModeToggle = queryByTestId(container, "toggle-dark-mode");
-
       expect(darkModeToggle).toBeTruthy();
     });
 
-    it('should not show the dark mode toggle when the theme prop is not "undefined"', async () => {
-      const { container } = await render(<Excalidraw theme="dark" />);
-      expect(h.state.theme).toBe(THEME.DARK);
+    it("should always show dark mode toggle when `UIOptions.canvasActions.theme` is true", async () => {
+      const { container } = await render(
+        <Excalidraw UIOptions={{ canvasActions: { theme: true } }} />,
+      );
+      expect(h.state.theme).toBe(THEME.LIGHT);
+      const darkModeToggle = queryByTestId(container, "toggle-dark-mode");
+      expect(darkModeToggle).toBeTruthy();
+    });
 
-      expect(queryByTestId(container, "toggle-dark-mode")).toBe(null);
+    describe("should never show dark mode toggle when `UIOptions.canvasActions.theme` is false", () => {
+      it("should not show when theme is not defined", async () => {
+        const { container } = await render(
+          <Excalidraw UIOptions={{ canvasActions: { theme: false } }} />,
+        );
+        expect(h.state.theme).toBe(THEME.LIGHT);
+        const darkModeToggle = queryByTestId(container, "toggle-dark-mode");
+        expect(darkModeToggle).toBeFalsy();
+      });
+
+      it("should not show when theme is defined", async () => {
+        const { container } = await render(
+          <Excalidraw
+            UIOptions={{ canvasActions: { theme: false } }}
+            theme={THEME.DARK}
+          />,
+        );
+        expect(h.state.theme).toBe(THEME.DARK);
+        const darkModeToggle = queryByTestId(container, "toggle-dark-mode");
+        expect(darkModeToggle).toBeFalsy();
+      });
+    });
+
+    it("should render dark theme when specified by `theme` prop", async () => {
+      await render(
+        <Excalidraw
+          theme={THEME.DARK}
+          UIOptions={{ canvasActions: { theme: false } }}
+        />,
+      );
+      expect(h.state.theme).toBe(THEME.DARK);
     });
   });
 

--- a/src/tests/packages/excalidraw.test.tsx
+++ b/src/tests/packages/excalidraw.test.tsx
@@ -101,11 +101,11 @@ describe("<Excalidraw/>", () => {
       expect(queryByTestId(container, "toggle-dark-mode")).toBe(null);
     });
 
-    it("should show theme mode toggle when `UIOptions.canvasActions.theme` is true", async () => {
+    it("should show theme mode toggle when `UIOptions.canvasActions.toggleTheme` is true", async () => {
       const { container } = await render(
         <Excalidraw
           theme={THEME.DARK}
-          UIOptions={{ canvasActions: { theme: true } }}
+          UIOptions={{ canvasActions: { toggleTheme: true } }}
         />,
       );
       expect(h.state.theme).toBe(THEME.DARK);
@@ -113,10 +113,10 @@ describe("<Excalidraw/>", () => {
       expect(darkModeToggle).toBeTruthy();
     });
 
-    it("should not show theme toggle when `UIOptions.canvasActions.theme` is false", async () => {
+    it("should not show theme toggle when `UIOptions.canvasActions.toggleTheme` is false", async () => {
       const { container } = await render(
         <Excalidraw
-          UIOptions={{ canvasActions: { theme: false } }}
+          UIOptions={{ canvasActions: { toggleTheme: false } }}
           theme={THEME.DARK}
         />,
       );
@@ -235,7 +235,7 @@ describe("<Excalidraw/>", () => {
 
       it("should hide the theme toggle when theme is false", async () => {
         const { container } = await render(
-          <Excalidraw UIOptions={{ canvasActions: { theme: false } }} />,
+          <Excalidraw UIOptions={{ canvasActions: { toggleTheme: false } }} />,
         );
 
         expect(queryByTestId(container, "toggle-dark-mode")).toBeNull();

--- a/src/types.ts
+++ b/src/types.ts
@@ -313,7 +313,6 @@ export interface ExcalidrawProps {
     pointerDownState: PointerDownState,
   ) => void;
   onScrollChange?: (scrollX: number, scrollY: number) => void;
-  defaultTheme?: Theme;
 }
 
 export type SceneData = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -344,6 +344,10 @@ export type ExportOpts = {
   ) => JSX.Element;
 };
 
+// NOTE at the moment, if action name coressponds to canvasAction prop, its
+// truthiness value will determine whether the action is rendered or not
+// (see manager renderAction). We also override canvasAction values in
+// excalidraw package index.tsx.
 type CanvasActions = {
   changeViewBackgroundColor?: boolean;
   clearCanvas?: boolean;

--- a/src/types.ts
+++ b/src/types.ts
@@ -350,7 +350,7 @@ type CanvasActions = {
   export?: false | ExportOpts;
   loadScene?: boolean;
   saveToActiveFile?: boolean;
-  theme?: boolean | null;
+  toggleTheme?: boolean | null;
   saveAsImage?: boolean;
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -350,7 +350,7 @@ type CanvasActions = {
   export?: false | ExportOpts;
   loadScene?: boolean;
   saveToActiveFile?: boolean;
-  theme?: boolean;
+  theme?: boolean | null;
   saveAsImage?: boolean;
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -313,6 +313,7 @@ export interface ExcalidrawProps {
     pointerDownState: PointerDownState,
   ) => void;
   onScrollChange?: (scrollX: number, scrollY: number) => void;
+  defaultTheme?: Theme;
 }
 
 export type SceneData = {


### PR DESCRIPTION
 - 🔧 fixed loading screen and default theme always set to light
          resulting in white screen splash before switching to dark mode

<hr />

### Note
the explanation below assumes the case when the user has previously selected `dark` theme and its value is stored in the local storage. But the changes are compatible with both themes.

### Previous Behavior

 - app loads and shows the white loading screen `<LoadingMessage />` while the language is being set (the app is being initialized - `initializeApp.ts`).
 - the canvas renders with the default app state assuming the theme to be `light`.
 - the app state from local storage resolved [`initialData`] prop and the theme is then set to `dark` as previously set by the user.

#### Problem
Splash of white screen
👇
https://www.loom.com/share/6ac6615a26a44125b8b04080f20936bf

#### After Fix
https://www.loom.com/share/28a59418d1b7432ab91e7ffe5ca47ee8

### Caveats
the current approach introduces another prop `defaultTheme`. I am not sure if we have the bandwidth for another prop.
 - Inside the `App`, the only apparent way to access the theme from the user's browser is to resolve `initialData` prop. But during the time it's being resolved, the default theme value from the initial state would still render a white canvas (the whole app in light theme).
 - `theme` prop cannot be set to the value from the local storage as it is a decisive prop for the `@excalidraw/excalidraw` package. Setting this by default will disable theme switching.

Suggestions and improvements are welcome 😊.
