### PR TITLE
fix: updated link for documentation page under help section

### DIFF
--- a/src/components/HelpDialog.tsx
+++ b/src/components/HelpDialog.tsx
@@ -12,7 +12,7 @@ const Header = () => (
   <div className="HelpDialog__header">
     <a
       className="HelpDialog__btn"
-      href="https://docs-excalidraw.vercel.app"
+      href="https://docs.excalidraw.com"
       target="_blank"
       rel="noopener noreferrer"
     >

--- a/src/components/HelpDialog.tsx
+++ b/src/components/HelpDialog.tsx
@@ -12,7 +12,7 @@ const Header = () => (
   <div className="HelpDialog__header">
     <a
       className="HelpDialog__btn"
-      href="https://github.com/excalidraw/excalidraw#documentation"
+      href="https://docs-excalidraw.vercel.app"
       target="_blank"
       rel="noopener noreferrer"
     >


### PR DESCRIPTION
Updated the link for documentation page under help section 
from - [https://github.com/excalidraw/excalidraw#documentation](https://github.com/excalidraw/excalidraw#documentation) 
to - [https://docs-excalidraw.vercel.app](https://docs-excalidraw.vercel.app) 

<img width="617" alt="image" src="https://github.com/excalidraw/excalidraw/assets/63002244/f4125c74-9741-4fda-9255-f6e160515001">

Issue - #6616
