### PR TITLE
fix: Can't vertical align when empty container in selection.

### DIFF
--- a/src/actions/actionProperties.tsx
+++ b/src/actions/actionProperties.tsx
@@ -870,7 +870,11 @@ export const actionChangeVerticalAlign = register({
             },
           ]}
           value={getFormValue(
-            elements,
+            elements.filter(
+              (el) =>
+                (isTextElement(el) && el.containerId) ||
+                getBoundTextElement(el) !== null,
+            ),
             appState,
             (element) => {
               if (isTextElement(element) && element.containerId) {


### PR DESCRIPTION
If there is no common value for the verticalAlign property in the selection, the middle vertical align button will be highlighted by default:
![Screenshot(23)](https://github.com/excalidraw/excalidraw/assets/19372367/e83a5257-70c9-4460-be84-852a2f1d88d4)

Because of this, when there are elements in the selection that have no verticalAlign property, the default value is always set to "middle," and the user can't set the vertical align of the relevant elements to "middle."

![Screenshot(17)](https://github.com/excalidraw/excalidraw/assets/19372367/6626a64b-09f6-4be5-b103-924e84c83632)

For example, in this selection, the vertical align can never be set to middle. Nothing happens when I click the middle button.

### My Fix: Only elements that are relevant to the action being performed should be sent to the getFormValue() function.