### PR TITLE
feat: adds support for stackblitz.com embeds

### DIFF
--- a/src/element/embeddable.ts
+++ b/src/element/embeddable.ts
@@ -52,6 +52,7 @@ const ALLOWED_DOMAINS = new Set([
   "link.excalidraw.com",
   "gist.github.com",
   "twitter.com",
+  "stackblitz.com",
 ]);
 
 const createSrcDoc = (body: string) => {


### PR DESCRIPTION
Adds `stackblitz.com` to the `ALLOWED_DOMAINS` list, making it possible to embed StackBlitz demos into Excalidraw. 
(You can read more on StackBlitz embeds in the [official docs](https://developer.stackblitz.com/guides/integration/embedding))

closes https://github.com/excalidraw/excalidraw/issues/6805

See the behavior in the video below using the following [embedded URL](https://stackblitz.com/edit/dvh?embed=1&file=style.css) as an example:

https://github.com/excalidraw/excalidraw/assets/1511906/3eb7a888-22d6-4edf-a6a6-53d31d136e3c

