### PR TITLE
perf: improve element in frame check

### DIFF
--- a/src/frame.ts
+++ b/src/frame.ts
@@ -707,6 +707,17 @@ export const isElementInFrame = (
     : element;
 
   if (frame) {
+    // Perf improvement:
+    // For an element that's already in a frame, if it's not being dragged
+    // then there is no need to refer to geometry (which, yes, is slow) to check if it's in a frame.
+    // It has to be in its containing frame.
+    if (
+      !appState.selectedElementIds[element.id] ||
+      !appState.selectedElementsAreBeingDragged
+    ) {
+      return true;
+    }
+
     if (_element.groupIds.length === 0) {
       return elementOverlapsWithFrame(_element, frame);
     }


### PR DESCRIPTION
While we're finding ways to move away from relying on `selectedElementIds`, this simple check avoid unnecessary geometry calls to check if the given element is in a frame, which actually improves the perf quite significantly.