### PR TITLE
fix: Revert use `ideographic` textBaseline to improve layout shift when editing text"

### DIFF
--- a/src/renderer/renderElement.ts
+++ b/src/renderer/renderElement.ts
@@ -34,7 +34,6 @@ import { AppState, BinaryFiles, Zoom } from "../types";
 import { getDefaultAppState } from "../appState";
 import {
   BOUND_TEXT_PADDING,
-  FONT_FAMILY,
   MAX_DECIMALS_FOR_SVG_EXPORT,
   MIME_TYPES,
   SVG_NS,
@@ -287,13 +286,7 @@ const drawElementOnCanvas = (
             : element.textAlign === "right"
             ? element.width
             : 0;
-
-        // FIXME temporary hack
-        context.textBaseline =
-          element.fontFamily === FONT_FAMILY.Virgil ||
-          element.fontFamily === FONT_FAMILY.Cascadia
-            ? "ideographic"
-            : "bottom";
+        context.textBaseline = "bottom";
 
         const lineHeightPx = getLineHeightInPx(
           element.fontSize,


### PR DESCRIPTION
Reverts excalidraw/excalidraw#6384