### PR TITLE
feat: disable canvas smoothing for text and other types

### DIFF
--- a/src/renderer/renderElement.ts
+++ b/src/renderer/renderElement.ts
@@ -989,7 +989,11 @@ export const renderElement = (
           element,
           renderConfig,
         );
+        if (element.type === "text" || element.type === "image") {
+          context.imageSmoothingEnabled = false;
+        }
         drawElementFromCanvas(elementWithCanvas, rc, context, renderConfig);
+        context.imageSmoothingEnabled = true;
       }
       break;
     }


### PR DESCRIPTION
(Proof of concept.)

fix https://github.com/excalidraw/excalidraw/issues/6171

Disables canvas smoothing for `text` and `image`. From testing, it seems to improve text and SVG rendering on small sizes, so it's not blurry.

Technically works for other element types too, but too often the aliasing is too severe. For example, take a look a the library desktop case (leftmost), below.

Smoothing disabled for all element types:

![image](https://user-images.githubusercontent.com/5153846/216312606-cc3853ba-701e-4be4-a066-c879bc75e9c5.png)

Smoothing enabled (production):

![image](https://user-images.githubusercontent.com/5153846/216312612-cdbc31a7-7ffb-47db-a4d9-fb5fc10ced7f.png)

