### PR TITLE
fix: apply the right type of roundness when pasting styles

### DIFF
--- a/src/actions/actionStyles.ts
+++ b/src/actions/actionStyles.ts
@@ -13,7 +13,11 @@ import {
   DEFAULT_TEXT_ALIGN,
 } from "../constants";
 import { getBoundTextElement } from "../element/textElement";
-import { hasBoundTextElement } from "../element/typeChecks";
+import {
+  hasBoundTextElement,
+  canApplyRoundnessTypeToElement,
+  getDefaultRoundnessTypeForElement,
+} from "../element/typeChecks";
 import { getSelectedElements } from "../scene";
 
 // `copiedStyles` is exported only for tests.
@@ -77,10 +81,14 @@ export const actionPasteStyles = register({
             fillStyle: elementStylesToCopyFrom?.fillStyle,
             opacity: elementStylesToCopyFrom?.opacity,
             roughness: elementStylesToCopyFrom?.roughness,
-            roundness:
-              element.type === elementStylesToCopyFrom.type
-                ? elementStylesToCopyFrom?.roundness
-                : element.roundness,
+            roundness: elementStylesToCopyFrom.roundness
+              ? canApplyRoundnessTypeToElement(
+                  elementStylesToCopyFrom.roundness.type,
+                  element,
+                )
+                ? elementStylesToCopyFrom.roundness
+                : getDefaultRoundnessTypeForElement(element)
+              : null,
           });
 
           if (isTextElement(newElement)) {

--- a/src/actions/actionStyles.ts
+++ b/src/actions/actionStyles.ts
@@ -77,7 +77,10 @@ export const actionPasteStyles = register({
             fillStyle: elementStylesToCopyFrom?.fillStyle,
             opacity: elementStylesToCopyFrom?.opacity,
             roughness: elementStylesToCopyFrom?.roughness,
-            roundness: elementStylesToCopyFrom?.roundness,
+            roundness:
+              element.type === elementStylesToCopyFrom.type
+                ? elementStylesToCopyFrom?.roundness
+                : element.roundness,
           });
 
           if (isTextElement(newElement)) {

--- a/src/element/typeChecks.ts
+++ b/src/element/typeChecks.ts
@@ -157,37 +157,26 @@ export const isBoundToContainer = (
 
 export const isUsingAdaptiveRadius = (type: string) => type === "rectangle";
 
+export const isUsingProportionalRadius = (type: string) =>
+  type === "line" || type === "arrow" || type === "diamond";
+
 export const canApplyRoundnessTypeToElement = (
   roundnessType: RoundnessType,
   element: ExcalidrawElement,
 ) => {
   if (
-    element.type !== "line" &&
-    element.type !== "arrow" &&
-    element.type !== "diamond" &&
-    element.type !== "rectangle"
+    (roundnessType === ROUNDNESS.ADAPTIVE_RADIUS ||
+      // if legacy roundness, it can be applied to elements that currently
+      // use adaptive radius
+      roundnessType === ROUNDNESS.LEGACY) &&
+    isUsingAdaptiveRadius(element.type)
   ) {
-    return false;
-  }
-
-  if (element.type === "line" || element.type === "arrow") {
-    if (roundnessType === ROUNDNESS.PROPORTIONAL_RADIUS) {
-      return true;
-    }
-    return false;
-  }
-
-  if (element.type === "diamond") {
-    if (roundnessType === ROUNDNESS.ADAPTIVE_RADIUS) {
-      return false;
-    }
     return true;
   }
-
-  if (element.type === "rectangle") {
-    if (roundnessType === ROUNDNESS.PROPORTIONAL_RADIUS) {
-      return false;
-    }
+  if (
+    roundnessType === ROUNDNESS.PROPORTIONAL_RADIUS &&
+    isUsingProportionalRadius(element.type)
+  ) {
     return true;
   }
 

--- a/src/element/typeChecks.ts
+++ b/src/element/typeChecks.ts
@@ -1,3 +1,4 @@
+import { ROUNDNESS } from "../constants";
 import { AppState } from "../types";
 import {
   ExcalidrawElement,
@@ -10,6 +11,7 @@ import {
   ExcalidrawImageElement,
   ExcalidrawTextElementWithContainer,
   ExcalidrawTextContainer,
+  RoundnessType,
 } from "./types";
 
 export const isGenericElement = (
@@ -154,3 +156,62 @@ export const isBoundToContainer = (
 };
 
 export const isUsingAdaptiveRadius = (type: string) => type === "rectangle";
+
+export const canApplyRoundnessTypeToElement = (
+  roundnessType: RoundnessType,
+  element: ExcalidrawElement,
+) => {
+  if (
+    element.type !== "line" &&
+    element.type !== "arrow" &&
+    element.type !== "diamond" &&
+    element.type !== "rectangle"
+  ) {
+    return false;
+  }
+
+  if (element.type === "line" || element.type === "arrow") {
+    if (roundnessType === ROUNDNESS.PROPORTIONAL_RADIUS) {
+      return true;
+    }
+    return false;
+  }
+
+  if (element.type === "diamond") {
+    if (roundnessType === ROUNDNESS.ADAPTIVE_RADIUS) {
+      return false;
+    }
+    return true;
+  }
+
+  if (element.type === "rectangle") {
+    if (roundnessType === ROUNDNESS.PROPORTIONAL_RADIUS) {
+      return false;
+    }
+    return true;
+  }
+
+  return false;
+};
+
+export const getDefaultRoundnessTypeForElement = (
+  element: ExcalidrawElement,
+) => {
+  if (
+    element.type === "arrow" ||
+    element.type === "line" ||
+    element.type === "diamond"
+  ) {
+    return {
+      type: ROUNDNESS.PROPORTIONAL_RADIUS,
+    };
+  }
+
+  if (element.type === "rectangle") {
+    return {
+      type: ROUNDNESS.ADAPTIVE_RADIUS,
+    };
+  }
+
+  return null;
+};


### PR DESCRIPTION
Since diamonds only use proportional radius for now, we shouldn't copy adaptive radius from rectangles to diamonds, which unfortunately it does in production at the moment. 

While we don't wanna copy adaptive radius roundness from rectangles to diamonds, we do want the target diamonds to be rounded if styles are copied from a rounded rectangle.

So, what we are doing in this fix is to first check if the given source roundness type can be applied to the target element. If not, we provide a default roundness for the target element, so that the target element is rounded also.