### PR TITLE
fix: prevent z-index from resetting on save when collaborating

### DIFF
--- a/src/zindex.ts
+++ b/src/zindex.ts
@@ -253,7 +253,7 @@ const shiftElementsToEnd = (
 ) => {
   const indicesToMove = getIndicesToMove(elements, appState);
   const targetElementsMap = getTargetElementsMap(elements, indicesToMove);
-  const displacedElements: ExcalidrawElement[] = [];
+  let displacedElements: ExcalidrawElement[] = [];
 
   let leadingIndex: number;
   let trailingIndex: number;
@@ -298,6 +298,7 @@ const shiftElementsToEnd = (
   const targetElements = Object.values(targetElementsMap).map((element) => {
     return bumpVersion(element);
   });
+  displacedElements = displacedElements.map((element) => bumpVersion(element));
 
   const leadingElements = elements.slice(0, leadingIndex);
   const trailingElements = elements.slice(trailingIndex + 1);

--- a/src/zindex.ts
+++ b/src/zindex.ts
@@ -252,7 +252,6 @@ const shiftElementsToEnd = (
   direction: "left" | "right",
 ) => {
   const indicesToMove = getIndicesToMove(elements, appState);
-  const targetElementsMap = getTargetElementsMap(elements, indicesToMove);
   let displacedElements: ExcalidrawElement[] = [];
 
   let leadingIndex: number;
@@ -295,8 +294,8 @@ const shiftElementsToEnd = (
     }
   }
 
-  const targetElements = Object.values(targetElementsMap).map((element) => {
-    return bumpVersion(element);
+  const targetElements = indicesToMove.map((index) => {
+    return bumpVersion(elements[index]);
   });
   displacedElements = displacedElements.map((element) => bumpVersion(element));
 


### PR DESCRIPTION
When using the collaboration feature and using for example `bring to front`, it would reset the next time it auto-saves.

The issue seems to be that the reconciliation algorithm falsely assumes the first (lower z-index) element is a duplicate and removes it. It does that because the displaced elements in `zIndex.ts`, while changed, don't receive a version bump.