### PR TITLE
fix: stale labeled arrow bounds cache after editing the label

### DIFF
--- a/src/element/textWysiwyg.test.tsx
+++ b/src/element/textWysiwyg.test.tsx
@@ -1511,7 +1511,7 @@ describe("textWysiwyg", () => {
     });
   });
 
-  it.only("should update labeled arrow version", async () => {
+  it("should update labeled arrow version", async () => {
     await render(<ExcalidrawApp />);
     const arrow = UI.createElement("arrow", {
       width: 300,

--- a/src/element/textWysiwyg.test.tsx
+++ b/src/element/textWysiwyg.test.tsx
@@ -1511,21 +1511,21 @@ describe("textWysiwyg", () => {
     });
   });
 
-  it("should update labeled arrow bounds", async () => {
+  it.only("should update labeled arrow version", async () => {
     await render(<ExcalidrawApp />);
     const arrow = UI.createElement("arrow", {
       width: 300,
       height: 0,
     });
 
+    mouse.select(arrow);
     Keyboard.keyPress(KEYS.ENTER);
     let editor = getTextEditor();
     await new Promise((r) => setTimeout(r, 0));
     updateTextEditor(editor, "Hello");
     editor.blur();
 
-    const bounds = getElementBounds(arrow.get());
-    const lineHeight = bounds[3] - bounds[1];
+    const { version } = arrow;
 
     mouse.select(arrow);
     Keyboard.keyPress(KEYS.ENTER);
@@ -1534,9 +1534,6 @@ describe("textWysiwyg", () => {
     updateTextEditor(editor, "Hello\nworld!");
     editor.blur();
 
-    const newBounds = getElementBounds(arrow.get());
-
-    expect(newBounds[1]).toBeCloseTo(bounds[1] - lineHeight / 2);
-    expect(newBounds[3]).toBeCloseTo(bounds[3] + lineHeight / 2);
+    expect(arrow.version).toEqual(version + 1);
   });
 });

--- a/src/element/textWysiwyg.test.tsx
+++ b/src/element/textWysiwyg.test.tsx
@@ -19,6 +19,7 @@ import { API } from "../tests/helpers/api";
 import { mutateElement } from "./mutateElement";
 import { resize } from "../tests/utils";
 import { getOriginalContainerHeightFromCache } from "./textWysiwyg";
+import { getElementBounds } from ".";
 
 // Unmount ReactDOM from root
 ReactDOM.unmountComponentAtNode(document.getElementById("root")!);
@@ -1508,5 +1509,34 @@ describe("textWysiwyg", () => {
       expect(text.containerId).toBe(null);
       expect(text.text).toBe("Excalidraw");
     });
+  });
+
+  it("should update labeled arrow bounds", async () => {
+    await render(<ExcalidrawApp />);
+    const arrow = UI.createElement("arrow", {
+      width: 300,
+      height: 0,
+    });
+
+    Keyboard.keyPress(KEYS.ENTER);
+    let editor = getTextEditor();
+    await new Promise((r) => setTimeout(r, 0));
+    updateTextEditor(editor, "Hello");
+    editor.blur();
+
+    const bounds = getElementBounds(arrow.get());
+    const lineHeight = bounds[3] - bounds[1];
+
+    mouse.select(arrow);
+    Keyboard.keyPress(KEYS.ENTER);
+    editor = getTextEditor();
+    await new Promise((r) => setTimeout(r, 0));
+    updateTextEditor(editor, "Hello\nworld!");
+    editor.blur();
+
+    const newBounds = getElementBounds(arrow.get());
+
+    expect(newBounds[1]).toBeCloseTo(bounds[1] - lineHeight / 2);
+    expect(newBounds[3]).toBeCloseTo(bounds[3] + lineHeight / 2);
   });
 });

--- a/src/element/textWysiwyg.test.tsx
+++ b/src/element/textWysiwyg.test.tsx
@@ -19,7 +19,6 @@ import { API } from "../tests/helpers/api";
 import { mutateElement } from "./mutateElement";
 import { resize } from "../tests/utils";
 import { getOriginalContainerHeightFromCache } from "./textWysiwyg";
-import { getElementBounds } from ".";
 
 // Unmount ReactDOM from root
 ReactDOM.unmountComponentAtNode(document.getElementById("root")!);

--- a/src/element/textWysiwyg.test.tsx
+++ b/src/element/textWysiwyg.test.tsx
@@ -1510,7 +1510,7 @@ describe("textWysiwyg", () => {
     });
   });
 
-  it("should update labeled arrow version", async () => {
+  it("should bump the version of labelled arrow when label updated", async () => {
     await render(<ExcalidrawApp />);
     const arrow = UI.createElement("arrow", {
       width: 300,

--- a/src/element/textWysiwyg.tsx
+++ b/src/element/textWysiwyg.tsx
@@ -20,7 +20,7 @@ import {
   ExcalidrawTextContainer,
 } from "./types";
 import { AppState } from "../types";
-import { mutateElement } from "./mutateElement";
+import { bumpVersion, mutateElement } from "./mutateElement";
 import {
   getBoundTextElementId,
   getContainerElement,
@@ -541,6 +541,9 @@ export const textWysiwyg = ({
               id: element.id,
             }),
           });
+        } else if (isArrowElement(container)) {
+          // updating an arrow label may change bounds, prevent stale cache:
+          bumpVersion(container);
         }
       } else {
         mutateElement(container, {


### PR DESCRIPTION
fix #6721 