### PR TITLE
fix: allow pointer events when editing a linear element

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1176,6 +1176,19 @@ class App extends React.Component<AppProps, AppState> {
         pendingImageElementId: this.state.pendingImageElementId,
       });
 
+    const shouldBlockPointerEvents =
+      !(
+        this.state.editingElement && isLinearElement(this.state.editingElement)
+      ) &&
+      (this.state.selectionElement ||
+        this.state.draggingElement ||
+        this.state.resizingElement ||
+        (this.state.activeTool.type === "laser" &&
+          // technically we can just test on this once we make it more safe
+          this.state.cursorButton === "down") ||
+        (this.state.editingElement &&
+          !isTextElement(this.state.editingElement)));
+
     return (
       <div
         className={clsx("excalidraw excalidraw-container", {
@@ -1183,17 +1196,9 @@ class App extends React.Component<AppProps, AppState> {
           "excalidraw--mobile": this.device.isMobile,
         })}
         style={{
-          ["--ui-pointerEvents" as any]:
-            this.state.selectionElement ||
-            this.state.draggingElement ||
-            this.state.resizingElement ||
-            (this.state.activeTool.type === "laser" &&
-              // technically we can just test on this once we make it more safe
-              this.state.cursorButton === "down") ||
-            (this.state.editingElement &&
-              !isTextElement(this.state.editingElement))
-              ? POINTER_EVENTS.disabled
-              : POINTER_EVENTS.enabled,
+          ["--ui-pointerEvents" as any]: shouldBlockPointerEvents
+            ? POINTER_EVENTS.disabled
+            : POINTER_EVENTS.enabled,
         }}
         ref={this.excalidrawContainerRef}
         onDrop={this.handleAppOnDrop}


### PR DESCRIPTION
With the line or arrow tool if you tap the screen with two fingers you can create multipoint lines by taping points one by one. There is a button on the mobile toolbar to complete the line, but it is currently disabled. If the user enters this mode there is practically no way out, just closing Excalidraw. This PR addresses this issue by allowing pointer events when editing a linear element.

![image](https://github.com/excalidraw/excalidraw/assets/14358394/06c26f99-5818-4032-a78a-ef2699cd1f26)
