### PR TITLE
feat: further reduce darkmode init flash

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,5 +1,14 @@
 <!DOCTYPE html>
 <html lang="en">
+  <script>
+    try {
+      // to minimize white flash on load when user has dark mode enabled
+      const theme = window.localStorage.getItem("excalidraw-theme");
+      if (theme === "dark") {
+        document.documentElement.classList.add("dark");
+      }
+    } catch {}
+  </script>
   <head>
     <meta charset="utf-8" />
     <title>Excalidraw | Hand-drawn look & feel • Collaborative • Secure</title>
@@ -51,7 +60,6 @@
       name="twitter:description"
       content="Excalidraw is a whiteboard tool that lets you easily sketch diagrams that have a hand-drawn feel to them."
     />
-
     <script>
       // Redirect Excalidraw+ users which have auto-redirect enabled.
       //
@@ -70,6 +78,13 @@
         window.location.href = "https://app.excalidraw.com";
       }
     </script>
+    
+    <style>
+      html.dark {
+        background-color: #121212;
+        color: #fff;
+      }
+    </style>
 
     <link rel="shortcut icon" href="favicon.ico" type="image/x-icon" />
 
@@ -98,7 +113,7 @@
     />
 
     <link rel="stylesheet" href="fonts.css" type="text/css" />
-    <% if (process.env.REACT_APP_DEV_DISABLE_LIVE_RELOAD === "true") { %>
+    <% if (process.env.REACT_APP_DEV_DISABLE_LIVE_RELOAD==="true" ) { %>
     <script>
       {
         const _WebSocket = window.WebSocket;
@@ -155,7 +170,7 @@
         width: 1px;
         overflow: hidden;
         clip: rect(1px, 1px, 1px, 1px);
-        white-space: nowrap; /* added line */
+        white-space: nowrap;
         user-select: none;
       }
 

--- a/public/index.html
+++ b/public/index.html
@@ -1,14 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <script>
-    try {
-      // to minimize white flash on load when user has dark mode enabled
-      const theme = window.localStorage.getItem("excalidraw-theme");
-      if (theme === "dark") {
-        document.documentElement.classList.add("dark");
-      }
-    } catch {}
-  </script>
   <head>
     <meta charset="utf-8" />
     <title>Excalidraw | Hand-drawn look & feel • Collaborative • Secure</title>
@@ -60,6 +51,26 @@
       name="twitter:description"
       content="Excalidraw is a whiteboard tool that lets you easily sketch diagrams that have a hand-drawn feel to them."
     />
+
+    <!------------------------------------------------------------------------->
+    <!--   to minimize white flash on load when user has dark mode enabled   -->
+    <script>
+      try {
+        //
+        const theme = window.localStorage.getItem("excalidraw-theme");
+        if (theme === "dark") {
+          document.documentElement.classList.add("dark");
+        }
+      } catch {}
+    </script>
+    <style>
+      html.dark {
+        background-color: #121212;
+        color: #fff;
+      }
+    </style>
+    <!------------------------------------------------------------------------->
+
     <script>
       // Redirect Excalidraw+ users which have auto-redirect enabled.
       //
@@ -78,13 +89,6 @@
         window.location.href = "https://app.excalidraw.com";
       }
     </script>
-
-    <style>
-      html.dark {
-        background-color: #121212;
-        color: #fff;
-      }
-    </style>
 
     <link rel="shortcut icon" href="favicon.ico" type="image/x-icon" />
 

--- a/public/index.html
+++ b/public/index.html
@@ -78,7 +78,7 @@
         window.location.href = "https://app.excalidraw.com";
       }
     </script>
-    
+
     <style>
       html.dark {
         background-color: #121212;

--- a/src/css/app.scss
+++ b/src/css/app.scss
@@ -34,6 +34,6 @@
 }
 
 .LoadingMessage--dark {
-  background-color: $oc-black;
-  color: $oc-white;
+  background-color: #121212;
+  color: #ced4da;
 }

--- a/src/excalidraw-app/index.tsx
+++ b/src/excalidraw-app/index.tsx
@@ -524,7 +524,8 @@ const ExcalidrawWrapper = () => {
 
   useEffect(() => {
     localStorage.setItem(STORAGE_KEYS.LOCAL_STORAGE_THEME, theme);
-    // currently only used for body styling during init, but may change
+    // currently only used for body styling during init (see public/index.html),
+    // but may change in the future
     document.documentElement.classList.toggle("dark", theme === THEME.DARK);
   }, [theme]);
 

--- a/src/excalidraw-app/index.tsx
+++ b/src/excalidraw-app/index.tsx
@@ -524,6 +524,8 @@ const ExcalidrawWrapper = () => {
 
   useEffect(() => {
     localStorage.setItem(STORAGE_KEYS.LOCAL_STORAGE_THEME, theme);
+    // currently only used for body styling during init, but may change
+    document.documentElement.classList.toggle("dark", theme === THEME.DARK);
   }, [theme]);
 
   const onChange = (


### PR DESCRIPTION
follow-up to https://github.com/excalidraw/excalidraw/pull/5660. Turns out there is still several frames before we render the init container (message) that sets the dark mode.

This PR tries to set basic dark theme as soon as we possibly can (I think). Still doesn't fix it 100% (when accessing excalidraw from a new tab), but let's as close as we can!

Not much of a difference on Chrome, but on Safari during reloading the tab it does.

/cc @mabdullahadeel @ad1992 