### PR TITLE
build: Add checks for vite compatibility.

### DIFF
--- a/src/packages/excalidraw/CHANGELOG.md
+++ b/src/packages/excalidraw/CHANGELOG.md
@@ -21,7 +21,7 @@ Please add the latest change on the top under the correct section.
 
 ### Fixes
 
-- Add support for building on vite [#7394] (https://github.com/excalidraw/excalidraw/pull/7394) to make sure that the correct build file is use when building for production or Preact on vite.
+- Add support for building on vite [#7394] (https://github.com/excalidraw/excalidraw/pull/7394) to make sure that the correct excalidraw file is used.
 
 - Umd build for browser since it was breaking in v0.17.0 [#7349](https://github.com/excalidraw/excalidraw/pull/7349). Also make sure that when using `Vite`, the `process.env.IS_PREACT` is set as `"true"` (string) and not a boolean.
 

--- a/src/packages/excalidraw/CHANGELOG.md
+++ b/src/packages/excalidraw/CHANGELOG.md
@@ -21,6 +21,8 @@ Please add the latest change on the top under the correct section.
 
 ### Fixes
 
+- Add support for building on vite [#7394] (https://github.com/excalidraw/excalidraw/pull/7394) to make sure that the correct build file is use when building for production or Preact on vite.
+
 - Umd build for browser since it was breaking in v0.17.0 [#7349](https://github.com/excalidraw/excalidraw/pull/7349). Also make sure that when using `Vite`, the `process.env.IS_PREACT` is set as `"true"` (string) and not a boolean.
 
 ```

--- a/src/packages/excalidraw/main.js
+++ b/src/packages/excalidraw/main.js
@@ -1,10 +1,10 @@
-if (process.env.IS_PREACT === "true") {
-  if (process.env.NODE_ENV === "production") {
+if ((process && process.env.IS_PREACT === "true") || import.meta.env.IS_PREACT === "true") {
+  if (process.env.NODE_ENV === "production" || import.meta.env.MODE === "production") {
     module.exports = require("./dist/excalidraw-with-preact.production.min.js");
   } else {
     module.exports = require("./dist/excalidraw-with-preact.development.js");
   }
-} else if (process.env.NODE_ENV === "production") {
+} else if ((process && process.env.NODE_ENV === "production") || import.meta.env.MODE === "production") {
   module.exports = require("./dist/excalidraw.production.min.js");
 } else {
   module.exports = require("./dist/excalidraw.development.js");


### PR DESCRIPTION
# What does this PR do? 

This PR brings vite support to the build sistem.

# Motivation 

It seems like [vite](https://vitejs.dev/) has a diffrent way of exporting  envrionment variables, as opposed to [create-react-app](https://create-react-app.dev/) and similar applications, so attempting build an application that uses `excalidraw` on `vite` will automatically deploy the development build (and since more recent changes, the Preact build since it seems to be skipping those checks and just falling through the first condition on the if tree). 

# Explanation of the changes

Whereas `create-react-app` will export variables using the [convention](https://create-react-app.dev/docs/adding-custom-environment-variables#what-other-env-files-can-be-used) `process.env.*` in order to let programs access (among other things) the environment configuration (DEV/PROD, etc..), `vite` will export variables using the [convention](https://vitejs.dev/guide/env-and-mode) `import.meta.env.*` . 

This PR adds a few checks to the main exports file to make sure to check for the correct variables on both vite and create-react-app (`process` is not defined on `vite`, for example) hence ensuring that users that use `excalidraw` projects on `vite`, can get the correct production build without having to manually modify the exports file. 