### PR TITLE
fix: Display error message on file permissions error

### DIFF
--- a/src/actions/actionExport.tsx
+++ b/src/actions/actionExport.tsx
@@ -197,7 +197,13 @@ export const actionSaveFileToDisk = register({
       } else {
         console.warn(error);
       }
-      return { commitToHistory: false };
+      return {
+        commitToHistory: false,
+        appState: {
+          ...appState,
+          errorMessage: "File editing is disabled.",
+        },
+      };
     }
   },
   keyTest: (event) =>


### PR DESCRIPTION
#### Changelog
- If `saveAsJson` throws, push an error message to app state.

#### Testing
- On Chrome, disable "file editing" from chrome://settings/content > Additional permissions > File editing.
- Open Excalidraw.
- Click "Save to..." button.
- Click on "Save to file".
- It should display this error message:
![image](https://user-images.githubusercontent.com/8978815/229314479-5453c3ec-7152-4425-b6c9-c959ce540835.png)
