### PR TITLE
fix: line editor points rendering below elements

### DIFF
--- a/src/renderer/renderScene.ts
+++ b/src/renderer/renderScene.ts
@@ -404,6 +404,8 @@ export const _renderScene = ({
       }),
     );
 
+    let editingLinearElement: NonDeleted<ExcalidrawLinearElement> | undefined =
+      undefined;
     visibleElements.forEach((element) => {
       try {
         renderElement(element, rc, context, renderConfig);
@@ -412,15 +414,10 @@ export const _renderScene = ({
         // correct element from visible elements
         if (appState.editingLinearElement?.elementId === element.id) {
           if (element) {
-            renderLinearPointHandles(
-              context,
-              appState,
-              renderConfig,
-              element as NonDeleted<ExcalidrawLinearElement>,
-            );
+            editingLinearElement =
+              element as NonDeleted<ExcalidrawLinearElement>;
           }
         }
-
         if (!isExporting) {
           renderLinkIcon(element, context, appState);
         }
@@ -428,6 +425,15 @@ export const _renderScene = ({
         console.error(error);
       }
     });
+
+    if (editingLinearElement) {
+      renderLinearPointHandles(
+        context,
+        appState,
+        renderConfig,
+        editingLinearElement,
+      );
+    }
 
     // Paint selection element
     if (appState.selectionElement) {


### PR DESCRIPTION
fixes:

![excal-bug-line-points-rendered-behind-elements](https://user-images.githubusercontent.com/5153846/197354287-dc68577e-1ef6-4493-aea7-f95afe787224.gif)

The addedd test case doesn't test for this case (which would need a image-comparison test), but it's a regression test for this general case.
