### PR TITLE
fix: compute container height from bound text correctly

### DIFF
--- a/src/element/textElement.test.ts
+++ b/src/element/textElement.test.ts
@@ -258,7 +258,7 @@ describe("Test measureText", () => {
         type: "ellipse",
         ...params,
       });
-      expect(computeContainerHeightForBoundText(element, 150)).toEqual(212);
+      expect(computeContainerHeightForBoundText(element, 150)).toEqual(226);
     });
 
     it("should compute container height correctly for diamond", () => {
@@ -266,7 +266,7 @@ describe("Test measureText", () => {
         type: "diamond",
         ...params,
       });
-      expect(computeContainerHeightForBoundText(element, 150)).toEqual(300);
+      expect(computeContainerHeightForBoundText(element, 150)).toEqual(320);
     });
   });
 

--- a/src/element/textElement.ts
+++ b/src/element/textElement.ts
@@ -757,13 +757,15 @@ export const computeContainerHeightForBoundText = (
   boundTextElementHeight: number,
 ) => {
   if (container.type === "ellipse") {
-    return Math.round((boundTextElementHeight / Math.sqrt(2)) * 2);
+    return Math.round(
+      ((boundTextElementHeight + BOUND_TEXT_PADDING * 2) / Math.sqrt(2)) * 2,
+    );
   }
   if (isArrowElement(container)) {
     return boundTextElementHeight + BOUND_TEXT_PADDING * 8 * 2;
   }
   if (container.type === "diamond") {
-    return 2 * boundTextElementHeight;
+    return 2 * (boundTextElementHeight + BOUND_TEXT_PADDING * 2);
   }
   return boundTextElementHeight + BOUND_TEXT_PADDING * 2;
 };

--- a/src/element/textElement.ts
+++ b/src/element/textElement.ts
@@ -280,6 +280,8 @@ export const getApproxLineHeight = (font: FontString) => {
     return cacheApproxLineHeight[font];
   }
   const fontSize = parseInt(font);
+
+  // Calculate line height relative to font size
   cacheApproxLineHeight[font] = fontSize * 1.2;
   return cacheApproxLineHeight[font];
 };

--- a/src/tests/clipboard.test.tsx
+++ b/src/tests/clipboard.test.tsx
@@ -182,3 +182,73 @@ describe("paste text as a single element", () => {
     });
   });
 });
+
+describe("Paste bound text container", () => {
+  const container = {
+    type: "ellipse",
+    id: "container-id",
+    x: 554.984375,
+    y: 196.0234375,
+    width: 166,
+    height: 187.01953125,
+    roundness: { type: 2 },
+    boundElements: [{ type: "text", id: "text-id" }],
+  };
+  const textElement = {
+    type: "text",
+    id: "text-id",
+    x: 560.51171875,
+    y: 202.033203125,
+    width: 154,
+    height: 175,
+    fontSize: 20,
+    fontFamily: 1,
+    text: "Excalidraw is a\nvirtual \nopensource \nwhiteboard for \nsketching \nhand-drawn like\ndiagrams",
+    baseline: 168,
+    textAlign: "center",
+    verticalAlign: "middle",
+    containerId: container.id,
+    originalText:
+      "Excalidraw is a virtual opensource whiteboard for sketching hand-drawn like diagrams",
+  };
+
+  it("should fix ellipse bounding box", async () => {
+    const data = JSON.stringify({
+      type: "excalidraw/clipboard",
+      elements: [container, textElement],
+    });
+    setClipboardText(data);
+    pasteWithCtrlCmdShiftV();
+
+    await waitFor(async () => {
+      await sleep(1);
+      expect(h.elements.length).toEqual(2);
+      const container = h.elements[0];
+      expect(container.height).toBe(354);
+      expect(container.width).toBe(166);
+    });
+  });
+
+  it("should fix diamond bounding box", async () => {
+    const data = JSON.stringify({
+      type: "excalidraw/clipboard",
+      elements: [
+        {
+          ...container,
+          type: "diamond",
+        },
+        textElement,
+      ],
+    });
+    setClipboardText(data);
+    pasteWithCtrlCmdShiftV();
+
+    await waitFor(async () => {
+      await sleep(1);
+      expect(h.elements.length).toEqual(2);
+      const container = h.elements[0];
+      expect(container.height).toBe(740);
+      expect(container.width).toBe(166);
+    });
+  });
+});


