### PR TITLE
Publish docker image on tag

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -2,6 +2,8 @@ name: Publish Docker
 
 on:
   push:
+    tags: 
+      - v*
     branches:
       - release
 
@@ -12,14 +14,26 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: excalidraw/excalidraw
+          flavor: |
+            latest=false
+          tags: |
+            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'release') }}
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
       - name: Login to DockerHub
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Build and push
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v4
         with:
           context: .
           push: true
-          tags: excalidraw/excalidraw:latest
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Expected behavior coming in this PR 
- On tag, publish-docker is triggered and publish tags `<major>.<minor>.<patch>` and `<major>.<minor>`
- Expected tag format is `v<major>.<minor>.<patch>`
- On branch release, it will publish tag `latest`

Tested in my own docker hub repo associated to my fork created for this purpose

References 
- https://github.com/excalidraw/excalidraw/pull/6540
- https://github.com/excalidraw/excalidraw/pull/6508
- https://github.com/excalidraw/excalidraw/issues/6507


