### PR TITLE
Refactor: Update buttons on the app to use the generic version

### DIFF
--- a/src/actions/actionZindex.tsx
+++ b/src/actions/actionZindex.tsx
@@ -16,6 +16,7 @@ import {
   SendToBackIcon,
 } from "../components/icons";
 import { isDarwin } from "../constants";
+import { Button } from "../components/Button";
 
 export const actionSendBackward = register({
   name: "sendBackward",
@@ -34,14 +35,13 @@ export const actionSendBackward = register({
     !event.shiftKey &&
     event.code === CODES.BRACKET_LEFT,
   PanelComponent: ({ updateData, appState }) => (
-    <button
-      type="button"
+    <Button
+      onSelect={() => updateData(null)}
       className="zIndexButton"
-      onClick={() => updateData(null)}
       title={`${t("labels.sendBackward")} — ${getShortcutKey("CtrlOrCmd+[")}`}
     >
       {SendBackwardIcon}
-    </button>
+    </Button>
   ),
 });
 
@@ -62,14 +62,13 @@ export const actionBringForward = register({
     !event.shiftKey &&
     event.code === CODES.BRACKET_RIGHT,
   PanelComponent: ({ updateData, appState }) => (
-    <button
-      type="button"
+    <Button
+      onSelect={() => updateData(null)}
       className="zIndexButton"
-      onClick={() => updateData(null)}
       title={`${t("labels.bringForward")} — ${getShortcutKey("CtrlOrCmd+]")}`}
     >
       {BringForwardIcon}
-    </button>
+    </Button>
   ),
 });
 
@@ -93,10 +92,9 @@ export const actionSendToBack = register({
         event.shiftKey &&
         event.code === CODES.BRACKET_LEFT,
   PanelComponent: ({ updateData, appState }) => (
-    <button
-      type="button"
+    <Button
+      onSelect={() => updateData(null)}
       className="zIndexButton"
-      onClick={() => updateData(null)}
       title={`${t("labels.sendToBack")} — ${
         isDarwin
           ? getShortcutKey("CtrlOrCmd+Alt+[")
@@ -104,7 +102,7 @@ export const actionSendToBack = register({
       }`}
     >
       {SendToBackIcon}
-    </button>
+    </Button>
   ),
 });
 
@@ -129,10 +127,9 @@ export const actionBringToFront = register({
         event.shiftKey &&
         event.code === CODES.BRACKET_RIGHT,
   PanelComponent: ({ updateData, appState }) => (
-    <button
-      type="button"
+    <Button
+      onSelect={() => updateData(null)}
       className="zIndexButton"
-      onClick={(event) => updateData(null)}
       title={`${t("labels.bringToFront")} — ${
         isDarwin
           ? getShortcutKey("CtrlOrCmd+Alt+]")
@@ -140,6 +137,6 @@ export const actionBringToFront = register({
       }`}
     >
       {BringToFrontIcon}
-    </button>
+    </Button>
   ),
 });

--- a/src/components/Dialog.tsx
+++ b/src/components/Dialog.tsx
@@ -16,6 +16,7 @@ import { AppState } from "../types";
 import { queryFocusableElements } from "../utils";
 import { useSetAtom } from "jotai";
 import { isLibraryMenuOpenAtom } from "./LibraryMenuHeaderContent";
+import { Button } from "./Button";
 
 export interface DialogProps {
   children: React.ReactNode;
@@ -93,14 +94,14 @@ export const Dialog = (props: DialogProps) => {
       <Island ref={setIslandNode}>
         <h2 id={`${id}-dialog-title`} className="Dialog__title">
           <span className="Dialog__titleContent">{props.title}</span>
-          <button
+          <Button
+            onSelect={onClose}
             className="Modal__close"
-            onClick={onClose}
             title={t("buttons.close")}
             aria-label={t("buttons.close")}
           >
             {useDevice().isMobile ? back : CloseIcon}
-          </button>
+          </Button>
         </h2>
         <div className="Dialog__content">{props.children}</div>
       </Island>

--- a/src/components/HelpButton.tsx
+++ b/src/components/HelpButton.tsx
@@ -1,3 +1,4 @@
+import { Button } from "./Button";
 import { HelpIcon } from "./icons";
 
 type HelpButtonProps = {
@@ -8,13 +9,12 @@ type HelpButtonProps = {
 };
 
 export const HelpButton = (props: HelpButtonProps) => (
-  <button
+  <Button
+    onSelect={props.onClick || (() => {})}
     className="help-icon"
-    onClick={props.onClick}
-    type="button"
     title={`${props.title} — ?`}
     aria-label={props.title}
   >
     {HelpIcon}
-  </button>
+  </Button>
 );

--- a/src/components/Sidebar/SidebarHeader.tsx
+++ b/src/components/Sidebar/SidebarHeader.tsx
@@ -6,6 +6,7 @@ import { SidebarPropsContext } from "./common";
 import { CloseIcon, PinIcon } from "../icons";
 import { withUpstreamOverride } from "../hoc/withUpstreamOverride";
 import { Tooltip } from "../Tooltip";
+import { Button } from "../Button";
 
 export const SidebarDockButton = (props: {
   checked: boolean;
@@ -68,14 +69,14 @@ const _SidebarHeader: React.FC<{
             />
           )}
           {renderCloseButton && (
-            <button
-              data-testid="sidebar-close"
+            <Button
+              onSelect={props.onClose || (() => {})}
               className="Sidebar__close-btn"
-              onClick={props.onClose}
+              data-testid="sidebar-close"
               aria-label={t("buttons.close")}
             >
               {CloseIcon}
-            </button>
+            </Button>
           )}
         </div>
       )}

--- a/src/components/dropdownMenu/DropdownMenuTrigger.tsx
+++ b/src/components/dropdownMenu/DropdownMenuTrigger.tsx
@@ -1,5 +1,6 @@
 import clsx from "clsx";
 import { useDevice, useExcalidrawAppState } from "../App";
+import { Button } from "../Button";
 
 const MenuTrigger = ({
   className = "",
@@ -21,15 +22,14 @@ const MenuTrigger = ({
     },
   ).trim();
   return (
-    <button
-      data-prevent-outside-click
+    <Button
+      onSelect={onToggle}
       className={classNames}
-      onClick={onToggle}
-      type="button"
+      data-prevent-outside-click
       data-testid="dropdown-menu-button"
     >
       {children}
-    </button>
+    </Button>
   );
 };
 


### PR DESCRIPTION
This PR refactor buttons throughout the app to use the generic version added with #6092. 

You can check the commit titles for a list of buttons updated:

These are buttons that were not updated (and I'm not sure they should), but I feel like they could.
 - the generic button maintain its size and the text inside gets clipped
   - Exit zen mode
   - Back to content

 - The generic button isn't prepared to receive a `ref`
   - Tool buttons
   - Color pickers

I think I went through all of them. There are a bunch that looks like a button but isn't haha. Anyways, let me know if I missed any.

I noticed the help button isn't being populated with a title properly, might want to create an issue for it if it doesn't exist already.

Closes #6105