### PR TITLE
fix: copy/paste not working on Safari - reintroduce to context menu

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -169,6 +169,7 @@ import {
   isArrowKey,
   KEYS,
   isAndroid,
+  isDarwin,
 } from "../keys";
 import { distance2d, getGridPoint, isPathALoop } from "../math";
 import { renderScene } from "../renderer/renderScene";
@@ -5978,7 +5979,7 @@ class App extends React.Component<AppProps, AppState> {
       } else {
         ContextMenu.push({
           options: [
-            this.device.isMobile &&
+            (this.device.isTouchScreen || isDarwin) &&
               navigator.clipboard && {
                 trackEvent: false,
                 name: "paste",
@@ -5990,7 +5991,9 @@ class App extends React.Component<AppProps, AppState> {
                 },
                 contextItemLabel: "labels.paste",
               },
-            this.device.isMobile && navigator.clipboard && separator,
+            (this.device.isTouchScreen || isDarwin) &&
+              navigator.clipboard &&
+              separator,
             probablySupportsClipboardBlob &&
               elements.length > 0 &&
               actionCopyAsPng,
@@ -6035,9 +6038,11 @@ class App extends React.Component<AppProps, AppState> {
       } else {
         ContextMenu.push({
           options: [
-            this.device.isMobile && actionCut,
-            this.device.isMobile && navigator.clipboard && actionCopy,
-            this.device.isMobile &&
+            (this.device.isTouchScreen || isDarwin) && actionCut,
+            (this.device.isTouchScreen || isDarwin) &&
+              navigator.clipboard &&
+              actionCopy,
+            (this.device.isTouchScreen || isDarwin) &&
               navigator.clipboard && {
                 name: "paste",
                 trackEvent: false,
@@ -6049,7 +6054,7 @@ class App extends React.Component<AppProps, AppState> {
                 },
                 contextItemLabel: "labels.paste",
               },
-            this.device.isMobile && separator,
+            (this.device.isTouchScreen || isDarwin) && separator,
             ...options,
             separator,
             actionCopyStyles,


### PR DESCRIPTION
This addresses #5504

I changed `this.device.isMobile` to `(this.device.isTouchScreen || isDarwin)` and not to `(this.device.isMobile || isDarwin)` based on the assumption that if the user is interacting with the device through the touch interface, then it is either a mobile device or possibly a tablet, or a device that may not have a keyboard, thus he/she has no other way to copy/paste except for the context menu.

If it were up to me, I would argue against the logic in #2868 and add copy/paste back to the context menu for all devices... if someone uses a browser that does not support paste, that is a personal choice, why remove the option for those using the most widely used browsers? That said, for non-touchscreen devices, the keyboard shortcuts work, except for Safari due to compatibility issues _Safari fails to fire paste events (onpaste, onbeforepaste) attached to the document (or body) when Cmd-V is pressed and the focus is not in a text input or text area node. [see: 75891](https://bugs.webkit.org/show_bug.cgi?id=75891)_ , thus the proposed logic to include `&& isDarwin`