### PR TITLE
fix: generic element's labels not flipping with them

### DIFF
--- a/src/actions/actionFlip.ts
+++ b/src/actions/actionFlip.ts
@@ -60,6 +60,7 @@ const flipSelectedElements = (
     getNonDeletedElements(elements),
     appState,
     {
+      includeBoundTextElement: true,
       includeElementsInFrames: true,
     },
   );


### PR DESCRIPTION
Most likely a regression after #6789

![Peek 2023-09-07 20-03](https://github.com/excalidraw/excalidraw/assets/45559664/c488e007-387c-4b99-af6d-b02d90ccd078)
