### PR TITLE
fix: drop onKeyDown if shift is down and element is resizing

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -3543,8 +3543,11 @@ class App extends React.Component<AppProps, AppState> {
   // Input handling
   private onKeyDown = withBatchedUpdates(
     (event: React.KeyboardEvent | KeyboardEvent) => {
+      if(this.state.resizingElement && event.shiftKey) {
+        event.stopPropagation();
+        return;
+      }
       // normalize `event.key` when CapsLock is pressed #2372
-
       if (
         "Proxy" in window &&
         ((!event.shiftKey && /^[A-Z]$/.test(event.key)) ||


### PR DESCRIPTION
I was working on a slow PC today and I noticed it choked on the resizing of sticky notes. I looked at what was happening with the performance profiler in the Developer Console and found that key-down events were firing on top of each other until the CPU got overwhelmed. Stopping event propagation and dropping the onKeyDown event if the element is resizing helped solve this issue.

