### PR TITLE
feat: recover scrolled position after Library re-opening

### DIFF
--- a/src/components/LibraryMenuItems.tsx
+++ b/src/components/LibraryMenuItems.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import { serializeLibraryAsJSON } from "../data/json";
 import { t } from "../i18n";
 import {
@@ -15,6 +15,7 @@ import { duplicateElements } from "../element/newElement";
 import { LibraryMenuControlButtons } from "./LibraryMenuControlButtons";
 import { LibraryDropdownMenu } from "./LibraryMenuHeaderContent";
 import LibraryMenuSection from "./LibraryMenuSection";
+import { useScrollPosition } from "../hooks/useScrollPosition";
 
 import "./LibraryMenuItems.scss";
 
@@ -38,6 +39,15 @@ export default function LibraryMenuItems({
   id: string;
 }) {
   const [selectedItems, setSelectedItems] = useState<LibraryItem["id"][]>([]);
+  const libraryContainerRef = useRef<HTMLDivElement>(null);
+  const scrollPosition = useScrollPosition<HTMLDivElement>(libraryContainerRef);
+
+  // This effect has to be called only on first render, therefore  `scrollPosition` isn't in the dependency array
+  useEffect(() => {
+    if (scrollPosition > 0) {
+      libraryContainerRef.current?.scrollTo(0, scrollPosition);
+    }
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   const unpublishedItems = libraryItems.filter(
     (item) => item.status !== "published",
@@ -181,6 +191,7 @@ export default function LibraryMenuItems({
           flex: publishedItems.length > 0 ? 1 : "0 1 auto",
           marginBottom: 0,
         }}
+        ref={libraryContainerRef}
       >
         <>
           {!isLibraryEmpty && (

--- a/src/components/LibraryMenuSection.tsx
+++ b/src/components/LibraryMenuSection.tsx
@@ -56,9 +56,11 @@ function LibraryRow({
 
 const EmptyLibraryRow = () => (
   <Stack.Row className="library-menu-items-container__row" gap={1}>
-    <Stack.Col>
-      <div className={clsx("library-unit")} />
-    </Stack.Col>
+    {Array.from({ length: ITEMS_PER_ROW }).map((_, index) => (
+      <Stack.Col key={index}>
+        <div className={clsx("library-unit", "library-unit--skeleton")} />
+      </Stack.Col>
+    ))}
   </Stack.Row>
 );
 

--- a/src/components/LibraryUnit.scss
+++ b/src/components/LibraryUnit.scss
@@ -20,6 +20,30 @@
       border-color: var(--color-primary);
       border-width: 1px;
     }
+
+    &--skeleton {
+      border-radius: var(--border-radius-lg);
+      background: linear-gradient(
+        -45deg,
+        var(--color-gray-10),
+        var(--color-gray-20),
+        var(--color-gray-10)
+      );
+      background-size: 200% 200%;
+      animation: library-unit__skeleton-animation 1.5s ease infinite;
+    }
+
+    @keyframes library-unit__skeleton-animation {
+      0% {
+        background-position: 0% 0%;
+      }
+      50% {
+        background-position: 100% 100%;
+      }
+      100% {
+        background-position: 0% 0%;
+      }
+    }
   }
 
   .library-unit__dragger {

--- a/src/components/LibraryUnit.tsx
+++ b/src/components/LibraryUnit.tsx
@@ -56,6 +56,7 @@ export const LibraryUnit = ({
         "library-unit__active": elements,
         "library-unit--hover": elements && isHovered,
         "library-unit--selected": selected,
+        "library-unit--skeleton": !svg,
       })}
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}

--- a/src/components/Stack.tsx
+++ b/src/components/Stack.tsx
@@ -1,6 +1,6 @@
 import "./Stack.scss";
 
-import React from "react";
+import React, { forwardRef } from "react";
 import clsx from "clsx";
 
 type StackProps = {
@@ -10,53 +10,52 @@ type StackProps = {
   justifyContent?: "center" | "space-around" | "space-between";
   className?: string | boolean;
   style?: React.CSSProperties;
+  ref: React.RefObject<HTMLDivElement>;
 };
 
-const RowStack = ({
-  children,
-  gap,
-  align,
-  justifyContent,
-  className,
-  style,
-}: StackProps) => {
-  return (
-    <div
-      className={clsx("Stack Stack_horizontal", className)}
-      style={{
-        "--gap": gap,
-        alignItems: align,
-        justifyContent,
-        ...style,
-      }}
-    >
-      {children}
-    </div>
-  );
-};
+const RowStack = forwardRef(
+  (
+    { children, gap, align, justifyContent, className, style }: StackProps,
+    ref: React.ForwardedRef<HTMLDivElement>,
+  ) => {
+    return (
+      <div
+        className={clsx("Stack Stack_horizontal", className)}
+        style={{
+          "--gap": gap,
+          alignItems: align,
+          justifyContent,
+          ...style,
+        }}
+        ref={ref}
+      >
+        {children}
+      </div>
+    );
+  },
+);
 
-const ColStack = ({
-  children,
-  gap,
-  align,
-  justifyContent,
-  className,
-  style,
-}: StackProps) => {
-  return (
-    <div
-      className={clsx("Stack Stack_vertical", className)}
-      style={{
-        "--gap": gap,
-        justifyItems: align,
-        justifyContent,
-        ...style,
-      }}
-    >
-      {children}
-    </div>
-  );
-};
+const ColStack = forwardRef(
+  (
+    { children, gap, align, justifyContent, className, style }: StackProps,
+    ref: React.ForwardedRef<HTMLDivElement>,
+  ) => {
+    return (
+      <div
+        className={clsx("Stack Stack_vertical", className)}
+        style={{
+          "--gap": gap,
+          justifyItems: align,
+          justifyContent,
+          ...style,
+        }}
+        ref={ref}
+      >
+        {children}
+      </div>
+    );
+  },
+);
 
 export default {
   Row: RowStack,

--- a/src/hooks/useScrollPosition.ts
+++ b/src/hooks/useScrollPosition.ts
@@ -1,0 +1,32 @@
+import { useEffect } from "react";
+import { atom, useAtom } from "jotai";
+import throttle from "lodash.throttle";
+
+const scrollPositionAtom = atom<number>(0);
+
+export const useScrollPosition = <T extends HTMLElement>(
+  elementRef: React.RefObject<T>,
+) => {
+  const [scrollPosition, setScrollPosition] = useAtom(scrollPositionAtom);
+
+  useEffect(() => {
+    const handleScroll = throttle(() => {
+      if (elementRef.current) {
+        const { scrollTop } = elementRef.current;
+        setScrollPosition(scrollTop);
+      }
+    }, 200);
+
+    if (elementRef.current) {
+      elementRef.current.addEventListener("scroll", handleScroll);
+    }
+
+    return () => {
+      if (elementRef.current) {
+        elementRef.current.removeEventListener("scroll", handleScroll);
+      }
+    };
+  }, [elementRef, setScrollPosition]);
+
+  return scrollPosition;
+};

--- a/src/hooks/useScrollPosition.ts
+++ b/src/hooks/useScrollPosition.ts
@@ -8,25 +8,26 @@ export const useScrollPosition = <T extends HTMLElement>(
   elementRef: React.RefObject<T>,
 ) => {
   const [scrollPosition, setScrollPosition] = useAtom(scrollPositionAtom);
+  const { current: element } = elementRef;
 
   useEffect(() => {
     const handleScroll = throttle(() => {
-      if (elementRef.current) {
-        const { scrollTop } = elementRef.current;
+      if (element) {
+        const { scrollTop } = element;
         setScrollPosition(scrollTop);
       }
     }, 200);
 
-    if (elementRef.current) {
-      elementRef.current.addEventListener("scroll", handleScroll);
+    if (element) {
+      element.addEventListener("scroll", handleScroll);
     }
 
     return () => {
-      if (elementRef.current) {
-        elementRef.current.removeEventListener("scroll", handleScroll);
+      if (element) {
+        element.removeEventListener("scroll", handleScroll);
       }
     };
-  }, [elementRef, setScrollPosition]);
+  }, [element, setScrollPosition]);
 
   return scrollPosition;
 };


### PR DESCRIPTION
Reopen the Library side panel and scroll to the same position as it was when closed. It also adds a skeleton placeholder, as it looks weird when the library is opened, scrolled down, and item content is still waiting to be rendered.