### PR TITLE
fix: refresh dimensions when elements loaded from shareable link and blob

### DIFF
--- a/src/data/blob.ts
+++ b/src/data/blob.ts
@@ -157,7 +157,7 @@ export const loadSceneOrLibraryFromBlob = async (
           },
           localAppState,
           localElements,
-          { repairBindings: true },
+          { repairBindings: true, refreshDimensions: true },
         ),
       };
     } else if (isValidLibrary(data)) {

--- a/src/excalidraw-app/data/index.ts
+++ b/src/excalidraw-app/data/index.ts
@@ -263,7 +263,7 @@ export const loadScene = async (
       await importFromBackend(id, privateKey),
       localDataState?.appState,
       localDataState?.elements,
-      { repairBindings: true },
+      { repairBindings: true, refreshDimensions: true },
     );
   } else {
     data = restore(localDataState || null, null, null, {

--- a/src/excalidraw-app/data/index.ts
+++ b/src/excalidraw-app/data/index.ts
@@ -266,7 +266,6 @@ export const loadScene = async (
       { repairBindings: true, refreshDimensions: true },
     );
   } else {
-    console.trace("DUDE");
     data = restore(localDataState || null, null, null, {
       repairBindings: true,
     });

--- a/src/excalidraw-app/data/index.ts
+++ b/src/excalidraw-app/data/index.ts
@@ -266,6 +266,7 @@ export const loadScene = async (
       { repairBindings: true, refreshDimensions: true },
     );
   } else {
+    console.trace("DUDE");
     data = restore(localDataState || null, null, null, {
       repairBindings: true,
     });


### PR DESCRIPTION
try opening https://excalidraw-git-aakansha-refresh-dims-on-json-load-excalidraw.vercel.app/#json=-DV4Cph-GwtrlhYpHZ-d5,Mq55Gk1Z99mCPwtNPEPrLQ vs in prod with same keys

- [x] Refresh dimensions when loaded from link
- [x] Refresh dims when loaded from file

When loaded from `LS` its not needed since `onFontLoad` takes care of it.