### PR TITLE
fix: normalizeLink - link.trim() is called before checking if link exists

### DIFF
--- a/src/data/url.ts
+++ b/src/data/url.ts
@@ -1,10 +1,10 @@
 import { sanitizeUrl } from "@braintree/sanitize-url";
 
 export const normalizeLink = (link: string) => {
-  link = link.trim();
   if (!link) {
     return link;
   }
+  link = link.trim();
   return sanitizeUrl(link);
 };
 


### PR DESCRIPTION
If we check for !link we should do it first.