### PR TITLE
fix: showing `grabbing` cursor when holding `spacebar`

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -2120,7 +2120,7 @@ class App extends React.Component<AppProps, AppState> {
       }
       if (event.key === KEYS.SPACE && gesture.pointers.size === 0) {
         isHoldingSpace = true;
-        setCursor(this.canvas, CURSOR_TYPE.GRABBING);
+        setCursor(this.canvas, CURSOR_TYPE.GRAB);
         event.preventDefault();
       }
 


### PR DESCRIPTION
fix https://github.com/excalidraw/excalidraw/issues/6007 (or at least it addresses the UX issue communicating the action improperly through the wrong cursor)