### PR TITLE
fix: consistent use of ZOOM_STEP

### DIFF
--- a/src/actions/actionCanvas.tsx
+++ b/src/actions/actionCanvas.tsx
@@ -2,7 +2,7 @@ import { ColorPicker } from "../components/ColorPicker";
 import { eraser, zoomIn, zoomOut } from "../components/icons";
 import { ToolButton } from "../components/ToolButton";
 import { DarkModeToggle } from "../components/DarkModeToggle";
-import { THEME, ZOOM_STEP } from "../constants";
+import { MIN_ZOOM, THEME, ZOOM_STEP } from "../constants";
 import { getCommonBounds, getNonDeletedElements } from "../element";
 import { ExcalidrawElement } from "../element/types";
 import { t } from "../i18n";
@@ -206,7 +206,7 @@ const zoomValueToFitBoundsOnViewport = (
   const zoomAdjustedToSteps =
     Math.floor(smallestZoomValue / ZOOM_STEP) * ZOOM_STEP;
   const clampedZoomValueToFitElements = Math.min(
-    Math.max(zoomAdjustedToSteps, ZOOM_STEP),
+    Math.max(zoomAdjustedToSteps, MIN_ZOOM),
     1,
   );
   return clampedZoomValueToFitElements as NormalizedZoomValue;

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -76,6 +76,7 @@ import {
   THEME,
   TOUCH_CTX_MENU_TIMEOUT,
   VERTICAL_ALIGN,
+  ZOOM_STEP,
 } from "../constants";
 import { loadFromBlob } from "../data";
 import Library, { distributeLibraryItemsOnSquareGrid } from "../data/library";
@@ -6097,7 +6098,7 @@ class App extends React.Component<AppProps, AppState> {
     // note that event.ctrlKey is necessary to handle pinch zooming
     if (event.metaKey || event.ctrlKey) {
       const sign = Math.sign(deltaY);
-      const MAX_STEP = 10;
+      const MAX_STEP = ZOOM_STEP * 100;
       const absDelta = Math.abs(deltaY);
       let delta = deltaY;
       if (absDelta > MAX_STEP) {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -122,6 +122,7 @@ export const TITLE_TIMEOUT = 10000;
 export const VERSION_TIMEOUT = 30000;
 export const SCROLL_TIMEOUT = 100;
 export const ZOOM_STEP = 0.1;
+export const MIN_ZOOM = 0.1;
 export const HYPERLINK_TOOLTIP_DELAY = 300;
 
 // Report a user inactive after IDLE_THRESHOLD milliseconds

--- a/src/scene/zoom.ts
+++ b/src/scene/zoom.ts
@@ -1,7 +1,8 @@
+import { MIN_ZOOM } from "../constants";
 import { AppState, NormalizedZoomValue } from "../types";
 
 export const getNormalizedZoom = (zoom: number): NormalizedZoomValue => {
-  return Math.max(0.1, Math.min(zoom, 30)) as NormalizedZoomValue;
+  return Math.max(MIN_ZOOM, Math.min(zoom, 30)) as NormalizedZoomValue;
 };
 
 export const getStateForZoom = (


### PR DESCRIPTION
I changed ZOOM_STEP in Obsidian to 0.05 only to find a few unintended consequences and inconsistent behaviors:
- ZOOM_STEP was honored when using the `+` & `-` buttons, but not using CTRL+Wheel
- ZOOM_STEP changed the minimum zoom level used when ZoomToFitElements (Shift+1). This results in inconsistent behavior because zoom to fit can decrease the zoom to 5% but using the zoom controls one can only get to 10%. More importantly, this had a weird side effect in that a phantom copy of the drawing appeared on the canvas when there were many elements and the zoom level was below 10% [#850](https://github.com/zsviczian/obsidian-excalidraw-plugin/issues/850).

I couldn't figure out the root cause of the phantom duplicate, but introducing MIN_ZOOM and consistent use of ZOOM_STEP solved my issues for now, as I did not want to change min zoom, only zoom step.