### PR TITLE
fix: abort freedraw line if second touch is detected

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -3514,6 +3514,9 @@ class App extends React.Component<AppProps, AppState> {
       this.setState({ contextMenu: null });
     }
 
+    if(this.state.draggingElement) {
+      console.log("dragging element");
+    }
     // remove any active selection when we start to interact with canvas
     // (mainly, we care about removing selection outside the component which
     //  would prevent our copy handling otherwise)

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -3542,11 +3542,6 @@ class App extends React.Component<AppProps, AppState> {
       selection.removeAllRanges();
     }
     this.maybeOpenContextMenuAfterPointerDownOnTouchDevices(event);
-    this.maybeCleanupAfterMissingPointerUp(event);
-
-    if (isSecondTouchFreedraw) {
-      return;
-    }
 
     //fires only once, if pen is detected, penMode is enabled
     //the user can disable this by toggling the penMode button
@@ -3578,6 +3573,12 @@ class App extends React.Component<AppProps, AppState> {
     this.savePointer(event.clientX, event.clientY, "down");
 
     this.updateGestureOnPointerDown(event);
+
+    if (isSecondTouchFreedraw) {
+      return;
+    }
+
+    this.maybeCleanupAfterMissingPointerUp(event);
 
     if (this.handleCanvasPanUsingWheelOrSpaceDrag(event)) {
       return;

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -3062,11 +3062,6 @@ class App extends React.Component<AppProps, AppState> {
       this.state.editingLinearElement &&
       !this.state.editingLinearElement.isDragging
     ) {
-      console.log(
-        "handlePointerMove",
-        "editingLinearElement",
-        this.state.multiElement?.id,
-      );
       const editingLinearElement = LinearElementEditor.handlePointerMove(
         event,
         scenePointerX,
@@ -3122,9 +3117,6 @@ class App extends React.Component<AppProps, AppState> {
       setCursorForShape(this.canvas, this.state);
 
       if (lastPoint === lastCommittedPoint) {
-        console.log(
-          "handleCanvasPointerMove, lastPoint === lastCommittedPoint",
-        );
         // if we haven't yet created a temp point and we're beyond commit-zone
         // threshold, add a point
         if (
@@ -3153,17 +3145,11 @@ class App extends React.Component<AppProps, AppState> {
           lastCommittedPoint[1],
         ) < LINE_CONFIRM_THRESHOLD
       ) {
-        console.log(
-          "handleCanvasPointerMove, lastPoint !== lastCommittedPoint, points.length>2, remove last point",
-        );
         setCursor(this.canvas, CURSOR_TYPE.POINTER);
         mutateElement(multiElement, {
           points: points.slice(0, -1),
         });
       } else {
-        console.log(
-          "handleCanvasPointerMove, lastPoint !== lastCommittedPoint, points.length<=2",
-        );
         const [gridX, gridY] = getGridPoint(
           scenePointerX,
           scenePointerY,
@@ -3634,10 +3620,6 @@ class App extends React.Component<AppProps, AppState> {
       this.state.activeTool.type === "arrow" ||
       this.state.activeTool.type === "line"
     ) {
-      console.log(
-        "handleLinearElementOnPointerDown",
-        this.state.multiElement?.id,
-      );
       this.handleLinearElementOnPointerDown(
         event,
         this.state.activeTool.type,
@@ -3669,10 +3651,6 @@ class App extends React.Component<AppProps, AppState> {
         y,
       });
     } else if (this.state.activeTool.type === "freedraw") {
-      console.log(
-        "handleFreeDrawElementOnPointerDown",
-        this.state.multiElement?.id,
-      );
       this.handleFreeDrawElementOnPointerDown(
         event,
         this.state.activeTool.type,
@@ -4558,7 +4536,6 @@ class App extends React.Component<AppProps, AppState> {
   private onPointerMoveFromPointerDownHandler(
     pointerDownState: PointerDownState,
   ) {
-    console.log("onPointerMoveFromPointerDownHandler");
     return withBatchedUpdatesThrottled((event: PointerEvent) => {
       // We need to initialize dragOffsetXY only after we've updated
       // `state.selectedElementIds` on pointerDown. Doing it here in pointerMove
@@ -4851,7 +4828,6 @@ class App extends React.Component<AppProps, AppState> {
           lastPoint && lastPoint[0] === dx && lastPoint[1] === dy;
 
         if (!discardPoint) {
-          console.log("freedraw pointer move", event);
           const pressures = draggingElement.simulatePressure
             ? draggingElement.pressures
             : [...draggingElement.pressures, event.pressure];
@@ -5210,7 +5186,6 @@ class App extends React.Component<AppProps, AppState> {
               ],
             ],
           });
-          console.log("setting multiElement", draggingElement.id);
           this.setState({
             multiElement: draggingElement,
             editingElement: this.state.draggingElement,

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -3500,17 +3500,18 @@ class App extends React.Component<AppProps, AppState> {
       this.setState({ contextMenu: null });
     }
 
+    this.updateGestureOnPointerDown(event);
+
     // if dragging element is freedraw and another pointerdown event occurs
     // a second finger is on the screen
     // discard the freedraw element if it is very short because it is likely
     // just a spike, otherwise finalize the freedraw element when the second
     // finger is lifted
-    this.updateGestureOnPointerDown(event);
-    const isSecondTouchFreedraw =
+    if (
       event.pointerType === "touch" &&
       this.state.draggingElement &&
-      this.state.draggingElement.type === "freedraw";
-    if (isSecondTouchFreedraw) {
+      this.state.draggingElement.type === "freedraw"
+    ) {
       const element = this.state.draggingElement as ExcalidrawFreeDrawElement;
       this.updateScene({
         ...(element.points.length < 10

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -3502,7 +3502,9 @@ class App extends React.Component<AppProps, AppState> {
 
     // if dragging element is freedraw and another pointerdown event occurs
     // a second finger is on the screen
-    // discard the freedraw element
+    // discard the freedraw element if it is very short because it is likely
+    // just a spike, otherwise finalize the freedraw element when the second
+    // finger is lifted
     if (
       event.pointerType === "touch" &&
       this.state.draggingElement &&
@@ -3510,9 +3512,13 @@ class App extends React.Component<AppProps, AppState> {
     ) {
       const element = this.state.draggingElement;
       this.updateScene({
-        elements: this.scene
-          .getElementsIncludingDeleted()
-          .filter((el) => el.id !== element.id),
+        ...(element.points.length > 3
+          ? {
+              elements: this.scene
+                .getElementsIncludingDeleted()
+                .filter((el) => el.id !== element.id),
+            }
+          : {}),
         appState: {
           draggingElement: null,
           editingElement: null,

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -4355,6 +4355,7 @@ class App extends React.Component<AppProps, AppState> {
   ): void => {
     if (this.state.multiElement) {
       const { multiElement } = this.state;
+
       // finalize if completing a loop
       if (
         multiElement.type === "line" &&

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -3532,7 +3532,6 @@ class App extends React.Component<AppProps, AppState> {
             }, {}),
         },
       });
-      return;
     }
 
     // remove any active selection when we start to interact with canvas

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -4812,7 +4812,7 @@ class App extends React.Component<AppProps, AppState> {
         return;
       }
 
-      if (draggingElement.type === "freedraw") {
+      if (draggingElement.type === "freedraw") { 
         const points = draggingElement.points;
         const dx = pointerCoords.x - draggingElement.x;
         const dy = pointerCoords.y - draggingElement.y;
@@ -4822,6 +4822,7 @@ class App extends React.Component<AppProps, AppState> {
           lastPoint && lastPoint[0] === dx && lastPoint[1] === dy;
 
         if (!discardPoint) {
+          console.log("freedraw pointer move", event);
           const pressures = draggingElement.simulatePressure
             ? draggingElement.pressures
             : [...draggingElement.pressures, event.pressure];

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -3505,6 +3505,7 @@ class App extends React.Component<AppProps, AppState> {
     // discard the freedraw element if it is very short because it is likely
     // just a spike, otherwise finalize the freedraw element when the second
     // finger is lifted
+    this.updateGestureOnPointerDown(event);
     const isSecondTouchFreedraw =
       event.pointerType === "touch" &&
       this.state.draggingElement &&
@@ -3532,6 +3533,7 @@ class App extends React.Component<AppProps, AppState> {
             }, {}),
         },
       });
+      return;
     }
 
     // remove any active selection when we start to interact with canvas
@@ -3542,6 +3544,7 @@ class App extends React.Component<AppProps, AppState> {
       selection.removeAllRanges();
     }
     this.maybeOpenContextMenuAfterPointerDownOnTouchDevices(event);
+    this.maybeCleanupAfterMissingPointerUp(event);
 
     //fires only once, if pen is detected, penMode is enabled
     //the user can disable this by toggling the penMode button
@@ -3571,14 +3574,6 @@ class App extends React.Component<AppProps, AppState> {
       cursorButton: "down",
     });
     this.savePointer(event.clientX, event.clientY, "down");
-
-    this.updateGestureOnPointerDown(event);
-
-    if (isSecondTouchFreedraw) {
-      return;
-    }
-
-    this.maybeCleanupAfterMissingPointerUp(event);
 
     if (this.handleCanvasPanUsingWheelOrSpaceDrag(event)) {
       return;

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -3541,11 +3541,12 @@ class App extends React.Component<AppProps, AppState> {
     if (selection?.anchorNode) {
       selection.removeAllRanges();
     }
+    this.maybeOpenContextMenuAfterPointerDownOnTouchDevices(event);
+    this.maybeCleanupAfterMissingPointerUp(event);
+
     if (isSecondTouchFreedraw) {
       return;
     }
-    this.maybeOpenContextMenuAfterPointerDownOnTouchDevices(event);
-    this.maybeCleanupAfterMissingPointerUp(event);
 
     //fires only once, if pen is detected, penMode is enabled
     //the user can disable this by toggling the penMode button

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -3541,6 +3541,9 @@ class App extends React.Component<AppProps, AppState> {
     if (selection?.anchorNode) {
       selection.removeAllRanges();
     }
+    if (isSecondTouchFreedraw) {
+      return;
+    }
     this.maybeOpenContextMenuAfterPointerDownOnTouchDevices(event);
     this.maybeCleanupAfterMissingPointerUp(event);
 
@@ -3574,10 +3577,6 @@ class App extends React.Component<AppProps, AppState> {
     this.savePointer(event.clientX, event.clientY, "down");
 
     this.updateGestureOnPointerDown(event);
-
-    if (isSecondTouchFreedraw) {
-      return;
-    }
 
     if (this.handleCanvasPanUsingWheelOrSpaceDrag(event)) {
       return;

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -3505,12 +3505,12 @@ class App extends React.Component<AppProps, AppState> {
     // discard the freedraw element if it is very short because it is likely
     // just a spike, otherwise finalize the freedraw element when the second
     // finger is lifted
-    if (
+    const isSecondTouchFreedraw =
       event.pointerType === "touch" &&
       this.state.draggingElement &&
-      this.state.draggingElement.type === "freedraw"
-    ) {
-      const element = this.state.draggingElement;
+      this.state.draggingElement.type === "freedraw";
+    if (isSecondTouchFreedraw) {
+      const element = this.state.draggingElement as ExcalidrawFreeDrawElement;
       this.updateScene({
         ...(element.points.length < 10
           ? {
@@ -3575,6 +3575,10 @@ class App extends React.Component<AppProps, AppState> {
 
     this.updateGestureOnPointerDown(event);
 
+    if (isSecondTouchFreedraw) {
+      return;
+    }
+
     if (this.handleCanvasPanUsingWheelOrSpaceDrag(event)) {
       return;
     }
@@ -3604,14 +3608,6 @@ class App extends React.Component<AppProps, AppState> {
     this.updateBindingEnabledOnPointerMove(event);
 
     if (this.handleSelectionOnPointerDown(event, pointerDownState)) {
-      return;
-    }
-
-    if (
-      event.pointerType === "touch" &&
-      this.state.draggingElement &&
-      this.state.draggingElement.type === "freedraw"
-    ) {
       return;
     }
 

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -3512,7 +3512,7 @@ class App extends React.Component<AppProps, AppState> {
     ) {
       const element = this.state.draggingElement;
       this.updateScene({
-        ...(element.points.length > 3
+        ...(element.points.length < 3
           ? {
               elements: this.scene
                 .getElementsIncludingDeleted()

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -3523,19 +3523,22 @@ class App extends React.Component<AppProps, AppState> {
       this.state.draggingElement.type === "freedraw"
     ) {
       const element = this.state.draggingElement;
-      this.setState((prevState) => {
-        return {
+      this.updateScene({
+        elements: this.scene
+          .getElementsIncludingDeleted()
+          .filter((el) => el.id !== element.id),
+        appState: {
           draggingElement: null,
           editingElement: null,
           startBoundElement: null,
           suggestedBindings: [],
-          selectedElementIds: Object.keys(prevState.selectedElementIds)
+          selectedElementIds: Object.keys(this.state.selectedElementIds)
             .filter((key) => key !== element.id)
             .reduce((obj: { [id: string]: boolean }, key) => {
-              obj[key] = prevState.selectedElementIds[key];
+              obj[key] = this.state.selectedElementIds[key];
               return obj;
             }, {}),
-        };
+        },
       });
       return;
     }

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -3514,9 +3514,16 @@ class App extends React.Component<AppProps, AppState> {
       this.setState({ contextMenu: null });
     }
 
-    if(this.state.draggingElement) {
-      console.log("dragging element");
+    // if dragging element and pointer down, this is indicates
+    // a second finger on the screen 
+    if (
+      event.pointerType === "touch" &&
+      this.state.draggingElement &&
+      this.state.draggingElement.type === "freedraw"
+    ) {
+      return;
     }
+
     // remove any active selection when we start to interact with canvas
     // (mainly, we care about removing selection outside the component which
     //  would prevent our copy handling otherwise)
@@ -4815,7 +4822,7 @@ class App extends React.Component<AppProps, AppState> {
         return;
       }
 
-      if (draggingElement.type === "freedraw") { 
+      if (draggingElement.type === "freedraw") {
         const points = draggingElement.points;
         const dx = pointerCoords.x - draggingElement.x;
         const dy = pointerCoords.y - draggingElement.y;

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -3512,7 +3512,7 @@ class App extends React.Component<AppProps, AppState> {
     ) {
       const element = this.state.draggingElement;
       this.updateScene({
-        ...(element.points.length < 3
+        ...(element.points.length < 10
           ? {
               elements: this.scene
                 .getElementsIncludingDeleted()

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -3607,6 +3607,14 @@ class App extends React.Component<AppProps, AppState> {
       return;
     }
 
+    if (
+      event.pointerType === "touch" &&
+      this.state.draggingElement &&
+      this.state.draggingElement.type === "freedraw"
+    ) {
+      return;
+    }
+
     const allowOnPointerDown =
       !this.state.penMode ||
       event.pointerType !== "touch" ||

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -3062,7 +3062,11 @@ class App extends React.Component<AppProps, AppState> {
       this.state.editingLinearElement &&
       !this.state.editingLinearElement.isDragging
     ) {
-      console.log("handlePointerMove", "editingLinearElement", this.state.multiElement?.id );
+      console.log(
+        "handlePointerMove",
+        "editingLinearElement",
+        this.state.multiElement?.id,
+      );
       const editingLinearElement = LinearElementEditor.handlePointerMove(
         event,
         scenePointerX,
@@ -3118,7 +3122,9 @@ class App extends React.Component<AppProps, AppState> {
       setCursorForShape(this.canvas, this.state);
 
       if (lastPoint === lastCommittedPoint) {
-        console.log("handleCanvasPointerMove, lastPoint === lastCommittedPoint");
+        console.log(
+          "handleCanvasPointerMove, lastPoint === lastCommittedPoint",
+        );
         // if we haven't yet created a temp point and we're beyond commit-zone
         // threshold, add a point
         if (
@@ -3147,13 +3153,17 @@ class App extends React.Component<AppProps, AppState> {
           lastCommittedPoint[1],
         ) < LINE_CONFIRM_THRESHOLD
       ) {
-        console.log("handleCanvasPointerMove, lastPoint !== lastCommittedPoint, points.length>2, remove last point");
+        console.log(
+          "handleCanvasPointerMove, lastPoint !== lastCommittedPoint, points.length>2, remove last point",
+        );
         setCursor(this.canvas, CURSOR_TYPE.POINTER);
         mutateElement(multiElement, {
           points: points.slice(0, -1),
         });
       } else {
-        console.log("handleCanvasPointerMove, lastPoint !== lastCommittedPoint, points.length<=2");
+        console.log(
+          "handleCanvasPointerMove, lastPoint !== lastCommittedPoint, points.length<=2",
+        );
         const [gridX, gridY] = getGridPoint(
           scenePointerX,
           scenePointerY,
@@ -3595,7 +3605,10 @@ class App extends React.Component<AppProps, AppState> {
       this.state.activeTool.type === "arrow" ||
       this.state.activeTool.type === "line"
     ) {
-      console.log("handleLinearElementOnPointerDown",this.state.multiElement?.id);
+      console.log(
+        "handleLinearElementOnPointerDown",
+        this.state.multiElement?.id,
+      );
       this.handleLinearElementOnPointerDown(
         event,
         this.state.activeTool.type,
@@ -3627,7 +3640,10 @@ class App extends React.Component<AppProps, AppState> {
         y,
       });
     } else if (this.state.activeTool.type === "freedraw") {
-      console.log("handleFreeDrawElementOnPointerDown",this.state.multiElement?.id);
+      console.log(
+        "handleFreeDrawElementOnPointerDown",
+        this.state.multiElement?.id,
+      );
       this.handleFreeDrawElementOnPointerDown(
         event,
         this.state.activeTool.type,

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -3514,13 +3514,29 @@ class App extends React.Component<AppProps, AppState> {
       this.setState({ contextMenu: null });
     }
 
-    // if dragging element and pointer down, this is indicates
-    // a second finger on the screen 
+    // if dragging element is freedraw and another pointerdown event occurs
+    // a second finger is on the screen
+    // discard the freedraw element
     if (
       event.pointerType === "touch" &&
       this.state.draggingElement &&
       this.state.draggingElement.type === "freedraw"
     ) {
+      const element = this.state.draggingElement;
+      this.setState((prevState) => {
+        return {
+          draggingElement: null,
+          editingElement: null,
+          startBoundElement: null,
+          suggestedBindings: [],
+          selectedElementIds: Object.keys(prevState.selectedElementIds)
+            .filter((key) => key !== element.id)
+            .reduce((obj: { [id: string]: boolean }, key) => {
+              obj[key] = prevState.selectedElementIds[key];
+              return obj;
+            }, {}),
+        };
+      });
       return;
     }
 

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -3062,6 +3062,7 @@ class App extends React.Component<AppProps, AppState> {
       this.state.editingLinearElement &&
       !this.state.editingLinearElement.isDragging
     ) {
+      console.log("handlePointerMove", "editingLinearElement", this.state.multiElement?.id );
       const editingLinearElement = LinearElementEditor.handlePointerMove(
         event,
         scenePointerX,
@@ -3117,6 +3118,7 @@ class App extends React.Component<AppProps, AppState> {
       setCursorForShape(this.canvas, this.state);
 
       if (lastPoint === lastCommittedPoint) {
+        console.log("handleCanvasPointerMove, lastPoint === lastCommittedPoint");
         // if we haven't yet created a temp point and we're beyond commit-zone
         // threshold, add a point
         if (
@@ -3145,11 +3147,13 @@ class App extends React.Component<AppProps, AppState> {
           lastCommittedPoint[1],
         ) < LINE_CONFIRM_THRESHOLD
       ) {
+        console.log("handleCanvasPointerMove, lastPoint !== lastCommittedPoint, points.length>2, remove last point");
         setCursor(this.canvas, CURSOR_TYPE.POINTER);
         mutateElement(multiElement, {
           points: points.slice(0, -1),
         });
       } else {
+        console.log("handleCanvasPointerMove, lastPoint !== lastCommittedPoint, points.length<=2");
         const [gridX, gridY] = getGridPoint(
           scenePointerX,
           scenePointerY,
@@ -3591,6 +3595,7 @@ class App extends React.Component<AppProps, AppState> {
       this.state.activeTool.type === "arrow" ||
       this.state.activeTool.type === "line"
     ) {
+      console.log("handleLinearElementOnPointerDown",this.state.multiElement?.id);
       this.handleLinearElementOnPointerDown(
         event,
         this.state.activeTool.type,
@@ -3622,6 +3627,7 @@ class App extends React.Component<AppProps, AppState> {
         y,
       });
     } else if (this.state.activeTool.type === "freedraw") {
+      console.log("handleFreeDrawElementOnPointerDown",this.state.multiElement?.id);
       this.handleFreeDrawElementOnPointerDown(
         event,
         this.state.activeTool.type,
@@ -4326,7 +4332,6 @@ class App extends React.Component<AppProps, AppState> {
   ): void => {
     if (this.state.multiElement) {
       const { multiElement } = this.state;
-
       // finalize if completing a loop
       if (
         multiElement.type === "line" &&
@@ -4508,6 +4513,7 @@ class App extends React.Component<AppProps, AppState> {
   private onPointerMoveFromPointerDownHandler(
     pointerDownState: PointerDownState,
   ) {
+    console.log("onPointerMoveFromPointerDownHandler");
     return withBatchedUpdatesThrottled((event: PointerEvent) => {
       // We need to initialize dragOffsetXY only after we've updated
       // `state.selectedElementIds` on pointerDown. Doing it here in pointerMove
@@ -5158,6 +5164,7 @@ class App extends React.Component<AppProps, AppState> {
               ],
             ],
           });
+          console.log("setting multiElement", draggingElement.id);
           this.setState({
             multiElement: draggingElement,
             editingElement: this.state.draggingElement,


### PR DESCRIPTION
See also: [#1065](https://github.com/zsviczian/obsidian-excalidraw-plugin/issues/1065) 
Placing a second finger on the canvas while drawing a freedraw shape results in a spike and the termination of the freedraw editing. Under normal conditions (i.e. drawing with your finger) this should not happen. This typically happens when using a pen, clicking the pen tool for the first time, and touching the canvas with your palm before touching it with the pen. In this scenario penMode does not activate before receiving the multi-touch input, resulting in the unwanted line.

The easiest way to simulate this situation is by touching the freedraw tool (i.e. not in penMode), then touching the canvas with one finger, and then, while the first finger stays on touching the canvas, touching the canvas with a second finger.

![9B61D10B-6F27-4D02-8639-F9BEFB1D8DC8](https://user-images.githubusercontent.com/14358394/230955766-ebce0155-1936-4d17-adce-19f9b9e1f4bb.png)

![image](https://user-images.githubusercontent.com/15788108/229863842-ac65c9c6-2686-430d-b000-3f2fb41a40ab.png)