### PR TITLE
fix: hide text align for labelled arrows

### DIFF
--- a/src/actions/actionProperties.tsx
+++ b/src/actions/actionProperties.tsx
@@ -54,6 +54,7 @@ import { mutateElement, newElementWith } from "../element/mutateElement";
 import {
   getBoundTextElement,
   getContainerElement,
+  suppportsHorizontalAlign,
 } from "../element/textElement";
 import {
   isBoundToContainer,
@@ -745,16 +746,19 @@ export const actionChangeTextAlign = register({
               value: "left",
               text: t("labels.left"),
               icon: TextAlignLeftIcon,
+              testId: "align-left",
             },
             {
               value: "center",
               text: t("labels.center"),
               icon: TextAlignCenterIcon,
+              testId: "align-horizontal-center",
             },
             {
               value: "right",
               text: t("labels.right"),
               icon: TextAlignRightIcon,
+              testId: "align-right",
             },
           ]}
           value={getFormValue(

--- a/src/actions/actionProperties.tsx
+++ b/src/actions/actionProperties.tsx
@@ -54,7 +54,6 @@ import { mutateElement, newElementWith } from "../element/mutateElement";
 import {
   getBoundTextElement,
   getContainerElement,
-  suppportsHorizontalAlign,
 } from "../element/textElement";
 import {
   isBoundToContainer,

--- a/src/components/Actions.tsx
+++ b/src/components/Actions.tsx
@@ -30,7 +30,10 @@ import clsx from "clsx";
 import { actionToggleZenMode } from "../actions";
 import "./Actions.scss";
 import { Tooltip } from "./Tooltip";
-import { shouldAllowVerticalAlign } from "../element/textElement";
+import {
+  shouldAllowVerticalAlign,
+  suppportsHorizontalAlign,
+} from "../element/textElement";
 
 export const SelectedShapeActions = ({
   appState,
@@ -122,7 +125,8 @@ export const SelectedShapeActions = ({
 
           {renderAction("changeFontFamily")}
 
-          {renderAction("changeTextAlign")}
+          {suppportsHorizontalAlign(targetElements) &&
+            renderAction("changeTextAlign")}
         </>
       )}
 

--- a/src/element/textElement.ts
+++ b/src/element/textElement.ts
@@ -662,14 +662,6 @@ export const shouldAllowVerticalAlign = (
       }
       return true;
     }
-    const boundTextElement = getBoundTextElement(element);
-    if (boundTextElement) {
-      if (isArrowElement(element)) {
-        return false;
-      }
-      return true;
-    }
-    return false;
   });
 };
 
@@ -685,13 +677,7 @@ export const suppportsHorizontalAlign = (
       }
       return true;
     }
-    const boundTextElement = getBoundTextElement(element);
-    if (boundTextElement) {
-      if (isArrowElement(element)) {
-        return false;
-      }
-      return true;
-    }
+
     return isTextElement(element);
   });
 };

--- a/src/element/textElement.ts
+++ b/src/element/textElement.ts
@@ -673,6 +673,29 @@ export const shouldAllowVerticalAlign = (
   });
 };
 
+export const suppportsHorizontalAlign = (
+  selectedElements: NonDeletedExcalidrawElement[],
+) => {
+  return selectedElements.some((element) => {
+    const hasBoundContainer = isBoundToContainer(element);
+    if (hasBoundContainer) {
+      const container = getContainerElement(element);
+      if (isTextElement(element) && isArrowElement(container)) {
+        return false;
+      }
+      return true;
+    }
+    const boundTextElement = getBoundTextElement(element);
+    if (boundTextElement) {
+      if (isArrowElement(element)) {
+        return false;
+      }
+      return true;
+    }
+    return isTextElement(element);
+  });
+};
+
 export const getTextBindableContainerAtPosition = (
   elements: readonly ExcalidrawElement[],
   appState: AppState,

--- a/src/element/textElement.ts
+++ b/src/element/textElement.ts
@@ -662,6 +662,7 @@ export const shouldAllowVerticalAlign = (
       }
       return true;
     }
+    return false;
   });
 };
 

--- a/src/tests/linearElementEditor.test.tsx
+++ b/src/tests/linearElementEditor.test.tsx
@@ -1179,5 +1179,17 @@ describe("Test Linear Elements", () => {
         easy"
       `);
     });
+
+    it("should not render horizontal align tool when element selected", () => {
+      createTwoPointerLinearElement("arrow");
+      const arrow = h.elements[0] as ExcalidrawLinearElement;
+
+      createBoundTextElement(DEFAULT_TEXT, arrow);
+      API.setSelectedElements([arrow]);
+
+      expect(queryByTestId(container, "align-left")).toBeNull();
+      expect(queryByTestId(container, "align-horizontal-center")).toBeNull();
+      expect(queryByTestId(container, "align-right")).toBeNull();
+    });
   });
 });


### PR DESCRIPTION
`Text align` is not really useful for labelled arrows hence I am proposing to hide it instead.
fixes #6316 