### PR TITLE
perf: memoize rendering of library

### DIFF
--- a/src/components/LibraryMenu.tsx
+++ b/src/components/LibraryMenu.tsx
@@ -39,7 +39,7 @@ const LibraryMenuWrapper = ({ children }: { children: React.ReactNode }) => {
 export const LibraryMenuContent = ({
   onInsertLibraryItems,
   pendingElements,
-  onAddToLibraryCallback,
+  onAddToLibrary,
   setAppState,
   libraryReturnUrl,
   library,
@@ -50,7 +50,7 @@ export const LibraryMenuContent = ({
 }: {
   pendingElements: LibraryItem["elements"];
   onInsertLibraryItems: (libraryItems: LibraryItems) => void;
-  onAddToLibraryCallback: () => void;
+  onAddToLibrary: () => void;
   setAppState: React.Component<any, UIAppState>["setState"];
   libraryReturnUrl: ExcalidrawProps["libraryReturnUrl"];
   library: Library;
@@ -61,7 +61,7 @@ export const LibraryMenuContent = ({
 }) => {
   const [libraryItemsData] = useAtom(libraryItemsAtom, jotaiScope);
 
-  const onAddToLibrary = useCallback(
+  const _onAddToLibrary = useCallback(
     (elements: LibraryItem["elements"]) => {
       const addToLibrary = async (
         processedElements: LibraryItem["elements"],
@@ -83,19 +83,14 @@ export const LibraryMenuContent = ({
           },
           ...libraryItems,
         ];
-        onAddToLibraryCallback();
+        onAddToLibrary();
         library.setLibrary(nextItems).catch(() => {
           setAppState({ errorMessage: t("alerts.errorAddingToLibrary") });
         });
       };
       addToLibrary(elements, libraryItemsData.libraryItems);
     },
-    [
-      onAddToLibraryCallback,
-      library,
-      setAppState,
-      libraryItemsData.libraryItems,
-    ],
+    [onAddToLibrary, library, setAppState, libraryItemsData.libraryItems],
   );
 
   const libraryItems = useMemo(
@@ -127,7 +122,7 @@ export const LibraryMenuContent = ({
       <LibraryMenuItems
         isLoading={libraryItemsData.status === "loading"}
         libraryItems={libraryItems}
-        onAddToLibrary={onAddToLibrary}
+        onAddToLibrary={_onAddToLibrary}
         onInsertLibraryItems={onInsertLibraryItems}
         pendingElements={pendingElements}
         id={id}
@@ -205,7 +200,7 @@ export const LibraryMenu = () => {
     <LibraryMenuContent
       pendingElements={pendingElements}
       onInsertLibraryItems={onInsertLibraryItems}
-      onAddToLibraryCallback={deselectItems}
+      onAddToLibrary={deselectItems}
       setAppState={setAppState}
       libraryReturnUrl={appProps.libraryReturnUrl}
       library={memoizedLibrary}

--- a/src/components/LibraryMenu.tsx
+++ b/src/components/LibraryMenu.tsx
@@ -184,6 +184,7 @@ export const LibraryMenu = () => {
   const elements = useExcalidrawElements();
   const [selectedItems, setSelectedItems] = useState<LibraryItem["id"][]>([]);
   const memoizedLibrary = useMemo(() => library, [library]);
+  // BUG: pendingElements are still causing some unnecessary rerenders because clicking into canvas returns some ids even when no element is selected.
   const pendingElements = usePendingElementsMemo(appState, elements);
 
   const onInsertLibraryItems = useCallback(

--- a/src/components/LibraryMenuItems.scss
+++ b/src/components/LibraryMenuItems.scss
@@ -73,6 +73,12 @@
       }
     }
 
+    &__grid {
+      display: grid;
+      grid-template-columns: 1fr 1fr 1fr 1fr;
+      grid-gap: 1rem;
+    }
+
     .separator {
       width: 100%;
       display: flex;

--- a/src/components/LibraryMenuItems.tsx
+++ b/src/components/LibraryMenuItems.tsx
@@ -29,6 +29,13 @@ import { useLibraryCache } from "../hooks/useLibraryItemSvg";
 
 import "./LibraryMenuItems.scss";
 
+// using an odd number of items per batch so the rendering creates an irregular
+// pattern which looks more organic
+const ITEMS_RENDERED_PER_BATCH = 17;
+// when render outputs cached we can render many more items per batch to
+// speed it up
+const CACHED_ITEMS_RENDERED_PER_BATCH = 64;
+
 export default function LibraryMenuItems({
   isLoading,
   libraryItems,
@@ -191,6 +198,11 @@ export default function LibraryMenuItems({
     [getInsertedElements, onInsertLibraryItems],
   );
 
+  const itemsRenderedPerBatch =
+    svgCache.size >= libraryItems.length
+      ? CACHED_ITEMS_RENDERED_PER_BATCH
+      : ITEMS_RENDERED_PER_BATCH;
+
   return (
     <div
       className="library-menu-items-container"
@@ -252,6 +264,7 @@ export default function LibraryMenuItems({
             <LibraryMenuSectionGrid>
               {pendingElements.length > 0 && (
                 <LibraryMenuSection
+                  itemsRenderedPerBatch={itemsRenderedPerBatch}
                   items={[{ id: null, elements: pendingElements }]}
                   onItemSelectToggle={onItemSelectToggle}
                   onItemDrag={onItemDrag}
@@ -261,6 +274,7 @@ export default function LibraryMenuItems({
                 />
               )}
               <LibraryMenuSection
+                itemsRenderedPerBatch={itemsRenderedPerBatch}
                 items={unpublishedItems}
                 onItemSelectToggle={onItemSelectToggle}
                 onItemDrag={onItemDrag}
@@ -283,6 +297,7 @@ export default function LibraryMenuItems({
           {publishedItems.length > 0 ? (
             <LibraryMenuSectionGrid>
               <LibraryMenuSection
+                itemsRenderedPerBatch={itemsRenderedPerBatch}
                 items={publishedItems}
                 onItemSelectToggle={onItemSelectToggle}
                 onItemDrag={onItemDrag}

--- a/src/components/LibraryMenuItems.tsx
+++ b/src/components/LibraryMenuItems.tsx
@@ -14,7 +14,10 @@ import Spinner from "./Spinner";
 import { duplicateElements } from "../element/newElement";
 import { LibraryMenuControlButtons } from "./LibraryMenuControlButtons";
 import { LibraryDropdownMenu } from "./LibraryMenuHeaderContent";
-import LibraryMenuSection from "./LibraryMenuSection";
+import {
+  LibraryMenuSection,
+  LibraryMenuSectionGrid,
+} from "./LibraryMenuSection";
 import { useLibraryCache } from "../hooks/useLibraryItemSvg";
 
 import "./LibraryMenuItems.scss";
@@ -51,17 +54,6 @@ export default function LibraryMenuItems({
   const publishedItems = useMemo(
     () => libraryItems.filter((item) => item.status === "published"),
     [libraryItems],
-  );
-
-  const personalItems = useMemo(
-    () => [
-      // append pending library item
-      ...(pendingElements.length
-        ? [{ id: null, elements: pendingElements }]
-        : []),
-      ...unpublishedItems,
-    ],
-    [pendingElements, unpublishedItems],
   );
 
   const showBtn = !libraryItems.length && !pendingElements.length;
@@ -239,15 +231,26 @@ export default function LibraryMenuItems({
               </div>
             </div>
           ) : (
-            <LibraryMenuSection
-              items={personalItems}
-              onItemSelectToggle={onItemSelectToggle}
-              onItemDrag={onItemDrag}
-              onClick={onItemClick}
-              onAddToLibrary={onAddToLibraryClick}
-              isItemSelected={isItemSelected}
-              svgCache={svgCache}
-            />
+            <LibraryMenuSectionGrid>
+              {pendingElements.length > 0 && (
+                <LibraryMenuSection
+                  items={[{ id: null, elements: pendingElements }]}
+                  onItemSelectToggle={onItemSelectToggle}
+                  onItemDrag={onItemDrag}
+                  onClick={onAddToLibraryClick}
+                  isItemSelected={isItemSelected}
+                  svgCache={svgCache}
+                />
+              )}
+              <LibraryMenuSection
+                items={unpublishedItems}
+                onItemSelectToggle={onItemSelectToggle}
+                onItemDrag={onItemDrag}
+                onClick={onItemClick}
+                isItemSelected={isItemSelected}
+                svgCache={svgCache}
+              />
+            </LibraryMenuSectionGrid>
           )}
         </>
 
@@ -260,14 +263,16 @@ export default function LibraryMenuItems({
             </div>
           )}
           {publishedItems.length > 0 ? (
-            <LibraryMenuSection
-              items={publishedItems}
-              onItemSelectToggle={onItemSelectToggle}
-              onItemDrag={onItemDrag}
-              onClick={onItemClick}
-              isItemSelected={isItemSelected}
-              svgCache={svgCache}
-            />
+            <LibraryMenuSectionGrid>
+              <LibraryMenuSection
+                items={publishedItems}
+                onItemSelectToggle={onItemSelectToggle}
+                onItemDrag={onItemDrag}
+                onClick={onItemClick}
+                isItemSelected={isItemSelected}
+                svgCache={svgCache}
+              />
+            </LibraryMenuSectionGrid>
           ) : unpublishedItems.length > 0 ? (
             <div
               style={{

--- a/src/components/LibraryMenuItems.tsx
+++ b/src/components/LibraryMenuItems.tsx
@@ -53,6 +53,17 @@ export default function LibraryMenuItems({
     [libraryItems],
   );
 
+  const personalItems = useMemo(
+    () => [
+      // append pending library item
+      ...(pendingElements.length
+        ? [{ id: null, elements: pendingElements }]
+        : []),
+      ...unpublishedItems,
+    ],
+    [pendingElements, unpublishedItems],
+  );
+
   const showBtn = !libraryItems.length && !pendingElements.length;
 
   const isLibraryEmpty =
@@ -158,29 +169,17 @@ export default function LibraryMenuItems({
     [selectedItems],
   );
 
-  const onExcalidrawLibraryItemClick = useCallback(
+  const onAddToLibraryClick = useCallback(() => {
+    onAddToLibrary(pendingElements);
+  }, [pendingElements, onAddToLibrary]);
+
+  const onItemClick = useCallback(
     (id: LibraryItem["id"] | null) => {
       if (id) {
         onInsertLibraryItems(getInsertedElements(id));
       }
     },
     [getInsertedElements, onInsertLibraryItems],
-  );
-
-  const onPersonalLibraryItemClick = useCallback(
-    (id: LibraryItem["id"] | null) => {
-      if (!id) {
-        onAddToLibrary(pendingElements);
-      } else {
-        onInsertLibraryItems(getInsertedElements(id));
-      }
-    },
-    [
-      getInsertedElements,
-      onAddToLibrary,
-      onInsertLibraryItems,
-      pendingElements,
-    ],
   );
 
   return (
@@ -241,16 +240,11 @@ export default function LibraryMenuItems({
             </div>
           ) : (
             <LibraryMenuSection
-              items={[
-                // append pending library item
-                ...(pendingElements.length
-                  ? [{ id: null, elements: pendingElements }]
-                  : []),
-                ...unpublishedItems,
-              ]}
+              items={personalItems}
               onItemSelectToggle={onItemSelectToggle}
               onItemDrag={onItemDrag}
-              onClick={onPersonalLibraryItemClick}
+              onClick={onItemClick}
+              onAddToLibrary={onAddToLibraryClick}
               isItemSelected={isItemSelected}
               svgCache={svgCache}
             />
@@ -270,7 +264,7 @@ export default function LibraryMenuItems({
               items={publishedItems}
               onItemSelectToggle={onItemSelectToggle}
               onItemDrag={onItemDrag}
-              onClick={onExcalidrawLibraryItemClick}
+              onClick={onItemClick}
               isItemSelected={isItemSelected}
               svgCache={svgCache}
             />

--- a/src/components/LibraryMenuSection.tsx
+++ b/src/components/LibraryMenuSection.tsx
@@ -1,12 +1,9 @@
-import React, { memo, ReactNode, useEffect, useMemo, useState } from "react";
+import React, { memo, ReactNode, useEffect, useState } from "react";
 import { EmptyLibraryUnit, LibraryUnit } from "./LibraryUnit";
 import { LibraryItem } from "../types";
 import { ExcalidrawElement, NonDeleted } from "../element/types";
 import { SvgCache } from "../hooks/useLibraryItemSvg";
 import { useTransition } from "../hooks/useTransition";
-
-const ITEMS_RENDERED_PER_BATCH = 17;
-const CACHED_ITEMS_RENDERED_PER_BATCH = 64;
 
 type LibraryOrPendingItem = (
   | LibraryItem
@@ -23,6 +20,7 @@ interface Props {
   onItemDrag: (id: LibraryItem["id"], event: React.DragEvent) => void;
   isItemSelected: (id: LibraryItem["id"] | null) => boolean;
   svgCache: SvgCache;
+  itemsRenderedPerBatch: number;
 }
 
 export const LibraryMenuSectionGrid = ({
@@ -41,15 +39,10 @@ export const LibraryMenuSection = memo(
     isItemSelected,
     onClick,
     svgCache,
+    itemsRenderedPerBatch,
   }: Props) => {
     const [, startTransition] = useTransition();
     const [index, setIndex] = useState(0);
-
-    const itemsRenderedPerBatch = useMemo(() => {
-      return svgCache.size === 0
-        ? ITEMS_RENDERED_PER_BATCH
-        : CACHED_ITEMS_RENDERED_PER_BATCH;
-    }, [svgCache]);
 
     useEffect(() => {
       if (index < items.length) {

--- a/src/components/LibraryMenuSection.tsx
+++ b/src/components/LibraryMenuSection.tsx
@@ -39,7 +39,7 @@ const LibraryRow = ({
   onAddToLibrary,
 }: Props) => {
   return (
-    <Stack.Row gap={1}>
+    <Stack.Row className="library-menu-items-container__row" gap={1}>
       {items.map((item) => (
         <Stack.Col key={item.id}>
           <LibraryUnit

--- a/src/components/LibraryMenuSection.tsx
+++ b/src/components/LibraryMenuSection.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from "react";
+import React, { memo, useEffect, useMemo, useState } from "react";
 import { LibraryUnit } from "./LibraryUnit";
 import { LibraryItem } from "../types";
 import Stack from "./Stack";
@@ -22,28 +22,30 @@ type LibraryOrPendingItem = (
 interface Props {
   items: LibraryOrPendingItem;
   onClick: (id: LibraryItem["id"] | null) => void;
+  onAddToLibrary?: () => void;
   onItemSelectToggle: (id: LibraryItem["id"], event: React.MouseEvent) => void;
   onItemDrag: (id: LibraryItem["id"], event: React.DragEvent) => void;
   isItemSelected: (id: LibraryItem["id"] | null) => boolean;
   svgCache: SvgCache;
 }
 
-function LibraryRow({
+const LibraryRow = ({
   items,
   onItemSelectToggle,
   onItemDrag,
   isItemSelected,
   onClick,
   svgCache,
-}: Props) {
+  onAddToLibrary,
+}: Props) => {
   return (
-    <Stack.Row className="library-menu-items-container__row">
+    <Stack.Row gap={1}>
       {items.map((item) => (
         <Stack.Col key={item.id}>
           <LibraryUnit
             elements={item?.elements}
             isPending={!item?.id && !!item?.elements}
-            onClick={onClick}
+            onClick={!item.id && onAddToLibrary ? onAddToLibrary : onClick}
             id={item?.id || null}
             selected={isItemSelected(item.id)}
             onToggle={onItemSelectToggle}
@@ -54,7 +56,7 @@ function LibraryRow({
       ))}
     </Stack.Row>
   );
-}
+};
 
 const EmptyLibraryRow = () => (
   <Stack.Row className="library-menu-items-container__row" gap={1}>
@@ -64,51 +66,55 @@ const EmptyLibraryRow = () => (
   </Stack.Row>
 );
 
-function LibraryMenuSection({
-  items,
-  onItemSelectToggle,
-  onItemDrag,
-  isItemSelected,
-  onClick,
-  svgCache,
-}: Props) {
-  const rows = Math.ceil(items.length / ITEMS_PER_ROW);
-  const [, startTransition] = useTransition();
-  const [index, setIndex] = useState(0);
+const LibraryMenuSection = memo(
+  ({
+    items,
+    onItemSelectToggle,
+    onItemDrag,
+    isItemSelected,
+    onClick,
+    svgCache,
+    onAddToLibrary,
+  }: Props) => {
+    const rows = Math.ceil(items.length / ITEMS_PER_ROW);
+    const [, startTransition] = useTransition();
+    const [index, setIndex] = useState(0);
 
-  const rowsRenderedPerBatch = useMemo(() => {
-    return svgCache.size === 0
-      ? ROWS_RENDERED_PER_BATCH
-      : CACHED_ROWS_RENDERED_PER_BATCH;
-  }, [svgCache]);
+    const rowsRenderedPerBatch = useMemo(() => {
+      return svgCache.size === 0
+        ? ROWS_RENDERED_PER_BATCH
+        : CACHED_ROWS_RENDERED_PER_BATCH;
+    }, [svgCache]);
 
-  useEffect(() => {
-    if (index < rows) {
-      startTransition(() => {
-        setIndex(index + rowsRenderedPerBatch);
-      });
-    }
-  }, [index, rows, startTransition, rowsRenderedPerBatch]);
+    useEffect(() => {
+      if (index < rows) {
+        startTransition(() => {
+          setIndex(index + rowsRenderedPerBatch);
+        });
+      }
+    }, [index, rows, startTransition, rowsRenderedPerBatch]);
 
-  return (
-    <>
-      {Array.from({ length: rows }).map((_, i) =>
-        i < index ? (
-          <LibraryRow
-            key={i}
-            items={items.slice(i * ITEMS_PER_ROW, (i + 1) * ITEMS_PER_ROW)}
-            onItemSelectToggle={onItemSelectToggle}
-            onItemDrag={onItemDrag}
-            onClick={onClick}
-            isItemSelected={isItemSelected}
-            svgCache={svgCache}
-          />
-        ) : (
-          <EmptyLibraryRow key={i} />
-        ),
-      )}
-    </>
-  );
-}
+    return (
+      <>
+        {Array.from({ length: rows }).map((_, i) =>
+          i < index ? (
+            <LibraryRow
+              key={i}
+              items={items.slice(i * ITEMS_PER_ROW, (i + 1) * ITEMS_PER_ROW)}
+              onItemSelectToggle={onItemSelectToggle}
+              onItemDrag={onItemDrag}
+              onClick={onClick}
+              onAddToLibrary={onAddToLibrary}
+              isItemSelected={isItemSelected}
+              svgCache={svgCache}
+            />
+          ) : (
+            <EmptyLibraryRow key={i} />
+          ),
+        )}
+      </>
+    );
+  },
+);
 
 export default LibraryMenuSection;

--- a/src/components/LibraryMenuSection.tsx
+++ b/src/components/LibraryMenuSection.tsx
@@ -5,7 +5,7 @@ import { ExcalidrawElement, NonDeleted } from "../element/types";
 import { SvgCache } from "../hooks/useLibraryItemSvg";
 import { useTransition } from "../hooks/useTransition";
 
-const ITEMS_RENDERED_PER_BATCH = 24;
+const ITEMS_RENDERED_PER_BATCH = 17;
 const CACHED_ITEMS_RENDERED_PER_BATCH = 64;
 
 type LibraryOrPendingItem = (

--- a/src/components/LibraryUnit.scss
+++ b/src/components/LibraryUnit.scss
@@ -30,7 +30,7 @@
         var(--color-gray-10)
       );
       background-size: 200% 200%;
-      animation: library-unit__skeleton-opacity-animation 0.3s linear;
+      animation: library-unit__skeleton-opacity-animation 0.2s linear;
     }
   }
 

--- a/src/components/LibraryUnit.tsx
+++ b/src/components/LibraryUnit.tsx
@@ -101,3 +101,5 @@ export const LibraryUnit = memo(
     );
   },
 );
+
+export const EmptyLibraryUnit = () => <div className={clsx("library-unit")} />;

--- a/src/components/LibraryUnit.tsx
+++ b/src/components/LibraryUnit.tsx
@@ -38,14 +38,13 @@ export const LibraryUnit = memo(
       }
 
       if (svg) {
-        svg.querySelector(".style-fonts")?.remove();
         node.innerHTML = svg.outerHTML;
       }
 
       return () => {
         node.innerHTML = "";
       };
-    }, [elements, svg]);
+    }, [svg]);
 
     const [isHovered, setIsHovered] = useState(false);
     const isMobile = useDevice().isMobile;

--- a/src/components/LibraryUnit.tsx
+++ b/src/components/LibraryUnit.tsx
@@ -103,4 +103,6 @@ export const LibraryUnit = memo(
   },
 );
 
-export const EmptyLibraryUnit = () => <div className={clsx("library-unit")} />;
+export const EmptyLibraryUnit = () => (
+  <div className="library-unit library-unit--skeleton" />
+);

--- a/src/components/LibraryUnit.tsx
+++ b/src/components/LibraryUnit.tsx
@@ -1,5 +1,5 @@
 import clsx from "clsx";
-import { useEffect, useRef, useState } from "react";
+import { memo, useEffect, useRef, useState } from "react";
 import { useDevice } from "../components/App";
 import { LibraryItem } from "../types";
 import "./LibraryUnit.scss";
@@ -7,95 +7,97 @@ import { CheckboxItem } from "./CheckboxItem";
 import { PlusIcon } from "./icons";
 import { SvgCache, useLibraryItemSvg } from "../hooks/useLibraryItemSvg";
 
-export const LibraryUnit = ({
-  id,
-  elements,
-  isPending,
-  onClick,
-  selected,
-  onToggle,
-  onDrag,
-  svgCache,
-}: {
-  id: LibraryItem["id"] | /** for pending item */ null;
-  elements?: LibraryItem["elements"];
-  isPending?: boolean;
-  onClick: (id: LibraryItem["id"] | null) => void;
-  selected: boolean;
-  onToggle: (id: string, event: React.MouseEvent) => void;
-  onDrag: (id: string, event: React.DragEvent) => void;
-  svgCache: SvgCache;
-}) => {
-  const ref = useRef<HTMLDivElement | null>(null);
-  const svg = useLibraryItemSvg(id, elements, svgCache);
+export const LibraryUnit = memo(
+  ({
+    id,
+    elements,
+    isPending,
+    onClick,
+    selected,
+    onToggle,
+    onDrag,
+    svgCache,
+  }: {
+    id: LibraryItem["id"] | /** for pending item */ null;
+    elements?: LibraryItem["elements"];
+    isPending?: boolean;
+    onClick: (id: LibraryItem["id"] | null) => void;
+    selected: boolean;
+    onToggle: (id: string, event: React.MouseEvent) => void;
+    onDrag: (id: string, event: React.DragEvent) => void;
+    svgCache: SvgCache;
+  }) => {
+    const ref = useRef<HTMLDivElement | null>(null);
+    const svg = useLibraryItemSvg(id, elements, svgCache);
 
-  useEffect(() => {
-    const node = ref.current;
+    useEffect(() => {
+      const node = ref.current;
 
-    if (!node) {
-      return;
-    }
+      if (!node) {
+        return;
+      }
 
-    if (svg) {
-      svg.querySelector(".style-fonts")?.remove();
-      node.innerHTML = svg.outerHTML;
-    }
+      if (svg) {
+        svg.querySelector(".style-fonts")?.remove();
+        node.innerHTML = svg.outerHTML;
+      }
 
-    return () => {
-      node.innerHTML = "";
-    };
-  }, [elements, svg]);
+      return () => {
+        node.innerHTML = "";
+      };
+    }, [elements, svg]);
 
-  const [isHovered, setIsHovered] = useState(false);
-  const isMobile = useDevice().isMobile;
-  const adder = isPending && (
-    <div className="library-unit__adder">{PlusIcon}</div>
-  );
+    const [isHovered, setIsHovered] = useState(false);
+    const isMobile = useDevice().isMobile;
+    const adder = isPending && (
+      <div className="library-unit__adder">{PlusIcon}</div>
+    );
 
-  return (
-    <div
-      className={clsx("library-unit", {
-        "library-unit__active": elements,
-        "library-unit--hover": elements && isHovered,
-        "library-unit--selected": selected,
-      })}
-      onMouseEnter={() => setIsHovered(true)}
-      onMouseLeave={() => setIsHovered(false)}
-    >
+    return (
       <div
-        className={clsx("library-unit__dragger", {
-          "library-unit__pulse": !!isPending,
+        className={clsx("library-unit", {
+          "library-unit__active": elements,
+          "library-unit--hover": elements && isHovered,
+          "library-unit--selected": selected,
         })}
-        ref={ref}
-        draggable={!!elements}
-        onClick={
-          !!elements || !!isPending
-            ? (event) => {
-                if (id && event.shiftKey) {
-                  onToggle(id, event);
-                } else {
-                  onClick(id);
+        onMouseEnter={() => setIsHovered(true)}
+        onMouseLeave={() => setIsHovered(false)}
+      >
+        <div
+          className={clsx("library-unit__dragger", {
+            "library-unit__pulse": !!isPending,
+          })}
+          ref={ref}
+          draggable={!!elements}
+          onClick={
+            !!elements || !!isPending
+              ? (event) => {
+                  if (id && event.shiftKey) {
+                    onToggle(id, event);
+                  } else {
+                    onClick(id);
+                  }
                 }
-              }
-            : undefined
-        }
-        onDragStart={(event) => {
-          if (!id) {
-            event.preventDefault();
-            return;
+              : undefined
           }
-          setIsHovered(false);
-          onDrag(id, event);
-        }}
-      />
-      {adder}
-      {id && elements && (isHovered || isMobile || selected) && (
-        <CheckboxItem
-          checked={selected}
-          onChange={(checked, event) => onToggle(id, event)}
-          className="library-unit__checkbox"
+          onDragStart={(event) => {
+            if (!id) {
+              event.preventDefault();
+              return;
+            }
+            setIsHovered(false);
+            onDrag(id, event);
+          }}
         />
-      )}
-    </div>
-  );
-};
+        {adder}
+        {id && elements && (isHovered || isMobile || selected) && (
+          <CheckboxItem
+            checked={selected}
+            onChange={(checked, event) => onToggle(id, event)}
+            className="library-unit__checkbox"
+          />
+        )}
+      </div>
+    );
+  },
+);

--- a/src/hooks/useLibraryItemSvg.ts
+++ b/src/hooks/useLibraryItemSvg.ts
@@ -39,6 +39,7 @@ export const useLibraryItemSvg = (
           // When there is no svg in cache export it and save to cache
           (async () => {
             const exportedSvg = await exportLibraryItemToSvg(elements);
+            exportedSvg.querySelector(".style-fonts")?.remove();
 
             if (exportedSvg) {
               svgCache.set(id, exportedSvg);


### PR DESCRIPTION
The Target of this PR is to minimize the number of unnecessary renders of the items in the library and the library itself.

There is an issue, when the user clicks on the canvas, a random item is added into `appState.selectedElementIds`. This will cause a new render of the personal part of the library (but items are memorized) and the first item with selected content (if there is any).

This may cause some conflicts when #6621 is merged.