### PR TITLE
fix: docker build architecture:linux/amd64 error occur on linux/arm64 instance

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM node:14-alpine AS build
 WORKDIR /opt/node_app
 
 COPY package.json yarn.lock ./
-RUN yarn --ignore-optional
+RUN yarn --ignore-optional --network-timeout 600000
 
 ARG NODE_ENV=production
 


### PR DESCRIPTION
I'm building a docker image on an Oracle ARM A1 instance that supports multiple system architectures, it includes linux/arm64/v8, linux/arm/v7, linux/arm/v6, linux/amd64, when build linux/amd64 image a error will occur causing the build to break.

```bash
$ sudo docker buildx build -t dejavumoe/excalidraw:master --platform=linux/arm/v7,linux/arm64,linux/arm/v6,linux/amd64 .
WARNING: No output specified with docker-container driver. Build result will only remain in the build cache. To push result image into registry use --push or to load image into docker use --load
[+] Building 444.6s (42/45)
 => [internal] load build definition from Dockerfile                                                                                                     0.0s
 => => transferring dockerfile: 361B                                                                                                                     0.0s
 => [internal] load .dockerignore                                                                                                                        0.0s
 => => transferring context: 171B                                                                                                                        0.0s
 => [linux/arm64 internal] load metadata for docker.io/library/nginx:1.21-alpine                                                                        13.2s
 => [linux/arm/v7 internal] load metadata for docker.io/library/nginx:1.21-alpine                                                                       13.0s
 => [linux/arm/v6 internal] load metadata for docker.io/library/nginx:1.21-alpine                                                                       13.0s
 => [linux/arm64 internal] load metadata for docker.io/library/node:14-alpine                                                                           13.0s
 => [linux/arm/v6 internal] load metadata for docker.io/library/node:14-alpine                                                                          13.0s
 => [linux/arm/v7 internal] load metadata for docker.io/library/node:14-alpine                                                                          13.0s
 => [linux/amd64 internal] load metadata for docker.io/library/node:14-alpine                                                                           13.2s
 => [linux/amd64 internal] load metadata for docker.io/library/nginx:1.21-alpine                                                                        13.3s
 => [auth] library/nginx:pull token for registry-1.docker.io                                                                                             0.0s
 => [auth] library/node:pull token for registry-1.docker.io                                                                                              0.0s
 => [linux/arm64 stage-1 1/2] FROM docker.io/library/nginx:1.21-alpine@sha256:a74534e76ee1121d418fa7394ca930eb67440deda413848bc67c68138535b989           5.3s
 => => resolve docker.io/library/nginx:1.21-alpine@sha256:a74534e76ee1121d418fa7394ca930eb67440deda413848bc67c68138535b989                               0.1s
 => => sha256:cf6da50c80867baf982c9b153f9a865d85315cd5ad151e4231464f4431ed56bf 1.39kB / 1.39kB                                                           0.3s
 => => sha256:8afa89adbc3f3f0da9fa8ef7e985fe0b532f7251e7c977a489ee74339a01756b 663B / 663B                                                               0.3s
 => => sha256:a6152c1358d2013d05f6427e35a1143d316e3d6c991a99bd487e51851aa08f6a 894B / 894B                                                               0.3s
 => => sha256:26f2acfc6bd7e4a69b3053d2afc859c9960a28ee8e5d0dabab8b8daf54aaa54c 600B / 600B                                                               0.3s
 => => sha256:bd7696c64f203025c2735d2ef6afa7d98949ae49220c55800945158e318cf88d 7.24MB / 7.24MB                                                           0.3s
 => => sha256:9981e73032c8833e387a8f96986e560edbed12c38119e0edb0439c9c2234eac9 2.72MB / 2.72MB                                                           0.3s
 => => extracting sha256:9981e73032c8833e387a8f96986e560edbed12c38119e0edb0439c9c2234eac9                                                                0.1s
 => => extracting sha256:bd7696c64f203025c2735d2ef6afa7d98949ae49220c55800945158e318cf88d                                                                1.4s
 => => extracting sha256:26f2acfc6bd7e4a69b3053d2afc859c9960a28ee8e5d0dabab8b8daf54aaa54c                                                                0.2s
 => => extracting sha256:a6152c1358d2013d05f6427e35a1143d316e3d6c991a99bd487e51851aa08f6a                                                                0.1s
 => => extracting sha256:8afa89adbc3f3f0da9fa8ef7e985fe0b532f7251e7c977a489ee74339a01756b                                                                0.2s
 => => extracting sha256:cf6da50c80867baf982c9b153f9a865d85315cd5ad151e4231464f4431ed56bf                                                                0.1s
 => [linux/arm64 build 1/6] FROM docker.io/library/node:14-alpine@sha256:2c6a909495ef3761328c10945cbe84c06d079f7ca49dc24271e73be8cab85ad7                5.2s
 => => resolve docker.io/library/node:14-alpine@sha256:2c6a909495ef3761328c10945cbe84c06d079f7ca49dc24271e73be8cab85ad7                                  0.1s
 => => sha256:f700c3735442610243d16f7a52efcc292ded89e094a716120c165453da924dde 445B / 445B                                                               0.2s
 => => sha256:4603e210a2738d975df88848a6721a1d605a6781815f108b19461c190741d19e 2.43MB / 2.43MB                                                           0.3s
 => => sha256:154b990034feb27be7718fffdbf1cc5bd228f75611887616d791bfdc848f79e1 37.78MB / 37.78MB                                                         1.0s
 => => sha256:a9eaa45ef418e883481a13c7d84fa9904f2ec56789c52a87ba5a9e6483f2b74f 3.26MB / 3.26MB                                                           0.4s
 => => extracting sha256:a9eaa45ef418e883481a13c7d84fa9904f2ec56789c52a87ba5a9e6483f2b74f                                                                0.1s
 => => extracting sha256:154b990034feb27be7718fffdbf1cc5bd228f75611887616d791bfdc848f79e1                                                                2.4s
 => => extracting sha256:4603e210a2738d975df88848a6721a1d605a6781815f108b19461c190741d19e                                                                0.3s
 => => extracting sha256:f700c3735442610243d16f7a52efcc292ded89e094a716120c165453da924dde                                                                0.1s
 => [linux/arm/v7 build 1/6] FROM docker.io/library/node:14-alpine@sha256:2c6a909495ef3761328c10945cbe84c06d079f7ca49dc24271e73be8cab85ad7               5.3s
 => => resolve docker.io/library/node:14-alpine@sha256:2c6a909495ef3761328c10945cbe84c06d079f7ca49dc24271e73be8cab85ad7                                  0.1s
 => => sha256:faadd7855b028bda6a656ae70048da2fd3f53c3e8a6ac95c4cbf0bbc4532a434 450B / 450B                                                               0.3s
 => => sha256:2a5e926097b317f0b6fbc9b796fc9a817f3e5e90c0de00e760990f7d1eeb8a7a 2.42MB / 2.42MB                                                           0.7s
 => => sha256:3bc6e7b84af556b5e2569d461a04c5b743c0618fed9a658388acfabc4f2f4c2c 36.51MB / 36.51MB                                                         0.9s
 => => sha256:c527615e4ffa2d5b9b777fd469b3b5ba7c1b1e9201c065be2c43569de48a3754 2.87MB / 2.87MB                                                           0.3s
 => => extracting sha256:c527615e4ffa2d5b9b777fd469b3b5ba7c1b1e9201c065be2c43569de48a3754                                                                0.2s
 => => extracting sha256:3bc6e7b84af556b5e2569d461a04c5b743c0618fed9a658388acfabc4f2f4c2c                                                                2.0s
 => => extracting sha256:2a5e926097b317f0b6fbc9b796fc9a817f3e5e90c0de00e760990f7d1eeb8a7a                                                                0.3s
 => => extracting sha256:faadd7855b028bda6a656ae70048da2fd3f53c3e8a6ac95c4cbf0bbc4532a434                                                                0.1s
 => [linux/arm/v6 build 1/6] FROM docker.io/library/node:14-alpine@sha256:2c6a909495ef3761328c10945cbe84c06d079f7ca49dc24271e73be8cab85ad7               5.2s
 => => resolve docker.io/library/node:14-alpine@sha256:2c6a909495ef3761328c10945cbe84c06d079f7ca49dc24271e73be8cab85ad7                                  0.1s
 => => sha256:e3e68a5fe8e80b3af6b80c362e2aba50e3f3c3b852bfa18f9daef56ae4981719 448B / 448B                                                               0.2s
 => => sha256:6a0a136f415dd94a47c12b3caa58ead5cf30f3dcee54a01ab839fd3df702924a 2.42MB / 2.42MB                                                           0.3s
 => => sha256:63d274a77f96106e54f7d9df19ccdc34ad44fd5258300fedc5d671aa444231b9 36.94MB / 36.94MB                                                         2.0s
 => => sha256:0269c10e600f3a375f36ddabdbd264ce9503a455f0d0969ce8a00f24eaecc032 3.11MB / 3.11MB                                                           0.3s
 => => extracting sha256:0269c10e600f3a375f36ddabdbd264ce9503a455f0d0969ce8a00f24eaecc032                                                                0.1s
 => => extracting sha256:63d274a77f96106e54f7d9df19ccdc34ad44fd5258300fedc5d671aa444231b9                                                                2.3s
 => => extracting sha256:6a0a136f415dd94a47c12b3caa58ead5cf30f3dcee54a01ab839fd3df702924a                                                                0.2s
 => => extracting sha256:e3e68a5fe8e80b3af6b80c362e2aba50e3f3c3b852bfa18f9daef56ae4981719                                                                0.2s
 => [linux/arm/v6 stage-1 1/2] FROM docker.io/library/nginx:1.21-alpine@sha256:a74534e76ee1121d418fa7394ca930eb67440deda413848bc67c68138535b989          6.0s
 => => resolve docker.io/library/nginx:1.21-alpine@sha256:a74534e76ee1121d418fa7394ca930eb67440deda413848bc67c68138535b989                               0.1s
 => => sha256:b8c016abb8aa993824c9a79b21e6822e3f8dd6a2ff902057413c6bc0fa9df59e 1.40kB / 1.40kB                                                           0.9s
 => => sha256:4bcc3cfe0858d9921a06565c0fd0004f89a7e91e0a5c0f779a300d14a15a6700 665B / 665B                                                               0.8s
 => => sha256:1e60f588f149c8cb92d2f71324e4563821f27587f993e77fc46b93cc4614b426 895B / 895B                                                               0.6s
 => => sha256:00908342ca093b91d4c93a78d6edb0369d419f387028eca65bcf82b643177767 603B / 603B                                                               0.3s
 => => sha256:c8bc8ea788d95de069fe03bbe013fec5b4222dfa8299d871272859ec2e6641a1 8.32MB / 8.32MB                                                           0.5s
 => => sha256:c319b1fc4ed70b8241a7ce6ac0c4015d354bf5cf8c01eb73c50b6709c0c46e49 2.62MB / 2.62MB                                                           0.3s
 => => extracting sha256:c319b1fc4ed70b8241a7ce6ac0c4015d354bf5cf8c01eb73c50b6709c0c46e49                                                                0.2s
 => => extracting sha256:c8bc8ea788d95de069fe03bbe013fec5b4222dfa8299d871272859ec2e6641a1                                                                0.4s
 => => extracting sha256:00908342ca093b91d4c93a78d6edb0369d419f387028eca65bcf82b643177767                                                                0.0s
 => => extracting sha256:1e60f588f149c8cb92d2f71324e4563821f27587f993e77fc46b93cc4614b426                                                                0.0s
 => => extracting sha256:4bcc3cfe0858d9921a06565c0fd0004f89a7e91e0a5c0f779a300d14a15a6700                                                                0.0s
 => => extracting sha256:b8c016abb8aa993824c9a79b21e6822e3f8dd6a2ff902057413c6bc0fa9df59e                                                                0.0s
 => [linux/arm/v7 stage-1 1/2] FROM docker.io/library/nginx:1.21-alpine@sha256:a74534e76ee1121d418fa7394ca930eb67440deda413848bc67c68138535b989          6.2s
 => => resolve docker.io/library/nginx:1.21-alpine@sha256:a74534e76ee1121d418fa7394ca930eb67440deda413848bc67c68138535b989                               0.1s
 => => sha256:57990e2a15eac1c83b9e29c5dfda78fd077a498c155da4486c421c44a108fb38 1.40kB / 1.40kB                                                           0.4s
 => => sha256:a27bfc6f3979a31acf1d713dc9ee3314dceae97deffad411a44b95073636d681 663B / 663B                                                               0.2s
 => => sha256:53f1d551ff1eed8114d3864ebd41528396cfc622aa19a5318b6bf483a3e425b4 894B / 894B                                                               0.3s
 => => sha256:a55a014735eb6d166127013d9930b536b60e7324f4e863ec272a620e14cbc3b9 602B / 602B                                                               0.2s
 => => sha256:26676822c338b52c016e8c9b8605134099a4cc61800dcdd2af06de3fed3f43d6 7.64MB / 7.64MB                                                           0.4s
 => => sha256:57fb4b5f1a47c953ca5703f0f81ce14e5d01cf23aa79558b5adb961cc526e320 2.42MB / 2.42MB                                                           0.3s
 => => extracting sha256:57fb4b5f1a47c953ca5703f0f81ce14e5d01cf23aa79558b5adb961cc526e320                                                                0.2s
 => => extracting sha256:26676822c338b52c016e8c9b8605134099a4cc61800dcdd2af06de3fed3f43d6                                                                0.4s
 => => extracting sha256:a55a014735eb6d166127013d9930b536b60e7324f4e863ec272a620e14cbc3b9                                                                0.0s
 => => extracting sha256:53f1d551ff1eed8114d3864ebd41528396cfc622aa19a5318b6bf483a3e425b4                                                                0.0s
 => => extracting sha256:a27bfc6f3979a31acf1d713dc9ee3314dceae97deffad411a44b95073636d681                                                                0.0s
 => => extracting sha256:57990e2a15eac1c83b9e29c5dfda78fd077a498c155da4486c421c44a108fb38                                                                0.0s
 => [linux/amd64 build 1/6] FROM docker.io/library/node:14-alpine@sha256:2c6a909495ef3761328c10945cbe84c06d079f7ca49dc24271e73be8cab85ad7                3.3s
 => => resolve docker.io/library/node:14-alpine@sha256:2c6a909495ef3761328c10945cbe84c06d079f7ca49dc24271e73be8cab85ad7                                  0.1s
 => => sha256:46ee9f8a4f5cb4fe8ab9e578aeee6c244dc183b355e932a4256213b002bd9201 449B / 449B                                                               0.2s
 => => sha256:ab15903128fe352a589737793ec1f8ea0aacf3ac9aced0df80b93d1491f7de90 2.37MB / 2.37MB                                                           0.3s
 => => sha256:859ef990dca35f4997719618b3cd70bfc31c3cdfb29b9f9bf44e985c297ab8f6 37.96MB / 37.96MB                                                         0.8s
 => => sha256:8921db27df2831fa6eaa85321205a2470c669b855f3ec95d5a3c2b46de0442c9 3.37MB / 3.37MB                                                           0.3s
 => => extracting sha256:8921db27df2831fa6eaa85321205a2470c669b855f3ec95d5a3c2b46de0442c9                                                                0.1s
 => => extracting sha256:859ef990dca35f4997719618b3cd70bfc31c3cdfb29b9f9bf44e985c297ab8f6                                                                1.5s
 => => extracting sha256:ab15903128fe352a589737793ec1f8ea0aacf3ac9aced0df80b93d1491f7de90                                                                0.2s
 => => extracting sha256:46ee9f8a4f5cb4fe8ab9e578aeee6c244dc183b355e932a4256213b002bd9201                                                                0.0s
 => [internal] load build context                                                                                                                        0.3s
 => => transferring context: 6.36MB                                                                                                                      0.1s
 => [linux/amd64 stage-1 1/2] FROM docker.io/library/nginx:1.21-alpine@sha256:a74534e76ee1121d418fa7394ca930eb67440deda413848bc67c68138535b989           5.6s
 => => resolve docker.io/library/nginx:1.21-alpine@sha256:a74534e76ee1121d418fa7394ca930eb67440deda413848bc67c68138535b989                               0.1s
 => => sha256:9da77f8e409edbb2c42db3d6a70f31754ac6e35c9ae981555b9f42ea42008a80 1.39kB / 1.39kB                                                           0.3s
 => => sha256:32261d4e220f3a41084ad35886169f9d753ffca4f8824ad934a43b1cddbad86c 664B / 664B                                                               0.4s
 => => sha256:06f5cb628050fa03f0928769c767bba57656e84312961cc39fbff63ae48c2f3e 893B / 893B                                                               0.5s
 => => sha256:e00351ea626cd356c69e58d33181233b47a904d3b6ee508948d6cc221d7b9cfa 603B / 603B                                                               0.7s
 => => sha256:a285f0f83eed13cf71ccb560c31dd31b5eb7be0cadb4f43319d6de59aa4e3c70 7.34MB / 7.34MB                                                           0.9s
 => => sha256:df9b9388f04ad6279a7410b85cedfdcb2208c0a003da7ab5613af71079148139 2.81MB / 2.81MB                                                           1.1s
 => => extracting sha256:df9b9388f04ad6279a7410b85cedfdcb2208c0a003da7ab5613af71079148139                                                                0.3s
 => => extracting sha256:a285f0f83eed13cf71ccb560c31dd31b5eb7be0cadb4f43319d6de59aa4e3c70                                                                0.4s
 => => extracting sha256:e00351ea626cd356c69e58d33181233b47a904d3b6ee508948d6cc221d7b9cfa                                                                0.0s
 => => extracting sha256:06f5cb628050fa03f0928769c767bba57656e84312961cc39fbff63ae48c2f3e                                                                0.1s
 => => extracting sha256:32261d4e220f3a41084ad35886169f9d753ffca4f8824ad934a43b1cddbad86c                                                                0.1s
 => => extracting sha256:9da77f8e409edbb2c42db3d6a70f31754ac6e35c9ae981555b9f42ea42008a80                                                                0.0s
 => [linux/amd64 build 2/6] WORKDIR /opt/node_app                                                                                                        1.4s
 => [linux/amd64 build 3/6] COPY package.json yarn.lock ./                                                                                               0.4s
 => ERROR [linux/amd64 build 4/6] RUN yarn --ignore-optional                                                                                           426.1s
 => [linux/arm/v6 build 2/6] WORKDIR /opt/node_app                                                                                                       0.2s
 => [linux/arm64 build 2/6] WORKDIR /opt/node_app                                                                                                        0.2s
 => [linux/arm/v7 build 2/6] WORKDIR /opt/node_app                                                                                                       0.2s
 => [linux/arm/v6 build 3/6] COPY package.json yarn.lock ./                                                                                              0.2s
 => [linux/arm64 build 3/6] COPY package.json yarn.lock ./                                                                                               0.2s
 => [linux/arm/v7 build 3/6] COPY package.json yarn.lock ./                                                                                              0.2s
 => [linux/arm/v6 build 4/6] RUN yarn --ignore-optional                                                                                                161.2s
 => [linux/arm64 build 4/6] RUN yarn --ignore-optional                                                                                                 111.9s
 => [linux/arm/v7 build 4/6] RUN yarn --ignore-optional                                                                                                108.2s
 => [linux/arm/v7 build 5/6] COPY . .                                                                                                                    1.0s
 => [linux/arm/v7 build 6/6] RUN yarn build:app:docker                                                                                                 164.1s
 => [linux/arm64 build 5/6] COPY . .                                                                                                                     1.0s
 => [linux/arm64 build 6/6] RUN yarn build:app:docker                                                                                                  165.6s
 => [linux/arm/v6 build 5/6] COPY . .                                                                                                                    0.9s
 => [linux/arm/v6 build 6/6] RUN yarn build:app:docker                                                                                                 209.5s
 => [linux/arm/v7 stage-1 2/2] COPY --from=build /opt/node_app/build /usr/share/nginx/html                                                               0.1s
 => [linux/arm64 stage-1 2/2] COPY --from=build /opt/node_app/build /usr/share/nginx/html                                                                0.1s
 => [linux/arm/v6 stage-1 2/2] COPY --from=build /opt/node_app/build /usr/share/nginx/html                                                               0.1s
------
 > [linux/amd64 build 4/6] RUN yarn --ignore-optional:
#0 3.900 yarn install v1.22.19
#0 6.344 [1/5] Validating package.json...
#0 6.387 [2/5] Resolving packages...
#0 20.39 [3/5] Fetching packages...
#0 120.2 info There appears to be trouble with your network connection. Retrying...
#0 185.7 info There appears to be trouble with your network connection. Retrying...
#0 239.7 info There appears to be trouble with your network connection. Retrying...
#0 299.9 info There appears to be trouble with your network connection. Retrying...
#0 360.7 error An unexpected error occurred: "https://registry.yarnpkg.com/@firebase/firestore/-/firestore-2.2.3.tgz: ESOCKETTIMEDOUT".
#0 360.7 info If you think this is a bug, please open a bug report with the information provided in "/opt/node_app/yarn-error.log".
#0 360.7 info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
------
Dockerfile:6
--------------------
   4 |
   5 |     COPY package.json yarn.lock ./
   6 | >>> RUN yarn --ignore-optional
   7 |
   8 |     ARG NODE_ENV=production
--------------------
ERROR: failed to solve: process "/bin/sh -c yarn --ignore-optional" did not complete successfully: exit code: 1
```

I just I just add a parameter to the yarn to prevent build failures due to timeouts, it does not affect the process of building Docker images for other architectures