### PR TITLE
fix: use canvas measureText to calculate width in measureText

### DIFF
--- a/src/element/textElement.test.ts
+++ b/src/element/textElement.test.ts
@@ -157,7 +157,7 @@ describe("Test measureText", () => {
 
     expect(res.container).toMatchInlineSnapshot(`
       <div
-        style="position: absolute; white-space: pre-wrap; font: Emoji 20px 20px; min-height: 1em; width: 191px; overflow: hidden; word-break: break-word; line-height: 0px;"
+        style="position: absolute; white-space: pre-wrap; font: Emoji 20px 20px; min-height: 1em; width: 111px; overflow: hidden; word-break: break-word; line-height: 0px;"
       >
         <span
           style="display: inline-block; overflow: hidden; width: 1px; height: 1px;"

--- a/src/element/textElement.ts
+++ b/src/element/textElement.ts
@@ -275,6 +275,7 @@ export const measureText = (
 
   if (maxWidth) {
     const lineHeight = getApproxLineHeight(font);
+
     container.style.width = `${String(Math.min(textWidth, maxWidth) + 1)}px`;
     container.style.overflow = "hidden";
     container.style.wordBreak = "break-word";
@@ -317,7 +318,7 @@ export const getApproxLineHeight = (font: FontString) => {
 };
 
 let canvas: HTMLCanvasElement | undefined;
-const getTextWidth = (text: string, font: FontString) => {
+const getLineWidth = (text: string, font: FontString) => {
   if (!canvas) {
     canvas = document.createElement("canvas");
   }
@@ -335,10 +336,18 @@ const getTextWidth = (text: string, font: FontString) => {
   return metrics.width;
 };
 
+const getTextWidth = (text: string, font: FontString) => {
+  const lines = text.split("\n");
+  let width = 0;
+  lines.forEach((line) => {
+    width = Math.max(width, getLineWidth(line, font));
+  });
+  return width;
+};
 export const wrapText = (text: string, font: FontString, maxWidth: number) => {
   const lines: Array<string> = [];
   const originalLines = text.split("\n");
-  const spaceWidth = getTextWidth(" ", font);
+  const spaceWidth = getLineWidth(" ", font);
 
   const push = (str: string) => {
     if (str.trim()) {
@@ -356,7 +365,7 @@ export const wrapText = (text: string, font: FontString, maxWidth: number) => {
 
       let index = 0;
       while (index < words.length) {
-        const currentWordWidth = getTextWidth(words[index], font);
+        const currentWordWidth = getLineWidth(words[index], font);
 
         // Start breaking longer words exceeding max width
         if (currentWordWidth >= maxWidth) {
@@ -405,7 +414,7 @@ export const wrapText = (text: string, font: FontString, maxWidth: number) => {
           // Start appending words in a line till max width reached
           while (currentLineWidthTillNow < maxWidth && index < words.length) {
             const word = words[index];
-            currentLineWidthTillNow = getTextWidth(currentLine + word, font);
+            currentLineWidthTillNow = getLineWidth(currentLine + word, font);
 
             if (currentLineWidthTillNow >= maxWidth) {
               push(currentLine);
@@ -453,7 +462,7 @@ export const charWidth = (() => {
       cachedCharWidth[font] = [];
     }
     if (!cachedCharWidth[font][ascii]) {
-      const width = getTextWidth(char, font);
+      const width = getLineWidth(char, font);
       cachedCharWidth[font][ascii] = width;
     }
 
@@ -513,7 +522,7 @@ export const getApproxCharsToFitInWidth = (font: FontString, width: number) => {
   while (widthTillNow <= width) {
     const batch = dummyText.substr(index, index + batchLength);
     str += batch;
-    widthTillNow += getTextWidth(str, font);
+    widthTillNow += getLineWidth(str, font);
     if (index === dummyText.length - 1) {
       index = 0;
     }
@@ -522,7 +531,7 @@ export const getApproxCharsToFitInWidth = (font: FontString, width: number) => {
 
   while (widthTillNow > width) {
     str = str.substr(0, str.length - 1);
-    widthTillNow = getTextWidth(str, font);
+    widthTillNow = getLineWidth(str, font);
   }
   return str.length;
 };

--- a/src/element/textElement.ts
+++ b/src/element/textElement.ts
@@ -271,9 +271,11 @@ export const measureText = (
   container.style.whiteSpace = "pre";
   container.style.font = font;
   container.style.minHeight = "1em";
+  const textWidth = getTextWidth(text, font);
+
   if (maxWidth) {
     const lineHeight = getApproxLineHeight(font);
-    container.style.width = `${String(maxWidth + 1)}px`;
+    container.style.width = `${String(Math.min(textWidth, maxWidth) + 1)}px`;
     container.style.overflow = "hidden";
     container.style.wordBreak = "break-word";
     container.style.lineHeight = `${String(lineHeight)}px`;
@@ -291,7 +293,10 @@ export const measureText = (
   // Baseline is important for positioning text on canvas
   const baseline = span.offsetTop + span.offsetHeight;
   // Since span adds 1px extra width to the container
-  const width = container.offsetWidth - 1;
+  let width = container.offsetWidth;
+  if (maxWidth && textWidth > maxWidth) {
+    width = width - 1;
+  }
   const height = container.offsetHeight;
   document.body.removeChild(container);
   if (isTestEnv()) {

--- a/src/element/textElement.ts
+++ b/src/element/textElement.ts
@@ -299,6 +299,7 @@ export const measureText = (
     width = width - 1;
   }
   const height = container.offsetHeight;
+  debugger;
   document.body.removeChild(container);
   if (isTestEnv()) {
     return { width, height, baseline, container };

--- a/src/element/textElement.ts
+++ b/src/element/textElement.ts
@@ -275,8 +275,8 @@ export const measureText = (
 
   if (maxWidth) {
     const lineHeight = getApproxLineHeight(font);
-
     container.style.width = `${String(Math.min(textWidth, maxWidth) + 1)}px`;
+
     container.style.overflow = "hidden";
     container.style.wordBreak = "break-word";
     container.style.lineHeight = `${String(lineHeight)}px`;

--- a/src/element/textElement.ts
+++ b/src/element/textElement.ts
@@ -299,7 +299,6 @@ export const measureText = (
     width = width - 1;
   }
   const height = container.offsetHeight;
-  debugger;
   document.body.removeChild(container);
   if (isTestEnv()) {
     return { width, height, baseline, container };

--- a/src/element/textElement.ts
+++ b/src/element/textElement.ts
@@ -336,7 +336,7 @@ const getLineWidth = (text: string, font: FontString) => {
   return metrics.width;
 };
 
-const getTextWidth = (text: string, font: FontString) => {
+export const getTextWidth = (text: string, font: FontString) => {
   const lines = text.split("\n");
   let width = 0;
   lines.forEach((line) => {

--- a/src/element/textWysiwyg.test.tsx
+++ b/src/element/textWysiwyg.test.tsx
@@ -862,7 +862,7 @@ describe("textWysiwyg", () => {
       resize(rectangle, "ne", [rectangle.x + 100, rectangle.y - 100]);
       expect([h.elements[1].x, h.elements[1].y]).toMatchInlineSnapshot(`
         Array [
-          110.5,
+          110,
           17,
         ]
       `);
@@ -910,7 +910,7 @@ describe("textWysiwyg", () => {
       resize(rectangle, "ne", [rectangle.x + 100, rectangle.y - 100]);
       expect([h.elements[1].x, h.elements[1].y]).toMatchInlineSnapshot(`
         Array [
-          426,
+          425,
           -539,
         ]
       `);
@@ -1026,7 +1026,7 @@ describe("textWysiwyg", () => {
       mouse.up(rectangle.x + 100, rectangle.y + 50);
       expect(rectangle.x).toBe(80);
       expect(rectangle.y).toBe(85);
-      expect(text.x).toBe(90.5);
+      expect(text.x).toBe(90);
       expect(text.y).toBe(90);
 
       Keyboard.withModifierKeys({ ctrl: true }, () => {

--- a/src/element/textWysiwyg.tsx
+++ b/src/element/textWysiwyg.tsx
@@ -367,7 +367,7 @@ export const textWysiwyg = ({
       });
       if (container) {
         const wrappedText = wrapText(
-          data,
+          `${editable.value}${data}`,
           font,
           getMaxContainerWidth(container),
         );

--- a/src/element/textWysiwyg.tsx
+++ b/src/element/textWysiwyg.tsx
@@ -28,6 +28,7 @@ import {
   getContainerDims,
   getContainerElement,
   getTextElementAngle,
+  getTextWidth,
   normalizeText,
   wrapText,
 } from "./textElement";
@@ -39,6 +40,7 @@ import { actionZoomIn, actionZoomOut } from "../actions/actionCanvas";
 import App from "../components/App";
 import { getMaxContainerHeight, getMaxContainerWidth } from "./newElement";
 import { LinearElementEditor } from "./linearElementEditor";
+import { parseClipboard } from "../clipboard";
 
 const getTransform = (
   width: number,
@@ -348,6 +350,32 @@ export const textWysiwyg = ({
   updateWysiwygStyle();
 
   if (onChange) {
+    editable.onpaste = async (event) => {
+      const clipboardData = await parseClipboard(event, true);
+      if (!clipboardData.text) {
+        return;
+      }
+      const data = normalizeText(clipboardData.text);
+      if (!data) {
+        return;
+      }
+      const container = getContainerElement(element);
+
+      const font = getFontString({
+        fontSize: app.state.currentItemFontSize,
+        fontFamily: app.state.currentItemFontFamily,
+      });
+      if (container) {
+        const wrappedText = wrapText(
+          data,
+          font,
+          getMaxContainerWidth(container),
+        );
+        const width = getTextWidth(wrappedText, font);
+        editable.style.width = `${width}px`;
+      }
+    };
+
     editable.oninput = () => {
       const updatedTextElement = Scene.getScene(element)?.getElement(
         id,

--- a/src/tests/data/__snapshots__/restore.test.ts.snap
+++ b/src/tests/data/__snapshots__/restore.test.ts.snap
@@ -312,7 +312,7 @@ Object {
   "versionNonce": 0,
   "verticalAlign": "middle",
   "width": 100,
-  "x": 0.5,
+  "x": 0,
   "y": 0,
 }
 `;

--- a/src/tests/linearElementEditor.test.tsx
+++ b/src/tests/linearElementEditor.test.tsx
@@ -1027,7 +1027,7 @@ describe("Test Linear Elements", () => {
       expect(getBoundTextElementPosition(container, textElement))
         .toMatchInlineSnapshot(`
         Object {
-          "x": 387.5,
+          "x": 387,
           "y": 70,
         }
       `);
@@ -1086,7 +1086,7 @@ describe("Test Linear Elements", () => {
       expect(getBoundTextElementPosition(container, textElement))
         .toMatchInlineSnapshot(`
         Object {
-          "x": 190.5,
+          "x": 190,
           "y": 20,
         }
       `);


### PR DESCRIPTION
A bug got introduced in https://github.com/excalidraw/excalidraw/pull/5996 when adding text to arrows

Before

<img width="575" alt="Screenshot 2022-12-23 at 9 13 59 PM" src="https://user-images.githubusercontent.com/11256141/209362207-02d76bac-4479-4157-a127-e2de2788eaec.png">

Now

<img width="498" alt="Screenshot 2022-12-23 at 9 14 21 PM" src="https://user-images.githubusercontent.com/11256141/209362248-4dba4a06-6563-4dcc-ba99-860bc36995a9.png">


Pending tasks for next PR

- [ ] A newline gets added when adding a letter to end in https://excalidraw-m66divtzf-excalidraw.vercel.app/#json=vfqSNglnZmD3jCVpe7pPY,N0ObgwJCj3oX5_bEj-Hsrw

- [ ]  Editor autogrows with below steps
1. open https://excalidraw-hzs43vab7-excalidraw.vercel.app/#json=V8IuuHiLiBN8Tz78LfHFV,O5phO7_M7NSG3kFPpGDZgA

2. edit
3. select all
4. delete
5. undo

- [ ] Specs
