### PR TITLE
fix: Add title to HelpButton so title does not render undefined

### DIFF
--- a/src/components/footer/Footer.tsx
+++ b/src/components/footer/Footer.tsx
@@ -1,6 +1,7 @@
 import clsx from "clsx";
 import { actionShortcuts } from "../../actions";
 import { ActionManager } from "../../actions/manager";
+import { t } from "../../i18n";
 import { AppState } from "../../types";
 import {
   ExitZenModeAction,
@@ -79,6 +80,7 @@ const Footer = ({
         <div style={{ position: "relative" }}>
           {renderWelcomeScreen && <welcomeScreenHelpHintTunnel.Out />}
           <HelpButton
+            title={t("helpDialog.title")}
             onClick={() => actionManager.executeAction(actionShortcuts)}
           />
         </div>


### PR DESCRIPTION
Fixes the `undefined -- ?` in the tooltip when hovering over the `<HelpButton />` in the `<Footer />` component.

Before:
![image](https://user-images.githubusercontent.com/11301291/219013228-24bcbc7f-394f-40f9-a304-7671485448f3.png)

After:
![image](https://user-images.githubusercontent.com/11301291/219013151-6fd80c41-7afe-4fd2-8d81-99ece609eccd.png)


It has been added in this commit https://github.com/excalidraw/excalidraw/commit/40d53d9231a7d814a8e9d672626f972147a50986#diff-c096857ee8ce97499b45a56c3d9bc8d9cc0e0a9c25ce378eb10a235a7dddf900R92 

and then removed in the following commit https://github.com/excalidraw/excalidraw/pull/6048/files#diff-c096857ee8ce97499b45a56c3d9bc8d9cc0e0a9c25ce378eb10a235a7dddf900L92
