### PR TITLE
docs: Fix links in excalidrawAPI

### DIFF
--- a/dev-docs/docs/@excalidraw/excalidraw/api/props/excalidraw-api.mdx
+++ b/dev-docs/docs/@excalidraw/excalidraw/api/props/excalidraw-api.mdx
@@ -38,9 +38,9 @@ You can use this prop when you want to access some [Excalidraw APIs](https://git
 | [setCursor](#setcursor) | `function` | This API can be used to set customise the mouse cursor on the canvas |
 | [resetCursor](#resetcursor) | `function` | This API can be used to reset to default mouse cursor on the canvas |
 | [toggleMenu](#togglemenu) | `function` | Toggles specific menus on/off |
-| [onChange](#onChange) | `function` | Subscribes to change events |
-| [onPointerDown](#onPointerDown) | `function` | Subscribes to `pointerdown` events |
-| [onPointerUp](#onPointerUp) | `function` | Subscribes to `pointerup` events |
+| [onChange](#onchange) | `function` | Subscribes to change events |
+| [onPointerDown](#onpointerdown) | `function` | Subscribes to `pointerdown` events |
+| [onPointerUp](#onpointerup) | `function` | Subscribes to `pointerup` events |
 
 :::info The `Ref` support has been removed in v0.17.0 so if you are using refs, please update the integration to use the `excalidrawAPI`.
 


### PR DESCRIPTION
Fix links for following properties:

* `onChange`
* `onPointerDown`
* `onPointerUp`
