### PR TITLE
feat: additional drag and drop image format support (webp, bmp, ico)

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -99,6 +99,9 @@ export const MIME_TYPES = {
   "excalidraw.png": "image/png",
   jpg: "image/jpeg",
   gif: "image/gif",
+  webp: "image/webp",
+  bmp: "image/bmp",
+  ico: "image/x-icon",
   binary: "application/octet-stream",
 } as const;
 
@@ -180,6 +183,9 @@ export const ALLOWED_IMAGE_MIME_TYPES = [
   MIME_TYPES.jpg,
   MIME_TYPES.svg,
   MIME_TYPES.gif,
+  MIME_TYPES.webp,
+  MIME_TYPES.bmp,
+  MIME_TYPES.ico,
 ] as const;
 
 export const MAX_ALLOWED_FILE_BYTES = 2 * 1024 * 1024;


### PR DESCRIPTION
I've received various requests for image formats, most recently a request to support webp [#820](https://github.com/zsviczian/obsidian-excalidraw-plugin/issues/820).

This seems like a no-brainer simple change. I don't see any downside. I've tested with sample files and it seems to work as expected.