### PR TITLE
fix: elements in non-existing frame getting removed

### DIFF
--- a/src/data/restore.ts
+++ b/src/data/restore.ts
@@ -370,6 +370,24 @@ const repairBoundElement = (
   }
 };
 
+/**
+ * Remove an element's frameId if its containing frame is non-existent
+ *
+ * NOTE mutates elements.
+ */
+const repairFrameMembership = (
+  element: Mutable<ExcalidrawElement>,
+  elementsMap: Map<string, Mutable<ExcalidrawElement>>,
+) => {
+  if (element.frameId) {
+    const containingFrame = elementsMap.get(element.frameId);
+
+    if (!containingFrame) {
+      element.frameId = null;
+    }
+  }
+};
+
 export const restoreElements = (
   elements: ImportedDataState["elements"],
   /** NOTE doesn't serve for reconciliation */
@@ -410,6 +428,10 @@ export const restoreElements = (
   // repair binding. Mutates elements.
   const restoredElementsMap = arrayToMap(restoredElements);
   for (const element of restoredElements) {
+    if (element.frameId) {
+      repairFrameMembership(element, restoredElementsMap);
+    }
+
     if (isTextElement(element) && element.containerId) {
       repairBoundElement(element, restoredElementsMap);
     } else if (element.boundElements) {

--- a/src/frame.ts
+++ b/src/frame.ts
@@ -304,7 +304,7 @@ export const groupsAreCompletelyOutOfFrame = (
 /**
  * Returns a map of frameId to frame elements. Includes empty frames.
  */
-export const groupByFrames = (elements: ExcalidrawElementsIncludingDeleted) => {
+export const groupByFrames = (elements: readonly ExcalidrawElement[]) => {
   const frameElementsMap = new Map<
     ExcalidrawElement["id"],
     ExcalidrawElement[]
@@ -591,8 +591,8 @@ export const updateFrameMembershipOfSelectedElements = (
 
   elementsToFilter.forEach((element) => {
     if (
-      !isFrameElement(element) &&
       element.frameId &&
+      !isFrameElement(element) &&
       !isElementInFrame(element, allElements, appState)
     ) {
       elementsToRemove.add(element);

--- a/src/frame.ts
+++ b/src/frame.ts
@@ -592,13 +592,16 @@ export const updateFrameMembershipOfSelectedElements = (
   elementsToFilter.forEach((element) => {
     if (
       !isFrameElement(element) &&
+      element.frameId &&
       !isElementInFrame(element, allElements, appState)
     ) {
       elementsToRemove.add(element);
     }
   });
 
-  return removeElementsFromFrame(allElements, [...elementsToRemove], appState);
+  return elementsToRemove.size > 0
+    ? removeElementsFromFrame(allElements, [...elementsToRemove], appState)
+    : allElements;
 };
 
 /**

--- a/src/zindex.ts
+++ b/src/zindex.ts
@@ -412,10 +412,16 @@ function shift(
         ...(frameElementsMap.get(element.id) ?? []),
         element,
       ];
+      frameElementsMap.delete(element.id);
     } else {
       finalElements = [...finalElements, element];
     }
   });
+
+  // in case root is non-existent, we want to keep its elements
+  for (const leftoverElements of frameElementsMap.values()) {
+    finalElements = [...finalElements, ...leftoverElements];
+  }
 
   return finalElements;
 }


### PR DESCRIPTION
fix issue reported https://discord.com/channels/723672430744174682/723672430744174685/1121405542435409982

description:
- elements that are in a non-existing frame will be removed when other elements are moved
- as can be reproduced here https://excalidraw.com/#json=P2C3bNY_tUguLfBlA88Tf,xBgX6-gB3mWWGY7X4EsidA

root cause
- `removeElementsFromFrame` depends on `shift` in `zindex.ts`
- which assumes that if an element has `frameId`, the frame must be present
- when the frame is non-existent, then all elements with the `frameId` will not be removed whenever `shift` is called

TODOs:
- [ ] investigate how an element can have `frameId` when its frame is non-existent
- [x] refactor `zindex.ts` so that when a frame is non-existent, its elements are kept