### PR TITLE
fix: getDefaultLineHeight should return default font family line height for unknown font

### DIFF
--- a/src/element/textElement.test.ts
+++ b/src/element/textElement.test.ts
@@ -332,6 +332,10 @@ describe("Test getDefaultLineHeight", () => {
     //@ts-ignore
     expect(getDefaultLineHeight()).toBe(1.25);
   });
+  it("should return line height using default font family when passing a unknown font", () => {
+    const UNKNOWN_FONT = -1;
+    expect(getDefaultLineHeight(UNKNOWN_FONT)).toBe(1.25);
+  });
   it("should return correct line height", () => {
     expect(getDefaultLineHeight(FONT_FAMILY.Cascadia)).toBe(1.2);
   });

--- a/src/element/textElement.test.ts
+++ b/src/element/textElement.test.ts
@@ -332,6 +332,10 @@ describe("Test getDefaultLineHeight", () => {
     //@ts-ignore
     expect(getDefaultLineHeight()).toBe(1.25);
   });
+  it("should return line height using default font family when not passed", () => {
+    const UNKNOWN_FONT = -1;
+    expect(getDefaultLineHeight(UNKNOWN_FONT)).toBe(1.25);
+  });
   it("should return correct line height", () => {
     expect(getDefaultLineHeight(FONT_FAMILY.Cascadia)).toBe(1.2);
   });

--- a/src/element/textElement.test.ts
+++ b/src/element/textElement.test.ts
@@ -332,10 +332,6 @@ describe("Test getDefaultLineHeight", () => {
     //@ts-ignore
     expect(getDefaultLineHeight()).toBe(1.25);
   });
-  it("should return line height using default font family when passing a unknown font", () => {
-    const UNKNOWN_FONT = -1;
-    expect(getDefaultLineHeight(UNKNOWN_FONT)).toBe(1.25);
-  });
   it("should return correct line height", () => {
     expect(getDefaultLineHeight(FONT_FAMILY.Cascadia)).toBe(1.2);
   });

--- a/src/element/textElement.test.ts
+++ b/src/element/textElement.test.ts
@@ -332,7 +332,7 @@ describe("Test getDefaultLineHeight", () => {
     //@ts-ignore
     expect(getDefaultLineHeight()).toBe(1.25);
   });
-  it("should return line height using default font family when not passed", () => {
+  it("should return line height using default font family when passing a unknown font", () => {
     const UNKNOWN_FONT = -1;
     expect(getDefaultLineHeight(UNKNOWN_FONT)).toBe(1.25);
   });

--- a/src/element/textElement.test.ts
+++ b/src/element/textElement.test.ts
@@ -333,7 +333,7 @@ describe("Test getDefaultLineHeight", () => {
     expect(getDefaultLineHeight()).toBe(1.25);
   });
 
-  it("should return line height using default font family for unknown fonts", () => {
+  it("should return line height using default font family for unknown font", () => {
     const UNKNOWN_FONT = 5;
     expect(getDefaultLineHeight(UNKNOWN_FONT)).toBe(1.25);
   });

--- a/src/element/textElement.test.ts
+++ b/src/element/textElement.test.ts
@@ -333,7 +333,7 @@ describe("Test getDefaultLineHeight", () => {
     expect(getDefaultLineHeight()).toBe(1.25);
   });
 
-  it("should return line height using default font family for unknown font", () => {
+  it("should return line height using default font family for unknown fonts", () => {
     const UNKNOWN_FONT = 5;
     expect(getDefaultLineHeight(UNKNOWN_FONT)).toBe(1.25);
   });

--- a/src/element/textElement.test.ts
+++ b/src/element/textElement.test.ts
@@ -337,6 +337,7 @@ describe("Test getDefaultLineHeight", () => {
     const UNKNOWN_FONT = -1;
     expect(getDefaultLineHeight(UNKNOWN_FONT)).toBe(1.25);
   });
+
   it("should return correct line height", () => {
     expect(getDefaultLineHeight(FONT_FAMILY.Cascadia)).toBe(1.2);
   });

--- a/src/element/textElement.test.ts
+++ b/src/element/textElement.test.ts
@@ -332,7 +332,8 @@ describe("Test getDefaultLineHeight", () => {
     //@ts-ignore
     expect(getDefaultLineHeight()).toBe(1.25);
   });
-  it("should return line height using default font family when passing a unknown font", () => {
+
+  it("should return line height using default font family when passing an unknown font", () => {
     const UNKNOWN_FONT = -1;
     expect(getDefaultLineHeight(UNKNOWN_FONT)).toBe(1.25);
   });

--- a/src/element/textElement.test.ts
+++ b/src/element/textElement.test.ts
@@ -333,8 +333,8 @@ describe("Test getDefaultLineHeight", () => {
     expect(getDefaultLineHeight()).toBe(1.25);
   });
 
-  it("should return line height using default font family when passing an unknown font", () => {
-    const UNKNOWN_FONT = -1;
+  it("should return line height using default font family for unknown font", () => {
+    const UNKNOWN_FONT = 5;
     expect(getDefaultLineHeight(UNKNOWN_FONT)).toBe(1.25);
   });
 

--- a/src/element/textElement.ts
+++ b/src/element/textElement.ts
@@ -887,11 +887,8 @@ const DEFAULT_LINE_HEIGHT = {
 };
 
 export const getDefaultLineHeight = (fontFamily: FontFamilyValues) => {
-  if (fontFamily) {
-    return (
-      DEFAULT_LINE_HEIGHT[fontFamily] ||
-      DEFAULT_LINE_HEIGHT[DEFAULT_FONT_FAMILY]
-    );
+  if (fontFamily in DEFAULT_LINE_HEIGHT) {
+    return DEFAULT_LINE_HEIGHT[fontFamily];
   }
   return DEFAULT_LINE_HEIGHT[DEFAULT_FONT_FAMILY];
 };

--- a/src/element/textElement.ts
+++ b/src/element/textElement.ts
@@ -888,7 +888,10 @@ const DEFAULT_LINE_HEIGHT = {
 
 export const getDefaultLineHeight = (fontFamily: FontFamilyValues) => {
   if (fontFamily) {
-    return DEFAULT_LINE_HEIGHT[fontFamily];
+    return (
+      DEFAULT_LINE_HEIGHT[fontFamily] ||
+      DEFAULT_LINE_HEIGHT[DEFAULT_FONT_FAMILY]
+    );
   }
   return DEFAULT_LINE_HEIGHT[DEFAULT_FONT_FAMILY];
 };


### PR DESCRIPTION
## Title

fix: `getDefaultLineHeight` always returns a default

## Why

The reason why I want to fix the `getDefaultLineHeight`'s return value is that after syncing with the latest `origin/master`, my forked excalidraw with my custom fonts app lost all text elements XD.

After doing some research, I found the `lineHeight` of the custom fonts is missing. Therefore, I prefer that `getDefaultLineHeight` always returns a value.


BTW: I forked the **AMAZING** excalidraw and added some custom fonts which is implemented at my [branch](https://github.com/CoyoteWaltz/excalidraw/tree/feat-addFonts/src/fork_by_coyote).

ALSO I wonder if there exists an elegant way to extend custom fonts with **minimal changes** and **better adoption with upcoming upper stream features**.

Thanks!
