### PR TITLE
chore: prepare release 0.17.2

### DIFF
--- a/src/packages/excalidraw/CHANGELOG.md
+++ b/src/packages/excalidraw/CHANGELOG.md
@@ -17,7 +17,7 @@ Please add the latest change on the top under the correct section.
 
 - `appState.openDialog` type was changed from `null | string` to `null | { name: string }`. [#7336](https://github.com/excalidraw/excalidraw/pull/7336)
 
-## 0.17.1 (2023-11-28)
+## 0.17.2 (2023-12-04)
 
 ### Fixes
 

--- a/src/packages/excalidraw/package.json
+++ b/src/packages/excalidraw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@excalidraw/excalidraw",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "main": "main.js",
   "types": "types/packages/excalidraw/index.d.ts",
   "files": [


### PR DESCRIPTION
Nothing meaningful changed so I'm just changing the changelog version as the 0.17.1 wasn't released as stable.