### PR TITLE
fix: failing `build:app:docker` post vite migration

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,5 +7,8 @@
 !package.json
 !public/
 !src/
+!excalidraw-app/
 !tsconfig.json
 !yarn.lock
+!index.html
+!vite.config.ts


### PR DESCRIPTION
Fix https://github.com/excalidraw/excalidraw/issues/6839
Followup from #6933

Added the following to docker context

- `index.html` required entrypoint for vite build
- `vite.config.ts` vite build config
- `excalidraw-app/` post refactor (Thanks @PseudoResonance)

Verified the following now work,

- docker image builds successfully
- docker compose up serves excalidraw on local port 3000