### PR TITLE
fix: chrome crashing when embedding scene on chrome arm

### DIFF
--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -89,7 +89,9 @@ export const exportCanvas = async (
     return await fileSave(blob, {
       description: "Export to PNG",
       name,
-      extension: appState.exportEmbedScene ? "excalidraw.png" : "png",
+      // FIXME reintroduce `excalidraw.png` when most people upgrade away
+      // from 111.0.5563.64 (arm64), see #6349
+      extension: /* appState.exportEmbedScene ? "excalidraw.png" : */ "png",
       fileHandle,
     });
   } else if (type === "clipboard") {


### PR DESCRIPTION
fix https://github.com/excalidraw/excalidraw/issues/6349

Saving with compound file extensions completely crashes Chrome 111.0.5563.64 (arm64).

Already fixed in 111.0.5563.65, but it doesn't seem to be shipped on arm platform yet (or the autoupdate doesn't update at least). Tracking bug https://bugs.chromium.org/p/chromium/issues/detail?id=1426358&q=111.0.5563.64%20crash&can=2