### PR TITLE
fix: change shortcut Key for full-screen from F to F11

### DIFF
--- a/src/components/HelpDialog.tsx
+++ b/src/components/HelpDialog.tsx
@@ -253,7 +253,7 @@ export const HelpDialog = ({ onClose }: { onClose?: () => void }) => {
               label={t("helpDialog.movePageLeftRight")}
               shortcuts={["Shift+PgUp/PgDn"]}
             />
-            <Shortcut label={t("buttons.fullScreen")} shortcuts={["F"]} />
+            <Shortcut label={t("buttons.fullScreen")} shortcuts={["F11"]} />
             <Shortcut
               label={t("buttons.zenMode")}
               shortcuts={[getShortcutKey("Alt+Z")]}


### PR DESCRIPTION
Fixed shortcut key conflict between frame tool and full-screen
Change "F" to "F11" in button key
fixes #6704
