### PR TITLE
docs: fix typo on homepage of developer docs

### DIFF
--- a/dev-docs/src/components/Homepage/index.js
+++ b/dev-docs/src/components/Homepage/index.js
@@ -15,7 +15,7 @@ const FeatureList = [
     Svg: require("@site/static/img/undraw_blank_canvas.svg").default,
     description: (
       <>
-        Want to build your own app powered by Excalidraw by don't know where to
+        Want to build your own app powered by Excalidraw but don't know where to
         start?
       </>
     ),


### PR DESCRIPTION
I found a fairly prominent typo on the homepage of the developer docs and raised an issue about it.

Currently, the problematic sentence reads: "Want to build your own app powered by Excalidraw **by** don't know where to start?"

I have fixed it to say: ""Want to build your own app powered by Excalidraw **but** don't know where to start?"

Here is an image of the current state of the developer docs with the typo.
![excalidraw-typo](https://github.com/excalidraw/excalidraw/assets/95320421/e9f17655-ba22-4b32-a373-f5eb2c401a5a)

Here is the only line in the source code that I changed in order to solve the issue.
![excalidraw-typo-source](https://github.com/excalidraw/excalidraw/assets/95320421/5968f6be-279f-4cfa-8373-b2e76e08eec2)

This is my first PR here and I'm eager to explore the codebase further! Thanks for maintaining this great piece of software, and please let me know if I failed to follow the contributing guidelines in any way.