### PR TITLE
feat: add laser pointer to view mode

### DIFF
--- a/src/actions/actionCanvas.tsx
+++ b/src/actions/actionCanvas.tsx
@@ -18,6 +18,7 @@ import {
   getDefaultAppState,
   isEraserActive,
   isHandToolActive,
+  isLaserPointerActive,
 } from "../appState";
 import { DEFAULT_CANVAS_BACKGROUND_PICKS } from "../colors";
 import { Bounds } from "../element/bounds";
@@ -438,4 +439,47 @@ export const actionToggleHandTool = register({
     };
   },
   keyTest: (event) => event.key === KEYS.H,
+});
+
+export const actionToggleLaserPointer = register({
+  name: "toggleLaserPointerTool",
+  viewMode: true,
+  trackEvent: { category: "menu" },
+  perform(elements, appState, _, app) {
+    let activeTool: AppState["activeTool"];
+
+    if (isLaserPointerActive(appState)) {
+      activeTool = updateActiveTool(appState, {
+        ...(appState.activeTool.lastActiveTool || {
+          type: appState.viewModeEnabled ? "hand" : "selection",
+        }),
+        lastActiveToolBeforeEraser: null,
+      });
+      setCursor(
+        app.interactiveCanvas,
+        appState.viewModeEnabled ? CURSOR_TYPE.GRAB : CURSOR_TYPE.POINTER,
+      );
+    } else {
+      activeTool = updateActiveTool(appState, {
+        type: "laser",
+        lastActiveToolBeforeEraser: appState.activeTool,
+      });
+      setCursor(app.interactiveCanvas, CURSOR_TYPE.CROSSHAIR);
+    }
+
+    return {
+      appState: {
+        ...appState,
+        selectedElementIds: {},
+        selectedGroupIds: {},
+        activeEmbeddable: null,
+        activeTool,
+      },
+      commitToHistory: true,
+    };
+  },
+  checked: (appState) => appState.activeTool.type === "laser",
+  contextItemLabel: "labels.laser",
+  keyTest: (event) =>
+    event.code === CODES.K && !event[KEYS.CTRL_OR_CMD] && !event.altKey,
 });

--- a/src/actions/types.ts
+++ b/src/actions/types.ts
@@ -124,7 +124,8 @@ export type ActionName =
   | "setFrameAsActiveTool"
   | "setEmbeddableAsActiveTool"
   | "createContainerFromText"
-  | "wrapTextInContainer";
+  | "wrapTextInContainer"
+  | "toggleLaserPointerTool";
 
 export type PanelComponentProps = {
   elements: readonly ExcalidrawElement[];

--- a/src/appState.ts
+++ b/src/appState.ts
@@ -266,3 +266,11 @@ export const isHandToolActive = ({
 }) => {
   return activeTool.type === "hand";
 };
+
+export const isLaserPointerActive = ({
+  activeTool,
+}: {
+  activeTool: AppState["activeTool"];
+}) => {
+  return activeTool.type === "laser";
+};

--- a/src/keys.ts
+++ b/src/keys.ts
@@ -22,6 +22,7 @@ export const CODES = {
   Z: "KeyZ",
   R: "KeyR",
   S: "KeyS",
+  K: "KeyK",
 } as const;
 
 export const KEYS = {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1,5 +1,6 @@
 {
   "labels": {
+    "laser": "Toggle laser pointer",
     "paste": "Paste",
     "pasteAsPlaintext": "Paste as plaintext",
     "pasteCharts": "Paste charts",


### PR DESCRIPTION
addresses #7101 
Laser pointer can be toggled with K in view mode.
K turns the laser pointer on, any other button turns it off.
Added laser pointer to the context menu in view mode - assuming the scenario that someone is presenting a drawing in view mode on an iPad without a keyboard.