### PR TITLE
feat: Add Trans component for interpolating JSX in translations

### DIFF
--- a/src/components/BraveMeasureTextError.tsx
+++ b/src/components/BraveMeasureTextError.tsx
@@ -1,4 +1,5 @@
 import Trans from "./Trans";
+
 const BraveMeasureTextError = () => {
   return (
     <div data-testid="brave-measure-text-error">

--- a/src/components/BraveMeasureTextError.tsx
+++ b/src/components/BraveMeasureTextError.tsx
@@ -1,39 +1,43 @@
-import { t } from "../i18n";
+import Trans from "./Trans";
 const BraveMeasureTextError = () => {
   return (
     <div data-testid="brave-measure-text-error">
       <p>
-        {t("errors.brave_measure_text_error.start")} &nbsp;
-        <span style={{ fontWeight: 600 }}>
-          {t("errors.brave_measure_text_error.aggressive_block_fingerprint")}
-        </span>{" "}
-        {t("errors.brave_measure_text_error.setting_enabled")}.
+        <Trans
+          i18nKey="errors.brave_measure_text_error.line1"
+          aggressiveBlockFingerprint={(el: any) => (
+            <span style={{ fontWeight: 600 }}>{el}</span>
+          )}
+        />
         <br />
         <br />
-        {t("errors.brave_measure_text_error.break")}{" "}
-        <span style={{ fontWeight: 600 }}>
-          {t("errors.brave_measure_text_error.text_elements")}
-        </span>{" "}
-        {t("errors.brave_measure_text_error.in_your_drawings")}.
-      </p>
-      <p>
-        {t("errors.brave_measure_text_error.strongly_recommend")}{" "}
-        <a href="http://docs.excalidraw.com/docs/@excalidraw/excalidraw/faq#turning-off-aggresive-block-fingerprinting-in-brave-browser">
-          {" "}
-          {t("errors.brave_measure_text_error.steps")}
-        </a>{" "}
-        {t("errors.brave_measure_text_error.how")}.
-      </p>
-      <p>
-        {t("errors.brave_measure_text_error.disable_setting")}{" "}
-        <a href="https://github.com/excalidraw/excalidraw/issues/new">
-          {t("errors.brave_measure_text_error.issue")}
-        </a>{" "}
-        {t("errors.brave_measure_text_error.write")}{" "}
-        <a href="https://discord.gg/UexuTaE">
-          {t("errors.brave_measure_text_error.discord")}
-        </a>
-        .
+        <Trans
+          i18nKey="errors.brave_measure_text_error.line2"
+          textElements={(el: any) => (
+            <span style={{ fontWeight: 600 }}>{el}</span>
+          )}
+        />
+        <br />
+        <br />
+        <Trans
+          i18nKey="errors.brave_measure_text_error.line3"
+          steps={(el: any) => (
+            <a href="http://docs.excalidraw.com/docs/@excalidraw/excalidraw/faq#turning-off-aggresive-block-fingerprinting-in-brave-browser">
+              {el}
+            </a>
+          )}
+        />
+        <br />
+        <br />
+        <Trans
+          i18nKey="errors.brave_measure_text_error.line4"
+          issue={(el: any) => (
+            <a href="https://github.com/excalidraw/excalidraw/issues/new">
+              {el}
+            </a>
+          )}
+          discord={(el: any) => <a href="https://discord.gg/UexuTaE">{el}</a>}
+        />
       </p>
     </div>
   );

--- a/src/components/BraveMeasureTextError.tsx
+++ b/src/components/BraveMeasureTextError.tsx
@@ -6,21 +6,19 @@ const BraveMeasureTextError = () => {
       <p>
         <Trans
           i18nKey="errors.brave_measure_text_error.line1"
-          aggressiveBlockFingerprint={(el) => (
-            <span style={{ fontWeight: 600 }}>{el}</span>
-          )}
+          bold={(el) => <span style={{ fontWeight: 600 }}>{el}</span>}
         />
       </p>
       <p>
         <Trans
           i18nKey="errors.brave_measure_text_error.line2"
-          textElements={(el) => <span style={{ fontWeight: 600 }}>{el}</span>}
+          bold={(el) => <span style={{ fontWeight: 600 }}>{el}</span>}
         />
       </p>
       <p>
         <Trans
           i18nKey="errors.brave_measure_text_error.line3"
-          steps={(el) => (
+          link={(el) => (
             <a href="http://docs.excalidraw.com/docs/@excalidraw/excalidraw/faq#turning-off-aggresive-block-fingerprinting-in-brave-browser">
               {el}
             </a>
@@ -30,12 +28,12 @@ const BraveMeasureTextError = () => {
       <p>
         <Trans
           i18nKey="errors.brave_measure_text_error.line4"
-          issue={(el) => (
+          issueLink={(el) => (
             <a href="https://github.com/excalidraw/excalidraw/issues/new">
               {el}
             </a>
           )}
-          discord={(el) => <a href="https://discord.gg/UexuTaE">{el}.</a>}
+          discordLink={(el) => <a href="https://discord.gg/UexuTaE">{el}.</a>}
         />
       </p>
     </div>

--- a/src/components/BraveMeasureTextError.tsx
+++ b/src/components/BraveMeasureTextError.tsx
@@ -6,7 +6,7 @@ const BraveMeasureTextError = () => {
       <p>
         <Trans
           i18nKey="errors.brave_measure_text_error.line1"
-          aggressiveBlockFingerprint={(el: React.ReactNode) => (
+          aggressiveBlockFingerprint={(el) => (
             <span style={{ fontWeight: 600 }}>{el}</span>
           )}
         />
@@ -14,15 +14,13 @@ const BraveMeasureTextError = () => {
       <p>
         <Trans
           i18nKey="errors.brave_measure_text_error.line2"
-          textElements={(el: React.ReactNode) => (
-            <span style={{ fontWeight: 600 }}>{el}</span>
-          )}
+          textElements={(el) => <span style={{ fontWeight: 600 }}>{el}</span>}
         />
       </p>
       <p>
         <Trans
           i18nKey="errors.brave_measure_text_error.line3"
-          steps={(el: React.ReactNode) => (
+          steps={(el) => (
             <a href="http://docs.excalidraw.com/docs/@excalidraw/excalidraw/faq#turning-off-aggresive-block-fingerprinting-in-brave-browser">
               {el}
             </a>
@@ -32,14 +30,12 @@ const BraveMeasureTextError = () => {
       <p>
         <Trans
           i18nKey="errors.brave_measure_text_error.line4"
-          issue={(el: React.ReactNode) => (
+          issue={(el) => (
             <a href="https://github.com/excalidraw/excalidraw/issues/new">
               {el}
             </a>
           )}
-          discord={(el: React.ReactNode) => (
-            <a href="https://discord.gg/UexuTaE">{el}.</a>
-          )}
+          discord={(el) => <a href="https://discord.gg/UexuTaE">{el}.</a>}
         />
       </p>
     </div>

--- a/src/components/BraveMeasureTextError.tsx
+++ b/src/components/BraveMeasureTextError.tsx
@@ -9,16 +9,16 @@ const BraveMeasureTextError = () => {
             <span style={{ fontWeight: 600 }}>{el}</span>
           )}
         />
-        <br />
-        <br />
+      </p>
+      <p>
         <Trans
           i18nKey="errors.brave_measure_text_error.line2"
           textElements={(el: any) => (
             <span style={{ fontWeight: 600 }}>{el}</span>
           )}
         />
-        <br />
-        <br />
+      </p>
+      <p>
         <Trans
           i18nKey="errors.brave_measure_text_error.line3"
           steps={(el: any) => (
@@ -27,8 +27,8 @@ const BraveMeasureTextError = () => {
             </a>
           )}
         />
-        <br />
-        <br />
+      </p>
+      <p>
         <Trans
           i18nKey="errors.brave_measure_text_error.line4"
           issue={(el: any) => (
@@ -36,7 +36,7 @@ const BraveMeasureTextError = () => {
               {el}
             </a>
           )}
-          discord={(el: any) => <a href="https://discord.gg/UexuTaE">{el}</a>}
+          discord={(el: any) => <a href="https://discord.gg/UexuTaE">{el}.</a>}
         />
       </p>
     </div>

--- a/src/components/BraveMeasureTextError.tsx
+++ b/src/components/BraveMeasureTextError.tsx
@@ -5,7 +5,7 @@ const BraveMeasureTextError = () => {
       <p>
         <Trans
           i18nKey="errors.brave_measure_text_error.line1"
-          aggressiveBlockFingerprint={(el: any) => (
+          aggressiveBlockFingerprint={(el: React.ReactNode) => (
             <span style={{ fontWeight: 600 }}>{el}</span>
           )}
         />
@@ -13,7 +13,7 @@ const BraveMeasureTextError = () => {
       <p>
         <Trans
           i18nKey="errors.brave_measure_text_error.line2"
-          textElements={(el: any) => (
+          textElements={(el: React.ReactNode) => (
             <span style={{ fontWeight: 600 }}>{el}</span>
           )}
         />
@@ -21,7 +21,7 @@ const BraveMeasureTextError = () => {
       <p>
         <Trans
           i18nKey="errors.brave_measure_text_error.line3"
-          steps={(el: any) => (
+          steps={(el: React.ReactNode) => (
             <a href="http://docs.excalidraw.com/docs/@excalidraw/excalidraw/faq#turning-off-aggresive-block-fingerprinting-in-brave-browser">
               {el}
             </a>
@@ -31,12 +31,14 @@ const BraveMeasureTextError = () => {
       <p>
         <Trans
           i18nKey="errors.brave_measure_text_error.line4"
-          issue={(el: any) => (
+          issue={(el: React.ReactNode) => (
             <a href="https://github.com/excalidraw/excalidraw/issues/new">
               {el}
             </a>
           )}
-          discord={(el: any) => <a href="https://discord.gg/UexuTaE">{el}.</a>}
+          discord={(el: React.ReactNode) => (
+            <a href="https://discord.gg/UexuTaE">{el}.</a>
+          )}
         />
       </p>
     </div>

--- a/src/components/Trans.test.tsx
+++ b/src/components/Trans.test.tsx
@@ -4,9 +4,10 @@ import fallbackLangData from "../locales/en.json";
 
 import Trans from "./Trans";
 
-describe("Trans", () => {
-  it("should translate", () => {
-    (fallbackLangData as any).transtest = {
+describe("Test <Trans/>", () => {
+  it("should translate the the strings correctly", () => {
+    //@ts-ignore
+    fallbackLangData.transTest = {
       key1: "Hello {{audience}}",
       key2: "Please {{connectLinkStart}}click the button{{connectLinkEnd}} to continue.",
       key3: "Please {{connectLinkStart}}click {{location}}{{connectLinkEnd}} to continue.",
@@ -16,33 +17,39 @@ describe("Trans", () => {
     const { getByTestId } = render(
       <>
         <div data-testid="test1">
-          <Trans i18nKey="transtest.key1" audience="world" />
+          <Trans i18nKey="transTest.key1" audience="world" />
         </div>
         <div data-testid="test2">
           <Trans
-            i18nKey="transtest.key2"
-            connectLink={(el: any) => <a href="https://example.com">{el}</a>}
+            i18nKey="transTest.key2"
+            connectLink={(el: React.ReactNode) => (
+              <a href="https://example.com">{el}</a>
+            )}
           />
         </div>
         <div data-testid="test3">
           <Trans
-            i18nKey="transtest.key3"
-            connectLink={(el: any) => <a href="https://example.com">{el}</a>}
+            i18nKey="transTest.key3"
+            connectLink={(el: React.ReactNode) => (
+              <a href="https://example.com">{el}</a>
+            )}
             location="the button"
           />
         </div>
         <div data-testid="test4">
           <Trans
-            i18nKey="transtest.key4"
-            connectLink={(el: any) => <a href="https://example.com">{el}</a>}
+            i18nKey="transTest.key4"
+            connectLink={(el: React.ReactNode) => (
+              <a href="https://example.com">{el}</a>
+            )}
             location="the button"
-            bold={(el: any) => <strong>{el}</strong>}
+            bold={(el: React.ReactNode) => <strong>{el}</strong>}
           />
         </div>
       </>,
     );
 
-    expect(getByTestId("test1").innerHTML).toEqual(`Hello world`);
+    expect(getByTestId("test1").innerHTML).toEqual("Hello world");
     expect(getByTestId("test2").innerHTML).toEqual(
       `Please <a href="https://example.com">click the button</a> to continue.`,
     );

--- a/src/components/Trans.test.tsx
+++ b/src/components/Trans.test.tsx
@@ -9,9 +9,9 @@ describe("Test <Trans/>", () => {
     //@ts-ignore
     fallbackLangData.transTest = {
       key1: "Hello {{audience}}",
-      key2: "Please {{connectLinkStart}}click the button{{connectLinkEnd}} to continue.",
-      key3: "Please {{connectLinkStart}}click {{location}}{{connectLinkEnd}} to continue.",
-      key4: "Please {{connectLinkStart}}click {{boldStart}}{{location}}{{boldEnd}}{{connectLinkEnd}} to continue.",
+      key2: "Please <link>click the button</link> to continue.",
+      key3: "Please <link>click {{location}}</link> to continue.",
+      key4: "Please <link>click <bold>{{location}}</bold></link> to continue.",
     };
 
     const { getByTestId } = render(
@@ -22,28 +22,22 @@ describe("Test <Trans/>", () => {
         <div data-testid="test2">
           <Trans
             i18nKey="transTest.key2"
-            connectLink={(el: React.ReactNode) => (
-              <a href="https://example.com">{el}</a>
-            )}
+            link={(el) => <a href="https://example.com">{el}</a>}
           />
         </div>
         <div data-testid="test3">
           <Trans
             i18nKey="transTest.key3"
-            connectLink={(el: React.ReactNode) => (
-              <a href="https://example.com">{el}</a>
-            )}
+            link={(el) => <a href="https://example.com">{el}</a>}
             location="the button"
           />
         </div>
         <div data-testid="test4">
           <Trans
             i18nKey="transTest.key4"
-            connectLink={(el: React.ReactNode) => (
-              <a href="https://example.com">{el}</a>
-            )}
+            link={(el) => <a href="https://example.com">{el}</a>}
             location="the button"
-            bold={(el: React.ReactNode) => <strong>{el}</strong>}
+            bold={(el) => <strong>{el}</strong>}
           />
         </div>
       </>,

--- a/src/components/Trans.test.tsx
+++ b/src/components/Trans.test.tsx
@@ -1,0 +1,56 @@
+import { render } from "@testing-library/react";
+
+import fallbackLangData from "../locales/en.json";
+
+import Trans from "./Trans";
+
+describe("Trans", () => {
+  it("should translate", () => {
+    (fallbackLangData as any).transtest = {
+      key1: "Hello {{audience}}",
+      key2: "Please {{connectLinkStart}}click the button{{connectLinkEnd}} to continue.",
+      key3: "Please {{connectLinkStart}}click {{location}}{{connectLinkEnd}} to continue.",
+      key4: "Please {{connectLinkStart}}click {{boldStart}}{{location}}{{boldEnd}}{{connectLinkEnd}} to continue.",
+    };
+
+    const { getByTestId } = render(
+      <>
+        <div data-testid="test1">
+          <Trans i18nKey="transtest.key1" audience="world" />
+        </div>
+        <div data-testid="test2">
+          <Trans
+            i18nKey="transtest.key2"
+            connectLink={(el: any) => <a href="https://example.com">{el}</a>}
+          />
+        </div>
+        <div data-testid="test3">
+          <Trans
+            i18nKey="transtest.key3"
+            connectLink={(el: any) => <a href="https://example.com">{el}</a>}
+            location="the button"
+          />
+        </div>
+        <div data-testid="test4">
+          <Trans
+            i18nKey="transtest.key4"
+            connectLink={(el: any) => <a href="https://example.com">{el}</a>}
+            location="the button"
+            bold={(el: any) => <strong>{el}</strong>}
+          />
+        </div>
+      </>,
+    );
+
+    expect(getByTestId("test1").innerHTML).toEqual(`Hello world`);
+    expect(getByTestId("test2").innerHTML).toEqual(
+      `Please <a href="https://example.com">click the button</a> to continue.`,
+    );
+    expect(getByTestId("test3").innerHTML).toEqual(
+      `Please <a href="https://example.com">click the button</a> to continue.`,
+    );
+    expect(getByTestId("test4").innerHTML).toEqual(
+      `Please <a href="https://example.com">click <strong>the button</strong></a> to continue.`,
+    );
+  });
+});

--- a/src/components/Trans.test.tsx
+++ b/src/components/Trans.test.tsx
@@ -12,6 +12,7 @@ describe("Test <Trans/>", () => {
       key2: "Please <link>click the button</link> to continue.",
       key3: "Please <link>click {{location}}</link> to continue.",
       key4: "Please <link>click <bold>{{location}}</bold></link> to continue.",
+      key5: "Please <connect-link>click the button</connect-link> to continue.",
     };
 
     const { getByTestId } = render(
@@ -40,6 +41,12 @@ describe("Test <Trans/>", () => {
             bold={(el) => <strong>{el}</strong>}
           />
         </div>
+        <div data-testid="test5">
+          <Trans
+            i18nKey="transTest.key5"
+            connect-link={(el) => <a href="https://example.com">{el}</a>}
+          />
+        </div>
       </>,
     );
 
@@ -52,6 +59,9 @@ describe("Test <Trans/>", () => {
     );
     expect(getByTestId("test4").innerHTML).toEqual(
       `Please <a href="https://example.com">click <strong>the button</strong></a> to continue.`,
+    );
+    expect(getByTestId("test5").innerHTML).toEqual(
+      `Please <a href="https://example.com">click the button</a> to continue.`,
     );
   });
 });

--- a/src/components/Trans.tsx
+++ b/src/components/Trans.tsx
@@ -7,7 +7,7 @@ const REGEXP = /{{(.+?)}}/g;
 const getTransChildren = (
   format: string,
   props: {
-    [key: string]: React.ReactNode | React.FC;
+    [key: string]: React.ReactNode | ((el: React.ReactNode) => React.ReactNode);
   },
 ) => {
   const stack: { name: string; children: React.ReactNode[] }[] = [
@@ -87,7 +87,7 @@ const Trans = ({
   ...props
 }: {
   i18nKey: string;
-  [key: string]: React.ReactNode | React.FC<any>;
+  [key: string]: React.ReactNode | ((el: React.ReactNode) => React.ReactNode);
 }) => {
   const { t } = useI18n();
 

--- a/src/components/Trans.tsx
+++ b/src/components/Trans.tsx
@@ -11,14 +11,23 @@ const getTransChildren = (format: string, props: { [key: string]: any }) => {
       children: [],
     },
   ];
-
   format.split(REGEXP).forEach((match, index) => {
+    // Pushing the content on both side of the Regex to stack
+    // eg for string - "Hello {{name}} Whats up?"
+    // "Hello" and "Whats up" will be pushed
     if (index % 2 === 0) {
       if (match.length === 0) {
         return;
       }
 
       stack[stack.length - 1].children.push(match);
+
+      // If the match ends with last stack variable appended with "End"
+      // This means we need to now replace the content with its actual value in prop
+      // eg format = "Please {{connectLinkStart}}click the button{{connectLinkEnd}} to continue", match = "connectLinkEnd", stack last item name = "connectLink"
+      // and props.connectLink = (el: any) => <a href="https://example.com">{el}</a>
+      // then its prop value will be pushed to "connectLink"'s children so on DOM when rendering its rendered as
+      // <a href="https://example.com">click the button</a>
     } else if (match === `${stack[stack.length - 1].name}End`) {
       const item = stack.pop()!;
       const itemChildren = React.createElement(
@@ -28,11 +37,18 @@ const getTransChildren = (format: string, props: { [key: string]: any }) => {
       );
       const fn = props[item.name];
       stack[stack.length - 1].children.push(fn(itemChildren));
+      // Check if the match value is present in props and set the prop value
+      // as children of last stack item
+      // eg format = Hello {{name}}, match = "name" and props.name = "Excalidraw"
+      // name will be populated with actual name prop value so its
+      // rendered on DOM as "Hello Excalidraw"
     } else if (props.hasOwnProperty(match)) {
       stack[stack.length - 1].children.push(props[match]);
+
+      // Compute the actual key and set the key as the name if its one of the props, eg for "Please {{connectLinkStart}}click the button{{connectLinkEnd}} to continue"
+      // key = "connectLink" and props contain "connectLink" then it will be pushed to stack
     } else if (/Start$/.test(match)) {
       const name = match.slice(0, match.length - 5);
-
       if (props.hasOwnProperty(name)) {
         stack.push({
           name,

--- a/src/components/Trans.tsx
+++ b/src/components/Trans.tsx
@@ -90,6 +90,8 @@ const Trans = ({
   [key: string]: React.ReactNode | React.FC<any>;
 }) => {
   const { t } = useI18n();
+
+  // This is needed to avoid unique key error in list which gets rendered from getTransChildren
   return React.createElement(
     React.Fragment,
     {},

--- a/src/components/Trans.tsx
+++ b/src/components/Trans.tsx
@@ -39,7 +39,7 @@ const getTransChildren = (
         });
       } else {
         console.warn(
-          `Trans: missed to pass in variable start/end ${match} for interpolating ${format}`,
+          `Trans: missed to pass in prop ${name} for interpolating ${format}`,
         );
       }
 

--- a/src/components/Trans.tsx
+++ b/src/components/Trans.tsx
@@ -1,0 +1,76 @@
+import React from "react";
+
+import { useI18n } from "../i18n";
+
+const REGEXP = /{{(.+?)}}/g;
+
+const getTransChildren = (format: string, props: { [key: string]: any }) => {
+  const stack: { name: string; children: any[] }[] = [
+    {
+      name: "",
+      children: [],
+    },
+  ];
+
+  format.split(REGEXP).forEach((match, index) => {
+    if (index % 2 === 0) {
+      if (match.length === 0) {
+        return;
+      }
+
+      stack[stack.length - 1].children.push(match);
+    } else if (match === `${stack[stack.length - 1].name}End`) {
+      const item = stack.pop()!;
+      const itemChildren = React.createElement(
+        React.Fragment,
+        {},
+        ...item.children,
+      );
+      const fn = props[item.name];
+      stack[stack.length - 1].children.push(fn(itemChildren));
+    } else if (props.hasOwnProperty(match)) {
+      stack[stack.length - 1].children.push(props[match]);
+    } else if (/Start$/.test(match)) {
+      const name = match.slice(0, match.length - 5);
+
+      if (props.hasOwnProperty(name)) {
+        stack.push({
+          name,
+          children: [],
+        });
+      } else {
+        console.warn(
+          `Trans: missed to pass in variable start/end ${match} for interpolating ${format}`,
+        );
+      }
+    } else {
+      console.warn(
+        `Trans: missed to pass in variable ${match} for interpolating ${format}`,
+      );
+    }
+  });
+
+  if (stack.length !== 1) {
+    console.warn(`Trans: stack not empty for interpolating ${format}`);
+  }
+
+  return stack[0].children;
+};
+
+const Trans = ({
+  i18nKey,
+  children,
+  ...props
+}: {
+  i18nKey: string;
+  [key: string]: any;
+}) => {
+  const { t } = useI18n();
+
+  return React.createElement.apply(
+    React.createElement,
+    [React.Fragment, {}].concat(getTransChildren(t(i18nKey), props)) as any,
+  );
+};
+
+export default Trans;

--- a/src/components/Trans.tsx
+++ b/src/components/Trans.tsx
@@ -37,10 +37,11 @@ const getTransChildren = (format: string, props: { [key: string]: any }) => {
       );
       const fn = props[item.name];
       stack[stack.length - 1].children.push(fn(itemChildren));
+
       // Check if the match value is present in props and set the prop value
       // as children of last stack item
       // eg format = Hello {{name}}, match = "name" and props.name = "Excalidraw"
-      // name will be populated with actual name prop value so its
+      // then its prop value will be pushed to "name"'s children so its
       // rendered on DOM as "Hello Excalidraw"
     } else if (props.hasOwnProperty(match)) {
       stack[stack.length - 1].children.push(props[match]);

--- a/src/components/Trans.tsx
+++ b/src/components/Trans.tsx
@@ -26,7 +26,7 @@ const getTransChildren = (format: string, props: { [key: string]: any }) => {
       // This means we need to now replace the content with its actual value in prop
       // eg format = "Please {{connectLinkStart}}click the button{{connectLinkEnd}} to continue", match = "connectLinkEnd", stack last item name = "connectLink"
       // and props.connectLink = (el: any) => <a href="https://example.com">{el}</a>
-      // then its prop value will be pushed to "connectLink"'s children so on DOM when rendering its rendered as
+      // then its prop value will be pushed to "connectLink"'s children so on DOM when rendering it's rendered as
       // <a href="https://example.com">click the button</a>
     } else if (match === `${stack[stack.length - 1].name}End`) {
       const item = stack.pop()!;
@@ -41,12 +41,12 @@ const getTransChildren = (format: string, props: { [key: string]: any }) => {
       // Check if the match value is present in props and set the prop value
       // as children of last stack item
       // eg format = Hello {{name}}, match = "name" and props.name = "Excalidraw"
-      // then its prop value will be pushed to "name"'s children so its
+      // then its prop value will be pushed to "name"'s children so it's
       // rendered on DOM as "Hello Excalidraw"
     } else if (props.hasOwnProperty(match)) {
       stack[stack.length - 1].children.push(props[match]);
 
-      // Compute the actual key and set the key as the name if its one of the props, eg for "Please {{connectLinkStart}}click the button{{connectLinkEnd}} to continue"
+      // Compute the actual key and set the key as the name if it's one of the props, eg for "Please {{connectLinkStart}}click the button{{connectLinkEnd}} to continue"
       // key = "connectLink" and props contain "connectLink" then it will be pushed to stack
     } else if (/Start$/.test(match)) {
       const name = match.slice(0, match.length - 5);

--- a/src/components/Trans.tsx
+++ b/src/components/Trans.tsx
@@ -53,9 +53,9 @@ const getTransChildren = (
           );
         }
       } else if (tagEndMatch !== null) {
-        // The match is </tag>. This means we need to replace the content with
+        // If tag end match is found, this means we need to replace the content with
         // its actual value in prop e.g. format = "Please <link>click the
-        // button</link> to continue", match = "</link>", stack last item name =
+        // button</link> to continue", tagEndMatch is for "</link>", stack last item name =
         // "link" and props.link = (el) => <a
         // href="https://example.com">{el}</a> then its prop value will be
         // pushed to "link"'s children so on DOM when rendering it's rendered as
@@ -78,7 +78,7 @@ const getTransChildren = (
           );
         }
       } else if (keyMatch !== null) {
-        // The match is {{key}}. Check if the key is present in props and set
+        // The match is for {{key}}. Check if the key is present in props and set
         // the prop value as children of last stack item e.g. format = "Hello
         // {{name}}", key = "name" and props.name = "Excalidraw" then its prop
         // value will be pushed to "name"'s children so it's rendered on DOM as
@@ -92,8 +92,8 @@ const getTransChildren = (
           );
         }
       } else {
-        // Pushing the content on both side of the Regex to stack eg for string -
-        // "Hello {{name}} Whats up?" "Hello" and "Whats up" will be pushed
+        // If none of cases match means we just need to push the string
+        // to stack eg - "Hello {{name}} Whats up?" "Hello", "Whats up" will be pushed
         stack[stack.length - 1].children.push(match);
       }
     });

--- a/src/components/Trans.tsx
+++ b/src/components/Trans.tsx
@@ -2,7 +2,10 @@ import React from "react";
 
 import { useI18n } from "../i18n";
 
-const REGEXP = /{{(.+?)}}/g;
+const REGEXP = /({{\w+?}})|(<\w+?>)|(<\/\w+?>)/g;
+const KEY_REGEXP = /{{(\w+?)}}/;
+const TAG_START_REGEXP = /<(\w+?)>/;
+const TAG_END_REGEXP = /<\/(\w+?)>/;
 
 const getTransChildren = (
   format: string,
@@ -16,47 +19,19 @@ const getTransChildren = (
       children: [],
     },
   ];
-  format.split(REGEXP).forEach((match, index) => {
-    // Pushing the content on both side of the Regex to stack
-    // eg for string - "Hello {{name}} Whats up?"
-    // "Hello" and "Whats up" will be pushed
-    if (index % 2 === 0) {
-      if (match.length === 0) {
-        return;
-      }
 
-      stack[stack.length - 1].children.push(match);
+  format.split(REGEXP).forEach((match) => {
+    if (match === undefined || match.length === 0) {
+      return;
+    }
 
-      // If the match ends with last stack variable appended with "End"
-      // This means we need to now replace the content with its actual value in prop
-      // eg format = "Please {{connectLinkStart}}click the button{{connectLinkEnd}} to continue", match = "connectLinkEnd", stack last item name = "connectLink"
-      // and props.connectLink = (el) => <a href="https://example.com">{el}</a>
-      // then its prop value will be pushed to "connectLink"'s children so on DOM when rendering it's rendered as
-      // <a href="https://example.com">click the button</a>
-    } else if (match === `${stack[stack.length - 1].name}End`) {
-      const item = stack.pop()!;
-      const itemChildren = React.createElement(
-        React.Fragment,
-        {},
-        ...item.children,
-      );
-      const fn = props[item.name];
-      if (typeof fn === "function") {
-        stack[stack.length - 1].children.push(fn(itemChildren));
-      }
+    const tagStartMatch = match.match(TAG_START_REGEXP);
 
-      // Check if the match value is present in props and set the prop value
-      // as children of last stack item
-      // eg format = Hello {{name}}, match = "name" and props.name = "Excalidraw"
-      // then its prop value will be pushed to "name"'s children so it's
-      // rendered on DOM as "Hello Excalidraw"
-    } else if (props.hasOwnProperty(match)) {
-      stack[stack.length - 1].children.push(props[match] as React.ReactNode);
-
-      // Compute the actual key and set the key as the name if it's one of the props, eg for "Please {{connectLinkStart}}click the button{{connectLinkEnd}} to continue"
-      // key = "connectLink" and props contain "connectLink" then it will be pushed to stack
-    } else if (/Start$/.test(match)) {
-      const name = match.slice(0, match.length - 5);
+    if (tagStartMatch !== null) {
+      // Set the tag name as the name if it's one of the props, eg for "Please
+      // <link>click the button</link> to continue" tagStartMatch[1] = "link"
+      // and props contain "link" then it will be pushed to stack.
+      const name = tagStartMatch[1];
       if (props.hasOwnProperty(name)) {
         stack.push({
           name,
@@ -67,11 +42,64 @@ const getTransChildren = (
           `Trans: missed to pass in variable start/end ${match} for interpolating ${format}`,
         );
       }
-    } else {
-      console.warn(
-        `Trans: missed to pass in variable ${match} for interpolating ${format}`,
-      );
+
+      return;
     }
+
+    const tagEndMatch = match.match(TAG_END_REGEXP);
+
+    if (tagEndMatch !== null) {
+      // The match is </tag>. This means we need to now replace the content with
+      // its actual value in prop eg format = "Please <link>click the
+      // button</link> to continue", match = "</link>", stack last item name =
+      // "link" and props.link = (el) => <a href="https://example.com">{el}</a>
+      // then its prop value will be pushed to "link"'s children so on DOM when
+      // rendering it's rendered as <a href="https://example.com">click the
+      // button</a>
+
+      if (tagEndMatch[1] === stack[stack.length - 1].name) {
+        const item = stack.pop()!;
+        const itemChildren = React.createElement(
+          React.Fragment,
+          {},
+          ...item.children,
+        );
+        const fn = props[item.name];
+        if (typeof fn === "function") {
+          stack[stack.length - 1].children.push(fn(itemChildren));
+        }
+      } else {
+        console.warn(
+          `Trans: unexpected end tag ${match} for interpolating ${format}`,
+        );
+      }
+
+      return;
+    }
+
+    const keyMatch = match.match(KEY_REGEXP);
+
+    if (keyMatch !== null) {
+      // Check if the match value is present in props and set the prop value as
+      // children of last stack item e.g. format = Hello {{name}}, keyMatch[1] =
+      // "name" and props.name = "Excalidraw" then its prop value will be pushed
+      // to "name"'s children so it's rendered on DOM as "Hello Excalidraw"
+      if (props.hasOwnProperty(keyMatch[1])) {
+        stack[stack.length - 1].children.push(
+          props[keyMatch[1]] as React.ReactNode,
+        );
+      } else {
+        console.warn(
+          `Trans: key ${match} not in props for interpolating ${format}`,
+        );
+      }
+
+      return;
+    }
+
+    // Pushing the content on both side of the Regex to stack eg for string -
+    // "Hello {{name}} Whats up?" "Hello" and "Whats up" will be pushed
+    stack[stack.length - 1].children.push(match);
   });
 
   if (stack.length !== 1) {

--- a/src/components/Trans.tsx
+++ b/src/components/Trans.tsx
@@ -90,8 +90,11 @@ const Trans = ({
   [key: string]: React.ReactNode | React.FC<any>;
 }) => {
   const { t } = useI18n();
-
-  return <>{getTransChildren(t(i18nKey), props)}</>;
+  return React.createElement(
+    React.Fragment,
+    {},
+    ...getTransChildren(t(i18nKey), props),
+  );
 };
 
 export default Trans;

--- a/src/components/__snapshots__/App.test.tsx.snap
+++ b/src/components/__snapshots__/App.test.tsx.snap
@@ -5,59 +5,46 @@ exports[`Test <App/> should show error modal when using brave and measureText AP
   data-testid="brave-measure-text-error"
 >
   <p>
-    Looks like you are using Brave browser with the
-      
+    Looks like you are using Brave browser with the 
     <span
       style="font-weight: 600;"
     >
       Aggressively Block Fingerprinting
     </span>
-     
-    setting enabled
-    .
-    <br />
-    <br />
-    This could result in breaking the
-     
+     setting enabled.
+  </p>
+  <p>
+    This could result in breaking the 
     <span
       style="font-weight: 600;"
     >
       Text Elements
     </span>
-     
-    in your drawings
-    .
+     in your drawings.
   </p>
   <p>
-    We strongly recommend disabling this setting. You can follow
-     
+    We strongly recommend disabling this setting. You can follow 
     <a
       href="http://docs.excalidraw.com/docs/@excalidraw/excalidraw/faq#turning-off-aggresive-block-fingerprinting-in-brave-browser"
     >
-       
       these steps
     </a>
-     
-    on how to do so
-    .
+     on how to do so.
   </p>
   <p>
-     If disabling this setting doesn't fix the display of text elements, please open an
-     
+     If disabling this setting doesn't fix the display of text elements, please open an 
     <a
       href="https://github.com/excalidraw/excalidraw/issues/new"
     >
       issue
     </a>
-     
-    on our GitHub, or write us on
-     
+     on our GitHub, or write us on 
     <a
       href="https://discord.gg/UexuTaE"
     >
       Discord
+      .
     </a>
-    .
   </p>
 </div>
 `;

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -208,10 +208,10 @@
     "collabSaveFailed": "Couldn't save to the backend database. If problems persist, you should save your file locally to ensure you don't lose your work.",
     "collabSaveFailed_sizeExceeded": "Couldn't save to the backend database, the canvas seems to be too big. You should save the file locally to ensure you don't lose your work.",
     "brave_measure_text_error": {
-      "line1": "Looks like you are using Brave browser with the {{aggressiveBlockFingerprintStart}}Aggressively Block Fingerprinting{{aggressiveBlockFingerprintEnd}} setting enabled.",
-      "line2": "This could result in breaking the {{textElementsStart}}Text Elements{{textElementsEnd}} in your drawings.",
-      "line3": "We strongly recommend disabling this setting. You can follow {{stepsStart}}these steps{{stepsEnd}} on how to do so.",
-      "line4": " If disabling this setting doesn't fix the display of text elements, please open an {{issueStart}}issue{{issueEnd}} on our GitHub, or write us on {{discordStart}}Discord{{discordEnd}}",
+      "line1": "Looks like you are using Brave browser with the <bold>Aggressively Block Fingerprinting</bold> setting enabled.",
+      "line2": "This could result in breaking the <bold>Text Elements</bold> in your drawings.",
+      "line3": "We strongly recommend disabling this setting. You can follow <link>these steps</link> on how to do so.",
+      "line4": " If disabling this setting doesn't fix the display of text elements, please open an <issueLink>issue</issueLink> on our GitHub, or write us on <discordLink>Discord</discordLink>",
       "discord": "Discord"
     }
   },

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -208,18 +208,10 @@
     "collabSaveFailed": "Couldn't save to the backend database. If problems persist, you should save your file locally to ensure you don't lose your work.",
     "collabSaveFailed_sizeExceeded": "Couldn't save to the backend database, the canvas seems to be too big. You should save the file locally to ensure you don't lose your work.",
     "brave_measure_text_error": {
-      "start": "Looks like you are using Brave browser with the",
-      "aggressive_block_fingerprint": "Aggressively Block Fingerprinting",
-      "setting_enabled": "setting enabled",
-      "break": "This could result in breaking the",
-      "text_elements": "Text Elements",
-      "in_your_drawings": "in your drawings",
-      "strongly_recommend": "We strongly recommend disabling this setting. You can follow",
-      "steps": "these steps",
-      "how": "on how to do so",
-      "disable_setting": " If disabling this setting doesn't fix the display of text elements, please open an",
-      "issue": "issue",
-      "write": "on our GitHub, or write us on",
+      "line1": "Looks like you are using Brave browser with the {{aggressiveBlockFingerprintStart}}Aggressively Block Fingerprinting{{aggressiveBlockFingerprintEnd}} setting enabled.",
+      "line2": "This could result in breaking the {{textElementsStart}}Text Elements{{textElementsEnd}} in your drawings.",
+      "line3": "We strongly recommend disabling this setting. You can follow {{stepsStart}}these steps{{stepsEnd}} on how to do so.",
+      "line4": " If disabling this setting doesn't fix the display of text elements, please open an {{issueStart}}issue{{issueEnd}} on our GitHub, or write us on {{discordStart}}Discord{{discordEnd}}",
       "discord": "Discord"
     }
   },


### PR DESCRIPTION
Fixes https://github.com/excalidraw/excalidraw/issues/6351
This is a proof of concept PR that shows a possible solution to #6351 (this already works, you can quickly test it by applying the diff at the bottom and removing `if (isBrave() && !isMeasureTextSupported()) {` in `App.tsx`).

`Trans` component make it possible to use JSX for translations.

Examples:

```json
{
  "example1": "Hello {{audience}}",
  "example2": "Please <link>click the button</link> to continue.",
  "example3": "Please <link>click {{location}}</link> to continue.",
  "example4": "Please <link>click <bold>{{location}}</bold></link> to continue.",
}
```

```jsx
<Trans i18nKey="example1" audience="world" />

<Trans
  i18nKey="example2"
  connectLink={(el) => <a href="https://example.com">{el}</a>}
/>

<Trans
  i18nKey="example3"
  connectLink={(el) => <a href="https://example.com">{el}</a>}
  location="the button"
/>

<Trans
  i18nKey="example4"
  connectLink={(el) => <a href="https://example.com">{el}</a>}
  location="the button"
  bold={(el) => <strong>{el}</strong>}
/>
```

Output:

```html
Hello world
Please <a href="https://example.com">click the button</a> to continue.
Please <a href="https://example.com">click the button</a> to continue.
Please <a href="https://example.com">click <strong>the button</strong></a> to continue.
```

`Trans` component can also be used instead of `t()`. E.g. `<span><Trans i18nKey="my.key" /></span>` is the same as `<span>{t("my.key")}</span>` and `<span><Trans i18nKey="my.key" name={currentName} /></span>` is the same as `<span>{t("my.key", { name: currentName })}</span>`
