### PR TITLE
feat: Adding option to paste tabular data as a rough table

### DIFF
--- a/src/charts.ts
+++ b/src/charts.ts
@@ -138,7 +138,7 @@ export const tryParseSpreadsheet = (text: string): ParseSpreadsheetResult => {
     .map((line) => line.trim().split("\t"));
 
   // Check for comma separated files
-  if (lines.length && lines[0].includes(",")) {
+  if (lines.length && lines[0][0].includes(",")) {
     lines = text
       .trim()
       .split("\n")
@@ -507,7 +507,6 @@ const table = (
     Math.max(...spreadsheet.cells!.flat().map((element) => element.length)) *
     cellHeight;
 
-  // fix csv
   const columns = new Array(numberOfColumns).fill(true).map((_, i) =>
     newLinearElement({
       backgroundColor,

--- a/src/charts.ts
+++ b/src/charts.ts
@@ -504,6 +504,8 @@ const table = (
   const cellWidth =
     Math.max(...spreadsheet.cells!.flat().map((element) => element.length)) *
     cellHeight;
+
+  //can't scale, fix it.
   const columns = new Array(numberOfColumns).fill(true).map((_, i) =>
     newLinearElement({
       backgroundColor,
@@ -540,20 +542,25 @@ const table = (
     }),
   );
 
-  // to do
-  //can't scale, fix it.
-  const text = newTextElement({
-    ...commonProps,
-    text: "test",
-    x: 0,
-    y: 0,
-    roundness: null,
-    strokeStyle: "solid",
-    textAlign: "center",
-    backgroundColor: "red",
-  });
+  const cellsContent = spreadsheet
+    .cells!.map((rows, i) =>
+      rows.map((content, j) =>
+        newTextElement({
+          ...commonProps,
+          groupIds: [groupId],
+          text: content,
+          x: x + j * cellWidth + cellWidth / 2,
+          y: y + i * cellHeight + cellHeight / 2,
+          roundness: null,
+          strokeStyle: "solid",
+          textAlign: "center",
+          backgroundColor,
+        }),
+      ),
+    )
+    .flat();
 
-  return [...(text ? [text] : []), ...columns, ...rows];
+  return [...columns, ...rows, ...cellsContent];
 };
 
 export const renderSpreadsheet = (

--- a/src/charts.ts
+++ b/src/charts.ts
@@ -50,7 +50,7 @@ const isNumericColumn = (lines: string[][], columnIndex: number) =>
 export const tryParseCells = (cells: string[][]): ParseSpreadsheetResult => {
   const numCols = cells[0].length;
 
-  if (numCols > 2) {
+  if (numCols > 2 && cells.length > 1) {
     return {
       type: VALID_SPREADSHEET,
       spreadsheet: {

--- a/src/charts.ts
+++ b/src/charts.ts
@@ -505,7 +505,7 @@ const table = (
   const cellHeight = commonProps.fontSize * 2;
   const cellWidth =
     Math.max(...spreadsheet.cells!.flat().map((element) => element.length)) *
-    cellHeight;
+    commonProps.fontSize;
 
   const columns = new Array(numberOfColumns).fill(true).map((_, i) =>
     newLinearElement({

--- a/src/charts.ts
+++ b/src/charts.ts
@@ -507,7 +507,7 @@ const table = (
     Math.max(...spreadsheet.cells!.flat().map((element) => element.length)) *
     cellHeight;
 
-  //can't scale, fix it.
+  // fix csv
   const columns = new Array(numberOfColumns).fill(true).map((_, i) =>
     newLinearElement({
       backgroundColor,
@@ -519,9 +519,10 @@ const table = (
       startArrowhead: null,
       endArrowhead: null,
       strokeWidth: 2,
+      height: cellHeight * (numberOfRows - 1),
       points: [
         [0, 0],
-        [0, cellWidth],
+        [0, cellHeight * (numberOfRows - 1)],
       ],
     }),
   );
@@ -537,9 +538,10 @@ const table = (
       startArrowhead: null,
       endArrowhead: null,
       strokeWidth: 2,
+      width: cellWidth * (numberOfColumns - 1),
       points: [
-        [cellWidth * (numberOfColumns - 1), 0],
         [0, 0],
+        [cellWidth * (numberOfColumns - 1), 0],
       ],
     }),
   );

--- a/src/charts.ts
+++ b/src/charts.ts
@@ -19,7 +19,8 @@ const GRID_OPACITY = 50;
 export interface Spreadsheet {
   title: string | null;
   labels: string[] | null;
-  values: number[];
+  values: number[] | null;
+  cells?: string[][];
 }
 
 export const NOT_SPREADSHEET = "NOT_SPREADSHEET";
@@ -50,7 +51,15 @@ export const tryParseCells = (cells: string[][]): ParseSpreadsheetResult => {
   const numCols = cells[0].length;
 
   if (numCols > 2) {
-    return { type: NOT_SPREADSHEET, reason: "More than 2 columns" };
+    return {
+      type: VALID_SPREADSHEET,
+      spreadsheet: {
+        title: null,
+        labels: null,
+        values: null,
+        cells,
+      },
+    };
   }
 
   if (numCols === 1) {
@@ -127,7 +136,7 @@ export const tryParseSpreadsheet = (text: string): ParseSpreadsheetResult => {
     .map((line) => line.trim().split("\t"));
 
   // Check for comma separated files
-  if (lines.length && lines[0].length !== 2) {
+  if (lines.length && lines[0].includes(",")) {
     lines = text
       .trim()
       .split("\n")
@@ -181,7 +190,7 @@ const commonProps = {
 
 const getChartDimentions = (spreadsheet: Spreadsheet) => {
   const chartWidth =
-    (BAR_WIDTH + BAR_GAP) * spreadsheet.values.length + BAR_GAP;
+    (BAR_WIDTH + BAR_GAP) * spreadsheet.values!.length + BAR_GAP;
   const chartHeight = BAR_HEIGHT + BAR_GAP * 2;
   return { chartWidth, chartHeight };
 };
@@ -235,7 +244,7 @@ const chartYLabels = (
     ...commonProps,
     x: x - BAR_GAP,
     y: y - BAR_HEIGHT - minYLabel.height / 2,
-    text: Math.max(...spreadsheet.values).toLocaleString(),
+    text: Math.max(...spreadsheet.values!).toLocaleString(),
     textAlign: "right",
   });
 
@@ -358,11 +367,11 @@ const chartTypeBar = (
   x: number,
   y: number,
 ): ChartElements => {
-  const max = Math.max(...spreadsheet.values);
+  const max = Math.max(...spreadsheet.values!);
   const groupId = randomId();
   const backgroundColor = bgColors[Math.floor(Math.random() * bgColors.length)];
 
-  const bars = spreadsheet.values.map((value, index) => {
+  const bars = spreadsheet.values!.map((value, index) => {
     const barHeight = (value / max) * BAR_HEIGHT;
     return newElement({
       backgroundColor,
@@ -394,13 +403,13 @@ const chartTypeLine = (
   x: number,
   y: number,
 ): ChartElements => {
-  const max = Math.max(...spreadsheet.values);
+  const max = Math.max(...spreadsheet.values!);
   const groupId = randomId();
   const backgroundColor = bgColors[Math.floor(Math.random() * bgColors.length)];
 
   let index = 0;
   const points = [];
-  for (const value of spreadsheet.values) {
+  for (const value of spreadsheet.values!) {
     const cx = index * (BAR_WIDTH + BAR_GAP);
     const cy = -(value / max) * BAR_HEIGHT;
     points.push([cx, cy]);
@@ -427,7 +436,7 @@ const chartTypeLine = (
     points: points as any,
   });
 
-  const dots = spreadsheet.values.map((value, index) => {
+  const dots = spreadsheet.values!.map((value, index) => {
     const cx = index * (BAR_WIDTH + BAR_GAP) + BAR_GAP / 2;
     const cy = -(value / max) * BAR_HEIGHT + BAR_GAP / 2;
     return newElement({
@@ -444,7 +453,7 @@ const chartTypeLine = (
     });
   });
 
-  const lines = spreadsheet.values.map((value, index) => {
+  const lines = spreadsheet.values!.map((value, index) => {
     const cx = index * (BAR_WIDTH + BAR_GAP) + BAR_GAP / 2;
     const cy = (value / max) * BAR_HEIGHT + BAR_GAP / 2 + BAR_GAP;
     return newLinearElement({
@@ -481,14 +490,81 @@ const chartTypeLine = (
   ];
 };
 
+const table = (
+  spreadsheet: Spreadsheet,
+  x: number,
+  y: number,
+): ChartElements => {
+  const groupId = randomId();
+  const backgroundColor = bgColors[Math.floor(Math.random() * bgColors.length)];
+
+  const numberOfColumns = spreadsheet.cells![0].length + 1;
+  const numberOfRows = spreadsheet.cells!.length + 1;
+  const cellHeight = commonProps.fontSize * 2;
+  const cellWidth =
+    Math.max(...spreadsheet.cells!.flat().map((element) => element.length)) *
+    cellHeight;
+  const columns = new Array(numberOfColumns).fill(true).map((_, i) =>
+    newLinearElement({
+      backgroundColor,
+      groupIds: [groupId],
+      ...commonProps,
+      type: "line",
+      x: x + i * cellWidth,
+      y,
+      startArrowhead: null,
+      endArrowhead: null,
+      strokeWidth: 2,
+      points: [
+        [0, 0],
+        [0, cellWidth],
+      ],
+    }),
+  );
+
+  const rows = new Array(numberOfRows).fill(true).map((_, i) =>
+    newLinearElement({
+      backgroundColor,
+      groupIds: [groupId],
+      ...commonProps,
+      type: "line",
+      x,
+      y: y + i * cellHeight,
+      startArrowhead: null,
+      endArrowhead: null,
+      strokeWidth: 2,
+      points: [
+        [cellWidth * (numberOfColumns - 1), 0],
+        [0, 0],
+      ],
+    }),
+  );
+
+  // to do
+  //can't scale, fix it.
+  const text = newTextElement({
+    ...commonProps,
+    text: "test",
+    x: 0,
+    y: 0,
+    roundness: null,
+    strokeStyle: "solid",
+    textAlign: "center",
+    backgroundColor: "red",
+  });
+
+  return [...(text ? [text] : []), ...columns, ...rows];
+};
+
 export const renderSpreadsheet = (
   chartType: string,
   spreadsheet: Spreadsheet,
   x: number,
   y: number,
 ): ChartElements => {
-  if (chartType === "line") {
-    return chartTypeLine(spreadsheet, x, y);
-  }
-  return chartTypeBar(spreadsheet, x, y);
+  return chartType === "line"
+    ? chartTypeLine(spreadsheet, x, y)
+    : chartType === "bar"
+    ? chartTypeBar(spreadsheet, x, y)
+    : table(spreadsheet, x, y);
 };

--- a/src/charts.ts
+++ b/src/charts.ts
@@ -82,6 +82,7 @@ export const tryParseCells = (cells: string[][]): ParseSpreadsheetResult => {
         title: hasHeader ? cells[0][0] : null,
         labels: null,
         values: values as number[],
+        cells,
       },
     };
   }
@@ -109,6 +110,7 @@ export const tryParseCells = (cells: string[][]): ParseSpreadsheetResult => {
       title: hasHeader ? cells[0][valueColumnIndex] : null,
       labels: rows.map((row) => row[labelColumnIndex]),
       values: rows.map((row) => tryParseNumber(row[valueColumnIndex])!),
+      cells,
     },
   };
 };

--- a/src/components/PasteChartDialog.tsx
+++ b/src/components/PasteChartDialog.tsx
@@ -112,16 +112,26 @@ export const PasteChartDialog = ({
       autofocus={false}
     >
       <div className={"container"}>
+        {appState.pasteDialog.data?.values && (
+          <>
+            <ChartPreviewBtn
+              chartType="bar"
+              spreadsheet={appState.pasteDialog.data}
+              selected={appState.currentChartType === "bar"}
+              onClick={handleChartClick}
+            />
+            <ChartPreviewBtn
+              chartType="line"
+              spreadsheet={appState.pasteDialog.data}
+              selected={appState.currentChartType === "line"}
+              onClick={handleChartClick}
+            />
+          </>
+        )}
         <ChartPreviewBtn
-          chartType="bar"
+          chartType="table"
           spreadsheet={appState.pasteDialog.data}
-          selected={appState.currentChartType === "bar"}
-          onClick={handleChartClick}
-        />
-        <ChartPreviewBtn
-          chartType="line"
-          spreadsheet={appState.pasteDialog.data}
-          selected={appState.currentChartType === "line"}
+          selected={appState.currentChartType === "table"}
           onClick={handleChartClick}
         />
       </div>

--- a/src/element/types.ts
+++ b/src/element/types.ts
@@ -7,7 +7,7 @@ import {
   VERTICAL_ALIGN,
 } from "../constants";
 
-export type ChartType = "bar" | "line";
+export type ChartType = "bar" | "line" | "table";
 export type FillStyle = "hachure" | "cross-hatch" | "solid";
 export type FontFamilyKeys = keyof typeof FONT_FAMILY;
 export type FontFamilyValues = typeof FONT_FAMILY[FontFamilyKeys];

--- a/src/table.test.ts
+++ b/src/table.test.ts
@@ -1,0 +1,46 @@
+import { Spreadsheet, tryParseCells, VALID_SPREADSHEET } from "./charts";
+
+describe("table", () => {
+  const spreadsheet = [
+    ["time", "value1", "value2"],
+    ["01:00", "61", "34"],
+    ["02:00", "-60", "-49"],
+    ["03:00", "85", "44"],
+    ["04:00", "-67", "33"],
+    ["05:00", "54", "-98"],
+    ["06:00", "95", "33"],
+  ];
+  it("Accept more tan tow column as a valid spreadsheet", () => {
+    const result = tryParseCells(spreadsheet);
+    expect(result.type).toBe(VALID_SPREADSHEET);
+  });
+  it("Spreadsheet object must be populated correctly with more than two columns", () => {
+    const result = tryParseCells(spreadsheet) as {
+      type: typeof VALID_SPREADSHEET;
+      spreadsheet: Spreadsheet;
+    };
+    expect(result.spreadsheet.title).toBeNull();
+    expect(result.spreadsheet.labels).toBeNull();
+    expect(result.spreadsheet.values).toBeNull();
+    expect(result.spreadsheet.cells).toEqual(spreadsheet);
+  });
+  it("Spreadsheet object must be populated correctly with two columns", () => {
+    const spreadsheet = [
+      ["time", "value"],
+      ["01:00", "61"],
+      ["02:00", "-60"],
+      ["03:00", "85"],
+      ["04:00", "-67"],
+      ["05:00", "54"],
+      ["06:00", "95"],
+    ];
+    const result = tryParseCells(spreadsheet) as {
+      type: typeof VALID_SPREADSHEET;
+      spreadsheet: Spreadsheet;
+    };
+    expect(result.spreadsheet.title).toBeTruthy();
+    expect(result.spreadsheet.labels).toBeTruthy();
+    expect(result.spreadsheet.values).toBeTruthy();
+    expect(result.spreadsheet.cells).toEqual(spreadsheet);
+  });
+});

--- a/src/tests/__snapshots__/charts.test.tsx.snap
+++ b/src/tests/__snapshots__/charts.test.tsx.snap
@@ -3,6 +3,24 @@
 exports[`tryParseSpreadsheet works for numbers with comma in them 1`] = `
 Object {
   "spreadsheet": Object {
+    "cells": Array [
+      Array [
+        "Week Index",
+        "Users",
+      ],
+      Array [
+        "Week 1",
+        "814",
+      ],
+      Array [
+        "Week 2",
+        "10,301",
+      ],
+      Array [
+        "Week 3",
+        "4,264",
+      ],
+    ],
     "labels": Array [
       "Week 1",
       "Week 2",


### PR DESCRIPTION
- If the user pest a spreadsheet of more than two columns only displays the table button.
- The user can paste a table. 
-  If the user pests a two columns spreadsheet, display the charts and table buttons. 
![1](https://user-images.githubusercontent.com/66743724/213571076-150402a7-8e9f-4e33-91f4-0ea98dfdd10d.jpg)
![2](https://user-images.githubusercontent.com/66743724/213571088-8d23d4f6-70f4-4bb8-b592-0257c78e8468.jpg)
![3](https://user-images.githubusercontent.com/66743724/213571096-f3f765f0-f310-4b6b-ba43-18e78523d03b.jpg)
![4](https://user-images.githubusercontent.com/66743724/213571109-e42641ff-ebaf-4ace-a8cc-734eeefe3143.jpg)
