### PR TITLE
Feat: Add additional fonts support

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -109,6 +109,21 @@ export const FONT_FAMILY = {
   Assistant: 4,
 };
 
+/**
+ * As a supplement to the original fonts, Virgil fonts only provide some character fonts,
+ * which cannot meet the needs of Chinese and other handwritten fonts.
+ * Users can add additional font supplements here. For example, when the user selects handwriting,
+ * Virgil and XinYeNianTi will take effect at the same time.
+ * ```
+ * export const FONT_FAMILY_ADDITIONAL = {
+ *   Virgil: ["XinYeNianTi"],
+ * };
+ * ```
+ */
+export const FONT_FAMILY_ADDITIONAL = {
+  // Virgil: ["XinYeNianTi"],
+};
+
 export const THEME = {
   LIGHT: "light",
   DARK: "dark",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,6 +3,7 @@ import {
   DEFAULT_VERSION,
   EVENT,
   FONT_FAMILY,
+  FONT_FAMILY_ADDITIONAL,
   isDarwin,
   WINDOWS_EMOJI_FALLBACK_FONT,
 } from "./constants";
@@ -84,7 +85,11 @@ export const getFontFamilyString = ({
 }) => {
   for (const [fontFamilyString, id] of Object.entries(FONT_FAMILY)) {
     if (id === fontFamily) {
-      return `${fontFamilyString}, ${WINDOWS_EMOJI_FALLBACK_FONT}`;
+      const additional = Object.entries(FONT_FAMILY_ADDITIONAL)
+        .filter(([name, value]) => name === fontFamilyString)
+        .flatMap(([name, value]) => value)
+        .join(", ");
+      return `${fontFamilyString}, ${WINDOWS_EMOJI_FALLBACK_FONT}, ${additional}`;
     }
   }
   return WINDOWS_EMOJI_FALLBACK_FONT;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -89,7 +89,10 @@ export const getFontFamilyString = ({
         .filter(([name, value]) => name === fontFamilyString)
         .flatMap(([name, value]) => value)
         .join(", ");
-      return `${fontFamilyString}, ${WINDOWS_EMOJI_FALLBACK_FONT}, ${additional}`;
+      if (additional) {
+        return `${fontFamilyString}, ${WINDOWS_EMOJI_FALLBACK_FONT}, ${additional}`;
+      }
+      return `${fontFamilyString}, ${WINDOWS_EMOJI_FALLBACK_FONT}`;
     }
   }
   return WINDOWS_EMOJI_FALLBACK_FONT;


### PR DESCRIPTION
As a supplement to the original fonts, Virgil fonts only provide some character fonts,
which cannot meet the needs of Chinese and other handwritten fonts.
Users can add additional font supplements here. For example, when the user selects handwriting,
Virgil and XinYeNianTi will take effect at the same time.
```
export const FONT_FAMILY_ADDITIONAL = {
  Virgil: ["XinYeNianTi"],
};
```

![image](https://github.com/excalidraw/excalidraw/assets/1937723/bf7a6115-98a7-42f2-ab42-ab021bc64042)