### PR TITLE
fix: Icon size in manifest

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -11,7 +11,7 @@
     {
       "src": "apple-touch-icon.png",
       "type": "image/png",
-      "sizes": "256x256"
+      "sizes": "180x180"
     }
   ],
   "start_url": "/",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -111,7 +111,7 @@ export default defineConfig({
           {
             src: "apple-touch-icon.png",
             type: "image/png",
-            sizes: "256x256",
+            sizes: "180x180",
           },
         ],
         start_url: "/",


### PR DESCRIPTION
https://excalidraw.com/apple-touch-icon.png is 180x180, not 256x256.