### PR TITLE
fix: Fix for Strange Symbol Appearing on Canvas after Deleting Grouped Graphics (Issue #7116)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
 ## 2020-10-13
 
 - Added ability to embed scene source into exported PNG/SVG files so you can import the scene from them (open via `Load` button or drag & drop). #2219
+
+## 2023-10-19
+
+- Removed Selected Group IDs after deleting selected items/groups.

--- a/src/actions/actionDeleteSelected.tsx
+++ b/src/actions/actionDeleteSelected.tsx
@@ -46,6 +46,7 @@ const deleteSelectedElements = (
     appState: {
       ...appState,
       selectedElementIds: {},
+      selectedGroupIds: {},
     },
   };
 };


### PR DESCRIPTION
Issue:

This pull request addresses the issue mentioned in excalidraw/excalidraw#7116, where when grouping selected graphics and subsequently deleting the grouped graphics, an unexpected symbol suddenly appears on the Excalidraw canvas. The symbol disappears upon clicking anywhere on the canvas.

Steps To Reproduce:

Create multiple graphical elements.
Perform a box selection to select these elements.
Right-click and choose the "Group Selection" option.
Delete the grouped selection.
Solution:

The appearance of the strange symbol was due to a selection error. After deletion, it was correctly removing items from the selected items but failing to remove the group from the selected groups. As a result, even though there were no elements left, the selection tool remained active, leading to the appearance of the symbol. To resolve this issue, I have now implemented a fix that sets the selected group IDs to null after the deletion of selected items. This ensures that the selection tool behaves as expected and no longer displays the mysterious symbol.

This pull request aims to address and resolve the issue reported in excalidraw/excalidraw#7116, improving the user experience in Excalidraw. Your feedback and suggestions are highly appreciated as we work towards enhancing the application's functionality.