### PR TITLE
fix: use displayName since name gets stripped off when uglifying/minifiyng in production

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -701,10 +701,11 @@ export const ReactChildrenToObject = <
     if (
       React.isValidElement(child) &&
       typeof child.type !== "string" &&
-      child?.type.name
+      //@ts-ignore
+      child?.type.displayName
     ) {
       // @ts-ignore
-      acc[child.type.name] = child;
+      acc[child.type.displayName] = child;
     }
     return acc;
   }, {} as Partial<T>);


### PR DESCRIPTION
Got introduced when `displayName` was changed to `name` in https://github.com/excalidraw/excalidraw/pull/5970
Before
<img width="1387" alt="Screenshot 2022-12-27 at 3 12 34 PM" src="https://user-images.githubusercontent.com/11256141/209646948-c1acd444-a2e4-423b-88b9-794647926bf7.png">

Now

<img width="1389" alt="Screenshot 2022-12-27 at 3 13 19 PM" src="https://user-images.githubusercontent.com/11256141/209647061-074daba5-411b-4729-96f1-d1bb18052674.png">
