### PR TITLE
fix: do not bind invisible part of an element to arrow

### DIFF
--- a/src/element/binding.ts
+++ b/src/element/binding.ts
@@ -27,6 +27,7 @@ import { LinearElementEditor } from "./linearElementEditor";
 import { arrayToMap, tupleToCoors } from "../utils";
 import { KEYS } from "../keys";
 import { getBoundTextElement, handleBindTextResize } from "./textElement";
+import { getContainingFrame, isPointInFrame } from "../frame";
 
 export type SuggestedBinding =
   | NonDeleted<ExcalidrawBindableElement>
@@ -274,6 +275,18 @@ export const getHoveredElementForBinding = (
       isBindableElement(element, false) &&
       bindingBorderTest(element, pointerCoords),
   );
+
+  if (hoveredElement) {
+    const frame = getContainingFrame(hoveredElement);
+
+    if (frame) {
+      if (isPointInFrame(pointerCoords, frame)) {
+        return hoveredElement as NonDeleted<ExcalidrawBindableElement>;
+      }
+      return null;
+    }
+  }
+
   return hoveredElement as NonDeleted<ExcalidrawBindableElement> | null;
 };
 
@@ -499,10 +512,22 @@ const getElligibleElementsForBindingElement = (
   return [
     getElligibleElementForBindingElement(linearElement, "start"),
     getElligibleElementForBindingElement(linearElement, "end"),
-  ].filter(
-    (element): element is NonDeleted<ExcalidrawBindableElement> =>
-      element != null,
-  );
+  ].filter((element): element is NonDeleted<ExcalidrawBindableElement> => {
+    if (element != null) {
+      const frame = getContainingFrame(element);
+      return frame
+        ? isPointInFrame(
+            getLinearElementEdgeCoors(linearElement, "start"),
+            frame,
+          ) ||
+            isPointInFrame(
+              getLinearElementEdgeCoors(linearElement, "end"),
+              frame,
+            )
+        : true;
+    }
+    return false;
+  });
 };
 
 const getElligibleElementForBindingElement = (

--- a/src/frame.ts
+++ b/src/frame.ts
@@ -1,6 +1,7 @@
 import {
   getCommonBounds,
   getElementAbsoluteCoords,
+  getElementBounds,
   isTextElement,
 } from "./element";
 import {
@@ -297,6 +298,15 @@ export const groupsAreCompletelyOutOfFrame = (
         FrameGeometry.isElementIntersectingFrame(element, frame),
     ) === undefined
   );
+};
+
+export const isPointInFrame = (
+  { x, y }: { x: number; y: number },
+  frame: ExcalidrawFrameElement,
+) => {
+  const [x1, y1, x2, y2] = getElementBounds(frame);
+
+  return x >= x1 && x <= x2 && y >= y1 && y <= y2;
 };
 
 // --------------------------- Frame Utils ------------------------------------


### PR DESCRIPTION
When we are moving an arrow, if binding is on, do not want to bind the arrow to the invisible parts of elements that are in some frame. 

closes #6777 