### PR TITLE
fix: color picker input closing problem

### DIFF
--- a/src/components/ColorPicker/ColorPicker.tsx
+++ b/src/components/ColorPicker/ColorPicker.tsx
@@ -66,7 +66,6 @@ const ColorPickerPopupContent = ({
   | "color"
   | "onChange"
   | "label"
-  | "label"
   | "elements"
   | "palette"
   | "updateData"
@@ -99,6 +98,8 @@ const ColorPickerPopupContent = ({
           if (container) {
             container.focus();
           }
+
+          updateData({ openPopup: null });
 
           e.preventDefault();
           e.stopPropagation();


### PR DESCRIPTION
fix #6595.

`updateData` was passed to `ColorPickerPopupContent` but never used anywhere and hence there the `appState.openPopup` is not reset.

Invoked `updateData` inside `onCloseAutoFocus` in `Popover.Content`.

![Preview GIF](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExZDhkMGUxNzZiNWZiODViZWIzMGQ1MDQ5NGM0M2U4NmY1MDQwYTAzNCZlcD12MV9pbnRlcm5hbF9naWZzX2dpZklkJmN0PWc/KT43apsNTwO00dBdu7/giphy.gif)