### PR TITLE
fix: provide HelpButton title prop

### DIFF
--- a/src/components/HelpButton.tsx
+++ b/src/components/HelpButton.tsx
@@ -1,7 +1,7 @@
+import { t } from "../i18n";
 import { HelpIcon } from "./icons";
 
 type HelpButtonProps = {
-  title?: string;
   name?: string;
   id?: string;
   onClick?(): void;
@@ -12,8 +12,8 @@ export const HelpButton = (props: HelpButtonProps) => (
     className="help-icon"
     onClick={props.onClick}
     type="button"
-    title={`${props.title} — ?`}
-    aria-label={props.title}
+    title={`${t("helpDialog.title")} — ?`}
+    aria-label={t("helpDialog.title")}
   >
     {HelpIcon}
   </button>

--- a/src/components/footer/Footer.tsx
+++ b/src/components/footer/Footer.tsx
@@ -1,7 +1,6 @@
 import clsx from "clsx";
 import { actionShortcuts } from "../../actions";
 import { ActionManager } from "../../actions/manager";
-import { t } from "../../i18n";
 import { AppState } from "../../types";
 import {
   ExitZenModeAction,
@@ -81,7 +80,6 @@ const Footer = ({
           {renderWelcomeScreen && <welcomeScreenHelpHintTunnel.Out />}
           <HelpButton
             onClick={() => actionManager.executeAction(actionShortcuts)}
-            title={t("helpDialog.title")}
           />
         </div>
       </div>

--- a/src/components/footer/Footer.tsx
+++ b/src/components/footer/Footer.tsx
@@ -1,6 +1,7 @@
 import clsx from "clsx";
 import { actionShortcuts } from "../../actions";
 import { ActionManager } from "../../actions/manager";
+import { t } from "../../i18n";
 import { AppState } from "../../types";
 import {
   ExitZenModeAction,
@@ -80,6 +81,7 @@ const Footer = ({
           {renderWelcomeScreen && <welcomeScreenHelpHintTunnel.Out />}
           <HelpButton
             onClick={() => actionManager.executeAction(actionShortcuts)}
+            title={t("helpDialog.title")}
           />
         </div>
       </div>


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/40431124/217766284-900d2a14-5592-4ecb-823b-e373403d1a8b.png)
After:
![image](https://user-images.githubusercontent.com/40431124/217766297-6cae98c8-bfc3-418b-92d4-63f6a3f7c19d.png)

`helpDialog.title` locale attribute seemed to be used when the word "Help" was used, so I didn't create a new attribute.
