### PR TITLE
fix: Correctly align text in sticky notes with possible non-Wysiwyg

### DIFF
--- a/src/actions/actionBoundText.tsx
+++ b/src/actions/actionBoundText.tsx
@@ -3,7 +3,7 @@ import { getNonDeletedElements, isTextElement } from "../element";
 import { mutateElement } from "../element/mutateElement";
 import {
   getBoundTextElement,
-  measureText,
+  measureTextElement,
   redrawTextBoundingBox,
 } from "../element/textElement";
 import {
@@ -15,7 +15,6 @@ import {
   ExcalidrawTextElement,
 } from "../element/types";
 import { getSelectedElements } from "../scene";
-import { getFontString } from "../utils";
 import { register } from "./register";
 
 export const actionUnbindText = register({
@@ -34,10 +33,8 @@ export const actionUnbindText = register({
     selectedElements.forEach((element) => {
       const boundTextElement = getBoundTextElement(element);
       if (boundTextElement) {
-        const { width, height, baseline } = measureText(
-          boundTextElement.originalText,
-          getFontString(boundTextElement),
-        );
+        const { width, height, baseline } =
+          measureTextElement(boundTextElement);
         mutateElement(boundTextElement as ExcalidrawTextElement, {
           containerId: null,
           width,

--- a/src/element/newElement.ts
+++ b/src/element/newElement.ts
@@ -13,7 +13,7 @@ import {
   FontFamilyValues,
   ExcalidrawRectangleElement,
 } from "../element/types";
-import { getFontString, getUpdatedTimestamp, isTestEnv } from "../utils";
+import { getUpdatedTimestamp, isTestEnv } from "../utils";
 import { randomInteger, randomId } from "../random";
 import { mutateElement, newElementWith } from "./mutateElement";
 import { getNewGroupIdsForDuplication } from "../groups";
@@ -24,8 +24,8 @@ import { getResizedElementAbsoluteCoords } from "./bounds";
 import {
   getContainerDims,
   getContainerElement,
-  measureText,
-  wrapText,
+  measureTextElement,
+  wrapTextElement,
 } from "./textElement";
 import { BOUND_TEXT_PADDING, VERTICAL_ALIGN } from "../constants";
 
@@ -133,7 +133,7 @@ export const newTextElement = (
     containerId?: ExcalidrawRectangleElement["id"];
   } & ElementConstructorOpts,
 ): NonDeleted<ExcalidrawTextElement> => {
-  const metrics = measureText(opts.text, getFontString(opts));
+  const metrics = measureTextElement(opts, { customData: opts.customData });
   const offsets = getTextElementPositionOffsets(opts, metrics);
   const textElement = newElementWith(
     {
@@ -176,7 +176,7 @@ const getAdjustedDimensions = (
     width: nextWidth,
     height: nextHeight,
     baseline: nextBaseline,
-  } = measureText(nextText, getFontString(element), maxWidth);
+  } = measureTextElement(element, { text: nextText }, maxWidth);
   const { textAlign, verticalAlign } = element;
   let x: number;
   let y: number;
@@ -185,9 +185,9 @@ const getAdjustedDimensions = (
     verticalAlign === VERTICAL_ALIGN.MIDDLE &&
     !element.containerId
   ) {
-    const prevMetrics = measureText(
-      element.text,
-      getFontString(element),
+    const prevMetrics = measureTextElement(
+      element,
+      { fontSize: element.fontSize },
       maxWidth,
     );
     const offsets = getTextElementPositionOffsets(element, {
@@ -259,11 +259,9 @@ export const refreshTextDimensions = (
   const container = getContainerElement(textElement);
   if (container) {
     // text = wrapText(text, getFontString(textElement), container.width);
-    text = wrapText(
+    text = wrapTextElement(textElement, getMaxContainerWidth(container), {
       text,
-      getFontString(textElement),
-      getMaxContainerWidth(container),
-    );
+    });
   }
   const dimensions = getAdjustedDimensions(textElement, text);
   return { text, ...dimensions };

--- a/src/element/resizeElements.ts
+++ b/src/element/resizeElements.ts
@@ -42,7 +42,7 @@ import {
   getBoundTextElement,
   getBoundTextElementId,
   handleBindTextResize,
-  measureText,
+  measureTextElement,
 } from "./textElement";
 
 export const normalizeAngle = (angle: number): number => {
@@ -289,9 +289,9 @@ const measureFontSizeFromWH = (
   if (nextFontSize < MIN_FONT_SIZE) {
     return null;
   }
-  const metrics = measureText(
-    element.text,
-    getFontString({ fontSize: nextFontSize, fontFamily: element.fontFamily }),
+  const metrics = measureTextElement(
+    element,
+    { fontSize: nextFontSize },
     element.containerId ? element.width : null,
   );
   return {

--- a/src/element/textWysiwyg.test.tsx
+++ b/src/element/textWysiwyg.test.tsx
@@ -10,8 +10,10 @@ import { BOUND_TEXT_PADDING, FONT_FAMILY } from "../constants";
 import {
   ExcalidrawTextElement,
   ExcalidrawTextElementWithContainer,
+  FontString,
 } from "./types";
 import * as textElementUtils from "./textElement";
+import { getFontString } from "../utils";
 import { API } from "../tests/helpers/api";
 import { mutateElement } from "./mutateElement";
 import { resize } from "../tests/utils";
@@ -625,39 +627,53 @@ describe("textWysiwyg", () => {
     });
 
     it("should wrap text and vertcially center align once text submitted", async () => {
-      jest
-        .spyOn(textElementUtils, "measureText")
-        .mockImplementation((text, font, maxWidth) => {
-          let width = INITIAL_WIDTH;
-          let height = APPROX_LINE_HEIGHT;
-          let baseline = 10;
-          if (!text) {
-            return {
-              width,
-              height,
-              baseline,
-            };
-          }
-          baseline = 30;
-          width = DUMMY_WIDTH;
-          if (text === "Hello \nWorld!") {
-            height = APPROX_LINE_HEIGHT * 2;
-          }
-          if (maxWidth) {
-            width = maxWidth;
-            // To capture cases where maxWidth passed is initial width
-            // due to which the text is not wrapped correctly
-            if (maxWidth === INITIAL_WIDTH) {
-              height = DUMMY_HEIGHT;
-            }
-          }
+      const mockMeasureText = (
+        text: string,
+        font: FontString,
+        maxWidth?: number | null,
+      ) => {
+        let width = INITIAL_WIDTH;
+        let height = APPROX_LINE_HEIGHT;
+        let baseline = 10;
+        if (!text) {
           return {
             width,
             height,
             baseline,
           };
-        });
+        }
+        baseline = 30;
+        width = DUMMY_WIDTH;
+        if (text === "Hello \nWorld!") {
+          height = APPROX_LINE_HEIGHT * 2;
+        }
+        if (maxWidth) {
+          width = maxWidth;
+          // To capture cases where maxWidth passed is initial width
+          // due to which the text is not wrapped correctly
+          if (maxWidth === INITIAL_WIDTH) {
+            height = DUMMY_HEIGHT;
+          }
+        }
+        return {
+          width,
+          height,
+          baseline,
+        };
+      };
 
+      jest
+        .spyOn(textElementUtils, "measureText")
+        .mockImplementation(mockMeasureText);
+      jest
+        .spyOn(textElementUtils, "measureTextElement")
+        .mockImplementation((element, next, maxWidth) => {
+          return mockMeasureText(
+            next?.text ?? element.text,
+            getFontString(element),
+            maxWidth,
+          );
+        });
       expect(h.elements.length).toBe(1);
 
       Keyboard.keyDown(KEYS.ENTER);

--- a/src/element/textWysiwyg.test.tsx
+++ b/src/element/textWysiwyg.test.tsx
@@ -908,13 +908,27 @@ describe("textWysiwyg", () => {
         getMaxContainerWidth(rectangle),
       );
 
+      const mockMeasureText = (
+        text: string,
+        font: FontString,
+        maxWidth?: number | null,
+      ) => {
+        if (text === wrappedText) {
+          return { width: rectangle.width, height: 200, baseline: 30 };
+        }
+        return { width: 0, height: 0, baseline: 0 };
+      };
       jest
         .spyOn(textElementUtils, "measureText")
-        .mockImplementation((text, font, maxWidth) => {
-          if (text === wrappedText) {
-            return { width: rectangle.width, height: 200, baseline: 30 };
-          }
-          return { width: 0, height: 0, baseline: 0 };
+        .mockImplementation(mockMeasureText);
+      jest
+        .spyOn(textElementUtils, "measureTextElement")
+        .mockImplementation((element, next, maxWidth) => {
+          return mockMeasureText(
+            next?.text ?? element.text,
+            getFontString(element),
+            maxWidth,
+          );
         });
 
       //@ts-ignore

--- a/src/element/textWysiwyg.tsx
+++ b/src/element/textWysiwyg.tsx
@@ -21,7 +21,6 @@ import {
   getContainerDims,
   getContainerElement,
   measureText,
-  measureTextElement,
   wrapText,
 } from "./textElement";
 import {
@@ -132,7 +131,11 @@ export const textWysiwyg = ({
         container ? getContainerDims(container).width : null,
       );
       // Rendered metrics
-      const rMetrics = measureTextElement(updatedTextElement);
+      const rMetrics = {
+        width: updatedTextElement.width,
+        height: updatedTextElement.height,
+        baseline: updatedTextElement.baseline,
+      };
 
       let maxWidth = eMetrics.width;
       let maxHeight = eMetrics.height;
@@ -156,11 +159,10 @@ export const textWysiwyg = ({
 
           // update height of the editor after properties updated
           const font = getFontString(updatedTextElement);
-          height = measureText(
-            updatedTextElement.originalText,
-            font,
-            containerDims.width,
-          ).height;
+          height =
+            getApproxLineHeight(font) *
+            updatedTextElement.text.split("\n").length;
+          height = Math.max(height, rMetrics.height);
         }
         if (!originalContainerHeight) {
           originalContainerHeight = containerDims.height;

--- a/src/element/textWysiwyg.tsx
+++ b/src/element/textWysiwyg.tsx
@@ -329,11 +329,9 @@ export const textWysiwyg = ({
         fontFamily: app.state.currentItemFontFamily,
       });
 
-      const wrappedText = wrapText(
-        data,
-        font,
-        getMaxContainerWidth(container!),
-      );
+      const wrappedText = container
+        ? wrapText(data, font, getMaxContainerWidth(container!))
+        : data;
       const dimensions = measureText(wrappedText, font);
       editable.style.height = `${dimensions.height}px`;
       if (data) {


### PR DESCRIPTION
This fixes #5789 without requiring Wysiwyg rendering of text.

This also fixes #5848, a regression introduced by #5845.