### PR TITLE
feat: add container to multiple text elements

### DIFF
--- a/src/actions/actionBoundText.tsx
+++ b/src/actions/actionBoundText.tsx
@@ -23,6 +23,7 @@ import {
   ExcalidrawTextElement,
 } from "../element/types";
 import { getSelectedElements } from "../scene";
+import { AppState } from "../types";
 import { getFontString } from "../utils";
 import { register } from "./register";
 
@@ -185,8 +186,8 @@ export const actionCreateContainerFromText = register({
   trackEvent: { category: "element" },
   predicate: (elements, appState) => {
     const selectedElements = getSelectedElements(elements, appState);
-    const areTextElements = selectedElements.every(el => isTextElement(el)) 
-    return selectedElements.length > 0 && areTextElements
+    const areTextElements = selectedElements.every((el) => isTextElement(el));
+    return selectedElements.length > 0 && areTextElements;
   },
   perform: (elements, appState) => {
     const selectedElements = getSelectedElements(
@@ -195,8 +196,8 @@ export const actionCreateContainerFromText = register({
     );
     let updatedElements = elements.slice();
     let updatedAppState = appState;
-    let containerIds:any = {};
-  
+    const containerIds: AppState["selectedElementIds"] = {};
+
     for (const textElement of selectedElements) {
       if (isTextElement(textElement)) {
         const container = newElement({
@@ -215,10 +216,10 @@ export const actionCreateContainerFromText = register({
           roundness:
             appState.currentItemRoundness === "round"
               ? {
-                  type: isUsingAdaptiveRadius("rectangle")
-                    ? ROUNDNESS.ADAPTIVE_RADIUS
-                    : ROUNDNESS.PROPORTIONAL_RADIUS,
-                }
+                type: isUsingAdaptiveRadius("rectangle")
+                  ? ROUNDNESS.ADAPTIVE_RADIUS
+                  : ROUNDNESS.PROPORTIONAL_RADIUS,
+              }
               : null,
           opacity: 100,
           locked: false,
@@ -234,7 +235,7 @@ export const actionCreateContainerFromText = register({
           ),
           groupIds: textElement.groupIds,
         });
-  
+
         // update bindings
         if (textElement.boundElements?.length) {
           const linearElementIds = textElement.boundElements
@@ -246,47 +247,47 @@ export const actionCreateContainerFromText = register({
           linearElements.forEach((ele) => {
             let startBinding = ele.startBinding;
             let endBinding = ele.endBinding;
-  
+
             if (startBinding?.elementId === textElement.id) {
               startBinding = {
                 ...startBinding,
                 elementId: container.id,
               };
             }
-  
+
             if (endBinding?.elementId === textElement.id) {
               endBinding = { ...endBinding, elementId: container.id };
             }
-  
+
             if (startBinding || endBinding) {
               mutateElement(ele, { startBinding, endBinding });
             }
           });
         }
-  
+
         mutateElement(textElement, {
           containerId: container.id,
           verticalAlign: VERTICAL_ALIGN.MIDDLE,
           boundElements: null,
         });
         redrawTextBoundingBox(textElement, container);
-  
+
         updatedElements = pushContainerBelowText(
           [...updatedElements, container],
           container,
           textElement,
-        )
+        );
         containerIds[container.id] = true;
       }
     }
-  
+
     if (Object.keys(containerIds).length > 0) {
       updatedAppState = {
         ...appState,
         selectedElementIds: containerIds,
       };
     }
-  
+
     return {
       elements: updatedElements,
       appState: updatedAppState,

--- a/src/actions/actionBoundText.tsx
+++ b/src/actions/actionBoundText.tsx
@@ -216,10 +216,10 @@ export const actionCreateContainerFromText = register({
           roundness:
             appState.currentItemRoundness === "round"
               ? {
-                type: isUsingAdaptiveRadius("rectangle")
-                  ? ROUNDNESS.ADAPTIVE_RADIUS
-                  : ROUNDNESS.PROPORTIONAL_RADIUS,
-              }
+                  type: isUsingAdaptiveRadius("rectangle")
+                    ? ROUNDNESS.ADAPTIVE_RADIUS
+                    : ROUNDNESS.PROPORTIONAL_RADIUS,
+                }
               : null,
           opacity: 100,
           locked: false,

--- a/src/actions/actionBoundText.tsx
+++ b/src/actions/actionBoundText.tsx
@@ -194,8 +194,7 @@ export const actionCreateContainerFromText = register({
       getNonDeletedElements(elements),
       appState,
     );
-    let updatedElements = elements.slice();
-    let updatedAppState = appState;
+    let updatedElements: readonly ExcalidrawElement[] = elements.slice();
     const containerIds: AppState["selectedElementIds"] = {};
 
     for (const textElement of selectedElements) {
@@ -285,16 +284,12 @@ export const actionCreateContainerFromText = register({
       }
     }
 
-    if (Object.keys(containerIds).length > 0) {
-      updatedAppState = {
-        ...appState,
-        selectedElementIds: containerIds,
-      };
-    }
-
     return {
       elements: updatedElements,
-      appState: updatedAppState,
+      appState: {
+        ...appState,
+        selectedElementIds: containerIds,
+      },
       commitToHistory: true,
     };
   },

--- a/src/actions/actionBoundText.tsx
+++ b/src/actions/actionBoundText.tsx
@@ -260,16 +260,20 @@ export const actionCreateContainerFromText = register({
             }
 
             if (startBinding || endBinding) {
-              mutateElement(ele, { startBinding, endBinding });
+              mutateElement(ele, { startBinding, endBinding }, false);
             }
           });
         }
 
-        mutateElement(textElement, {
-          containerId: container.id,
-          verticalAlign: VERTICAL_ALIGN.MIDDLE,
-          boundElements: null,
-        });
+        mutateElement(
+          textElement,
+          {
+            containerId: container.id,
+            verticalAlign: VERTICAL_ALIGN.MIDDLE,
+            boundElements: null,
+          },
+          false,
+        );
         redrawTextBoundingBox(textElement, container);
 
         updatedElements = pushContainerBelowText(

--- a/src/actions/actionBoundText.tsx
+++ b/src/actions/actionBoundText.tsx
@@ -185,107 +185,111 @@ export const actionCreateContainerFromText = register({
   trackEvent: { category: "element" },
   predicate: (elements, appState) => {
     const selectedElements = getSelectedElements(elements, appState);
-    return selectedElements.length === 1 && isTextElement(selectedElements[0]);
+    const areTextElements = selectedElements.every(el => isTextElement(el)) 
+    return selectedElements.length > 0 && areTextElements
   },
   perform: (elements, appState) => {
     const selectedElements = getSelectedElements(
       getNonDeletedElements(elements),
       appState,
     );
-    const updatedElements = elements.slice();
-    if (selectedElements.length === 1 && isTextElement(selectedElements[0])) {
-      const textElement = selectedElements[0];
-      const container = newElement({
-        type: "rectangle",
-        backgroundColor: appState.currentItemBackgroundColor,
-        boundElements: [
-          ...(textElement.boundElements || []),
-          { id: textElement.id, type: "text" },
-        ],
-        angle: textElement.angle,
-        fillStyle: appState.currentItemFillStyle,
-        strokeColor: appState.currentItemStrokeColor,
-        roughness: appState.currentItemRoughness,
-        strokeWidth: appState.currentItemStrokeWidth,
-        strokeStyle: appState.currentItemStrokeStyle,
-        roundness:
-          appState.currentItemRoundness === "round"
-            ? {
-                type: isUsingAdaptiveRadius("rectangle")
-                  ? ROUNDNESS.ADAPTIVE_RADIUS
-                  : ROUNDNESS.PROPORTIONAL_RADIUS,
-              }
-            : null,
-        opacity: 100,
-        locked: false,
-        x: textElement.x - BOUND_TEXT_PADDING,
-        y: textElement.y - BOUND_TEXT_PADDING,
-        width: computeContainerDimensionForBoundText(
-          textElement.width,
-          "rectangle",
-        ),
-        height: computeContainerDimensionForBoundText(
-          textElement.height,
-          "rectangle",
-        ),
-        groupIds: textElement.groupIds,
-      });
-
-      // update bindings
-      if (textElement.boundElements?.length) {
-        const linearElementIds = textElement.boundElements
-          .filter((ele) => ele.type === "arrow")
-          .map((el) => el.id);
-        const linearElements = updatedElements.filter((ele) =>
-          linearElementIds.includes(ele.id),
-        ) as ExcalidrawLinearElement[];
-        linearElements.forEach((ele) => {
-          let startBinding = ele.startBinding;
-          let endBinding = ele.endBinding;
-
-          if (startBinding?.elementId === textElement.id) {
-            startBinding = {
-              ...startBinding,
-              elementId: container.id,
-            };
-          }
-
-          if (endBinding?.elementId === textElement.id) {
-            endBinding = { ...endBinding, elementId: container.id };
-          }
-
-          if (startBinding || endBinding) {
-            mutateElement(ele, { startBinding, endBinding });
-          }
+    let updatedElements = elements.slice();
+    let updatedAppState = appState;
+    let containerIds:any = {};
+  
+    for (const textElement of selectedElements) {
+      if (isTextElement(textElement)) {
+        const container = newElement({
+          type: "rectangle",
+          backgroundColor: appState.currentItemBackgroundColor,
+          boundElements: [
+            ...(textElement.boundElements || []),
+            { id: textElement.id, type: "text" },
+          ],
+          angle: textElement.angle,
+          fillStyle: appState.currentItemFillStyle,
+          strokeColor: appState.currentItemStrokeColor,
+          roughness: appState.currentItemRoughness,
+          strokeWidth: appState.currentItemStrokeWidth,
+          strokeStyle: appState.currentItemStrokeStyle,
+          roundness:
+            appState.currentItemRoundness === "round"
+              ? {
+                  type: isUsingAdaptiveRadius("rectangle")
+                    ? ROUNDNESS.ADAPTIVE_RADIUS
+                    : ROUNDNESS.PROPORTIONAL_RADIUS,
+                }
+              : null,
+          opacity: 100,
+          locked: false,
+          x: textElement.x - BOUND_TEXT_PADDING,
+          y: textElement.y - BOUND_TEXT_PADDING,
+          width: computeContainerDimensionForBoundText(
+            textElement.width,
+            "rectangle",
+          ),
+          height: computeContainerDimensionForBoundText(
+            textElement.height,
+            "rectangle",
+          ),
+          groupIds: textElement.groupIds,
         });
-      }
-
-      mutateElement(textElement, {
-        containerId: container.id,
-        verticalAlign: VERTICAL_ALIGN.MIDDLE,
-        boundElements: null,
-      });
-      redrawTextBoundingBox(textElement, container);
-
-      return {
-        elements: pushContainerBelowText(
-          [...elements, container],
+  
+        // update bindings
+        if (textElement.boundElements?.length) {
+          const linearElementIds = textElement.boundElements
+            .filter((ele) => ele.type === "arrow")
+            .map((el) => el.id);
+          const linearElements = updatedElements.filter((ele) =>
+            linearElementIds.includes(ele.id),
+          ) as ExcalidrawLinearElement[];
+          linearElements.forEach((ele) => {
+            let startBinding = ele.startBinding;
+            let endBinding = ele.endBinding;
+  
+            if (startBinding?.elementId === textElement.id) {
+              startBinding = {
+                ...startBinding,
+                elementId: container.id,
+              };
+            }
+  
+            if (endBinding?.elementId === textElement.id) {
+              endBinding = { ...endBinding, elementId: container.id };
+            }
+  
+            if (startBinding || endBinding) {
+              mutateElement(ele, { startBinding, endBinding });
+            }
+          });
+        }
+  
+        mutateElement(textElement, {
+          containerId: container.id,
+          verticalAlign: VERTICAL_ALIGN.MIDDLE,
+          boundElements: null,
+        });
+        redrawTextBoundingBox(textElement, container);
+  
+        updatedElements = pushContainerBelowText(
+          [...updatedElements, container],
           container,
           textElement,
-        ),
-        appState: {
-          ...appState,
-          selectedElementIds: {
-            [container.id]: true,
-            [textElement.id]: false,
-          },
-        },
-        commitToHistory: true,
+        )
+        containerIds[container.id] = true;
+      }
+    }
+  
+    if (Object.keys(containerIds).length > 0) {
+      updatedAppState = {
+        ...appState,
+        selectedElementIds: containerIds,
       };
     }
+  
     return {
       elements: updatedElements,
-      appState,
+      appState: updatedAppState,
       commitToHistory: true,
     };
   },


### PR DESCRIPTION
Closes #6418

Updated `actionCreateContainerFromText` action to take multiple text elements.
Iterated over each element and adding containers to them


https://user-images.githubusercontent.com/51131670/230577307-4a6a56af-94c1-4ec5-ac6a-9fa515fea2f7.mov


