### PR TITLE
feat: Add VITE_APP_WS_SERVER_PATH and VITE_APP_BASE_PATH environment variables for hosting on subpath

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -6,6 +6,7 @@ VITE_APP_LIBRARY_BACKEND=https://us-central1-excalidraw-room-persistence.cloudfu
 
 # collaboration WebSocket server (https://github.com/excalidraw/excalidraw-room)
 VITE_APP_WS_SERVER_URL=http://localhost:3002
+VITE_APP_WS_SERVER_PATH=
 
 # set this only if using the collaboration workflow we use on excalidraw.com
 VITE_APP_PORTAL_URL=
@@ -29,6 +30,8 @@ FAST_REFRESH=false
 
 # The port the run the dev server
 VITE_APP_PORT=3000
+# The subpath the server will be hosted at
+VITE_APP_BASE_PATH=
 
 #Debug flags
 

--- a/.env.production
+++ b/.env.production
@@ -12,6 +12,10 @@ VITE_APP_PLUS_APP=https://app.excalidraw.com
 # Fill to set socket server URL used for collaboration.
 # Meant for forks only: excalidraw.com uses custom VITE_APP_PORTAL_URL flow
 VITE_APP_WS_SERVER_URL=
+VITE_APP_WS_SERVER_PATH=
+
+# The subpath the server will be hosted at
+VITE_APP_BASE_PATH=
 
 VITE_APP_FIREBASE_CONFIG='{"apiKey":"AIzaSyAd15pYlMci_xIp9ko6wkEsDzAAA0Dn0RU","authDomain":"excalidraw-room-persistence.firebaseapp.com","databaseURL":"https://excalidraw-room-persistence.firebaseio.com","projectId":"excalidraw-room-persistence","storageBucket":"excalidraw-room-persistence.appspot.com","messagingSenderId":"654800341332","appId":"1:654800341332:web:4a692de832b55bd57ce0c1"}'
 

