### PR TITLE
fix: fixed trailing zeros appearing in ToolButton

### DIFF
--- a/src/components/ToolButton.tsx
+++ b/src/components/ToolButton.tsx
@@ -123,7 +123,7 @@ export const ToolButton = React.forwardRef((props: ToolButtonProps, ref) => {
         ref={innerRef}
         disabled={isLoading || props.isLoading}
       >
-        {(props.icon || props.label) && (
+        {(props.icon || props.label) ? (
           <div className="ToolIcon__icon" aria-hidden="true">
             {props.icon || props.label}
             {props.keyBindingLabel && (
@@ -131,14 +131,14 @@ export const ToolButton = React.forwardRef((props: ToolButtonProps, ref) => {
                 {props.keyBindingLabel}
               </span>
             )}
-            {props.isLoading && <Spinner />}
+            {props.isLoading ? <Spinner />: null}
           </div>
-        )}
-        {props.showAriaLabel && (
+        ): null}
+        {props.showAriaLabel ? (
           <div className="ToolIcon__label">
-            {props["aria-label"]} {isLoading && <Spinner />}
+            {props["aria-label"]} {isLoading ? <Spinner /> : null}
           </div>
-        )}
+        ) : null}
         {props.children}
       </button>
     );
@@ -174,9 +174,9 @@ export const ToolButton = React.forwardRef((props: ToolButtonProps, ref) => {
       />
       <div className="ToolIcon__icon">
         {props.icon}
-        {props.keyBindingLabel && (
+        {props.keyBindingLabel ? (
           <span className="ToolIcon__keybinding">{props.keyBindingLabel}</span>
-        )}
+        ): null}
       </div>
     </label>
   );


### PR DESCRIPTION
## Problem 
There were some 0's appearing in some page because of using `&&` in the ToolButton component.

## Screenshot 
<img width="1673" alt="Screen Shot 2022-12-02 at 3 15 48 PM" src="https://user-images.githubusercontent.com/56454082/205301247-8b8729da-2872-49ed-a2da-28c4b77c49bd.png">
