### PR TITLE
fix: disable reverse binding from shapes to arrows, don't bind arrows in a group, allow arrow binding when endpoints are dragged

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -7067,10 +7067,10 @@ class App extends React.Component<AppProps, AppState> {
         } else {
           selectedElements = selectedElements.filter(
             (elem) =>
-              (isArrowElement(elem) && (
-                (elem as ExcalidrawLinearElement).endBinding !== null ||
-                (elem as ExcalidrawLinearElement).startBinding !== null
-              )) || elem.groupIds.length === 0
+              (isArrowElement(elem) &&
+                ((elem as ExcalidrawLinearElement).endBinding !== null ||
+                  (elem as ExcalidrawLinearElement).startBinding !== null)) ||
+              elem.groupIds.length === 0,
           );
         }
 

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -7050,9 +7050,20 @@ class App extends React.Component<AppProps, AppState> {
       }
 
       if (pointerDownState.drag.hasOccurred || isResizing || isRotating) {
+        // grouped arrows shouldn't bind to an element, unless they're explicitly selected and dragged to that element
+        let selectedElements = this.scene.getSelectedElements(this.state);
+        if (this.state.selectedLinearElement && this.state.selectedLinearElement.isDragging) {
+          selectedElements = selectedElements.filter(
+            (elem) => !((elem.id === this.state.selectedLinearElement?.elementId) && elem.groupIds.length > 0)
+          );
+        } else {
+          selectedElements = selectedElements.filter(
+            (elem) => elem.groupIds.length === 0
+          );
+        }
         (isBindingEnabled(this.state)
           ? bindOrUnbindSelectedElements
-          : unbindLinearElements)(this.scene.getSelectedElements(this.state));
+          : unbindLinearElements)(selectedElements);
       }
 
       if (activeTool.type === "laser") {

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -7050,7 +7050,8 @@ class App extends React.Component<AppProps, AppState> {
       }
 
       if (pointerDownState.drag.hasOccurred || isResizing || isRotating) {
-        // grouped arrows shouldn't bind/unbind to an element, unless they're explicitly selected and dragged to that element
+        // Grouped arrows shouldn't bind/unbind to an element unless they're explicitly selected and dragged to that element.
+        // If a grouped arrow is bound, unbind when necessary.
         let selectedElements = this.scene.getSelectedElements(this.state);
         if (
           this.state.selectedLinearElement &&
@@ -7065,9 +7066,14 @@ class App extends React.Component<AppProps, AppState> {
           );
         } else {
           selectedElements = selectedElements.filter(
-            (elem) => elem.groupIds.length === 0,
+            (elem) =>
+              (isArrowElement(elem) && (
+                (elem as ExcalidrawLinearElement).endBinding !== null ||
+                (elem as ExcalidrawLinearElement).startBinding !== null
+              )) || elem.groupIds.length === 0
           );
         }
+
         (isBindingEnabled(this.state)
           ? bindOrUnbindSelectedElements
           : unbindLinearElements)(selectedElements);

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -7050,15 +7050,22 @@ class App extends React.Component<AppProps, AppState> {
       }
 
       if (pointerDownState.drag.hasOccurred || isResizing || isRotating) {
-        // grouped arrows shouldn't bind to an element, unless they're explicitly selected and dragged to that element
+        // grouped arrows shouldn't bind/unbind to an element, unless they're explicitly selected and dragged to that element
         let selectedElements = this.scene.getSelectedElements(this.state);
-        if (this.state.selectedLinearElement && this.state.selectedLinearElement.isDragging) {
+        if (
+          this.state.selectedLinearElement &&
+          this.state.selectedLinearElement.isDragging
+        ) {
           selectedElements = selectedElements.filter(
-            (elem) => !((elem.id === this.state.selectedLinearElement?.elementId) && elem.groupIds.length > 0)
+            (elem) =>
+              !(
+                elem.id === this.state.selectedLinearElement?.elementId &&
+                elem.groupIds.length > 0
+              ),
           );
         } else {
           selectedElements = selectedElements.filter(
-            (elem) => elem.groupIds.length === 0
+            (elem) => elem.groupIds.length === 0,
           );
         }
         (isBindingEnabled(this.state)

--- a/src/element/binding.ts
+++ b/src/element/binding.ts
@@ -548,6 +548,12 @@ const getElligibleElementsForBindableElementAndWhere = (
       if (!canBindStart && !canBindEnd) {
         return null;
       }
+      // don't bind linear element if it's in a group
+      if (canBindStart || canBindEnd) {
+        if (element.groupIds.length > 0) {
+          return null;
+        }
+      }
       return [
         element,
         canBindStart && canBindEnd ? "both" : canBindStart ? "start" : "end",

--- a/src/element/binding.ts
+++ b/src/element/binding.ts
@@ -497,9 +497,6 @@ export const getEligibleElementsForBinding = (
 const getElligibleElementsForBindingElement = (
   linearElement: NonDeleted<ExcalidrawLinearElement>,
 ): NonDeleted<ExcalidrawBindableElement>[] => {
-  if (linearElement.groupIds.length > 0) {
-    return [];
-  }
   return [
     getElligibleElementForBindingElement(linearElement, "start"),
     getElligibleElementForBindingElement(linearElement, "end"),
@@ -519,7 +516,7 @@ const getElligibleElementForBindingElement = (
   );
 };
 
-const getLinearElementEdgeCoors = (
+export const getLinearElementEdgeCoors = (
   linearElement: NonDeleted<ExcalidrawLinearElement>,
   startOrEnd: "start" | "end",
 ): { x: number; y: number } => {
@@ -550,12 +547,6 @@ const getElligibleElementsForBindableElementAndWhere = (
       );
       if (!canBindStart && !canBindEnd) {
         return null;
-      }
-      // don't bind linear element if it's in a group
-      if (canBindStart || canBindEnd) {
-        if (element.groupIds.length > 0) {
-          return null;
-        }
       }
       return [
         element,

--- a/src/element/binding.ts
+++ b/src/element/binding.ts
@@ -497,6 +497,9 @@ export const getEligibleElementsForBinding = (
 const getElligibleElementsForBindingElement = (
   linearElement: NonDeleted<ExcalidrawLinearElement>,
 ): NonDeleted<ExcalidrawBindableElement>[] => {
+  if (linearElement.groupIds.length > 0) {
+    return [];
+  }
   return [
     getElligibleElementForBindingElement(linearElement, "start"),
     getElligibleElementForBindingElement(linearElement, "end"),


### PR DESCRIPTION
Submitting a PR now without unit tests to get early feedback. I did some local testing (see gifs below), but if there are other edge cases to try out, please let me know.

## Problem
This is a fix for https://github.com/excalidraw/excalidraw/issues/4324 and #6952 

As discussed in this [comment](https://github.com/excalidraw/excalidraw/issues/4324#issuecomment-1664282239) if we have a group that consists of one or more elements and an arrow, the expected functionality is

1.  when editing this group (resizing or moving) no binding should happen

1.  when editing the individual arrow within the group the current binding flow should be executed

And reverse binding from shapes to arrows should not happen.


## Solution
We only allow binding by explicitly dragging the endpoints of the arrow. This will preclude the grouping issue in #4324. To unbind an arrow from a shape we allow both the explicit dragging of the endpoint away from the shape **or** moving the arrow away entirely.
 
We determine when the element(s) selected consist of: 1) a binding element (i.e. arrow) or a 2) bindable element (e.g. ellipse, rectangle, etc.)

Showing the arrow binding occurs for both endpoints and unbinding for moving the arrow away
![Kapture 2023-10-09 at 18 42 43](https://github.com/excalidraw/excalidraw/assets/1409392/b7232f34-9c7d-4063-8a09-a74cb35156bb)

![Kapture 2023-10-09 at 18 38 05](https://github.com/excalidraw/excalidraw/assets/1409392/9d024ec0-9672-47f6-acce-8aef23a62144)

This shows that the grouping issue is fixed.
![Kapture 2023-10-09 at 18 39 33](https://github.com/excalidraw/excalidraw/assets/1409392/f2f838d9-345e-4815-880e-905c8f37cacd)


## Testing
Did local testing, and currently writing up some unit tests. 


