### PR TITLE
perf: Limiting the suggested binding to fix performance issue

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -7379,6 +7379,9 @@ class App extends React.Component<AppProps, AppState> {
   private maybeSuggestBindingForAll(
     selectedElements: NonDeleted<ExcalidrawElement>[],
   ): void {
+    if (selectedElements.length > 50) {
+      return;
+    }
     const suggestedBindings = getEligibleElementsForBinding(selectedElements);
     this.setState({ suggestedBindings });
   }


### PR DESCRIPTION
Enhancing #6262
Limiting the suggested  binding to fix performance issue, for now to 50

Root cause problem :  on selection of multiple shapes containing  arrows, on movement it starts comparing for binding with each arrows to shapes, leads to performance issue; which we here limit it to 50 

Fix : when more than 50 shapes selected we skip binding comparing

