### PR TITLE
feat: generic button export

### DIFF
--- a/src/components/Button.scss
+++ b/src/components/Button.scss
@@ -1,0 +1,18 @@
+@import "../css/variables.module";
+@import "../css/theme";
+
+.excalidraw {
+  .excalidraw-button {
+    @include outlineButtonStyles;
+    background-color: var(--island-bg-color);
+    width: var(--lg-button-size);
+    height: var(--lg-button-size);
+
+    svg {
+      width: var(--lg-icon-size);
+      height: var(--lg-icon-size);
+    }
+
+    overflow: hidden;
+  }
+}

--- a/src/components/Button.scss
+++ b/src/components/Button.scss
@@ -1,18 +1,8 @@
-@import "../css/variables.module";
 @import "../css/theme";
 
 .excalidraw {
   .excalidraw-button {
     @include outlineButtonStyles;
-    background-color: var(--island-bg-color);
-    width: var(--lg-button-size);
-    height: var(--lg-button-size);
-
-    svg {
-      width: var(--lg-icon-size);
-      height: var(--lg-icon-size);
-    }
-
     overflow: hidden;
   }
 }

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,0 +1,23 @@
+interface ButtonProps extends React.HTMLAttributes<HTMLButtonElement> {
+  children: React.ReactNode;
+  className?: string;
+  type?: "button" | "submit" | "reset";
+}
+
+/**
+ * A generic button component that follows Excalidraw's design system.
+ * Style can be customised using `className` or `style` prop.
+ * Accepts all props that a regular `button` element accepts.
+ */
+export const Button = ({
+  children,
+  className,
+  type = "button",
+  ...rest
+}: ButtonProps) => {
+  return (
+    <button type={type} className={`excalidraw-button ${className}`} {...rest}>
+      {children}
+    </button>
+  );
+};

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,3 +1,5 @@
+import "./Button.scss";
+
 interface ButtonProps extends React.HTMLAttributes<HTMLButtonElement> {
   type?: "button" | "submit" | "reset";
   onSelect: () => any;

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,7 +1,8 @@
 interface ButtonProps extends React.HTMLAttributes<HTMLButtonElement> {
+  type?: "button" | "submit" | "reset";
+  onSelect: () => any;
   children: React.ReactNode;
   className?: string;
-  type?: "button" | "submit" | "reset";
 }
 
 /**
@@ -10,13 +11,22 @@ interface ButtonProps extends React.HTMLAttributes<HTMLButtonElement> {
  * Accepts all props that a regular `button` element accepts.
  */
 export const Button = ({
-  children,
-  className,
   type = "button",
+  onSelect,
+  children,
+  className = "",
   ...rest
 }: ButtonProps) => {
   return (
-    <button type={type} className={`excalidraw-button ${className}`} {...rest}>
+    <button
+      onClick={(event) => {
+        onSelect();
+        rest.onClick?.(event);
+      }}
+      type={type}
+      className={`excalidraw-button ${className}`}
+      {...rest}
+    >
       {children}
     </button>
   );

--- a/src/components/CollabButton.scss
+++ b/src/components/CollabButton.scss
@@ -2,29 +2,22 @@
 
 .excalidraw {
   .collab-button {
-    @include outlineButtonStyles;
-    width: var(--lg-button-size);
-    height: var(--lg-button-size);
+    --button-bg: var(--color-primary);
+    --button-color: white;
+    --button-border: var(--color-primary);
 
-    svg {
-      width: var(--lg-icon-size);
-      height: var(--lg-icon-size);
-    }
-    background-color: var(--color-primary);
-    border-color: var(--color-primary);
-    color: white;
+    --button-width: var(--lg-button-size);
+    --button-height: var(--lg-button-size);
+
+    --button-hover-bg: var(--color-primary-darker);
+    --button-hover-border: var(--color-primary-darker);
+
+    --button-active-bg: var(--color-primary-darker);
+
     flex-shrink: 0;
 
-    &:hover {
-      background-color: var(--color-primary-darker);
-      border-color: var(--color-primary-darker);
-    }
-
-    &:active {
-      background-color: var(--color-primary-darker);
-    }
-
-    &.active {
+    // double .active to force specificity
+    &.active.active {
       background-color: #0fb884;
       border-color: #0fb884;
 

--- a/src/components/CollabButton.tsx
+++ b/src/components/CollabButton.tsx
@@ -3,6 +3,7 @@ import { UsersIcon } from "./icons";
 
 import "./CollabButton.scss";
 import clsx from "clsx";
+import { Button } from "./Button";
 
 const CollabButton = ({
   isCollaborating,
@@ -14,10 +15,10 @@ const CollabButton = ({
   onClick: () => void;
 }) => {
   return (
-    <button
+    <Button
       className={clsx("collab-button", { active: isCollaborating })}
       type="button"
-      onClick={onClick}
+      onSelect={onClick}
       style={{ position: "relative" }}
       title={t("labels.liveCollaboration")}
     >
@@ -25,7 +26,7 @@ const CollabButton = ({
       {collaboratorCount > 0 && (
         <div className="CollabButton-collaborators">{collaboratorCount}</div>
       )}
-    </button>
+    </Button>
   );
 };
 

--- a/src/components/dropdownMenu/DropdownMenu.scss
+++ b/src/components/dropdownMenu/DropdownMenu.scss
@@ -73,7 +73,7 @@
       }
 
       &:hover {
-        background-color: var(--button-hover);
+        background-color: var(--button-hover-bg);
         text-decoration: none;
       }
 

--- a/src/css/styles.scss
+++ b/src/css/styles.scss
@@ -408,7 +408,7 @@
     pointer-events: all;
 
     &:hover {
-      background-color: var(--button-hover);
+      background-color: var(--button-hover-bg);
     }
 
     &:active {

--- a/src/css/styles.scss
+++ b/src/css/styles.scss
@@ -583,20 +583,6 @@
       padding: 0;
     }
   }
-
-  .excalidraw-button {
-    @include outlineButtonStyles;
-    background-color: var(--island-bg-color);
-    width: var(--lg-button-size);
-    height: var(--lg-button-size);
-
-    svg {
-      width: var(--lg-icon-size);
-      height: var(--lg-icon-size);
-    }
-
-    overflow: hidden;
-  }
 }
 
 .ErrorSplash.excalidraw {

--- a/src/css/styles.scss
+++ b/src/css/styles.scss
@@ -583,6 +583,20 @@
       padding: 0;
     }
   }
+
+  .excalidraw-button {
+    @include outlineButtonStyles;
+    background-color: var(--island-bg-color);
+    width: var(--lg-button-size);
+    height: var(--lg-button-size);
+
+    svg {
+      width: var(--lg-icon-size);
+      height: var(--lg-icon-size);
+    }
+
+    overflow: hidden;
+  }
 }
 
 .ErrorSplash.excalidraw {

--- a/src/css/theme.scss
+++ b/src/css/theme.scss
@@ -35,7 +35,7 @@
   --shadow-island: 0px 7px 14px rgba(0, 0, 0, 0.05),
     0px 0px 3.12708px rgba(0, 0, 0, 0.0798),
     0px 0px 0.931014px rgba(0, 0, 0, 0.1702);
-  --button-hover: var(--color-gray-10);
+  --button-hover-bg: var(--color-gray-10);
   --default-border-color: var(--color-gray-30);
 
   --default-button-size: 2rem;
@@ -135,7 +135,7 @@
     --popup-text-inverted-color: #2c2c2c;
     --select-highlight-color: #{$oc-blue-4};
     --text-primary-color: var(--color-gray-40);
-    --button-hover: var(--color-gray-80);
+    --button-hover-bg: var(--color-gray-80);
     --default-border-color: var(--color-gray-80);
     --shadow-island: 0px 13px 33px rgba(0, 0, 0, 0.07),
       0px 4.13px 9.94853px rgba(0, 0, 0, 0.0456112),

--- a/src/css/variables.module.scss
+++ b/src/css/variables.module.scss
@@ -39,11 +39,11 @@
 
   .ToolIcon__icon {
     &:hover {
-      background: var(--button-hover);
+      background: var(--button-hover-bg);
     }
 
     &:active {
-      background: var(--button-hover);
+      background: var(--button-hover-bg);
       border: 1px solid var(--color-primary-darkest);
     }
   }
@@ -54,24 +54,25 @@
   justify-content: center;
   align-items: center;
   padding: 0.625rem;
-  width: var(--default-button-size);
-  height: var(--default-button-size);
+  width: var(--button-width, var(--default-button-size));
+  height: var(--button-height, var(--default-button-size));
   box-sizing: border-box;
   border-width: 1px;
   border-style: solid;
-  border-color: var(--default-border-color);
+  border-color: var(--button-border, var(--default-border-color));
   border-radius: var(--border-radius-lg);
   cursor: pointer;
-  background-color: transparent;
-  color: var(--text-primary-color);
+  background-color: var(--button-bg, var(--island-bg-color));
+  color: var(--button-color, var(--text-primary-color));
 
   &:hover {
-    background-color: var(--button-hover);
+    background-color: var(--button-hover-bg);
+    border-color: var(--button-hover-border, var(--default-border-color));
   }
 
   &:active {
-    background-color: var(--button-hover);
-    border-color: var(--color-primary-darkest);
+    background-color: var(--button-active-bg);
+    border-color: var(--button-active-border, var(--color-primary-darkest));
   }
 
   &.active {
@@ -83,7 +84,10 @@
     }
 
     svg {
-      color: var(--color-primary-darker);
+      color: var(--button-color, var(--color-primary-darker));
+
+      width: var(--button-width, var(--lg-icon-size));
+      height: var(--button-height, var(--lg-icon-size));
     }
   }
 }

--- a/src/packages/excalidraw/example/CustomFooter.tsx
+++ b/src/packages/excalidraw/example/CustomFooter.tsx
@@ -26,7 +26,7 @@ const CustomFooter = ({
   return (
     <>
       <Button
-        onClick={() => alert("General Kenobi!")}
+        onSelect={() => alert("General Kenobi!")}
         className="you are a bold one"
         style={{ marginLeft: "1rem" }}
         title="Hello there!"

--- a/src/packages/excalidraw/example/CustomFooter.tsx
+++ b/src/packages/excalidraw/example/CustomFooter.tsx
@@ -1,5 +1,7 @@
 import { ExcalidrawImperativeAPI } from "../../../types";
 import { MIME_TYPES } from "../entry";
+import { Button } from "../../../components/Button";
+
 const COMMENT_SVG = (
   <svg
     xmlns="http://www.w3.org/2000/svg"
@@ -23,6 +25,14 @@ const CustomFooter = ({
 }) => {
   return (
     <>
+      <Button
+        onClick={() => alert("General Kenobi!")}
+        className="you are a bold one"
+        style={{ marginLeft: "1rem" }}
+        title="Hello there!"
+      >
+        {COMMENT_SVG}
+      </Button>
       <button
         className="custom-element"
         onClick={() => {

--- a/src/packages/excalidraw/index.tsx
+++ b/src/packages/excalidraw/index.tsx
@@ -239,6 +239,7 @@ export {
 } from "../../utils";
 
 export { Sidebar } from "../../components/Sidebar/Sidebar";
+export { Button } from "../../components/Button";
 export { Footer };
 export { MainMenu };
 export { useDevice } from "../../components/App";


### PR DESCRIPTION
The motivation for this PR is that host applications have had to resort to manually implementing/mimicking Excalidraw's button styling if they wanted to stay visually consistent when implementing custom buttons. This PR exports a generic button component that follows Excalidraw's design system. Usage is really quite straightforward but an example has been added in the examples section as well. If we need anything else here, please add your feedback below.