### PR TITLE
fix: Can't toggle penMode off due to missing typecheck in togglePenMode

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -2716,9 +2716,7 @@ class App extends React.Component<AppProps, AppState> {
     });
   };
 
-  togglePenMode = (force?: boolean) => {
-    //input onChange calls togglePenMode with event as argument
-    force = typeof force === "boolean" ? force : undefined;
+  togglePenMode = (force: boolean | null) => {
     this.setState((prevState) => {
       return {
         penMode: force ?? !prevState.penMode,

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -2717,6 +2717,8 @@ class App extends React.Component<AppProps, AppState> {
   };
 
   togglePenMode = (force?: boolean) => {
+    //input onChange calls togglePenMode with event as argument
+    force = typeof force === "boolean" ? force : undefined;
     this.setState((prevState) => {
       return {
         penMode: force ?? !prevState.penMode,

--- a/src/components/LayerUI.tsx
+++ b/src/components/LayerUI.tsx
@@ -66,7 +66,7 @@ interface LayerUIProps {
   elements: readonly NonDeletedExcalidrawElement[];
   onLockToggle: () => void;
   onHandToolToggle: () => void;
-  onPenModeToggle: () => void;
+  onPenModeToggle: AppClassProperties["togglePenMode"];
   showExitZenModeBtn: boolean;
   langCode: Language["code"];
   renderTopRightUI?: ExcalidrawProps["renderTopRightUI"];
@@ -258,7 +258,7 @@ const LayerUI = ({
                           <PenModeButton
                             zenModeEnabled={appState.zenModeEnabled}
                             checked={appState.penMode}
-                            onChange={onPenModeToggle}
+                            onChange={() => onPenModeToggle(null)}
                             title={t("toolBar.penMode")}
                             penDetected={appState.penDetected}
                           />

--- a/src/components/MobileMenu.tsx
+++ b/src/components/MobileMenu.tsx
@@ -35,7 +35,7 @@ type MobileMenuProps = {
   elements: readonly NonDeletedExcalidrawElement[];
   onLockToggle: () => void;
   onHandToolToggle: () => void;
-  onPenModeToggle: () => void;
+  onPenModeToggle: AppClassProperties["togglePenMode"];
 
   renderTopRightUI?: (
     isMobile: boolean,
@@ -94,7 +94,7 @@ export const MobileMenu = ({
                   )}
                   <PenModeButton
                     checked={appState.penMode}
-                    onChange={onPenModeToggle}
+                    onChange={() => onPenModeToggle(null)}
                     title={t("toolBar.penMode")}
                     isMobile
                     penDetected={appState.penDetected}


### PR DESCRIPTION
If you activate pen mode by touching the screen with a pen, currently there is no way to disable it because onPenModeToggle calls the function with an event argument which is interpreted as a force true.