--- a/excalidraw-app/collab/Collab.tsx
+++ b/excalidraw-app/collab/Collab.tsx
@@ -427,6 +427,9 @@ class Collab extends PureComponent<Props, CollabState> {
 
       this.portal.socket = this.portal.open(
         socketIOClient(socketServerData.url, {
+          ...(socketServerData.path
+            ? { path: `${socketServerData.path}/socket.io/` }
+            : {}),
           transports: socketServerData.polling
             ? ["websocket", "polling"]
             : ["websocket"],

--- a/excalidraw-app/data/index.ts
+++ b/excalidraw-app/data/index.ts
@@ -65,11 +65,13 @@ const generateRoomId = async () => {
  */
 export const getCollabServer = async (): Promise<{
   url: string;
+  path: string;
   polling: boolean;
 }> => {
   if (import.meta.env.VITE_APP_WS_SERVER_URL) {
     return {
       url: import.meta.env.VITE_APP_WS_SERVER_URL,
+      path: import.meta.env.VITE_APP_WS_SERVER_PATH,
       polling: true,
     };
   }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,6 +11,7 @@ export default defineConfig(({ mode }) => {
   const envVars = loadEnv(mode, process.cwd());
 
   return {
+    ...(envVars.VITE_APP_BASE_PATH ? { base: envVars.VITE_APP_BASE_PATH } : {}),
     server: {
       port: Number(envVars.VITE_APP_PORT || 3000),
       // open the browser

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,178 +5,180 @@ import { ViteEjsPlugin } from "vite-plugin-ejs";
 import { VitePWA } from "vite-plugin-pwa";
 import checker from "vite-plugin-checker";
 
-// To load .env.local variables
-const envVars = loadEnv("", process.cwd());
-
 // https://vitejs.dev/config/
-export default defineConfig({
-  server: {
-    port: Number(envVars.VITE_APP_PORT || 3000),
-    // open the browser
-    open: true,
-  },
-  build: {
-    outDir: "build",
-    rollupOptions: {
-      output: {
-        // Creating separate chunk for locales except for en and percentages.json so they
-        // can be cached at runtime and not merged with
-        // app precache. en.json and percentages.json are needed for first load
-        // or fallback hence not clubbing with locales so first load followed by offline mode works fine. This is how CRA used to work too.
-        manualChunks(id) {
-          if (
-            id.includes("src/locales") &&
-            id.match(/en.json|percentages.json/) === null
-          ) {
-            const index = id.indexOf("locales/");
-            // Taking the substring after "locales/"
-            return `locales/${id.substring(index + 8)}`;
-          }
-        },
-      },
-    },
-    sourcemap: true,
-  },
-  plugins: [
-    react(),
-    checker({
-      typescript: true,
-      eslint:
-        envVars.VITE_APP_ENABLE_ESLINT === "false"
-          ? undefined
-          : { lintCommand: 'eslint "./src/**/*.{js,ts,tsx}"' },
-      overlay: {
-        initialIsOpen: envVars.VITE_APP_COLLAPSE_OVERLAY === "false",
-        badgeStyle: "margin-bottom: 4rem; margin-left: 1rem",
-      },
-    }),
-    svgrPlugin(),
-    ViteEjsPlugin(),
-    VitePWA({
-      registerType: "autoUpdate",
-      devOptions: {
-        /* set this flag to true to enable in Development mode */
-        enabled: false,
-      },
+export default defineConfig(({ mode }) => {
+  // To load .env.local variables
+  const envVars = loadEnv(mode, process.cwd());
 
-      workbox: {
-        // Don't push fonts and locales to app precache
-        globIgnores: ["fonts.css", "**/locales/**", "service-worker.js"],
-        runtimeCaching: [
-          {
-            urlPattern: new RegExp("/.+.(ttf|woff2|otf)"),
-            handler: "CacheFirst",
-            options: {
-              cacheName: "fonts",
-              expiration: {
-                maxEntries: 50,
-                maxAgeSeconds: 60 * 60 * 24 * 90, // <== 90 days
-              },
-            },
-          },
-          {
-            urlPattern: new RegExp("fonts.css"),
-            handler: "StaleWhileRevalidate",
-            options: {
-              cacheName: "fonts",
-              expiration: {
-                maxEntries: 50,
-              },
-            },
-          },
-          {
-            urlPattern: new RegExp("locales/[^/]+.js"),
-            handler: "CacheFirst",
-            options: {
-              cacheName: "locales",
-              expiration: {
-                maxEntries: 50,
-                maxAgeSeconds: 60 * 60 * 24 * 30, // <== 30 days
-              },
-            },
-          },
-        ],
-      },
-      manifest: {
-        short_name: "Excalidraw",
-        name: "Excalidraw",
-        description:
-          "Excalidraw is a whiteboard tool that lets you easily sketch diagrams that have a hand-drawn feel to them.",
-        icons: [
-          {
-            src: "android-chrome-192x192.png",
-            sizes: "192x192",
-            type: "image/png",
-          },
-          {
-            src: "apple-touch-icon.png",
-            type: "image/png",
-            sizes: "256x256",
-          },
-        ],
-        start_url: "/",
-        display: "standalone",
-        theme_color: "#121212",
-        background_color: "#ffffff",
-        file_handlers: [
-          {
-            action: "/",
-            accept: {
-              "application/vnd.excalidraw+json": [".excalidraw"],
-            },
-          },
-        ],
-        share_target: {
-          action: "/web-share-target",
-          method: "POST",
-          enctype: "multipart/form-data",
-          params: {
-            files: [
-              {
-                name: "file",
-                accept: [
-                  "application/vnd.excalidraw+json",
-                  "application/json",
-                  ".excalidraw",
-                ],
-              },
-            ],
+  return {
+    server: {
+      port: Number(envVars.VITE_APP_PORT || 3000),
+      // open the browser
+      open: true,
+    },
+    build: {
+      outDir: "build",
+      rollupOptions: {
+        output: {
+          // Creating separate chunk for locales except for en and percentages.json so they
+          // can be cached at runtime and not merged with
+          // app precache. en.json and percentages.json are needed for first load
+          // or fallback hence not clubbing with locales so first load followed by offline mode works fine. This is how CRA used to work too.
+          manualChunks(id) {
+            if (
+              id.includes("src/locales") &&
+              id.match(/en.json|percentages.json/) === null
+            ) {
+              const index = id.indexOf("locales/");
+              // Taking the substring after "locales/"
+              return `locales/${id.substring(index + 8)}`;
+            }
           },
         },
-        screenshots: [
-          {
-            src: "/screenshots/virtual-whiteboard.png",
-            type: "image/png",
-            sizes: "462x945",
-          },
-          {
-            src: "/screenshots/wireframe.png",
-            type: "image/png",
-            sizes: "462x945",
-          },
-          {
-            src: "/screenshots/illustration.png",
-            type: "image/png",
-            sizes: "462x945",
-          },
-          {
-            src: "/screenshots/shapes.png",
-            type: "image/png",
-            sizes: "462x945",
-          },
-          {
-            src: "/screenshots/collaboration.png",
-            type: "image/png",
-            sizes: "462x945",
-          },
-          {
-            src: "/screenshots/export.png",
-            type: "image/png",
-            sizes: "462x945",
-          },
-        ],
       },
-    }),
-  ],
-  publicDir: "./public",
+      sourcemap: true,
+    },
+    plugins: [
+      react(),
+      checker({
+        typescript: true,
+        eslint:
+          envVars.VITE_APP_ENABLE_ESLINT === "false"
+            ? undefined
+            : { lintCommand: 'eslint "./src/**/*.{js,ts,tsx}"' },
+        overlay: {
+          initialIsOpen: envVars.VITE_APP_COLLAPSE_OVERLAY === "false",
+          badgeStyle: "margin-bottom: 4rem; margin-left: 1rem",
+        },
+      }),
+      svgrPlugin(),
+      ViteEjsPlugin(),
+      VitePWA({
+        registerType: "autoUpdate",
+        devOptions: {
+          /* set this flag to true to enable in Development mode */
+          enabled: false,
+        },
+
+        workbox: {
+          // Don't push fonts and locales to app precache
+          globIgnores: ["fonts.css", "**/locales/**", "service-worker.js"],
+          runtimeCaching: [
+            {
+              urlPattern: new RegExp("/.+.(ttf|woff2|otf)"),
+              handler: "CacheFirst",
+              options: {
+                cacheName: "fonts",
+                expiration: {
+                  maxEntries: 50,
+                  maxAgeSeconds: 60 * 60 * 24 * 90, // <== 90 days
+                },
+              },
+            },
+            {
+              urlPattern: new RegExp("fonts.css"),
+              handler: "StaleWhileRevalidate",
+              options: {
+                cacheName: "fonts",
+                expiration: {
+                  maxEntries: 50,
+                },
+              },
+            },
+            {
+              urlPattern: new RegExp("locales/[^/]+.js"),
+              handler: "CacheFirst",
+              options: {
+                cacheName: "locales",
+                expiration: {
+                  maxEntries: 50,
+                  maxAgeSeconds: 60 * 60 * 24 * 30, // <== 30 days
+                },
+              },
+            },
+          ],
+        },
+        manifest: {
+          short_name: "Excalidraw",
+          name: "Excalidraw",
+          description:
+            "Excalidraw is a whiteboard tool that lets you easily sketch diagrams that have a hand-drawn feel to them.",
+          icons: [
+            {
+              src: "android-chrome-192x192.png",
+              sizes: "192x192",
+              type: "image/png",
+            },
+            {
+              src: "apple-touch-icon.png",
+              type: "image/png",
+              sizes: "256x256",
+            },
+          ],
+          start_url: "/",
+          display: "standalone",
+          theme_color: "#121212",
+          background_color: "#ffffff",
+          file_handlers: [
+            {
+              action: "/",
+              accept: {
+                "application/vnd.excalidraw+json": [".excalidraw"],
+              },
+            },
+          ],
+          share_target: {
+            action: "/web-share-target",
+            method: "POST",
+            enctype: "multipart/form-data",
+            params: {
+              files: [
+                {
+                  name: "file",
+                  accept: [
+                    "application/vnd.excalidraw+json",
+                    "application/json",
+                    ".excalidraw",
+                  ],
+                },
+              ],
+            },
+          },
+          screenshots: [
+            {
+              src: "/screenshots/virtual-whiteboard.png",
+              type: "image/png",
+              sizes: "462x945",
+            },
+            {
+              src: "/screenshots/wireframe.png",
+              type: "image/png",
+              sizes: "462x945",
+            },
+            {
+              src: "/screenshots/illustration.png",
+              type: "image/png",
+              sizes: "462x945",
+            },
+            {
+              src: "/screenshots/shapes.png",
+              type: "image/png",
+              sizes: "462x945",
+            },
+            {
+              src: "/screenshots/collaboration.png",
+              type: "image/png",
+              sizes: "462x945",
+            },
+            {
+              src: "/screenshots/export.png",
+              type: "image/png",
+              sizes: "462x945",
+            },
+          ],
+        },
+      }),
+    ],
+    publicDir: "./public",
+  };
 });


### PR DESCRIPTION
This adds 2 environment variables to allow Excalidraw to be hosted on a subpath rather than at the server root. Together with excalidraw/excalidraw-room#363.

`VITE_APP_WS_SERVER_PATH` takes a string path such as `/excalidraw` and appends `/socket.io/` and is passed to SocketIO in the path variable when set. Otherwise the path is the default value of `/socket.io/`. The status page, normally at the root, is also adjusted accordingly to host at the given path.

This change breaks compatibility with the official Excalidraw portal server, as I had to change `getCollabServer` to return a path option as well, however the official server only needs to return `/` as a path to maintain compatibility. The main concern is that all clients would need to reload and fetch the updated scripts.

`VITE_APP_BASE_PATH` takes a string path such as `/excalidraw/` and sets the server base parameter when set. This allows the client server to host files with any base path and doesn't break compatibility if the variable is unset.

Additionally, I noticed that `vite.config.ts` is only loading the .env.local environment variables regardless of the mode, meaning the variables set in .env.production and .env.development pointless, so I moved the `loadEnv` call into the `defineConfig`, and passed it the current mode. This required changing the return value to be explicitly defined, and to retain the existing style, I had to indent all lines by 2 spaces making the diff annoying to read, so I put that change into its own commit to make it a bit easier to see.