### PR TITLE
fix: library ids cross-contamination on multiple insert

### DIFF
--- a/src/components/LibraryMenuItems.tsx
+++ b/src/components/LibraryMenuItems.tsx
@@ -12,6 +12,7 @@ import { MIME_TYPES } from "../constants";
 import Spinner from "./Spinner";
 import LibraryMenuBrowseButton from "./LibraryMenuBrowseButton";
 import clsx from "clsx";
+import { duplicateElements } from "../element/newElement";
 
 const CELLS_PER_ROW = 4;
 
@@ -96,7 +97,14 @@ const LibraryMenuItems = ({
     } else {
       targetElements = libraryItems.filter((item) => item.id === id);
     }
-    return targetElements;
+    return targetElements.map((item) => {
+      return {
+        ...item,
+        // duplicate each library item before inserting on canvas to confine
+        // ids and bindings to each library item. See #6465
+        elements: duplicateElements(item.elements),
+      };
+    });
   };
 
   const createLibraryItemCompo = (params: {


### PR DESCRIPTION
fix https://github.com/excalidraw/excalidraw/issues/6465

haven't written tests for this because it'd super hard to test this behavior (it happens at a level really hard to drill down into)