### PR TITLE
fix: update perfect freehand library to fix extra dot

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "nanoid": "3.3.3",
     "open-color": "1.9.1",
     "pako": "1.0.11",
-    "perfect-freehand": "1.0.16",
+    "perfect-freehand": "1.2.0",
     "pica": "7.1.1",
     "png-chunk-text": "1.0.0",
     "png-chunks-encode": "1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9022,10 +9022,10 @@ pepjs@0.5.3:
   resolved "https://registry.npmjs.org/pepjs/-/pepjs-0.5.3.tgz"
   integrity sha512-5yHVB9OHqKd9fr/OIsn8ss0NgThQ9buaqrEuwr9Or5YjPp6h+WTDKWZI+xZLaBGZCtODTnFtlSHNmhFsq67THg==
 
-perfect-freehand@1.0.16:
-  version "1.0.16"
-  resolved "https://registry.yarnpkg.com/perfect-freehand/-/perfect-freehand-1.0.16.tgz#38575ef946ff513b9c94057c763cac003b504020"
-  integrity sha512-D4+avUeR8CHSl2vaPbPYX/dNpSMRYO3VOFp7qSSc+LRkSgzQbLATVnXosy7VxtsSHEh1C5t8K8sfmo0zCVnfWQ==
+perfect-freehand@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/perfect-freehand/-/perfect-freehand-1.2.0.tgz#706a0f854544f6175772440c51d3b0563eb3988a"
+  integrity sha512-h/0ikF1M3phW7CwpZ5MMvKnfpHficWoOEyr//KVNTxV4F6deRK1eYMtHyBKEAKFK0aXIEUK9oBvlF6PNXMDsAw==
 
 performance-now@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
#5717

As mentioned by @YIRU69 the bug still exist in excalidraw, this is due to the usage of version of [steveruizok/perfect-freehand](https://github.com/steveruizok/perfect-freehand) that still has the bug.

Upgrading to 1.2.0 make things better 🧙‍♀️, however, seems like if there still exist some cases when the dot appear.