### PR TITLE
fix: use `ideographic` textBaseline to improve layout shift when editing text

### DIFF
--- a/src/renderer/renderElement.ts
+++ b/src/renderer/renderElement.ts
@@ -34,6 +34,7 @@ import { AppState, BinaryFiles, Zoom } from "../types";
 import { getDefaultAppState } from "../appState";
 import {
   BOUND_TEXT_PADDING,
+  FONT_FAMILY,
   MAX_DECIMALS_FOR_SVG_EXPORT,
   MIME_TYPES,
   SVG_NS,
@@ -286,7 +287,13 @@ const drawElementOnCanvas = (
             : element.textAlign === "right"
             ? element.width
             : 0;
-        context.textBaseline = "bottom";
+
+        // FIXME temporary hack
+        context.textBaseline =
+          element.fontFamily === FONT_FAMILY.Virgil ||
+          element.fontFamily === FONT_FAMILY.Cascadia
+            ? "ideographic"
+            : "bottom";
 
         const lineHeightPx = getLineHeightInPx(
           element.fontSize,


### PR DESCRIPTION
this is a hack that only slightly improves https://github.com/excalidraw/excalidraw/issues/6380. Proper fix will have to be implemented through either reintroducing baseline, or reverting other parts of https://github.com/excalidraw/excalidraw/pull/6187 responsible for this regression