### PR TITLE
fix: double state update incorrectly resetting state

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1153,6 +1153,8 @@ class App extends React.Component<AppProps, AppState> {
     ) {
       // defer so that the commitToHistory flag isn't reset via current update
       setTimeout(() => {
+        // execute only if the conditions still holds
+        // when the deferred callback executes
         this.state.editingLinearElement &&
           this.actionManager.executeAction(actionFinalize);
       });

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1153,7 +1153,8 @@ class App extends React.Component<AppProps, AppState> {
     ) {
       // defer so that the commitToHistory flag isn't reset via current update
       setTimeout(() => {
-        this.actionManager.executeAction(actionFinalize);
+        this.state.editingLinearElement &&
+          this.actionManager.executeAction(actionFinalize);
       });
     }
 

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1153,8 +1153,9 @@ class App extends React.Component<AppProps, AppState> {
     ) {
       // defer so that the commitToHistory flag isn't reset via current update
       setTimeout(() => {
-        // execute only if the conditions still holds
-        // when the deferred callback executes
+        // execute only if the condition still holds when the deferred callback
+        // executes (it can be scheduled multiple times depending on how
+        // many times the component renders)
         this.state.editingLinearElement &&
           this.actionManager.executeAction(actionFinalize);
       });


### PR DESCRIPTION
See #5703 for details
This solution feels like a sticking plaster. I do not have the patience to dig deeper to understand why this

https://github.com/excalidraw/excalidraw/blob/9cccac1458c8ff6b79452305cbbed7032522f18b/src/components/App.tsx#L1150-L1158

is called twice, but if I abort the second time, the issue is resolved.