### PR DESCRIPTION
Pasting an older version of element (Rhombus and Ellipse) before text wrapping was fixed led to one extra edit to fix.

Try pasting below in the prod vs this PR. It was due to height being incorrectly computed (padding wasn't considered hence the extra edit).

```
{"type":"excalidraw/clipboard","elements":[{"id":"zrR8vTKGuH_E7uEOkF2pF","type":"ellipse","x":555.23046875,"y":196.0234375,"width":166,"height":187.01953125,"angle":0,"strokeColor":"#000000","backgroundColor":"transparent","fillStyle":"hachure","strokeWidth":1,"strokeStyle":"solid","roughness":1,"opacity":100,"groupIds":[],"roundness":{"type":2},"seed":733356165,"version":38,"versionNonce":1100933963,"isDeleted":false,"boundElements":[{"type":"text","id":"6_ZlMG6ID0xNDNkjanOuw"}],"updated":1677139260395,"link":null,"locked":false},{"id":"6_ZlMG6ID0xNDNkjanOuw","type":"text","x":560.7578125,"y":202.033203125,"width":154,"height":175,"angle":0,"strokeColor":"#000000","backgroundColor":"transparent","fillStyle":"hachure","strokeWidth":1,"strokeStyle":"solid","roughness":1,"opacity":100,"groupIds":[],"roundness":null,"seed":310534219,"version":90,"versionNonce":1552974565,"isDeleted":false,"boundElements":null,"updated":1677139260395,"link":null,"locked":false,"text":"dlasdl;asdsads\nd ad asd as \ndsadsadasdsa\ndasdsadsadas\ndasdsadsdada\nsdasdsadasdsa\ndadad","fontSize":20,"fontFamily":1,"textAlign":"center","verticalAlign":"middle","baseline":168,"containerId":"zrR8vTKGuH_E7uEOkF2pF","originalText":"dlasdl;asdsadsd ad asd as dsadsadasdsadasdsadsadasdasdsadsdadasdasdsadasdsadadad"},{"id":"3df_r4YqsZHn63z_kV6fi","type":"diamond","x":830.69921875,"y":206.5,"width":176.46484375,"height":187.42578125,"angle":0,"strokeColor":"#000000","backgroundColor":"transparent","fillStyle":"hachure","strokeWidth":1,"strokeStyle":"solid","roughness":1,"opacity":100,"groupIds":[],"roundness":{"type":2},"seed":721223883,"version":40,"versionNonce":1423526379,"isDeleted":false,"boundElements":[{"type":"text","id":"R_JSRNZ8td7omit04OqZO"}],"updated":1677139260395,"link":null,"locked":false},{"id":"R_JSRNZ8td7omit04OqZO","type":"text","x":836.931640625,"y":225.212890625,"width":164,"height":150,"angle":0,"strokeColor":"#000000","backgroundColor":"transparent","fillStyle":"hachure","strokeWidth":1,"strokeStyle":"solid","roughness":1,"opacity":100,"groupIds":[],"roundness":null,"seed":2024444939,"version":89,"versionNonce":2007555653,"isDeleted":false,"boundElements":null,"updated":1677139260395,"link":null,"locked":false,"text":"dskjdkljasldsadk\nsadajsdksajdjas\nldjaldjkalsjdksalj\ndasjkdlasdasda\nsdasdsadasdas\ndasd","fontSize":20,"fontFamily":1,"textAlign":"center","verticalAlign":"middle","baseline":143,"containerId":"3df_r4YqsZHn63z_kV6fi","originalText":"dskjdkljasldsadksadajsdksajdjasldjaldjkalsjdksaljdasjkdlasdasdasdasdsadasdasdasd"}],"files":{}}
```

Tried adding a e2e test for this but to due `measureText` being tricky to mock, I am not adding the test in this PR, once https://github.com/excalidraw/excalidraw/pull/6187 is merged I will add in that PR

EDIT
Added the test as the PR was merged
