### PR TITLE
arm64 multiarch support

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -23,3 +23,4 @@ jobs:
           context: .
           push: true
           tags: excalidraw/excalidraw:latest
+          platforms: linux/amd64, linux/arm64, linux/arm/v7

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,16 @@
-FROM node:18 AS build
+FROM --platform=${BUILDPLATFORM} node:18 AS build
 
 WORKDIR /opt/node_app
 
 COPY package.json yarn.lock ./
-RUN yarn --ignore-optional --network-timeout 600000
+RUN npm_config_target_arch=${TARGETARCH} yarn --ignore-optional --network-timeout 600000
 
 ARG NODE_ENV=production
 
 COPY . .
-RUN yarn build:app:docker
+RUN npm_config_target_arch=${TARGETARCH} yarn build:app:docker
 
-FROM nginx:1.21-alpine
+FROM --platform=${TARGETPLATFORM} nginx:1.21-alpine
 
 COPY --from=build /opt/node_app/build /usr/share/nginx/html
 


### PR DESCRIPTION
Change the Dockerfile to run on multiple architectures (mainly adding arm64 and arm/v7) via cross compilation instead of emulation.

I've a multiarch build from this PR published here if you want to test https://hub.docker.com/r/tigh/excalidraw