### PR TITLE
refactor: :recycle: wrapText

### DIFF
--- a/src/element/textElement.ts
+++ b/src/element/textElement.ts
@@ -360,22 +360,15 @@ const breakLine = (line: string, font: FontString, maxWidth: number) => {
     ) {
       lastLineWidth += wordWidth;
       lines[lines.length - 1] += word;
+      if (lastLineWidth > maxWidth) {
+        lines[lines.length - 1] = removeTrailingSpaces(
+          lines[lines.length - 1],
+          lastLineWidth,
+          maxWidth,
+          spaceWidth,
+        );
+      }
       return; // next word
-    }
-
-    if (lastLineWidth > maxWidth) {
-      // if the method that draw the text is refactored, this code must be removed
-      // remove trailing spaces
-      const spacesToRemove = Math.ceil((lastLineWidth - maxWidth) / spaceWidth);
-      lines[lines.length - 1] = lines[lines.length - 1].slice(
-        0,
-        -spacesToRemove,
-      );
-    }
-    // remove previous line if only has spaces
-    if (lines.length > 0 && lines[lines.length - 1].trim().length === 0) {
-      // if the method that draw the text is refactored, this code must be removed
-      lines.splice(-1);
     }
 
     if (
@@ -388,8 +381,35 @@ const breakLine = (line: string, font: FontString, maxWidth: number) => {
     }
 
     lastLineWidth = getLineWidth(lines[lines.length - 1], font);
+
+    if (lastLineWidth > maxWidth) {
+      lines[lines.length - 1] = removeTrailingSpaces(
+        lines[lines.length - 1],
+        lastLineWidth,
+        maxWidth,
+        spaceWidth,
+      );
+    }
+    // remove previous line if only has spaces
+    if (lines.length > 0 && lines[lines.length - 1].trim().length === 0) {
+      // if the method that draw the text is refactored, this code must be removed
+      lines.splice(-1);
+    }
+
+    lastLineWidth = getLineWidth(lines[lines.length - 1], font);
   });
   return lines;
+};
+
+// if the method that draw the text is refactored, this code must be removed
+const removeTrailingSpaces = (
+  line: string,
+  lastLineWidth: number,
+  maxWidth: number,
+  spaceWidth: number,
+) => {
+  const spacesToRemove = Math.ceil((lastLineWidth - maxWidth) / spaceWidth);
+  return line.slice(0, -spacesToRemove);
 };
 
 const breakWord = (word: string, font: FontString, maxWidth: number) => {

--- a/src/element/textElement.ts
+++ b/src/element/textElement.ts
@@ -339,21 +339,7 @@ const splitLineInWords = (line: string): Array<string> => {
 };
 
 const breakLine = (line: string, font: FontString, maxWidth: number) => {
-  const words = splitLineInWords(line).reduce(
-    // flatMap is so slow
-    (array: Array<string>, word: string) => {
-      if (
-        getLineWidth(word.trim(), font) <= maxWidth ||
-        Array.from(word.trim()).length === 1
-      ) {
-        array.push(word);
-      } else {
-        array.push(...breakWord(word, font, maxWidth));
-      }
-      return array;
-    },
-    [],
-  );
+  const words = splitLineInWords(line);
   const lines: Array<string> = [];
   let lastLineWidth = 0;
   const spaceWidth = getLineWidth(" ", font);
@@ -374,7 +360,6 @@ const breakLine = (line: string, font: FontString, maxWidth: number) => {
     ) {
       lastLineWidth += wordWidth;
       lines[lines.length - 1] += word;
-
       return; // next word
     }
 
@@ -393,8 +378,16 @@ const breakLine = (line: string, font: FontString, maxWidth: number) => {
       lines.splice(-1);
     }
 
-    lastLineWidth = wordWidth;
-    lines.push(word);
+    if (
+      wordWithoutTrailingSpaces.length <= 1 ||
+      getLineWidth(wordWithoutTrailingSpaces, font) <= maxWidth
+    ) {
+      lines.push(word);
+    } else {
+      lines.push(...breakWord(word, font, maxWidth));
+    }
+
+    lastLineWidth = getLineWidth(lines[lines.length - 1], font);
   });
   return lines;
 };
