### PR TITLE
fix: Library dropdown visibility issue for mobile

### DIFF
--- a/src/components/dropdownMenu/DropdownMenu.scss
+++ b/src/components/dropdownMenu/DropdownMenu.scss
@@ -11,8 +11,6 @@
       top: auto;
       left: 0;
       width: 100%;
-      display: flex;
-      flex-direction: column;
       row-gap: 0.75rem;
 
       .dropdown-menu-container {


### PR DESCRIPTION
Fixed: #6611
Issue: Dropdown items were not visible on mobile devices.

Before
![image](https://github.com/excalidraw/excalidraw/assets/56750020/4d8329be-7dd8-4de8-aea8-2daa8261824c)

After
![image](https://github.com/excalidraw/excalidraw/assets/56750020/445265a2-48a7-46af-8125-fb1b5b369b91)

Cause
Display flex for mobile devices was causing the issue. 