### PR TITLE
feat: reintroduce `x` shortcut for `freedraw`

### DIFF
--- a/src/shapes.tsx
+++ b/src/shapes.tsx
@@ -58,7 +58,7 @@ export const SHAPES = [
   {
     icon: FreedrawIcon,
     value: "freedraw",
-    key: KEYS.P,
+    key: [KEYS.P, KEYS.X],
     numericKey: KEYS["7"],
     fillable: false,
   },


### PR DESCRIPTION
reintroducing the `x` shortcut for freedraw because it [breaks people's workflows](https://github.com/excalidraw/excalidraw/pull/5832#issuecomment-1304899745). Keeping it as undocumented so we don't onboard new users on it.