### PR TITLE
fix: declare css variable for font in excalidraw so its available in host

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -167,9 +167,6 @@
       body,
       html {
         margin: 0;
-        --ui-font: Assistant, system-ui, BlinkMacSystemFont, -apple-system,
-          Segoe UI, Roboto, Helvetica, Arial, sans-serif;
-        font-family: var(--ui-font);
         -webkit-text-size-adjust: 100%;
 
         width: 100%;

--- a/src/css/styles.scss
+++ b/src/css/styles.scss
@@ -8,6 +8,10 @@
 }
 
 .excalidraw {
+  --ui-font: Assistant, system-ui, BlinkMacSystemFont, -apple-system, Segoe UI,
+    Roboto, Helvetica, Arial, sans-serif;
+  font-family: var(--ui-font);
+
   position: relative;
   overflow: hidden;
   color: var(--text-primary-color);


### PR DESCRIPTION
Introduced in [editor redesign](https://github.com/excalidraw/excalidraw/pull/5780/files)
Will do a patch release post merge