### PR TITLE
fix: disable FAST_REFRESH to fix live reload

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -20,3 +20,5 @@ REACT_APP_DEV_ENABLE_SW=
 # whether to disable live reload / HMR. Usuaully what you want to do when
 # debugging Service Workers.
 REACT_APP_DEV_DISABLE_LIVE_RELOAD=
+
+FAST_REFRESH=false


### PR DESCRIPTION
Submitted an issue https://github.com/facebook/create-react-app/issues/12843 but disabling "FAST_REFRESH" fixes the live reload which broke recently