### PR TITLE
feat: Add a `subtype?: string` property to `ExcalidrawElement`.

### DIFF
--- a/src/data/restore.ts
+++ b/src/data/restore.ts
@@ -92,7 +92,8 @@ const repairBinding = (binding: PointBinding | null) => {
 };
 
 const restoreElementWithProperties = <
-  T extends Required<Omit<ExcalidrawElement, "customData">> & {
+  T extends Required<Omit<ExcalidrawElement, "subtype" | "customData">> & {
+    subtype?: ExcalidrawElement["subtype"];
     customData?: ExcalidrawElement["customData"];
     /** @deprecated */
     boundElementIds?: readonly ExcalidrawElement["id"][];
@@ -158,6 +159,9 @@ const restoreElementWithProperties = <
     locked: element.locked ?? false,
   };
 
+  if ("subtype" in element) {
+    base.subtype = element.subtype;
+  }
   if ("customData" in element) {
     base.customData = element.customData;
   }

--- a/src/element/types.ts
+++ b/src/element/types.ts
@@ -65,6 +65,7 @@ type _ExcalidrawElementBase = Readonly<{
   updated: number;
   link: string | null;
   locked: boolean;
+  subtype?: string;
   customData?: Record<string, any>;
 }>;
 


### PR DESCRIPTION
This PR just adds an optional `subtype` property to `ExcalidrawElement`.  See #6958 and #6037 for details.