### PR TITLE
fix: disable scaling bound text when using shift resize

### DIFF
--- a/src/element/resizeElements.ts
+++ b/src/element/resizeElements.ts
@@ -195,15 +195,8 @@ const measureFontSizeFromWidth = (
   nextWidth: number,
 ): number | null => {
   // We only use width to scale font on resize
-  let width = element.width;
+  const width = element.width;
 
-  const hasContainer = isBoundToContainer(element);
-  if (hasContainer) {
-    const container = getContainerElement(element);
-    if (container) {
-      width = getMaxContainerWidth(container);
-    }
-  }
   const nextFontSize = element.fontSize * (nextWidth / width);
   if (nextFontSize < MIN_FONT_SIZE) {
     return null;
@@ -414,29 +407,11 @@ export const resizeSingleElement = (
         fontSize: stateOfBoundTextElementAtResize.fontSize,
       };
     }
-    if (shouldMaintainAspectRatio) {
-      const updatedElement = {
-        ...element,
-        width: eleNewWidth,
-        height: eleNewHeight,
-      };
 
-      const nextFontSize = measureFontSizeFromWidth(
-        boundTextElement,
-        getMaxContainerWidth(updatedElement),
-      );
-      if (nextFontSize === null) {
-        return;
-      }
-      boundTextFont = {
-        fontSize: nextFontSize,
-      };
-    } else {
-      const minWidth = getApproxMinLineWidth(getFontString(boundTextElement));
-      const minHeight = getApproxMinLineHeight(getFontString(boundTextElement));
-      eleNewWidth = Math.ceil(Math.max(eleNewWidth, minWidth));
-      eleNewHeight = Math.ceil(Math.max(eleNewHeight, minHeight));
-    }
+    const minWidth = getApproxMinLineWidth(getFontString(boundTextElement));
+    const minHeight = getApproxMinLineHeight(getFontString(boundTextElement));
+    eleNewWidth = Math.ceil(Math.max(eleNewWidth, minWidth));
+    eleNewHeight = Math.ceil(Math.max(eleNewHeight, minHeight));
   }
 
   const [newBoundsX1, newBoundsY1, newBoundsX2, newBoundsY2] =


### PR DESCRIPTION
To align with other Apps like Miro, Whimiscal, Tldraw, Canva - for bound text containers the font size is not scaled when resizing (with/without shift) however for some of the apps when using sticky note tool the font size is scaled for resizing.

So since we have bound text containers - I am disabling scaling font size when using shift+resize