### PR TITLE
fix: center align text when bind to container via context menu

### DIFF
--- a/src/actions/actionBoundText.tsx
+++ b/src/actions/actionBoundText.tsx
@@ -1,4 +1,9 @@
-import { BOUND_TEXT_PADDING, ROUNDNESS, VERTICAL_ALIGN } from "../constants";
+import {
+  BOUND_TEXT_PADDING,
+  ROUNDNESS,
+  VERTICAL_ALIGN,
+  TEXT_ALIGN,
+} from "../constants";
 import { getNonDeletedElements, isTextElement, newElement } from "../element";
 import { mutateElement } from "../element/mutateElement";
 import {
@@ -132,6 +137,7 @@ export const actionBindText = register({
     mutateElement(textElement, {
       containerId: container.id,
       verticalAlign: VERTICAL_ALIGN.MIDDLE,
+      textAlign: TEXT_ALIGN.CENTER,
     });
     mutateElement(container, {
       boundElements: (container.boundElements || []).concat({

--- a/src/element/textWysiwyg.test.tsx
+++ b/src/element/textWysiwyg.test.tsx
@@ -19,6 +19,7 @@ import { API } from "../tests/helpers/api";
 import { mutateElement } from "./mutateElement";
 import { resize } from "../tests/utils";
 import { getOriginalContainerHeightFromCache } from "./textWysiwyg";
+import { actionBindText } from "../actions/actionBoundText";
 
 // Unmount ReactDOM from root
 ReactDOM.unmountComponentAtNode(document.getElementById("root")!);
@@ -1502,6 +1503,37 @@ describe("textWysiwyg", () => {
           textAlign: TEXT_ALIGN.LEFT,
           boundElements: null,
         }),
+      );
+    });
+
+    it("should text be centered when binding to a rectangle", async () => {
+      const rectangle1 = API.createElement({
+        type: "rectangle",
+        id: "rectangle1",
+        width: 100,
+        height: 100,
+      });
+
+      const text1 = API.createElement({
+        type: "text",
+        id: "text1",
+        text: "Snorf",
+      });
+
+      h.elements = [rectangle1, text1];
+
+      API.setSelectedElements([rectangle1, text1]);
+
+      expect(h.state.selectedElementIds[(rectangle1.id, text1.id)]).toBe(true);
+
+      h.app.actionManager.executeAction(actionBindText);
+
+      const container = h.elements.at(-2)!;
+
+      expect(container.type).toBe("rectangle");
+      expect(text1.x).toBe(container.x + container.width / 2 - text1.width / 2);
+      expect(text1.y).toBe(
+        container.y + container.height / 2 - text1.height / 2,
       );
     });
   });

--- a/src/element/textWysiwyg.test.tsx
+++ b/src/element/textWysiwyg.test.tsx
@@ -19,7 +19,6 @@ import { API } from "../tests/helpers/api";
 import { mutateElement } from "./mutateElement";
 import { resize } from "../tests/utils";
 import { getOriginalContainerHeightFromCache } from "./textWysiwyg";
-import { actionBindText } from "../actions/actionBoundText";
 
 // Unmount ReactDOM from root
 ReactDOM.unmountComponentAtNode(document.getElementById("root")!);
@@ -778,6 +777,13 @@ describe("textWysiwyg", () => {
       ]);
       expect(text.containerId).toBe(rectangle.id);
       expect(text.verticalAlign).toBe(VERTICAL_ALIGN.MIDDLE);
+      expect(text.textAlign).toBe(TEXT_ALIGN.CENTER);
+      expect(text.x).toBe(
+        h.elements[0].x + h.elements[0].width / 2 - text.width / 2,
+      );
+      expect(text.y).toBe(
+        h.elements[0].y + h.elements[0].height / 2 - text.height / 2,
+      );
     });
 
     it("should update font family correctly on undo/redo by selecting bounded text when font family was updated", async () => {
@@ -1503,37 +1509,6 @@ describe("textWysiwyg", () => {
           textAlign: TEXT_ALIGN.LEFT,
           boundElements: null,
         }),
-      );
-    });
-
-    it("should text be centered when binding to a rectangle", async () => {
-      const rectangle1 = API.createElement({
-        type: "rectangle",
-        id: "rectangle1",
-        width: 100,
-        height: 100,
-      });
-
-      const text1 = API.createElement({
-        type: "text",
-        id: "text1",
-        text: "Snorf",
-      });
-
-      h.elements = [rectangle1, text1];
-
-      API.setSelectedElements([rectangle1, text1]);
-
-      expect(h.state.selectedElementIds[(rectangle1.id, text1.id)]).toBe(true);
-
-      h.app.actionManager.executeAction(actionBindText);
-
-      const container = h.elements.at(-2)!;
-
-      expect(container.type).toBe("rectangle");
-      expect(text1.x).toBe(container.x + container.width / 2 - text1.width / 2);
-      expect(text1.y).toBe(
-        container.y + container.height / 2 - text1.height / 2,
       );
     });
   });

--- a/src/tests/binding.test.tsx
+++ b/src/tests/binding.test.tsx
@@ -4,10 +4,7 @@ import { UI, Pointer, Keyboard } from "./helpers/ui";
 import { getTransformHandles } from "../element/transformHandles";
 import { API } from "./helpers/api";
 import { KEYS } from "../keys";
