### PR TITLE
fix: incorrectly duplicating items on paste/library insert (#6467

### DIFF
--- a/src/data/restore.ts
+++ b/src/data/restore.ts
@@ -369,6 +369,9 @@ export const restoreElements = (
   localElements: readonly ExcalidrawElement[] | null | undefined,
   opts?: { refreshDimensions?: boolean; repairBindings?: boolean } | undefined,
 ): ExcalidrawElement[] => {
+  // used to detect duplicate top-level element ids
+  const existingIds = new Set<string>();
+
   const localElementsMap = localElements ? arrayToMap(localElements) : null;
   const restoredElements = (elements || []).reduce((elements, element) => {
     // filtering out selection, which is legacy, no longer kept in elements,
@@ -383,6 +386,10 @@ export const restoreElements = (
         if (localElement && localElement.version > migratedElement.version) {
           migratedElement = bumpVersion(migratedElement, localElement.version);
         }
+        if (existingIds.has(migratedElement.id)) {
+          migratedElement = { ...migratedElement, id: randomId() };
+        }
+        existingIds.add(migratedElement.id);
         elements.push(migratedElement);
       }
     }

--- a/src/tests/__snapshots__/regressionTests.test.tsx.snap
+++ b/src/tests/__snapshots__/regressionTests.test.tsx.snap
@@ -13431,7 +13431,7 @@ Object {
   "boundElements": null,
   "fillStyle": "hachure",
   "groupIds": Array [
-    "id6",
+    "id4_copy",
   ],
   "height": 10,
   "id": "id0_copy",
@@ -13464,7 +13464,7 @@ Object {
   "boundElements": null,
   "fillStyle": "hachure",
   "groupIds": Array [
-    "id6",
+    "id4_copy",
   ],
   "height": 10,
   "id": "id1_copy",
@@ -13497,7 +13497,7 @@ Object {
   "boundElements": null,
   "fillStyle": "hachure",
   "groupIds": Array [
-    "id6",
+    "id4_copy",
   ],
   "height": 10,
   "id": "id2_copy",
@@ -13981,7 +13981,7 @@ Object {
           "boundElements": null,
           "fillStyle": "hachure",
           "groupIds": Array [
-            "id6",
+            "id4_copy",
           ],
           "height": 10,
           "id": "id0_copy",
@@ -14011,7 +14011,7 @@ Object {
           "boundElements": null,
           "fillStyle": "hachure",
           "groupIds": Array [
-            "id6",
+            "id4_copy",
           ],
           "height": 10,
           "id": "id1_copy",
@@ -14041,7 +14041,7 @@ Object {
           "boundElements": null,
           "fillStyle": "hachure",
           "groupIds": Array [
-            "id6",
+            "id4_copy",
           ],
           "height": 10,
           "id": "id2_copy",

--- a/src/tests/helpers/api.ts
+++ b/src/tests/helpers/api.ts
@@ -211,7 +211,10 @@ export class API {
           type,
           startArrowhead: null,
           endArrowhead: null,
-          points: rest.points ?? [],
+          points: rest.points ?? [
+            [0, 0],
+            [100, 100],
+          ],
         });
         break;
       case "image":


### PR DESCRIPTION
Pasting/inserting library currently breaks arrow bindings in some cases. Replaced the ad-hoc duplicating with our new `duplicateElements()` helper.