### PR TITLE
fix: #5666  — change size font when resize container

### DIFF
--- a/src/element/resizeElements.ts
+++ b/src/element/resizeElements.ts
@@ -709,8 +709,8 @@ const resizeMultipleElements = (
         if (boundTextElement) {
           const nextFont = measureFontSizeFromWH(
             boundTextElement,
-            width - BOUND_TEXT_PADDING * 2,
-            height - BOUND_TEXT_PADDING * 2,
+            boundTextElement.width + (width - element.width),
+            boundTextElement.height + (height - element.height),
           );
 
           if (nextFont === null) {

--- a/src/element/resizeElements.ts
+++ b/src/element/resizeElements.ts
@@ -499,8 +499,8 @@ export const resizeSingleElement = (
     if (shouldMaintainAspectRatio) {
       const nextFont = measureFontSizeFromWH(
         boundTextElement,
-        eleNewWidth - BOUND_TEXT_PADDING * 2,
-        eleNewHeight - BOUND_TEXT_PADDING * 2,
+        boundTextElement.width + (eleNewWidth - element.width),
+        boundTextElement.height + (eleNewHeight - element.height),
       );
       if (nextFont === null) {
         return;

--- a/src/element/resizeElements.ts
+++ b/src/element/resizeElements.ts
@@ -1,4 +1,4 @@
-import { BOUND_TEXT_PADDING, SHIFT_LOCKING_ANGLE } from "../constants";
+import { SHIFT_LOCKING_ANGLE } from "../constants";
 import { rescalePoints } from "../points";
 
 import {


### PR DESCRIPTION
change size of a text element by difference old size and new size of a associated container with this text element


What does a bug look like?

https://user-images.githubusercontent.com/301646/188576833-7af41864-9619-4cec-9f2d-66f9f1912a1b.mov
