### PR TITLE
fix: Avatar outline on safari & center

### DIFF
--- a/src/components/Avatar.scss
+++ b/src/components/Avatar.scss
@@ -4,8 +4,8 @@
   .Avatar {
     width: 1.25rem;
     height: 1.25rem;
+    position: relative;
     border-radius: 100%;
-    outline: 2px solid var(--avatar-border-color);
     outline-offset: 2px;
     display: flex;
     justify-content: center;
@@ -19,6 +19,17 @@
     &-img {
       width: 100%;
       height: 100%;
+      border-radius: 100%;
+    }
+
+    &::before {
+      content: "";
+      position: absolute;
+      top: -3px;
+      right: -3px;
+      bottom: -3px;
+      left: -3px;
+      border: 1px solid var(--avatar-border-color);
       border-radius: 100%;
     }
   }

--- a/src/components/UserList.scss
+++ b/src/components/UserList.scss
@@ -7,6 +7,7 @@
     display: flex;
     flex-wrap: wrap;
     justify-content: flex-end;
+    align-items: center;
     gap: 0.625rem;
 
     &:empty {


### PR DESCRIPTION
- fix outline on Safari:

  (below, before fix)

  ![image](https://user-images.githubusercontent.com/5153846/207932892-8e97cc06-a84b-46d8-92f5-047b795d95f4.png)

- center vertically:

  (below, fixed)

  ![image](https://user-images.githubusercontent.com/5153846/207932830-54b85eb4-f879-46b8-a85f-020ec1f62ac2.png)
