### PR TITLE
fix: utils leaking Scene state (#6461

### DIFF
--- a/src/element/newElement.test.ts
+++ b/src/element/newElement.test.ts
@@ -46,6 +46,7 @@ describe("duplicating single elements", () => {
 
     assertCloneObjects(element, copy);
 
+    // assert we clone the object's prototype
     // @ts-ignore
     expect(copy.__proto__).toEqual({ hello: "world" });
     expect(copy.hasOwnProperty("hello")).toBe(false);

--- a/src/element/newElement.test.ts
+++ b/src/element/newElement.test.ts
@@ -1,8 +1,9 @@
-import { duplicateElement } from "./newElement";
+import { duplicateElement, duplicateElements } from "./newElement";
 import { mutateElement } from "./mutateElement";
 import { API } from "../tests/helpers/api";
 import { FONT_FAMILY, ROUNDNESS } from "../constants";
 import { isPrimitive } from "../utils";
+import { ExcalidrawLinearElement } from "./types";
 
 const assertCloneObjects = (source: any, clone: any) => {
   for (const key in clone) {
@@ -15,79 +16,310 @@ const assertCloneObjects = (source: any, clone: any) => {
   }
 };
 
-it("clones arrow element", () => {
-  const element = API.createElement({
-    type: "arrow",
-    x: 0,
-    y: 0,
-    strokeColor: "#000000",
-    backgroundColor: "transparent",
-    fillStyle: "hachure",
-    strokeWidth: 1,
-    strokeStyle: "solid",
-    roundness: { type: ROUNDNESS.PROPORTIONAL_RADIUS },
-    roughness: 1,
-    opacity: 100,
+describe("duplicating single elements", () => {
+  it("clones arrow element", () => {
+    const element = API.createElement({
+      type: "arrow",
+      x: 0,
+      y: 0,
+      strokeColor: "#000000",
+      backgroundColor: "transparent",
+      fillStyle: "hachure",
+      strokeWidth: 1,
+      strokeStyle: "solid",
+      roundness: { type: ROUNDNESS.PROPORTIONAL_RADIUS },
+      roughness: 1,
+      opacity: 100,
+    });
+
+    // @ts-ignore
+    element.__proto__ = { hello: "world" };
+
+    mutateElement(element, {
+      points: [
+        [1, 2],
+        [3, 4],
+      ],
+    });
+
+    const copy = duplicateElement(null, new Map(), element);
+
+    assertCloneObjects(element, copy);
+
+    // @ts-ignore
+    expect(copy.__proto__).toEqual({ hello: "world" });
+    expect(copy.hasOwnProperty("hello")).toBe(false);
+
+    expect(copy.points).not.toBe(element.points);
+    expect(copy).not.toHaveProperty("shape");
+    expect(copy.id).not.toBe(element.id);
+    expect(typeof copy.id).toBe("string");
+    expect(copy.seed).not.toBe(element.seed);
+    expect(typeof copy.seed).toBe("number");
+    expect(copy).toEqual({
+      ...element,
+      id: copy.id,
+      seed: copy.seed,
+    });
   });
 
-  // @ts-ignore
-  element.__proto__ = { hello: "world" };
+  it("clones text element", () => {
+    const element = API.createElement({
+      type: "text",
+      x: 0,
+      y: 0,
+      strokeColor: "#000000",
+      backgroundColor: "transparent",
+      fillStyle: "hachure",
+      strokeWidth: 1,
+      strokeStyle: "solid",
+      roundness: null,
+      roughness: 1,
+      opacity: 100,
+      text: "hello",
+      fontSize: 20,
+      fontFamily: FONT_FAMILY.Virgil,
+      textAlign: "left",
+      verticalAlign: "top",
+    });
 
-  mutateElement(element, {
-    points: [
-      [1, 2],
-      [3, 4],
-    ],
-  });
+    const copy = duplicateElement(null, new Map(), element);
 
-  const copy = duplicateElement(null, new Map(), element);
+    assertCloneObjects(element, copy);
 
-  assertCloneObjects(element, copy);
-
-  // @ts-ignore
-  expect(copy.__proto__).toEqual({ hello: "world" });
-  expect(copy.hasOwnProperty("hello")).toBe(false);
-
-  expect(copy.points).not.toBe(element.points);
-  expect(copy).not.toHaveProperty("shape");
-  expect(copy.id).not.toBe(element.id);
-  expect(typeof copy.id).toBe("string");
-  expect(copy.seed).not.toBe(element.seed);
-  expect(typeof copy.seed).toBe("number");
-  expect(copy).toEqual({
-    ...element,
-    id: copy.id,
-    seed: copy.seed,
+    expect(copy).not.toHaveProperty("points");
+    expect(copy).not.toHaveProperty("shape");
+    expect(copy.id).not.toBe(element.id);
+    expect(typeof copy.id).toBe("string");
+    expect(typeof copy.seed).toBe("number");
   });
 });
 
-it("clones text element", () => {
-  const element = API.createElement({
-    type: "text",
-    x: 0,
-    y: 0,
-    strokeColor: "#000000",
-    backgroundColor: "transparent",
-    fillStyle: "hachure",
-    strokeWidth: 1,
-    strokeStyle: "solid",
-    roundness: null,
-    roughness: 1,
-    opacity: 100,
-    text: "hello",
-    fontSize: 20,
-    fontFamily: FONT_FAMILY.Virgil,
-    textAlign: "left",
-    verticalAlign: "top",
+describe("duplicating multiple elements", () => {
+  it("duplicateElements should clone bindings", () => {
+    const rectangle1 = API.createElement({
+      type: "rectangle",
+      id: "rectangle1",
+      boundElements: [
+        { id: "arrow1", type: "arrow" },
+        { id: "arrow2", type: "arrow" },
+        { id: "text1", type: "text" },
+      ],
+    });
+
+    const text1 = API.createElement({
+      type: "text",
+      id: "text1",
+      containerId: "rectangle1",
+    });
+
+    const arrow1 = API.createElement({
+      type: "arrow",
+      id: "arrow1",
+      startBinding: {
+        elementId: "rectangle1",
+        focus: 0.2,
+        gap: 7,
+      },
+    });
+
+    const arrow2 = API.createElement({
+      type: "arrow",
+      id: "arrow2",
+      endBinding: {
+        elementId: "rectangle1",
+        focus: 0.2,
+        gap: 7,
+      },
+      boundElements: [{ id: "text2", type: "text" }],
+    });
+
+    const text2 = API.createElement({
+      type: "text",
+      id: "text2",
+      containerId: "arrow2",
+    });
+
+    // -------------------------------------------------------------------------
+
+    const origElements = [rectangle1, text1, arrow1, arrow2, text2] as const;
+    const clonedElements = duplicateElements(origElements);
+
+    // generic id in-equality checks
+    // --------------------------------------------------------------------------
+    expect(origElements.map((e) => e.type)).toEqual(
+      clonedElements.map((e) => e.type),
+    );
+    origElements.forEach((origElement, idx) => {
+      const clonedElement = clonedElements[idx];
+      expect(origElement).toEqual(
+        expect.objectContaining({
+          id: expect.not.stringMatching(clonedElement.id),
+          type: clonedElement.type,
+        }),
+      );
+      if ("containerId" in origElement) {
+        expect(origElement.containerId).not.toBe(
+          (clonedElement as any).containerId,
+        );
+      }
+      if ("endBinding" in origElement) {
+        if (origElement.endBinding) {
+          expect(origElement.endBinding.elementId).not.toBe(
+            (clonedElement as any).endBinding?.elementId,
+          );
+        } else {
+          expect((clonedElement as any).endBinding).toBeNull();
+        }
+      }
+      if ("startBinding" in origElement) {
+        if (origElement.startBinding) {
+          expect(origElement.startBinding.elementId).not.toBe(
+            (clonedElement as any).startBinding?.elementId,
+          );
+        } else {
+          expect((clonedElement as any).startBinding).toBeNull();
+        }
+      }
+    });
+    // --------------------------------------------------------------------------
+
+    const clonedArrows = clonedElements.filter(
+      (e) => e.type === "arrow",
+    ) as ExcalidrawLinearElement[];
+
+    const [clonedRectangle, clonedText1, , clonedArrow2, clonedArrowLabel] =
+      clonedElements as any as typeof origElements;
+
+    expect(clonedText1.containerId).toBe(clonedRectangle.id);
+    expect(
+      clonedRectangle.boundElements!.find((e) => e.id === clonedText1.id),
+    ).toEqual(
+      expect.objectContaining({
+        id: clonedText1.id,
+        type: clonedText1.type,
+      }),
+    );
+
+    clonedArrows.forEach((arrow) => {
+      // console.log(arrow);
+      expect(
+        clonedRectangle.boundElements!.find((e) => e.id === arrow.id),
+      ).toEqual(
+        expect.objectContaining({
+          id: arrow.id,
+          type: arrow.type,
+        }),
+      );
+
+      if (arrow.endBinding) {
+        expect(arrow.endBinding.elementId).toBe(clonedRectangle.id);
+      }
+      if (arrow.startBinding) {
+        expect(arrow.startBinding.elementId).toBe(clonedRectangle.id);
+      }
+    });
+
+    expect(clonedArrow2.boundElements).toEqual([
+      { type: "text", id: clonedArrowLabel.id },
+    ]);
+    expect(clonedArrowLabel.containerId).toBe(clonedArrow2.id);
   });
 
-  const copy = duplicateElement(null, new Map(), element);
+  it("should remove id references of elements that aren't found", () => {
+    const rectangle1 = API.createElement({
+      type: "rectangle",
+      id: "rectangle1",
+      boundElements: [
+        // should keep
+        { id: "arrow1", type: "arrow" },
+        // should drop
+        { id: "arrow-not-exists", type: "arrow" },
+        // should drop
+        { id: "text-not-exists", type: "text" },
+      ],
+    });
 
-  assertCloneObjects(element, copy);
+    const arrow1 = API.createElement({
+      type: "arrow",
+      id: "arrow1",
+      startBinding: {
+        elementId: "rectangle1",
+        focus: 0.2,
+        gap: 7,
+      },
+    });
 
-  expect(copy).not.toHaveProperty("points");
-  expect(copy).not.toHaveProperty("shape");
-  expect(copy.id).not.toBe(element.id);
-  expect(typeof copy.id).toBe("string");
-  expect(typeof copy.seed).toBe("number");
+    const text1 = API.createElement({
+      type: "text",
+      id: "text1",
+      containerId: "rectangle-not-exists",
+    });
+
+    const arrow2 = API.createElement({
+      type: "arrow",
+      id: "arrow2",
+      startBinding: {
+        elementId: "rectangle1",
+        focus: 0.2,
+        gap: 7,
+      },
+      endBinding: {
+        elementId: "rectangle-not-exists",
+        focus: 0.2,
+        gap: 7,
+      },
+    });
+
+    const arrow3 = API.createElement({
+      type: "arrow",
+      id: "arrow2",
+      startBinding: {
+        elementId: "rectangle-not-exists",
+        focus: 0.2,
+        gap: 7,
+      },
+      endBinding: {
+        elementId: "rectangle1",
+        focus: 0.2,
+        gap: 7,
+      },
+    });
+
+    // -------------------------------------------------------------------------
+
+    const origElements = [rectangle1, text1, arrow1, arrow2, arrow3] as const;
+    const clonedElements = duplicateElements(
+      origElements,
+    ) as any as typeof origElements;
+    const [
+      clonedRectangle,
+      clonedText1,
+      clonedArrow1,
+      clonedArrow2,
+      clonedArrow3,
+    ] = clonedElements;
+
+    expect(clonedRectangle.boundElements).toEqual([
+      { id: clonedArrow1.id, type: "arrow" },
+    ]);
+
+    expect(clonedText1.containerId).toBe(null);
+
+    expect(clonedArrow2.startBinding).toEqual({
+      ...arrow2.startBinding,
+      elementId: clonedRectangle.id,
+    });
+    expect(clonedArrow2.endBinding).toBe(null);
+
+    expect(clonedArrow3.startBinding).toBe(null);
+    expect(clonedArrow3.endBinding).toEqual({
+      ...arrow3.endBinding,
+      elementId: clonedRectangle.id,
+    });
+  });
+
+  describe("should duplicate all group ids", () => {
+    // TOOD
+  });
 });

--- a/src/element/newElement.test.ts
+++ b/src/element/newElement.test.ts
@@ -320,6 +320,48 @@ describe("duplicating multiple elements", () => {
   });
 
   describe("should duplicate all group ids", () => {
-    // TOOD
+    it("should regenerate all group ids and keep them consistent across elements", () => {
+      const rectangle1 = API.createElement({
+        type: "rectangle",
+        groupIds: ["g1"],
+      });
+      const rectangle2 = API.createElement({
+        type: "rectangle",
+        groupIds: ["g2", "g1"],
+      });
+      const rectangle3 = API.createElement({
+        type: "rectangle",
+        groupIds: ["g2", "g1"],
+      });
+
+      const origElements = [rectangle1, rectangle2, rectangle3] as const;
+      const clonedElements = duplicateElements(
+        origElements,
+      ) as any as typeof origElements;
+      const [clonedRectangle1, clonedRectangle2, clonedRectangle3] =
+        clonedElements;
+
+      expect(rectangle1.groupIds[0]).not.toBe(clonedRectangle1.groupIds[0]);
+      expect(rectangle2.groupIds[0]).not.toBe(clonedRectangle2.groupIds[0]);
+      expect(rectangle2.groupIds[1]).not.toBe(clonedRectangle2.groupIds[1]);
+
+      expect(clonedRectangle1.groupIds[0]).toBe(clonedRectangle2.groupIds[1]);
+      expect(clonedRectangle2.groupIds[0]).toBe(clonedRectangle3.groupIds[0]);
+      expect(clonedRectangle2.groupIds[1]).toBe(clonedRectangle3.groupIds[1]);
+    });
+
+    it("should keep and regenerate ids of groups even if invalid", () => {
+      // lone element shouldn't be able to be grouped with itself,
+      // but hard to check against in a performant way so we ignore it
+      const rectangle1 = API.createElement({
+        type: "rectangle",
+        groupIds: ["g1"],
+      });
+
+      const [clonedRectangle1] = duplicateElements([rectangle1]);
+
+      expect(typeof clonedRectangle1.groupIds[0]).toBe("string");
+      expect(rectangle1.groupIds[0]).not.toBe(clonedRectangle1.groupIds[0]);
+    });
   });
 });

--- a/src/element/newElement.ts
+++ b/src/element/newElement.ts
@@ -588,13 +588,3 @@ export const duplicateElements = (elements: readonly ExcalidrawElement[]) => {
 
   return clonedElements;
 };
-
-// @ts-ignore
-window.wrapSelected = (...args) => {
-  const id = args[0];
-  const value = args.length === 2 ? args[1] : id;
-  if (window.h.state.selectedElementIds[id]) {
-    return `(${value})`;
-  }
-  return value;
-};

--- a/src/element/newElement.ts
+++ b/src/element/newElement.ts
@@ -406,6 +406,9 @@ const _deepCopyElement = (val: any, depth: number = 0) => {
     return arr;
   }
 
+  // we're not cloning non-array & non-plain-object objects because we
+  // don't support them on excalidraw elements yet. If we do, we need to make
+  // sure we start cloning them, so let's warn about it.
   if (process.env.NODE_ENV === "development") {
     if (
       objectType !== "[object Object]" &&

--- a/src/element/newElement.ts
+++ b/src/element/newElement.ts
@@ -13,7 +13,12 @@ import {
   FontFamilyValues,
   ExcalidrawTextContainer,
 } from "../element/types";
-import { getFontString, getUpdatedTimestamp, isTestEnv } from "../utils";
+import {
+  arrayToMap,
+  getFontString,
+  getUpdatedTimestamp,
+  isTestEnv,
+} from "../utils";
 import { randomInteger, randomId } from "../random";
 import { mutateElement, newElementWith } from "./mutateElement";
 import { getNewGroupIdsForDuplication } from "../groups";
@@ -357,16 +362,24 @@ export const newImageElement = (
   };
 };
 
-// Simplified deep clone for the purpose of cloning ExcalidrawElement only
-// (doesn't clone Date, RegExp, Map, Set, Typed arrays etc.)
+// Simplified deep clone for the purpose of cloning ExcalidrawElement.
+//
+// Only clones plain objects and arrays. Doesn't clone Date, RegExp, Map, Set,
+// Typed arrays and other non-null objects.
 //
 // Adapted from https://github.com/lukeed/klona
-export const deepCopyElement = (val: any, depth: number = 0) => {
+//
+// The reason for `deepCopyElement()` wrapper is type safety (only allow
+// passing ExcalidrawElement as the top-level argument).
+const _deepCopyElement = (val: any, depth: number = 0) => {
+  // only clone non-primitives
   if (val == null || typeof val !== "object") {
     return val;
   }
 
-  if (Object.prototype.toString.call(val) === "[object Object]") {
+  const objectType = Object.prototype.toString.call(val);
+
+  if (objectType === "[object Object]") {
     const tmp =
       typeof val.constructor === "function"
         ? Object.create(Object.getPrototypeOf(val))
@@ -378,7 +391,7 @@ export const deepCopyElement = (val: any, depth: number = 0) => {
         if (depth === 0 && (key === "shape" || key === "canvas")) {
           continue;
         }
-        tmp[key] = deepCopyElement(val[key], depth + 1);
+        tmp[key] = _deepCopyElement(val[key], depth + 1);
       }
     }
     return tmp;
@@ -388,12 +401,39 @@ export const deepCopyElement = (val: any, depth: number = 0) => {
     let k = val.length;
     const arr = new Array(k);
     while (k--) {
-      arr[k] = deepCopyElement(val[k], depth + 1);
+      arr[k] = _deepCopyElement(val[k], depth + 1);
     }
     return arr;
   }
 
+  if (process.env.NODE_ENV === "development") {
+    if (
+      objectType !== "[object Object]" &&
+      objectType !== "[object Array]" &&
+      objectType.startsWith("[object ")
+    ) {
+      console.warn(
+        `_deepCloneElement: unexpected object type ${objectType}. This value will not be cloned!`,
+      );
+    }
+  }
+
   return val;
+};
+
+/**
+ * Clones ExcalidrawElement data structure. Does not regenerate id, nonce, or
+ * any value. The purpose is to to break object references for immutability
+ * reasons, whenever we want to keep the original element, but ensure it's not
+ * mutated.
+ *
+ * Only clones plain objects and arrays. Doesn't clone Date, RegExp, Map, Set,
+ * Typed arrays and other non-null objects.
+ */
+export const deepCopyElement = <T extends ExcalidrawElement>(
+  val: T,
+): Mutable<T> => {
+  return _deepCopyElement(val);
 };
 
 /**
@@ -410,13 +450,13 @@ export const deepCopyElement = (val: any, depth: number = 0) => {
  * @param element Element to duplicate
  * @param overrides Any element properties to override
  */
-export const duplicateElement = <TElement extends Mutable<ExcalidrawElement>>(
+export const duplicateElement = <TElement extends ExcalidrawElement>(
   editingGroupId: AppState["editingGroupId"],
   groupIdMapForOperation: Map<GroupId, GroupId>,
   element: TElement,
   overrides?: Partial<TElement>,
-): TElement => {
-  let copy: TElement = deepCopyElement(element);
+): Readonly<TElement> => {
+  let copy = deepCopyElement(element);
 
   if (isTestEnv()) {
     copy.id = `${copy.id}_copy`;
@@ -448,4 +488,113 @@ export const duplicateElement = <TElement extends Mutable<ExcalidrawElement>>(
     copy = Object.assign(copy, overrides);
   }
   return copy;
+};
+
+/**
+ * Clones elements, regenerating their ids (including bindings) and group ids.
+ *
+ * If bindings don't exist in the elements array, they are removed. Therefore,
+ * it's advised to supply the whole elements array, or sets of elements that
+ * are encapsulated (such as library items), if the purpose is to retain
+ * bindings to the cloned elements intact.
+ */
+export const duplicateElements = (elements: readonly ExcalidrawElement[]) => {
+  const clonedElements: ExcalidrawElement[] = [];
+
+  const origElementsMap = arrayToMap(elements);
+
+  // used for for migrating old ids to new ids
+  const elementNewIdsMap = new Map<
+    /* orig */ ExcalidrawElement["id"],
+    /* new */ ExcalidrawElement["id"]
+  >();
+
+  const maybeGetNewId = (id: ExcalidrawElement["id"]) => {
+    // if we've already migrated the element id, return the new one directly
+    if (elementNewIdsMap.has(id)) {
+      return elementNewIdsMap.get(id)!;
+    }
+    // if we haven't migrated the element id, but an old element with the same
+    // id exists, generate a new id for it and return it
+    if (origElementsMap.has(id)) {
+      const newId = randomId();
+      elementNewIdsMap.set(id, newId);
+      return newId;
+    }
+    // if old element doesn't exist, return null to mark it for removal
+    return null;
+  };
+
+  const groupNewIdsMap = new Map</* orig */ GroupId, /* new */ GroupId>();
+
+  for (const element of elements) {
+    const clonedElement: Mutable<ExcalidrawElement> = _deepCopyElement(element);
+
+    clonedElement.id = maybeGetNewId(element.id)!;
+
+    if (clonedElement.groupIds) {
+      clonedElement.groupIds = clonedElement.groupIds.map((groupId) => {
+        if (!groupNewIdsMap.has(groupId)) {
+          groupNewIdsMap.set(groupId, randomId());
+        }
+        return groupNewIdsMap.get(groupId)!;
+      });
+    }
+
+    if ("containerId" in clonedElement && clonedElement.containerId) {
+      const newContainerId = maybeGetNewId(clonedElement.containerId);
+      clonedElement.containerId = newContainerId;
+    }
+
+    if ("boundElements" in clonedElement && clonedElement.boundElements) {
+      clonedElement.boundElements = clonedElement.boundElements.reduce(
+        (
+          acc: Mutable<NonNullable<ExcalidrawElement["boundElements"]>>,
+          binding,
+        ) => {
+          const newBindingId = maybeGetNewId(binding.id);
+          if (newBindingId) {
+            acc.push({ ...binding, id: newBindingId });
+          }
+          return acc;
+        },
+        [],
+      );
+    }
+
+    if ("endBinding" in clonedElement && clonedElement.endBinding) {
+      const newEndBindingId = maybeGetNewId(clonedElement.endBinding.elementId);
+      clonedElement.endBinding = newEndBindingId
+        ? {
+            ...clonedElement.endBinding,
+            elementId: newEndBindingId,
+          }
+        : null;
+    }
+    if ("startBinding" in clonedElement && clonedElement.startBinding) {
+      const newEndBindingId = maybeGetNewId(
+        clonedElement.startBinding.elementId,
+      );
+      clonedElement.startBinding = newEndBindingId
+        ? {
+            ...clonedElement.startBinding,
+            elementId: newEndBindingId,
+          }
+        : null;
+    }
+
+    clonedElements.push(clonedElement);
+  }
+
+  return clonedElements;
+};
+
+// @ts-ignore
+window.wrapSelected = (...args) => {
+  const id = args[0];
+  const value = args.length === 2 ? args[1] : id;
+  if (window.h.state.selectedElementIds[id]) {
+    return `(${value})`;
+  }
+  return value;
 };

--- a/src/scene/export.ts
+++ b/src/scene/export.ts
@@ -90,6 +90,9 @@ export const exportToSvg = async (
     exportEmbedScene?: boolean;
   },
   files: BinaryFiles | null,
+  opts?: {
+    serializeAsJSON?: () => string;
+  },
 ): Promise<SVGSVGElement> => {
   const {
     exportPadding = DEFAULT_EXPORT_PADDING,
@@ -103,7 +106,9 @@ export const exportToSvg = async (
       metadata = await (
         await import(/* webpackChunkName: "image" */ "../../src/data/image")
       ).encodeSvgMetadata({
-        text: serializeAsJSON(elements, appState, files || {}, "local"),
+        text: opts?.serializeAsJSON
+          ? opts?.serializeAsJSON?.()
+          : serializeAsJSON(elements, appState, files || {}, "local"),
       });
     } catch (error: any) {
       console.error(error);

--- a/src/tests/packages/utils.unmocked.test.ts
+++ b/src/tests/packages/utils.unmocked.test.ts
@@ -3,6 +3,10 @@ import { ImportedDataState } from "../../data/types";
 import * as utils from "../../packages/utils";
 import { API } from "../helpers/api";
 
+// NOTE this test file is using the actual API, unmocked. Hence splitting it
+// from the other test file, because I couldn't figure out how to test
+// mocked and unmocked API in the same file.
+
 describe("embedding scene data", () => {
   describe("exportToSvg", () => {
     it("embedding scene data shouldn't modify them", async () => {

--- a/src/tests/packages/utils.unmocked.test.ts
+++ b/src/tests/packages/utils.unmocked.test.ts
@@ -1,0 +1,63 @@
+import { decodePngMetadata, decodeSvgMetadata } from "../../data/image";
+import { ImportedDataState } from "../../data/types";
+import * as utils from "../../packages/utils";
+import { API } from "../helpers/api";
+
+describe("embedding scene data", () => {
+  describe("exportToSvg", () => {
+    it("embedding scene data shouldn't modify them", async () => {
+      const rectangle = API.createElement({ type: "rectangle" });
+      const ellipse = API.createElement({ type: "ellipse" });
+
+      const sourceElements = [rectangle, ellipse];
+
+      const svgNode = await utils.exportToSvg({
+        elements: sourceElements,
+        appState: {
+          viewBackgroundColor: "#ffffff",
+          gridSize: null,
+          exportEmbedScene: true,
+        },
+        files: null,
+      });
+
+      const svg = svgNode.outerHTML;
+
+      const parsedString = await decodeSvgMetadata({ svg });
+      const importedData: ImportedDataState = JSON.parse(parsedString);
+
+      expect(sourceElements.map((x) => x.id)).toEqual(
+        importedData.elements?.map((el) => el.id),
+      );
+    });
+  });
+
+  // skipped because we can't test png encoding right now
+  // (canvas.toBlob not supported in jsdom)
+  describe.skip("exportToBlob", () => {
+    it("embedding scene data shouldn't modify them", async () => {
+      const rectangle = API.createElement({ type: "rectangle" });
+      const ellipse = API.createElement({ type: "ellipse" });
+
+      const sourceElements = [rectangle, ellipse];
+
+      const blob = await utils.exportToBlob({
+        mimeType: "image/png",
+        elements: sourceElements,
+        appState: {
+          viewBackgroundColor: "#ffffff",
+          gridSize: null,
+          exportEmbedScene: true,
+        },
+        files: null,
+      });
+
+      const parsedString = await decodePngMetadata(blob);
+      const importedData: ImportedDataState = JSON.parse(parsedString);
+
+      expect(sourceElements.map((x) => x.id)).toEqual(
+        importedData.elements?.map((el) => el.id),
+      );
+    });
+  });
+});


### PR DESCRIPTION
fix https://github.com/excalidraw/excalidraw/issues/6453

In https://github.com/excalidraw/excalidraw/pull/6443 we've introduced a hacky solution for export utils not having access to elements when retrieving them through our Scene class. But, it broke some logic because the ad-hoc Scene polluted references with elements that weren't actually on the scene and shouldn't be considered (the `id:element` mapping would replace the actual elements on canvas with the mock elements).

This PR fixes it by duplicating the elements (and most importantly regenerating their ids) before populating the ad-hoc Scene in export utils.

The newly introduced `duplicateElements` helper ensures that all ids including that of bindings are regenerated but kept consistent (so that bindings are preserved). We'll actually use this helper later (I believe there's one unrelated bug due to incorrect duplication).

---

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 5279c53</samp>

### Summary
🎨🧪♻️

<!--
1.  🎨 - This emoji represents the addition of a new feature or enhancement, such as the `duplicateElements` function and the option to customize the scene serialization function in `exportToSvg`.
2.  🧪 - This emoji represents the addition or improvement of tests, such as the new test file for `exportToSvg` and `exportToBlob` and the tests for `duplicateElements`.
3.  ♻️ - This emoji represents the refactoring or improvement of code quality, such as the `passElementsSafely` helper function and the refactored `deepCopyElement` function.
-->
Added a new feature to duplicate multiple elements and improved the export functions. The main changes are:

> _We'll `exportToSvg` and `exportToBlob` with ease_
> _We'll clone and duplicate our elements as we please_
> _We'll test our code with jest and jsdom, one, two, three_
> _We're the jolly coders of the `utils` library_

### Walkthrough
*  Rename and refactor `deepCopyElement` function to ensure type safety and immutability, and add a wrapper function to perform type check ([link](https://github.com/excalidraw/excalidraw/pull/6461/files?diff=unified&w=0#diff-205831ba144cafaba7bdcaab8e1affeb0eb97a4da50714294f73d307347e5d8eL360-R382), [link](https://github.com/excalidraw/excalidraw/pull/6461/files?diff=unified&w=0#diff-205831ba144cafaba7bdcaab8e1affeb0eb97a4da50714294f73d307347e5d8eL381-R394), [link](https://github.com/excalidraw/excalidraw/pull/6461/files?diff=unified&w=0#diff-205831ba144cafaba7bdcaab8e1affeb0eb97a4da50714294f73d307347e5d8eL391-R439))
* Add `duplicateElements` function to clone an array of elements, regenerating their ids and group ids, and updating their bindings and containers ([link](https://github.com/excalidraw/excalidraw/pull/6461/files?diff=unified&w=0#diff-205831ba144cafaba7bdcaab8e1affeb0eb97a4da50714294f73d307347e5d8eL413-R459))
* Update import statements to include `duplicateElements` and `arrayToMap` functions ([link](https://github.com/excalidraw/excalidraw/pull/6461/files?diff=unified&w=0#diff-eb3c7d3b2122429a45c47066dce3aea85ea40e385f8f7ce53e32484c78abc311L1-R6), [link](https://github.com/excalidraw/excalidraw/pull/6461/files?diff=unified&w=0#diff-205831ba144cafaba7bdcaab8e1affeb0eb97a4da50714294f73d307347e5d8eL16-R21), [link](https://github.com/excalidraw/excalidraw/pull/6461/files?diff=unified&w=0#diff-38000639f2f5947b0254239a2d498f800cfba3ce0ccdd9a10eec865e5ca99fa9L18-R35))
* Modify `exportToCanvas`, `exportToBlob`, and `exportToSvg` functions to use `passElementsSafely` helper function instead of creating a new `Scene` instance and replacing all elements, to handle cases where elements are not cached by the `Scene` instance ([link](https://github.com/excalidraw/excalidraw/pull/6461/files?diff=unified&w=0#diff-38000639f2f5947b0254239a2d498f800cfba3ce0ccdd9a10eec865e5ca99fa9L47-R66), [link](https://github.com/excalidraw/excalidraw/pull/6461/files?diff=unified&w=0#diff-38000639f2f5947b0254239a2d498f800cfba3ce0ccdd9a10eec865e5ca99fa9L125-R136), [link](https://github.com/excalidraw/excalidraw/pull/6461/files?diff=unified&w=0#diff-38000639f2f5947b0254239a2d498f800cfba3ce0ccdd9a10eec865e5ca99fa9L181-R202))
* Modify `exportToBlob` and `exportToClipboard` functions to pass the original, uncloned elements to the `serializeAsJSON` and `copyToClipboard` functions, to ensure that the ids of the elements are stable and consistent when embedding the scene data into the blob and clipboard metadata ([link](https://github.com/excalidraw/excalidraw/pull/6461/files?diff=unified&w=0#diff-38000639f2f5947b0254239a2d498f800cfba3ce0ccdd9a10eec865e5ca99fa9L153-R157), [link](https://github.com/excalidraw/excalidraw/pull/6461/files?diff=unified&w=0#diff-38000639f2f5947b0254239a2d498f800cfba3ce0ccdd9a10eec865e5ca99fa9L206-L213), [link](https://github.com/excalidraw/excalidraw/pull/6461/files?diff=unified&w=0#diff-38000639f2f5947b0254239a2d498f800cfba3ce0ccdd9a10eec865e5ca99fa9L228-R227))
* Modify `exportToSvg` function in `src/scene/export.ts` to accept an optional `opts` argument, to allow passing a custom `serializeAsJSON` function ([link](https://github.com/excalidraw/excalidraw/pull/6461/files?diff=unified&w=0#diff-91b6e2243746c6661270480d9d05856a54d6af764eabe54f1f2df33f082b7b47R93-R95), [link](https://github.com/excalidraw/excalidraw/pull/6461/files?diff=unified&w=0#diff-91b6e2243746c6661270480d9d05856a54d6af764eabe54f1f2df33f082b7b47L106-R111))
* Add `describe` block to group the existing tests for duplicating single elements under a common label, and add new tests for duplicating multiple elements ([link](https://github.com/excalidraw/excalidraw/pull/6461/files?diff=unified&w=0#diff-eb3c7d3b2122429a45c47066dce3aea85ea40e385f8f7ce53e32484c78abc311L18-R324))
* Add a new test file `src/tests/packages/utils.unmocked.test.ts` to test the embedding of scene data into the exported svg and blob formats, using the `decodeSvgMetadata` and `decodePngMetadata` functions, the custom `serializeAsJSON` function, and the `API` helper ([link](https://github.com/excalidraw/excalidraw/pull/6461/files?diff=unified&w=0#diff-1a88936accdafb66d57c0291966be78140226f3d8b4d92baa0e245d87acf888dR1-R63))
* Remove the global function `window.wrapSelected` before merging, as it is not part of the pull request and was added for debugging purposes ([link](https://github.com/excalidraw/excalidraw/pull/6461/files?diff=unified&w=0#diff-205831ba144cafaba7bdcaab8e1affeb0eb97a4da50714294f73d307347e5d8eR492-R600))

