### PR TITLE
feat: Change "Ajudar" to "Ajuda" in helpDialog of src/locales/pt-BR.json

### DIFF
--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -312,7 +312,7 @@
     "shortcuts": "Atalhos de teclado",
     "textFinish": "Encerrar edição (editor de texto)",
     "textNewLine": "Adicionar nova linha (editor de texto)",
-    "title": "Ajudar",
+    "title": "Ajuda",
     "view": "Visualizar",
     "zoomToFit": "Ampliar para encaixar todos os elementos",
     "zoomToSelection": "Ampliar a seleção",


### PR DESCRIPTION
Context: In the menu we have an option "help" that in the portuguese version looks like this:

![image](https://user-images.githubusercontent.com/66224956/221596077-13191699-7a6f-4487-a673-b65c18d6d8fa.png)

But, in Brazilian portuguese (pt-BR) the word "Ajuda" makes more sense in this context since "Ajuda" is a noun and "Ajudar" is a verb.

As is, it can be interpreted as "Help excalidraw" and not "If you need help, click here"

The modifications in this PR look up to change this word into the expected result below, and I think the best way was by updating `src/locales/pt-BR.json` file.
![image](https://user-images.githubusercontent.com/66224956/221597438-f881b86b-e143-47d7-b239-619737627b4f.png)
![image](https://user-images.githubusercontent.com/66224956/221597542-c2b76f01-4c0d-4433-908d-62a250de08f1.png)

If it doesn't make sense, I'm happy to hear why - And if I need to change other parts of the code, please let me know!