### PR TITLE
fix: Fixes the shortcut collision between "toggleHandTool" and "distributeHorizontally"

### DIFF
--- a/src/actions/actionCanvas.tsx
+++ b/src/actions/actionCanvas.tsx
@@ -438,5 +438,6 @@ export const actionToggleHandTool = register({
       commitToHistory: true,
     };
   },
-  keyTest: (event) => !event.altKey && event.key === KEYS.H,
+  keyTest: (event) =>
+    !event.altKey && !event[KEYS.CTRL_OR_CMD] && event.key === KEYS.H,
 });

--- a/src/actions/actionCanvas.tsx
+++ b/src/actions/actionCanvas.tsx
@@ -438,5 +438,5 @@ export const actionToggleHandTool = register({
       commitToHistory: true,
     };
   },
-  keyTest: (event) => event.key === KEYS.H,
+  keyTest: (event) => !event.altKey && event.key === KEYS.H,
 });


### PR DESCRIPTION
### Issue
#7188 

### Fix
The shortcut `H` for Hand tools doesn't filter out the `ALT` key presses.
This PR adds the filter on the Hand tools shorcut.

### Possible improvements
* Other shortcuts from `actionCanvas.tsx`  doesn't exclude the `ALT`  and might also need this filter
* The `CTRL` key press should probably also be filtered out