### PR TITLE
docs: Fix argument type of excalidrawAPI.addFiles()

### DIFF
--- a/dev-docs/docs/@excalidraw/excalidraw/api/props/excalidraw-api.mdx
+++ b/dev-docs/docs/@excalidraw/excalidraw/api/props/excalidraw-api.mdx
@@ -205,7 +205,7 @@ function App() {
 <pre>
   (files:{" "}
   <a href="https://github.com/excalidraw/excalidraw/blob/master/src/types.ts#L59">
-    BinaryFileData
+    BinaryFileData[]
   </a>
   ) => void
 </pre>


### PR DESCRIPTION
When I passed a file data to `addFiles()`, it throwed an error saying `files.reduce` is not defined.

Passing an arrary of files worked.

Therefore, it looks like the argument should be an array, not raw file data.
