### PR TITLE
feat: File name displayed near menu saves onClick

### DIFF
--- a/src/components/fileName/fileName.tsx
+++ b/src/components/fileName/fileName.tsx
@@ -1,0 +1,14 @@
+import { useExcalidrawActionManager } from "../App";
+import { actionSaveToActiveFile } from "../../actions";
+function FileName(props: any) {
+  const actionManager = useExcalidrawActionManager();
+  return (
+    <>
+      <span onClick={() => actionManager.executeAction(actionSaveToActiveFile)}>
+        <b>{props.name.slice(0, -11)}</b>
+      </span>
+    </>
+  );
+}
+
+export default FileName;

--- a/src/components/main-menu/DefaultItems.scss
+++ b/src/components/main-menu/DefaultItems.scss
@@ -19,3 +19,10 @@
     }
   }
 }
+
+.fileNameFlexBox{
+  display:flex;
+  flex-direction: row;
+  gap: 4px;
+  align-items: center;
+}

--- a/src/components/main-menu/MainMenu.tsx
+++ b/src/components/main-menu/MainMenu.tsx
@@ -1,5 +1,9 @@
 import React from "react";
-import { useDevice, useExcalidrawSetAppState } from "../App";
+import {
+  useDevice,
+  useExcalidrawSetAppState,
+  useExcalidrawAppState,
+} from "../App";
 import DropdownMenu from "../dropdownMenu/DropdownMenu";
 
 import * as DefaultItems from "./DefaultItems";
@@ -11,6 +15,7 @@ import { withInternalFallback } from "../hoc/withInternalFallback";
 import { composeEventHandlers } from "../../utils";
 import { useTunnels } from "../../context/tunnels";
 import { useUIAppState } from "../../context/ui-appState";
+import FileName from "../fileName/fileName";
 
 const MainMenu = Object.assign(
   withInternalFallback(
@@ -29,41 +34,49 @@ const MainMenu = Object.assign(
       const device = useDevice();
       const appState = useUIAppState();
       const setAppState = useExcalidrawSetAppState();
+      const excaliAppState = useExcalidrawAppState();
       const onClickOutside = device.isMobile
         ? undefined
         : () => setAppState({ openMenu: null });
 
       return (
         <MainMenuTunnel.In>
-          <DropdownMenu open={appState.openMenu === "canvas"}>
-            <DropdownMenu.Trigger
-              onToggle={() => {
-                setAppState({
-                  openMenu: appState.openMenu === "canvas" ? null : "canvas",
-                });
-              }}
-              data-testid="main-menu-trigger"
-            >
-              {HamburgerMenuIcon}
-            </DropdownMenu.Trigger>
-            <DropdownMenu.Content
-              onClickOutside={onClickOutside}
-              onSelect={composeEventHandlers(onSelect, () => {
-                setAppState({ openMenu: null });
-              })}
-            >
-              {children}
-              {device.isMobile && appState.collaborators.size > 0 && (
-                <fieldset className="UserList-Wrapper">
-                  <legend>{t("labels.collaborators")}</legend>
-                  <UserList
-                    mobile={true}
-                    collaborators={appState.collaborators}
-                  />
-                </fieldset>
-              )}
-            </DropdownMenu.Content>
-          </DropdownMenu>
+          <div className="fileNameFlexBox">
+            <DropdownMenu open={appState.openMenu === "canvas"}>
+              <DropdownMenu.Trigger
+                onToggle={() => {
+                  setAppState({
+                    openMenu: appState.openMenu === "canvas" ? null : "canvas",
+                  });
+                }}
+                data-testid="main-menu-trigger"
+              >
+                {HamburgerMenuIcon}
+              </DropdownMenu.Trigger>
+              <DropdownMenu.Content
+                onClickOutside={onClickOutside}
+                onSelect={composeEventHandlers(onSelect, () => {
+                  setAppState({ openMenu: null });
+                })}
+              >
+                {children}
+                {device.isMobile && appState.collaborators.size > 0 && (
+                  <fieldset className="UserList-Wrapper">
+                    <legend>{t("labels.collaborators")}</legend>
+                    <UserList
+                      mobile={true}
+                      collaborators={appState.collaborators}
+                    />
+                  </fieldset>
+                )}
+              </DropdownMenu.Content>
+            </DropdownMenu>
+            {excaliAppState.fileHandle !== null && !device.isMobile ? (
+              <span>
+                <FileName name={excaliAppState.fileHandle.name}></FileName>
+              </span>
+            ) : null}
+          </div>
         </MainMenuTunnel.In>
       );
     },


### PR DESCRIPTION
Fixes issue #1674 

- [X] Shows the filename next to the main menu button like this:
![image](https://github.com/excalidraw/excalidraw/assets/57312417/c27e6f30-b609-4ad1-9d49-16da9c668a85)
- [X] Displays it only when you are working on a saved file or if you have opened a file: `appState.fileHandle` is defined
- [X] On clicking the file name text it 'saves to current file'

