### PR TITLE
docs: add note for tests that have requisites

### DIFF
--- a/dev-docs/docs/introduction/contributing.mdx
+++ b/dev-docs/docs/introduction/contributing.mdx
@@ -70,8 +70,7 @@ It's also a good idea to consider if your change should include additional tests
 Finally - always manually test your changes using the convenient staging environment deployed for each pull request. As much as local development attempts to replicate production, there can still be subtle differences in behavior. For larger features consider testing your change in multiple browsers as well.
 
 :::note
-Some tests require aproval from the maintainers to run. 
-These tests are the `lint`, `semantic` and `test` tests.
+Some checks, such as the `lint` and `test`, require approval from the maintainers to run. 
 They will appear as `Expected — Waiting for status to be reported` in the PR checks when they are waiting for approval.
 :::
 

--- a/dev-docs/docs/introduction/contributing.mdx
+++ b/dev-docs/docs/introduction/contributing.mdx
@@ -69,6 +69,11 @@ It's also a good idea to consider if your change should include additional tests
 
 Finally - always manually test your changes using the convenient staging environment deployed for each pull request. As much as local development attempts to replicate production, there can still be subtle differences in behavior. For larger features consider testing your change in multiple browsers as well.
 
+:::note
+Some tests require aproval from the maintainers to run. 
+These tests are the `lint`, `semantic` and `test` tests.
+They will appear as `Expected — Waiting for status to be reported` in the PR checks when they are waiting for approval.
+:::
 
 ## Translating
 


### PR DESCRIPTION
- add a note admonition that species tests that require aproval before they are run to the contributing documentation.