### PR TITLE
fix: use pull request in semantic workflow for better security

### DIFF
--- a/.github/workflows/semantic-pr-title.yml
+++ b/.github/workflows/semantic-pr-title.yml
@@ -1,11 +1,7 @@
 name: Semantic PR title
 
 on:
-  pull_request_target:
-    types:
-      - opened
-      - edited
-      - synchronize
+  pull_request:
 
 jobs:
   semantic:

--- a/.github/workflows/semantic-pr-title.yml
+++ b/.github/workflows/semantic-pr-title.yml
@@ -2,6 +2,10 @@ name: Semantic PR title
 
 on:
   pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
 
 jobs:
   semantic:


### PR DESCRIPTION
Here is a nice article on how `pull_request_target` differs from `pull_request` https://securitylab.github.com/research/github-actions-preventing-pwn-requests/

As per `semantic-pr-title` it shouldn't need a write permission hence changing to `pull_request`