### PR TITLE
fix: add readme back to npm package which was mistakenly removed

### DIFF
--- a/scripts/release.js
+++ b/scripts/release.js
@@ -1,21 +1,8 @@
-const fs = require("fs");
 const { execSync } = require("child_process");
 
 const excalidrawDir = `${__dirname}/../src/packages/excalidraw`;
 const excalidrawPackage = `${excalidrawDir}/package.json`;
 const pkg = require(excalidrawPackage);
-
-const originalReadMe = fs.readFileSync(`${excalidrawDir}/README.md`, "utf8");
-
-const updateReadme = () => {
-  const excalidrawIndex = originalReadMe.indexOf("### Excalidraw");
-
-  // remove note for stable readme
-  const data = originalReadMe.slice(excalidrawIndex);
-
-  // update readme
-  fs.writeFileSync(`${excalidrawDir}/README.md`, data, "utf8");
-};
 
 const publish = () => {
   try {
@@ -30,15 +17,10 @@ const publish = () => {
 };
 
 const release = () => {
-  updateReadme();
   console.info("Note for stable readme removed");
 
   publish();
   console.info(`Published ${pkg.version}!`);
-
-  // revert readme after release
-  fs.writeFileSync(`${excalidrawDir}/README.md`, originalReadMe, "utf8");
-  console.info("Readme reverted");
 };
 
 release();

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -17,8 +17,6 @@ const publish = () => {
 };
 
 const release = () => {
-  console.info("Note for stable readme removed");
-
   publish();
   console.info(`Published ${pkg.version}!`);
 };

--- a/src/packages/excalidraw/CHANGELOG.md
+++ b/src/packages/excalidraw/CHANGELOG.md
@@ -11,7 +11,7 @@ The change should be grouped under one of the below section and must contain PR 
 Please add the latest change on the top under the correct section.
 -->
 
-## 0.15.1 (2023-04-18)
+## Unreleased
 
 ### Docs
 

--- a/src/packages/excalidraw/CHANGELOG.md
+++ b/src/packages/excalidraw/CHANGELOG.md
@@ -11,6 +11,12 @@ The change should be grouped under one of the below section and must contain PR 
 Please add the latest change on the top under the correct section.
 -->
 
+## 0.15.1 (2023-04-18)
+
+### Docs
+
+- Add the readme back to the package which was mistakenly removed [#6484](https://github.com/excalidraw/excalidraw/pull/6484)
+
 ## 0.15.0 (2023-04-18)
 
 ### Features


### PR DESCRIPTION
Since the note for unstable readme is no longer there hence removing this script to update readme - due to this the package version `0.15.0` was released without any readme