### PR TITLE
feat: changing container stroke color will not change text if text has a different color

### DIFF
--- a/src/actions/actionProperties.tsx
+++ b/src/actions/actionProperties.tsx
@@ -201,12 +201,23 @@ export const actionChangeStrokeColor = register({
   name: "changeStrokeColor",
   trackEvent: false,
   perform: (elements, appState, value) => {
+    const containers = getSelectedElements(elements, appState, false)
+      .filter((el) => el.boundElements)
+      .map((el) => el.id);
     return {
       ...(value.currentItemStrokeColor && {
         elements: changeProperty(
           elements,
           appState,
           (el) => {
+            if (
+              isTextElement(el) &&
+              el.containerId &&
+              containers.includes(el.containerId) &&
+              getContainerElement(el)?.strokeColor !== el.strokeColor
+            ) {
+              return el;
+            }
             return hasStrokeColor(el.type)
               ? newElementWith(el, {
                   strokeColor: value.currentItemStrokeColor,


### PR DESCRIPTION
This is an issue that has been bothering me for a long time. I've also seen various issues raised regarding this. For example #5972 

It is possible to manually change the text color, however, each time I change the color of the container, I need to redo the text color change. My proposal is to only change the text color in the container if the container stroke color is the same as the text color. i.e if the user has decided to have a different text color, then honor that decision.

Before:

https://user-images.githubusercontent.com/14358394/209372919-ee4baaac-b02b-4aa9-94c6-0d21c12e8e92.mp4

After:

https://user-images.githubusercontent.com/14358394/209372934-5fcff15c-71ea-4222-83a9-a9a3b3dd464f.mp4


