### PR TITLE
feat: introduce dynamic port handling in Docker environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,18 @@ RUN yarn build:app:docker
 
 FROM nginx:1.21-alpine
 
-COPY --from=build /opt/node_app/build /usr/share/nginx/html
+# Set a default value for PORT if it's not set
+# Using :80 for backward compatibility with the
+# original value in /etc/nginx/conf.d/default.conf
+ENV PORT=${PORT:-80}
+EXPOSE ${PORT}
 
-HEALTHCHECK CMD wget -q -O /dev/null http://localhost || exit 1
+COPY --from=build /opt/node_app/build /usr/share/nginx/html
+COPY docker-config/nginx.conf.template /etc/nginx/conf.d/nginx.conf.template
+COPY docker-config/docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
+
+HEALTHCHECK  --interval=30s --timeout=3s --retries=3 \
+    CMD wget -q -O /dev/null http://localhost:${PORT} || exit 1

--- a/docker-config/docker-entrypoint.sh
+++ b/docker-config/docker-entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+/etc/init.d/nginx stop
+# Substitute the PORT in the Nginx config template and remove comments
+envsubst '$PORT' < /etc/nginx/conf.d/nginx.conf.template | grep -v '^#' > /etc/nginx/conf.d/default.conf
+if [ $? -ne 0 ]; then
+  echo "Error: Failed to update /etc/nginx/conf.d/default.conf. with port ${PORT}"
+  exit 1
+fi
+/etc/init.d/nginx restart
+
+exec "$@"

--- a/docker-config/nginx.conf.template
+++ b/docker-config/nginx.conf.template
@@ -1,0 +1,44 @@
+# /etc/nginx/conf.d/default.conf file found in nginx:1.21-alpine
+server {
+    listen       $PORT;
+    server_name  localhost;
+
+    #access_log  /var/log/nginx/host.access.log  main;
+
+    location / {
+        root   /usr/share/nginx/html;
+        index  index.html index.htm;
+    }
+
+    #error_page  404              /404.html;
+
+    # redirect server error pages to the static page /50x.html
+    #
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+
+    # proxy the PHP scripts to Apache listening on 127.0.0.1:80
+    #
+    #location ~ \.php$ {
+    #    proxy_pass   http://127.0.0.1;
+    #}
+
+    # pass the PHP scripts to FastCGI server listening on 127.0.0.1:9000
+    #
+    #location ~ \.php$ {
+    #    root           html;
+    #    fastcgi_pass   127.0.0.1:9000;
+    #    fastcgi_index  index.php;
+    #    fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
+    #    include        fastcgi_params;
+    #}
+
+    # deny access to .htaccess files, if Apache's document root
+    # concurs with nginx's one
+    #
+    #location ~ /\.ht {
+    #    deny  all;
+    #}
+}


### PR DESCRIPTION
This pull request introduces a new feature that enables dynamic port configuration when deploying the Excalidraw application in a Dockerized environment.

Please note that this change only brings port substitution in Nginx configuration without applying any further optimization.

## Motivation

In its current state, the Docker setup for Excalidraw has the Nginx server in `/etc/nginx/conf.d/default.conf` listening on port 80 by default. While this works seamlessly in many environments, it poses challenges in scenarios where there are permissions limitations on the execution role, making it unable to bind to this port.

For instance, when deploying on platforms like Heroku, the web process is required to listen for HTTP traffic on a dynamically assigned $PORT, set by Heroku itself (see [Heroku doc](https://devcenter.heroku.com/articles/container-registry-and-runtime#dockerfile-commands-and-runtime)).

```
nginx: [warn] the "user" directive makes sense only if the master process runs with super-user privileges, ignored in /etc/nginx/nginx.conf:2
```
* https://stackoverflow.com/q/61788582
* https://stackoverflow.com/q/47364019

This limitation extends to on-premise deployment scenarios where similar port binding restrictions may exist. Enabling dynamic port configuration aligns with Excalidraw's MIT License ethos, fostering broader on-premise adoption. It opens up opportunities for contributions from a community of developers who, due to company policies, cannot use the service hosted at https://excalidraw.com/.

## Testing

* local build and run
* successful deployment to Heroku