### PR TITLE
feat: Widen `ActionName` and `ShortcutName` to include `custom.${string}`

### DIFF
--- a/src/actions/shortcuts.ts
+++ b/src/actions/shortcuts.ts
@@ -2,11 +2,12 @@ import { isDarwin } from "../constants";
 import { t } from "../i18n";
 import { SubtypeOf } from "../utility-types";
 import { getShortcutKey } from "../utils";
-import { ActionName } from "./types";
+import { ActionName, CustomActionName } from "./types";
 
 export type ShortcutName =
   | SubtypeOf<
       ActionName,
+      | CustomActionName
       | "toggleTheme"
       | "loadScene"
       | "clearCanvas"
@@ -39,6 +40,15 @@ export type ShortcutName =
     >
   | "saveScene"
   | "imageExport";
+
+export const registerCustomShortcuts = (
+  shortcuts: Record<CustomActionName, string[]>,
+) => {
+  for (const key in shortcuts) {
+    const shortcut = key as CustomActionName;
+    shortcutMap[shortcut] = shortcuts[shortcut];
+  }
+};
 
 const shortcutMap: Record<ShortcutName, string[]> = {
   toggleTheme: [getShortcutKey("Shift+Alt+D")],

--- a/src/actions/types.ts
+++ b/src/actions/types.ts
@@ -35,7 +35,11 @@ type ActionFn = (
 export type UpdaterFn = (res: ActionResult) => void;
 export type ActionFilterFn = (action: Action) => void;
 
+export const makeCustomActionName = (name: string) =>
+  `custom.${name}` as CustomActionName;
+export type CustomActionName = `custom.${string}`;
 export type ActionName =
+  | CustomActionName
   | "copy"
   | "cut"
   | "paste"


### PR DESCRIPTION
Also provided:
- `makeCustomActionName`: avoids hard-coding `custom.${string}`
- `registerCustomShortcuts`: accepts shortcuts named `custom.${string}`

The main current consumers are `ExcalidrawElement` subtype support, and the MathJax subtype.