### PR TITLE
fix: free draw flip not scaling correctly

### DIFF
--- a/src/actions/actionFlip.ts
+++ b/src/actions/actionFlip.ts
@@ -141,12 +141,12 @@ const flipElement = (
     element,
     width,
     height,
-    true,
+    false,
   );
 
   resizeSingleElement(
     new Map().set(element.id, element),
-    false,
+    true,
     element,
     usingNWHandle ? "nw" : "ne",
     false,

--- a/src/actions/actionFlip.ts
+++ b/src/actions/actionFlip.ts
@@ -6,9 +6,7 @@ import { ExcalidrawElement, NonDeleted } from "../element/types";
 import { normalizeAngle, resizeSingleElement } from "../element/resizeElements";
 import { AppState } from "../types";
 import { getTransformHandles } from "../element/transformHandles";
-import { isLinearElement } from "../element/typeChecks";
 import { updateBoundElements } from "../element/binding";
-import { LinearElementEditor } from "../element/linearElementEditor";
 import { arrayToMap } from "../utils";
 import { getResizedElementAbsoluteCoords } from "../element/bounds";
 
@@ -119,13 +117,6 @@ const flipElement = (
   const height = element.height;
   const originalAngle = normalizeAngle(element.angle);
 
-  let finalOffsetX = 0;
-  if (isLinearElement(element)) {
-    finalOffsetX =
-      element.points.reduce((max, point) => Math.max(max, point[0]), 0) * 2 -
-      element.width;
-  }
-
   // Rotate back to zero, if necessary
   mutateElement(element, {
     angle: normalizeAngle(0),
@@ -146,31 +137,22 @@ const flipElement = (
     }
   }
 
-  if (isLinearElement(element)) {
-    for (let index = 1; index < element.points.length; index++) {
-      LinearElementEditor.movePoints(element, [
-        { index, point: [-element.points[index][0], element.points[index][1]] },
-      ]);
-    }
-    LinearElementEditor.normalizePoints(element);
-  } else {
-    const [axTopLeft, ayTopLeft] = getResizedElementAbsoluteCoords(
-      element,
-      width,
-      height,
-      true,
-    );
+  const [axTopLeft, ayTopLeft] = getResizedElementAbsoluteCoords(
+    element,
+    width,
+    height,
+    true,
+  );
 
-    resizeSingleElement(
-      new Map().set(element.id, element),
-      false,
-      element,
-      usingNWHandle ? "nw" : "ne",
-      false,
-      usingNWHandle ? axTopLeft + width * 2 : ayTopLeft - width * 2,
-      ayTopLeft,
-    );
-  }
+  resizeSingleElement(
+    new Map().set(element.id, element),
+    false,
+    element,
+    usingNWHandle ? "nw" : "ne",
+    false,
+    usingNWHandle ? axTopLeft + width * 2 : ayTopLeft - width * 2,
+    ayTopLeft,
+  );
 
   // Rotate by (360 degrees - original angle)
   let angle = normalizeAngle(2 * Math.PI - originalAngle);
@@ -184,7 +166,7 @@ const flipElement = (
 
   // Move back to original spot to appear "flipped in place"
   mutateElement(element, {
-    x: originalX + finalOffsetX,
+    x: originalX,
     y: originalY,
   });
 

--- a/src/tests/flip.test.tsx
+++ b/src/tests/flip.test.tsx
@@ -79,6 +79,8 @@ const createAndReturnOneDraw = (angle: number = 0) => {
   });
 };
 
+const FLIP_PRECISION_DECIMALS = 7;
+
 // Rectangle element
 
 it("flips an unrotated rectangle horizontally correctly", () => {
@@ -408,9 +410,15 @@ it("flips an unrotated arrow horizontally correctly", () => {
   h.app.actionManager.executeAction(actionFlipHorizontal);
 
   // Check if width and height did not change
-  expect(API.getSelectedElements()[0].width).toEqual(originalWidth);
+  expect(API.getSelectedElements()[0].width).toBeCloseTo(
+    originalWidth,
+    FLIP_PRECISION_DECIMALS,
+  );
 
-  expect(API.getSelectedElements()[0].height).toEqual(originalHeight);
+  expect(API.getSelectedElements()[0].height).toBeCloseTo(
+    originalHeight,
+    FLIP_PRECISION_DECIMALS,
+  );
 });
 
 it("flips an unrotated arrow vertically correctly", () => {
@@ -422,9 +430,15 @@ it("flips an unrotated arrow vertically correctly", () => {
   h.app.actionManager.executeAction(actionFlipVertical);
 
   // Check if width and height did not change
-  expect(API.getSelectedElements()[0].width).toEqual(originalWidth);
+  expect(API.getSelectedElements()[0].width).toBeCloseTo(
+    originalWidth,
+    FLIP_PRECISION_DECIMALS,
+  );
 
-  expect(API.getSelectedElements()[0].height).toEqual(originalHeight);
+  expect(API.getSelectedElements()[0].height).toBeCloseTo(
+    originalHeight,
+    FLIP_PRECISION_DECIMALS,
+  );
 });
 
 //@TODO fix the tests with rotation
@@ -439,10 +453,15 @@ it.skip("flips a rotated arrow horizontally correctly", () => {
   h.app.actionManager.executeAction(actionFlipHorizontal);
 
   // Check if width and height did not change
-  expect(API.getSelectedElements()[0].width).toEqual(originalWidth);
+  expect(API.getSelectedElements()[0].width).toBeCloseTo(
+    originalWidth,
+    FLIP_PRECISION_DECIMALS,
+  );
 
-  expect(API.getSelectedElements()[0].height).toEqual(originalHeight);
-
+  expect(API.getSelectedElements()[0].height).toBeCloseTo(
+    originalHeight,
+    FLIP_PRECISION_DECIMALS,
+  );
   // Check angle
   expect(API.getSelectedElements()[0].angle).toBeCloseTo(expectedAngle);
 });
@@ -458,9 +477,15 @@ it.skip("flips a rotated arrow vertically correctly", () => {
   h.app.actionManager.executeAction(actionFlipVertical);
 
   // Check if width and height did not change
-  expect(API.getSelectedElements()[0].width).toEqual(originalWidth);
+  expect(API.getSelectedElements()[0].width).toBeCloseTo(
+    originalWidth,
+    FLIP_PRECISION_DECIMALS,
+  );
 
-  expect(API.getSelectedElements()[0].height).toEqual(originalHeight);
+  expect(API.getSelectedElements()[0].height).toBeCloseTo(
+    originalHeight,
+    FLIP_PRECISION_DECIMALS,
+  );
 
   // Check angle
   expect(API.getSelectedElements()[0].angle).toBeCloseTo(expectedAngle);
@@ -477,9 +502,15 @@ it("flips an unrotated line horizontally correctly", () => {
   h.app.actionManager.executeAction(actionFlipHorizontal);
 
   // Check if width and height did not change
-  expect(API.getSelectedElements()[0].width).toEqual(originalWidth);
+  expect(API.getSelectedElements()[0].width).toBeCloseTo(
+    originalWidth,
+    FLIP_PRECISION_DECIMALS,
+  );
 
-  expect(API.getSelectedElements()[0].height).toEqual(originalHeight);
+  expect(API.getSelectedElements()[0].height).toBeCloseTo(
+    originalHeight,
+    FLIP_PRECISION_DECIMALS,
+  );
 });
 
 it("flips an unrotated line vertically correctly", () => {
@@ -491,9 +522,15 @@ it("flips an unrotated line vertically correctly", () => {
   h.app.actionManager.executeAction(actionFlipVertical);
 
   // Check if width and height did not change
-  expect(API.getSelectedElements()[0].width).toEqual(originalWidth);
+  expect(API.getSelectedElements()[0].width).toBeCloseTo(
+    originalWidth,
+    FLIP_PRECISION_DECIMALS,
+  );
 
-  expect(API.getSelectedElements()[0].height).toEqual(originalHeight);
+  expect(API.getSelectedElements()[0].height).toBeCloseTo(
+    originalHeight,
+    FLIP_PRECISION_DECIMALS,
+  );
 });
 
 it.skip("flips a rotated line horizontally correctly", () => {
@@ -508,9 +545,15 @@ it.skip("flips a rotated line horizontally correctly", () => {
   h.app.actionManager.executeAction(actionFlipHorizontal);
 
   // Check if width and height did not change
-  expect(API.getSelectedElements()[0].width).toEqual(originalWidth);
+  expect(API.getSelectedElements()[0].width).toBeCloseTo(
+    originalWidth,
+    FLIP_PRECISION_DECIMALS,
+  );
 
-  expect(API.getSelectedElements()[0].height).toEqual(originalHeight);
+  expect(API.getSelectedElements()[0].height).toBeCloseTo(
+    originalHeight,
+    FLIP_PRECISION_DECIMALS,
+  );
 
   // Check angle
   expect(API.getSelectedElements()[0].angle).toBeCloseTo(expectedAngle);
@@ -528,9 +571,15 @@ it.skip("flips a rotated line vertically correctly", () => {
   h.app.actionManager.executeAction(actionFlipVertical);
 
   // Check if width and height did not change
-  expect(API.getSelectedElements()[0].width).toEqual(originalWidth);
+  expect(API.getSelectedElements()[0].width).toBeCloseTo(
+    originalWidth,
+    FLIP_PRECISION_DECIMALS,
+  );
 
-  expect(API.getSelectedElements()[0].height).toEqual(originalHeight);
+  expect(API.getSelectedElements()[0].height).toBeCloseTo(
+    originalHeight,
+    FLIP_PRECISION_DECIMALS,
+  );
 
   // Check angle
   expect(API.getSelectedElements()[0].angle).toBeCloseTo(expectedAngle);
@@ -549,9 +598,9 @@ it("flips an unrotated drawing horizontally correctly", () => {
   h.app.actionManager.executeAction(actionFlipHorizontal);
 
   // Check if width and height did not change
-  expect(draw.width).toEqual(originalWidth);
+  expect(draw.width).toBeCloseTo(originalWidth, FLIP_PRECISION_DECIMALS);
 
-  expect(draw.height).toEqual(originalHeight);
+  expect(draw.height).toBeCloseTo(originalHeight, FLIP_PRECISION_DECIMALS);
 });
 
 it("flips an unrotated drawing vertically correctly", () => {
@@ -565,9 +614,9 @@ it("flips an unrotated drawing vertically correctly", () => {
   h.app.actionManager.executeAction(actionFlipVertical);
 
   // Check if width and height did not change
-  expect(draw.width).toEqual(originalWidth);
+  expect(draw.width).toBeCloseTo(originalWidth, FLIP_PRECISION_DECIMALS);
 
-  expect(draw.height).toEqual(originalHeight);
+  expect(draw.height).toBeCloseTo(originalHeight, FLIP_PRECISION_DECIMALS);
 });
 
 it("flips a rotated drawing horizontally correctly", () => {
@@ -584,9 +633,9 @@ it("flips a rotated drawing horizontally correctly", () => {
   h.app.actionManager.executeAction(actionFlipHorizontal);
 
   // Check if width and height did not change
-  expect(draw.width).toEqual(originalWidth);
+  expect(draw.width).toBeCloseTo(originalWidth, FLIP_PRECISION_DECIMALS);
 
-  expect(draw.height).toEqual(originalHeight);
+  expect(draw.height).toBeCloseTo(originalHeight, FLIP_PRECISION_DECIMALS);
 
   // Check angle
   expect(draw.angle).toBeCloseTo(expectedAngle);
@@ -606,9 +655,16 @@ it("flips a rotated drawing vertically correctly", () => {
   h.app.actionManager.executeAction(actionFlipVertical);
 
   // Check if width and height did not change
-  expect(API.getSelectedElement().width).toEqual(originalWidth);
 
-  expect(API.getSelectedElement().height).toEqual(originalHeight);
+  expect(API.getSelectedElement().width).toBeCloseTo(
+    originalWidth,
+    FLIP_PRECISION_DECIMALS,
+  );
+
+  expect(API.getSelectedElement().height).toBeCloseTo(
+    originalHeight,
+    FLIP_PRECISION_DECIMALS,
+  );
 
   // Check angle
   expect(API.getSelectedElement().angle).toBeCloseTo(expectedAngle);


### PR DESCRIPTION
Fixed #5750 freedraw flip by correctly calculating transform handle final point, to avoid scaling issues
