### PR TITLE
test: disable flaky test

### DIFF
--- a/src/element/textWysiwyg.test.tsx
+++ b/src/element/textWysiwyg.test.tsx
@@ -224,7 +224,8 @@ describe("textWysiwyg", () => {
       expect(h.elements.length).toBe(1);
     });
 
-    it("should bump the version of a labeled arrow when the label is updated", async () => {
+    // FIXME too flaky. No one knows why.
+    it.skip("should bump the version of a labeled arrow when the label is updated", async () => {
       const arrow = UI.createElement("arrow", {
         width: 300,
         height: 0,

--- a/src/element/textWysiwyg.test.tsx
+++ b/src/element/textWysiwyg.test.tsx
@@ -223,6 +223,19 @@ describe("textWysiwyg", () => {
       expect(h.state.editingElement?.id).toBe(text.id);
       expect(h.elements.length).toBe(1);
     });
+
+    it("should bump the version of a labeled arrow when the label is updated", async () => {
+      const arrow = UI.createElement("arrow", {
+        width: 300,
+        height: 0,
+      });
+      await UI.editText(arrow, "Hello");
+      const { version } = arrow;
+
+      await UI.editText(arrow, "Hello\nworld!");
+
+      expect(arrow.version).toEqual(version + 1);
+    });
   });
 
   describe("Test container-unbound text", () => {
@@ -1505,19 +1518,5 @@ describe("textWysiwyg", () => {
       expect(text.containerId).toBe(null);
       expect(text.text).toBe("Excalidraw");
     });
-  });
-
-  it("should bump the version of a labeled arrow when the label is updated", async () => {
-    await render(<Excalidraw handleKeyboardGlobally={true} />);
-    const arrow = UI.createElement("arrow", {
-      width: 300,
-      height: 0,
-    });
-    await UI.editText(arrow, "Hello");
-    const { version } = arrow;
-
-    await UI.editText(arrow, "Hello\nworld!");
-
-    expect(arrow.version).toEqual(version + 1);
   });
 });


### PR DESCRIPTION
this test case was a sibling of `describe()` block that also rendered `<App/>`. Maybe that's the issue, maybe not :).

EDIT: guess not