### PR TITLE
fix: frame name input can't delete completely

### DIFF
--- a/src/frame.ts
+++ b/src/frame.ts
@@ -658,8 +658,8 @@ export const getFrameLikeTitle = (
   frameIdx: number,
 ) => {
   const existingName = element.name?.trim();
-  if (existingName) {
-    return existingName;
+  if (existingName || existingName === "") {
+    return element.name!;
   }
   // TODO name frames AI only is specific to AI frames
   return isFrameElement(element) ? `Frame ${frameIdx}` : `AI Frame ${frameIdx}`;


### PR DESCRIPTION
I found that I cannot completely rename the input box of the frame. 
I added a feature to completely delete it if it is an empty string, but after blurring, it still shows "Frame 1".

![CleanShot 2023-12-04 at 23 05 40](https://github.com/excalidraw/excalidraw/assets/44605072/86e1488a-1a7b-4ab6-9493-8c83d1026b50)
