### PR TITLE
fix: frame name field

### DIFF
--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -1254,6 +1254,7 @@ class App extends React.Component<AppProps, AppState> {
                 name: e.target.value,
               });
             }}
+            onFocus={(e) => e.target.select()}
             onBlur={() => reset()}
             onKeyDown={(event) => {
               // for some inexplicable reason, `onBlur` triggered on ESC

--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -1228,10 +1228,7 @@ class App extends React.Component<AppProps, AppState> {
       const FRAME_NAME_EDIT_PADDING = 6;
 
       const reset = () => {
-        if (f.name?.trim() === "") {
-          mutateElement(f, { name: null });
-        }
-
+        mutateElement(f, { name: f.name?.trim() || null });
         this.setState({ editingFrame: null });
       };
 

--- a/packages/excalidraw/frame.ts
+++ b/packages/excalidraw/frame.ts
@@ -659,7 +659,7 @@ export const getFrameLikeTitle = (
 ) => {
   const existingName = element.name?.trim();
   if (existingName) {
-    return existingName;
+    return element.name!;
   }
   // TODO name frames AI only is specific to AI frames
   return isFrameElement(element) ? `Frame ${frameIdx}` : `AI Frame ${frameIdx}`;


### PR DESCRIPTION
- on focus select the entire input text of the frame name
- trim name on reset to allow trailing whitespace