### PR TITLE
fix: improperly cache-busting on canvas scale instead of zoom

### DIFF
--- a/src/renderer/renderElement.ts
+++ b/src/renderer/renderElement.ts
@@ -88,6 +88,7 @@ export interface ExcalidrawElementWithCanvas {
   canvas: HTMLCanvasElement;
   theme: RenderConfig["theme"];
   scale: number;
+  zoomValue: RenderConfig["zoom"]["value"];
   canvasOffsetX: number;
   canvasOffsetY: number;
   boundTextElementVersion: number | null;
@@ -202,6 +203,7 @@ const generateElementCanvas = (
     canvas,
     theme: renderConfig.theme,
     scale,
+    zoomValue: zoom.value,
     canvasOffsetX,
     canvasOffsetY,
     boundTextElementVersion: getBoundTextElement(element)?.version || null,
@@ -712,7 +714,7 @@ const generateElementWithCanvas = (
   const prevElementWithCanvas = elementWithCanvasCache.get(element);
   const shouldRegenerateBecauseZoom =
     prevElementWithCanvas &&
-    prevElementWithCanvas.scale !== zoom.value &&
+    prevElementWithCanvas.zoomValue !== zoom.value &&
     !renderConfig?.shouldCacheIgnoreZoom;
   const boundTextElementVersion = getBoundTextElement(element)?.version || null;
 


### PR DESCRIPTION
fix https://github.com/excalidraw/excalidraw/issues/6472