### PR TITLE
fix: Fix text element inside container when rotated

### DIFF
--- a/src/element/newElement.ts
+++ b/src/element/newElement.ts
@@ -283,7 +283,6 @@ const getAdjustedDimensions = (
 
     [x, y] = adjustXYWithRotation(
       {
-        s: true,
         e: textAlign === "center" || textAlign === "left",
         w: textAlign === "center" || textAlign === "right",
       },


### PR DESCRIPTION
This is rather an easy fix if looking at the lines changed ... actually just one line.

But this let me wonder why not a problem when box is not rotated?? 🧐

So, the explanation is: when the box is not rotated (90deg), with s: true, X will always X=X+sin(angle)*delta, and sin(90deg)* delta !always! = 0 ! Amazing mathematics!! 😝

![Monosnap screencast 2023-11-17 23-22-39](https://github.com/excalidraw/excalidraw/assets/499599/98dc29e1-3aaf-4d2c-b795-55301497cc66)
