### PR TITLE
fix: change pointer-events of toolbar and footer to none

### DIFF
--- a/src/components/LayerUI.scss
+++ b/src/components/LayerUI.scss
@@ -17,6 +17,16 @@
     pointer-events: none;
     z-index: var(--zIndex-layerUI);
 
+    &.disable-pointerEvents {
+      .layer-ui__wrapper__footer > * {
+        pointer-events: none;
+      }
+
+      .footer-center > * {
+        pointer-events: none;
+      }
+    }
+
     &__top-right {
       display: flex;
       gap: 0.75rem;

--- a/src/css/styles.scss
+++ b/src/css/styles.scss
@@ -275,6 +275,10 @@
     }
   }
 
+  .layer-ui__wrapper.disable-pointerEvents .shapes-section > * {
+    pointer-events: none;
+  }
+
   .App-menu_top {
     grid-template-columns: 1fr 2fr 1fr;
     grid-gap: 2rem;


### PR DESCRIPTION
Unlike the app menu top (except the toolbar) and left, the toolbar and footer can become targets of pointer events while drawing, dragging, resizing and etc.

it would be nice to have same pointer events for a consistent user experience.

Before: 
![before](https://github.com/excalidraw/excalidraw/assets/70563791/e894d034-7cba-43eb-b99b-989eef44e6ba)

After:
![after](https://github.com/excalidraw/excalidraw/assets/70563791/949ce44b-a55b-400b-a82b-6d4087807df9)
