### PR TITLE
fix: polyfill `Element.replaceChildren`

### DIFF
--- a/src/polyfill.ts
+++ b/src/polyfill.ts
@@ -22,5 +22,12 @@ const polyfill = () => {
       configurable: true,
     });
   }
+
+  if (!Element.prototype.replaceChildren) {
+    Element.prototype.replaceChildren = function (...nodes) {
+      this.innerHTML = "";
+      this.append(...nodes);
+    };
+  }
 };
 export default polyfill;


### PR DESCRIPTION
fix https://github.com/excalidraw/excalidraw/issues/7033

turns out `replaceChildren` is not yet that [widely supported](https://caniuse.com/?search=replaceChildren)