### PR TITLE
docs: Fix Props.onPointerUpdate() arguments

### DIFF
--- a/dev-docs/docs/@excalidraw/excalidraw/api/props/props.mdx
+++ b/dev-docs/docs/@excalidraw/excalidraw/api/props/props.mdx
@@ -72,10 +72,10 @@ Here you can try saving the data to your backend or local storage for example.
 This callback is triggered when mouse pointer is updated.
 
 ```js
-({ x, y }, button, pointersMap}) => void;
+({pointer, button, pointersMap}) => void;
 ```
 
-1.`{x, y}`: Pointer coordinates
+1.`pointer`: [`CollaboratorPointer`](https://github.com/excalidraw/excalidraw/blob/master/src/types.ts#L61) having the pointer coordinates and type.
 
 2.`button`: The position of the button. This will be one of `["down", "up"]`
 


### PR DESCRIPTION
The document says that there are 3 arguments, but the behavior and source code are suggesting that there are only 1 argument with 3 properties.

https://github.com/excalidraw/excalidraw/blob/a04cc707c323c95edce13a8691d0fa973d4549eb/src/components/App.tsx#L9151-L9161
