### PR TITLE
docs: fix closing tag in readme (#6424

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
     An open source virtual hand-drawn style whiteboard. </br>
     Collaborative and end-to-end encrypted. </br>
   <br />
-  </h3>
+  </h2>
 </div>
 
 <br />


### PR DESCRIPTION
I've noticed that the opening tag is `<h2>` but the closing tag is `</h3>`