### PR TITLE
fix: resize sometimes throwing on missing null-checks

### DIFF
--- a/src/element/resizeElements.ts
+++ b/src/element/resizeElements.ts
@@ -162,11 +162,12 @@ const rotateSingleElement = (
 
   mutateElement(element, { angle });
   if (boundTextElementId) {
-    const textElement = Scene.getScene(element)!.getElement(
-      boundTextElementId,
-    ) as ExcalidrawTextElementWithContainer;
+    const textElement =
+      Scene.getScene(element)?.getElement<ExcalidrawTextElementWithContainer>(
+        boundTextElementId,
+      );
 
-    if (!isArrowElement(element)) {
+    if (textElement && !isArrowElement(element)) {
       mutateElement(textElement, { angle });
     }
   }
@@ -201,8 +202,10 @@ const measureFontSizeFromWH = (
 
   const hasContainer = isBoundToContainer(element);
   if (hasContainer) {
-    const container = getContainerElement(element)!;
-    width = getMaxContainerWidth(container);
+    const container = getContainerElement(element);
+    if (container) {
+      width = getMaxContainerWidth(container);
+    }
   }
   const nextFontSize = element.fontSize * (nextWidth / width);
   if (nextFontSize < MIN_FONT_SIZE) {
@@ -211,7 +214,7 @@ const measureFontSizeFromWH = (
   const metrics = measureText(
     element.text,
     getFontString({ fontSize: nextFontSize, fontFamily: element.fontFamily }),
-    hasContainer ? width : null,
+    element.containerId ? width : null,
   );
   return {
     size: nextFontSize,
@@ -765,10 +768,11 @@ const rotateMultipleElements = (
     });
     const boundTextElementId = getBoundTextElementId(element);
     if (boundTextElementId) {
-      const textElement = Scene.getScene(element)!.getElement(
-        boundTextElementId,
-      ) as ExcalidrawTextElementWithContainer;
-      if (!isArrowElement(element)) {
+      const textElement =
+        Scene.getScene(element)?.getElement<ExcalidrawTextElementWithContainer>(
+          boundTextElementId,
+        );
+      if (textElement && !isArrowElement(element)) {
         mutateElement(textElement, {
           x: textElement.x + (rotatedCX - cx),
           y: textElement.y + (rotatedCY - cy),


### PR DESCRIPTION
fix https://github.com/excalidraw/excalidraw/issues/6009

Not quite fully fixed. We have a race condition in resizing where the resize handler holds onto an object that's no longer in the Scene elements array by the time it tries to retrieve the scene using the element.

But, it turns out this bug is not really an edge case and affects any sticky notes that are part of a group. As such it affects large swathes of libraries and user shapes, so we need to fix this asap.

This fix also seems to not exhibit and UX issues. That said, we need to figure out the root cause and fix it properly.

Also, how many times have we been burned by doing unnecessary type assertions? Let's stop doing that unless we're 99% certain it's safe. /cc @ad1992