### PR TITLE
fix: fonts not rendered on init if `loadingdone` not fired

### DIFF
--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -2,6 +2,8 @@
 interface Document {
   fonts?: {
     ready?: Promise<void>;
+    check?: (font: string, text?: string) => boolean;
+    load?: (font: string, text?: string) => Promise<FontFace[]>;
     addEventListener?(
       type: "loading" | "loadingdone" | "loadingerror",
       listener: (this: Document, ev: Event) => any,

--- a/src/scene/Fonts.ts
+++ b/src/scene/Fonts.ts
@@ -1,0 +1,95 @@
+import { isTextElement, refreshTextDimensions } from "../element";
+import { newElementWith } from "../element/mutateElement";
+import { ExcalidrawElement, ExcalidrawTextElement } from "../element/types";
+import { invalidateShapeForElement } from "../renderer/renderElement";
+import { getFontString } from "../utils";
+import type Scene from "./Scene";
+
+export class Fonts {
+  private scene: Scene;
+  private onSceneUpdated: () => void;
+
+  constructor({
+    scene,
+    onSceneUpdated,
+  }: {
+    scene: Scene;
+    onSceneUpdated: () => void;
+  }) {
+    this.scene = scene;
+    this.onSceneUpdated = onSceneUpdated;
+  }
+
+  // it's ok to track fonts across multiple instances only once, so let's use
+  // a static member to reduce memory footprint
+  private static loadedFontFaces = new Set<string>();
+
+  /**
+   * if we load a (new) font, it's likely that text elements using it have
+   * already been rendered using a fallback font. Thus, we want invalidate
+   * their shapes and rerender. See #637.
+   *
+   * Invalidates text elements and rerenders scene, provided that at least one
+   * of the supplied fontFaces has not already been processed.
+   */
+  public onFontsLoaded = (fontFaces: readonly FontFace[]) => {
+    if (
+      fontFaces &&
+      (!fontFaces.length ||
+        // bail if all fonts with have been processed. We're checking just a
+        // subset of the font properties (though it should be enough), so it
+        // can technically bail on a false positive.
+        fontFaces.every((fontFace) => {
+          const sig = `${fontFace.family}-${fontFace.style}-${fontFace.weight}`;
+          if (Fonts.loadedFontFaces.has(sig)) {
+            return true;
+          }
+          Fonts.loadedFontFaces.add(sig);
+          return false;
+        }))
+    ) {
+      return false;
+    }
+
+    let didUpdate = false;
+
+    this.scene.mapElements((element) => {
+      if (isTextElement(element)) {
+        invalidateShapeForElement(element);
+        didUpdate = true;
+        return newElementWith(element, {
+          ...refreshTextDimensions(element),
+        });
+      }
+      return element;
+    });
+
+    if (didUpdate) {
+      this.onSceneUpdated();
+    }
+  };
+
+  public loadFontsForElements = async (
+    elements: readonly ExcalidrawElement[],
+  ) => {
+    const fontFaces = await Promise.all(
+      [
+        ...new Set(
+          elements
+            .filter((element) => isTextElement(element))
+            .map((element) => (element as ExcalidrawTextElement).fontFamily),
+        ),
+      ].map((fontFamily) => {
+        const fontString = getFontString({
+          fontFamily,
+          fontSize: 16,
+        });
+        if (!document.fonts?.check?.(fontString)) {
+          return document.fonts?.load?.(fontString);
+        }
+        return undefined;
+      }),
+    );
+    this.onFontsLoaded(fontFaces.flat().filter(Boolean) as FontFace[]);
+  };
+}

--- a/src/scene/Fonts.ts
+++ b/src/scene/Fonts.ts
@@ -34,19 +34,17 @@ export class Fonts {
    */
   public onFontsLoaded = (fontFaces: readonly FontFace[]) => {
     if (
-      fontFaces &&
-      (!fontFaces.length ||
-        // bail if all fonts with have been processed. We're checking just a
-        // subset of the font properties (though it should be enough), so it
-        // can technically bail on a false positive.
-        fontFaces.every((fontFace) => {
-          const sig = `${fontFace.family}-${fontFace.style}-${fontFace.weight}`;
-          if (Fonts.loadedFontFaces.has(sig)) {
-            return true;
-          }
-          Fonts.loadedFontFaces.add(sig);
-          return false;
-        }))
+      // bail if all fonts with have been processed. We're checking just a
+      // subset of the font properties (though it should be enough), so it
+      // can technically bail on a false positive.
+      fontFaces.every((fontFace) => {
+        const sig = `${fontFace.family}-${fontFace.style}-${fontFace.weight}`;
+        if (Fonts.loadedFontFaces.has(sig)) {
+          return true;
+        }
+        Fonts.loadedFontFaces.add(sig);
+        return false;
+      })
     ) {
       return false;
     }


### PR DESCRIPTION
On some browsers (Safari, though we may have reports from some mobile Chromium browsers as well), the [FontFaceSet `loadingdone`](https://developer.mozilla.org/en-US/docs/Web/API/FontFaceSet/loadingdone_event) is not being fired, which results in the fonts not being rendered correctly on init until after all text shapes are invalidated (which may be never unless manually edited).

- This PR fixes that by manually loading fonts for existing text elements on init.
- On top of that, we're now checking if the font has not been already loaded so that we don't invalidate elements and rerender the scene unnecessarily (fixes a potential infinite loop https://github.com/excalidraw/excalidraw/pull/5883).