### PR TITLE
feat: hex color picker

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "points-on-curve": "0.2.0",
     "pwacompat": "2.0.17",
     "react": "18.2.0",
+    "react-colorful": "5.6.1",
     "react-dom": "18.2.0",
     "react-scripts": "4.0.3",
     "roughjs": "4.5.2",

--- a/src/components/ColorPicker.scss
+++ b/src/components/ColorPicker.scss
@@ -46,6 +46,10 @@
     top: -11px;
   }
 
+  .color-picker-content--multi {
+    padding: 0.25rem;
+  }
+
   .color-picker-content--default {
     padding: 0.5rem;
     display: grid;
@@ -68,6 +72,10 @@
       color: $oc-gray-6;
       font-size: 12px;
       padding: 0 0.25rem;
+    }
+
+    &-button svg {
+      color: var(--icon-fill-color);
     }
 
     &-colors {

--- a/src/components/ColorPicker.tsx
+++ b/src/components/ColorPicker.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { HexColorPicker } from "react-colorful";
 import { Popover } from "./Popover";
 import { isTransparent } from "../utils";
 
@@ -12,6 +13,43 @@ import { AppState } from "../types";
 
 const MAX_CUSTOM_COLORS = 5;
 const MAX_DEFAULT_COLORS = 15;
+const PALETTE_ICON = (
+  <svg
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="M10.5566 8.62411L14.1753 10.8096L8.69444 19.8846C8.37003 20.4218 7.76997 20.7295 7.14444 20.6796V20.6796C6.36571 20.6174 5.73623 20.0197 5.63385 19.2452L5.50014 18.2336C5.41328 17.5765 5.55264 16.9094 5.8953 16.3421L10.5566 8.62411Z"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    />
+    <rect
+      x="9.84003"
+      y="5.72208"
+      width="8.45496"
+      height="2.11374"
+      rx="1.05687"
+      transform="rotate(31.1299 9.84003 5.72208)"
+      fill="currentColor"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    />
+    <path
+      d="M13.2886 4.10089C13.8921 3.10161 15.1914 2.78078 16.1907 3.3843V3.3843C17.19 3.98781 17.5108 5.28713 16.9073 6.28641L14.7217 9.90512L11.103 7.7196L13.2886 4.10089Z"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    />
+  </svg>
+);
 
 export const getCustomColors = (
   elements: readonly ExcalidrawElement[],
@@ -108,7 +146,8 @@ const Picker = ({
   const activeItem = React.useRef<HTMLButtonElement>();
   const gallery = React.useRef<HTMLDivElement>();
   const colorInput = React.useRef<HTMLInputElement>();
-
+  const [showMultiColorPicker, setShowMultiColorPicker] =
+    React.useState<Boolean>(false);
   const [customColors] = React.useState(() => {
     if (type === "canvasBackground") {
       return [];
@@ -263,10 +302,27 @@ const Picker = ({
         // to allow focusing by clicking but not by tabbing
         tabIndex={-1}
       >
-        <div className="color-picker-content--default">
-          {renderColors(colors)}
+        {!showMultiColorPicker && (
+          <div className="color-picker-content--default">
+            {renderColors(colors)}
+          </div>
+        )}
+        {showMultiColorPicker && (
+          <div className="color-picker-content--multi">
+            <HexColorPicker color={color || undefined} onChange={onChange} />
+          </div>
+        )}
+        <div className="color-picker-content--canvas">
+          <button
+            className="color-picker-content--canvas-button"
+            onClick={() => {
+              setShowMultiColorPicker(!showMultiColorPicker);
+            }}
+          >
+            {PALETTE_ICON}
+          </button>
         </div>
-        {!!customColors.length && (
+        {!!customColors.length && !showMultiColorPicker && (
           <div className="color-picker-content--canvas">
             <span className="color-picker-content--canvas-title">
               {t("labels.canvasColors")}

--- a/src/components/ColorPicker.tsx
+++ b/src/components/ColorPicker.tsx
@@ -13,43 +13,67 @@ import { AppState } from "../types";
 
 const MAX_CUSTOM_COLORS = 5;
 const MAX_DEFAULT_COLORS = 15;
-const PALETTE_ICON = (
-  <svg
-    width="24"
-    height="24"
-    viewBox="0 0 24 24"
-    fill="none"
-    xmlns="http://www.w3.org/2000/svg"
-  >
-    <path
-      d="M10.5566 8.62411L14.1753 10.8096L8.69444 19.8846C8.37003 20.4218 7.76997 20.7295 7.14444 20.6796V20.6796C6.36571 20.6174 5.73623 20.0197 5.63385 19.2452L5.50014 18.2336C5.41328 17.5765 5.55264 16.9094 5.8953 16.3421L10.5566 8.62411Z"
+const ICONS = {
+  PALETTE: (
+    <svg
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M10.5566 8.62411L14.1753 10.8096L8.69444 19.8846C8.37003 20.4218 7.76997 20.7295 7.14444 20.6796V20.6796C6.36571 20.6174 5.73623 20.0197 5.63385 19.2452L5.50014 18.2336C5.41328 17.5765 5.55264 16.9094 5.8953 16.3421L10.5566 8.62411Z"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      />
+      <rect
+        x="9.84003"
+        y="5.72208"
+        width="8.45496"
+        height="2.11374"
+        rx="1.05687"
+        transform="rotate(31.1299 9.84003 5.72208)"
+        fill="currentColor"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      />
+      <path
+        d="M13.2886 4.10089C13.8921 3.10161 15.1914 2.78078 16.1907 3.3843V3.3843C17.19 3.98781 17.5108 5.28713 16.9073 6.28641L14.7217 9.90512L11.103 7.7196L13.2886 4.10089Z"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      />
+    </svg>
+  ),
+  GRID: (
+    <svg
+      width="24px"
+      height="24px"
+      viewBox="0 0 24 24"
+      role="img"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-labelledby="gridLargeIconTitle"
       stroke="currentColor"
       stroke-width="2"
       stroke-linecap="round"
       stroke-linejoin="round"
-    />
-    <rect
-      x="9.84003"
-      y="5.72208"
-      width="8.45496"
-      height="2.11374"
-      rx="1.05687"
-      transform="rotate(31.1299 9.84003 5.72208)"
-      fill="currentColor"
-      stroke="currentColor"
-      stroke-width="2"
-      stroke-linecap="round"
-      stroke-linejoin="round"
-    />
-    <path
-      d="M13.2886 4.10089C13.8921 3.10161 15.1914 2.78078 16.1907 3.3843V3.3843C17.19 3.98781 17.5108 5.28713 16.9073 6.28641L14.7217 9.90512L11.103 7.7196L13.2886 4.10089Z"
-      stroke="currentColor"
-      stroke-width="2"
-      stroke-linecap="round"
-      stroke-linejoin="round"
-    />
-  </svg>
-);
+      fill="none"
+      color="#000000"
+    >
+      <title id="gridLargeIconTitle">Large Grid</title>{" "}
+      <rect width="7" height="7" x="3" y="3" />{" "}
+      <rect width="7" height="7" x="14" y="3" />{" "}
+      <rect width="7" height="7" x="3" y="14" />{" "}
+      <rect width="7" height="7" x="14" y="14" />{" "}
+    </svg>
+  ),
+};
 
 export const getCustomColors = (
   elements: readonly ExcalidrawElement[],
@@ -319,7 +343,7 @@ const Picker = ({
               setShowMultiColorPicker(!showMultiColorPicker);
             }}
           >
-            {PALETTE_ICON}
+            {showMultiColorPicker ? ICONS.GRID : ICONS.PALETTE}
           </button>
         </div>
         {!!customColors.length && !showMultiColorPicker && (

--- a/yarn.lock
+++ b/yarn.lock
@@ -10151,6 +10151,11 @@ react-app-polyfill@^2.0.0:
     regenerator-runtime "^0.13.7"
     whatwg-fetch "^3.4.1"
 
+react-colorful@5.6.1:
+  version "5.6.1"
+  resolved "https://registry.yarnpkg.com/react-colorful/-/react-colorful-5.6.1.tgz#7dc2aed2d7c72fac89694e834d179e32f3da563b"
+  integrity sha512-1exovf0uGTGyq5mXQT0zgQ80uvj2PCwvF8zY1RN9/vbJVSjSo3fsB/4L3ObbF7u70NduSiK4xu4Y6q1MHoUGEw==
+
 react-dev-utils@^11.0.3:
   version "11.0.4"
   resolved "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-11.0.4.tgz"


### PR DESCRIPTION
#5582 

This feature is related to @cydoniansky request 😀

## Use Case
As a user, I want to select a custom color using a multi color picker, so I can fill any elements that allow to select color.

## Integration
![multiColorPicker](https://user-images.githubusercontent.com/7658097/193367580-d92d2b78-934b-44b7-8138-0aeddde584c6.gif)

I integrated the multi color picker inside the existing color picker, above the existing colors, there is now a button with a "palette" icon. 

When clicking on it, it display the multi color picker instead of predefined colors. You can then select a custom color from the picker.

If clicking again on the "palette" button, it will display predefined colors (maybe there is something that can be improved there, a back icon for example, let me know).

## External dependencie
I added a picker color using the library [react-colorful](https://github.com/omgovich/react-colorful). It's a tiny (2,8 KB) color picker component for React.


I'm very happy to contribute to Escalidraw, big thanks to you for this tool that I really enjoy 💃!
