### PR TITLE
fix: add fallbacks for all fonts

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,7 +1,7 @@
-import cssVariables from "./css/variables.module.scss";
-import { AppProps } from "./types";
-import { ExcalidrawElement, FontFamilyValues } from "./element/types";
 import oc from "open-color";
+import cssVariables from "./css/variables.module.scss";
+import { ExcalidrawElement, FontFamilyValues } from "./element/types";
+import { AppProps } from "./types";
 
 export const isDarwin = /Mac|iPod|iPhone|iPad/.test(navigator.platform);
 export const isWindows = /^Win/.test(navigator.platform);
@@ -88,12 +88,18 @@ export const FONT_FAMILY = {
   Cascadia: 3,
 };
 
+export const WINDOWS_EMOJI_FALLBACK_FONT = "'Segoe UI Emoji'";
+
+export const FONT_FAMILY_FALLBACKS = {
+  [FONT_FAMILY.Virgil]: `'Comic Sans MS', 'Segoe Print', 'Bradley Hand', 'Lucida Handwriting', 'Marker Felt', cursive, ${WINDOWS_EMOJI_FALLBACK_FONT}`,
+  [FONT_FAMILY.Helvetica]: `-apple-system,BlinkMacSystemFont, 'Segoe UI', 'Noto Sans', Helvetica, Arial, sans-serif, 'Apple Color Emoji', ${WINDOWS_EMOJI_FALLBACK_FONT}`,
+  [FONT_FAMILY.Cascadia]: `ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, 'Liberation Mono', monospace, ${WINDOWS_EMOJI_FALLBACK_FONT}`,
+};
+
 export const THEME = {
   LIGHT: "light",
   DARK: "dark",
 };
-
-export const WINDOWS_EMOJI_FALLBACK_FONT = "Segoe UI Emoji";
 
 export const DEFAULT_FONT_SIZE = 20;
 export const DEFAULT_FONT_FAMILY: FontFamilyValues = FONT_FAMILY.Virgil;

--- a/src/tests/__snapshots__/linearElementEditor.test.tsx.snap
+++ b/src/tests/__snapshots__/linearElementEditor.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`Test Linear Elements Test bound text element should match styles for te
   class="excalidraw-wysiwyg"
   data-type="wysiwyg"
   dir="auto"
-  style="position: absolute; display: inline-block; min-height: 1em; margin: 0px; padding: 0px; border: 0px; outline: 0; resize: none; background: transparent; overflow: hidden; z-index: var(--zIndex-wysiwyg); word-break: break-word; white-space: pre-wrap; overflow-wrap: break-word; box-sizing: content-box; width: 10.5px; height: 25px; left: 35px; top: 7.5px; transform: translate(0px, 0px) scale(1) rotate(0deg); text-align: center; vertical-align: middle; color: rgb(0, 0, 0); opacity: 1; filter: var(--theme-filter); max-height: -7.5px; font: Emoji 20px 20px; line-height: 1.25; font-family: Virgil, Segoe UI Emoji;"
+  style="position: absolute; display: inline-block; min-height: 1em; margin: 0px; padding: 0px; border: 0px; outline: 0; resize: none; background: transparent; overflow: hidden; z-index: var(--zIndex-wysiwyg); word-break: break-word; white-space: pre-wrap; overflow-wrap: break-word; box-sizing: content-box; width: 10.5px; height: 25px; left: 35px; top: 7.5px; transform: translate(0px, 0px) scale(1) rotate(0deg); text-align: center; vertical-align: middle; color: rgb(0, 0, 0); opacity: 1; filter: var(--theme-filter); max-height: -7.5px; font: 'Segoe UI Emoji' 20px 20px; line-height: 1.25; font-family: Virgil, 'Comic Sans MS', 'Segoe Print', 'Bradley Hand', 'Lucida Handwriting', 'Marker Felt', cursive, 'Segoe UI Emoji';"
   tabindex="0"
   wrap="off"
 />

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,21 +1,21 @@
 import oc from "open-color";
-
+import { unstable_batchedUpdates } from "react-dom";
+import { isEraserActive, isHandToolActive } from "./appState";
 import colors from "./colors";
 import {
   CURSOR_TYPE,
   DEFAULT_VERSION,
   EVENT,
   FONT_FAMILY,
+  FONT_FAMILY_FALLBACKS,
   isDarwin,
   MIME_TYPES,
   THEME,
   WINDOWS_EMOJI_FALLBACK_FONT,
 } from "./constants";
 import { FontFamilyValues, FontString } from "./element/types";
-import { AppState, DataURL, LastActiveTool, Zoom } from "./types";
-import { unstable_batchedUpdates } from "react-dom";
 import { SHAPES } from "./shapes";
-import { isEraserActive, isHandToolActive } from "./appState";
+import { AppState, DataURL, LastActiveTool, Zoom } from "./types";
 import { ResolutionType } from "./utility-types";
 
 let mockDateTime: string | null = null;
@@ -81,7 +81,7 @@ export const getFontFamilyString = ({
 }) => {
   for (const [fontFamilyString, id] of Object.entries(FONT_FAMILY)) {
     if (id === fontFamily) {
-      return `${fontFamilyString}, ${WINDOWS_EMOJI_FALLBACK_FONT}`;
+      return `${fontFamilyString}, ${FONT_FAMILY_FALLBACKS[id]}`;
     }
   }
   return WINDOWS_EMOJI_FALLBACK_FONT;


### PR DESCRIPTION
Closes #6479

In the case that the WOFF2 fonts cannot be requested from the various font URLs eg. https://excalidraw.com/Virgil.woff2, then provide fallbacks for Windows, macOS and Linux.

This can happen if the SVG is loaded in an environment with a Content Security Policy set up, like if an SVG file is included in a readme on GitHub:

https://github.com/excalidraw/excalidraw/issues/4855

For example, the following screenshot was taken of the broken fonts in an Excalidraw SVG file which was rendered in a Markdown file on GitHub:

| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Before&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<br />fallback: `Segoe UI` | After<br />fallback: `ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, 'Liberation Mono', monospace` |
| - | - |
| <img src="https://user-images.githubusercontent.com/1935696/233049521-9228c352-7a4a-4a93-9dd0-0fe59ab35044.png" width="214" alt="Screenshot 2023-04-19 at 12 34 19" /> | ![Screenshot 2023-04-19 at 12 34 45](https://user-images.githubusercontent.com/1935696/233049696-47acb346-b7e0-419c-84ed-abeac336449a.png) |

---

The main part of this change is this here (and fixing all of the references to `FONT_FAMILY`):

```diff
export const FONT_FAMILY = {
- Virgil: 1,
- Helvetica: 2,
- Cascadia: 3,
+ Virgil: {
+   id: 1,
+   fallback:
+     "'Comic Sans MS', 'Segoe Print', 'Bradley Hand', 'Lucida Handwriting', 'Marker Felt', cursive",
+ },
+ Helvetica: {
+   id: 2,
+   fallback:
+     "-apple-system,BlinkMacSystemFont, 'Segoe UI', 'Noto Sans', Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji'",
+ },
+ Cascadia: {
+   id: 3,
+   fallback:
+     "ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, 'Liberation Mono', monospace",
+ },
};
```

This may require a notice of a breaking change, since it breaks the public API exposed by Excalidraw.