### PR TITLE
feat: create bound container from text

### DIFF
--- a/src/actions/actionBoundText.tsx
+++ b/src/actions/actionBoundText.tsx
@@ -18,8 +18,6 @@ import {
 } from "../element/textWysiwyg";
 import {
   hasBoundTextElement,
-  isArrowElement,
-  isLinearElement,
   isTextBindableContainer,
   isUsingAdaptiveRadius,
 } from "../element/typeChecks";

--- a/src/actions/actionBoundText.tsx
+++ b/src/actions/actionBoundText.tsx
@@ -139,27 +139,46 @@ export const actionBindText = register({
     redrawTextBoundingBox(textElement, container);
 
     return {
-      elements: adjustZIndexForContainer(elements, textElement, container.id),
+      elements: pushTextAboveContainer(elements, container, textElement),
       appState: { ...appState, selectedElementIds: { [container.id]: true } },
       commitToHistory: true,
     };
   },
 });
 
-const adjustZIndexForContainer = (
+const pushTextAboveContainer = (
   elements: readonly ExcalidrawElement[],
+  container: ExcalidrawElement,
   textElement: ExcalidrawTextElement,
-  containerId: string,
 ) => {
   const updatedElements = elements.slice();
   const textElementIndex = updatedElements.findIndex(
     (ele) => ele.id === textElement.id,
   );
   updatedElements.splice(textElementIndex, 1);
+
   const containerIndex = updatedElements.findIndex(
-    (ele) => ele.id === containerId,
+    (ele) => ele.id === container.id,
   );
   updatedElements.splice(containerIndex + 1, 0, textElement);
+  return updatedElements;
+};
+
+const pushContainerBelowText = (
+  elements: readonly ExcalidrawElement[],
+  container: ExcalidrawElement,
+  textElement: ExcalidrawTextElement,
+) => {
+  const updatedElements = elements.slice();
+  const containerIndex = updatedElements.findIndex(
+    (ele) => ele.id === container.id,
+  );
+  updatedElements.splice(containerIndex, 1);
+
+  const textElementIndex = updatedElements.findIndex(
+    (ele) => ele.id === textElement.id,
+  );
+  updatedElements.splice(textElementIndex, 0, container);
   return updatedElements;
 };
 
@@ -218,10 +237,10 @@ export const actionCreateContainerFromText = register({
       redrawTextBoundingBox(textElement, container);
 
       return {
-        elements: adjustZIndexForContainer(
+        elements: pushContainerBelowText(
           [...elements, container],
+          container,
           textElement,
-          container.id,
         ),
         appState: {
           ...appState,

--- a/src/actions/actionBoundText.tsx
+++ b/src/actions/actionBoundText.tsx
@@ -228,6 +228,7 @@ export const actionCreateContainerFromText = register({
           textElement.height,
           "rectangle",
         ),
+        groupIds: textElement.groupIds,
       });
       mutateElement(textElement, {
         containerId: container.id,

--- a/src/actions/actionBoundText.tsx
+++ b/src/actions/actionBoundText.tsx
@@ -20,6 +20,7 @@ import {
 import {
   hasBoundTextElement,
   isTextBindableContainer,
+  isUsingAdaptiveRadius,
 } from "../element/typeChecks";
 import {
   ExcalidrawElement,
@@ -189,7 +190,14 @@ export const actionCreateContainerFromText = register({
         roughness: appState.currentItemRoughness,
         strokeWidth: appState.currentItemStrokeWidth,
         strokeStyle: appState.currentItemStrokeStyle,
-        roundness: { type: ROUNDNESS.PROPORTIONAL_RADIUS },
+        roundness:
+          appState.currentItemRoundness === "round"
+            ? {
+                type: isUsingAdaptiveRadius("rectangle")
+                  ? ROUNDNESS.ADAPTIVE_RADIUS
+                  : ROUNDNESS.PROPORTIONAL_RADIUS,
+              }
+            : null,
         opacity: 100,
         locked: false,
         x: textElement.x - BOUND_TEXT_PADDING,

--- a/src/actions/actionBoundText.tsx
+++ b/src/actions/actionBoundText.tsx
@@ -7,8 +7,7 @@ import {
 import { getNonDeletedElements, isTextElement, newElement } from "../element";
 import { mutateElement } from "../element/mutateElement";
 import {
-  computeContainerHeightForBoundText,
-  computeContainerWidthForBoundText,
+  computeContainerDimensionForBoundText,
   getBoundTextElement,
   measureText,
   redrawTextBoundingBox,
@@ -202,11 +201,11 @@ export const actionCreateContainerFromText = register({
         locked: false,
         x: textElement.x - BOUND_TEXT_PADDING,
         y: textElement.y - BOUND_TEXT_PADDING,
-        width: computeContainerWidthForBoundText(
+        width: computeContainerDimensionForBoundText(
           textElement.width,
           "rectangle",
         ),
-        height: computeContainerHeightForBoundText(
+        height: computeContainerDimensionForBoundText(
           textElement.height,
           "rectangle",
         ),

--- a/src/actions/types.ts
+++ b/src/actions/types.ts
@@ -113,7 +113,8 @@ export type ActionName =
   | "toggleLock"
   | "toggleLinearEditor"
   | "toggleEraserTool"
-  | "toggleHandTool";
+  | "toggleHandTool"
+  | "createContainerFromText";
 
 export type PanelComponentProps = {
   elements: readonly ExcalidrawElement[];

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -284,6 +284,7 @@ import { actionPaste } from "../actions/actionClipboard";
 import { actionToggleHandTool } from "../actions/actionCanvas";
 import { jotaiStore } from "../jotai";
 import { activeConfirmDialogAtom } from "./ActiveConfirmDialog";
+import { actionCreateContainerFromText } from "../actions/actionBoundText";
 
 const deviceContextInitialValue = {
   isSmScreen: false,
@@ -6237,6 +6238,7 @@ class App extends React.Component<AppProps, AppState> {
       actionGroup,
       actionUnbindText,
       actionBindText,
+      actionCreateContainerFromText,
       actionUngroup,
       CONTEXT_MENU_SEPARATOR,
       actionAddToLibrary,

--- a/src/element/textElement.test.ts
+++ b/src/element/textElement.test.ts
@@ -1,7 +1,7 @@
 import { BOUND_TEXT_PADDING } from "../constants";
 import { API } from "../tests/helpers/api";
 import {
-  computeContainerHeightForBoundText,
+  computeContainerDimensionForBoundText,
   getContainerCoords,
   getMaxContainerWidth,
   getMaxContainerHeight,
@@ -214,7 +214,7 @@ describe("Test measureText", () => {
     });
   });
 
-  describe("Test computeContainerHeightForBoundText", () => {
+  describe("Test computeContainerDimensionForBoundText", () => {
     const params = {
       width: 178,
       height: 194,
@@ -225,7 +225,7 @@ describe("Test measureText", () => {
         type: "rectangle",
         ...params,
       });
-      expect(computeContainerHeightForBoundText(150, element.type)).toEqual(
+      expect(computeContainerDimensionForBoundText(150, element.type)).toEqual(
         160,
       );
     });
@@ -235,7 +235,7 @@ describe("Test measureText", () => {
         type: "ellipse",
         ...params,
       });
-      expect(computeContainerHeightForBoundText(150, element.type)).toEqual(
+      expect(computeContainerDimensionForBoundText(150, element.type)).toEqual(
         226,
       );
     });
@@ -245,7 +245,7 @@ describe("Test measureText", () => {
         type: "diamond",
         ...params,
       });
-      expect(computeContainerHeightForBoundText(150, element.type)).toEqual(
+      expect(computeContainerDimensionForBoundText(150, element.type)).toEqual(
         320,
       );
     });

--- a/src/element/textElement.test.ts
+++ b/src/element/textElement.test.ts
@@ -225,7 +225,9 @@ describe("Test measureText", () => {
         type: "rectangle",
         ...params,
       });
-      expect(computeContainerHeightForBoundText(element, 150)).toEqual(160);
+      expect(computeContainerHeightForBoundText(150, element.type)).toEqual(
+        160,
+      );
     });
 
     it("should compute container height correctly for ellipse", () => {
@@ -233,7 +235,9 @@ describe("Test measureText", () => {
         type: "ellipse",
         ...params,
       });
-      expect(computeContainerHeightForBoundText(element, 150)).toEqual(226);
+      expect(computeContainerHeightForBoundText(150, element.type)).toEqual(
+        226,
+      );
     });
 
     it("should compute container height correctly for diamond", () => {
@@ -241,7 +245,9 @@ describe("Test measureText", () => {
         type: "diamond",
         ...params,
       });
-      expect(computeContainerHeightForBoundText(element, 150)).toEqual(320);
+      expect(computeContainerHeightForBoundText(150, element.type)).toEqual(
+        320,
+      );
     });
   });
 

--- a/src/element/textElement.test.ts
+++ b/src/element/textElement.test.ts
@@ -35,10 +35,11 @@ describe("Test wrapText", () => {
 
   describe("When text doesn't contain new lines", () => {
     const text = "Hello whats up";
+
     [
       {
         desc: "break all words when width of each word is less than container width",
-        width: 90,
+        width: 80,
         res: `Hello 
 whats 
 up`,
@@ -62,7 +63,7 @@ p`,
       {
         desc: "break words as per the width",
 
-        width: 150,
+        width: 140,
         res: `Hello whats 
 up`,
       },
@@ -93,7 +94,7 @@ whats up`;
     [
       {
         desc: "break all words when width of each word is less than container width",
-        width: 90,
+        width: 80,
         res: `Hello
 whats 
 up`,

--- a/src/element/textElement.ts
+++ b/src/element/textElement.ts
@@ -320,7 +320,6 @@ export const wrapText = (text: string, font: FontString, maxWidth: number) => {
   const lines: Array<string> = [];
   const originalLines = text.split("\n");
   const spaceWidth = getLineWidth(" ", font);
-
   const push = (str: string) => {
     if (str.trim()) {
       lines.push(str);
@@ -725,6 +724,7 @@ export const computeContainerHeightForBoundText = (
   boundTextElementHeight: number,
   containerType: typeof VALID_CONTAINER_TYPES[number],
 ) => {
+  boundTextElementHeight = Math.round(boundTextElementHeight);
   if (containerType === "ellipse") {
     return Math.round(
       ((boundTextElementHeight + BOUND_TEXT_PADDING * 2) / Math.sqrt(2)) * 2,
@@ -743,6 +743,7 @@ export const computeContainerWidthForBoundText = (
   boundTextElementWidth: number,
   containerType: typeof VALID_CONTAINER_TYPES[number],
 ) => {
+  boundTextElementWidth = Math.round(boundTextElementWidth);
   if (containerType === "ellipse") {
     return Math.round(
       ((boundTextElementWidth + BOUND_TEXT_PADDING * 2) / Math.sqrt(2)) * 2,

--- a/src/element/textElement.ts
+++ b/src/element/textElement.ts
@@ -717,14 +717,12 @@ const VALID_CONTAINER_TYPES = new Set([
   "arrow",
 ]);
 
-export type ValidContainerType<T> = T extends Set<infer U> ? U : never;
-
 export const isValidTextContainer = (element: ExcalidrawElement) =>
   VALID_CONTAINER_TYPES.has(element.type);
 
 export const computeContainerDimensionForBoundText = (
   dimension: number,
-  containerType: ValidContainerType<typeof VALID_CONTAINER_TYPES>,
+  containerType: ExtractSetType<typeof VALID_CONTAINER_TYPES>,
 ) => {
   dimension = Math.ceil(dimension);
   const padding = BOUND_TEXT_PADDING * 2;

--- a/src/element/textElement.ts
+++ b/src/element/textElement.ts
@@ -393,7 +393,7 @@ export const wrapText = (text: string, font: FontString, maxWidth: number) => {
           const word = words[index];
           currentLineWidthTillNow = getLineWidth(currentLine + word, font);
 
-          if (currentLineWidthTillNow >= maxWidth) {
+          if (currentLineWidthTillNow > maxWidth) {
             push(currentLine);
             currentLineWidthTillNow = 0;
             currentLine = "";

--- a/src/element/textElement.ts
+++ b/src/element/textElement.ts
@@ -724,7 +724,7 @@ export const computeContainerHeightForBoundText = (
   boundTextElementHeight: number,
   containerType: typeof VALID_CONTAINER_TYPES[number],
 ) => {
-  boundTextElementHeight = Math.round(boundTextElementHeight);
+  boundTextElementHeight = Math.ceil(boundTextElementHeight);
   if (containerType === "ellipse") {
     return Math.round(
       ((boundTextElementHeight + BOUND_TEXT_PADDING * 2) / Math.sqrt(2)) * 2,
@@ -743,7 +743,7 @@ export const computeContainerWidthForBoundText = (
   boundTextElementWidth: number,
   containerType: typeof VALID_CONTAINER_TYPES[number],
 ) => {
-  boundTextElementWidth = Math.round(boundTextElementWidth);
+  boundTextElementWidth = Math.ceil(boundTextElementWidth);
   if (containerType === "ellipse") {
     return Math.round(
       ((boundTextElementWidth + BOUND_TEXT_PADDING * 2) / Math.sqrt(2)) * 2,

--- a/src/element/textElement.ts
+++ b/src/element/textElement.ts
@@ -12,11 +12,7 @@ import { BOUND_TEXT_PADDING, TEXT_ALIGN, VERTICAL_ALIGN } from "../constants";
 import { MaybeTransformHandleType } from "./transformHandles";
 import Scene from "../scene/Scene";
 import { isTextElement } from ".";
-import {
-  isBoundToContainer,
-  isImageElement,
-  isArrowElement,
-} from "./typeChecks";
+import { isBoundToContainer, isArrowElement } from "./typeChecks";
 import { LinearElementEditor } from "./linearElementEditor";
 import { AppState } from "../types";
 import { isTextBindableContainer } from "./typeChecks";

--- a/src/element/textElement.ts
+++ b/src/element/textElement.ts
@@ -85,8 +85,8 @@ export const redrawTextBoundingBox = (
       let nextHeight = containerDims.height;
       if (metrics.height > maxContainerHeight) {
         nextHeight = computeContainerHeightForBoundText(
-          container,
           metrics.height,
+          container.type,
         );
         mutateElement(container, { height: nextHeight });
         maxContainerHeight = getMaxContainerHeight(container);
@@ -189,8 +189,8 @@ export const handleBindTextResize = (
     // increase height in case text element height exceeds
     if (nextHeight > maxHeight) {
       containerHeight = computeContainerHeightForBoundText(
-        container,
         nextHeight,
+        container.type,
       );
 
       const diff = containerHeight - containerDims.height;
@@ -714,32 +714,51 @@ export const getTextBindableContainerAtPosition = (
   return isTextBindableContainer(hitElement, false) ? hitElement : null;
 };
 
-export const isValidTextContainer = (element: ExcalidrawElement) => {
-  return (
-    element.type === "rectangle" ||
-    element.type === "ellipse" ||
-    element.type === "diamond" ||
-    isImageElement(element) ||
-    isArrowElement(element)
-  );
-};
+const VALID_CONTAINER_TYPES = [
+  "rectangle",
+  "ellipse",
+  "diamond",
+  "image",
+  "arrow",
+];
+
+export const isValidTextContainer = (element: ExcalidrawElement) =>
+  VALID_CONTAINER_TYPES.includes(element.type);
 
 export const computeContainerHeightForBoundText = (
-  container: NonDeletedExcalidrawElement,
   boundTextElementHeight: number,
+  containerType: typeof VALID_CONTAINER_TYPES[number],
 ) => {
-  if (container.type === "ellipse") {
+  if (containerType === "ellipse") {
     return Math.round(
       ((boundTextElementHeight + BOUND_TEXT_PADDING * 2) / Math.sqrt(2)) * 2,
     );
   }
-  if (isArrowElement(container)) {
+  if (containerType === "arrow") {
     return boundTextElementHeight + BOUND_TEXT_PADDING * 8 * 2;
   }
-  if (container.type === "diamond") {
+  if (containerType === "diamond") {
     return 2 * (boundTextElementHeight + BOUND_TEXT_PADDING * 2);
   }
   return boundTextElementHeight + BOUND_TEXT_PADDING * 2;
+};
+
+export const computeContainerWidthForBoundText = (
+  boundTextElementWidth: number,
+  containerType: typeof VALID_CONTAINER_TYPES[number],
+) => {
+  if (containerType === "ellipse") {
+    return Math.round(
+      ((boundTextElementWidth + BOUND_TEXT_PADDING * 2) / Math.sqrt(2)) * 2,
+    );
+  }
+  if (containerType === "arrow") {
+    return boundTextElementWidth + BOUND_TEXT_PADDING * 8 * 2;
+  }
+  if (containerType === "diamond") {
+    return 2 * (boundTextElementWidth + BOUND_TEXT_PADDING * 2);
+  }
+  return boundTextElementWidth + BOUND_TEXT_PADDING * 2;
 };
 
 export const getMaxContainerWidth = (container: ExcalidrawElement) => {

--- a/src/element/textElement.ts
+++ b/src/element/textElement.ts
@@ -709,53 +709,54 @@ export const getTextBindableContainerAtPosition = (
   return isTextBindableContainer(hitElement, false) ? hitElement : null;
 };
 
-const VALID_CONTAINER_TYPES = [
+const VALID_CONTAINER_TYPES = new Set([
   "rectangle",
   "ellipse",
   "diamond",
   "image",
   "arrow",
-];
+]);
+
+export type ValidContainerType<T> = T extends Set<infer U> ? U : never;
 
 export const isValidTextContainer = (element: ExcalidrawElement) =>
-  VALID_CONTAINER_TYPES.includes(element.type);
+  VALID_CONTAINER_TYPES.has(element.type);
 
 export const computeContainerHeightForBoundText = (
   boundTextElementHeight: number,
-  containerType: typeof VALID_CONTAINER_TYPES[number],
+  containerType: ValidContainerType<typeof VALID_CONTAINER_TYPES>,
 ) => {
   boundTextElementHeight = Math.ceil(boundTextElementHeight);
+  const padding = BOUND_TEXT_PADDING * 2;
+
   if (containerType === "ellipse") {
-    return Math.round(
-      ((boundTextElementHeight + BOUND_TEXT_PADDING * 2) / Math.sqrt(2)) * 2,
-    );
+    return Math.round(((boundTextElementHeight + padding) / Math.sqrt(2)) * 2);
   }
   if (containerType === "arrow") {
-    return boundTextElementHeight + BOUND_TEXT_PADDING * 8 * 2;
+    return boundTextElementHeight + padding * 8;
   }
   if (containerType === "diamond") {
-    return 2 * (boundTextElementHeight + BOUND_TEXT_PADDING * 2);
+    return 2 * (boundTextElementHeight + padding);
   }
-  return boundTextElementHeight + BOUND_TEXT_PADDING * 2;
+  return boundTextElementHeight + padding;
 };
 
 export const computeContainerWidthForBoundText = (
   boundTextElementWidth: number,
-  containerType: typeof VALID_CONTAINER_TYPES[number],
+  containerType: ValidContainerType<typeof VALID_CONTAINER_TYPES>,
 ) => {
   boundTextElementWidth = Math.ceil(boundTextElementWidth);
+  const padding = BOUND_TEXT_PADDING * 2;
   if (containerType === "ellipse") {
-    return Math.round(
-      ((boundTextElementWidth + BOUND_TEXT_PADDING * 2) / Math.sqrt(2)) * 2,
-    );
+    return Math.round(((boundTextElementWidth + padding) / Math.sqrt(2)) * 2);
   }
   if (containerType === "arrow") {
-    return boundTextElementWidth + BOUND_TEXT_PADDING * 8 * 2;
+    return boundTextElementWidth + padding * 8;
   }
   if (containerType === "diamond") {
-    return 2 * (boundTextElementWidth + BOUND_TEXT_PADDING * 2);
+    return 2 * (boundTextElementWidth + padding);
   }
-  return boundTextElementWidth + BOUND_TEXT_PADDING * 2;
+  return boundTextElementWidth + padding;
 };
 
 export const getMaxContainerWidth = (container: ExcalidrawElement) => {

--- a/src/element/textElement.ts
+++ b/src/element/textElement.ts
@@ -80,7 +80,7 @@ export const redrawTextBoundingBox = (
 
       let nextHeight = containerDims.height;
       if (metrics.height > maxContainerHeight) {
-        nextHeight = computeContainerHeightForBoundText(
+        nextHeight = computeContainerDimensionForBoundText(
           metrics.height,
           container.type,
         );
@@ -184,7 +184,7 @@ export const handleBindTextResize = (
     }
     // increase height in case text element height exceeds
     if (nextHeight > maxHeight) {
-      containerHeight = computeContainerHeightForBoundText(
+      containerHeight = computeContainerDimensionForBoundText(
         nextHeight,
         container.type,
       );
@@ -722,41 +722,23 @@ export type ValidContainerType<T> = T extends Set<infer U> ? U : never;
 export const isValidTextContainer = (element: ExcalidrawElement) =>
   VALID_CONTAINER_TYPES.has(element.type);
 
-export const computeContainerHeightForBoundText = (
-  boundTextElementHeight: number,
+export const computeContainerDimensionForBoundText = (
+  dimension: number,
   containerType: ValidContainerType<typeof VALID_CONTAINER_TYPES>,
 ) => {
-  boundTextElementHeight = Math.ceil(boundTextElementHeight);
+  dimension = Math.ceil(dimension);
   const padding = BOUND_TEXT_PADDING * 2;
 
   if (containerType === "ellipse") {
-    return Math.round(((boundTextElementHeight + padding) / Math.sqrt(2)) * 2);
+    return Math.round(((dimension + padding) / Math.sqrt(2)) * 2);
   }
   if (containerType === "arrow") {
-    return boundTextElementHeight + padding * 8;
+    return dimension + padding * 8;
   }
   if (containerType === "diamond") {
-    return 2 * (boundTextElementHeight + padding);
+    return 2 * (dimension + padding);
   }
-  return boundTextElementHeight + padding;
-};
-
-export const computeContainerWidthForBoundText = (
-  boundTextElementWidth: number,
-  containerType: ValidContainerType<typeof VALID_CONTAINER_TYPES>,
-) => {
-  boundTextElementWidth = Math.ceil(boundTextElementWidth);
-  const padding = BOUND_TEXT_PADDING * 2;
-  if (containerType === "ellipse") {
-    return Math.round(((boundTextElementWidth + padding) / Math.sqrt(2)) * 2);
-  }
-  if (containerType === "arrow") {
-    return boundTextElementWidth + padding * 8;
-  }
-  if (containerType === "diamond") {
-    return 2 * (boundTextElementWidth + padding);
-  }
-  return boundTextElementWidth + padding;
+  return dimension + padding;
 };
 
 export const getMaxContainerWidth = (container: ExcalidrawElement) => {

--- a/src/element/textWysiwyg.test.tsx
+++ b/src/element/textWysiwyg.test.tsx
@@ -19,6 +19,8 @@ import { API } from "../tests/helpers/api";
 import { mutateElement } from "./mutateElement";
 import { resize } from "../tests/utils";
 import { getOriginalContainerHeightFromCache } from "./textWysiwyg";
+import { getTextWidth, wrapText } from "./textElement";
+import { getFontString } from "../utils";
 // Unmount ReactDOM from root
 ReactDOM.unmountComponentAtNode(document.getElementById("root")!);
 
@@ -1306,6 +1308,79 @@ describe("textWysiwyg", () => {
           ]
         `);
       });
+    });
+
+    it("should wrap text in a container when wrap text in container triggered from context menu", async () => {
+      UI.clickTool("text");
+      mouse.clickAt(20, 30);
+      const editor = document.querySelector(
+        ".excalidraw-textEditorContainer > textarea",
+      ) as HTMLTextAreaElement;
+
+      fireEvent.change(editor, {
+        target: {
+          value: "Excalidraw is an opensource virtual collaborative whiteboard",
+        },
+      });
+
+      editor.dispatchEvent(new Event("input"));
+      await new Promise((cb) => setTimeout(cb, 0));
+      editor.blur();
+      expect(h.elements[1].width).toBe(600);
+      expect(h.elements[1].height).toBe(24);
+      expect((h.elements[1] as ExcalidrawTextElement).text).toBe(
+        "Excalidraw is an opensource virtual collaborative whiteboard",
+      );
+
+      API.setSelectedElements([h.elements[1]]);
+
+      fireEvent.contextMenu(GlobalTestState.canvas, {
+        button: 2,
+        clientX: 20,
+        clientY: 30,
+      });
+
+      const contextMenu = document.querySelector(".context-menu");
+      fireEvent.click(
+        queryByText(contextMenu as HTMLElement, "Wrap text in a container")!,
+      );
+      expect(h.elements.length).toBe(3);
+
+      expect(h.elements[1]).toEqual(
+        expect.objectContaining({
+          angle: 0,
+          backgroundColor: "transparent",
+          boundElements: [
+            {
+              id: h.elements[2].id,
+              type: "text",
+            },
+          ],
+          fillStyle: "hachure",
+          groupIds: [],
+          height: 34,
+          isDeleted: false,
+          link: null,
+          locked: false,
+          opacity: 100,
+          roughness: 1,
+          roundness: {
+            type: 3,
+          },
+          strokeColor: "#000000",
+          strokeStyle: "solid",
+          strokeWidth: 1,
+          type: "rectangle",
+          updated: 1,
+          version: 1,
+          width: 610,
+          x: 15,
+          y: 25,
+        }),
+      );
+      expect((h.elements[2] as ExcalidrawTextElement).text).toBe(
+        "Excalidraw is an opensource virtual collaborative whiteboard",
+      );
     });
   });
 });

--- a/src/element/textWysiwyg.test.tsx
+++ b/src/element/textWysiwyg.test.tsx
@@ -19,8 +19,7 @@ import { API } from "../tests/helpers/api";
 import { mutateElement } from "./mutateElement";
 import { resize } from "../tests/utils";
 import { getOriginalContainerHeightFromCache } from "./textWysiwyg";
-import { getTextWidth, wrapText } from "./textElement";
-import { getFontString } from "../utils";
+
 // Unmount ReactDOM from root
 ReactDOM.unmountComponentAtNode(document.getElementById("root")!);
 

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -165,3 +165,5 @@ declare module "image-blob-reduce" {
   const reduce: ImageBlobReduce.ImageBlobReduceStatic;
   export = reduce;
 }
+
+type ExtractSetType<T extends Set<any>> = T extends Set<infer U> ? U : never;

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -110,6 +110,7 @@
     "increaseFontSize": "Increase font size",
     "unbindText": "Unbind text",
     "bindText": "Bind text to the container",
+    "createContainerFromText": "Create Container from text",
     "link": {
       "edit": "Edit link",
       "create": "Create link",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -110,7 +110,7 @@
     "increaseFontSize": "Increase font size",
     "unbindText": "Unbind text",
     "bindText": "Bind text to the container",
-    "createContainerFromText": "Create Container from text",
+    "createContainerFromText": "Wrap text in a container",
     "link": {
       "edit": "Edit link",
       "create": "Create link",

--- a/src/tests/__snapshots__/contextmenu.test.tsx.snap
+++ b/src/tests/__snapshots__/contextmenu.test.tsx.snap
@@ -120,6 +120,15 @@ Object {
         },
       },
       Object {
+        "contextItemLabel": "labels.createContainerFromText",
+        "name": "createContainerFromText",
+        "perform": [Function],
+        "predicate": [Function],
+        "trackEvent": Object {
+          "category": "element",
+        },
+      },
+      Object {
         "PanelComponent": [Function],
         "contextItemLabel": "labels.ungroup",
         "keyTest": [Function],
@@ -4508,6 +4517,15 @@ Object {
         },
       },
       Object {
+        "contextItemLabel": "labels.createContainerFromText",
+        "name": "createContainerFromText",
+        "perform": [Function],
+        "predicate": [Function],
+        "trackEvent": Object {
+          "category": "element",
+        },
+      },
+      Object {
         "PanelComponent": [Function],
         "contextItemLabel": "labels.ungroup",
         "keyTest": [Function],
@@ -5042,6 +5060,15 @@ Object {
       Object {
         "contextItemLabel": "labels.bindText",
         "name": "bindText",
+        "perform": [Function],
+        "predicate": [Function],
+        "trackEvent": Object {
+          "category": "element",
+        },
+      },
+      Object {
+        "contextItemLabel": "labels.createContainerFromText",
+        "name": "createContainerFromText",
         "perform": [Function],
         "predicate": [Function],
         "trackEvent": Object {
@@ -5889,6 +5916,15 @@ Object {
         },
       },
       Object {
+        "contextItemLabel": "labels.createContainerFromText",
+        "name": "createContainerFromText",
+        "perform": [Function],
+        "predicate": [Function],
+        "trackEvent": Object {
+          "category": "element",
+        },
+      },
+      Object {
         "PanelComponent": [Function],
         "contextItemLabel": "labels.ungroup",
         "keyTest": [Function],
@@ -6219,6 +6255,15 @@ Object {
       Object {
         "contextItemLabel": "labels.bindText",
         "name": "bindText",
+        "perform": [Function],
+        "predicate": [Function],
+        "trackEvent": Object {
+          "category": "element",
+        },
+      },
+      Object {
+        "contextItemLabel": "labels.createContainerFromText",
+        "name": "createContainerFromText",
         "perform": [Function],
         "predicate": [Function],
         "trackEvent": Object {


### PR DESCRIPTION
closes https://github.com/excalidraw/excalidraw/issues/5670


https://user-images.githubusercontent.com/11256141/222403703-6bc4f5b2-826f-43ce-a683-41823e7f43c8.mp4

- [x] Add tests
- [x] There was a corner case where when splitting words, and if they add up to exact `max width` it was still splitting it, that's fixed now.
eg max width of container = 100
The text is "Hello world there"
Width of world + there = 100 still it will split it was splitting it to `Hello\nWorld\nthere`
- [x] consider groups
- [x] consider bindings
