### PR TITLE
fix: text wrapping issue

### DIFF
--- a/src/element/textWysiwyg.tsx
+++ b/src/element/textWysiwyg.tsx
@@ -277,6 +277,9 @@ export const textWysiwyg = ({
         // As firefox, Safari needs little higher dimensions on DOM
         textElementWidth += 0.5;
       }
+      const magicOffset = excalidrawContainer
+        ? parseFloat(getComputedStyle(excalidrawContainer).fontSize)
+        : 16;
       // Make sure text editor height doesn't go beyond viewport
       const editorMaxHeight =
         (appState.height - viewportY) / appState.zoom.value;
@@ -284,9 +287,9 @@ export const textWysiwyg = ({
         font: getFontString(updatedTextElement),
         // must be defined *after* font ¯\_(ツ)_/¯
         lineHeight: `${lineHeight}px`,
-        width: `${textElementWidth}px`,
+        width: `${textElementWidth+magicOffset*2}px`,
         height: `${textElementHeight}px`,
-        left: `${viewportX}px`,
+        left: `${viewportX-magicOffset}px`,
         top: `${viewportY}px`,
         transform: getTransform(
           textElementWidth,

--- a/src/element/textWysiwyg.tsx
+++ b/src/element/textWysiwyg.tsx
@@ -347,7 +347,7 @@ export const textWysiwyg = ({
     boxSizing: "content-box",
   });
 
-  const magicOffset = 
+  const magicOffset =
     (excalidrawContainer
       ? parseFloat(getComputedStyle(excalidrawContainer).fontSize)
       : 16) / 16;

--- a/src/element/textWysiwyg.tsx
+++ b/src/element/textWysiwyg.tsx
@@ -273,9 +273,6 @@ export const textWysiwyg = ({
       if (!container) {
         maxWidth = (appState.width - 8 - viewportX) / appState.zoom.value;
         textElementWidth = Math.min(textElementWidth, maxWidth);
-      } else if (isFirefox || isSafari) {
-        // As firefox, Safari needs little higher dimensions on DOM
-        textElementWidth += 0.5;
       }
       const magicOffset = excalidrawContainer
         ? parseFloat(getComputedStyle(excalidrawContainer).fontSize)
@@ -287,9 +284,9 @@ export const textWysiwyg = ({
         font: getFontString(updatedTextElement),
         // must be defined *after* font ¯\_(ツ)_/¯
         lineHeight: `${lineHeight}px`,
-        width: `${textElementWidth+magicOffset*2}px`,
+        width: `${textElementWidth + magicOffset * 2}px`,
         height: `${textElementHeight}px`,
-        left: `${viewportX-magicOffset}px`,
+        left: `${viewportX - magicOffset}px`,
         top: `${viewportY}px`,
         transform: getTransform(
           textElementWidth,

--- a/src/element/textWysiwyg.tsx
+++ b/src/element/textWysiwyg.tsx
@@ -350,7 +350,26 @@ export const textWysiwyg = ({
     overflowWrap: "break-word",
     boxSizing: "content-box",
   });
+  const onEditableInput = () => {
+    const updatedTextElement = Scene.getScene(element)?.getElement(
+      id,
+    ) as ExcalidrawTextElement;
+    const font = getFontString(updatedTextElement);
+    if (isBoundToContainer(element)) {
+      const container = getContainerElement(element);
+      const wrappedText = wrapText(
+        normalizeText(editable.value),
+        font,
+        getMaxContainerWidth(container!),
+      );
+      const { width, height } = measureText(wrappedText, font);
+      editable.style.width = `${width}px`;
+      editable.style.height = `${height}px`;
+    }
+  };
+
   updateWysiwygStyle();
+  onEditableInput();
 
   if (onChange) {
     editable.onpaste = async (event) => {
@@ -380,21 +399,7 @@ export const textWysiwyg = ({
     };
 
     editable.oninput = () => {
-      const updatedTextElement = Scene.getScene(element)?.getElement(
-        id,
-      ) as ExcalidrawTextElement;
-      const font = getFontString(updatedTextElement);
-      if (isBoundToContainer(element)) {
-        const container = getContainerElement(element);
-        const wrappedText = wrapText(
-          normalizeText(editable.value),
-          font,
-          getMaxContainerWidth(container!),
-        );
-        const { width, height } = measureText(wrappedText, font);
-        editable.style.width = `${width}px`;
-        editable.style.height = `${height}px`;
-      }
+      onEditableInput();
       onChange(normalizeText(editable.value));
     };
   }

--- a/src/element/textWysiwyg.tsx
+++ b/src/element/textWysiwyg.tsx
@@ -11,7 +11,7 @@ import {
   isBoundToContainer,
   isTextElement,
 } from "./typeChecks";
-import { CLASSES, VERTICAL_ALIGN } from "../constants";
+import { CLASSES, isFirefox, isSafari, VERTICAL_ALIGN } from "../constants";
 import {
   ExcalidrawElement,
   ExcalidrawLinearElement,
@@ -348,9 +348,11 @@ export const textWysiwyg = ({
   });
 
   const magicOffset =
-    (excalidrawContainer
-      ? parseFloat(getComputedStyle(excalidrawContainer).fontSize)
-      : 16) / 8;
+    isFirefox || isSafari
+      ? (excalidrawContainer
+          ? parseFloat(getComputedStyle(excalidrawContainer).fontSize)
+          : 16) / 16
+      : 0;
 
   const onEditableInput = () => {
     const updatedTextElement = Scene.getScene(element)?.getElement(

--- a/src/element/textWysiwyg.tsx
+++ b/src/element/textWysiwyg.tsx
@@ -270,13 +270,15 @@ export const textWysiwyg = ({
       const lineHeight = updatedTextElement.containerId
         ? approxLineHeight
         : updatedTextElement.height / lines.length;
+      let magicOffset = 0;
       if (!container) {
         maxWidth = (appState.width - 8 - viewportX) / appState.zoom.value;
         textElementWidth = Math.min(textElementWidth, maxWidth);
+      } else {
+        magicOffset = excalidrawContainer
+          ? parseFloat(getComputedStyle(excalidrawContainer).fontSize)
+          : 16;
       }
-      const magicOffset = excalidrawContainer
-        ? parseFloat(getComputedStyle(excalidrawContainer).fontSize)
-        : 16;
       // Make sure text editor height doesn't go beyond viewport
       const editorMaxHeight =
         (appState.height - viewportY) / appState.zoom.value;

--- a/src/element/textWysiwyg.tsx
+++ b/src/element/textWysiwyg.tsx
@@ -347,6 +347,7 @@ export const textWysiwyg = ({
     boxSizing: "content-box",
   });
 
+  //As Firefox, Safari needs little higher dimensions on DOM
   const magicOffset =
     isFirefox || isSafari
       ? (excalidrawContainer

--- a/src/element/textWysiwyg.tsx
+++ b/src/element/textWysiwyg.tsx
@@ -11,7 +11,7 @@ import {
   isBoundToContainer,
   isTextElement,
 } from "./typeChecks";
-import { CLASSES, isFirefox, isSafari, VERTICAL_ALIGN } from "../constants";
+import { CLASSES, VERTICAL_ALIGN } from "../constants";
 import {
   ExcalidrawElement,
   ExcalidrawLinearElement,

--- a/src/element/textWysiwyg.tsx
+++ b/src/element/textWysiwyg.tsx
@@ -270,14 +270,10 @@ export const textWysiwyg = ({
       const lineHeight = updatedTextElement.containerId
         ? approxLineHeight
         : updatedTextElement.height / lines.length;
-      let magicOffset = 0;
+
       if (!container) {
         maxWidth = (appState.width - 8 - viewportX) / appState.zoom.value;
         textElementWidth = Math.min(textElementWidth, maxWidth);
-      } else {
-        magicOffset = excalidrawContainer
-          ? parseFloat(getComputedStyle(excalidrawContainer).fontSize)
-          : 16;
       }
       // Make sure text editor height doesn't go beyond viewport
       const editorMaxHeight =
@@ -286,9 +282,9 @@ export const textWysiwyg = ({
         font: getFontString(updatedTextElement),
         // must be defined *after* font ¯\_(ツ)_/¯
         lineHeight: `${lineHeight}px`,
-        width: `${textElementWidth + magicOffset * 2}px`,
+        width: `${textElementWidth}px`,
         height: `${textElementHeight}px`,
-        left: `${viewportX - magicOffset}px`,
+        left: `${viewportX}px`,
         top: `${viewportY}px`,
         transform: getTransform(
           textElementWidth,
@@ -350,6 +346,12 @@ export const textWysiwyg = ({
     overflowWrap: "break-word",
     boxSizing: "content-box",
   });
+
+  const magicOffset =
+    (excalidrawContainer
+      ? parseFloat(getComputedStyle(excalidrawContainer).fontSize)
+      : 16) / 8;
+
   const onEditableInput = () => {
     const updatedTextElement = Scene.getScene(element)?.getElement(
       id,
@@ -363,7 +365,7 @@ export const textWysiwyg = ({
         getMaxContainerWidth(container!),
       );
       const { width, height } = measureText(wrappedText, font);
-      editable.style.width = `${width}px`;
+      editable.style.width = `${width + magicOffset}px`;
       editable.style.height = `${height}px`;
     }
   };

--- a/src/element/textWysiwyg.tsx
+++ b/src/element/textWysiwyg.tsx
@@ -11,7 +11,7 @@ import {
   isBoundToContainer,
   isTextElement,
 } from "./typeChecks";
-import { CLASSES, isFirefox, isSafari, VERTICAL_ALIGN } from "../constants";
+import { CLASSES, VERTICAL_ALIGN } from "../constants";
 import {
   ExcalidrawElement,
   ExcalidrawLinearElement,
@@ -347,13 +347,10 @@ export const textWysiwyg = ({
     boxSizing: "content-box",
   });
 
-  //As Firefox, Safari needs little higher dimensions on DOM
-  const magicOffset =
-    isFirefox || isSafari
-      ? (excalidrawContainer
-          ? parseFloat(getComputedStyle(excalidrawContainer).fontSize)
-          : 16) / 16
-      : 0;
+  const magicOffset = 
+    (excalidrawContainer
+      ? parseFloat(getComputedStyle(excalidrawContainer).fontSize)
+      : 16) / 16;
 
   const onEditableInput = () => {
     const updatedTextElement = Scene.getScene(element)?.getElement(


### PR DESCRIPTION
fixes #6318. Key change is moving the firefox & safari additional offset to editable.oninput, plus running onEditableInput after the first initialization of editable. This fixes the issue in Obsidian as well as on MacOS Chrome.

test image: https://excalidraw-git-zsviczian-fix-6318-excalidraw.vercel.app/#json=DjinA5_7y5Esi0FzXaHZ7,6QmlWWAk8ZDW-uXuOrXSTw