### PR TITLE
feat: add support for val.town embeds

### DIFF
--- a/src/element/embeddable.ts
+++ b/src/element/embeddable.ts
@@ -40,6 +40,9 @@ const RE_TWITTER = /(?:http(?:s)?:\/\/)?(?:(?:w){3}.)?twitter.com/;
 const RE_TWITTER_EMBED =
   /^<blockquote[\s\S]*?\shref=["'](https:\/\/twitter.com\/[^"']*)/i;
 
+const RE_VALTOWN =
+  /^https:\/\/(?:www\.)?val.town\/(v|embed)\/[a-zA-Z_$][0-9a-zA-Z_$]+\.[a-zA-Z_$][0-9a-zA-Z_$]+/;
+
 const RE_GENERIC_EMBED =
   /^<(?:iframe|blockquote)[\s\S]*?\s(?:src|href)=["']([^"']*)["'][\s\S]*?>$/i;
 
@@ -53,6 +56,7 @@ const ALLOWED_DOMAINS = new Set([
   "gist.github.com",
   "twitter.com",
   "stackblitz.com",
+  "val.town",
 ]);
 
 const createSrcDoc = (body: string) => {
@@ -118,6 +122,14 @@ export const getEmbedLink = (link: string | null | undefined): EmbeddedLink => {
       link,
     )}`;
     aspectRatio = { w: 550, h: 550 };
+    embeddedLinkCache.set(originalLink, { link, aspectRatio, type });
+    return { link, aspectRatio, type };
+  }
+
+  const valLink = link.match(RE_VALTOWN);
+  if (valLink) {
+    link =
+      valLink[1] === "embed" ? valLink[0] : valLink[0].replace("/v", "/embed");
     embeddedLinkCache.set(originalLink, { link, aspectRatio, type });
     return { link, aspectRatio, type };
   }


### PR DESCRIPTION
Make it possible to embed vals in excalidraw drawings.

> Val Town is a social website to write and run code. 
> 
> You write JavaScript/TypeScript on our website and we run it on our servers. Create APIs, scheduled functions, email yourself, and persist small pieces of data — all from the browser and instantly deployed.

<img width="1624" alt="image" src="https://github.com/excalidraw/excalidraw/assets/17577332/20eb9f1b-04b6-4308-b80a-90b9bcdebc54">
