### PR TITLE
feat: allow `avif`, `jfif`, `webp`, `bmp`, `ico` image types (#6500

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -5743,7 +5743,7 @@ class App extends React.Component<AppProps, AppState> {
 
       const imageFile = await fileOpen({
         description: "Image",
-        extensions: ["jpg", "png", "svg", "gif"],
+        extensions: ["jpg", "png", "svg", "gif", "avif", "jfif", "webp", "bmp"],
       });
 
       const imageElement = this.createImageElement({

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -60,6 +60,7 @@ import {
   ENV,
   EVENT,
   GRID_SIZE,
+  IMAGE_MIME_TYPES,
   IMAGE_RENDER_TIMEOUT,
   isAndroid,
   isBrave,
@@ -5743,7 +5744,9 @@ class App extends React.Component<AppProps, AppState> {
 
       const imageFile = await fileOpen({
         description: "Image",
-        extensions: ["jpg", "png", "svg", "gif", "avif", "jfif", "webp", "bmp"],
+        extensions: Object.keys(
+          IMAGE_MIME_TYPES,
+        ) as (keyof typeof IMAGE_MIME_TYPES)[],
       });
 
       const imageElement = this.createImageElement({

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -105,14 +105,9 @@ export const CANVAS_ONLY_ACTIONS = ["selectAll"];
 
 export const GRID_SIZE = 20; // TODO make it configurable?
 
-export const MIME_TYPES = {
-  excalidraw: "application/vnd.excalidraw+json",
-  excalidrawlib: "application/vnd.excalidrawlib+json",
-  json: "application/json",
+export const IMAGE_MIME_TYPES = {
   svg: "image/svg+xml",
-  "excalidraw.svg": "image/svg+xml",
   png: "image/png",
-  "excalidraw.png": "image/png",
   jpg: "image/jpeg",
   gif: "image/gif",
   webp: "image/webp",
@@ -120,7 +115,20 @@ export const MIME_TYPES = {
   ico: "image/x-icon",
   avif: "image/avif",
   jfif: "image/jfif",
+} as const;
+
+export const MIME_TYPES = {
+  json: "application/json",
+  // excalidraw data
+  excalidraw: "application/vnd.excalidraw+json",
+  excalidrawlib: "application/vnd.excalidrawlib+json",
+  // image-encoded excalidraw data
+  "excalidraw.svg": "image/svg+xml",
+  "excalidraw.png": "image/png",
+  // binary
   binary: "application/octet-stream",
+  // image
+  ...IMAGE_MIME_TYPES,
 } as const;
 
 export const EXPORT_DATA_TYPES = {
@@ -190,18 +198,6 @@ export const EXPORT_SCALES = [1, 2, 3];
 export const DEFAULT_EXPORT_PADDING = 10; // px
 
 export const DEFAULT_MAX_IMAGE_WIDTH_OR_HEIGHT = 1440;
-
-export const ALLOWED_IMAGE_MIME_TYPES = [
-  MIME_TYPES.png,
-  MIME_TYPES.jpg,
-  MIME_TYPES.svg,
-  MIME_TYPES.gif,
-  MIME_TYPES.webp,
-  MIME_TYPES.avif,
-  MIME_TYPES.jfif,
-  MIME_TYPES.bmp,
-  MIME_TYPES.ico,
-] as const;
 
 export const MAX_ALLOWED_FILE_BYTES = 2 * 1024 * 1024;
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -118,6 +118,8 @@ export const MIME_TYPES = {
   webp: "image/webp",
   bmp: "image/bmp",
   ico: "image/x-icon",
+  avif: "image/avif",
+  jfif: "image/jfif",
   binary: "application/octet-stream",
 } as const;
 
@@ -195,6 +197,8 @@ export const ALLOWED_IMAGE_MIME_TYPES = [
   MIME_TYPES.svg,
   MIME_TYPES.gif,
   MIME_TYPES.webp,
+  MIME_TYPES.avif,
+  MIME_TYPES.jfif,
   MIME_TYPES.bmp,
   MIME_TYPES.ico,
 ] as const;

--- a/src/data/blob.ts
+++ b/src/data/blob.ts
@@ -1,6 +1,6 @@
 import { nanoid } from "nanoid";
 import { cleanAppStateForExport } from "../appState";
-import { ALLOWED_IMAGE_MIME_TYPES, MIME_TYPES } from "../constants";
+import { IMAGE_MIME_TYPES, MIME_TYPES } from "../constants";
 import { clearElementsForExport } from "../element";
 import { ExcalidrawElement, FileId } from "../element/types";
 import { CanvasError } from "../errors";
@@ -117,11 +117,9 @@ export const isImageFileHandle = (handle: FileSystemHandle | null) => {
 
 export const isSupportedImageFile = (
   blob: Blob | null | undefined,
-): blob is Blob & { type: typeof ALLOWED_IMAGE_MIME_TYPES[number] } => {
+): blob is Blob & { type: ValueOf<typeof IMAGE_MIME_TYPES> } => {
   const { type } = blob || {};
-  return (
-    !!type && (ALLOWED_IMAGE_MIME_TYPES as readonly string[]).includes(type)
-  );
+  return !!type && (Object.values(IMAGE_MIME_TYPES) as string[]).includes(type);
 };
 
 export const loadSceneOrLibraryFromBlob = async (

--- a/src/data/filesystem.ts
+++ b/src/data/filesystem.ts
@@ -8,20 +8,7 @@ import { EVENT, MIME_TYPES } from "../constants";
 import { AbortError } from "../errors";
 import { debounce } from "../utils";
 
-type FILE_EXTENSION =
-  | "gif"
-  | "jpg"
-  | "avif"
-  | "jfif"
-  | "webp"
-  | "bmp"
-  | "png"
-  | "excalidraw.png"
-  | "svg"
-  | "excalidraw.svg"
-  | "json"
-  | "excalidraw"
-  | "excalidrawlib";
+type FILE_EXTENSION = Exclude<keyof typeof MIME_TYPES, "binary">;
 
 const INPUT_CHANGE_INTERVAL_MS = 500;
 

--- a/src/data/filesystem.ts
+++ b/src/data/filesystem.ts
@@ -11,6 +11,10 @@ import { debounce } from "../utils";
 type FILE_EXTENSION =
   | "gif"
   | "jpg"
+  | "avif"
+  | "jfif"
+  | "webp"
+  | "bmp"
   | "png"
   | "excalidraw.png"
   | "svg"

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,9 +29,9 @@ import { isOverScrollBars } from "./scene";
 import { MaybeTransformHandleType } from "./element/transformHandles";
 import Library from "./data/library";
 import type { FileSystemHandle } from "./data/filesystem";
-import type { ALLOWED_IMAGE_MIME_TYPES, MIME_TYPES } from "./constants";
+import type { IMAGE_MIME_TYPES, MIME_TYPES } from "./constants";
 import { ContextMenuItems } from "./components/ContextMenu";
-import { Merge, ForwardRef } from "./utility-types";
+import { Merge, ForwardRef, ValueOf } from "./utility-types";
 import React from "react";
 
 export type Point = Readonly<RoughPoint>;
@@ -60,7 +60,7 @@ export type DataURL = string & { _brand: "DataURL" };
 
 export type BinaryFileData = {
   mimeType:
-    | typeof ALLOWED_IMAGE_MIME_TYPES[number]
+    | ValueOf<typeof IMAGE_MIME_TYPES>
     // future user or unknown file type
     | typeof MIME_TYPES.binary;
   id: FileId;
@@ -419,7 +419,7 @@ export type AppClassProperties = {
     FileId,
     {
       image: HTMLImageElement | Promise<HTMLImageElement>;
-      mimeType: typeof ALLOWED_IMAGE_MIME_TYPES[number];
+      mimeType: ValueOf<typeof IMAGE_MIME_TYPES>;
     }
   >;
   files: BinaryFiles;


### PR DESCRIPTION
fix https://github.com/excalidraw/excalidraw/issues/6478

(the `bmp`/`ico` was already allowed through paste/drag&drop https://github.com/excalidraw/excalidraw/pull/5749, but not via file picker).