### PR TITLE
docs: Changed codesanbox steps in contributing.mdx and added links to integration.mdx

### DIFF
--- a/dev-docs/docs/@excalidraw/excalidraw/integration.mdx
+++ b/dev-docs/docs/@excalidraw/excalidraw/integration.mdx
@@ -1,5 +1,11 @@
 # Integration
 
+See [here](https://marketplace.visualstudio.com/items?itemName=pomdtr.excalidraw-editor) for VSCode intergration
+
+See [here](https://www.npmjs.com/package/@excalidraw/excalidraw) for npm package
+
+[Use Directly in Browser](https://docs.excalidraw.com/docs/@excalidraw/excalidraw/integration#browser)
+
 ## Module bundler
 
 If you are using a module bundler (for instance, Webpack), you can import it as an ES6 module as shown below
@@ -50,6 +56,8 @@ export default function App() {
 The `types` are available at `@excalidraw/excalidraw/types`, you can view [example for typescript](https://codesandbox.io/s/excalidraw-types-9h2dm)
 
 ## Browser
+
+Excalidraw can be rendered directly in your browser.
 
 To use it in a browser directly:
 

--- a/dev-docs/docs/introduction/contributing.mdx
+++ b/dev-docs/docs/introduction/contributing.mdx
@@ -26,11 +26,11 @@ In case you want to pick up something from the roadmap, comment on that issue an
 ### Option 2 - CodeSandbox
 
 1. Go to https://codesandbox.io/p/github/excalidraw/excalidraw
-1. Connect your GitHub account (Sign in on top left corner)
+1. Connect your GitHub account (Sign in on the top left corner)
 1. Tap on `Create Branch` in the top right corner
 1. Click on the page icon on the left-hand side to access files
 1. Write code
-1. Commit and PR automatically by clicking on the Pull request symbol in the left-hand side
+1. Commit and PR automatically by clicking on the Pull request symbol on the left-hand side
 
 ## Pull Request Guidelines
 

--- a/dev-docs/docs/introduction/contributing.mdx
+++ b/dev-docs/docs/introduction/contributing.mdx
@@ -26,11 +26,11 @@ In case you want to pick up something from the roadmap, comment on that issue an
 ### Option 2 - CodeSandbox
 
 1. Go to https://codesandbox.io/p/github/excalidraw/excalidraw
-1. Connect your GitHub account
-1. Go to Git tab on left side
-1. Tap on `Fork Sandbox`
-1. Write your code
-1. Commit and PR automatically
+1. Connect your GitHub account (Sign in on top left corner)
+1. Tap on `Create Branch` in the top right corner
+1. Click on the page icon on the left-hand side to access files
+1. Write code
+1. Commit and PR automatically by clicking on the Pull request symbol in the left-hand side
 
 ## Pull Request Guidelines
 


### PR DESCRIPTION
I changed the steps for the codesandbox section in Setup for the contributing docs. The instructions were incorrect and couldn't be executed. I added a few links to the beginning of the integration section of the docs along with a few clarification sentences at the bottom of the page. The links link to sections in the integration section as well as a link to the VSCode extension.