### PR TITLE
ci(docker): Publish excalidraw docker images to GHCR

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -12,6 +12,12 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+            registry: ghcr.io
+            username: ${{ github.actor }}
+            password: ${{ secrets.GITHUB_TOKEN }}
       - name: Login to DockerHub
         uses: docker/login-action@v2
         with:
@@ -22,4 +28,7 @@ jobs:
         with:
           context: .
           push: true
-          tags: excalidraw/excalidraw:latest
+          tags: |
+            excalidraw/excalidraw:latest
+            ghcr.io/${{ github.repository_owner }}/excalidraw:latest
+

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -15,9 +15,9 @@ jobs:
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         with:
-            registry: ghcr.io
-            username: ${{ github.actor }}
-            password: ${{ secrets.GITHUB_TOKEN }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Login to DockerHub
         uses: docker/login-action@v2
         with:


### PR DESCRIPTION
Hi 👋🏼 Dockerhub has pretty dumb rate limits of 100 pulls/6 hours. It would be great if the image could also be pushed to another docker registry like GHCR, Quay, or ECR.

This PR publishes the image for excalidraw to GHCR.

After a merge and release the docker image will be available for people to use from excalidraw's GHCR packages

https://github.com/orgs/excalidraw/packages

Thanks!