### PR TITLE
fix: add an offset of 0.5px for text editor in containers

### DIFF
--- a/src/element/textWysiwyg.tsx
+++ b/src/element/textWysiwyg.tsx
@@ -273,8 +273,7 @@ export const textWysiwyg = ({
       if (!container) {
         maxWidth = (appState.width - 8 - viewportX) / appState.zoom.value;
         textElementWidth = Math.min(textElementWidth, maxWidth);
-      } else if (isFirefox || isSafari) {
-        // As firefox, Safari needs little higher dimensions on DOM
+      } else {
         textElementWidth += 0.5;
       }
       // Make sure text editor height doesn't go beyond viewport

--- a/src/element/textWysiwyg.tsx
+++ b/src/element/textWysiwyg.tsx
@@ -11,7 +11,7 @@ import {
   isBoundToContainer,
   isTextElement,
 } from "./typeChecks";
-import { CLASSES, isFirefox, isSafari, VERTICAL_ALIGN } from "../constants";
+import { CLASSES, VERTICAL_ALIGN } from "../constants";
 import {
   ExcalidrawElement,
   ExcalidrawLinearElement,

--- a/src/tests/__snapshots__/linearElementEditor.test.tsx.snap
+++ b/src/tests/__snapshots__/linearElementEditor.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`Test Linear Elements Test bound text element should match styles for te
   class="excalidraw-wysiwyg"
   data-type="wysiwyg"
   dir="auto"
-  style="position: absolute; display: inline-block; min-height: 1em; margin: 0px; padding: 0px; border: 0px; outline: 0; resize: none; background: transparent; overflow: hidden; z-index: var(--zIndex-wysiwyg); word-break: break-word; white-space: pre-wrap; overflow-wrap: break-word; box-sizing: content-box; width: 10px; height: 24px; left: 35px; top: 8px; transform: translate(0px, 0px) scale(1) rotate(0deg); text-align: center; vertical-align: middle; color: rgb(0, 0, 0); opacity: 1; filter: var(--theme-filter); max-height: -8px; font: Emoji 20px 20px; line-height: 24px; font-family: Virgil, Segoe UI Emoji;"
+  style="position: absolute; display: inline-block; min-height: 1em; margin: 0px; padding: 0px; border: 0px; outline: 0; resize: none; background: transparent; overflow: hidden; z-index: var(--zIndex-wysiwyg); word-break: break-word; white-space: pre-wrap; overflow-wrap: break-word; box-sizing: content-box; width: 10.5px; height: 24px; left: 35px; top: 8px; transform: translate(0px, 0px) scale(1) rotate(0deg); text-align: center; vertical-align: middle; color: rgb(0, 0, 0); opacity: 1; filter: var(--theme-filter); max-height: -8px; font: Emoji 20px 20px; line-height: 24px; font-family: Virgil, Segoe UI Emoji;"
   tabindex="0"
   wrap="off"
 />


### PR DESCRIPTION
An attempt to fix https://github.com/excalidraw/excalidraw/issues/6318

In chrome, the below test case breaks due to diff in measurements of canvas vs DOM hence I am adding `0.5px` to the text editor irrespective of the browser

```
{"type":"excalidraw/clipboard","elements":[{"type":"rectangle","version":330,"versionNonce":2052614281,"isDeleted":false,"id":"31vXnfdx8kajVSVVIfvCP","fillStyle":"hachure","strokeWidth":4,"strokeStyle":"solid","roughness":2,"opacity":100,"angle":0,"x":565.0773024358487,"y":797.405287044643,"strokeColor":"#c92a2a","backgroundColor":"transparent","width":416.63022605391654,"height":326.8,"seed":317114057,"groupIds":[],"roundness":{"type":3},"boundElements":[{"type":"text","id":"Tw9ge3wKmBk2-lojWy5Ps"}],"updated":1678186715202,"link":null,"locked":false},{"type":"text","version":485,"versionNonce":1143406727,"isDeleted":false,"id":"Tw9ge3wKmBk2-lojWy5Ps","fillStyle":"hachure","strokeWidth":4,"strokeStyle":"solid","roughness":2,"opacity":100,"angle":0,"x":625.0085348475725,"y":921.205287044643,"strokeColor":"#c92a2a","backgroundColor":"transparent","width":296.76776123046875,"height":79.2,"seed":149202503,"groupIds":[],"roundness":null,"boundElements":null,"updated":1678186715203,"link":null,"locked":false,"fontSize":66.11873594372629,"fontFamily":1,"text":"This is a","textAlign":"center","verticalAlign":"middle","containerId":"31vXnfdx8kajVSVVIfvCP","originalText":"This is a"}],"files":{}}
```

Earlier before I merged https://github.com/excalidraw/excalidraw/pull/6187, there was `1px` being added to DOM measurements to align with canvas
![image](https://user-images.githubusercontent.com/11256141/223414412-ab97b296-ab85-4949-9871-ce7b4047d6c9.png)
I had removed it thinking its not needed anymore as per the testing and only added an offset for `ff` and `safari` but looks like we need to introduce it to align with text editor measurements