### PR TITLE
fix: Delete last element when draggingElement.type === "selection"

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -6400,9 +6400,11 @@ class App extends React.Component<AppProps, AppState> {
         isInvisiblySmallElement(draggingElement)
       ) {
         // remove invisible element which was added in onPointerDown
-        this.scene.replaceAllElements(
-          this.scene.getElementsIncludingDeleted().slice(0, -1),
-        );
+        if (draggingElement.type !== "selection") {
+          this.scene.replaceAllElements(
+            this.scene.getElementsIncludingDeleted().slice(0, -1),
+          );
+        }
         this.setState({
           draggingElement: null,
         });


### PR DESCRIPTION
I am working on the Mermaid integration into Obsidian-Excalidraw. In Obsidian CTRL/CMD+Click on a link or an image element performs a navigate to link action (if the click is over an image element, the action opens the image file). This action is processed in the onPointerDown property/event of the Excalidraw component. If the image is a mermaid SVG, CTRL+Click opens the mermaid Modal. But, in this situation, the top element in the scene was deleted. Adding this check solves the problem.