### PR TITLE
feat: hidden feature - support perfect-freehand options for freedraw 

### DIFF
--- a/src/renderer/renderElement.ts
+++ b/src/renderer/renderElement.ts
@@ -237,7 +237,16 @@ const drawElementOnCanvas = (
         rc.draw(fillShape);
       }
 
-      context.fillStyle = element.strokeColor;
+      if (!fillShape && element.customData?.strokeOptions?.hasOutline) {
+        context.lineWidth =
+          (element.strokeWidth / 5) *
+            element.customData.strokeOptions.outlineWidth ?? 1;
+        context.strokeStyle = element.strokeColor;
+        context.stroke(path);
+        context.fillStyle = element.backgroundColor;
+      } else {
+        context.fillStyle = element.strokeColor;
+      }
       context.fill(path);
 
       context.restore();
@@ -1185,7 +1194,19 @@ export const renderElementToSvg = (
       );
       node.setAttribute("stroke", "none");
       const path = svgRoot.ownerDocument!.createElementNS(SVG_NS, "path");
-      path.setAttribute("fill", element.strokeColor);
+      if (!shape && element.customData?.strokeOptions?.hasOutline) {
+        path.setAttribute("fill", element.backgroundColor);
+        path.setAttribute("stroke", element.strokeColor);
+        path.setAttribute(
+          "stroke-width",
+          `${
+            (element.strokeWidth / 5) *
+              element.customData.strokeOptions.outlineWidth ?? 1
+          }`,
+        );
+      } else {
+        path.setAttribute("fill", element.strokeColor);
+      }
       path.setAttribute("d", getFreeDrawSvgPath(element));
       node.appendChild(path);
       root.appendChild(node);
@@ -1328,15 +1349,26 @@ export function getFreeDrawSvgPath(element: ExcalidrawFreeDrawElement) {
     : [[0, 0, 0.5]];
 
   // Consider changing the options for simulated pressure vs real pressure
-  const options: StrokeOptions = {
-    simulatePressure: element.simulatePressure,
-    size: element.strokeWidth * 4.25,
-    thinning: 0.6,
-    smoothing: 0.5,
-    streamline: 0.5,
-    easing: (t) => Math.sin((t * Math.PI) / 2), // https://easings.net/#easeOutSine
-    last: !!element.lastCommittedPoint, // LastCommittedPoint is added on pointerup
-  };
+  const options: StrokeOptions = element.customData?.strokeOptions?.options //zsviczian
+    ? { ...element.customData?.strokeOptions?.options }
+    : {
+        simulatePressure: element.simulatePressure,
+        size: element.strokeWidth * 4.25,
+        thinning: 0.6,
+        smoothing: 0.5,
+        streamline: 0.5,
+        easing: (t) => Math.sin((t * Math.PI) / 2), // https://easings.net/#easeOutSine
+        last: !!element.lastCommittedPoint, // LastCommittedPoint is added on pointerup
+      };
+
+  if (element.customData?.strokeOptions?.options) {
+    options.simulatePressure =
+      options.simulatePressure ?? element.simulatePressure;
+    options.size = options.size
+      ? (options.size * element.strokeWidth) / 4
+      : element.strokeWidth * 4.25;
+    options.last = !!element.lastCommittedPoint;
+  }
 
   return getSvgPathFromStroke(getStroke(inputPoints as number[][], options));
 }


### PR DESCRIPTION
Over the past 2 years, I've received multiple requests for the Obsidian-Excalidraw plugin to support different pen styles. Perfect freehand is very powerful, but the Excalidraw UI hides many of its features. This PR is a simple implementation of a hidden feature to support perfect freehand options.

I'd like to include this in the main Excalidraw package to maintain compatibility between the Obsidian plugin and Excalidraw.com. I have many users who draw in Obsidian-Excalidraw and share some of their work via Excalidraw.com with others.

The implementation is simple. The hidden feature works with the following data structure in customData:
```json
strokeOptions: {
  hasOutline: boolean;
  outlineWidth: number;
  options: StrokeOptions; 
}
```
If hasOutline is set to true, the freedraw line will have an outline, In this case the elmenet.strokeColor will be used for the outline, and the element.backgroundColor for the fill color of the stroke itself.
Even if hasOutline is true, but the element is a closed shape, then freedraw will not have an outline, but will behave as currently, i.e. the freedraw line will be strokeColor, and the filled area background color.

