### PR TITLE
fix: rotate the text element when binding to a rotated container

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -2746,6 +2746,7 @@ class App extends React.Component<AppProps, AppState> {
           groupIds: container?.groupIds ?? [],
           locked: false,
           lineHeight,
+          angle: container?.angle ?? 0,
         });
 
     if (!existingTextElement && shouldBindToContainer && container) {

--- a/src/element/textWysiwyg.test.tsx
+++ b/src/element/textWysiwyg.test.tsx
@@ -526,6 +526,39 @@ describe("textWysiwyg", () => {
       ]);
     });
 
+    it("should set the text element angle to same as container angle when binding to rotated container", async () => {
+      const rectangle = API.createElement({
+        type: "rectangle",
+        x: 10,
+        y: 20,
+        width: 90,
+        height: 75,
+        backgroundColor: "red",
+        angle: 45,
+      });
+      h.elements = [rectangle];
+      mouse.doubleClickAt(rectangle.x + 10, rectangle.y + 10);
+      const text = h.elements[1] as ExcalidrawTextElementWithContainer;
+      expect(text.type).toBe("text");
+      expect(text.containerId).toBe(rectangle.id);
+      expect(rectangle.boundElements).toStrictEqual([
+        { id: text.id, type: "text" },
+      ]);
+      expect(text.angle).toBe(rectangle.angle);
+      mouse.down();
+      const editor = document.querySelector(
+        ".excalidraw-textEditorContainer > textarea",
+      ) as HTMLTextAreaElement;
+
+      fireEvent.change(editor, { target: { value: "Hello World!" } });
+
+      await new Promise((r) => setTimeout(r, 0));
+      editor.blur();
+      expect(rectangle.boundElements).toStrictEqual([
+        { id: text.id, type: "text" },
+      ]);
+    });
+
     it("should compute the container height correctly and not throw error when height is updated while editing the text", async () => {
       const diamond = API.createElement({
         type: "diamond",

--- a/src/element/textWysiwyg.test.tsx
+++ b/src/element/textWysiwyg.test.tsx
@@ -529,11 +529,8 @@ describe("textWysiwyg", () => {
     it("should set the text element angle to same as container angle when binding to rotated container", async () => {
       const rectangle = API.createElement({
         type: "rectangle",
-        x: 10,
-        y: 20,
         width: 90,
         height: 75,
-        backgroundColor: "red",
         angle: 45,
       });
       h.elements = [rectangle];

--- a/src/element/textWysiwyg.tsx
+++ b/src/element/textWysiwyg.tsx
@@ -569,10 +569,6 @@ export const textWysiwyg = ({
     const container = getContainerElement(updateElement);
 
     if (container) {
-      // update the child to take the angle of the parent
-      mutateElement(updateElement, {
-        angle: container.angle,
-      });
       text = updateElement.text;
       if (editable.value.trim()) {
         const boundTextElementId = getBoundTextElementId(container);

--- a/src/element/textWysiwyg.tsx
+++ b/src/element/textWysiwyg.tsx
@@ -569,6 +569,10 @@ export const textWysiwyg = ({
     const container = getContainerElement(updateElement);
 
     if (container) {
+      // update the child to take the angle of the parent
+      mutateElement(updateElement, {
+        angle: container.angle,
+      });
       text = updateElement.text;
       if (editable.value.trim()) {
         const boundTextElementId = getBoundTextElementId(container);
@@ -590,6 +594,7 @@ export const textWysiwyg = ({
           ),
         });
       }
+
       redrawTextBoundingBox(updateElement, container);
     }
 

--- a/src/element/textWysiwyg.tsx
+++ b/src/element/textWysiwyg.tsx
@@ -590,7 +590,6 @@ export const textWysiwyg = ({
           ),
         });
       }
-
       redrawTextBoundingBox(updateElement, container);
     }
 


### PR DESCRIPTION
Fixes #6476 