### PR TITLE
Enable eraser stylus events, execute via eraser tool.

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -38,6 +38,8 @@ export const POINTER_BUTTON = {
   WHEEL: 1,
   SECONDARY: 2,
   TOUCH: -1,
+  // Pen eraser button: https://developer.mozilla.org/en-US/docs/Web/API/Pointer_events
+  ERASER: 5,
 } as const;
 
 export enum EVENT {

--- a/src/types.ts
+++ b/src/types.ts
@@ -466,6 +466,8 @@ export type PointerDownState = Readonly<{
     hasHitCommonBoundingBoxOfSelectedElements: boolean;
   };
   withCmdOrCtrl: boolean;
+  // Whether the event was triggered with an eraser button
+  withEraserButton: boolean;
   drag: {
     // Might change during the pointer interaction
     hasOccurred: boolean;


### PR DESCRIPTION
Implements a standard semantic, where the eraser tool activates in the
eraser orientation without switching the primary tool.

This is activated for for pens, like the windows surface pens,
which implement the the [standard eraser button state].

Implemented via a "tool stack" on the pointer action.
If the eraser button is used, then switch to eraser for the span of the
pointer drag event, then pop back to the previous tool on button up.

[standard eraser button state]: https://developer.mozilla.org/en-US/docs/Web/API/Pointer_events#determining_button_states

Related to:
https://github.com/excalidraw/excalidraw/issues/5281
https://github.com/zsviczian/obsidian-excalidraw-plugin/issues/965