### PR TITLE
fix: text element should be rendered correctly when pasted  to a version before measurements change

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1653,7 +1653,7 @@ class App extends React.Component<AppProps, AppState> {
     this.scene.replaceAllElements(nextElements);
 
     newElements.forEach((newElement) => {
-      if (isTextElement(newElement) && isBoundToContainer(newElement)) {
+      if (isTextElement(newElement)) {
         const container = getContainerElement(newElement);
         redrawTextBoundingBox(newElement, container);
       }


### PR DESCRIPTION
After merging #6187 , If you try pasting the text element from new version (which has text measurements change) to an older version (which doesn't have the changes) - The text element turns blank unless edited or refreshed as the baseline isn't introduced (baseline was removed in #6187)
Try pasting this element to https://excalidraw-joczb93fv-excalidraw.vercel.app/ (one commit before #6187 merge)
```
{"type":"excalidraw/clipboard","elements":[{"id":"iTklLxWPoTs2CFuWImre4","type":"text","x":-4840.892271069522,"y":2854.26437412141,"width":146.71995544433594,"height":33.6,"angle":0,"strokeColor":"#d9480f","backgroundColor":"transparent","fillStyle":"solid","strokeWidth":1,"strokeStyle":"solid","roughness":1,"opacity":100,"groupIds":[],"roundness":null,"seed":1793203390,"version":13,"versionNonce":21200510,"isDeleted":false,"boundElements":null,"updated":1679050766538,"link":null,"locked":false,"text":"Hello World","fontSize":28,"fontFamily":1,"textAlign":"center","verticalAlign":"top","containerId":null,"originalText":"Hello World"}],"files":{}}
```
<img width="1328" alt="Screenshot 2023-03-17 at 4 36 57 PM" src="https://user-images.githubusercontent.com/11256141/225888200-9c1058f7-773f-44f9-b1a7-9f30cf0ff8b4.png">


This however doesn't happen for containers since we are redrawing bounding box once pasted. So with this fix I am redrawing the bounding box for all text elements (irrespective of whether its a regular text element or text container) and once this fix is pulled into older version it will started working when you try pasting a text element from new version to your version.  Redrawing bounding box makes sure that `baseline` is introduced.

