### PR TITLE
fix: grid jittery after partition PR

### DIFF
--- a/src/renderer/renderScene.ts
+++ b/src/renderer/renderScene.ts
@@ -934,10 +934,8 @@ const _renderStaticScene = ({
     strokeGrid(
       context,
       appState.gridSize,
-      -Math.ceil(appState.zoom.value / appState.gridSize) * appState.gridSize +
-        (appState.scrollX % appState.gridSize),
-      -Math.ceil(appState.zoom.value / appState.gridSize) * appState.gridSize +
-        (appState.scrollY % appState.gridSize),
+      appState.scrollX,
+      appState.scrollY,
       appState.zoom,
       normalizedWidth / appState.zoom.value,
       normalizedHeight / appState.zoom.value,


### PR DESCRIPTION
fixes #6934

I don't understand the intended purpose of 
```typescript
      -Math.ceil(appState.zoom.value / appState.gridSize) * appState.gridSize +
        (appState.scrollX % appState.gridSize),
      -Math.ceil(appState.zoom.value / appState.gridSize) * appState.gridSize +
        (appState.scrollY % appState.gridSize),
```

replacing it with code similar to code before #6759 seems to fix the issue
