### PR TITLE
build: use caret for specifying node version to avoid major upgrades automatically

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "vitest-canvas-mock": "0.3.2"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": "^18.0.0"
   },
   "homepage": ".",
   "name": "excalidraw",


### PR DESCRIPTION
Additionally, vercel was also warning about using `>=18.0.0` for node version so that would also be gone with this.