### PR TITLE
fix: add some types to CSSProperties to fix issues where types don't …

### DIFF
--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -120,3 +120,12 @@ declare module "image-blob-reduce" {
   const reduce: ImageBlobReduce.ImageBlobReduceStatic;
   export = reduce;
 }
+
+declare namespace React {
+  interface CSSProperties {
+    "--swatch-color"?: string;
+    "--max-width"?: string;
+    "--padding"?: number;
+    "--gap"?: number;
+  }
+}


### PR DESCRIPTION
This is my first time using excalidraw and I think it's a great project and I love it. But when I execute pnpm build, there are some errors:

TS2322: Type '{ "--swatch-color": string;  } | undefined' is not assignable to type 'CSSProperties | undefined'.
TS2339: Property 'toBeChecked' does not exist on type 'JestMatchers'.

I searched for issues and pull requests and found a similar problem:https://github.com/excalidraw/excalidraw/issues/6294

I saw a reply welcome pr, so I tried to add more types to solve this problem.
