### PR TITLE
Fix: rename `stroke` to `text color` for text elements

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -18,7 +18,7 @@
     "delete": "Delete",
     "copyStyles": "Copy styles",
     "pasteStyles": "Paste styles",
-    "stroke": "Stroke",
+    "stroke": "Text color",
     "background": "Background",
     "fill": "Fill",
     "strokeWidth": "Stroke width",


### PR DESCRIPTION
I solved #6392 issue. 
You able to see changes in below image
![image](https://user-images.githubusercontent.com/81804004/233843708-eb40bb35-1935-4aa9-9a5b-c09a90700032.png)

I changed `Stroke` label to `Text color` label. 