### PR TITLE
fix: locales wrong line break

### DIFF
--- a/src/locales/sk-SK.json
+++ b/src/locales/sk-SK.json
@@ -241,7 +241,7 @@
     "text_editing": "Stlačte Escape alebo CtrlOrCmd+ENTER na ukončenie editovania",
     "linearElementMulti": "Kliknite na počiatočný bod alebo stlačte Escape alebo Enter na ukončenie",
     "lockAngle": "Počas rotácie obmedzíte uhol podržaním SHIFT",
-    "resize": "Počas zmeny veľkosti zachováte proporcie podržaním SHIFT,\\npodržaním ALT meníte veľkosť so zachovaním stredu",
+    "resize": "Počas zmeny veľkosti zachováte proporcie podržaním SHIFT,\npodržaním ALT meníte veľkosť so zachovaním stredu",
     "resizeImage": "Podržte SHIFT pre voľnú zmenu veľkosti, podržte ALT pre zmenu veľkosti od stredu",
     "rotate": "Počas rotácie obmedzíte uhol podržaním SHIFT",
     "lineEditor_info": "Podržte CtrlOrCmd a kliknite dva krát alebo stlačte CtrlOrCmd + Enter pre editáciu bodov",

--- a/src/locales/zh-TW.json
+++ b/src/locales/zh-TW.json
@@ -241,7 +241,7 @@
     "text_editing": "按跳脫鍵或 Ctrl 或 Cmd + Enter 以結束編輯",
     "linearElementMulti": "按下 Escape 或 Enter 以結束繪製",
     "lockAngle": "按住 SHIFT 可限制旋轉角度",
-    "resize": "縮放時按住 Shift 可保持原比例縮放；\\n按住 Alt 可由中心點進行縮放",
+    "resize": "縮放時按住 Shift 可保持原比例縮放；\n按住 Alt 可由中心點進行縮放",
     "resizeImage": "按住 SHIFT 可任意縮放，按住 ALT 可由中央縮放。",
     "rotate": "旋轉時按住 Shift 可限制旋轉角度",
     "lineEditor_info": "按住 Ctrl 或 Cmd 並雙擊或按住 Ctrl 或 Cmd + Enter 來編輯控制點",


### PR DESCRIPTION
## Bug fixes

- Fix locales wrong line break (`\n` instead of `\\n` in `sk-SK.json` and `zh-TW.json`)
