### PR TITLE
fix: indenting via `tab` clashing with IME compositor

### DIFF
--- a/src/element/textWysiwyg.tsx
+++ b/src/element/textWysiwyg.tsx
@@ -463,7 +463,7 @@ export const textWysiwyg = ({
           event.code === CODES.BRACKET_RIGHT))
     ) {
       event.preventDefault();
-      if (getLanguage().code === "ja-JP") {
+      if (event.isComposing) {
         return;
       } else if (event.shiftKey || event.code === CODES.BRACKET_LEFT) {
         outdent();

--- a/src/element/textWysiwyg.tsx
+++ b/src/element/textWysiwyg.tsx
@@ -41,7 +41,6 @@ import App from "../components/App";
 import { getMaxContainerHeight, getMaxContainerWidth } from "./newElement";
 import { LinearElementEditor } from "./linearElementEditor";
 import { parseClipboard } from "../clipboard";
-import { getLanguage } from "../i18n";
 
 const getTransform = (
   width: number,

--- a/src/element/textWysiwyg.tsx
+++ b/src/element/textWysiwyg.tsx
@@ -41,6 +41,7 @@ import App from "../components/App";
 import { getMaxContainerHeight, getMaxContainerWidth } from "./newElement";
 import { LinearElementEditor } from "./linearElementEditor";
 import { parseClipboard } from "../clipboard";
+import { getLanguage } from "../i18n";
 
 const getTransform = (
   width: number,
@@ -463,7 +464,9 @@ export const textWysiwyg = ({
           event.code === CODES.BRACKET_RIGHT))
     ) {
       event.preventDefault();
-      if (event.shiftKey || event.code === CODES.BRACKET_LEFT) {
+      if (getLanguage().code === "ja-JP") {
+        return;
+      } else if (event.shiftKey || event.code === CODES.BRACKET_LEFT) {
         outdent();
       } else {
         indent();


### PR DESCRIPTION
ref: Japanese text input with tab key doesn't work properly #6218

# Situation
Enter Japanese and press the tab key.

# Current issue
When the tab key is pressed and auto correct by the IME is performed, the word entered remains and the input result is [the word entered] + [the auto correct word].

# Modifications
- ~~This phenomenon seemed to occur when the outdent or indent method was executed, so I changed it so that the outdent or indent method is not executed if the current language code is "ja-JP"
I don't think it is necessary to adjust indentation with tabs for Japanese input IMO.~~

- check event.isComposing and if it is true, it will not adjust indentation.


![test](https://user-images.githubusercontent.com/57059705/219846738-8e20feef-3a7f-41d3-8551-4558553404b8.gif)



