### PR TITLE
build: stops ignoring .env files from docker context so env variables get set during react app build.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 *
-!.env
+!.env.development
+!.env.production
 !.eslintrc.json
 !.npmrc
 !.prettierrc


### PR DESCRIPTION
* this fixes the issue where Browse Libraries button link was broken in docker/self-hosted versions of excalidraw

Fixes #5802 and fixes #5662  