### PR TITLE
fix: lines points removal in collab mode

### DIFF
--- a/src/actions/actionDeleteSelected.tsx
+++ b/src/actions/actionDeleteSelected.tsx
@@ -78,11 +78,11 @@ export const actionDeleteSelected = register({
         // case: deleting last remaining point
         element.points.length < 2
       ) {
-        const nextElements = elements.filter((el) => el.id !== element.id);
-        const nextAppState = handleGroupEditingState(appState, nextElements);
+        const result = deleteSelectedElements(elements, appState);
+        const nextAppState = handleGroupEditingState(appState, elements);
 
         return {
-          elements: nextElements,
+          elements: result.elements,
           appState: {
             ...nextAppState,
             editingLinearElement: null,

--- a/src/actions/actionFinalize.tsx
+++ b/src/actions/actionFinalize.tsx
@@ -33,11 +33,13 @@ export const actionFinalize = register({
             endBindingElement,
           );
         }
+        if (isInvisiblySmallElement(element)) {
+          mutateElement(element, {
+            isDeleted: true,
+          });
+        }
         return {
-          elements:
-            element.points.length < 2 || isInvisiblySmallElement(element)
-              ? elements.filter((el) => el.id !== element.id)
-              : undefined,
+          elements,
           appState: {
             ...appState,
             cursorButton: "up",

--- a/src/data/restore.ts
+++ b/src/data/restore.ts
@@ -15,7 +15,11 @@ import {
   getNormalizedDimensions,
   isInvisiblySmallElement,
 } from "../element";
-import { isLinearElementType } from "../element/typeChecks";
+import {
+  isFreeDrawElement,
+  isLinearElement,
+  isLinearElementType,
+} from "../element/typeChecks";
 import { randomId } from "../random";
 import {
   DEFAULT_FONT_FAMILY,
@@ -237,7 +241,14 @@ export const restoreElements = (
   return (elements || []).reduce((elements, element) => {
     // filtering out selection, which is legacy, no longer kept in elements,
     // and causing issues if retained
-    if (element.type !== "selection" && !isInvisiblySmallElement(element)) {
+    if (element.type !== "selection") {
+      if (
+        !isLinearElement(element) &&
+        !isFreeDrawElement(element) &&
+        isInvisiblySmallElement(element)
+      ) {
+        return elements;
+      }
       let migratedElement: ExcalidrawElement | null = restoreElement(element);
       if (migratedElement) {
         const localElement = localElementsMap?.get(element.id);

--- a/src/excalidraw-app/data/index.ts
+++ b/src/excalidraw-app/data/index.ts
@@ -7,7 +7,6 @@ import {
 import { serializeAsJSON } from "../../data/json";
 import { restore } from "../../data/restore";
 import { ImportedDataState } from "../../data/types";
-import { isInvisiblySmallElement } from "../../element/sizeHelpers";
 import { isInitializedImageElement } from "../../element/typeChecks";
 import { ExcalidrawElement, FileId } from "../../element/types";
 import { t } from "../../i18n";
@@ -39,7 +38,7 @@ export const isSyncableElement = (
     }
     return false;
   }
-  return !isInvisiblySmallElement(element);
+  return true;
 };
 
 export const getSyncableElements = (elements: readonly ExcalidrawElement[]) =>


### PR DESCRIPTION
Fixed points removal by flagging the element with isDeleted before sending the broadcast and fixing isSyncableElement logic to allow invisibly small elements to be synced. Fixed finalization action: when there is one point the linear element must be deleted and peers must update accordingly.

This fixes #5678. I am trying to learn something about the code base and I managed to resolve the issue, but I would love some advice. :D 