### PR TITLE
fix: syncing 1-point lines to remote clients

### DIFF
--- a/src/actions/actionDeleteSelected.tsx
+++ b/src/actions/actionDeleteSelected.tsx
@@ -78,7 +78,12 @@ export const actionDeleteSelected = register({
         // case: deleting last remaining point
         element.points.length < 2
       ) {
-        const nextElements = elements.filter((el) => el.id !== element.id);
+        const nextElements = elements.map((el) => {
+          if (el.id === element.id) {
+            return newElementWith(el, { isDeleted: true });
+          }
+          return el;
+        });
         const nextAppState = handleGroupEditingState(appState, nextElements);
 
         return {


### PR DESCRIPTION
When deleting the last point and confirming, it correctly deletes the line element since 1-point lines do not make sense. But, there's a bug where it syncs the 1-line element to remote clients, because we were removing it from the array altogether instead marking it as `isDeleted`.