### PR TITLE
fix: compute bounding box correctly for text element when multiple element resizing

### DIFF
--- a/src/element/resizeElements.ts
+++ b/src/element/resizeElements.ts
@@ -693,7 +693,9 @@ const resizeMultipleElements = (
       };
       const fontSize = measureFontSizeFromWidth(
         boundTextElement ?? (element.orig as ExcalidrawTextElement),
-        getMaxContainerWidth(updatedElement),
+        boundTextElement
+          ? getMaxContainerWidth(updatedElement)
+          : updatedElement.width,
       );
 
       if (!fontSize) {


### PR DESCRIPTION
fixes https://github.com/excalidraw/excalidraw/issues/6306