### PR TITLE
build: temporarily disable pre-commit

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,2 @@
 #!/bin/sh
-yarn lint-staged
+# yarn lint-staged


### PR DESCRIPTION
fix https://github.com/excalidraw/excalidraw/issues/6094

Until we fix the eslint CLIEngine issue. What's also on the table is removing precommit hooks altogether.