### PR TITLE
feat: clean unused images only after 24hrs (local-only)

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -5243,6 +5243,7 @@ class App extends React.Component<AppProps, AppState> {
               id: fileId,
               dataURL,
               created: Date.now(),
+              lastRetrieved: Date.now(),
             },
           };
           const cachedImageData = this.imageCache.get(fileId);

--- a/src/excalidraw-app/data/FileManager.ts
+++ b/src/excalidraw-app/data/FileManager.ts
@@ -195,6 +195,7 @@ export const encodeFilesForUpload = async ({
         id,
         mimeType: fileData.mimeType,
         created: Date.now(),
+        lastRetrieved: Date.now(),
       },
     });
 

--- a/src/excalidraw-app/data/firebase.ts
+++ b/src/excalidraw-app/data/firebase.ts
@@ -330,6 +330,7 @@ export const loadFilesFromFirebase = async (
             id,
             dataURL,
             created: metadata?.created || Date.now(),
+            lastRetrieved: metadata?.created || Date.now(),
           });
         } else {
           erroredFiles.set(id, true);

--- a/src/packages/excalidraw/example/App.tsx
+++ b/src/packages/excalidraw/example/App.tsx
@@ -148,6 +148,7 @@ export default function App() {
             dataURL: reader.result as BinaryFileData["dataURL"],
             mimeType: MIME_TYPES.jpg,
             created: 1644915140367,
+            lastRetrieved: 1644915140367,
           },
         ];
 

--- a/src/tests/export.test.tsx
+++ b/src/tests/export.test.tsx
@@ -158,6 +158,7 @@ describe("export", () => {
         dataURL: await getDataURL(await API.loadFile("./fixtures/deer.png")),
         mimeType: "image/png",
         created: Date.now(),
+        lastRetrieved: Date.now(),
       },
     } as const;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -61,7 +61,18 @@ export type BinaryFileData = {
     | typeof MIME_TYPES.binary;
   id: FileId;
   dataURL: DataURL;
+  /**
+   * Epoch timestamp in milliseconds
+   */
   created: number;
+  /**
+   * Indicates when the file was last retrieved from storage to be loaded
+   * onto the scene. We use this flag to determine whether to delete unused
+   * files from storage.
+   *
+   * Epoch timestamp in milliseconds.
+   */
+  lastRetrieved: number | undefined;
 };
 
 export type BinaryFileMetadata = Omit<BinaryFileData, "dataURL">;

--- a/src/types.ts
+++ b/src/types.ts
@@ -72,7 +72,7 @@ export type BinaryFileData = {
    *
    * Epoch timestamp in milliseconds.
    */
-  lastRetrieved: number | undefined;
+  lastRetrieved?: number;
 };
 
 export type BinaryFileMetadata = Omit<BinaryFileData, "dataURL">;


### PR DESCRIPTION
The exact case is not fully known, but there is a potential race condition where the locally stored images are removed from storage as unused, even though they actually are being used. There were reports around tab syncing / collab.

This PR makes it so that "unused" images are only cleared after 24hrs. For this purpose we set up a new flag `lastRetrieved` which we update on each retrieval from storage, and save it back.

@ad1992 thinking of factoring out the `lastRetrieved` attribute into host app (but the types may be annoying) since it has no editor behavior on its own. We can decide later. Merging for now to get this into prod.