### PR TITLE
feat: Closing of "Save to.." Dialog on Save To Disk

### DIFF
--- a/excalidraw-app/components/ExportToExcalidrawPlus.tsx
+++ b/excalidraw-app/components/ExportToExcalidrawPlus.tsx
@@ -80,7 +80,8 @@ export const ExportToExcalidrawPlus: React.FC<{
   appState: Partial<AppState>;
   files: BinaryFiles;
   onError: (error: Error) => void;
-}> = ({ elements, appState, files, onError }) => {
+  onSuccess: () => void;
+}> = ({ elements, appState, files, onError, onSuccess }) => {
   const { t } = useI18n();
   return (
     <Card color="primary">
@@ -107,6 +108,7 @@ export const ExportToExcalidrawPlus: React.FC<{
           try {
             trackEvent("export", "eplus", `ui (${getFrame()})`);
             await exportToExcalidrawPlus(elements, appState, files);
+            onSuccess();
           } catch (error: any) {
             console.error(error);
             if (error.name !== "AbortError") {

--- a/excalidraw-app/index.tsx
+++ b/excalidraw-app/index.tsx
@@ -608,7 +608,7 @@ const ExcalidrawWrapper = () => {
     canvas: HTMLCanvasElement,
   ) => {
     if (exportedElements.length === 0) {
-      return window.alert(t("alerts.cannotExportEmptyCanvas"));
+      throw new Error(t("alerts.cannotExportEmptyCanvas"));
     }
     if (canvas) {
       try {
@@ -624,7 +624,7 @@ const ExcalidrawWrapper = () => {
         );
 
         if (errorMessage) {
-          setErrorMessage(errorMessage);
+          throw new Error(errorMessage);
         }
 
         if (url) {
@@ -634,7 +634,7 @@ const ExcalidrawWrapper = () => {
         if (error.name !== "AbortError") {
           const { width, height } = canvas;
           console.error(error, { width, height });
-          setErrorMessage(error.message);
+          throw new Error(error.message);
         }
       }
     }
@@ -712,6 +712,11 @@ const ExcalidrawWrapper = () => {
                         appState: {
                           errorMessage: error.message,
                         },
+                      });
+                    }}
+                    onSuccess={() => {
+                      excalidrawAPI?.updateScene({
+                        appState: { openDialog: null },
                       });
                     }}
                   />

--- a/src/actions/actionExport.tsx
+++ b/src/actions/actionExport.tsx
@@ -191,7 +191,10 @@ export const actionSaveFileToDisk = register({
         },
         app.files,
       );
-      return { commitToHistory: false, appState: { ...appState, fileHandle } };
+      return {
+        commitToHistory: false,
+        appState: { ...appState, openDialog: null, fileHandle },
+      };
     } catch (error: any) {
       if (error?.name !== "AbortError") {
         console.error(error);

--- a/src/actions/actionExport.tsx
+++ b/src/actions/actionExport.tsx
@@ -193,7 +193,12 @@ export const actionSaveFileToDisk = register({
       );
       return {
         commitToHistory: false,
-        appState: { ...appState, openDialog: null, fileHandle },
+        appState: {
+          ...appState,
+          openDialog: null,
+          fileHandle,
+          toast: { message: t("toast.fileSaved") },
+        },
       };
     } catch (error: any) {
       if (error?.name !== "AbortError") {

--- a/src/components/JSONExportDialog.tsx
+++ b/src/components/JSONExportDialog.tsx
@@ -23,12 +23,15 @@ export type ExportCB = (
 const JSONExportModal = ({
   elements,
   appState,
+  setAppState,
   files,
   actionManager,
   exportOpts,
   canvas,
+  onCloseRequest,
 }: {
   appState: UIAppState;
+  setAppState: React.Component<any, UIAppState>["setState"];
   files: BinaryFiles;
   elements: readonly NonDeletedExcalidrawElement[];
   actionManager: ActionManager;
@@ -72,9 +75,14 @@ const JSONExportModal = ({
               title={t("exportDialog.link_button")}
               aria-label={t("exportDialog.link_button")}
               showAriaLabel={true}
-              onClick={() => {
-                onExportToBackend(elements, appState, files, canvas);
-                trackEvent("export", "link", `ui (${getFrame()})`);
+              onClick={async () => {
+                try {
+                  trackEvent("export", "link", `ui (${getFrame()})`);
+                  await onExportToBackend(elements, appState, files, canvas);
+                  onCloseRequest();
+                } catch (error: any) {
+                  setAppState({ errorMessage: error.message });
+                }
               }}
             />
           </Card>
@@ -114,6 +122,7 @@ export const JSONExportDialog = ({
           <JSONExportModal
             elements={elements}
             appState={appState}
+            setAppState={setAppState}
             files={files}
             actionManager={actionManager}
             onCloseRequest={handleClose}

--- a/src/components/ToolButton.tsx
+++ b/src/components/ToolButton.tsx
@@ -83,12 +83,12 @@ export const ToolButton = React.forwardRef((props: ToolButtonProps, ref) => {
     }
   };
 
-  useEffect(
-    () => () => {
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
       isMountedRef.current = false;
-    },
-    [],
-  );
+    };
+  }, []);
 
   const lastPointerTypeRef = useRef<PointerType | null>(null);
 


### PR DESCRIPTION
## Pull Request: Closing of Dialog on Save To Disk

**Description:**

This pull request addresses a user flow issue by adding functionality to close the dialog box when the "Save to Disk" action is performed. 

**Issue:**

More information about the issue can be found on the following GitHub issue created by [@starlove54](https://github.com/starlove54): [excalidraw/excalidraw#7156](https://github.com/excalidraw/excalidraw/issues/7156)

**Changes Made:**

I have made this PR in accordance with the issue mentioned above. Prior to this change, when a user clicked the "Save to Disk" button, the dialog box for "Save to" was not disappearing, resulting in a suboptimal user experience. This pull request resolves this issue by adding the functionality to close the dialog box upon clicking the "Save to Disk" button.

**How to Test:**

To test this change, follow these steps:
1. Open Excalidraw.
2. Create or open a drawing.
3. Click the "Save to Disk" button.
4. The "Save to" dialog box should now close after clicking "Save to Disk."

**Checklist:**

- [x] I have tested this change thoroughly.
- [x] I have added relevant comments and documentation where necessary.
- [x] My code follows the project's coding style guidelines.
- [ ] I have updated the changelog if applicable.

I am looking forward to your feedback and any necessary adjustments to ensure the seamless integration of this feature into Excalidraw.

Thank you!