@@ -409,7 +402,7 @@ const breakWord = (word: string, font: FontString, maxWidth: number) => {
       return;
     }
     const widthWithLastLine = getLineWidth(
-      wordSections[wordSections.length - 1] + symbol.trimEnd(),
+      wordSections[wordSections.length - 1] + symbol,
       font,
     );
 

--- a/src/element/textElement.ts
+++ b/src/element/textElement.ts
@@ -416,22 +416,17 @@ const breakWord = (word: string, font: FontString, maxWidth: number) => {
   const trimmedWord = word.trimEnd();
   const symbols = Array.from(trimmedWord);
   const wordSections: Array<string> = [];
+  let lastWordWidth = 0;
   symbols.forEach((symbol) => {
+    const currentCharWidth = charWidth.calculate(symbol, font);
     if (wordSections.length === 0) {
       wordSections.push(symbol);
+      lastWordWidth = currentCharWidth;
       return;
     }
-    const widthWithLastLine = getLineWidth(
-      wordSections[wordSections.length - 1] + symbol,
-      font,
-    );
-
+    const widthWithLastLine = lastWordWidth + currentCharWidth;
     // fits in wordSection above
-    if (
-      widthWithLastLine <= maxWidth ||
-      widthWithLastLine <=
-        getLineWidth(wordSections[wordSections.length - 1], font)
-    ) {
+    if (widthWithLastLine <= maxWidth || widthWithLastLine <= lastWordWidth) {
       wordSections[wordSections.length - 1] += symbol;
       return; // next word
     }

--- a/src/element/textElement.ts
+++ b/src/element/textElement.ts
@@ -360,7 +360,10 @@ const breakLine = (line: string, font: FontString, maxWidth: number) => {
     ) {
       lastLineWidth += wordWidth;
       lines[lines.length - 1] += word;
-      if (lastLineWidth > maxWidth) {
+      if (
+        lastLineWidth > maxWidth &&
+        lines[lines.length - 1].slice(-1) === " "
+      ) {
         lines[lines.length - 1] = removeTrailingSpaces(
           lines[lines.length - 1],
           lastLineWidth,
@@ -382,7 +385,7 @@ const breakLine = (line: string, font: FontString, maxWidth: number) => {
 
     lastLineWidth = getLineWidth(lines[lines.length - 1], font);
 
-    if (lastLineWidth > maxWidth) {
+    if (lastLineWidth > maxWidth && lines[lines.length - 1].slice(-1) === " ") {
       lines[lines.length - 1] = removeTrailingSpaces(
         lines[lines.length - 1],
         lastLineWidth,
@@ -390,13 +393,14 @@ const breakLine = (line: string, font: FontString, maxWidth: number) => {
         spaceWidth,
       );
     }
+
+    lastLineWidth = getLineWidth(lines[lines.length - 1], font);
+
     // remove previous line if only has spaces
     if (lines.length > 0 && lines[lines.length - 1].trim().length === 0) {
       // if the method that draw the text is refactored, this code must be removed
       lines.splice(-1);
     }
-
-    lastLineWidth = getLineWidth(lines[lines.length - 1], font);
   });
   return lines;
 };
@@ -408,7 +412,11 @@ const removeTrailingSpaces = (
   maxWidth: number,
   spaceWidth: number,
 ) => {
-  const spacesToRemove = Math.ceil((lastLineWidth - maxWidth) / spaceWidth);
+  const spacesToRemove = Math.min(
+    Math.ceil((lastLineWidth - maxWidth) / spaceWidth),
+    line.length - line.trimEnd().length,
+  );
+
   return line.slice(0, -spacesToRemove);
 };
 
@@ -427,6 +435,7 @@ const breakWord = (word: string, font: FontString, maxWidth: number) => {
     const widthWithLastLine = lastWordWidth + currentCharWidth;
     // fits in wordSection above
     if (widthWithLastLine <= maxWidth || widthWithLastLine <= lastWordWidth) {
+      lastWordWidth = widthWithLastLine;
       wordSections[wordSections.length - 1] += symbol;
       return; // next word
     }

--- a/src/element/textElement.ts
+++ b/src/element/textElement.ts
@@ -323,12 +323,14 @@ export const getTextHeight = (text: string, font: FontString) => {
 export const wrapText = (text: string, font: FontString, maxWidth: number) => {
   return text
     .split("\n")
-    .flatMap((line) => {
-      // break big lines
-      return getLineWidth(line.trimEnd(), font) <= maxWidth
-        ? line
-        : breakLine(line, font, maxWidth);
-    })
+    .reduce((array: Array<string>, line: string) => {
+      if (getLineWidth(line, font) <= maxWidth) {
+        array.push(line);
+      } else {
+        array.push(...breakLine(line, font, maxWidth));
+      }
+      return array;
+    }, [])
     .join("\n");
 };
 
@@ -337,13 +339,21 @@ const splitLineInWords = (line: string): Array<string> => {
 };
 
 const breakLine = (line: string, font: FontString, maxWidth: number) => {
-  const words = splitLineInWords(line).flatMap((word) => {
-    // break big words
-    return getLineWidth(word.trim(), font) <= maxWidth ||
-      Array.from(word.trim()).length === 1
-      ? word
-      : breakWord(word, font, maxWidth);
-  });
+  const words = splitLineInWords(line).reduce(
+    // flatMap is so slow
+    (array: Array<string>, word: string) => {
+      if (
+        getLineWidth(word.trim(), font) <= maxWidth ||
+        Array.from(word.trim()).length === 1
+      ) {
+        array.push(word);
+      } else {
+        array.push(...breakWord(word, font, maxWidth));
+      }
+      return array;
+    },
+    [],
+  );
   const lines: Array<string> = [];
   let lastLineWidth = 0;
   const spaceWidth = getLineWidth(" ", font);

--- a/src/element/textElement.ts
+++ b/src/element/textElement.ts
@@ -363,22 +363,26 @@ const breakLine = (line: string, font: FontString, maxWidth: number) => {
       lastLineWidth + wordWidthWithoutTrailingSpaces <= maxWidth
     ) {
       lastLineWidth += wordWidth;
-
-      if (lastLineWidth > maxWidth) {
-        // if the method that draw the text is refactored, this code must be removed
-        // remove trailing spaces
-        const spacesToRemove = Math.ceil(
-          (lastLineWidth - maxWidth) / spaceWidth,
-        );
-        word = word.slice(0, -spacesToRemove);
-      }
       lines[lines.length - 1] += word;
+
       return; // next word
+    }
+
+    if (lastLineWidth > maxWidth) {
+      // if the method that draw the text is refactored, this code must be removed
+      // remove trailing spaces
+      const spacesToRemove = Math.ceil((lastLineWidth - maxWidth) / spaceWidth);
+      lines[lines.length - 1] = lines[lines.length - 1].slice(
+        0,
+        -spacesToRemove,
+      );
     }
     // remove previous line if only has spaces
     if (lines.length > 0 && lines[lines.length - 1].trim().length === 0) {
+      // if the method that draw the text is refactored, this code must be removed
       lines.splice(-1);
     }
+
     lastLineWidth = wordWidth;
     lines.push(word);
   });


### PR DESCRIPTION
wrapText refactor

- [x] Refactoring for better readability
- [x] Check and update tests (only if is necessary)
- [x] Improve performance

___

About the tests, i think that is necessary redefine them (like i did on the original PR), for example:

**current test:**
Test wrapText › When text contain new lines › should respect new lines and break all words when width of each word is less than container width
**for this input:**
```
Hello
whats up
```
**and this width:**
`90 (80 without padding)`
**the current expected result is:**
```
Hello
whats
up
```
**But, if each letter has width of 10, then:**
```
Hello = 50
whats = 50
 (space) = 10
up = 20
```
**then:**
`whats + (space) + up = 50 + 10 + 20 = 80`
`80 <= 80 = true!`
**the correct result must be:**
```
Hello
whats up
```
(that is my result)
