### PR TITLE
feat: render bold lines in grid

### DIFF
--- a/src/renderer/renderScene.ts
+++ b/src/renderer/renderScene.ts
@@ -151,73 +151,26 @@ const fillCircle = (
   }
 };
 
-const strokeGrid = ({
-  context,
-  gridSize,
-  scrollX,
-  scrollY,
-  width,
-  height,
-  zoom,
-  boldLineInterval = 50,
-}: {
-  context: CanvasRenderingContext2D;
-  gridSize: number;
-  scrollX: number;
-  scrollY: number;
-  width: number;
-  height: number;
-  zoom: number;
-  boldLineInterval?: number;
-}) => {
-  enum GridLineColor {
-    Bold = "rgba(0,0,0,0.4)",
-    Regular = "rgba(0,0,0,0.1)",
-  }
+const strokeGrid = (
+  context: CanvasRenderingContext2D,
+  gridSize: number,
+  offsetX: number,
+  offsetY: number,
+  width: number,
+  height: number,
+) => {
   context.save();
+  context.strokeStyle = "rgba(0,0,0,0.1)";
   context.beginPath();
-
-  const scaledGridSize = gridSize * zoom;
-  const offsetX = -Math.ceil(zoom / gridSize) * gridSize + (scrollX % gridSize);
-  const offsetY = -Math.ceil(zoom / gridSize) * gridSize + (scrollY % gridSize);
-
-  const originLineX = Math.floor(scrollX / scaledGridSize);
-  const originLineY = Math.floor(scrollY / scaledGridSize);
-
-  // Render horizontal grid lines
-  for (
-    let x = offsetX;
-    x < offsetX + width + scaledGridSize * 2;
-    x += scaledGridSize
-  ) {
-    const lineIndexX = Math.floor(x / scaledGridSize) - originLineX;
-    context.beginPath();
-    context.strokeStyle =
-      lineIndexX % boldLineInterval === 0
-        ? GridLineColor.Bold
-        : GridLineColor.Regular;
-    context.moveTo(x, offsetY - scaledGridSize);
-    context.lineTo(x, offsetY + height + scaledGridSize * 2);
-    context.stroke();
+  for (let x = offsetX; x < offsetX + width + gridSize * 2; x += gridSize) {
+    context.moveTo(x, offsetY - gridSize);
+    context.lineTo(x, offsetY + height + gridSize * 2);
   }
-
-  // Render vertical grid lines
-  for (
-    let y = offsetY;
-    y < offsetY + height + scaledGridSize * 2;
-    y += scaledGridSize
-  ) {
-    const lineIndexY = Math.floor(y / scaledGridSize) - originLineY;
-    context.beginPath();
-    context.strokeStyle =
-      lineIndexY % boldLineInterval === 0
-        ? GridLineColor.Bold
-        : GridLineColor.Regular;
-    context.moveTo(offsetX - scaledGridSize, y);
-    context.lineTo(offsetX + width + scaledGridSize * 2, y);
-    context.stroke();
+  for (let y = offsetY; y < offsetY + height + gridSize * 2; y += gridSize) {
+    context.moveTo(offsetX - gridSize, y);
+    context.lineTo(offsetX + width + gridSize * 2, y);
   }
-
+  context.stroke();
   context.restore();
 };
 
@@ -461,15 +414,18 @@ export const _renderScene = ({
 
     // Grid
     if (renderGrid && appState.gridSize) {
-      strokeGrid({
+      strokeGrid(
         context,
-        gridSize: appState.gridSize,
-        scrollX: renderConfig.scrollX,
-        scrollY: renderConfig.scrollY,
-        width: normalizedCanvasWidth / renderConfig.zoom.value,
-        height: normalizedCanvasHeight / renderConfig.zoom.value,
-        zoom: renderConfig.zoom.value,
-      });
+        appState.gridSize,
+        -Math.ceil(renderConfig.zoom.value / appState.gridSize) *
+          appState.gridSize +
+          (renderConfig.scrollX % appState.gridSize),
+        -Math.ceil(renderConfig.zoom.value / appState.gridSize) *
+          appState.gridSize +
+          (renderConfig.scrollY % appState.gridSize),
+        normalizedCanvasWidth / renderConfig.zoom.value,
+        normalizedCanvasHeight / renderConfig.zoom.value,
+      );
     }
 
     // Paint visible elements

--- a/src/renderer/renderScene.ts
+++ b/src/renderer/renderScene.ts
@@ -154,23 +154,44 @@ const fillCircle = (
 const strokeGrid = (
   context: CanvasRenderingContext2D,
   gridSize: number,
-  offsetX: number,
-  offsetY: number,
+  scrollX: number,
+  scrollY: number,
+  zoom: Zoom,
   width: number,
   height: number,
 ) => {
+  const BOLD_LINE_FREQUENCY = 5;
+  enum GridLineColor {
+    Bold = "rgba(0,0,0,0.3)",
+    Regular = "rgba(0,0,0,0.1)",
+  }
+
+  const offsetX =
+    -Math.round(zoom.value / gridSize) * gridSize + (scrollX % gridSize);
+  const offsetY =
+    -Math.round(zoom.value / gridSize) * gridSize + (scrollY % gridSize);
+
   context.save();
-  context.strokeStyle = "rgba(0,0,0,0.1)";
-  context.beginPath();
   for (let x = offsetX; x < offsetX + width + gridSize * 2; x += gridSize) {
+    context.beginPath();
+    context.strokeStyle =
+      Math.round(x - scrollX) % (BOLD_LINE_FREQUENCY * gridSize) === 0
+        ? GridLineColor.Bold
+        : GridLineColor.Regular;
     context.moveTo(x, offsetY - gridSize);
     context.lineTo(x, offsetY + height + gridSize * 2);
+    context.stroke();
   }
   for (let y = offsetY; y < offsetY + height + gridSize * 2; y += gridSize) {
+    context.beginPath();
+    context.strokeStyle =
+      Math.round(y - scrollY) % (BOLD_LINE_FREQUENCY * gridSize) === 0
+        ? GridLineColor.Bold
+        : GridLineColor.Regular;
     context.moveTo(offsetX - gridSize, y);
     context.lineTo(offsetX + width + gridSize * 2, y);
+    context.stroke();
   }
-  context.stroke();
   context.restore();
 };
 
@@ -417,12 +438,9 @@ export const _renderScene = ({
       strokeGrid(
         context,
         appState.gridSize,
-        -Math.ceil(renderConfig.zoom.value / appState.gridSize) *
-          appState.gridSize +
-          (renderConfig.scrollX % appState.gridSize),
-        -Math.ceil(renderConfig.zoom.value / appState.gridSize) *
-          appState.gridSize +
-          (renderConfig.scrollY % appState.gridSize),
+        renderConfig.scrollX,
+        renderConfig.scrollY,
+        renderConfig.zoom,
         normalizedCanvasWidth / renderConfig.zoom.value,
         normalizedCanvasHeight / renderConfig.zoom.value,
       );

--- a/src/renderer/renderScene.ts
+++ b/src/renderer/renderScene.ts
@@ -161,9 +161,10 @@ const strokeGrid = (
   height: number,
 ) => {
   const BOLD_LINE_FREQUENCY = 5;
+
   enum GridLineColor {
-    Bold = "rgba(0,0,0,0.3)",
-    Regular = "rgba(0,0,0,0.1)",
+    Bold = "#cccccc",
+    Regular = "#e5e5e5",
   }
 
   const offsetX =
@@ -171,23 +172,30 @@ const strokeGrid = (
   const offsetY =
     -Math.round(zoom.value / gridSize) * gridSize + (scrollY % gridSize);
 
+  const lineWidth = Math.min(1 / zoom.value, 1);
+
+  const spaceWidth = 1 / zoom.value;
+  const lineDash = [lineWidth * 3, spaceWidth + (lineWidth + spaceWidth)];
+
   context.save();
+  context.lineWidth = lineWidth;
+
   for (let x = offsetX; x < offsetX + width + gridSize * 2; x += gridSize) {
+    const isBold =
+      Math.round(x - scrollX) % (BOLD_LINE_FREQUENCY * gridSize) === 0;
     context.beginPath();
-    context.strokeStyle =
-      Math.round(x - scrollX) % (BOLD_LINE_FREQUENCY * gridSize) === 0
-        ? GridLineColor.Bold
-        : GridLineColor.Regular;
+    context.setLineDash(isBold ? [] : lineDash);
+    context.strokeStyle = isBold ? GridLineColor.Bold : GridLineColor.Regular;
     context.moveTo(x, offsetY - gridSize);
     context.lineTo(x, offsetY + height + gridSize * 2);
     context.stroke();
   }
   for (let y = offsetY; y < offsetY + height + gridSize * 2; y += gridSize) {
+    const isBold =
+      Math.round(y - scrollY) % (BOLD_LINE_FREQUENCY * gridSize) === 0;
     context.beginPath();
-    context.strokeStyle =
-      Math.round(y - scrollY) % (BOLD_LINE_FREQUENCY * gridSize) === 0
-        ? GridLineColor.Bold
-        : GridLineColor.Regular;
+    context.setLineDash(isBold ? [] : lineDash);
+    context.strokeStyle = isBold ? GridLineColor.Bold : GridLineColor.Regular;
     context.moveTo(offsetX - gridSize, y);
     context.lineTo(offsetX + width + gridSize * 2, y);
     context.stroke();

--- a/src/renderer/renderScene.ts
+++ b/src/renderer/renderScene.ts
@@ -151,26 +151,73 @@ const fillCircle = (
   }
 };
 
-const strokeGrid = (
-  context: CanvasRenderingContext2D,
-  gridSize: number,
-  offsetX: number,
-  offsetY: number,
-  width: number,
-  height: number,
-) => {
+const strokeGrid = ({
+  context,
+  gridSize,
+  scrollX,
+  scrollY,
+  width,
+  height,
+  zoom,
+  boldLineInterval = 50,
+}: {
+  context: CanvasRenderingContext2D;
+  gridSize: number;
+  scrollX: number;
+  scrollY: number;
+  width: number;
+  height: number;
+  zoom: number;
+  boldLineInterval?: number;
+}) => {
+  enum GridLineColor {
+    Bold = "rgba(0,0,0,0.4)",
+    Regular = "rgba(0,0,0,0.1)",
+  }
   context.save();
-  context.strokeStyle = "rgba(0,0,0,0.1)";
   context.beginPath();
-  for (let x = offsetX; x < offsetX + width + gridSize * 2; x += gridSize) {
-    context.moveTo(x, offsetY - gridSize);
-    context.lineTo(x, offsetY + height + gridSize * 2);
+
+  const scaledGridSize = gridSize * zoom;
+  const offsetX = -Math.ceil(zoom / gridSize) * gridSize + (scrollX % gridSize);
+  const offsetY = -Math.ceil(zoom / gridSize) * gridSize + (scrollY % gridSize);
+
+  const originLineX = Math.floor(scrollX / scaledGridSize);
+  const originLineY = Math.floor(scrollY / scaledGridSize);
+
+  // Render horizontal grid lines
+  for (
+    let x = offsetX;
+    x < offsetX + width + scaledGridSize * 2;
+    x += scaledGridSize
+  ) {
+    const lineIndexX = Math.floor(x / scaledGridSize) - originLineX;
+    context.beginPath();
+    context.strokeStyle =
+      lineIndexX % boldLineInterval === 0
+        ? GridLineColor.Bold
+        : GridLineColor.Regular;
+    context.moveTo(x, offsetY - scaledGridSize);
+    context.lineTo(x, offsetY + height + scaledGridSize * 2);
+    context.stroke();
   }
-  for (let y = offsetY; y < offsetY + height + gridSize * 2; y += gridSize) {
-    context.moveTo(offsetX - gridSize, y);
-    context.lineTo(offsetX + width + gridSize * 2, y);
+
+  // Render vertical grid lines
+  for (
+    let y = offsetY;
+    y < offsetY + height + scaledGridSize * 2;
+    y += scaledGridSize
+  ) {
+    const lineIndexY = Math.floor(y / scaledGridSize) - originLineY;
+    context.beginPath();
+    context.strokeStyle =
+      lineIndexY % boldLineInterval === 0
+        ? GridLineColor.Bold
+        : GridLineColor.Regular;
+    context.moveTo(offsetX - scaledGridSize, y);
+    context.lineTo(offsetX + width + scaledGridSize * 2, y);
+    context.stroke();
   }
-  context.stroke();
+
   context.restore();
 };
 
@@ -414,18 +461,15 @@ export const _renderScene = ({
 
     // Grid
     if (renderGrid && appState.gridSize) {
-      strokeGrid(
+      strokeGrid({
         context,
-        appState.gridSize,
-        -Math.ceil(renderConfig.zoom.value / appState.gridSize) *
-          appState.gridSize +
-          (renderConfig.scrollX % appState.gridSize),
-        -Math.ceil(renderConfig.zoom.value / appState.gridSize) *
-          appState.gridSize +
-          (renderConfig.scrollY % appState.gridSize),
-        normalizedCanvasWidth / renderConfig.zoom.value,
-        normalizedCanvasHeight / renderConfig.zoom.value,
-      );
+        gridSize: appState.gridSize,
+        scrollX: renderConfig.scrollX,
+        scrollY: renderConfig.scrollY,
+        width: normalizedCanvasWidth / renderConfig.zoom.value,
+        height: normalizedCanvasHeight / renderConfig.zoom.value,
+        zoom: renderConfig.zoom.value,
+      });
     }
 
     // Paint visible elements


### PR DESCRIPTION
This PR turns moves calculation of the `offsetX` and `offsetY` inside the `strokeGrid` function. Also changes color of every 5th line to darker grey (`rgba(0, 0, 0, 0.4)`) to make grid clearer and more appealing (imho).

Darker lines are related to app coordinates and not to the users viewport, so they stay in the same position when user is moving across the scene. The position of the darker lines is calculated so that they meet at 0, 0.

Here is the screenshot:
![image](https://github.com/excalidraw/excalidraw/assets/7094061/6e53b4aa-a134-4198-b609-17ad91e43f90)