### PR TITLE
fix: onPointerMove cancels ContextMenu locked element selection on Mobile

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -5955,7 +5955,9 @@ class App extends React.Component<AppProps, AppState> {
   ) {
     return withBatchedUpdatesThrottled((event: PointerEvent) => {
       //To avoid pointerMove canceling the selection of locked elements on mobile
-      if(Boolean(this.state.contextMenu)) return;
+      if (Boolean(this.state.contextMenu)) {
+        return;
+      }
 
       // We need to initialize dragOffsetXY only after we've updated
       // `state.selectedElementIds` on pointerDown. Doing it here in pointerMove

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -5954,6 +5954,9 @@ class App extends React.Component<AppProps, AppState> {
     pointerDownState: PointerDownState,
   ) {
     return withBatchedUpdatesThrottled((event: PointerEvent) => {
+      //To avoid pointerMove canceling the selection of locked elements on mobile
+      if(Boolean(this.state.contextMenu)) return;
+
       // We need to initialize dragOffsetXY only after we've updated
       // `state.selectedElementIds` on pointerDown. Doing it here in pointerMove
       // event handler should hopefully ensure we're already working with


### PR DESCRIPTION
If you lock an element on a touch screen it is extremely hard/impossible to unlock. You long press, the locked element selection flashes up, the context menu is opened, but by the time you would unlock the element, the selection is no more. This is because the onPointerMove event handler overrides the selection. When the context menu is active the onPointerMove function should abort.