### PR TITLE
Add elementId argument to generateIdForFile function

### DIFF
--- a/dev-docs/docs/@excalidraw/excalidraw/api/props/props.mdx
+++ b/dev-docs/docs/@excalidraw/excalidraw/api/props/props.mdx
@@ -135,7 +135,7 @@ It is invoked with empty items when user clears the library. You can use this ca
 This prop if passed will be triggered when clicked on `link`. To handle the redirect yourself (such as when using your own router for internal links), you must call `event.preventDefault()`.
 
 <pre>
-(element: <a href="https://github.com/excalidraw/excalidraw/blob/master/src/element/types.ts#L114">ExcalidrawElement</a>, 
+(element: <a href="https://github.com/excalidraw/excalidraw/blob/master/src/element/types.ts#L114">ExcalidrawElement</a>,
  event: CustomEvent&lt;&#123; nativeEvent: MouseEvent }&gt;) => void
 </pre>
 
@@ -191,7 +191,7 @@ This prop indicates whether the shows the grid. When supplied, the value takes p
 
 ### libraryReturnUrl
 
-If supplied, this URL will be used when user tries to install a library from [libraries.excalidraw.com](https://libraries.excalidraw.com).  
+If supplied, this URL will be used when user tries to install a library from [libraries.excalidraw.com](https://libraries.excalidraw.com).
 Defaults to *window.location.origin + window.location.pathname*. To install the libraries in the same tab from which it was opened, you need to set `window.name` (to any alphanumeric string) — if it's not set it will open in a new tab.
 
 ### theme
@@ -225,6 +225,6 @@ This prop indicates whether to `focus` the Excalidraw component on page load. De
 Allows you to override `id` generation for files added on canvas (images). By default, an SHA-1 digest of the file is used.
 
 ```tsx
-(file: File) => string | Promise<string>
+(file: File, elementId: string) => string | Promise<string>
 ```
 

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -6480,7 +6480,7 @@ class App extends React.Component<AppProps, AppState> {
     // generate image id (by default the file digest) before any
     // resizing/compression takes place to keep it more portable
     const fileId = await ((this.props.generateIdForFile?.(
-      imageFile,
+      imageFile, imageElement.id
     ) as Promise<FileId>) || generateIdFromFile(imageFile));
 
     if (!fileId) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -348,7 +348,7 @@ export interface ExcalidrawProps {
   handleKeyboardGlobally?: boolean;
   onLibraryChange?: (libraryItems: LibraryItems) => void | Promise<any>;
   autoFocus?: boolean;
-  generateIdForFile?: (file: File) => string | Promise<string>;
+  generateIdForFile?: (file: File, elementId: string) => string | Promise<string>;
   onLinkOpen?: (
     element: NonDeletedExcalidrawElement,
     event: CustomEvent<{


### PR DESCRIPTION
We use excalidraw in our product and it's working great. We wanted to add support for images and so decided to use `generateIdForFile` prop to determine when an image was added to the added. That seemed easier to do that finding it out from `onChange` elements argument.

When our `generateIdForFile` callback is called, we would upload the image to our server which would generate an id for the image and send it back to the client. We would then resolve the promise with that id. That worked file for a single user but breaks when in a collaborative session.

The `initializeImageElement` function mutates the `imageElement` with the `fileId` returned by `generateIdForFile` promise. But it breaks in the following scenario

- `initialzieImageElement` calls `generateIdForFile` and waits for it to resolve
- `generateIdForFile` starts uploading file to server and waits for server to return an id
- In the meanwhile we have already communicated the new image element to other collaborators
- One of the collaborators moves the image a bit and that is communicated to the user who added the image
- The image element in the first user's `elements` list gets overwritten by the update from other collaborator
- The server finally comes back an id for the file
- `initializeImageElement` mutates the `imageElement` it had with the `fileId`. But that element is no longer used in excalidraw `elements` list. So the image element is now left with a `fileId` of null.

If `generateIdForFile` also sends the element id along with the file id, then we can manually update the `fileId` for given element id once we get the response from upload server. Something like this

```
async function generateIdForFile(fileId: File, elementId: string) {
  const { fileId } = await uploadToServer(readFileContents(File));
  excalidrawElementRef.current.updateScene({
    elements:   excalidrawElementRef.current.getSceneElementsIncludingDeleted().map(element => {
      if(element.id === elementId) {
        return {
          ...element,
          fileId
        }
      } else {
        return element
      }
    })
  });
  return fileId;
}
```

The addition of elementId should not break any other part of the application since there's only one place where `generateIdForFile` is called.