### PR TITLE
fix: make zoomToFit fitToViewport account for sidebar

### DIFF
--- a/src/actions/actionCanvas.tsx
+++ b/src/actions/actionCanvas.tsx
@@ -265,7 +265,21 @@ export const zoomToFit = ({
       30.0,
     ) as NormalizedZoomValue;
 
-    scrollX = (appState.width / 2) * (1 / newZoomValue) - centerX;
+    let appStateWidth = appState.width;
+
+    if (appState.openSidebar) {
+      const sidebarDOMElem = document.querySelector(
+        ".sidebar",
+      ) as HTMLElement | null;
+      const sidebarWidth = sidebarDOMElem?.offsetWidth ?? 0;
+      const isRTL = document.documentElement.getAttribute("dir") === "rtl";
+
+      appStateWidth = !isRTL
+        ? appState.width - sidebarWidth
+        : appState.width + sidebarWidth;
+    }
+
+    scrollX = (appStateWidth / 2) * (1 / newZoomValue) - centerX;
     scrollY = (appState.height / 2) * (1 / newZoomValue) - centerY;
   } else {
     newZoomValue = zoomValueToFitBoundsOnViewport(commonBounds, {


### PR DESCRIPTION
This PR slightly improves the behaviour of the `zoomToFit` function when called with the `fitToViewport` flag. It now accounts for the presence of the sidebar when it is open.

One particular issue it addresses is in E+ when clicking on a slide preview in the presentation/frames sidebar. Right now, clicking on a slide/frame preview does centre the frame on the scene but it does not account for the sidebar being open so the centering happens relative to the appWidth and not appWidth - sidebarWidth.

With this PR, the centering will now happen relative to the actually visible canvas area. (The PR should also account for RTL orientation too when the sidebar is on the left.)