### PR TITLE
fix: Set `type="button"` on <button>'s to prevent form submission

### DIFF
--- a/src/components/ColorPicker.tsx
+++ b/src/components/ColorPicker.tsx
@@ -214,6 +214,7 @@ const Picker = ({
       return (
         <button
           className="color-picker-swatch"
+          type="button"
           onClick={(event) => {
             (event.currentTarget as HTMLButtonElement).focus();
             onChange(_color);
@@ -380,6 +381,7 @@ export const ColorPicker = ({
             style={color ? { "--swatch-color": color } : undefined}
             onClick={() => setActive(!isActive)}
             ref={pickerButton}
+            type="button"
           />
         </div>
         <ColorInput


### PR DESCRIPTION
Summary of changes:
Set `type="button"` on `<button>`'s to prevent `<form>` submission

Reason for change:
Currently, the <button> type is not specified, at least in the `ColorPicker`.  This causes a click on them to submit any ancestor `<form>`'s.  