### PR TITLE
fix: remove overflow hidden from button

### DIFF
--- a/src/components/Button.scss
+++ b/src/components/Button.scss
@@ -3,6 +3,5 @@
 .excalidraw {
   .excalidraw-button {
     @include outlineButtonStyles;
-    overflow: hidden;
   }
 }


### PR DESCRIPTION
Introduced in https://github.com/excalidraw/excalidraw/pull/6092 which was breaking collaborator count.

Before
![image](https://user-images.githubusercontent.com/11256141/212294460-fc0c3130-487d-4d75-8a48-7370c9d2d36e.png)

Now
<img width="55" alt="Screenshot 2023-01-13 at 3 39 49 PM" src="https://user-images.githubusercontent.com/11256141/212294520-667cd4b5-ff4c-402a-8338-4601734fc01b.png">
