### PR TITLE
fix: Correctly paste contents parsed by `JSON.parse()` as text.

### DIFF
--- a/src/clipboard.test.ts
+++ b/src/clipboard.test.ts
@@ -1,0 +1,27 @@
+import { parseClipboard } from "./clipboard";
+
+describe("Test parseClipboard", () => {
+  it("should parse valid json correctly", async () => {
+    let text = "123";
+
+    let clipboardData = await parseClipboard({
+      //@ts-ignore
+      clipboardData: {
+        getData: () => text,
+      },
+    });
+
+    expect(clipboardData.text).toBe(text);
+
+    text = "[123]";
+
+    clipboardData = await parseClipboard({
+      //@ts-ignore
+      clipboardData: {
+        getData: () => text,
+      },
+    });
+
+    expect(clipboardData.text).toBe(text);
+  });
+});

--- a/src/clipboard.ts
+++ b/src/clipboard.ts
@@ -156,15 +156,13 @@ export const parseClipboard = async (
         files: systemClipboardData.files,
       };
     }
-    return appClipboardData;
-  } catch {
-    // system clipboard doesn't contain excalidraw elements → return plaintext
-    // unless we set a flag to prefer in-app clipboard because browser didn't
-    // support storing to system clipboard on copy
-    return PREFER_APP_CLIPBOARD && appClipboardData.elements
-      ? appClipboardData
-      : { text: systemClipboard };
-  }
+  } catch {}
+  // system clipboard doesn't contain excalidraw elements → return plaintext
+  // unless we set a flag to prefer in-app clipboard because browser didn't
+  // support storing to system clipboard on copy
+  return PREFER_APP_CLIPBOARD && appClipboardData.elements
+    ? appClipboardData
+    : { text: systemClipboard };
 };
 
 export const copyBlobToClipboardAsPng = async (blob: Blob | Promise<Blob>) => {

--- a/src/clipboard.ts
+++ b/src/clipboard.ts
@@ -156,7 +156,7 @@ export const parseClipboard = async (
         files: systemClipboardData.files,
       };
     }
-  } catch {}
+  } catch (e) {}
   // system clipboard doesn't contain excalidraw elements → return plaintext
   // unless we set a flag to prefer in-app clipboard because browser didn't
   // support storing to system clipboard on copy

--- a/src/element/textWysiwyg.test.tsx
+++ b/src/element/textWysiwyg.test.tsx
@@ -17,6 +17,7 @@ import { API } from "../tests/helpers/api";
 import { mutateElement } from "./mutateElement";
 import { resize } from "../tests/utils";
 import { getMaxContainerWidth } from "./newElement";
+import { parseClipboard } from "../clipboard";
 // Unmount ReactDOM from root
 ReactDOM.unmountComponentAtNode(document.getElementById("root")!);
 
@@ -218,6 +219,21 @@ describe("textWysiwyg", () => {
       expect(editor).not.toBe(null);
       expect(h.state.editingElement?.id).toBe(text.id);
       expect(h.elements.length).toBe(1);
+    });
+  });
+
+  describe("Test general text", () => {
+    it("should parse non-ExcalidrawElement data correctly", async () => {
+      const text = "123";
+
+      const clipboardData = await parseClipboard({
+        //@ts-ignore
+        clipboardData: {
+          getData: () => text,
+        },
+      });
+
+      expect(clipboardData.text).toBe(text);
     });
   });
 

--- a/src/element/textWysiwyg.test.tsx
+++ b/src/element/textWysiwyg.test.tsx
@@ -17,7 +17,6 @@ import { API } from "../tests/helpers/api";
 import { mutateElement } from "./mutateElement";
 import { resize } from "../tests/utils";
 import { getMaxContainerWidth } from "./newElement";
-import { parseClipboard } from "../clipboard";
 // Unmount ReactDOM from root
 ReactDOM.unmountComponentAtNode(document.getElementById("root")!);
 
@@ -219,21 +218,6 @@ describe("textWysiwyg", () => {
       expect(editor).not.toBe(null);
       expect(h.state.editingElement?.id).toBe(text.id);
       expect(h.elements.length).toBe(1);
-    });
-  });
-
-  describe("Test general text", () => {
-    it("should parse non-ExcalidrawElement data correctly", async () => {
-      const text = "123";
-
-      const clipboardData = await parseClipboard({
-        //@ts-ignore
-        clipboardData: {
-          getData: () => text,
-        },
-      });
-
-      expect(clipboardData.text).toBe(text);
     });
   });
 


### PR DESCRIPTION
Fixes #5867.  Clipboard contents parsed as `number` types did not throw an exception, thus an empty `appClipboardData` was being returned.