### PR TITLE
fix: don't jump text to end when out of viewport in safari

### DIFF
--- a/src/element/textWysiwyg.tsx
+++ b/src/element/textWysiwyg.tsx
@@ -297,6 +297,7 @@ export const textWysiwyg = ({
         filter: "var(--theme-filter)",
         maxHeight: `${editorMaxHeight}px`,
       });
+      editable.scrollTop = 0;
       // For some reason updating font attribute doesn't set font family
       // hence updating font family explicitly for test environment
       if (isTestEnv()) {


### PR DESCRIPTION

https://user-images.githubusercontent.com/11256141/229852137-73ba75f4-1a66-4ba5-b57f-4a8409eb9930.mov

