### PR TITLE
fix: exportToSvg does not render mask for arrow text

### DIFF
--- a/src/scene/export.ts
+++ b/src/scene/export.ts
@@ -14,6 +14,18 @@ import {
 
 export const SVG_EXPORT_TAG = `<!-- svg-source:excalidraw -->`;
 
+const createScene = (
+  elements: readonly NonDeletedExcalidrawElement[],
+): Scene | null => {
+  if (!elements || Scene.getScene(elements[0])) {
+    return null;
+  }
+  const scene = new Scene();
+  scene.replaceAllElements(elements);
+  elements?.forEach((el) => Scene.mapElementToScene(el, scene));
+  return scene;
+};
+
 export const exportToCanvas = async (
   elements: readonly NonDeletedExcalidrawElement[],
   appState: AppState,
@@ -37,6 +49,7 @@ export const exportToCanvas = async (
     return { canvas, scale: appState.exportScale };
   },
 ) => {
+  const scene = createScene(elements);
   const [minX, minY, width, height] = getCanvasSize(elements, exportPadding);
 
   const { canvas, scale = 1 } = createCanvas(width, height);
@@ -76,6 +89,7 @@ export const exportToCanvas = async (
     },
   });
 
+  scene?.destroy();
   return canvas;
 };
 
@@ -97,6 +111,7 @@ export const exportToSvg = async (
     exportScale = 1,
     exportEmbedScene,
   } = appState;
+  const scene = createScene(elements);
   let metadata = "";
   if (exportEmbedScene) {
     try {
@@ -169,6 +184,7 @@ export const exportToSvg = async (
     exportWithDarkMode: appState.exportWithDarkMode,
   });
 
+  scene?.destroy();
   return svgRoot;
 };
 


### PR DESCRIPTION
When calling [exportToSvg](https://github.com/excalidraw/excalidraw/blob/73a45e19889de08be64faf2cdddae2b9ecaa1a20/src/scene/Scene.ts#L27-L28) and `exportToBlob`, `exportToCanvas` arrows do not have the mask behind the label.

before:
<img width="524" alt="image" src="https://user-images.githubusercontent.com/22638687/207845846-40fa4bd4-fa5e-47e9-8de5-11e2abdb7312.png">

after:
<img width="437" alt="image" src="https://user-images.githubusercontent.com/22638687/207845868-b352ddb1-7994-4f13-a0b2-f2e19bd72935.png">

In

https://github.com/excalidraw/excalidraw/blob/73a45e19889de08be64faf2cdddae2b9ecaa1a20/src/renderer/renderElement.ts#L1087-L1090

`boundText` is always null, if calling `exportToSvg` from ExcalidrawLib with elements[] external to the currently loaded scene because `Scene.getScene(element) returns null here:

https://github.com/excalidraw/excalidraw/blob/73a45e19889de08be64faf2cdddae2b9ecaa1a20/src/element/textElement.ts#L524-L537

This can be overcome by creating a temporary scene if elements are not found in the `sceneMapByElement`

https://github.com/excalidraw/excalidraw/blob/73a45e19889de08be64faf2cdddae2b9ecaa1a20/src/scene/Scene.ts#L27-L28