### PR TITLE
fix: disable caching bounds for arrow labels

### DIFF
--- a/src/element/bounds.ts
+++ b/src/element/bounds.ts
@@ -54,7 +54,11 @@ export class ElementBounds {
   static getBounds(element: ExcalidrawElement) {
     const cachedBounds = ElementBounds.boundsCache.get(element);
 
-    if (cachedBounds?.version && cachedBounds.version === element.version) {
+    if (
+      cachedBounds?.version &&
+      cachedBounds.version === element.version &&
+      (element.type !== "text" || !element.containerId)
+    ) {
       return cachedBounds.bounds;
     }
 

--- a/src/element/bounds.ts
+++ b/src/element/bounds.ts
@@ -13,6 +13,7 @@ import { Point } from "../types";
 import { generateRoughOptions } from "../scene/Shape";
 import {
   isArrowElement,
+  isBoundToContainer,
   isFreeDrawElement,
   isLinearElement,
   isTextElement,
@@ -57,7 +58,9 @@ export class ElementBounds {
     if (
       cachedBounds?.version &&
       cachedBounds.version === element.version &&
-      (element.type !== "text" || !element.containerId)
+      // we don't invalidate cache when we update containers and not labels,
+      // which is causing problems down the line. Fix TBA.
+      !isBoundToContainer(element)
     ) {
       return cachedBounds.bounds;
     }


### PR DESCRIPTION
Since we've recently stopped updating arrow labels, we don't invalidate Bounds cache for labels when container is moved. This is causing bugs when checking for visibility and such.

This PR is a hotfix to ignore cache for bound text. Proper fix after proper analysis.