### PR TITLE
fix: show filename on title

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -682,6 +682,14 @@ class App extends React.Component<AppProps, AppState> {
         if (typeof this.props.name !== "undefined") {
           name = this.props.name;
         }
+
+        const fileName = actionResult?.appState?.fileHandle?.name;
+        if (fileName) {
+          document.title = fileName;
+        } else {
+          document.title = APP_NAME;
+        }
+
         this.setState(
           (state) => {
             // using Object.assign instead of spread to fool TS 4.2.2+ into

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -118,7 +118,6 @@ export const EXPORT_SOURCE =
 export const IMAGE_RENDER_TIMEOUT = 500;
 export const TAP_TWICE_TIMEOUT = 300;
 export const TOUCH_CTX_MENU_TIMEOUT = 500;
-export const TITLE_TIMEOUT = 10000;
 export const VERSION_TIMEOUT = 30000;
 export const SCROLL_TIMEOUT = 100;
 export const ZOOM_STEP = 0.1;

--- a/src/excalidraw-app/index.tsx
+++ b/src/excalidraw-app/index.tsx
@@ -5,14 +5,7 @@ import { trackEvent } from "../analytics";
 import { getDefaultAppState } from "../appState";
 import { ErrorDialog } from "../components/ErrorDialog";
 import { TopErrorBoundary } from "../components/TopErrorBoundary";
-import {
-  APP_NAME,
-  COOKIES,
-  EVENT,
-  THEME,
-  TITLE_TIMEOUT,
-  VERSION_TIMEOUT,
-} from "../constants";
+import { APP_NAME, COOKIES, EVENT, THEME, VERSION_TIMEOUT } from "../constants";
 import { loadFromBlob } from "../data/blob";
 import {
   ExcalidrawElement,
@@ -369,11 +362,6 @@ const ExcalidrawWrapper = () => {
       }
     };
 
-    const titleTimeout = setTimeout(
-      () => (document.title = APP_NAME),
-      TITLE_TIMEOUT,
-    );
-
     const syncData = debounce(() => {
       if (isTestEnv()) {
         return;
@@ -460,7 +448,6 @@ const ExcalidrawWrapper = () => {
         visibilityChange,
         false,
       );
-      clearTimeout(titleTimeout);
     };
   }, [collabAPI, excalidrawAPI, setLangCode]);
 


### PR DESCRIPTION
I don't know how many people use `Excalidraw` as a standalone web app on macOS or any OS but there is a problem when we're working on many files it would be hard to understand which file is currently opened. so like other application UX we can show the current file name on `Title`:

<img width="1023" alt="Screenshot 2022-11-03 at 20 08 36" src="https://user-images.githubusercontent.com/1549069/199814170-2c5d5df0-9a33-444a-9843-83568ee86867.png">
