### PR TITLE
fix: make `a` focus styling better

### DIFF
--- a/src/css/styles.scss
+++ b/src/css/styles.scss
@@ -164,6 +164,11 @@
     box-shadow: 0 0 0 2px var(--focus-highlight-color);
   }
 
+  a:focus-visible {
+    outline: none;
+    text-decoration: underline;
+  }
+
   .buttonList {
     .ToolIcon__icon {
       all: unset !important;


### PR DESCRIPTION
Improving `a` focus styling. Especially not great when we autofocus first focusable element in the modal, which in some cases turns out to be `a` elements.

Before:

![image](https://user-images.githubusercontent.com/5153846/236529318-5b459061-c2d4-4dca-9d3f-c2187d122585.png)

After:

![image](https://user-images.githubusercontent.com/5153846/236529339-0419a41d-eb08-4b7b-a0ce-4ab2fba262c1.png)
