### PR TITLE
fix: don't refresh dimensions for text containers on font load

### DIFF
--- a/src/data/blob.ts
+++ b/src/data/blob.ts
@@ -155,7 +155,7 @@ export const loadSceneOrLibraryFromBlob = async (
           },
           localAppState,
           localElements,
-          { repairBindings: true, refreshDimensions: true },
+          { repairBindings: true, refreshDimensions: false },
         ),
       };
     } else if (isValidLibrary(data)) {

--- a/src/excalidraw-app/data/index.ts
+++ b/src/excalidraw-app/data/index.ts
@@ -263,7 +263,7 @@ export const loadScene = async (
       await importFromBackend(id, privateKey),
       localDataState?.appState,
       localDataState?.elements,
-      { repairBindings: true, refreshDimensions: true },
+      { repairBindings: true, refreshDimensions: false },
     );
   } else {
     data = restore(localDataState || null, null, null, {

--- a/src/scene/Fonts.ts
+++ b/src/scene/Fonts.ts
@@ -1,5 +1,6 @@
 import { isTextElement, refreshTextDimensions } from "../element";
 import { newElementWith } from "../element/mutateElement";
+import { isBoundToContainer } from "../element/typeChecks";
 import { ExcalidrawElement, ExcalidrawTextElement } from "../element/types";
 import { invalidateShapeForElement } from "../renderer/renderElement";
 import { getFontString } from "../utils";
@@ -52,7 +53,7 @@ export class Fonts {
     let didUpdate = false;
 
     this.scene.mapElements((element) => {
-      if (isTextElement(element)) {
+      if (isTextElement(element) && !isBoundToContainer(element)) {
         invalidateShapeForElement(element);
         didUpdate = true;
         return newElementWith(element, {


### PR DESCRIPTION
To test  try opening [https://excalidraw-git-aakansha-no-refresh-text-containers-excalidraw.vercel.app/#json=Soy3LkNbWr9H9ghDWSUOY,8Bc7JZUTrT0p4SqOlZ-YzQ](https://excalidraw-git-aakansha-no-refresh-text-containers-excalidraw.vercel.app/#json=Soy3LkNbWr9H9ghDWSUOY,8Bc7JZUTrT0p4SqOlZ-YzQ) and reload - the diagrams should remain the same as it was before unless you try to edit it