### PR TITLE
fix: ColorPicker getColor

### DIFF
--- a/src/components/ColorPicker.tsx
+++ b/src/components/ColorPicker.tsx
@@ -66,7 +66,7 @@ const getColor = (color: string): string | null => {
     return color;
   }
 
-  // testing for `#` first fixes a bug on Electron (more specfically, an 
+  // testing for `#` first fixes a bug on Electron (more specfically, an
   // Obsidian popout window), where a hex color without `#` is (incorrectly)
   // considered valid
   return isValidColor(`#${color}`)

--- a/src/components/ColorPicker.tsx
+++ b/src/components/ColorPicker.tsx
@@ -66,6 +66,9 @@ const getColor = (color: string): string | null => {
     return color;
   }
 
+  // testing for `#` first fixes a bug on Electron (more specfically, an 
+  // Obsidian popout window), where a hex color without `#` is (incorrectly)
+  // considered valid
   return isValidColor(`#${color}`)
     ? `#${color}`
     : isValidColor(color)

--- a/src/components/ColorPicker.tsx
+++ b/src/components/ColorPicker.tsx
@@ -66,10 +66,10 @@ const getColor = (color: string): string | null => {
     return color;
   }
 
-  return isValidColor(color)
-    ? color
-    : isValidColor(`#${color}`)
+  return isValidColor(`#${color}`)
     ? `#${color}`
+    : isValidColor(color)
+    ? color
     : null;
 };
 


### PR DESCRIPTION
I encountered a strange error in the Obsidian Electron browser.

A six-digit hex color string e.g. "ba5f36" was recognized as a valid color by `isValidColor` even though it did not have a leading `#`. In debugger `style.color` had a valid value. As such `getColor` returned the six-digit value without leading `#`, however, the excalidraw canvas did not recognize the value as a color and the resulting stroke color was black.

By switching the sequence of testing in getColor, and first testing for ```isValidColor(`#${color}`)``` a correct color is returned even in the Electron browser, without impacting the original logic of the getColor function.

```typescript
const isValidColor = (color: string) => {
  const style = new Option().style;
  style.color = color;
  return !!style.color;
};

const getColor = (color: string): string | null => {
  if (isTransparent(color)) {
    return color;
  }

  return isValidColor(`#${color}`)
    ? `#${color}`
    : isValidColor(color)
    ? color
    : null;
};
```


