### PR TITLE
fix: bugs related to frames

### DIFF
--- a/src/actions/actionAlign.tsx
+++ b/src/actions/actionAlign.tsx
@@ -10,7 +10,6 @@ import {
 import { ToolButton } from "../components/ToolButton";
 import { getNonDeletedElements } from "../element";
 import { ExcalidrawElement } from "../element/types";
-import { updateFrameMembershipOfSelectedElements } from "../frame";
 import { t } from "../i18n";
 import { KEYS } from "../keys";
 import { getSelectedElements, isSomeElementSelected } from "../scene";
@@ -47,9 +46,8 @@ const alignSelectedElements = (
 
   const updatedElementsMap = arrayToMap(updatedElements);
 
-  return updateFrameMembershipOfSelectedElements(
-    elements.map((element) => updatedElementsMap.get(element.id) || element),
-    appState,
+  return elements.map(
+    (element) => updatedElementsMap.get(element.id) || element,
   );
 };
 

--- a/src/actions/actionDistribute.tsx
+++ b/src/actions/actionDistribute.tsx
@@ -6,7 +6,6 @@ import { ToolButton } from "../components/ToolButton";
 import { distributeElements, Distribution } from "../distribute";
 import { getNonDeletedElements } from "../element";
 import { ExcalidrawElement } from "../element/types";
-import { updateFrameMembershipOfSelectedElements } from "../frame";
 import { t } from "../i18n";
 import { CODES, KEYS } from "../keys";
 import { getSelectedElements, isSomeElementSelected } from "../scene";
@@ -43,9 +42,8 @@ const distributeSelectedElements = (
 
   const updatedElementsMap = arrayToMap(updatedElements);
 
-  return updateFrameMembershipOfSelectedElements(
-    elements.map((element) => updatedElementsMap.get(element.id) || element),
-    appState,
+  return elements.map(
+    (element) => updatedElementsMap.get(element.id) || element,
   );
 };
 

--- a/src/actions/actionDuplicateSelection.tsx
+++ b/src/actions/actionDuplicateSelection.tsx
@@ -104,8 +104,8 @@ const duplicateElements = (
 
   const idsOfElementsToDuplicate = arrayToMap(
     getSelectedElements(sortedElements, appState, {
-      includeBoundTextElement: true,
-      includeElementsInFrames: true,
+      includeBoundTextElement: false,
+      includeElementsInFrames: false,
     }),
   );
 

--- a/src/actions/actionFlip.ts
+++ b/src/actions/actionFlip.ts
@@ -19,10 +19,7 @@ export const actionFlipHorizontal = register({
   trackEvent: { category: "element" },
   perform: (elements, appState) => {
     return {
-      elements: updateFrameMembershipOfSelectedElements(
-        flipSelectedElements(elements, appState, "horizontal"),
-        appState,
-      ),
+      elements: flipSelectedElements(elements, appState, "horizontal"),
       appState,
       commitToHistory: true,
     };

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -245,6 +245,7 @@ import {
   isTransparent,
   easeToValuesRAF,
   muteFSAbortError,
+  arrayToMap,
 } from "../utils";
 import {
   ContextMenu,
@@ -1094,6 +1095,12 @@ class App extends React.Component<AppProps, AppState> {
           },
         );
       }
+
+      // update frame membership if needed
+      updateFrameMembershipOfSelectedElements(
+        this.scene.getElementsIncludingDeleted(),
+        this.state,
+      );
     },
   );
 
@@ -3018,11 +3025,13 @@ class App extends React.Component<AppProps, AppState> {
                   !(isTextElement(element) && element.containerId)),
             );
 
+    const elementsMap = arrayToMap(elements);
+
     return getElementsAtPosition(elements, (element) =>
       hitTest(element, this.state, this.frameNameBoundsCache, x, y),
     ).filter((element) => {
       // hitting a frame's element from outside the frame is not considered a hit
-      const containingFrame = getContainingFrame(element);
+      const containingFrame = getContainingFrame(element, elementsMap);
       return containingFrame && this.state.shouldRenderFrames
         ? isCursorInFrame({ x, y }, containingFrame)
         : true;
@@ -5845,7 +5854,10 @@ class App extends React.Component<AppProps, AppState> {
             );
 
             if (linearElement?.frameId) {
-              const frame = getContainingFrame(linearElement);
+              const frame = getContainingFrame(
+                linearElement,
+                arrayToMap(this.scene.getElementsIncludingDeleted()),
+              );
 
               if (frame && linearElement) {
                 if (!elementOverlapsWithFrame(linearElement, frame)) {

--- a/src/scene/selection.ts
+++ b/src/scene/selection.ts
@@ -10,6 +10,7 @@ import {
   getContainingFrame,
   getFrameElements,
 } from "../frame";
+import { arrayToMap } from "../utils";
 
 /**
  * Frames and their containing elements are not to be selected at the same time.
@@ -46,11 +47,13 @@ export const getElementsWithinSelection = (
   const [selectionX1, selectionY1, selectionX2, selectionY2] =
     getElementAbsoluteCoords(selection);
 
+  const elementsMap = arrayToMap(elements);
+
   let elementsInSelection = elements.filter((element) => {
     let [elementX1, elementY1, elementX2, elementY2] =
       getElementBounds(element);
 
-    const containingFrame = getContainingFrame(element);
+    const containingFrame = getContainingFrame(element, elementsMap);
     if (containingFrame) {
       const [fx1, fy1, fx2, fy2] = getElementBounds(containingFrame);
 
@@ -76,7 +79,7 @@ export const getElementsWithinSelection = (
     : elementsInSelection;
 
   elementsInSelection = elementsInSelection.filter((element) => {
-    const containingFrame = getContainingFrame(element);
+    const containingFrame = getContainingFrame(element, elementsMap);
 
     if (containingFrame) {
       return elementOverlapsWithFrame(element, containingFrame);


### PR DESCRIPTION
close #6703 #6699 

for #6699 the bug is caused because `getContainingFrame` returns `null` (which happens when `element` in `Scene.getScene(element)` is a new element and `scene.replaceAllElements` has not yet been called)

so the fix is to put the frame membership update function call in `syncActionResult` after the new elements returned from actions have been used to update elements in a scene