### PR TITLE
fix: midpoint of line is put on previous line

### DIFF
--- a/src/element/linearElementEditor.ts
+++ b/src/element/linearElementEditor.ts
@@ -414,10 +414,18 @@ export class LinearElementEditor {
       editorMidPointsCache.version === element.version &&
       editorMidPointsCache.zoom === appState.zoom.value
     ) {
+      LinearElementEditor.clearEditorMidPointsCache();
+      LinearElementEditor.updateEditorMidPointsCache(element, appState);
       return editorMidPointsCache.points;
     }
     LinearElementEditor.updateEditorMidPointsCache(element, appState);
     return editorMidPointsCache.points!;
+  };
+
+  static clearEditorMidPointsCache = () => {
+    editorMidPointsCache.version = null;
+    editorMidPointsCache.points = [];
+    editorMidPointsCache.zoom = null;
   };
 
   static updateEditorMidPointsCache = (


### PR DESCRIPTION
Relevant issue: #5928 
This PR fixed the issue that the midpoint of a newly created line will shift to the previous line when multiple lines are created or copied by clearing EditorMidPointsCache when certain conditions are met.