### PR TITLE
fix: delete setCursor when resize

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -4155,12 +4155,6 @@ class App extends React.Component<AppProps, AppState> {
         );
       }
       if (pointerDownState.resize.handleType) {
-        setCursor(
-          this.canvas,
-          getCursorForResizingElement({
-            transformHandleType: pointerDownState.resize.handleType,
-          }),
-        );
         pointerDownState.resize.isResizing = true;
         pointerDownState.resize.offset = tupleToCoors(
           getResizeOffsetXY(


### PR DESCRIPTION
After rotating, it will set wrong cursor when resizing 

<img width="416" alt="image" src="https://github.com/excalidraw/excalidraw/assets/87802698/ecde94cb-41ce-4b04-82ea-09ee4017517c">

<img width="394" alt="image" src="https://github.com/excalidraw/excalidraw/assets/87802698/ec17df15-564b-4baf-bbeb-4074857705da">

