### PR TITLE
fix: bindings do not survive history serialization

### DIFF
--- a/src/element/newElement.ts
+++ b/src/element/newElement.ts
@@ -366,7 +366,8 @@ export const deepCopyElement = (val: any, depth: number = 0) => {
         : {};
     for (const key in val) {
       if (val.hasOwnProperty(key)) {
-        // don't copy top-level shape property, which we want to regenerate
+        // don't copy non-serializable objects like these caches. They'll be
+        // populated when the element is rendered.
         if (depth === 0 && (key === "shape" || key === "canvas")) {
           continue;
         }

--- a/src/element/newElement.ts
+++ b/src/element/newElement.ts
@@ -370,10 +370,6 @@ export const deepCopyElement = (val: any, depth: number = 0) => {
         if (depth === 0 && (key === "shape" || key === "canvas")) {
           continue;
         }
-        if (key === "boundElements") {
-          tmp[key] = null;
-          continue;
-        }
         tmp[key] = deepCopyElement(val[key], depth + 1);
       }
     }
@@ -427,6 +423,7 @@ export const duplicateElement = <TElement extends Mutable<ExcalidrawElement>>(
   } else {
     copy.id = randomId();
   }
+  copy.boundElements = null;
   copy.updated = getUpdatedTimestamp();
   copy.seed = randomInteger();
   copy.groupIds = getNewGroupIdsForDuplication(

--- a/src/element/textWysiwyg.test.tsx
+++ b/src/element/textWysiwyg.test.tsx
@@ -1157,7 +1157,7 @@ describe("textWysiwyg", () => {
       expect(duplicatedText.containerId).toBe(duplicatedRectangle.id);
     });
 
-    it("undo should restore bound text when container is deleted", async () => {
+    it("undo should work", async () => {
       Keyboard.keyPress(KEYS.ENTER);
       const editor = document.querySelector(
         ".excalidraw-textEditorContainer > textarea",
@@ -1168,26 +1168,33 @@ describe("textWysiwyg", () => {
       expect(rectangle.boundElements).toStrictEqual([
         { id: h.elements[1].id, type: "text" },
       ]);
+      let text = h.elements[1] as ExcalidrawTextElementWithContainer;
+      const originalRectX = rectangle.x;
+      const originalRectY = rectangle.y;
+      const originalTextX = text.x;
+      const originalTextY = text.y;
+
       mouse.select(rectangle);
-      Keyboard.keyPress(KEYS.DELETE);
-      expect(rectangle.isDeleted).toBe(true);
-      expect(
-        (h.elements[1] as ExcalidrawTextElementWithContainer).isDeleted,
-      ).toBe(true);
+      mouse.downAt(rectangle.x, rectangle.y);
+      mouse.moveTo(rectangle.x + 100, rectangle.y + 50);
+      mouse.up(rectangle.x + 100, rectangle.y + 50);
+      expect(rectangle.x).toBe(80);
+      expect(rectangle.y).toBe(85);
+      expect(text.x).toBe(89.5);
+      expect(text.y).toBe(90);
 
       Keyboard.withModifierKeys({ ctrl: true }, () => {
         Keyboard.keyPress(KEYS.Z);
       });
-      const textElement = h.elements[1] as ExcalidrawTextElementWithContainer;
-
-      expect(rectangle.isDeleted).toBe(false);
+      expect(rectangle.x).toBe(originalRectX);
+      expect(rectangle.y).toBe(originalRectY);
+      text = h.elements[1] as ExcalidrawTextElementWithContainer;
+      expect(text.x).toBe(originalTextX);
+      expect(text.y).toBe(originalTextY);
       expect(rectangle.boundElements).toStrictEqual([
-        { id: textElement.id, type: "text" },
+        { id: text.id, type: "text" },
       ]);
-      //@todo Check this later why text attribute isDeleted not set to false
-      //expect(textElement.isDeleted).toBe(false);
-
-      expect(textElement.containerId).toBe(rectangle.id);
+      expect(text.containerId).toBe(rectangle.id);
     });
   });
 });

--- a/src/element/textWysiwyg.test.tsx
+++ b/src/element/textWysiwyg.test.tsx
@@ -1156,5 +1156,38 @@ describe("textWysiwyg", () => {
 
       expect(duplicatedText.containerId).toBe(duplicatedRectangle.id);
     });
+
+    it("undo should restore bound text when container is deleted", async () => {
+      Keyboard.keyPress(KEYS.ENTER);
+      const editor = document.querySelector(
+        ".excalidraw-textEditorContainer > textarea",
+      ) as HTMLTextAreaElement;
+      await new Promise((r) => setTimeout(r, 0));
+      fireEvent.change(editor, { target: { value: "Hello" } });
+      editor.blur();
+      expect(rectangle.boundElements).toStrictEqual([
+        { id: h.elements[1].id, type: "text" },
+      ]);
+      mouse.select(rectangle);
+      Keyboard.keyPress(KEYS.DELETE);
+      expect(rectangle.isDeleted).toBe(true);
+      expect(
+        (h.elements[1] as ExcalidrawTextElementWithContainer).isDeleted,
+      ).toBe(true);
+
+      Keyboard.withModifierKeys({ ctrl: true }, () => {
+        Keyboard.keyPress(KEYS.Z);
+      });
+      const textElement = h.elements[1] as ExcalidrawTextElementWithContainer;
+
+      expect(rectangle.isDeleted).toBe(false);
+      expect(rectangle.boundElements).toStrictEqual([
+        { id: textElement.id, type: "text" },
+      ]);
+      //@todo Check this later why text attribute isDeleted not set to false
+      //expect(textElement.isDeleted).toBe(false);
+
+      expect(textElement.containerId).toBe(rectangle.id);
+    });
   });
 });


### PR DESCRIPTION
https://github.com/excalidraw/excalidraw/pull/5938 actually broke history, because we're resetting the `boundElements` on the wrong level. Instead of resetting in the `deepCopyElement()` (which should always clone verbatim, where applicable), we should be doing it in `duplicateElement()`.