### PR TITLE
fix: utils build

### DIFF
--- a/src/packages/utils/package.json
+++ b/src/packages/utils/package.json
@@ -58,5 +58,8 @@
     "build:umd": "cross-env NODE_ENV=production webpack --config webpack.prod.config.js",
     "build:umd:withAnalyzer": "cross-env NODE_ENV=production ANALYZER=true webpack --config webpack.prod.config.js",
     "pack": "yarn build:umd && yarn pack"
+  },
+  "dependencies": {
+    "style-loader": "3.3.3"
   }
 }

--- a/src/packages/utils/webpack.prod.config.js
+++ b/src/packages/utils/webpack.prod.config.js
@@ -21,12 +21,18 @@ module.exports = {
   module: {
     rules: [
       {
+        test: /\.mjs$/,
+        include: /node_modules/,
+        type: "javascript/auto"
+      },
+      {
         test: /\.(sa|sc|c)ss$/,
         exclude: /node_modules/,
         use: ["style-loader", { loader: "css-loader" }, "sass-loader"],
       },
       {
         test: /\.(ts|tsx|js)$/,
+        exclude: /node_modules\/@babel\/runtime/,
         use: [
           {
             loader: "ts-loader",

--- a/src/packages/utils/yarn.lock
+++ b/src/packages/utils/yarn.lock
@@ -2330,6 +2330,11 @@ strip-ansi@^3.0.0:
   dependencies:
     ansi-regex "^2.0.0"
 
+style-loader@3.3.3:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/style-loader/-/style-loader-3.3.3.tgz#bba8daac19930169c0c9c96706749a597ae3acff"
+  integrity sha512-53BiGLXAcll9maCYtZi2RCQZKa8NQQai5C4horqKyRmHj9H7QmcUyucrH+4KW/gBQbXM2AsB0axoEcFZPlfPcw==
+
 supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"


### PR DESCRIPTION
https://github.com/excalidraw/excalidraw/issues/6907

Issue: The project couldn't resolve the style-loader dependency.
Error:

vbnet

Module not found: Error: Can't resolve 'style-loader' ...

Solution: Added "style-loader": "3.3.3" to the dependencies in package.json.

Issue: There was a parsing error due to the presence of ES6 modules in the node_modules directory with the .mjs extension.
Error:

bash

ERROR in ../../../node_modules/jotai/esm/index.mjs ...
export 'createContext' (imported as 'createContext') was not found in 'react'...

Solution: Added a rule in webpack.prod.config.js to treat .mjs files from node_modules as javascript/auto.

javascript

{
    test: /\.mjs$/,
    include: /node_modules/,
    type: "javascript/auto"
},

Issue: Babel's runtime had some issue while being parsed in the webpack process.
Error:

sql

ERROR in ../../../node_modules/@babel/runtime/regenerator/index.js ...
Module parse failed: 'import' and 'export' may appear only with 'sourceType: module'...

Solution: Excluded the @babel/runtime from the TypeScript and Babel loaders rule in webpack.prod.config.js.

javascript

{
    test: /\.(ts|tsx|js)$/,
    exclude: /node_modules\/@babel\/runtime/,
    ...
}