### PR TITLE
fix: Corrected typo in toggle theme shortcut

### DIFF
--- a/src/actions/shortcuts.ts
+++ b/src/actions/shortcuts.ts
@@ -38,7 +38,7 @@ export type ShortcutName =
   | "imageExport";
 
 const shortcutMap: Record<ShortcutName, string[]> = {
-  toggleTheme: [getShortcutKey("Shit+Alt+D")],
+  toggleTheme: [getShortcutKey("Shift+Alt+D")],
   saveScene: [getShortcutKey("CtrlOrCmd+S")],
   loadScene: [getShortcutKey("CtrlOrCmd+O")],
   imageExport: [getShortcutKey("CtrlOrCmd+Shift+E")],


### PR DESCRIPTION
Exactly what it sounds like - the word `shift` was missing a letter.