### PR TITLE
fix: z-index inconsistencies during addition / deletion in frames

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -6501,7 +6501,7 @@ class App extends React.Component<AppProps, AppState> {
             }
 
             nextElements = updateFrameMembershipOfSelectedElements(
-              this.scene.getElementsIncludingDeleted(),
+              nextElements,
               this.state,
               this,
             );

--- a/src/frame.test.tsx
+++ b/src/frame.test.tsx
@@ -1,3 +1,4 @@
+import { ExcalidrawElement } from "./element/types";
 import {
   convertToExcalidrawElements,
   Excalidraw,
@@ -28,7 +29,20 @@ describe("adding elements to frames", () => {
     }, []);
   };
 
-  describe("resizing frame over elements", () => {
+  function resizeFrameOverElement(
+    frame: ExcalidrawElement,
+    element: ExcalidrawElement,
+  ) {
+    mouse.clickAt(0, 0);
+    mouse.downAt(frame.x + frame.width, frame.y + frame.height);
+    mouse.moveTo(
+      element.x + element.width + 50,
+      element.y + element.height + 50,
+    );
+    mouse.up();
+  }
+
+  describe("resizing frame over all elements", () => {
     const testElements = async (
       containerType: "arrow" | "rectangle",
       initialOrder: ElementType[],
@@ -61,13 +75,7 @@ describe("adding elements to frames", () => {
 
       const container = h.elements[1];
 
-      mouse.clickAt(0, 0);
-      mouse.downAt(frame.x + frame.width, frame.y + frame.height);
-      mouse.moveTo(
-        container.x + container.width + 100,
-        container.y + container.height + 100,
-      );
-      mouse.up();
+      resizeFrameOverElement(frame, container);
       assertOrder(h.elements, expectedOrder);
 
       expect(h.elements[0].frameId).toBe(frame.id);
@@ -93,7 +101,7 @@ describe("adding elements to frames", () => {
       await testElements(
         "rectangle",
         ["text", "rectangle", "frame"],
-        ["text", "rectangle", "frame"],
+        ["rectangle", "text", "frame"],
       );
 
       await testElements(
@@ -104,7 +112,7 @@ describe("adding elements to frames", () => {
       await testElements(
         "arrow",
         ["text", "arrow", "frame"],
-        ["text", "arrow", "frame"],
+        ["arrow", "text", "frame"],
       );
 
       // FIXME failing in tests (it fails to add elements to frame for some
@@ -123,6 +131,208 @@ describe("adding elements to frames", () => {
       //   ["frame", "text", "arrow"],
       //   ["text", "arrow", "frame"],
       // );
+    });
+  });
+
+  /**
+   * TODO:
+   * dragging element into the frame
+   *
+   * selecting frame (mouseClick) should not call "addElementsToFrame"
+   * removing element from frame should not again call "addElementsToFrame"
+   * - related, "existingElements" are empty in tests due to this, but no in browser
+   */
+  describe("resizing frame over rectangles one by one", async () => {
+    let frame: ExcalidrawElement;
+    let rect1: ExcalidrawElement;
+    let rect2: ExcalidrawElement;
+    let rect3: ExcalidrawElement;
+    let rect4: ExcalidrawElement;
+
+    beforeEach(async () => {
+      await render(<Excalidraw />);
+
+      frame = API.createElement({ id: "id0", type: "frame", x: 0, y: 0 });
+      rect1 = API.createElement({
+        id: "id1",
+        type: "rectangle",
+        x: -1000,
+        y: -1000,
+      });
+      rect2 = API.createElement({
+        id: "id2",
+        type: "rectangle",
+        x: 100,
+        y: 100,
+      });
+      rect3 = API.createElement({
+        id: "id3",
+        type: "rectangle",
+        x: 200,
+        y: 200,
+      });
+      rect4 = API.createElement({
+        id: "id4",
+        type: "rectangle",
+        x: 1000,
+        y: 1000,
+      });
+    });
+
+    describe("when frame is in a layer below", async () => {
+      it("should add an element", async () => {
+        h.elements = [frame, rect2];
+
+        resizeFrameOverElement(frame, rect2);
+
+        expect(h.elements[0].frameId).toBe(frame.id);
+        expect(h.elements).toEqual([rect2, frame]);
+      });
+
+      it("should add elements", async () => {
+        h.elements = [frame, rect2, rect3];
+
+        resizeFrameOverElement(frame, rect2);
+        resizeFrameOverElement(frame, rect3);
+
+        expect(rect2.frameId).toBe(frame.id);
+        expect(rect3.frameId).toBe(frame.id);
+        expect(h.elements).toEqual([rect2, rect3, frame]);
+      });
+
+      it("should add elements when there are other other elements in between", async () => {
+        h.elements = [frame, rect1, rect2, rect4, rect3];
+
+        resizeFrameOverElement(frame, rect2);
+        resizeFrameOverElement(frame, rect3);
+
+        expect(rect2.frameId).toBe(frame.id);
+        expect(rect3.frameId).toBe(frame.id);
+        expect(h.elements).toEqual([rect2, rect3, frame, rect1, rect4]);
+      });
+
+      it("should add elements when there are other elements in between and the order is reversed", async () => {
+        h.elements = [frame, rect3, rect4, rect2, rect1];
+
+        resizeFrameOverElement(frame, rect2);
+        resizeFrameOverElement(frame, rect3);
+
+        expect(rect2.frameId).toBe(frame.id);
+        expect(rect3.frameId).toBe(frame.id);
+        expect(h.elements).toEqual([rect2, rect3, frame, rect4, rect1]);
+      });
+
+      it("should add elements when resizing down", async () => {
+        h.elements = [frame, rect1, rect2, rect3, rect4];
+
+        resizeFrameOverElement(frame, rect4);
+        resizeFrameOverElement(frame, rect3);
+
+        expect(rect2.frameId).toBe(frame.id);
+        expect(rect3.frameId).toBe(frame.id);
+        expect(h.elements).toEqual([rect2, rect3, frame, rect4, rect1]);
+      });
+    });
+
+    describe("when frame is in a layer above", async () => {
+      it("should add an element", async () => {
+        h.elements = [rect2, frame];
+
+        resizeFrameOverElement(frame, rect2);
+
+        expect(h.elements[0].frameId).toBe(frame.id);
+        expect(h.elements).toEqual([rect2, frame]);
+      });
+
+      it("should add elements", async () => {
+        h.elements = [rect2, rect3, frame];
+
+        resizeFrameOverElement(frame, rect2);
+        resizeFrameOverElement(frame, rect3);
+
+        expect(rect2.frameId).toBe(frame.id);
+        expect(rect3.frameId).toBe(frame.id);
+        expect(h.elements).toEqual([rect3, rect2, frame]);
+      });
+
+      it("should add elements when there are other other elements in between", async () => {
+        h.elements = [rect1, rect2, rect4, rect3, frame];
+
+        resizeFrameOverElement(frame, rect2);
+        resizeFrameOverElement(frame, rect3);
+
+        expect(rect2.frameId).toBe(frame.id);
+        expect(rect3.frameId).toBe(frame.id);
+        expect(h.elements).toEqual([rect1, rect4, rect3, rect2, frame]);
+      });
+
+      it("should add elements when there are other elements in between and the order is reversed", async () => {
+        h.elements = [rect3, rect4, rect2, rect1, frame];
+
+        resizeFrameOverElement(frame, rect2);
+        resizeFrameOverElement(frame, rect3);
+
+        expect(rect2.frameId).toBe(frame.id);
+        expect(rect3.frameId).toBe(frame.id);
+        expect(h.elements).toEqual([rect4, rect1, rect3, rect2, frame]);
+      });
+
+      it("should add elements when resizing down", async () => {
+        h.elements = [rect1, rect2, rect3, rect4, frame];
+
+        resizeFrameOverElement(frame, rect4);
+        resizeFrameOverElement(frame, rect3);
+
+        expect(rect2.frameId).toBe(frame.id);
+        expect(rect3.frameId).toBe(frame.id);
+        expect(h.elements).toEqual([rect1, rect2, rect3, frame, rect4]);
+      });
+    });
+
+    describe("when frame is in an inner layer", async () => {
+      it("should add elements", async () => {
+        h.elements = [rect2, frame, rect3];
+
+        resizeFrameOverElement(frame, rect2);
+        resizeFrameOverElement(frame, rect3);
+
+        expect(rect2.frameId).toBe(frame.id);
+        expect(rect3.frameId).toBe(frame.id);
+        expect(h.elements).toEqual([rect2, rect3, frame]);
+      });
+
+      it("should add elements when there are other other elements in between", async () => {
+        h.elements = [rect2, rect1, frame, rect4, rect3];
+
+        resizeFrameOverElement(frame, rect2);
+        resizeFrameOverElement(frame, rect3);
+
+        expect(rect2.frameId).toBe(frame.id);
+        expect(rect3.frameId).toBe(frame.id);
+        expect(h.elements).toEqual([rect1, rect2, rect3, frame, rect4]);
+      });
+
+      it("should add elements when there are other elements in between and the order is reversed", async () => {
+        h.elements = [rect3, rect4, frame, rect2, rect1];
+
+        resizeFrameOverElement(frame, rect2);
+        resizeFrameOverElement(frame, rect3);
+
+        expect(rect2.frameId).toBe(frame.id);
+        expect(rect3.frameId).toBe(frame.id);
+        expect(h.elements).toEqual([rect4, rect3, rect2, frame, rect1]);
+      });
+
+      it("should add elements when resizing down", async () => {
+        h.elements = [rect1, rect2, frame, rect3, rect4];
+
+        resizeFrameOverElement(frame, rect4);
+        resizeFrameOverElement(frame, rect3);
+
+        expect(rect2.frameId).toBe(frame.id);
+        expect(rect3.frameId).toBe(frame.id);
+        expect(h.elements).toEqual([rect1, rect2, rect3, frame, rect4]);
+      });
     });
   });
 });

--- a/src/frame.test.tsx
+++ b/src/frame.test.tsx
@@ -4,27 +4,11 @@ import {
   Excalidraw,
 } from "./packages/excalidraw/index";
 import { API } from "./tests/helpers/api";
-import { Pointer } from "./tests/helpers/ui";
+import { Keyboard, Pointer } from "./tests/helpers/ui";
 import { render } from "./tests/test-utils";
 
 const { h } = window;
 const mouse = new Pointer("mouse");
-
-/**
- * FIXME!:
- * try to solve the failing tests below
- * unify the test with tests below
- *
- * test more comple cases
- * - bounded text / arrows
- * - different elements (i.e. arrows)
- * - multiple frames
- * - groups containing frames and etc.
- *
- * selecting frame (mouseClick) should not call "addElementsToFrame"
- * removing element from frame should not again call "addElementsToFrame"
- * - related, "existingElements" are empty in tests due to this, but not in browser
- */
 
 describe("adding elements to frames", () => {
   type ElementType = string;
@@ -58,76 +42,287 @@ describe("adding elements to frames", () => {
     mouse.up();
   }
 
-  describe("resizing frame over all elements", () => {
-    const testElements = async (
-      containerType: "arrow" | "rectangle",
-      initialOrder: ElementType[],
-      expectedOrder: ElementType[],
-    ) => {
-      await render(<Excalidraw />);
+  function dragElementIntoFrame(
+    frame: ExcalidrawElement,
+    element: ExcalidrawElement,
+  ) {
+    mouse.clickAt(element.x, element.y);
+    mouse.downAt(element.x + element.width / 2, element.y + element.height / 2);
+    mouse.moveTo(frame.x + frame.width / 2, frame.y + frame.height / 2);
+    mouse.up();
+  }
 
-      const frame = API.createElement({ type: "frame", x: 0, y: 0 });
+  function selectElementAndDuplicate(
+    element: ExcalidrawElement,
+    moveTo: [number, number] = [element.x + 25, element.y + 25],
+  ) {
+    const [x, y] = [
+      element.x + element.width / 2,
+      element.y + element.height / 2,
+    ];
 
-      h.elements = reorderElements(
-        [
-          frame,
-          ...convertToExcalidrawElements([
-            {
-              type: containerType,
-              x: 100,
-              y: 100,
-              height: 10,
-              label: { text: "xx" },
-            },
-          ]),
-        ],
-        initialOrder,
-      );
+    Keyboard.withModifierKeys({ alt: true }, () => {
+      mouse.downAt(x, y);
+      mouse.moveTo(moveTo[0], moveTo[1]);
+      mouse.up();
+    });
+  }
 
-      assertOrder(h.elements, initialOrder);
+  function expectEqualIds(expected: ExcalidrawElement[]) {
+    expect(h.elements.map((x) => x.id)).toEqual(expected.map((x) => x.id));
+  }
 
-      expect(h.elements[1].frameId).toBe(null);
-      expect(h.elements[2].frameId).toBe(null);
+  let frame: ExcalidrawElement;
+  let rect1: ExcalidrawElement;
+  let rect2: ExcalidrawElement;
+  let rect3: ExcalidrawElement;
+  let rect4: ExcalidrawElement;
+  let text: ExcalidrawElement;
+  let arrow: ExcalidrawElement;
 
-      const container = h.elements[1];
+  beforeEach(async () => {
+    await render(<Excalidraw />);
 
-      resizeFrameOverElement(frame, container);
-      assertOrder(h.elements, expectedOrder);
+    frame = API.createElement({ id: "id0", type: "frame", x: 0, width: 150 });
+    rect1 = API.createElement({
+      id: "id1",
+      type: "rectangle",
+      x: -1000,
+    });
+    rect2 = API.createElement({
+      id: "id2",
+      type: "rectangle",
+      x: 200,
+      width: 50,
+    });
+    rect3 = API.createElement({
+      id: "id3",
+      type: "rectangle",
+      x: 400,
+      width: 50,
+    });
+    rect4 = API.createElement({
+      id: "id4",
+      type: "rectangle",
+      x: 1000,
+      width: 50,
+    });
+    text = API.createElement({
+      id: "id5",
+      type: "text",
+      x: 100,
+    });
+    arrow = API.createElement({
+      id: "id6",
+      type: "arrow",
+      x: 100,
+      boundElements: [{ id: text.id, type: "text" }],
+    });
+  });
 
-      expect(h.elements[0].frameId).toBe(frame.id);
-      expect(h.elements[1].frameId).toBe(frame.id);
-    };
+  const commonTestCases = async (
+    func: typeof resizeFrameOverElement | typeof dragElementIntoFrame,
+  ) => {
+    describe("when frame is in a layer below", async () => {
+      it("should add an element", async () => {
+        h.elements = [frame, rect2];
 
-    it("resizing over text containers / labelled arrows", async () => {
-      await testElements(
+        func(frame, rect2);
+
+        expect(h.elements[0].frameId).toBe(frame.id);
+        expectEqualIds([rect2, frame]);
+      });
+
+      it("should add elements", async () => {
+        h.elements = [frame, rect2, rect3];
+
+        func(frame, rect2);
+        func(frame, rect3);
+
+        expect(rect2.frameId).toBe(frame.id);
+        expect(rect3.frameId).toBe(frame.id);
+        expectEqualIds([rect2, rect3, frame]);
+      });
+
+      it("should add elements when there are other other elements in between", async () => {
+        h.elements = [frame, rect1, rect2, rect4, rect3];
+
+        func(frame, rect2);
+        func(frame, rect3);
+
+        expect(rect2.frameId).toBe(frame.id);
+        expect(rect3.frameId).toBe(frame.id);
+        expectEqualIds([rect2, rect3, frame, rect1, rect4]);
+      });
+
+      it("should add elements when there are other elements in between and the order is reversed", async () => {
+        h.elements = [frame, rect3, rect4, rect2, rect1];
+
+        func(frame, rect2);
+        func(frame, rect3);
+
+        expect(rect2.frameId).toBe(frame.id);
+        expect(rect3.frameId).toBe(frame.id);
+        expectEqualIds([rect2, rect3, frame, rect4, rect1]);
+      });
+    });
+
+    describe("when frame is in a layer above", async () => {
+      it("should add an element", async () => {
+        h.elements = [rect2, frame];
+
+        func(frame, rect2);
+
+        expect(h.elements[0].frameId).toBe(frame.id);
+        expectEqualIds([rect2, frame]);
+      });
+
+      it("should add elements", async () => {
+        h.elements = [rect2, rect3, frame];
+
+        func(frame, rect2);
+        func(frame, rect3);
+
+        expect(rect2.frameId).toBe(frame.id);
+        expect(rect3.frameId).toBe(frame.id);
+        expectEqualIds([rect3, rect2, frame]);
+      });
+
+      it("should add elements when there are other other elements in between", async () => {
+        h.elements = [rect1, rect2, rect4, rect3, frame];
+
+        func(frame, rect2);
+        func(frame, rect3);
+
+        expect(rect2.frameId).toBe(frame.id);
+        expect(rect3.frameId).toBe(frame.id);
+        expectEqualIds([rect1, rect4, rect3, rect2, frame]);
+      });
+
+      it("should add elements when there are other elements in between and the order is reversed", async () => {
+        h.elements = [rect3, rect4, rect2, rect1, frame];
+
+        func(frame, rect2);
+        func(frame, rect3);
+
+        expect(rect2.frameId).toBe(frame.id);
+        expect(rect3.frameId).toBe(frame.id);
+        expectEqualIds([rect4, rect1, rect3, rect2, frame]);
+      });
+    });
+
+    describe("when frame is in an inner layer", async () => {
+      it("should add elements", async () => {
+        h.elements = [rect2, frame, rect3];
+
+        func(frame, rect2);
+        func(frame, rect3);
+
+        expect(rect2.frameId).toBe(frame.id);
+        expect(rect3.frameId).toBe(frame.id);
+        expectEqualIds([rect2, rect3, frame]);
+      });
+
+      it("should add elements when there are other other elements in between", async () => {
+        h.elements = [rect2, rect1, frame, rect4, rect3];
+
+        func(frame, rect2);
+        func(frame, rect3);
+
+        expect(rect2.frameId).toBe(frame.id);
+        expect(rect3.frameId).toBe(frame.id);
+        expectEqualIds([rect1, rect2, rect3, frame, rect4]);
+      });
+
+      it("should add elements when there are other elements in between and the order is reversed", async () => {
+        h.elements = [rect3, rect4, frame, rect2, rect1];
+
+        func(frame, rect2);
+        func(frame, rect3);
+
+        expect(rect2.frameId).toBe(frame.id);
+        expect(rect3.frameId).toBe(frame.id);
+        expectEqualIds([rect4, rect3, rect2, frame, rect1]);
+      });
+    });
+  };
+
+  const resizingTest = async (
+    containerType: "arrow" | "rectangle",
+    initialOrder: ElementType[],
+    expectedOrder: ElementType[],
+  ) => {
+    await render(<Excalidraw />);
+
+    const frame = API.createElement({ type: "frame", x: 0, y: 0 });
+
+    h.elements = reorderElements(
+      [
+        frame,
+        ...convertToExcalidrawElements([
+          {
+            type: containerType,
+            x: 100,
+            y: 100,
+            height: 10,
+            label: { text: "xx" },
+          },
+        ]),
+      ],
+      initialOrder,
+    );
+
+    assertOrder(h.elements, initialOrder);
+
+    expect(h.elements[1].frameId).toBe(null);
+    expect(h.elements[2].frameId).toBe(null);
+
+    const container = h.elements[1];
+
+    resizeFrameOverElement(frame, container);
+    assertOrder(h.elements, expectedOrder);
+
+    expect(h.elements[0].frameId).toBe(frame.id);
+    expect(h.elements[1].frameId).toBe(frame.id);
+  };
+
+  describe("resizing frame over elements", async () => {
+    await commonTestCases(resizeFrameOverElement);
+
+    it("resizing over text containers and labelled arrows", async () => {
+      await resizingTest(
         "rectangle",
         ["frame", "rectangle", "text"],
         ["rectangle", "text", "frame"],
       );
-      await testElements(
+      await resizingTest(
         "rectangle",
         ["frame", "text", "rectangle"],
         ["rectangle", "text", "frame"],
       );
-      await testElements(
+      await resizingTest(
         "rectangle",
         ["rectangle", "text", "frame"],
         ["rectangle", "text", "frame"],
       );
-      await testElements(
+      await resizingTest(
         "rectangle",
         ["text", "rectangle", "frame"],
         ["rectangle", "text", "frame"],
       );
-
-      await testElements(
+      await resizingTest(
         "arrow",
         ["frame", "arrow", "text"],
         ["arrow", "text", "frame"],
       );
-      await testElements(
+      await resizingTest(
         "arrow",
         ["text", "arrow", "frame"],
+        ["arrow", "text", "frame"],
+      );
+      await resizingTest(
+        "arrow",
+        ["frame", "arrow", "text"],
         ["arrow", "text", "frame"],
       );
 
@@ -142,186 +337,40 @@ describe("adding elements to frames", () => {
       //   ["arrow", "text", "frame"],
       //   ["arrow", "text", "frame"],
       // );
-      // await testElements(
-      //   "arrow",
-      //   ["frame", "text", "arrow"],
-      //   ["text", "arrow", "frame"],
-      // );
+    });
+
+    it("should add arrow bound with text when frame is in a layer below", async () => {
+      h.elements = [frame, arrow, text];
+
+      resizeFrameOverElement(frame, arrow);
+
+      expect(arrow.frameId).toBe(frame.id);
+      expect(text.frameId).toBe(frame.id);
+      expectEqualIds([arrow, text, frame]);
+    });
+
+    it("should add arrow bound with text when frame is in a layer above", async () => {
+      h.elements = [arrow, text, frame];
+
+      resizeFrameOverElement(frame, arrow);
+
+      expect(arrow.frameId).toBe(frame.id);
+      expect(text.frameId).toBe(frame.id);
+      expectEqualIds([arrow, text, frame]);
+    });
+
+    it("should add arrow bound with text when frame is in an inner layer", async () => {
+      h.elements = [arrow, frame, text];
+
+      resizeFrameOverElement(frame, arrow);
+
+      expect(arrow.frameId).toBe(frame.id);
+      expect(text.frameId).toBe(frame.id);
+      expectEqualIds([arrow, text, frame]);
     });
   });
 
-  function dragElementIntoFrame(
-    frame: ExcalidrawElement,
-    element: ExcalidrawElement,
-  ) {
-    mouse.clickAt(element.x, element.y);
-    mouse.downAt(element.x + element.width / 2, element.y + element.height / 2);
-    mouse.moveTo(frame.x + frame.width / 2, frame.y + frame.height / 2);
-    mouse.up();
-  }
-
-  let frame: ExcalidrawElement;
-  let rect1: ExcalidrawElement;
-  let rect2: ExcalidrawElement;
-  let rect3: ExcalidrawElement;
-  let rect4: ExcalidrawElement;
-
-  beforeEach(async () => {
-    await render(<Excalidraw />);
-
-    frame = API.createElement({ id: "id0", type: "frame", x: 0 });
-    rect1 = API.createElement({
-      id: "id1",
-      type: "rectangle",
-      x: -1000,
-    });
-    rect2 = API.createElement({
-      id: "id2",
-      type: "rectangle",
-      x: 150,
-    });
-    rect3 = API.createElement({
-      id: "id3",
-      type: "rectangle",
-      x: 300,
-    });
-    rect4 = API.createElement({
-      id: "id4",
-      type: "rectangle",
-      x: 1000,
-    });
-  });
-
-  const commonTestCases = async (
-    func: typeof resizeFrameOverElement | typeof dragElementIntoFrame,
-  ) => {
-    describe("when frame is in a layer below", async () => {
-      it("should add an element", async () => {
-        h.elements = [frame, rect2];
-
-        func(frame, rect2);
-
-        expect(h.elements[0].frameId).toBe(frame.id);
-        expect(h.elements).toEqual([rect2, frame]);
-      });
-
-      it("should add elements", async () => {
-        h.elements = [frame, rect2, rect3];
-
-        func(frame, rect2);
-        func(frame, rect3);
-
-        expect(rect2.frameId).toBe(frame.id);
-        expect(rect3.frameId).toBe(frame.id);
-        expect(h.elements).toEqual([rect2, rect3, frame]);
-      });
-
-      it("should add elements when there are other other elements in between", async () => {
-        h.elements = [frame, rect1, rect2, rect4, rect3];
-
-        func(frame, rect2);
-        func(frame, rect3);
-
-        expect(rect2.frameId).toBe(frame.id);
-        expect(rect3.frameId).toBe(frame.id);
-        expect(h.elements).toEqual([rect2, rect3, frame, rect1, rect4]);
-      });
-
-      it("should add elements when there are other elements in between and the order is reversed", async () => {
-        h.elements = [frame, rect3, rect4, rect2, rect1];
-
-        func(frame, rect2);
-        func(frame, rect3);
-
-        expect(rect2.frameId).toBe(frame.id);
-        expect(rect3.frameId).toBe(frame.id);
-        expect(h.elements).toEqual([rect2, rect3, frame, rect4, rect1]);
-      });
-    });
-
-    describe("when frame is in a layer above", async () => {
-      it("should add an element", async () => {
-        h.elements = [rect2, frame];
-
-        func(frame, rect2);
-
-        expect(h.elements[0].frameId).toBe(frame.id);
-        expect(h.elements).toEqual([rect2, frame]);
-      });
-
-      it("should add elements", async () => {
-        h.elements = [rect2, rect3, frame];
-
-        func(frame, rect2);
-        func(frame, rect3);
-
-        expect(rect2.frameId).toBe(frame.id);
-        expect(rect3.frameId).toBe(frame.id);
-        expect(h.elements).toEqual([rect3, rect2, frame]);
-      });
-
-      it("should add elements when there are other other elements in between", async () => {
-        h.elements = [rect1, rect2, rect4, rect3, frame];
-
-        func(frame, rect2);
-        func(frame, rect3);
-
-        expect(rect2.frameId).toBe(frame.id);
-        expect(rect3.frameId).toBe(frame.id);
-        expect(h.elements).toEqual([rect1, rect4, rect3, rect2, frame]);
-      });
-
-      it("should add elements when there are other elements in between and the order is reversed", async () => {
-        h.elements = [rect3, rect4, rect2, rect1, frame];
-
-        func(frame, rect2);
-        func(frame, rect3);
-
-        expect(rect2.frameId).toBe(frame.id);
-        expect(rect3.frameId).toBe(frame.id);
-        expect(h.elements).toEqual([rect4, rect1, rect3, rect2, frame]);
-      });
-    });
-
-    describe("when frame is in an inner layer", async () => {
-      it("should add elements", async () => {
-        h.elements = [rect2, frame, rect3];
-
-        func(frame, rect2);
-        func(frame, rect3);
-
-        expect(rect2.frameId).toBe(frame.id);
-        expect(rect3.frameId).toBe(frame.id);
-        expect(h.elements).toEqual([rect2, rect3, frame]);
-      });
-
-      it("should add elements when there are other other elements in between", async () => {
-        h.elements = [rect2, rect1, frame, rect4, rect3];
-
-        func(frame, rect2);
-        func(frame, rect3);
-
-        expect(rect2.frameId).toBe(frame.id);
-        expect(rect3.frameId).toBe(frame.id);
-        expect(h.elements).toEqual([rect1, rect2, rect3, frame, rect4]);
-      });
-
-      it("should add elements when there are other elements in between and the order is reversed", async () => {
-        h.elements = [rect3, rect4, frame, rect2, rect1];
-
-        func(frame, rect2);
-        func(frame, rect3);
-
-        expect(rect2.frameId).toBe(frame.id);
-        expect(rect3.frameId).toBe(frame.id);
-        expect(h.elements).toEqual([rect4, rect3, rect2, frame, rect1]);
-      });
-    });
-  };
-
-  describe("resizing frame over elements", async () => {
-    await commonTestCases(resizeFrameOverElement);
-
+  describe("resizing frame over elements but downwards", async () => {
     it("should add elements when frame is in a layer below", async () => {
       h.elements = [frame, rect1, rect2, rect3, rect4];
 
@@ -330,7 +379,7 @@ describe("adding elements to frames", () => {
 
       expect(rect2.frameId).toBe(frame.id);
       expect(rect3.frameId).toBe(frame.id);
-      expect(h.elements).toEqual([rect2, rect3, frame, rect4, rect1]);
+      expectEqualIds([rect2, rect3, frame, rect4, rect1]);
     });
 
     it("should add elements when frame is in a layer above", async () => {
@@ -341,10 +390,10 @@ describe("adding elements to frames", () => {
 
       expect(rect2.frameId).toBe(frame.id);
       expect(rect3.frameId).toBe(frame.id);
-      expect(h.elements).toEqual([rect1, rect2, rect3, frame, rect4]);
+      expectEqualIds([rect1, rect2, rect3, frame, rect4]);
     });
 
-    it("should add elements when is in an inner layer", async () => {
+    it("should add elements when frame is in an inner layer", async () => {
       h.elements = [rect1, rect2, frame, rect3, rect4];
 
       resizeFrameOverElement(frame, rect4);
@@ -352,11 +401,40 @@ describe("adding elements to frames", () => {
 
       expect(rect2.frameId).toBe(frame.id);
       expect(rect3.frameId).toBe(frame.id);
-      expect(h.elements).toEqual([rect1, rect2, rect3, frame, rect4]);
+      expectEqualIds([rect1, rect2, rect3, frame, rect4]);
     });
   });
 
   describe("dragging elements into the frame", async () => {
     await commonTestCases(dragElementIntoFrame);
+
+    it("should drag element inside, duplicate it and keep it in frame", () => {
+      h.elements = [frame, rect2];
+
+      dragElementIntoFrame(frame, rect2);
+
+      const rect2_copy = { ...rect2, id: `${rect2.id}_copy` };
+
+      selectElementAndDuplicate(rect2);
+
+      expect(rect2_copy.frameId).toBe(frame.id);
+      expect(rect2.frameId).toBe(frame.id);
+      expectEqualIds([rect2_copy, rect2, frame]);
+    });
+
+    it("should drag element inside, duplicate it and remove it from frame", () => {
+      h.elements = [frame, rect2];
+
+      dragElementIntoFrame(frame, rect2);
+
+      const rect2_copy = { ...rect2, id: `${rect2.id}_copy` };
+
+      // move the rect2 outside the frame
+      selectElementAndDuplicate(rect2, [-1000, -1000]);
+
+      expect(rect2_copy.frameId).toBe(frame.id);
+      expect(rect2.frameId).toBe(null);
+      expectEqualIds([rect2_copy, frame, rect2]);
+    });
   });
 });

--- a/src/frame.test.tsx
+++ b/src/frame.test.tsx
@@ -1,3 +1,4 @@
+// TODO rewrite tests since now it does not depends on the order
 import {
   convertToExcalidrawElements,
   Excalidraw,

--- a/src/frame.test.tsx
+++ b/src/frame.test.tsx
@@ -1,4 +1,3 @@
-// TODO rewrite tests since now it does not depends on the order
 import {
   convertToExcalidrawElements,
   Excalidraw,

--- a/src/frame.ts
+++ b/src/frame.ts
@@ -14,12 +14,11 @@ import {
   getBoundTextElement,
   getContainerElement,
 } from "./element/textElement";
-import { arrayToMap, findIndex } from "./utils";
+import { arrayToMap } from "./utils";
 import { mutateElement } from "./element/mutateElement";
 import { AppClassProperties, AppState, StaticCanvasAppState } from "./types";
 import { getElementsWithinSelection, getSelectedElements } from "./scene";
 import { isFrameElement } from "./element";
-import { moveOneRight } from "./zindex";
 import { getElementsInGroup, selectGroupsFromGivenElements } from "./groups";
 import Scene, { ExcalidrawElementsIncludingDeleted } from "./scene/Scene";
 import { getElementLineSegments } from "./element/bounds";
@@ -468,9 +467,6 @@ export const addElementsToFrame = (
     }
   }
 
-  let nextElements = allElements.slice();
-
-  const frameBoundary = findIndex(nextElements, (e) => e.frameId === frame.id);
   for (const element of omitGroupsContainingFrames(
     allElements,
     _elementsToAdd,
@@ -483,35 +479,17 @@ export const addElementsToFrame = (
         },
         false,
       );
-
-      const frameIndex = findIndex(nextElements, (e) => e.id === frame.id);
-      const elementIndex = findIndex(nextElements, (e) => e.id === element.id);
-
-      if (elementIndex < frameBoundary) {
-        nextElements = [
-          ...nextElements.slice(0, elementIndex),
-          ...nextElements.slice(elementIndex + 1, frameBoundary),
-          element,
-          ...nextElements.slice(frameBoundary),
-        ];
-      } else if (elementIndex > frameIndex) {
-        nextElements = [
-          ...nextElements.slice(0, frameIndex),
-          element,
-          ...nextElements.slice(frameIndex, elementIndex),
-          ...nextElements.slice(elementIndex + 1),
-        ];
-      }
     }
   }
 
-  return nextElements;
+  // FIXME! probably no need to copy since there is only mutation and order does not change?
+  return allElements.slice();
 };
 
 export const removeElementsFromFrame = (
   allElements: ExcalidrawElementsIncludingDeleted,
   elementsToRemove: NonDeletedExcalidrawElement[],
-  appState: AppState,
+  appState: AppState, // FIXME! no need for appState
 ) => {
   const _elementsToRemove: ExcalidrawElement[] = [];
 
@@ -535,13 +513,8 @@ export const removeElementsFromFrame = (
     );
   }
 
-  const nextElements = moveOneRight(
-    allElements,
-    appState,
-    Array.from(_elementsToRemove),
-  );
-
-  return nextElements;
+  // FIXME! probably no need to copy since there is only mutation and order does not change?
+  return allElements.slice();
 };
 
 export const removeAllElementsFromFrame = (

--- a/src/frame.ts
+++ b/src/frame.ts
@@ -475,17 +475,15 @@ export const addElementsToFrame = (
     },
     {},
   );
+
   const frameIndex = allElementsIndex[frame.id];
-  const leftFrameBoundary = findIndex(
+  const leftFrameBoundaryIndex = findIndex(
     allElements,
     (e) => e.frameId === frame.id,
   );
-  const leftFrameBoundaryIndex =
-    leftFrameBoundary >= 0 ? leftFrameBoundary : frameIndex;
 
-  const existingFrameElements = allElements.slice(
-    leftFrameBoundaryIndex,
-    frameIndex,
+  const existingFrameElements = allElements.filter(
+    (element) => element.frameId === frame.id,
   );
   const newFrameElements = omitGroupsContainingFrames(
     allElements,
@@ -519,8 +517,9 @@ export const addElementsToFrame = (
 
   const frameElement = allElements[frameIndex];
   const nextLeftNonFrameElements = allElements
-    .slice(0, leftFrameBoundaryIndex)
+    .slice(0, leftFrameBoundaryIndex >= 0 ? leftFrameBoundaryIndex : frameIndex)
     .filter((element) => !newLeftFrameElementsIndex[element.id]);
+
   const nextRightNonFrameElements = allElements
     .slice(frameIndex + 1)
     .filter((element) => !newRightFrameElementsIndex[element.id]);

--- a/src/frame.ts
+++ b/src/frame.ts
@@ -483,12 +483,12 @@ export const addElementsToFrame = (
     (e) => e.frameId === frame.id,
   );
 
-  const existingFrameElements = allElements.filter(
+  const existingFrameChildren = allElements.filter(
     (element) => element.frameId === frame.id,
   );
 
-  const newLeftFrameElements: ExcalidrawElement[] = [];
-  const newRightFrameElements: ExcalidrawElement[] = [];
+  const addedFrameChildren_left: ExcalidrawElement[] = [];
+  const addedFrameChildren_right: ExcalidrawElement[] = [];
 
   for (const element of omitGroupsContainingFrames(
     allElements,
@@ -496,9 +496,9 @@ export const addElementsToFrame = (
   )) {
     if (element.frameId !== frame.id && !isFrameElement(element)) {
       if (allElementsIndex[element.id] > frameIndex) {
-        newRightFrameElements.push(element);
+        addedFrameChildren_right.push(element);
       } else {
-        newLeftFrameElements.push(element);
+        addedFrameChildren_left.push(element);
       }
 
       mutateElement(
@@ -512,11 +512,11 @@ export const addElementsToFrame = (
   }
 
   const frameElement = allElements[frameIndex];
-  const frameElements = newLeftFrameElements
-    .concat(existingFrameElements)
-    .concat(newRightFrameElements);
+  const nextFrameChildren = addedFrameChildren_left
+    .concat(existingFrameChildren)
+    .concat(addedFrameChildren_right);
 
-  const frameElementsIndex = frameElements.reduce(
+  const nextFrameChildrenMap = nextFrameChildren.reduce(
     (acc: Record<string, boolean>, element) => {
       acc[element.id] = true;
       return acc;
@@ -524,18 +524,18 @@ export const addElementsToFrame = (
     {},
   );
 
-  const nextLeftNonFrameElements = allElements
+  const nextOtherElements_left = allElements
     .slice(0, leftFrameBoundaryIndex >= 0 ? leftFrameBoundaryIndex : frameIndex)
-    .filter((element) => !frameElementsIndex[element.id]);
+    .filter((element) => !nextFrameChildrenMap[element.id]);
 
-  const nextRightNonFrameElements = allElements
+  const nextOtherElement_right = allElements
     .slice(frameIndex + 1)
-    .filter((element) => !frameElementsIndex[element.id]);
+    .filter((element) => !nextFrameChildrenMap[element.id]);
 
-  const nextElements = nextLeftNonFrameElements
-    .concat(frameElements)
+  const nextElements = nextOtherElements_left
+    .concat(nextFrameChildren)
     .concat([frameElement])
-    .concat(nextRightNonFrameElements);
+    .concat(nextOtherElement_right);
 
   return nextElements;
 };

--- a/src/renderer/renderScene.ts
+++ b/src/renderer/renderScene.ts
@@ -76,11 +76,7 @@ import {
   isEmbeddableOrFrameLabel,
   createPlaceholderEmbeddableLabel,
 } from "../element/embeddable";
-import {
-  elementOverlapsWithFrame,
-  getTargetFrame,
-  isElementInFrame,
-} from "../frame";
+import { getTargetFrame, isElementInFrame } from "../frame";
 import "canvas-roundrect-polyfill";
 
 export const DEFAULT_SPACING = 2;
@@ -944,109 +940,113 @@ const _renderStaticScene = ({
     );
   }
 
-  const groupsToBeAddedToFrame = new Set<string>();
+  // FIXME! seems this is not referenced anywhere? regression?
+  // const groupsToBeAddedToFrame = new Set<string>();
 
-  visibleElements.forEach((element) => {
-    if (
-      element.groupIds.length > 0 &&
-      appState.frameToHighlight &&
-      appState.selectedElementIds[element.id] &&
-      (elementOverlapsWithFrame(element, appState.frameToHighlight) ||
-        element.groupIds.find((groupId) => groupsToBeAddedToFrame.has(groupId)))
-    ) {
-      element.groupIds.forEach((groupId) =>
-        groupsToBeAddedToFrame.add(groupId),
-      );
+  // visibleElements.forEach((element) => {
+  //   if (
+  //     element.groupIds.length > 0 &&
+  //     appState.frameToHighlight &&
+  //     appState.selectedElementIds[element.id] &&
+  //     (elementOverlapsWithFrame(element, appState.frameToHighlight) ||
+  //       element.groupIds.find((groupId) => groupsToBeAddedToFrame.has(groupId)))
+  //   ) {
+  //     element.groupIds.forEach((groupId) =>
+  //       groupsToBeAddedToFrame.add(groupId),
+  //     );
+  //   }
+  // });
+
+  const renderVisibleElement = (
+    element: NonDeletedExcalidrawElement,
+    renderFunc?: () => void,
+  ) => {
+    try {
+      const render = () =>
+        renderFunc
+          ? renderFunc()
+          : renderElement(element, rc, context, renderConfig, appState);
+
+      // - when exporting the whole canvas, we DO NOT apply clipping
+      // - when we are exporting a particular frame, apply clipping
+      //   if the containing frame is not selected, apply clipping
+      const frameId = element.frameId || appState.frameToHighlight?.id;
+
+      if (
+        frameId &&
+        ((renderConfig.isExporting && isOnlyExportingSingleFrame(elements)) ||
+          (!renderConfig.isExporting &&
+            appState.frameRendering.enabled &&
+            appState.frameRendering.clip))
+      ) {
+        context.save();
+
+        const frame = getTargetFrame(element, appState);
+
+        // FIXME! do we need to check isElementInFrame here? double-check!
+        if (frame && isElementInFrame(element, elements, appState)) {
+          frameClip(frame, context, renderConfig, appState);
+        }
+
+        render();
+
+        context.restore();
+      } else {
+        render();
+      }
+
+      if (!isExporting) {
+        renderLinkIcon(element, context, appState);
+      }
+    } catch (error: unknown) {
+      console.error(error);
+    }
+  };
+
+  const groupedVisibleElements = {
+    embeddables: new Array<NonDeletedExcalidrawElement>(),
+    frames: new Array<NonDeletedExcalidrawElement>(),
+    others: new Array<NonDeletedExcalidrawElement>(),
+  } as const;
+
+  // Group different element types
+  visibleElements.forEach((el) => {
+    // FIXME! why is frame label considered embeddable?
+    if (isEmbeddableOrFrameLabel(el)) {
+      groupedVisibleElements.embeddables.push(el);
+    } else if (isFrameElement(el)) {
+      groupedVisibleElements.frames.push(el);
+    } else {
+      groupedVisibleElements.others.push(el);
     }
   });
 
-  // Paint visible elements
-  visibleElements
-    .filter((el) => !isEmbeddableOrFrameLabel(el))
-    .forEach((element) => {
-      try {
-        // - when exporting the whole canvas, we DO NOT apply clipping
-        // - when we are exporting a particular frame, apply clipping
-        //   if the containing frame is not selected, apply clipping
-        const frameId = element.frameId || appState.frameToHighlight?.id;
+  // First paint visible elements
+  groupedVisibleElements.others.forEach((element) => {
+    renderVisibleElement(element);
+  });
 
-        if (
-          frameId &&
-          ((renderConfig.isExporting && isOnlyExportingSingleFrame(elements)) ||
-            (!renderConfig.isExporting &&
-              appState.frameRendering.enabled &&
-              appState.frameRendering.clip))
-        ) {
-          context.save();
+  // Then paint frames
+  groupedVisibleElements.frames.forEach((element) => {
+    renderVisibleElement(element);
+  });
 
-          const frame = getTargetFrame(element, appState);
+  // Then paint embeddables
+  groupedVisibleElements.embeddables.forEach((element) => {
+    renderVisibleElement(element, () => {
+      renderElement(element, rc, context, renderConfig, appState);
 
-          // TODO do we need to check isElementInFrame here?
-          if (frame && isElementInFrame(element, elements, appState)) {
-            frameClip(frame, context, renderConfig, appState);
-          }
-          renderElement(element, rc, context, renderConfig, appState);
-          context.restore();
-        } else {
-          renderElement(element, rc, context, renderConfig, appState);
-        }
-        if (!isExporting) {
-          renderLinkIcon(element, context, appState);
-        }
-      } catch (error: any) {
-        console.error(error);
+      if (
+        isEmbeddableElement(element) &&
+        (isExporting || !element.validated) &&
+        element.width &&
+        element.height
+      ) {
+        const label = createPlaceholderEmbeddableLabel(element);
+        renderElement(label, rc, context, renderConfig, appState);
       }
     });
-
-  // render embeddables on top
-  visibleElements
-    .filter((el) => isEmbeddableOrFrameLabel(el))
-    .forEach((element) => {
-      try {
-        const render = () => {
-          renderElement(element, rc, context, renderConfig, appState);
-
-          if (
-            isEmbeddableElement(element) &&
-            (isExporting || !element.validated) &&
-            element.width &&
-            element.height
-          ) {
-            const label = createPlaceholderEmbeddableLabel(element);
-            renderElement(label, rc, context, renderConfig, appState);
-          }
-          if (!isExporting) {
-            renderLinkIcon(element, context, appState);
-          }
-        };
-        // - when exporting the whole canvas, we DO NOT apply clipping
-        // - when we are exporting a particular frame, apply clipping
-        //   if the containing frame is not selected, apply clipping
-        const frameId = element.frameId || appState.frameToHighlight?.id;
-
-        if (
-          frameId &&
-          ((renderConfig.isExporting && isOnlyExportingSingleFrame(elements)) ||
-            (!renderConfig.isExporting &&
-              appState.frameRendering.enabled &&
-              appState.frameRendering.clip))
-        ) {
-          context.save();
-
-          const frame = getTargetFrame(element, appState);
-
-          if (frame && isElementInFrame(element, elements, appState)) {
-            frameClip(frame, context, renderConfig, appState);
-          }
-          render();
-          context.restore();
-        } else {
-          render();
-        }
-      } catch (error: any) {
-        console.error(error);
-      }
-    });
+  });
 };
 
 /** throttled to animation framerate */


### PR DESCRIPTION
Fixed the re-ordering issues for "adding element/s to frame" by re-implementing the algorithm (introduced in #6123) to a more correct, resilient and performant version (also due to "downgrade" in #6904). Added number of test cases so these won't regress in the future, specifically for:

* Resizing frame over elements - all at once, one by one, with elements in between, with or without bounded element
* Dragging elements into the frame - all at once, one by one, with elements in between
* Resizing frame down - addition of elements followed by removal
* Duplicating an element inside the frame, while keeping it inside or dragging it outside the frame
* For most of the above, covered cases when the frame is in a bottom, middle or top layer

---

Addition/deletion in frames leads to weird z-index inconsistencies. While some operations re-order the elements, others don't and retain the z-index value.

Consider these cube train examples (not a definitive list):

1. Adding an element by extending the frame
    1. Modifies the z-index of Cube#4 (assuming by design)
    2. Removing modifies the z-index by shifting Cube#4 right on top of the frame (assuming by design)

https://github.com/excalidraw/excalidraw/assets/20387666/2c7717f4-febb-4a49-a074-0c10b7977af2

2. Adding an element by dragging it into the frame
    1. Does not modify z-index - hence inconsistency with 1) point i). I would expect unified behaviour here (is this by design?)
    2. Removing modifies the z-index wrongly (looks like a bug?)

https://github.com/excalidraw/excalidraw/assets/20387666/cda9332c-aa05-4a5e-b675-f9aaee1aaa54

3. Removing the second element dragged into the frame
    1. Does precisely what was done in 1) point ii). and does not retain the z-index - which would be fine unless the first element didn't retain the z-index (hence inconsistency, looks like a bug?)

https://github.com/excalidraw/excalidraw/assets/20387666/fc841c31-1ad6-4fa7-be70-cb2060e8fa1c

~~The proposed solution renders frames after all the visible elements, treating frames similarly to embeddables. Therefore there is no need for re-ordering elements on every addition/deletion, improving performance and mitigating all the z-index inconsistencies. However, from the UX perspective, having frames always on top feels like a step back, therefore an alternative solution might be needed.~~