-import {
-  actionCreateContainerFromText,
-  actionBindText,
-} from "../actions/actionBoundText";
+import { actionCreateContainerFromText } from "../actions/actionBoundText";
 
 const { h } = window;
 
@@ -311,34 +308,5 @@ describe("element binding", () => {
     expect(arrow1.endBinding?.elementId).toBe(container.id);
     expect(arrow2.startBinding?.elementId).toBe(container.id);
     expect(arrow2.endBinding?.elementId).toBe(rectangle1.id);
-  });
-
-  it("should text be centered when binding to a rectangle", async () => {
-    const rectangle1 = API.createElement({
-      type: "rectangle",
-      id: "rectangle1",
-      width: 100,
-      height: 100,
-    });
-
-    const text1 = API.createElement({
-      type: "text",
-      id: "text1",
-      text: "Snorf",
-    });
-
-    h.elements = [rectangle1, text1];
-
-    API.setSelectedElements([rectangle1, text1]);
-
-    expect(h.state.selectedElementIds[(rectangle1.id, text1.id)]).toBe(true);
-
-    h.app.actionManager.executeAction(actionBindText);
-
-    const container = h.elements.at(-2)!;
-
-    expect(container.type).toBe("rectangle");
-    expect(text1.x).toBe(container.x + container.width / 2 - text1.width / 2);
-    expect(text1.y).toBe(container.y + container.height / 2 - text1.height / 2);
   });
 });

--- a/src/tests/binding.test.tsx
+++ b/src/tests/binding.test.tsx
@@ -4,7 +4,7 @@ import { UI, Pointer, Keyboard } from "./helpers/ui";
 import { getTransformHandles } from "../element/transformHandles";
 import { API } from "./helpers/api";
 import { KEYS } from "../keys";
-import { actionCreateContainerFromText } from "../actions/actionBoundText";
+import { actionCreateContainerFromText, actionBindText } from "../actions/actionBoundText";
 
 const { h } = window;
 
@@ -308,5 +308,34 @@ describe("element binding", () => {
     expect(arrow1.endBinding?.elementId).toBe(container.id);
     expect(arrow2.startBinding?.elementId).toBe(container.id);
     expect(arrow2.endBinding?.elementId).toBe(rectangle1.id);
+  });
+  
+  it("should text be centered when binding to a rectangle", async () => {
+    const rectangle1 = API.createElement({
+      type: "rectangle",
+      id: "rectangle1",
+      width: 100,
+      height: 100,
+    });
+
+    const text1 = API.createElement({
+      type: "text",
+      id: "text1",
+      text: "Snorf",
+    });
+
+    h.elements = [rectangle1, text1];
+
+    API.setSelectedElements([rectangle1, text1]);
+
+    expect(h.state.selectedElementIds[rectangle1.id, text1.id]).toBe(true);
+
+    h.app.actionManager.executeAction(actionBindText);
+
+    const container = h.elements.at(-2)!;
+    
+    expect(container.type).toBe("rectangle");
+    expect(text1.x).toBe(container.x+container.width/2-text1.width/2);
+    expect(text1.y).toBe(container.y+container.height/2-text1.height/2);
   });
 });

--- a/src/tests/binding.test.tsx
+++ b/src/tests/binding.test.tsx
@@ -4,7 +4,10 @@ import { UI, Pointer, Keyboard } from "./helpers/ui";
 import { getTransformHandles } from "../element/transformHandles";
 import { API } from "./helpers/api";
 import { KEYS } from "../keys";
-import { actionCreateContainerFromText, actionBindText } from "../actions/actionBoundText";
+import {
+  actionCreateContainerFromText,
+  actionBindText,
+} from "../actions/actionBoundText";
 
 const { h } = window;
 
@@ -309,7 +312,7 @@ describe("element binding", () => {
     expect(arrow2.startBinding?.elementId).toBe(container.id);
     expect(arrow2.endBinding?.elementId).toBe(rectangle1.id);
   });
-  
+
   it("should text be centered when binding to a rectangle", async () => {
     const rectangle1 = API.createElement({
       type: "rectangle",
@@ -328,14 +331,14 @@ describe("element binding", () => {
 
     API.setSelectedElements([rectangle1, text1]);
 
-    expect(h.state.selectedElementIds[rectangle1.id, text1.id]).toBe(true);
+    expect(h.state.selectedElementIds[(rectangle1.id, text1.id)]).toBe(true);
 
     h.app.actionManager.executeAction(actionBindText);
 
     const container = h.elements.at(-2)!;
-    
+
     expect(container.type).toBe("rectangle");
-    expect(text1.x).toBe(container.x+container.width/2-text1.width/2);
-    expect(text1.y).toBe(container.y+container.height/2-text1.height/2);
+    expect(text1.x).toBe(container.x + container.width / 2 - text1.width / 2);
+    expect(text1.y).toBe(container.y + container.height / 2 - text1.height / 2);
   });
 });


### PR DESCRIPTION
- [ ] closes #6434
- [x] Add tests