### PR TITLE
perf: improve rendering performance for Library

### DIFF
--- a/src/components/LibraryMenu.tsx
+++ b/src/components/LibraryMenu.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from "react";
+import React, { useCallback } from "react";
 import Library, {
   distributeLibraryItemsOnSquareGrid,
   libraryItemsAtom,
@@ -43,8 +43,6 @@ export const LibraryMenuContent = ({
   library,
   id,
   appState,
-  selectedItems,
-  onSelectItems,
 }: {
   pendingElements: LibraryItem["elements"];
   onInsertLibraryItems: (libraryItems: LibraryItems) => void;
@@ -54,8 +52,6 @@ export const LibraryMenuContent = ({
   library: Library;
   id: string;
   appState: UIAppState;
-  selectedItems: LibraryItem["id"][];
-  onSelectItems: (id: LibraryItem["id"][]) => void;
 }) => {
   const [libraryItemsData] = useAtom(libraryItemsAtom, jotaiScope);
 
@@ -113,8 +109,6 @@ export const LibraryMenuContent = ({
         }
         onInsertLibraryItems={onInsertLibraryItems}
         pendingElements={pendingElements}
-        selectedItems={selectedItems}
-        onSelectItems={onSelectItems}
         id={id}
         libraryReturnUrl={libraryReturnUrl}
         theme={appState.theme}
@@ -143,9 +137,8 @@ export const LibraryMenu = () => {
   const setAppState = useExcalidrawSetAppState();
   const elements = useExcalidrawElements();
 
-  const [selectedItems, setSelectedItems] = useState<LibraryItem["id"][]>([]);
-
-  const deselectItems = useCallback(() => {
+  const onAddToLibrary = useCallback(() => {
+    // deselect canvas elements
     setAppState({
       selectedElementIds: {},
       selectedGroupIds: {},
@@ -158,14 +151,12 @@ export const LibraryMenu = () => {
       onInsertLibraryItems={(libraryItems) => {
         onInsertElements(distributeLibraryItemsOnSquareGrid(libraryItems));
       }}
-      onAddToLibrary={deselectItems}
+      onAddToLibrary={onAddToLibrary}
       setAppState={setAppState}
       libraryReturnUrl={appProps.libraryReturnUrl}
       library={library}
       id={id}
       appState={appState}
-      selectedItems={selectedItems}
-      onSelectItems={setSelectedItems}
     />
   );
 };

--- a/src/components/LibraryMenuItems.tsx
+++ b/src/components/LibraryMenuItems.tsx
@@ -14,18 +14,16 @@ import Spinner from "./Spinner";
 import { duplicateElements } from "../element/newElement";
 import { LibraryMenuControlButtons } from "./LibraryMenuControlButtons";
 import { LibraryDropdownMenu } from "./LibraryMenuHeaderContent";
-
-import "./LibraryMenuItems.scss";
 import LibraryMenuSection from "./LibraryMenuSection";
 
-const LibraryMenuItems = ({
+import "./LibraryMenuItems.scss";
+
+export default function LibraryMenuItems({
   isLoading,
   libraryItems,
   onAddToLibrary,
   onInsertLibraryItems,
   pendingElements,
-  selectedItems,
-  onSelectItems,
   theme,
   id,
   libraryReturnUrl,
@@ -35,12 +33,12 @@ const LibraryMenuItems = ({
   pendingElements: LibraryItem["elements"];
   onInsertLibraryItems: (libraryItems: LibraryItems) => void;
   onAddToLibrary: (elements: LibraryItem["elements"]) => void;
-  selectedItems: LibraryItem["id"][];
-  onSelectItems: (id: LibraryItem["id"][]) => void;
   libraryReturnUrl: ExcalidrawProps["libraryReturnUrl"];
   theme: UIAppState["theme"];
   id: string;
-}) => {
+}) {
+  const [selectedItems, setSelectedItems] = useState<LibraryItem["id"][]>([]);
+
   const unpublishedItems = libraryItems.filter(
     (item) => item.status !== "published",
   );
@@ -75,7 +73,7 @@ const LibraryMenuItems = ({
         const rangeEnd = orderedItems.findIndex((item) => item.id === id);
 
         if (rangeStart === -1 || rangeEnd === -1) {
-          onSelectItems([...selectedItems, id]);
+          setSelectedItems([...selectedItems, id]);
           return;
         }
 
@@ -93,14 +91,14 @@ const LibraryMenuItems = ({
           [],
         );
 
-        onSelectItems(nextSelectedIds);
+        setSelectedItems(nextSelectedIds);
       } else {
-        onSelectItems([...selectedItems, id]);
+        setSelectedItems([...selectedItems, id]);
       }
       setLastSelectedItem(id);
     } else {
       setLastSelectedItem(null);
-      onSelectItems(selectedItems.filter((_id) => _id !== id));
+      setSelectedItems(selectedItems.filter((_id) => _id !== id));
     }
   };
 
@@ -171,7 +169,7 @@ const LibraryMenuItems = ({
       {!isLibraryEmpty && (
         <LibraryDropdownMenu
           selectedItems={selectedItems}
-          onSelectItems={onSelectItems}
+          onSelectItems={setSelectedItems}
           className="library-menu-dropdown-container--in-heading"
         />
       )}
@@ -272,13 +270,11 @@ const LibraryMenuItems = ({
           >
             <LibraryDropdownMenu
               selectedItems={selectedItems}
-              onSelectItems={onSelectItems}
+              onSelectItems={setSelectedItems}
             />
           </LibraryMenuControlButtons>
         )}
       </Stack.Col>
     </div>
   );
-};
-
-export default LibraryMenuItems;
+}

--- a/src/components/LibraryMenuItems.tsx
+++ b/src/components/LibraryMenuItems.tsx
@@ -204,7 +204,6 @@ const LibraryMenuItems = ({
                     : []),
                   ...unpublishedItems,
                 ]}
-                itemsPerRow={4}
                 onItemSelectToggle={onItemSelectToggle}
                 onItemDrag={onItemDrag}
                 isItemSelected={isItemSelected}
@@ -224,7 +223,6 @@ const LibraryMenuItems = ({
           {publishedItems.length > 0 ? (
             <LibraryMenuSection
               items={publishedItems}
-              itemsPerRow={4}
               onItemSelectToggle={onItemSelectToggle}
               onItemDrag={onItemDrag}
               isItemSelected={isItemSelected}

--- a/src/components/LibraryMenuItems.tsx
+++ b/src/components/LibraryMenuItems.tsx
@@ -104,24 +104,27 @@ const LibraryMenuItems = ({
     }
   };
 
-  const getInsertedElements = (id: string) => {
-    let targetElements;
-    if (selectedItems.includes(id)) {
-      targetElements = libraryItems.filter((item) =>
-        selectedItems.includes(item.id),
-      );
-    } else {
-      targetElements = libraryItems.filter((item) => item.id === id);
-    }
-    return targetElements.map((item) => {
-      return {
-        ...item,
-        // duplicate each library item before inserting on canvas to confine
-        // ids and bindings to each library item. See #6465
-        elements: duplicateElements(item.elements, { randomizeSeed: true }),
-      };
-    });
-  };
+  const getInsertedElements = useCallback(
+    (id: string) => {
+      let targetElements;
+      if (selectedItems.includes(id)) {
+        targetElements = libraryItems.filter((item) =>
+          selectedItems.includes(item.id),
+        );
+      } else {
+        targetElements = libraryItems.filter((item) => item.id === id);
+      }
+      return targetElements.map((item) => {
+        return {
+          ...item,
+          // duplicate each library item before inserting on canvas to confine
+          // ids and bindings to each library item. See #6465
+          elements: duplicateElements(item.elements, { randomizeSeed: true }),
+        };
+      });
+    },
+    [libraryItems, selectedItems],
+  );
 
   const onItemDrag = (id: LibraryItem["id"], event: React.DragEvent) => {
     event.dataTransfer.setData(

--- a/src/components/LibraryMenuItems.tsx
+++ b/src/components/LibraryMenuItems.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useCallback, useState } from "react";
 import { serializeLibraryAsJSON } from "../data/json";
 import { t } from "../i18n";
 import {
@@ -138,6 +138,22 @@ const LibraryMenuItems = ({
     return selectedItems.includes(id);
   };
 
+  const onItemClick = useCallback(
+    (id: LibraryItem["id"] | null) => {
+      if (!id) {
+        onAddToLibrary(pendingElements);
+      } else {
+        onInsertLibraryItems(getInsertedElements(id));
+      }
+    },
+    [
+      getInsertedElements,
+      onAddToLibrary,
+      onInsertLibraryItems,
+      pendingElements,
+    ],
+  );
+
   return (
     <div
       className="library-menu-items-container"
@@ -206,6 +222,7 @@ const LibraryMenuItems = ({
                 ]}
                 onItemSelectToggle={onItemSelectToggle}
                 onItemDrag={onItemDrag}
+                onClick={onItemClick}
                 isItemSelected={isItemSelected}
               />
             )}
@@ -225,6 +242,7 @@ const LibraryMenuItems = ({
               items={publishedItems}
               onItemSelectToggle={onItemSelectToggle}
               onItemDrag={onItemDrag}
+              onClick={onItemClick}
               isItemSelected={isItemSelected}
             />
           ) : unpublishedItems.length > 0 ? (

--- a/src/components/LibraryMenuItems.tsx
+++ b/src/components/LibraryMenuItems.tsx
@@ -202,34 +202,32 @@ const LibraryMenuItems = ({
               <Spinner />
             </div>
           )}
-          <div className="library-menu-items-private-library-container">
-            {!pendingElements.length && !unpublishedItems.length ? (
-              <div className="library-menu-items__no-items">
-                <div className="library-menu-items__no-items__label">
-                  {t("library.noItems")}
-                </div>
-                <div className="library-menu-items__no-items__hint">
-                  {publishedItems.length > 0
-                    ? t("library.hint_emptyPrivateLibrary")
-                    : t("library.hint_emptyLibrary")}
-                </div>
+          {!pendingElements.length && !unpublishedItems.length ? (
+            <div className="library-menu-items__no-items">
+              <div className="library-menu-items__no-items__label">
+                {t("library.noItems")}
               </div>
-            ) : (
-              <LibraryMenuSection
-                items={[
-                  // append pending library item
-                  ...(pendingElements.length
-                    ? [{ id: null, elements: pendingElements }]
-                    : []),
-                  ...unpublishedItems,
-                ]}
-                onItemSelectToggle={onItemSelectToggle}
-                onItemDrag={onItemDrag}
-                onClick={onItemClick}
-                isItemSelected={isItemSelected}
-              />
-            )}
-          </div>
+              <div className="library-menu-items__no-items__hint">
+                {publishedItems.length > 0
+                  ? t("library.hint_emptyPrivateLibrary")
+                  : t("library.hint_emptyLibrary")}
+              </div>
+            </div>
+          ) : (
+            <LibraryMenuSection
+              items={[
+                // append pending library item
+                ...(pendingElements.length
+                  ? [{ id: null, elements: pendingElements }]
+                  : []),
+                ...unpublishedItems,
+              ]}
+              onItemSelectToggle={onItemSelectToggle}
+              onItemDrag={onItemDrag}
+              onClick={onItemClick}
+              isItemSelected={isItemSelected}
+            />
+          )}
         </>
 
         <>

--- a/src/components/LibraryMenuItems.tsx
+++ b/src/components/LibraryMenuItems.tsx
@@ -18,6 +18,7 @@ import { LibraryMenuControlButtons } from "./LibraryMenuControlButtons";
 import { LibraryDropdownMenu } from "./LibraryMenuHeaderContent";
 
 import "./LibraryMenuItems.scss";
+import LibraryMenuSection from "./LibraryMenuSection";
 
 const CELLS_PER_ROW = 4;
 
@@ -44,161 +45,6 @@ const LibraryMenuItems = ({
   theme: UIAppState["theme"];
   id: string;
 }) => {
-  const [lastSelectedItem, setLastSelectedItem] = useState<
-    LibraryItem["id"] | null
-  >(null);
-
-  const onItemSelectToggle = (
-    id: LibraryItem["id"],
-    event: React.MouseEvent,
-  ) => {
-    const shouldSelect = !selectedItems.includes(id);
-
-    const orderedItems = [...unpublishedItems, ...publishedItems];
-
-    if (shouldSelect) {
-      if (event.shiftKey && lastSelectedItem) {
-        const rangeStart = orderedItems.findIndex(
-          (item) => item.id === lastSelectedItem,
-        );
-        const rangeEnd = orderedItems.findIndex((item) => item.id === id);
-
-        if (rangeStart === -1 || rangeEnd === -1) {
-          onSelectItems([...selectedItems, id]);
-          return;
-        }
-
-        const selectedItemsMap = arrayToMap(selectedItems);
-        const nextSelectedIds = orderedItems.reduce(
-          (acc: LibraryItem["id"][], item, idx) => {
-            if (
-              (idx >= rangeStart && idx <= rangeEnd) ||
-              selectedItemsMap.has(item.id)
-            ) {
-              acc.push(item.id);
-            }
-            return acc;
-          },
-          [],
-        );
-
-        onSelectItems(nextSelectedIds);
-      } else {
-        onSelectItems([...selectedItems, id]);
-      }
-      setLastSelectedItem(id);
-    } else {
-      setLastSelectedItem(null);
-      onSelectItems(selectedItems.filter((_id) => _id !== id));
-    }
-  };
-
-  const getInsertedElements = (id: string) => {
-    let targetElements;
-    if (selectedItems.includes(id)) {
-      targetElements = libraryItems.filter((item) =>
-        selectedItems.includes(item.id),
-      );
-    } else {
-      targetElements = libraryItems.filter((item) => item.id === id);
-    }
-    return targetElements.map((item) => {
-      return {
-        ...item,
-        // duplicate each library item before inserting on canvas to confine
-        // ids and bindings to each library item. See #6465
-        elements: duplicateElements(item.elements, { randomizeSeed: true }),
-      };
-    });
-  };
-
-  const createLibraryItemCompo = (params: {
-    item:
-      | LibraryItem
-      | /* pending library item */ {
-          id: null;
-          elements: readonly NonDeleted<ExcalidrawElement>[];
-        }
-      | null;
-    onClick?: () => void;
-    key: string;
-  }) => {
-    return (
-      <Stack.Col key={params.key}>
-        <LibraryUnit
-          elements={params.item?.elements}
-          isPending={!params.item?.id && !!params.item?.elements}
-          onClick={params.onClick || (() => {})}
-          id={params.item?.id || null}
-          selected={!!params.item?.id && selectedItems.includes(params.item.id)}
-          onToggle={onItemSelectToggle}
-          onDrag={(id, event) => {
-            event.dataTransfer.setData(
-              MIME_TYPES.excalidrawlib,
-              serializeLibraryAsJSON(getInsertedElements(id)),
-            );
-          }}
-        />
-      </Stack.Col>
-    );
-  };
-
-  const renderLibrarySection = (
-    items: (
-      | LibraryItem
-      | /* pending library item */ {
-          id: null;
-          elements: readonly NonDeleted<ExcalidrawElement>[];
-        }
-    )[],
-  ) => {
-    const _items = items.map((item) => {
-      if (item.id) {
-        return createLibraryItemCompo({
-          item,
-          onClick: () => onInsertLibraryItems(getInsertedElements(item.id)),
-          key: item.id,
-        });
-      }
-      return createLibraryItemCompo({
-        key: "__pending__item__",
-        item,
-        onClick: () => onAddToLibrary(pendingElements),
-      });
-    });
-
-    // ensure we render all empty cells if no items are present
-    let rows = chunk(_items, CELLS_PER_ROW);
-    if (!rows.length) {
-      rows = [[]];
-    }
-
-    return rows.map((rowItems, index, rows) => {
-      if (index === rows.length - 1) {
-        // pad row with empty cells
-        rowItems = rowItems.concat(
-          new Array(CELLS_PER_ROW - rowItems.length)
-            .fill(null)
-            .map((_, index) => {
-              return createLibraryItemCompo({
-                key: `empty_${index}`,
-                item: null,
-              });
-            }),
-        );
-      }
-      return (
-        <Stack.Row
-          align="center"
-          key={index}
-          className="library-menu-items-container__row"
-        >
-          {rowItems}
-        </Stack.Row>
-      );
-    });
-  };
-
   const unpublishedItems = libraryItems.filter(
     (item) => item.status !== "published",
   );
@@ -271,13 +117,16 @@ const LibraryMenuItems = ({
                 </div>
               </div>
             ) : (
-              renderLibrarySection([
-                // append pending library item
-                ...(pendingElements.length
-                  ? [{ id: null, elements: pendingElements }]
-                  : []),
-                ...unpublishedItems,
-              ])
+              <LibraryMenuSection
+                items={[
+                  // append pending library item
+                  ...(pendingElements.length
+                    ? [{ id: null, elements: pendingElements }]
+                    : []),
+                  ...unpublishedItems,
+                ]}
+                itemsPerRow={4}
+              />
             )}
           </div>
         </>
@@ -291,7 +140,7 @@ const LibraryMenuItems = ({
             </div>
           )}
           {publishedItems.length > 0 ? (
-            renderLibrarySection(publishedItems)
+            <LibraryMenuSection items={publishedItems} itemsPerRow={4} />
           ) : unpublishedItems.length > 0 ? (
             <div
               style={{

--- a/src/components/LibraryMenuSection.tsx
+++ b/src/components/LibraryMenuSection.tsx
@@ -54,13 +54,13 @@ function LibraryRow({
   );
 }
 
-const EmptyLibraryRow = ({ showSpinner }: { showSpinner: boolean }) => (
-  <Stack.Row gap={1}>
-    <Stack.Col>
-      <div className={clsx("library-unit")}>
-        {showSpinner && <Spinner synchronized />}
-      </div>
-    </Stack.Col>
+const EmptyLibraryRow = () => (
+  <Stack.Row className="library-menu-items-container__row" gap={1}>
+    {Array.from({ length: ITEMS_PER_ROW }).map((_, index) => (
+      <Stack.Col>
+        <div className={clsx("library-unit", "library-unit--skeleton")} />
+      </Stack.Col>
+    ))}
   </Stack.Row>
 );
 
@@ -103,7 +103,7 @@ function LibraryMenuSection({
             isItemSelected={isItemSelected}
           />
         ) : (
-          <EmptyLibraryRow key={i} showSpinner={i === index} />
+          <EmptyLibraryRow key={i} />
         ),
       )}
     </>

--- a/src/components/LibraryMenuSection.tsx
+++ b/src/components/LibraryMenuSection.tsx
@@ -36,7 +36,7 @@ function LibraryRow({
   onClick,
 }: Props) {
   return (
-    <Stack.Row gap={1}>
+    <Stack.Row className="library-menu-items-container__row">
       {items.map((item) => (
         <Stack.Col key={item.id}>
           <LibraryUnit

--- a/src/components/LibraryMenuSection.tsx
+++ b/src/components/LibraryMenuSection.tsx
@@ -51,6 +51,16 @@ function LibraryRow({
   );
 }
 
+const EmptyLibraryRow = ({ showSpinner }: { showSpinner: boolean }) => (
+  <Stack.Row gap={1}>
+    <Stack.Col>
+      <div className={clsx("library-unit")}>
+        {showSpinner && <Spinner synchronized />}
+      </div>
+    </Stack.Col>
+  </Stack.Row>
+);
+
 function LibraryMenuSection({
   items,
   onItemSelectToggle,
@@ -72,27 +82,20 @@ function LibraryMenuSection({
 
   return (
     <>
-      {Array.from({ length: rows }).map((_, i) => (
-        <React.Fragment key={i}>
-          {i < index ? (
-            <LibraryRow
-              items={items.slice(i * ITEMS_PER_ROW, (i + 1) * ITEMS_PER_ROW)}
-              onItemSelectToggle={onItemSelectToggle}
-              onItemDrag={onItemDrag}
-              onClick={onClick}
-              isItemSelected={isItemSelected}
-            />
-          ) : (
-            <Stack.Row gap={1}>
-              <Stack.Col>
-                <div className={clsx("library-unit")}>
-                  {i === index + 1 && <Spinner />}
-                </div>
-              </Stack.Col>
-            </Stack.Row>
-          )}
-        </React.Fragment>
-      ))}
+      {Array.from({ length: rows }).map((_, i) =>
+        i < index ? (
+          <LibraryRow
+            key={i}
+            items={items.slice(i * ITEMS_PER_ROW, (i + 1) * ITEMS_PER_ROW)}
+            onItemSelectToggle={onItemSelectToggle}
+            onItemDrag={onItemDrag}
+            onClick={onClick}
+            isItemSelected={isItemSelected}
+          />
+        ) : (
+          <EmptyLibraryRow key={i} showSpinner={i === index} />
+        ),
+      )}
     </>
   );
 }

--- a/src/components/LibraryMenuSection.tsx
+++ b/src/components/LibraryMenuSection.tsx
@@ -19,14 +19,7 @@ type LibraryOrPendingItem = (
 
 interface Props {
   items: LibraryOrPendingItem;
-  onItemSelectToggle: (id: LibraryItem["id"], event: React.MouseEvent) => void;
-  onItemDrag: (id: LibraryItem["id"], event: React.DragEvent) => void;
-  isItemSelected: (id: LibraryItem["id"] | null) => boolean;
-}
-
-interface LibraryRowProps {
-  items: LibraryOrPendingItem;
-  onClick?: () => void;
+  onClick: (id: LibraryItem["id"] | null) => void;
   onItemSelectToggle: (id: LibraryItem["id"], event: React.MouseEvent) => void;
   onItemDrag: (id: LibraryItem["id"], event: React.DragEvent) => void;
   isItemSelected: (id: LibraryItem["id"] | null) => boolean;
@@ -34,19 +27,19 @@ interface LibraryRowProps {
 
 function LibraryRow({
   items,
-  onClick,
   onItemSelectToggle,
   onItemDrag,
   isItemSelected,
-}: LibraryRowProps) {
+  onClick,
+}: Props) {
   return (
-    <>
+    <Stack.Row gap={1}>
       {items.map((item) => (
         <Stack.Col key={item.id}>
           <LibraryUnit
             elements={item?.elements}
             isPending={!item?.id && !!item?.elements}
-            onClick={onClick || (() => {})}
+            onClick={onClick}
             id={item?.id || null}
             selected={isItemSelected(item.id)}
             onToggle={onItemSelectToggle}
@@ -54,7 +47,7 @@ function LibraryRow({
           />
         </Stack.Col>
       ))}
-    </>
+    </Stack.Row>
   );
 }
 
@@ -63,6 +56,7 @@ function LibraryMenuSection({
   onItemSelectToggle,
   onItemDrag,
   isItemSelected,
+  onClick,
 }: Props) {
   const rows = Math.ceil(items.length / ITEMS_PER_ROW);
   const [, startTransition] = useTransition();
@@ -81,14 +75,13 @@ function LibraryMenuSection({
       {Array.from({ length: rows }).map((_, i) => (
         <React.Fragment key={i}>
           {i < index ? (
-            <Stack.Row gap={1}>
-              <LibraryRow
-                items={items.slice(i * ITEMS_PER_ROW, (i + 1) * ITEMS_PER_ROW)}
-                onItemSelectToggle={onItemSelectToggle}
-                onItemDrag={onItemDrag}
-                isItemSelected={isItemSelected}
-              />
-            </Stack.Row>
+            <LibraryRow
+              items={items.slice(i * ITEMS_PER_ROW, (i + 1) * ITEMS_PER_ROW)}
+              onItemSelectToggle={onItemSelectToggle}
+              onItemDrag={onItemDrag}
+              onClick={onClick}
+              isItemSelected={isItemSelected}
+            />
           ) : (
             <Stack.Row gap={1}>
               <Stack.Col>

--- a/src/components/LibraryMenuSection.tsx
+++ b/src/components/LibraryMenuSection.tsx
@@ -8,7 +8,7 @@ import { useAtom } from "jotai";
 import { libraryItemSvgsCache } from "../hooks/useLibraryItemSvg";
 
 const ITEMS_PER_ROW = 4;
-const ROWS_RENDERED_PER_BATCH = 8;
+const ROWS_RENDERED_PER_BATCH = 6;
 const CACHED_ROWS_RENDERED_PER_BATCH = 16;
 
 type LibraryOrPendingItem = (

--- a/src/components/LibraryMenuSection.tsx
+++ b/src/components/LibraryMenuSection.tsx
@@ -6,6 +6,9 @@ import Spinner from "./Spinner";
 import clsx from "clsx";
 import { ExcalidrawElement, NonDeleted } from "../element/types";
 
+const ITEMS_PER_ROW = 4;
+const ROWS_RENDERED_PER_BATCH = 4;
+
 type LibraryOrPendingItem = (
   | LibraryItem
   | /* pending library item */ {
@@ -16,7 +19,6 @@ type LibraryOrPendingItem = (
 
 interface Props {
   items: LibraryOrPendingItem;
-  itemsPerRow: number;
   onItemSelectToggle: (id: LibraryItem["id"], event: React.MouseEvent) => void;
   onItemDrag: (id: LibraryItem["id"], event: React.DragEvent) => void;
   isItemSelected: (id: LibraryItem["id"] | null) => boolean;
@@ -58,19 +60,18 @@ function LibraryRow({
 
 function LibraryMenuSection({
   items,
-  itemsPerRow,
   onItemSelectToggle,
   onItemDrag,
   isItemSelected,
 }: Props) {
-  const rows = Math.ceil(items.length / itemsPerRow);
+  const rows = Math.ceil(items.length / ITEMS_PER_ROW);
   const [_, startTransition] = useTransition();
   const [index, setIndex] = useState(0);
 
   useEffect(() => {
     if (index < rows) {
       startTransition(() => {
-        setIndex(index + 1);
+        setIndex(index + ROWS_RENDERED_PER_BATCH);
       });
     }
   }, [index, rows, startTransition]);
@@ -82,7 +83,7 @@ function LibraryMenuSection({
           {i < index ? (
             <Stack.Row gap={1}>
               <LibraryRow
-                items={items.slice(i * itemsPerRow, (i + 1) * itemsPerRow)}
+                items={items.slice(i * ITEMS_PER_ROW, (i + 1) * ITEMS_PER_ROW)}
                 onItemSelectToggle={onItemSelectToggle}
                 onItemDrag={onItemDrag}
                 isItemSelected={isItemSelected}

--- a/src/components/LibraryMenuSection.tsx
+++ b/src/components/LibraryMenuSection.tsx
@@ -1,13 +1,16 @@
-import React, { useEffect, useState, useTransition } from "react";
+import React, { useEffect, useMemo, useState, useTransition } from "react";
 import { LibraryUnit } from "./LibraryUnit";
 import { LibraryItem } from "../types";
 import Stack from "./Stack";
 import Spinner from "./Spinner";
 import clsx from "clsx";
 import { ExcalidrawElement, NonDeleted } from "../element/types";
+import { useAtom } from "jotai";
+import { libraryItemSvgsCache } from "../hooks/useLibraryItemSvg";
 
 const ITEMS_PER_ROW = 4;
-const ROWS_RENDERED_PER_BATCH = 4;
+const ROWS_RENDERED_PER_BATCH = 8;
+const CACHED_ROWS_RENDERED_PER_BATCH = 16;
 
 type LibraryOrPendingItem = (
   | LibraryItem
@@ -71,14 +74,21 @@ function LibraryMenuSection({
   const rows = Math.ceil(items.length / ITEMS_PER_ROW);
   const [, startTransition] = useTransition();
   const [index, setIndex] = useState(0);
+  const [svgCache] = useAtom(libraryItemSvgsCache);
+
+  const rowsRenderedPerBatch = useMemo(() => {
+    return svgCache.size === 0
+      ? ROWS_RENDERED_PER_BATCH
+      : CACHED_ROWS_RENDERED_PER_BATCH;
+  }, [svgCache]);
 
   useEffect(() => {
     if (index < rows) {
       startTransition(() => {
-        setIndex(index + ROWS_RENDERED_PER_BATCH);
+        setIndex(index + rowsRenderedPerBatch);
       });
     }
-  }, [index, rows, startTransition]);
+  }, [index, rows, startTransition, rowsRenderedPerBatch]);
 
   return (
     <>

--- a/src/components/LibraryMenuSection.tsx
+++ b/src/components/LibraryMenuSection.tsx
@@ -65,7 +65,7 @@ function LibraryMenuSection({
   isItemSelected,
 }: Props) {
   const rows = Math.ceil(items.length / ITEMS_PER_ROW);
-  const [_, startTransition] = useTransition();
+  const [, startTransition] = useTransition();
   const [index, setIndex] = useState(0);
 
   useEffect(() => {

--- a/src/components/LibraryMenuSection.tsx
+++ b/src/components/LibraryMenuSection.tsx
@@ -2,7 +2,6 @@ import React, { useEffect, useMemo, useState, useTransition } from "react";
 import { LibraryUnit } from "./LibraryUnit";
 import { LibraryItem } from "../types";
 import Stack from "./Stack";
-import Spinner from "./Spinner";
 import clsx from "clsx";
 import { ExcalidrawElement, NonDeleted } from "../element/types";
 import { useAtom } from "jotai";
@@ -56,7 +55,7 @@ function LibraryRow({
 
 const EmptyLibraryRow = () => (
   <Stack.Row className="library-menu-items-container__row" gap={1}>
-    {Array.from({ length: ITEMS_PER_ROW }).map((_, index) => (
+    {Array.from({ length: ITEMS_PER_ROW }).map(() => (
       <Stack.Col>
         <div className={clsx("library-unit", "library-unit--skeleton")} />
       </Stack.Col>

--- a/src/components/LibraryMenuSection.tsx
+++ b/src/components/LibraryMenuSection.tsx
@@ -1,0 +1,85 @@
+import React, { useEffect, useState, useTransition } from "react";
+import { LibraryUnit } from "./LibraryUnit";
+import { LibraryItem } from "../types";
+import Stack from "./Stack";
+import Spinner from "./Spinner";
+import clsx from "clsx";
+import { ExcalidrawElement, NonDeleted } from "../element/types";
+
+type LibraryOrPendingItem = (
+  | LibraryItem
+  | /* pending library item */ {
+      id: null;
+      elements: readonly NonDeleted<ExcalidrawElement>[];
+    }
+)[];
+
+interface Props {
+  items: LibraryOrPendingItem;
+  itemsPerRow: number;
+}
+
+interface LibraryRowProps {
+  items: LibraryOrPendingItem;
+  onClick?: () => void;
+}
+
+function LibraryRow({ items, onClick }: LibraryRowProps) {
+  return (
+    <>
+      {items.map((item) => (
+        <Stack.Col key={item.id}>
+          <LibraryUnit
+            elements={item?.elements}
+            isPending={!item?.id && !!item?.elements}
+            onClick={onClick || (() => {})}
+            id={item?.id || null}
+            selected={false}
+            onToggle={() => {}}
+            onDrag={() => {}}
+          />
+        </Stack.Col>
+      ))}
+    </>
+  );
+}
+
+function LibraryMenuSection({ items, itemsPerRow }: Props) {
+  const rows = Math.ceil(items.length / itemsPerRow);
+  const [_, startTransition] = useTransition();
+  const [index, setIndex] = useState(0);
+
+  useEffect(() => {
+    if (index < rows) {
+      startTransition(() => {
+        setIndex(index + 1);
+      });
+    }
+  }, [index, rows, startTransition]);
+
+  return (
+    <>
+      {Array.from({ length: rows }).map((_, i) => (
+        <React.Fragment key={i}>
+          {i < index ? (
+            <Stack.Row gap={1}>
+              <LibraryRow
+                items={items.slice(i * itemsPerRow, (i + 1) * itemsPerRow)}
+              />
+            </Stack.Row>
+          ) : (
+            <Stack.Row gap={1}>
+              <Stack.Col>
+                <div className={clsx("library-unit")}>
+                  <Spinner />
+                </div>
+              </Stack.Col>
+            </Stack.Row>
+          )}
+        </React.Fragment>
+      ))}
+    </>
+  );
+}
+
+export default LibraryMenuSection;

--- a/src/components/LibraryMenuSection.tsx
+++ b/src/components/LibraryMenuSection.tsx
@@ -55,11 +55,9 @@ function LibraryRow({
 
 const EmptyLibraryRow = () => (
   <Stack.Row className="library-menu-items-container__row" gap={1}>
-    {Array.from({ length: ITEMS_PER_ROW }).map(() => (
-      <Stack.Col>
-        <div className={clsx("library-unit", "library-unit--skeleton")} />
-      </Stack.Col>
-    ))}
+    <Stack.Col>
+      <div className={clsx("library-unit")} />
+    </Stack.Col>
   </Stack.Row>
 );
 

--- a/src/components/LibraryMenuSection.tsx
+++ b/src/components/LibraryMenuSection.tsx
@@ -17,14 +17,26 @@ type LibraryOrPendingItem = (
 interface Props {
   items: LibraryOrPendingItem;
   itemsPerRow: number;
+  onItemSelectToggle: (id: LibraryItem["id"], event: React.MouseEvent) => void;
+  onItemDrag: (id: LibraryItem["id"], event: React.DragEvent) => void;
+  isItemSelected: (id: LibraryItem["id"] | null) => boolean;
 }
 
 interface LibraryRowProps {
   items: LibraryOrPendingItem;
   onClick?: () => void;
+  onItemSelectToggle: (id: LibraryItem["id"], event: React.MouseEvent) => void;
+  onItemDrag: (id: LibraryItem["id"], event: React.DragEvent) => void;
+  isItemSelected: (id: LibraryItem["id"] | null) => boolean;
 }
 
-function LibraryRow({ items, onClick }: LibraryRowProps) {
+function LibraryRow({
+  items,
+  onClick,
+  onItemSelectToggle,
+  onItemDrag,
+  isItemSelected,
+}: LibraryRowProps) {
   return (
     <>
       {items.map((item) => (
@@ -34,9 +46,9 @@ function LibraryRow({ items, onClick }: LibraryRowProps) {
             isPending={!item?.id && !!item?.elements}
             onClick={onClick || (() => {})}
             id={item?.id || null}
-            selected={false}
-            onToggle={() => {}}
-            onDrag={() => {}}
+            selected={isItemSelected(item.id)}
+            onToggle={onItemSelectToggle}
+            onDrag={onItemDrag}
           />
         </Stack.Col>
       ))}
@@ -44,7 +56,13 @@ function LibraryRow({ items, onClick }: LibraryRowProps) {
   );
 }
 
-function LibraryMenuSection({ items, itemsPerRow }: Props) {
+function LibraryMenuSection({
+  items,
+  itemsPerRow,
+  onItemSelectToggle,
+  onItemDrag,
+  isItemSelected,
+}: Props) {
   const rows = Math.ceil(items.length / itemsPerRow);
   const [_, startTransition] = useTransition();
   const [index, setIndex] = useState(0);
@@ -65,13 +83,16 @@ function LibraryMenuSection({ items, itemsPerRow }: Props) {
             <Stack.Row gap={1}>
               <LibraryRow
                 items={items.slice(i * itemsPerRow, (i + 1) * itemsPerRow)}
+                onItemSelectToggle={onItemSelectToggle}
+                onItemDrag={onItemDrag}
+                isItemSelected={isItemSelected}
               />
             </Stack.Row>
           ) : (
             <Stack.Row gap={1}>
               <Stack.Col>
                 <div className={clsx("library-unit")}>
-                  <Spinner />
+                  {i === index + 1 && <Spinner />}
                 </div>
               </Stack.Col>
             </Stack.Row>

--- a/src/components/LibraryUnit.scss
+++ b/src/components/LibraryUnit.scss
@@ -23,7 +23,12 @@
 
     &--skeleton {
       border-radius: var(--border-radius-lg);
-      background: linear-gradient(-45deg, #f0f0f0, #ddd, #f0f0f0);
+      background: linear-gradient(
+        -45deg,
+        var(--color-gray-10),
+        var(--color-gray-20),
+        var(--color-gray-10)
+      );
       background-size: 200% 200%;
       animation: library-unit__skeleton-animation 1.5s ease infinite;
     }

--- a/src/components/LibraryUnit.scss
+++ b/src/components/LibraryUnit.scss
@@ -20,6 +20,25 @@
       border-color: var(--color-primary);
       border-width: 1px;
     }
+
+    &--skeleton {
+      border-radius: var(--border-radius-lg);
+      background: linear-gradient(-45deg, #f0f0f0, #ddd, #f0f0f0);
+      background-size: 200% 200%;
+      animation: library-unit__skeleton-animation 1.5s ease infinite;
+    }
+
+    @keyframes library-unit__skeleton-animation {
+      0% {
+        background-position: 0% 0%;
+      }
+      50% {
+        background-position: 100% 100%;
+      }
+      100% {
+        background-position: 0% 0%;
+      }
+    }
   }
 
   .library-unit__dragger {

--- a/src/components/LibraryUnit.scss
+++ b/src/components/LibraryUnit.scss
@@ -20,30 +20,6 @@
       border-color: var(--color-primary);
       border-width: 1px;
     }
-
-    &--skeleton {
-      border-radius: var(--border-radius-lg);
-      background: linear-gradient(
-        -45deg,
-        var(--color-gray-10),
-        var(--color-gray-20),
-        var(--color-gray-10)
-      );
-      background-size: 200% 200%;
-      animation: library-unit__skeleton-animation 1.5s ease infinite;
-    }
-
-    @keyframes library-unit__skeleton-animation {
-      0% {
-        background-position: 0% 0%;
-      }
-      50% {
-        background-position: 100% 100%;
-      }
-      100% {
-        background-position: 0% 0%;
-      }
-    }
   }
 
   .library-unit__dragger {

--- a/src/components/LibraryUnit.tsx
+++ b/src/components/LibraryUnit.tsx
@@ -56,6 +56,7 @@ export const LibraryUnit = ({
         "library-unit__active": elements,
         "library-unit--hover": elements && isHovered,
         "library-unit--selected": selected,
+        "library-unit--skeleton": !svg,
       })}
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}

--- a/src/components/LibraryUnit.tsx
+++ b/src/components/LibraryUnit.tsx
@@ -56,7 +56,6 @@ export const LibraryUnit = ({
         "library-unit__active": elements,
         "library-unit--hover": elements && isHovered,
         "library-unit--selected": selected,
-        "library-unit--skeleton": !svg,
       })}
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}

--- a/src/components/LibraryUnit.tsx
+++ b/src/components/LibraryUnit.tsx
@@ -1,12 +1,11 @@
 import clsx from "clsx";
 import { useEffect, useRef, useState } from "react";
 import { useDevice } from "../components/App";
-import { exportToSvg } from "../packages/utils";
 import { LibraryItem } from "../types";
 import "./LibraryUnit.scss";
 import { CheckboxItem } from "./CheckboxItem";
 import { PlusIcon } from "./icons";
-import { COLOR_PALETTE } from "../colors";
+import { useLibraryItemSvg } from "../hooks/useLibraryItemSvg";
 
 export const LibraryUnit = ({
   id,
@@ -26,32 +25,24 @@ export const LibraryUnit = ({
   onDrag: (id: string, event: React.DragEvent) => void;
 }) => {
   const ref = useRef<HTMLDivElement | null>(null);
+  const svg = useLibraryItemSvg(id, elements);
+
   useEffect(() => {
     const node = ref.current;
+
     if (!node) {
       return;
     }
 
-    (async () => {
-      if (!elements) {
-        return;
-      }
-      const svg = await exportToSvg({
-        elements,
-        appState: {
-          exportBackground: false,
-          viewBackgroundColor: COLOR_PALETTE.white,
-        },
-        files: null,
-      });
+    if (svg) {
       svg.querySelector(".style-fonts")?.remove();
       node.innerHTML = svg.outerHTML;
-    })();
+    }
 
     return () => {
       node.innerHTML = "";
     };
-  }, [elements]);
+  }, [elements, svg]);
 
   const [isHovered, setIsHovered] = useState(false);
   const isMobile = useDevice().isMobile;

--- a/src/components/LibraryUnit.tsx
+++ b/src/components/LibraryUnit.tsx
@@ -19,7 +19,7 @@ export const LibraryUnit = ({
   id: LibraryItem["id"] | /** for pending item */ null;
   elements?: LibraryItem["elements"];
   isPending?: boolean;
-  onClick: () => void;
+  onClick: (id: LibraryItem["id"] | null) => void;
   selected: boolean;
   onToggle: (id: string, event: React.MouseEvent) => void;
   onDrag: (id: string, event: React.DragEvent) => void;
@@ -72,7 +72,7 @@ export const LibraryUnit = ({
                 if (id && event.shiftKey) {
                   onToggle(id, event);
                 } else {
-                  onClick();
+                  onClick(id);
                 }
               }
             : undefined

--- a/src/components/Spinner.scss
+++ b/src/components/Spinner.scss
@@ -15,6 +15,7 @@ $duration: 1.6s;
 
     svg {
       animation: rotate $duration linear infinite;
+      animation-delay: var(--spinner-delay);
       transform-origin: center center;
     }
 

--- a/src/components/Spinner.tsx
+++ b/src/components/Spinner.tsx
@@ -5,13 +5,26 @@ import "./Spinner.scss";
 const Spinner = ({
   size = "1em",
   circleWidth = 8,
+  synchronized = false,
 }: {
   size?: string | number;
   circleWidth?: number;
+  synchronized?: boolean;
 }) => {
+  const mountTime = React.useRef(Date.now());
+  const mountDelay = -(mountTime.current % 1600);
+
   return (
     <div className="Spinner">
-      <svg viewBox="0 0 100 100" style={{ width: size, height: size }}>
+      <svg
+        viewBox="0 0 100 100"
+        style={{
+          width: size,
+          height: size,
+          // fix for remounting causing spinner flicker
+          ["--spinner-delay" as any]: synchronized ? `${mountDelay}ms` : 0,
+        }}
+      >
         <circle
           cx="50"
           cy="50"

--- a/src/hooks/useLibraryItemSvg.ts
+++ b/src/hooks/useLibraryItemSvg.ts
@@ -1,0 +1,59 @@
+import { atom, useAtom } from "jotai";
+import { useEffect, useState } from "react";
+import { COLOR_PALETTE } from "../colors";
+import { exportToSvg } from "../packages/utils";
+import { LibraryItem } from "../types";
+
+export const libraryItemSvgsCache = atom<Map<LibraryItem["id"], SVGSVGElement>>(
+  new Map(),
+);
+
+const exportLibraryItemToSvg = async (elements: LibraryItem["elements"]) => {
+  return await exportToSvg({
+    elements,
+    appState: {
+      exportBackground: false,
+      viewBackgroundColor: COLOR_PALETTE.white,
+    },
+    files: null,
+  });
+};
+
+export const useLibraryItemSvg = (
+  id: LibraryItem["id"] | null,
+  elements: LibraryItem["elements"] | undefined,
+): SVGSVGElement | undefined => {
+  const [svgCache, setSvgCache] = useAtom(libraryItemSvgsCache);
+  const [svg, setSvg] = useState<SVGSVGElement>();
+
+  useEffect(() => {
+    if (elements) {
+      if (id) {
+        // Try to load cached svg
+        const cachedSvg = svgCache.get(id);
+
+        if (cachedSvg) {
+          setSvg(cachedSvg);
+        } else {
+          // When there is no svg in cache export it and save to cache
+          (async () => {
+            const exportedSvg = await exportLibraryItemToSvg(elements);
+
+            if (exportedSvg) {
+              setSvgCache(svgCache.set(id, exportedSvg));
+              setSvg(exportedSvg);
+            }
+          })();
+        }
+      } else {
+        // When we have no id (usualy selected items from canvas) just export the svg
+        (async () => {
+          const exportedSvg = await exportLibraryItemToSvg(elements);
+          setSvg(exportedSvg);
+        })();
+      }
+    }
+  }, [id, elements, svgCache, setSvgCache, setSvg]);
+
+  return svg;
+};


### PR DESCRIPTION
This is proof of concept of speeding up of rending of the Library and its content when it contains hundreds or thousands of items and what will be the performance of rendering them in batches (by row) rather than all in one go.

Currently, it doesn't handle any callbacks or edge cases, ale when there is more than one section; they are rendered in parallel (there is no actual added value in moving this into a separate component).