### PR TITLE
perf: break early if the line width <= max width of the container

### DIFF
--- a/src/element/textElement.test.ts
+++ b/src/element/textElement.test.ts
@@ -1,3 +1,4 @@
+import { wrap } from "@sentry/browser/dist/helpers";
 import { BOUND_TEXT_PADDING } from "../constants";
 import { API } from "../tests/helpers/api";
 import {
@@ -26,7 +27,7 @@ describe("Test wrapText", () => {
     expect(res).toBe("😀");
   });
 
-  it("should show the text correctly when min width reached", () => {
+  it("should show the text correctly when max width reached", () => {
     const text = "Hello😀";
     const maxWidth = 10;
     const res = wrapText(text, font, maxWidth);
@@ -175,6 +176,14 @@ break it now`,
         expect(res).toEqual(data.res);
       });
     });
+  });
+
+  it("should wrap the text correctly when word length is exactly equal to max width", () => {
+    const text = "Hello Excalidraw";
+    // Length of "Excalidraw" is 100 and exacty equal to max width
+    const res = wrapText(text, font, 100);
+    expect(res).toEqual(`Hello 
+Excalidraw`);
   });
 });
 

--- a/src/element/textElement.test.ts
+++ b/src/element/textElement.test.ts
@@ -16,7 +16,7 @@ describe("Test wrapText", () => {
     const text = "Hello whats up     ";
     const maxWidth = 200 - BOUND_TEXT_PADDING * 2;
     const res = wrapText(text, font, maxWidth);
-    expect(res).toBe("Hello whats up    ");
+    expect(res).toBe(text);
   });
 
   it("should work with emojis", () => {
@@ -136,6 +136,7 @@ whats up`,
       });
     });
   });
+
   describe("When text is long", () => {
     const text = `hellolongtextthisiswhatsupwithyouIamtypingggggandtypinggg break it now`;
     [

--- a/src/element/textElement.test.ts
+++ b/src/element/textElement.test.ts
@@ -1,4 +1,3 @@
-import { wrap } from "@sentry/browser/dist/helpers";
 import { BOUND_TEXT_PADDING } from "../constants";
 import { API } from "../tests/helpers/api";
 import {

--- a/src/element/textElement.ts
+++ b/src/element/textElement.ts
@@ -327,12 +327,15 @@ export const wrapText = (text: string, font: FontString, maxWidth: number) => {
     }
   };
   originalLines.forEach((originalLine) => {
-    const words = originalLine.split(" ");
-    // This means its newline so push it
-    if (words.length === 1 && words[0] === "") {
-      lines.push(words[0]);
+    const currentLineWidth = getTextWidth(originalLine, font);
+
+    //Push the line if its <= maxWidth
+    if (currentLineWidth <= maxWidth) {
+      lines.push(originalLine);
       return; // continue
     }
+    const words = originalLine.split(" ");
+
     let currentLine = "";
     let currentLineWidthTillNow = 0;
 
@@ -340,6 +343,7 @@ export const wrapText = (text: string, font: FontString, maxWidth: number) => {
 
     while (index < words.length) {
       const currentWordWidth = getLineWidth(words[index], font);
+
       // This will only happen when single word takes entire width
       if (currentWordWidth === maxWidth) {
         push(words[index]);

--- a/src/element/textElement.ts
+++ b/src/element/textElement.ts
@@ -321,11 +321,21 @@ export const wrapText = (text: string, font: FontString, maxWidth: number) => {
   const lines: Array<string> = [];
   const originalLines = text.split("\n");
   const spaceWidth = getLineWidth(" ", font);
+
+  let currentLine = "";
+  let currentLineWidthTillNow = 0;
+
   const push = (str: string) => {
     if (str.trim()) {
       lines.push(str);
     }
   };
+
+  const resetParams = () => {
+    currentLine = "";
+    currentLineWidthTillNow = 0;
+  };
+
   originalLines.forEach((originalLine) => {
     const currentLineWidth = getTextWidth(originalLine, font);
 
@@ -336,8 +346,7 @@ export const wrapText = (text: string, font: FontString, maxWidth: number) => {
     }
     const words = originalLine.split(" ");
 
-    let currentLine = "";
-    let currentLineWidthTillNow = 0;
+    resetParams();
 
     let index = 0;
 
@@ -355,8 +364,8 @@ export const wrapText = (text: string, font: FontString, maxWidth: number) => {
         // push current line since the current word exceeds the max width
         // so will be appended in next line
         push(currentLine);
-        currentLine = "";
-        currentLineWidthTillNow = 0;
+
+        resetParams();
 
         while (words[index].length > 0) {
           const currentChar = String.fromCodePoint(
@@ -374,10 +383,11 @@ export const wrapText = (text: string, font: FontString, maxWidth: number) => {
             currentLine += currentChar;
           }
         }
+
         // push current line if appending space exceeds max width
         if (currentLineWidthTillNow + spaceWidth >= maxWidth) {
           push(currentLine);
-          currentLine = "";
+          resetParams();
           currentLineWidthTillNow = 0;
         } else {
           // space needs to be appended before next word
@@ -386,7 +396,6 @@ export const wrapText = (text: string, font: FontString, maxWidth: number) => {
           currentLine += " ";
           currentLineWidthTillNow += spaceWidth;
         }
-
         index++;
       } else {
         // Start appending words in a line till max width reached
@@ -396,8 +405,7 @@ export const wrapText = (text: string, font: FontString, maxWidth: number) => {
 
           if (currentLineWidthTillNow > maxWidth) {
             push(currentLine);
-            currentLineWidthTillNow = 0;
-            currentLine = "";
+            resetParams();
 
             break;
           }
@@ -408,22 +416,15 @@ export const wrapText = (text: string, font: FontString, maxWidth: number) => {
           if (currentLineWidthTillNow + spaceWidth >= maxWidth) {
             const word = currentLine.slice(0, -1);
             push(word);
-            currentLine = "";
-            currentLineWidthTillNow = 0;
+            resetParams();
             break;
           }
         }
-        if (currentLineWidthTillNow === maxWidth) {
-          currentLine = "";
-          currentLineWidthTillNow = 0;
-        }
       }
     }
-    if (currentLine) {
+    if (currentLine.slice(-1) === " ") {
       // only remove last trailing space which we have added when joining words
-      if (currentLine.slice(-1) === " ") {
-        currentLine = currentLine.slice(0, -1);
-      }
+      currentLine = currentLine.slice(0, -1);
       push(currentLine);
     }
   });

--- a/src/element/textElement.ts
+++ b/src/element/textElement.ts
@@ -367,10 +367,6 @@ export const wrapText = (text: string, font: FontString, maxWidth: number) => {
           words[index] = words[index].slice(currentChar.length);
 
           if (currentLineWidthTillNow >= maxWidth) {
-            // only remove last trailing space which we have added when joining words
-            if (currentLine.slice(-1) === " ") {
-              currentLine = currentLine.slice(0, -1);
-            }
             push(currentLine);
             currentLine = currentChar;
             currentLineWidthTillNow = width;

--- a/src/element/textElement.ts
+++ b/src/element/textElement.ts
@@ -388,7 +388,6 @@ export const wrapText = (text: string, font: FontString, maxWidth: number) => {
         if (currentLineWidthTillNow + spaceWidth >= maxWidth) {
           push(currentLine);
           resetParams();
-          currentLineWidthTillNow = 0;
         } else {
           // space needs to be appended before next word
           // as currentLine contains chars which couldn't be appended


### PR DESCRIPTION
- [x] break early if the line width <= max width of the container
- [x] Add tests
- [x] Remove dead code

`wrapText` now has 100% coverage