### PR TITLE
feat: Splitting curves in linear elements like lines and arrows

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "pwacompat": "2.0.17",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "roughjs": "4.6.4",
+    "roughjs": "4.6.5",
     "sass": "1.51.0",
     "socket.io-client": "2.3.1",
     "tunnel-rat": "0.1.2"

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -3750,9 +3750,27 @@ class App extends React.Component<AppProps, AppState> {
       return;
     }
 
+    let { x: sceneX, y: sceneY } = viewportCoordsToSceneCoords(
+      event,
+      this.state,
+    );
+
     const selectedElements = this.scene.getSelectedElements(this.state);
 
     if (selectedElements.length === 1 && isLinearElement(selectedElements[0])) {
+      const pointUnderCursorIndex = LinearElementEditor.getPointIndexUnderCursor(
+        selectedElements[0],
+        this.state.zoom,
+        sceneX,
+        sceneY,
+      );
+      if (pointUnderCursorIndex >= 0) {
+        LinearElementEditor.toggleSegmentSplitAtIndex(
+          selectedElements[0],
+          pointUnderCursorIndex,
+        );
+        return;
+      }
       if (
         event[KEYS.CTRL_OR_CMD] &&
         (!this.state.editingLinearElement ||
@@ -3775,11 +3793,6 @@ class App extends React.Component<AppProps, AppState> {
     }
 
     resetCursor(this.interactiveCanvas);
-
-    let { x: sceneX, y: sceneY } = viewportCoordsToSceneCoords(
-      event,
-      this.state,
-    );
 
     const selectedGroupIds = getSelectedGroupIds(this.state);
 

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -3758,18 +3758,20 @@ class App extends React.Component<AppProps, AppState> {
     const selectedElements = this.scene.getSelectedElements(this.state);
 
     if (selectedElements.length === 1 && isLinearElement(selectedElements[0])) {
-      const pointUnderCursorIndex = LinearElementEditor.getPointIndexUnderCursor(
-        selectedElements[0],
-        this.state.zoom,
-        sceneX,
-        sceneY,
-      );
-      if (pointUnderCursorIndex >= 0) {
-        LinearElementEditor.toggleSegmentSplitAtIndex(
+      if (selectedElements[0].roundness) {
+        const pointUnderCursorIndex = LinearElementEditor.getPointIndexUnderCursor(
           selectedElements[0],
-          pointUnderCursorIndex,
+          this.state.zoom,
+          sceneX,
+          sceneY,
         );
-        return;
+        if (pointUnderCursorIndex >= 0) {
+          LinearElementEditor.toggleSegmentSplitAtIndex(
+            selectedElements[0],
+            pointUnderCursorIndex,
+          );
+          return;
+        } 
       }
       if (
         event[KEYS.CTRL_OR_CMD] &&

--- a/src/data/restore.ts
+++ b/src/data/restore.ts
@@ -285,7 +285,7 @@ const restoreElement = (
         points,
         x,
         y,
-        segmentSplitIndices: [],
+        segmentSplitIndices: element.segmentSplitIndices ? [...element.segmentSplitIndices] : [],
       });
     }
 

--- a/src/data/restore.ts
+++ b/src/data/restore.ts
@@ -285,6 +285,7 @@ const restoreElement = (
         points,
         x,
         y,
+        segmentSplitIndices: [],
       });
     }
 

--- a/src/element/bounds.ts
+++ b/src/element/bounds.ts
@@ -741,7 +741,7 @@ export const getElementPointsCoords = (
   element: ExcalidrawLinearElement,
   points: readonly (readonly [number, number])[],
 ): [number, number, number, number] => {
-  // This might be computationally heavey
+  // This might be computationally heavy
   const gen = rough.generator();
   const curve =
     element.roundness == null

--- a/src/element/linearElementEditor.ts
+++ b/src/element/linearElementEditor.ts
@@ -1472,6 +1472,28 @@ export class LinearElementEditor {
 
     return coords;
   };
+
+  static toggleSegmentSplitAtIndex(
+    element: NonDeleted<ExcalidrawLinearElement>,
+    appState: AppState,
+    index: number,
+  ) {
+    let found = false;
+    const splitIndices = (element.segmentSplitIndices || []).filter((idx) => {
+      if (idx === index) {
+        found = true;
+        return false;
+      }
+      return true;
+    });
+    if (!found) {
+      splitIndices.push(index);
+    }
+
+    mutateElement(element, {
+      segmentSplitIndices: splitIndices,
+    });
+  }
 }
 
 const normalizeSelectedPoints = (

--- a/src/element/linearElementEditor.ts
+++ b/src/element/linearElementEditor.ts
@@ -1475,7 +1475,6 @@ export class LinearElementEditor {
 
   static toggleSegmentSplitAtIndex(
     element: NonDeleted<ExcalidrawLinearElement>,
-    appState: AppState,
     index: number,
   ) {
     let found = false;
@@ -1491,7 +1490,7 @@ export class LinearElementEditor {
     }
 
     mutateElement(element, {
-      segmentSplitIndices: splitIndices,
+      segmentSplitIndices: splitIndices.sort(),
     });
   }
 }

--- a/src/element/mutateElement.ts
+++ b/src/element/mutateElement.ts
@@ -25,7 +25,7 @@ export const mutateElement = <TElement extends Mutable<ExcalidrawElement>>(
 
   // casting to any because can't use `in` operator
   // (see https://github.com/microsoft/TypeScript/issues/21732)
-  const { points, fileId } = updates as any;
+  const { points, fileId, segmentSplitIndices } = updates as any;
 
   if (typeof points !== "undefined") {
     updates = { ...getSizeFromPoints(points), ...updates };
@@ -86,6 +86,7 @@ export const mutateElement = <TElement extends Mutable<ExcalidrawElement>>(
   if (
     typeof updates.height !== "undefined" ||
     typeof updates.width !== "undefined" ||
+    typeof segmentSplitIndices !== "undefined" ||
     typeof fileId != "undefined" ||
     typeof points !== "undefined"
   ) {

--- a/src/element/newElement.ts
+++ b/src/element/newElement.ts
@@ -374,6 +374,7 @@ export const newLinearElement = (
     endBinding: null,
     startArrowhead: opts.startArrowhead || null,
     endArrowhead: opts.endArrowhead || null,
+    segmentSplitIndices: [],
   };
 };
 

--- a/src/element/types.ts
+++ b/src/element/types.ts
@@ -195,6 +195,7 @@ export type ExcalidrawLinearElement = _ExcalidrawElementBase &
   Readonly<{
     type: "line" | "arrow";
     points: readonly Point[];
+    segmentSplitIndices: readonly number[] | null;
     lastCommittedPoint: Point | null;
     startBinding: PointBinding | null;
     endBinding: PointBinding | null;

--- a/src/renderer/renderScene.ts
+++ b/src/renderer/renderScene.ts
@@ -157,10 +157,13 @@ const fillCircle = (
   cy: number,
   radius: number,
   stroke = true,
+  noFill = false,
 ) => {
   context.beginPath();
   context.arc(cx, cy, radius, 0, Math.PI * 2);
-  context.fill();
+  if (!noFill) {
+    context.fill();
+  }
   if (stroke) {
     context.stroke();
   }
@@ -224,6 +227,7 @@ const renderSingleLinearPoint = (
   point: Point,
   radius: number,
   isSelected: boolean,
+  isSegmentSplitting: boolean,
   isPhantomPoint = false,
 ) => {
   context.strokeStyle = "#5e5ad8";
@@ -242,6 +246,16 @@ const renderSingleLinearPoint = (
     radius / appState.zoom.value,
     !isPhantomPoint,
   );
+  if (isSegmentSplitting) {
+    fillCircle(
+      context,
+      point[0],
+      point[1],
+      (radius + 4) / appState.zoom.value,
+      true,
+      true,
+    );
+  }
 };
 
 const renderLinearPointHandles = (
@@ -265,7 +279,9 @@ const renderLinearPointHandles = (
     const isSelected =
       !!appState.editingLinearElement?.selectedPointsIndices?.includes(idx);
 
-    renderSingleLinearPoint(context, appState, point, radius, isSelected);
+    const segmented = element.segmentSplitIndices ? element.segmentSplitIndices.includes(idx) : false;
+
+    renderSingleLinearPoint(context, appState, point, radius, isSelected, segmented);
   });
 
   //Rendering segment mid points
@@ -293,6 +309,7 @@ const renderLinearPointHandles = (
           segmentMidPoint,
           radius,
           false,
+          false,
         );
         highlightPoint(segmentMidPoint, context, appState);
       } else {
@@ -303,6 +320,7 @@ const renderLinearPointHandles = (
           segmentMidPoint,
           radius,
           false,
+          false,
         );
       }
     } else if (appState.editingLinearElement || points.length === 2) {
@@ -311,6 +329,7 @@ const renderLinearPointHandles = (
         appState,
         segmentMidPoint,
         POINT_HANDLE_SIZE / 2,
+        false,
         false,
         true,
       );

--- a/src/renderer/renderScene.ts
+++ b/src/renderer/renderScene.ts
@@ -279,7 +279,7 @@ const renderLinearPointHandles = (
     const isSelected =
       !!appState.editingLinearElement?.selectedPointsIndices?.includes(idx);
 
-    const segmented = element.segmentSplitIndices ? element.segmentSplitIndices.includes(idx) : false;
+    const segmented = element.roundness ? (element.segmentSplitIndices ? element.segmentSplitIndices.includes(idx) : false) : false;
 
     renderSingleLinearPoint(context, appState, point, radius, isSelected, segmented);
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -6459,10 +6459,10 @@ rollup@^3.25.2:
   optionalDependencies:
     fsevents "~2.3.2"
 
-roughjs@4.6.4:
-  version "4.6.4"
-  resolved "https://registry.yarnpkg.com/roughjs/-/roughjs-4.6.4.tgz#b6f39b44645854a6e0a4a28b078368701eb7f939"
-  integrity sha512-s6EZ0BntezkFYMf/9mGn7M8XGIoaav9QQBCnJROWB3brUWQ683Q2LbRD/hq0Z3bAJ/9NVpU/5LpiTWvQMyLDhw==
+roughjs@4.6.5:
+  version "4.6.5"
+  resolved "https://registry.yarnpkg.com/roughjs/-/roughjs-4.6.5.tgz#1db965cf1a043cb7f05181dd7d119f7960fba8d8"
+  integrity sha512-4Q6XBbZWlp8yj1uipq2bQ1CPlxMhW/ukufwkuhh+2L79utk+O5kMSbfVh4UNBMtKJ3PxHQ9Ou3ncNt1iQcphJA==
   dependencies:
     hachure-fill "^0.5.2"
     path-data-parser "^0.1.0"


### PR DESCRIPTION
When you draw a curved line through a set of points, Excalidraw draws a single curve going through the points. 

Now, if you double-click on one of the points it starts a new curve from that point. If any segment of the curve contains only 2 points, then a line is drawn between those two points. 

The point where the curve is being split is shown with an extra concentric circle, while normal points are shown as plain circles.

e.g Take the following curve

<img width="759" alt="Screenshot 2023-10-22 at 5 54 05 PM" src="https://github.com/excalidraw/excalidraw/assets/833927/2d319dfd-8afa-486c-84da-16b1b366db00">

Here's when curve is split at  **E** 

<img width="759" alt="Screenshot 2023-10-22 at 5 54 26 PM" src="https://github.com/excalidraw/excalidraw/assets/833927/7731868e-bae9-4e23-ac41-c895919a1da6">

Here's when curve is split at **D and E** 

<img width="759" alt="Screenshot 2023-10-22 at 5 54 51 PM" src="https://github.com/excalidraw/excalidraw/assets/833927/fc5fce01-75a3-452b-91a2-86aaa9ce23fa">

Here's when curve is split at only **D**  - you see two distinct curves

<img width="759" alt="Screenshot 2023-10-22 at 5 55 19 PM" src="https://github.com/excalidraw/excalidraw/assets/833927/8884f72c-71a9-4869-bc42-33c75fc37e5c">


Here's when curve is split at **C and D**  you get a line between two curves
<img width="759" alt="Screenshot 2023-10-22 at 5 55 44 PM" src="https://github.com/excalidraw/excalidraw/assets/833927/e71f18df-0efc-4117-a698-1af70bcb3186">


This functionality is only enabled on "rounded" line elements at the moment. Linear lines are unchanged. 
