### PR TITLE
fix: division by zero in findFocusPointForEllipse leads to infinite loop in wrapText freezing Excalidraw

### DIFF
--- a/src/element/collision.ts
+++ b/src/element/collision.ts
@@ -790,7 +790,7 @@ export const findFocusPointForEllipse = (
 
   if (n === 0) {
     // if zero {-0, 0}, fall back to a same-sign value in the similar range
-    n = (Object.is(Math.sign(n), -0) ? -1 : 1) * 0.01;
+    n = (Object.is(n, -0) ? -1 : 1) * 0.01;
   }
 
   const x = -(a ** 2 * m) / (n ** 2 * b ** 2 + m ** 2 * a ** 2);

--- a/src/element/collision.ts
+++ b/src/element/collision.ts
@@ -786,7 +786,12 @@ export const findFocusPointForEllipse = (
       orientation * py * Math.sqrt(Math.max(0, squares - a ** 2 * b ** 2))) /
     squares;
 
-  const n = (-m * px - 1) / py;
+  let n = (-m * px - 1) / py;
+
+  if (n === 0) {
+    // if zero {-0, 0}, fall back to a same-sign value in the similar range
+    n = (Object.is(Math.sign(n), -0) ? -1 : 1) * 0.01;
+  }
 
   const x = -(a ** 2 * m) / (n ** 2 * b ** 2 + m ** 2 * a ** 2);
   return GA.point(x, (-m * x - 1) / (n === 0 ? 0.0001 : n));

--- a/src/element/collision.ts
+++ b/src/element/collision.ts
@@ -794,7 +794,7 @@ export const findFocusPointForEllipse = (
   }
 
   const x = -(a ** 2 * m) / (n ** 2 * b ** 2 + m ** 2 * a ** 2);
-  return GA.point(x, (-m * x - 1) / (n === 0 ? 0.0001 : n));
+  return GA.point(x, (-m * x - 1) / n);
 };
 
 export const findFocusPointForRectangulars = (

--- a/src/element/collision.ts
+++ b/src/element/collision.ts
@@ -789,7 +789,7 @@ export const findFocusPointForEllipse = (
   const n = (-m * px - 1) / py;
 
   const x = -(a ** 2 * m) / (n ** 2 * b ** 2 + m ** 2 * a ** 2);
-  return GA.point(x, (-m * x - 1) / n);
+  return GA.point(x, (-m * x - 1) / (n === 0 ? 0.0001 : n));
 };
 
 export const findFocusPointForRectangulars = (

--- a/src/element/textElement.test.ts
+++ b/src/element/textElement.test.ts
@@ -184,6 +184,13 @@ break it now`,
     expect(res).toEqual(`Hello 
 Excalidraw`);
   });
+
+  it("should return the text as is if max width in invalid", () => {
+    const text = "Hello Excalidraw";
+    expect(wrapText(text, font, NaN)).toEqual(text);
+    expect(wrapText(text, font, -1)).toEqual(text);
+    expect(wrapText(text, font, Infinity)).toEqual(text);
+  });
 });
 
 describe("Test measureText", () => {

--- a/src/element/textElement.test.ts
+++ b/src/element/textElement.test.ts
@@ -185,7 +185,7 @@ break it now`,
 Excalidraw`);
   });
 
-  it("should return the text as is if max width in invalid", () => {
+  it("should return the text as is if max width is invalid", () => {
     const text = "Hello Excalidraw";
     expect(wrapText(text, font, NaN)).toEqual(text);
     expect(wrapText(text, font, -1)).toEqual(text);

--- a/src/element/textElement.ts
+++ b/src/element/textElement.ts
@@ -324,7 +324,7 @@ export const getTextHeight = (text: string, font: FontString) => {
 };
 
 export const wrapText = (text: string, font: FontString, maxWidth: number) => {
-  if(!maxWidth) {
+  if (!maxWidth) {
     return text;
   }
 

--- a/src/element/textElement.ts
+++ b/src/element/textElement.ts
@@ -327,7 +327,7 @@ export const wrapText = (text: string, font: FontString, maxWidth: number) => {
   // if maxWidth is not finite or NaN which can happen in case of bugs in
   // computation, we need to make sure we don't continue as we'll end up
   // in an infinite loop
-  if (!Number.isFinite(maxWidth)) {
+  if (!Number.isFinite(maxWidth) || maxWidth < 0) {
     return text;
   }
 

--- a/src/element/textElement.ts
+++ b/src/element/textElement.ts
@@ -324,6 +324,10 @@ export const getTextHeight = (text: string, font: FontString) => {
 };
 
 export const wrapText = (text: string, font: FontString, maxWidth: number) => {
+  if(!maxWidth) {
+    return text;
+  }
+
   const lines: Array<string> = [];
   const originalLines = text.split("\n");
   const spaceWidth = getLineWidth(" ", font);

--- a/src/element/textElement.ts
+++ b/src/element/textElement.ts
@@ -324,7 +324,10 @@ export const getTextHeight = (text: string, font: FontString) => {
 };
 
 export const wrapText = (text: string, font: FontString, maxWidth: number) => {
-  if (!maxWidth) {
+  // if maxWidth is not finite or NaN which can happen in case of bugs in
+  // computation, we need to make sure we don't continue as we'll end up
+  // in an infinite loop
+  if (!Number.isFinite(maxWidth)) {
     return text;
   }
 


### PR DESCRIPTION
[#1054](https://github.com/zsviczian/obsidian-excalidraw-plugin/issues/1054) 
I was not able to reproduce the issue with the same file on Excalidraw.com, but that is likely because the issue was triggered by the Obsidian plugin updating container sizes while loading a drawing. The container size update is there because text transclusions might change the length of text in container-bound text elements. In this drawing, an arrow was pointing from a rectangle to an ellipse and the arrow had a label. All the stars were aligned and Excalidraw froze...

![image](https://user-images.githubusercontent.com/14358394/226189056-29db8d5b-08a4-4403-92ba-8b1865242b01.png)

The user had the gird enabled, therefore coordinates of the ellipse and arrow were all round numbers. When the rectangle gets resized during the Obsidian load process, this triggers an update of all its bound elements, including the arrow, which triggers the recalculation of binding points. In this case, numbers played out such that n equaled zero:

![image](https://user-images.githubusercontent.com/14358394/226188917-aa276352-4bbe-4e3f-a46e-a49e3e5a3a05.png)

The knock-on effect was that `focusPointAbsolute` was assigned a value of `[NaN, NaN]`.

https://github.com/excalidraw/excalidraw/blob/0726911fa608d1c1ad9480badbafa61f2acd8b9c/src/element/binding.ts#L415-L419

As a consequence, the arrow endpoint was updated to `[NaN, NaN]`. This lead to `maxWidth = NaN` 

https://github.com/excalidraw/excalidraw/blob/0726911fa608d1c1ad9480badbafa61f2acd8b9c/src/element/textElement.ts#L177-L186

This resulted in `wrapText` getting held up in an infinite loop, freezing Obsidian completely every time the user opened this drawing.

https://github.com/excalidraw/excalidraw/blob/0726911fa608d1c1ad9480badbafa61f2acd8b9c/src/element/textElement.ts#L407-L429