### PR TITLE
fix: hide TopRightUI in view mode and display with Library button also in MobileMenu

### DIFF
--- a/src/components/LayerUI.tsx
+++ b/src/components/LayerUI.tsx
@@ -411,7 +411,8 @@ const LayerUI = ({
                 onClick={onCollabButtonClick}
               />
             )}
-            {renderTopRightUI?.(device.isMobile, appState)}
+            {!appState.viewModeEnabled &&
+              renderTopRightUI?.(device.isMobile, appState)}
             {!appState.viewModeEnabled && (
               <LibraryButton appState={appState} setAppState={setAppState} />
             )}

--- a/src/components/MobileMenu.tsx
+++ b/src/components/MobileMenu.tsx
@@ -111,8 +111,9 @@ export const MobileMenu = ({
                     />
                   </Stack.Row>
                 </Island>
-                {renderTopRightUI && renderTopRightUI(true, appState)}
                 <div className="mobile-misc-tools-container">
+                  {!appState.viewModeEnabled &&
+                    renderTopRightUI?.(true, appState)}
                   <PenModeButton
                     checked={appState.penMode}
                     onChange={onPenModeToggle}


### PR DESCRIPTION
Moved TopRightUI into the `mobile-misc-tools-container` to be displayed with the Library as in LayerUI for sake of consistency.
Added condition to hide the TopRightUI when viewModeEnabled. 