### PR TITLE
fix: `ExcalidrawArrowElement` rather than `ExcalidrawArrowEleement`

### DIFF
--- a/src/element/types.ts
+++ b/src/element/types.ts
@@ -142,7 +142,7 @@ export type ExcalidrawTextContainer =
   | ExcalidrawDiamondElement
   | ExcalidrawEllipseElement
   | ExcalidrawImageElement
-  | ExcalidrawArrowEleement;
+  | ExcalidrawArrowElement;
 
 export type ExcalidrawTextElementWithContainer = {
   containerId: ExcalidrawTextContainer["id"];
@@ -167,7 +167,7 @@ export type ExcalidrawLinearElement = _ExcalidrawElementBase &
     endArrowhead: Arrowhead | null;
   }>;
 
-export type ExcalidrawArrowEleement = ExcalidrawLinearElement &
+export type ExcalidrawArrowElement = ExcalidrawLinearElement &
   Readonly<{
     type: "arrow";
   }>;


### PR DESCRIPTION
I found this while merging `excalidraw:master` into #2993.