### PR TITLE
fix: text jumps when editing on Android Chrome

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -4720,7 +4720,11 @@ class App extends React.Component<AppProps, AppState> {
         pointerDownState.drag.hasOccurred = true;
         // prevent dragging even if we're no longer holding cmd/ctrl otherwise
         // it would have weird results (stuff jumping all over the screen)
-        if (selectedElements.length > 0 && !pointerDownState.withCmdOrCtrl && !this.state.editingElement) {
+        if (
+          selectedElements.length > 0 &&
+          !pointerDownState.withCmdOrCtrl &&
+          !this.state.editingElement
+        ) {
           const [dragX, dragY] = getGridPoint(
             pointerCoords.x - pointerDownState.drag.offset.x,
             pointerCoords.y - pointerDownState.drag.offset.y,

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -4720,7 +4720,7 @@ class App extends React.Component<AppProps, AppState> {
         pointerDownState.drag.hasOccurred = true;
         // prevent dragging even if we're no longer holding cmd/ctrl otherwise
         // it would have weird results (stuff jumping all over the screen)
-        if (selectedElements.length > 0 && !pointerDownState.withCmdOrCtrl) {
+        if (selectedElements.length > 0 && !pointerDownState.withCmdOrCtrl && !this.state.editingElement) {
           const [dragX, dragY] = getGridPoint(
             pointerCoords.x - pointerDownState.drag.offset.x,
             pointerCoords.y - pointerDownState.drag.offset.y,

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -4720,6 +4720,7 @@ class App extends React.Component<AppProps, AppState> {
         pointerDownState.drag.hasOccurred = true;
         // prevent dragging even if we're no longer holding cmd/ctrl otherwise
         // it would have weird results (stuff jumping all over the screen)
+        // Checking for editingElement to avoid jump while editing on mobile #6503
         if (
           selectedElements.length > 0 &&
           !pointerDownState.withCmdOrCtrl &&

--- a/src/element/textWysiwyg.tsx
+++ b/src/element/textWysiwyg.tsx
@@ -151,6 +151,7 @@ export const textWysiwyg = ({
       return;
     }
     const { textAlign, verticalAlign } = updatedTextElement;
+
     if (updatedTextElement && isTextElement(updatedTextElement)) {
       let coordX = updatedTextElement.x;
       let coordY = updatedTextElement.y;

--- a/src/element/textWysiwyg.tsx
+++ b/src/element/textWysiwyg.tsx
@@ -151,7 +151,7 @@ export const textWysiwyg = ({
       return;
     }
     const { textAlign, verticalAlign } = updatedTextElement;
-
+    console.log("updateWysiwygStyle()",updatedTextElement);
     if (updatedTextElement && isTextElement(updatedTextElement)) {
       let coordX = updatedTextElement.x;
       let coordY = updatedTextElement.y;

--- a/src/element/textWysiwyg.tsx
+++ b/src/element/textWysiwyg.tsx
@@ -644,9 +644,10 @@ export const textWysiwyg = ({
       target instanceof HTMLInputElement &&
       target.closest(".color-picker-input") &&
       isWritableElement(target);
-
+    
+    console.log("#8 setTimeout(); bindBlurEvent(); before editable.onblur=handleSubmit", event);
     setTimeout(() => {
-      console.log("#8 setTimeout(); bindBlurEvent(); before editable.onblur=handleSubmit", event);
+      console.log("#9 timeout(); bindBlurEvent(); before editable.onblur=handleSubmit", event);
       editable.onblur = handleSubmit;
       if (target && isTargetColorPicker) {
         target.onblur = () => {
@@ -677,14 +678,14 @@ export const textWysiwyg = ({
       window.addEventListener("pointerup", bindBlurEvent);
       // handle edge-case where pointerup doesn't fire e.g. due to user
       // alt-tabbing away
-      console.log("#9 onPointerDown(); before addEventListner('blur', handleSubmit) - edge-case where pointerup doesn't fire e.g. due to user alt-tabbing away", event);
+      console.log("#10 onPointerDown(); before addEventListner('blur', handleSubmit) - edge-case where pointerup doesn't fire e.g. due to user alt-tabbing away", event);
       window.addEventListener("blur", handleSubmit);
     }
   };
 
   // handle updates of textElement properties of editing element
   const unbindUpdate = Scene.getScene(element)!.addCallback(() => {
-    console.log("#10 unbindUpdate() callback; before updatedWysiwygStyle()", element);
+    console.log("#11 unbindUpdate() callback; before updatedWysiwygStyle()", element);
     console.trace();
     updateWysiwygStyle();
     const isColorPickerActive = !!document.activeElement?.closest(
@@ -701,7 +702,9 @@ export const textWysiwyg = ({
 
   // select on init (focusing is done separately inside the bindBlurEvent()
   // because we need it to happen *after* the blur event from `pointerdown`)
+  console.log("#12 editable.select(); textWysiwyg()");
   editable.select();
+  console.log("#13 editable.select(); textWysiwyg()");
   bindBlurEvent();
 
   // reposition wysiwyg in case of canvas is resized. Using ResizeObserver
@@ -709,14 +712,17 @@ export const textWysiwyg = ({
   let observer: ResizeObserver | null = null;
   if (canvas && "ResizeObserver" in window) {
     observer = new window.ResizeObserver(() => {
-      console.log("#11 window.ResizeObserver(); before updatedWysiwygStyle()");
+      console.log("#13 observer observe; before updatedWysiwygStyle()");
       updateWysiwygStyle();
     });
+    console.log("#14 before add observer");
     observer.observe(canvas);
   } else {
+    console.log("#15 before add resize event listner");
     window.addEventListener("resize", updateWysiwygStyle);
   }
 
+  console.log("#16 before add event listners: pointerdown, wheel");
   window.addEventListener("pointerdown", onPointerDown);
   window.addEventListener("wheel", stopEvent, {
     passive: false,

--- a/src/element/textWysiwyg.tsx
+++ b/src/element/textWysiwyg.tsx
@@ -122,7 +122,7 @@ export const textWysiwyg = ({
   excalidrawContainer: HTMLDivElement | null;
   app: App;
 }) => {
-  console.log({location: "textWysiwyg()", element});
+  console.log("#1 textWysiwyg()", element);
   const textPropertiesUpdated = (
     updatedTextElement: ExcalidrawTextElement,
     editable: HTMLTextAreaElement,
@@ -152,7 +152,7 @@ export const textWysiwyg = ({
       return;
     }
     const { textAlign, verticalAlign } = updatedTextElement;
-    console.log({location: "updateWysiwygStyle()", updatedTextElement});
+    console.log("#2 updateWysiwygStyle()", updatedTextElement);
     if (updatedTextElement && isTextElement(updatedTextElement)) {
       let coordX = updatedTextElement.x;
       let coordY = updatedTextElement.y;
@@ -356,7 +356,7 @@ export const textWysiwyg = ({
     overflowWrap: "break-word",
     boxSizing: "content-box",
   });
-  console.log({location: "1. before updateWysiwygStyle() call in textWysiwyg();"})
+  console.log("#3 1. before updateWysiwygStyle() call in textWysiwyg();")
   updateWysiwygStyle();
 
   if (onChange) {
@@ -414,12 +414,12 @@ export const textWysiwyg = ({
     if (!event.shiftKey && actionZoomIn.keyTest(event)) {
       event.preventDefault();
       app.actionManager.executeAction(actionZoomIn);
-      console.log({location: "2. before updateWysiwygStyle(); onkeydown !event.shitKey, zoomIn", event});
+      console.log("#4 2. before updateWysiwygStyle(); onkeydown !event.shitKey, zoomIn", event);
       updateWysiwygStyle();
     } else if (!event.shiftKey && actionZoomOut.keyTest(event)) {
       event.preventDefault();
       app.actionManager.executeAction(actionZoomOut);
-      console.log({location: "2. before updateWysiwygStyle(); onkeydown !event.shitKey, zoomOut", event});
+      console.log("#5 2. before updateWysiwygStyle(); onkeydown !event.shitKey, zoomOut", event);
       updateWysiwygStyle();
     } else if (actionDecreaseFontSize.keyTest(event)) {
       app.actionManager.executeAction(actionDecreaseFontSize);
@@ -428,7 +428,7 @@ export const textWysiwyg = ({
     } else if (event.key === KEYS.ESCAPE) {
       event.preventDefault();
       submittedViaKeyboard = true;
-      console.log({location: "1. before handleSubmit(); ESCAPE", event});
+      console.log("#6 1. before handleSubmit(); ESCAPE", event);
       handleSubmit();
     } else if (event.key === KEYS.ENTER && event[KEYS.CTRL_OR_CMD]) {
       event.preventDefault();
@@ -436,7 +436,7 @@ export const textWysiwyg = ({
         return;
       }
       submittedViaKeyboard = true;
-      console.log({location: "2. before handleSubmit(); submittedViaKeyboard === true", event});
+      console.log("#7 2. before handleSubmit(); submittedViaKeyboard === true", event);
       handleSubmit();
     } else if (
       event.key === KEYS.TAB ||
@@ -645,7 +645,7 @@ export const textWysiwyg = ({
       isWritableElement(target);
 
     setTimeout(() => {
-      console.log({loction: "setTimeout(); bindBlurEvent(); before editable.onblur=handleSubmit", event});
+      console.log("#8 setTimeout(); bindBlurEvent(); before editable.onblur=handleSubmit", event);
       editable.onblur = handleSubmit;
       if (target && isTargetColorPicker) {
         target.onblur = () => {
@@ -676,14 +676,14 @@ export const textWysiwyg = ({
       window.addEventListener("pointerup", bindBlurEvent);
       // handle edge-case where pointerup doesn't fire e.g. due to user
       // alt-tabbing away
-      console.log({location: "onPointerDown(); before addEventListner('blur', handleSubmit) - edge-case where pointerup doesn't fire e.g. due to user alt-tabbing away", event});
+      console.log("#9 onPointerDown(); before addEventListner('blur', handleSubmit) - edge-case where pointerup doesn't fire e.g. due to user alt-tabbing away", event);
       window.addEventListener("blur", handleSubmit);
     }
   };
 
   // handle updates of textElement properties of editing element
   const unbindUpdate = Scene.getScene(element)!.addCallback(() => {
-    console.log({location: "unbindUpdate() callback; before updatedWysiwygStyle()", element});
+    console.log("#10 unbindUpdate() callback; before updatedWysiwygStyle()", element);
     updateWysiwygStyle();
     const isColorPickerActive = !!document.activeElement?.closest(
       ".color-picker-input",
@@ -707,7 +707,7 @@ export const textWysiwyg = ({
   let observer: ResizeObserver | null = null;
   if (canvas && "ResizeObserver" in window) {
     observer = new window.ResizeObserver(() => {
-      console.log({location: "window.ResizeObserver(); before updatedWysiwygStyle()"});
+      console.log("#11 window.ResizeObserver(); before updatedWysiwygStyle()");
       updateWysiwygStyle();
     });
     observer.observe(canvas);

--- a/src/element/textWysiwyg.tsx
+++ b/src/element/textWysiwyg.tsx
@@ -700,7 +700,7 @@ export const textWysiwyg = ({
   // select on init (focusing is done separately inside the bindBlurEvent()
   // because we need it to happen *after* the blur event from `pointerdown`)
   editable.select();
-  bindBlurEvent();
+  setTimeout(()=>bindBlurEvent());
 
   // reposition wysiwyg in case of canvas is resized. Using ResizeObserver
   // is preferred so we catch changes from host, where window may not resize.

--- a/src/element/textWysiwyg.tsx
+++ b/src/element/textWysiwyg.tsx
@@ -428,6 +428,7 @@ export const textWysiwyg = ({
     } else if (event.key === KEYS.ESCAPE) {
       event.preventDefault();
       submittedViaKeyboard = true;
+      console.log("1. handleSubmit editable.onkeydown ESCAPE" ,event);
       handleSubmit();
     } else if (event.key === KEYS.ENTER && event[KEYS.CTRL_OR_CMD]) {
       event.preventDefault();
@@ -435,6 +436,7 @@ export const textWysiwyg = ({
         return;
       }
       submittedViaKeyboard = true;
+      console.log("2. handleSubmit editable.onkeydown submittedViaKeyboard" ,event);
       handleSubmit();
     } else if (
       event.key === KEYS.TAB ||
@@ -643,6 +645,7 @@ export const textWysiwyg = ({
       isWritableElement(target);
 
     setTimeout(() => {
+      console.log("3. setTimeout, bindBlurEvent editable.onblur=handleSubmit", event);
       editable.onblur = handleSubmit;
       if (target && isTargetColorPicker) {
         target.onblur = () => {
@@ -673,6 +676,7 @@ export const textWysiwyg = ({
       window.addEventListener("pointerup", bindBlurEvent);
       // handle edge-case where pointerup doesn't fire e.g. due to user
       // alt-tabbing away
+      console.log("4. onPointerDown addEventListner(blur) handleSubmit - edge-case where pointerup doesn't fire e.g. due to user alt-tabbing away", event);
       window.addEventListener("blur", handleSubmit);
     }
   };

--- a/src/element/textWysiwyg.tsx
+++ b/src/element/textWysiwyg.tsx
@@ -153,6 +153,7 @@ export const textWysiwyg = ({
     }
     const { textAlign, verticalAlign } = updatedTextElement;
     console.log("#2 updateWysiwygStyle()", updatedTextElement);
+    console.trace();
     if (updatedTextElement && isTextElement(updatedTextElement)) {
       let coordX = updatedTextElement.x;
       let coordY = updatedTextElement.y;
@@ -684,6 +685,7 @@ export const textWysiwyg = ({
   // handle updates of textElement properties of editing element
   const unbindUpdate = Scene.getScene(element)!.addCallback(() => {
     console.log("#10 unbindUpdate() callback; before updatedWysiwygStyle()", element);
+    console.trace();
     updateWysiwygStyle();
     const isColorPickerActive = !!document.activeElement?.closest(
       ".color-picker-input",

--- a/src/element/textWysiwyg.tsx
+++ b/src/element/textWysiwyg.tsx
@@ -122,7 +122,6 @@ export const textWysiwyg = ({
   excalidrawContainer: HTMLDivElement | null;
   app: App;
 }) => {
-  console.log("#1 textWysiwyg()", element);
   const textPropertiesUpdated = (
     updatedTextElement: ExcalidrawTextElement,
     editable: HTMLTextAreaElement,
@@ -152,8 +151,6 @@ export const textWysiwyg = ({
       return;
     }
     const { textAlign, verticalAlign } = updatedTextElement;
-    console.log("#2 updateWysiwygStyle()", updatedTextElement);
-    console.trace();
     if (updatedTextElement && isTextElement(updatedTextElement)) {
       let coordX = updatedTextElement.x;
       let coordY = updatedTextElement.y;
@@ -357,7 +354,6 @@ export const textWysiwyg = ({
     overflowWrap: "break-word",
     boxSizing: "content-box",
   });
-  console.log("#3 1. before updateWysiwygStyle() call in textWysiwyg();")
   updateWysiwygStyle();
 
   if (onChange) {
@@ -415,12 +411,10 @@ export const textWysiwyg = ({
     if (!event.shiftKey && actionZoomIn.keyTest(event)) {
       event.preventDefault();
       app.actionManager.executeAction(actionZoomIn);
-      console.log("#4 2. before updateWysiwygStyle(); onkeydown !event.shitKey, zoomIn", event);
       updateWysiwygStyle();
     } else if (!event.shiftKey && actionZoomOut.keyTest(event)) {
       event.preventDefault();
       app.actionManager.executeAction(actionZoomOut);
-      console.log("#5 2. before updateWysiwygStyle(); onkeydown !event.shitKey, zoomOut", event);
       updateWysiwygStyle();
     } else if (actionDecreaseFontSize.keyTest(event)) {
       app.actionManager.executeAction(actionDecreaseFontSize);
@@ -429,7 +423,6 @@ export const textWysiwyg = ({
     } else if (event.key === KEYS.ESCAPE) {
       event.preventDefault();
       submittedViaKeyboard = true;
-      console.log("#6 1. before handleSubmit(); ESCAPE", event);
       handleSubmit();
     } else if (event.key === KEYS.ENTER && event[KEYS.CTRL_OR_CMD]) {
       event.preventDefault();
@@ -437,7 +430,6 @@ export const textWysiwyg = ({
         return;
       }
       submittedViaKeyboard = true;
-      console.log("#7 2. before handleSubmit(); submittedViaKeyboard === true", event);
       handleSubmit();
     } else if (
       event.key === KEYS.TAB ||
@@ -644,10 +636,8 @@ export const textWysiwyg = ({
       target instanceof HTMLInputElement &&
       target.closest(".color-picker-input") &&
       isWritableElement(target);
-    
-    console.log("#8 setTimeout(); bindBlurEvent(); before editable.onblur=handleSubmit", event);
+
     setTimeout(() => {
-      console.log("#9 timeout(); bindBlurEvent(); before editable.onblur=handleSubmit", event);
       editable.onblur = handleSubmit;
       if (target && isTargetColorPicker) {
         target.onblur = () => {
@@ -678,15 +668,12 @@ export const textWysiwyg = ({
       window.addEventListener("pointerup", bindBlurEvent);
       // handle edge-case where pointerup doesn't fire e.g. due to user
       // alt-tabbing away
-      console.log("#10 onPointerDown(); before addEventListner('blur', handleSubmit) - edge-case where pointerup doesn't fire e.g. due to user alt-tabbing away", event);
       window.addEventListener("blur", handleSubmit);
     }
   };
 
   // handle updates of textElement properties of editing element
   const unbindUpdate = Scene.getScene(element)!.addCallback(() => {
-    console.log("#11 unbindUpdate() callback; before updatedWysiwygStyle()", element);
-    console.trace();
     updateWysiwygStyle();
     const isColorPickerActive = !!document.activeElement?.closest(
       ".color-picker-input",
@@ -702,9 +689,7 @@ export const textWysiwyg = ({
 
   // select on init (focusing is done separately inside the bindBlurEvent()
   // because we need it to happen *after* the blur event from `pointerdown`)
-  console.log("#12 editable.select(); textWysiwyg()");
   editable.select();
-  console.log("#13 editable.select(); textWysiwyg()");
   bindBlurEvent();
 
   // reposition wysiwyg in case of canvas is resized. Using ResizeObserver
@@ -712,17 +697,13 @@ export const textWysiwyg = ({
   let observer: ResizeObserver | null = null;
   if (canvas && "ResizeObserver" in window) {
     observer = new window.ResizeObserver(() => {
-      console.log("#13 observer observe; before updatedWysiwygStyle()");
       updateWysiwygStyle();
     });
-    console.log("#14 before add observer");
     observer.observe(canvas);
   } else {
-    console.log("#15 before add resize event listner");
     window.addEventListener("resize", updateWysiwygStyle);
   }
 
-  console.log("#16 before add event listners: pointerdown, wheel");
   window.addEventListener("pointerdown", onPointerDown);
   window.addEventListener("wheel", stopEvent, {
     passive: false,

--- a/src/element/textWysiwyg.tsx
+++ b/src/element/textWysiwyg.tsx
@@ -122,6 +122,7 @@ export const textWysiwyg = ({
   excalidrawContainer: HTMLDivElement | null;
   app: App;
 }) => {
+  console.log("textWysiwyg()", element);
   const textPropertiesUpdated = (
     updatedTextElement: ExcalidrawTextElement,
     editable: HTMLTextAreaElement,
@@ -355,6 +356,7 @@ export const textWysiwyg = ({
     overflowWrap: "break-word",
     boxSizing: "content-box",
   });
+  console.log("1. call updateWysiwygStyle from textWysiwyg();")
   updateWysiwygStyle();
 
   if (onChange) {
@@ -412,10 +414,12 @@ export const textWysiwyg = ({
     if (!event.shiftKey && actionZoomIn.keyTest(event)) {
       event.preventDefault();
       app.actionManager.executeAction(actionZoomIn);
+      console.log("2. call updatedWysiwygStyle onkeydown !event.shitKey, zoomIn");
       updateWysiwygStyle();
     } else if (!event.shiftKey && actionZoomOut.keyTest(event)) {
       event.preventDefault();
       app.actionManager.executeAction(actionZoomOut);
+      console.log("3. call updatedWysiwygStyle onkeydown !event.shitKey, zoomOut");
       updateWysiwygStyle();
     } else if (actionDecreaseFontSize.keyTest(event)) {
       app.actionManager.executeAction(actionDecreaseFontSize);
@@ -675,6 +679,7 @@ export const textWysiwyg = ({
 
   // handle updates of textElement properties of editing element
   const unbindUpdate = Scene.getScene(element)!.addCallback(() => {
+    console.log("4. call updatedWysiwygStyle unbindUpdate");
     updateWysiwygStyle();
     const isColorPickerActive = !!document.activeElement?.closest(
       ".color-picker-input",
@@ -698,6 +703,7 @@ export const textWysiwyg = ({
   let observer: ResizeObserver | null = null;
   if (canvas && "ResizeObserver" in window) {
     observer = new window.ResizeObserver(() => {
+      console.log("5. call updatedWysiwygStyle resize observer");
       updateWysiwygStyle();
     });
     observer.observe(canvas);

--- a/src/element/textWysiwyg.tsx
+++ b/src/element/textWysiwyg.tsx
@@ -700,7 +700,7 @@ export const textWysiwyg = ({
   // select on init (focusing is done separately inside the bindBlurEvent()
   // because we need it to happen *after* the blur event from `pointerdown`)
   editable.select();
-  setTimeout(()=>bindBlurEvent());
+  setTimeout(bindBlurEvent,50); //delay to address #6469
 
   // reposition wysiwyg in case of canvas is resized. Using ResizeObserver
   // is preferred so we catch changes from host, where window may not resize.

--- a/src/element/textWysiwyg.tsx
+++ b/src/element/textWysiwyg.tsx
@@ -676,7 +676,7 @@ export const textWysiwyg = ({
       window.addEventListener("pointerup", bindBlurEvent);
       // handle edge-case where pointerup doesn't fire e.g. due to user
       // alt-tabbing away
-      console.log({location: "onPointerDown(); before addEventListner('blur', handleSubmit) - edge-case where pointerup doesn't fire e.g. due to user alt-tabbing away", event);
+      console.log({location: "onPointerDown(); before addEventListner('blur', handleSubmit) - edge-case where pointerup doesn't fire e.g. due to user alt-tabbing away", event});
       window.addEventListener("blur", handleSubmit);
     }
   };

--- a/src/element/textWysiwyg.tsx
+++ b/src/element/textWysiwyg.tsx
@@ -122,7 +122,7 @@ export const textWysiwyg = ({
   excalidrawContainer: HTMLDivElement | null;
   app: App;
 }) => {
-  console.log("textWysiwyg()", element);
+  console.log({location: "textWysiwyg()", element});
   const textPropertiesUpdated = (
     updatedTextElement: ExcalidrawTextElement,
     editable: HTMLTextAreaElement,
@@ -152,7 +152,7 @@ export const textWysiwyg = ({
       return;
     }
     const { textAlign, verticalAlign } = updatedTextElement;
-    console.log("updateWysiwygStyle()",updatedTextElement);
+    console.log({location: "updateWysiwygStyle()", updatedTextElement});
     if (updatedTextElement && isTextElement(updatedTextElement)) {
       let coordX = updatedTextElement.x;
       let coordY = updatedTextElement.y;
@@ -356,7 +356,7 @@ export const textWysiwyg = ({
     overflowWrap: "break-word",
     boxSizing: "content-box",
   });
-  console.log("1. call updateWysiwygStyle from textWysiwyg();")
+  console.log({location: "1. before updateWysiwygStyle() call in textWysiwyg();"})
   updateWysiwygStyle();
 
   if (onChange) {
@@ -414,12 +414,12 @@ export const textWysiwyg = ({
     if (!event.shiftKey && actionZoomIn.keyTest(event)) {
       event.preventDefault();
       app.actionManager.executeAction(actionZoomIn);
-      console.log("2. call updatedWysiwygStyle onkeydown !event.shitKey, zoomIn");
+      console.log({location: "2. before updateWysiwygStyle(); onkeydown !event.shitKey, zoomIn", event});
       updateWysiwygStyle();
     } else if (!event.shiftKey && actionZoomOut.keyTest(event)) {
       event.preventDefault();
       app.actionManager.executeAction(actionZoomOut);
-      console.log("3. call updatedWysiwygStyle onkeydown !event.shitKey, zoomOut");
+      console.log({location: "2. before updateWysiwygStyle(); onkeydown !event.shitKey, zoomOut", event});
       updateWysiwygStyle();
     } else if (actionDecreaseFontSize.keyTest(event)) {
       app.actionManager.executeAction(actionDecreaseFontSize);
@@ -428,7 +428,7 @@ export const textWysiwyg = ({
     } else if (event.key === KEYS.ESCAPE) {
       event.preventDefault();
       submittedViaKeyboard = true;
-      console.log("1. handleSubmit editable.onkeydown ESCAPE" ,event);
+      console.log({location: "1. before handleSubmit(); ESCAPE", event});
       handleSubmit();
     } else if (event.key === KEYS.ENTER && event[KEYS.CTRL_OR_CMD]) {
       event.preventDefault();
@@ -436,7 +436,7 @@ export const textWysiwyg = ({
         return;
       }
       submittedViaKeyboard = true;
-      console.log("2. handleSubmit editable.onkeydown submittedViaKeyboard" ,event);
+      console.log({location: "2. before handleSubmit(); submittedViaKeyboard === true", event});
       handleSubmit();
     } else if (
       event.key === KEYS.TAB ||
@@ -645,7 +645,7 @@ export const textWysiwyg = ({
       isWritableElement(target);
 
     setTimeout(() => {
-      console.log("3. setTimeout, bindBlurEvent editable.onblur=handleSubmit", event);
+      console.log({loction: "setTimeout(); bindBlurEvent(); before editable.onblur=handleSubmit", event});
       editable.onblur = handleSubmit;
       if (target && isTargetColorPicker) {
         target.onblur = () => {
@@ -676,14 +676,14 @@ export const textWysiwyg = ({
       window.addEventListener("pointerup", bindBlurEvent);
       // handle edge-case where pointerup doesn't fire e.g. due to user
       // alt-tabbing away
-      console.log("4. onPointerDown addEventListner(blur) handleSubmit - edge-case where pointerup doesn't fire e.g. due to user alt-tabbing away", event);
+      console.log({location: "onPointerDown(); before addEventListner('blur', handleSubmit) - edge-case where pointerup doesn't fire e.g. due to user alt-tabbing away", event);
       window.addEventListener("blur", handleSubmit);
     }
   };
 
   // handle updates of textElement properties of editing element
   const unbindUpdate = Scene.getScene(element)!.addCallback(() => {
-    console.log("4. call updatedWysiwygStyle unbindUpdate");
+    console.log({location: "unbindUpdate() callback; before updatedWysiwygStyle()", element});
     updateWysiwygStyle();
     const isColorPickerActive = !!document.activeElement?.closest(
       ".color-picker-input",
@@ -700,14 +700,14 @@ export const textWysiwyg = ({
   // select on init (focusing is done separately inside the bindBlurEvent()
   // because we need it to happen *after* the blur event from `pointerdown`)
   editable.select();
-  setTimeout(bindBlurEvent,50); //delay to address #6469
+  bindBlurEvent();
 
   // reposition wysiwyg in case of canvas is resized. Using ResizeObserver
   // is preferred so we catch changes from host, where window may not resize.
   let observer: ResizeObserver | null = null;
   if (canvas && "ResizeObserver" in window) {
     observer = new window.ResizeObserver(() => {
-      console.log("5. call updatedWysiwygStyle resize observer");
+      console.log({location: "window.ResizeObserver(); before updatedWysiwygStyle()"});
       updateWysiwygStyle();
     });
     observer.observe(canvas);


### PR DESCRIPTION
solves #6469

Seems for some reason Excalidraw registers an element drag - that is why the text jumps.  Debouncing the call to dragSelectedElement() when `this.state.editingElement` solves the problem.

![image](https://user-images.githubusercontent.com/14358394/233725169-02e069ae-5f3a-495a-a4da-d68218428465.png)

![image](https://user-images.githubusercontent.com/14358394/233725430-84504155-a219-4471-b664-88236bc2e370.png)
