### PR TITLE
feat: Expose custom context menu handler

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -5959,6 +5959,10 @@ class App extends React.Component<AppProps, AppState> {
       container.getBoundingClientRect();
     const left = event.clientX - offsetLeft;
     const top = event.clientY - offsetTop;
+    const openContextMenu =
+      typeof this.props.openCustomContextMenu === "function"
+        ? this.props.openCustomContextMenu
+        : this._openContextMenu;
 
     if (element && !this.state.selectedElementIds[element.id]) {
       this.setState(
@@ -5973,11 +5977,11 @@ class App extends React.Component<AppProps, AppState> {
           this.scene.getNonDeletedElements(),
         ),
         () => {
-          this._openContextMenu({ top, left }, type);
+          openContextMenu({ top, left }, type);
         },
       );
     } else {
-      this._openContextMenu({ top, left }, type);
+      openContextMenu({ top, left }, type);
     }
   };
 

--- a/src/packages/excalidraw/README.md
+++ b/src/packages/excalidraw/README.md
@@ -657,6 +657,15 @@ The `<Sidebar.Header>` component takes these props children (all are optional):
 
 For example code, see the example [`App.tsx`](https://github.com/excalidraw/excalidraw/blob/master/src/packages/excalidraw/example/App.tsx#L524) file.
 
+#### `openCustomContextMenu`
+
+Optional function that can open custom context menu. It takes the following props:
+
+| name | type | description |
+| --- | --- | --- |
+| position | <pre>{ left: number; top: number; }</pre> | Context menu click position |
+| type | <pre>"canvas" \| "element"</pre> | Context menu clicked on element type |
+
 #### `viewModeEnabled`
 
 This prop indicates whether the app is in `view mode`. When supplied, the value takes precedence over `intialData.appState.viewModeEnabled`, the `view mode` will be fully controlled by the host app, and users won't be able to toggle it from within the app.

--- a/src/packages/excalidraw/example/App.tsx
+++ b/src/packages/excalidraw/example/App.tsx
@@ -107,6 +107,8 @@ export default function App() {
   const [viewModeEnabled, setViewModeEnabled] = useState(false);
   const [zenModeEnabled, setZenModeEnabled] = useState(false);
   const [gridModeEnabled, setGridModeEnabled] = useState(false);
+  const [customContextMenuEnabled, setCustomContextMenuEnabled] =
+    useState(false);
   const [blobUrl, setBlobUrl] = useState<string>("");
   const [canvasUrl, setCanvasUrl] = useState<string>("");
   const [exportWithDarkMode, setExportWithDarkMode] = useState(false);
@@ -537,6 +539,21 @@ export default function App() {
     );
   };
 
+  const openCustomContextMenu = (
+    {
+      left,
+      top,
+    }: {
+      left: number;
+      top: number;
+    },
+    type: "canvas" | "element",
+  ) => {
+    window.alert(
+      `Context menu click on type "${type}" at (x: ${left}, y: ${top})`,
+    );
+  };
+
   return (
     <div className="App" ref={appRef}>
       <h1> Excalidraw Example</h1>
@@ -650,6 +667,16 @@ export default function App() {
             />
             Show collaborators
           </label>
+          <label>
+            <input
+              type="checkbox"
+              checked={customContextMenuEnabled}
+              onChange={() => {
+                setCustomContextMenuEnabled(!customContextMenuEnabled);
+              }}
+            />
+            Custom context menu
+          </label>
           <div>
             <button onClick={onCopy.bind(null, "png")}>
               Copy to Clipboard as PNG
@@ -717,6 +744,9 @@ export default function App() {
             onPointerDown={onPointerDown}
             onScrollChange={rerenderCommentIcons}
             renderSidebar={renderSidebar}
+            openCustomContextMenu={
+              customContextMenuEnabled ? openCustomContextMenu : undefined
+            }
           />
           {Object.keys(commentIcons || []).length > 0 && renderCommentIcons()}
           {comment && renderComment()}

--- a/src/packages/excalidraw/index.tsx
+++ b/src/packages/excalidraw/index.tsx
@@ -22,6 +22,7 @@ const ExcalidrawBase = (props: ExcalidrawProps) => {
     renderTopRightUI,
     renderFooter,
     renderSidebar,
+    openCustomContextMenu,
     langCode = defaultLang.code,
     viewModeEnabled,
     zenModeEnabled,
@@ -113,6 +114,7 @@ const ExcalidrawBase = (props: ExcalidrawProps) => {
           onPointerDown={onPointerDown}
           onScrollChange={onScrollChange}
           renderSidebar={renderSidebar}
+          openCustomContextMenu={openCustomContextMenu}
         />
       </Provider>
     </InitializeApp>

--- a/src/types.ts
+++ b/src/types.ts
@@ -331,6 +331,16 @@ export interface ExcalidrawProps {
    * Render function that renders custom <Sidebar /> component.
    */
   renderSidebar?: () => JSX.Element | null;
+  openCustomContextMenu?: (
+    {
+      left,
+      top,
+    }: {
+      left: number;
+      top: number;
+    },
+    type: "canvas" | "element",
+  ) => void;
 }
 
 export type SceneData = {


### PR DESCRIPTION
While using excalidraw package we want to have more control over canvas context menu. With `openCustomContextMenu` an external caller can override default excalidraw behavior on context menu click and control which actions are available and how the context menu component look and feel.


https://user-images.githubusercontent.com/38251534/208268180-56b71a7d-a0c3-4357-ac89-7d7445056abb.mov