### PR TITLE
docs: Fix link in API/Children Components/MainMenu

### DIFF
--- a/dev-docs/docs/@excalidraw/excalidraw/api/children-components/main-menu.mdx
+++ b/dev-docs/docs/@excalidraw/excalidraw/api/children-components/main-menu.mdx
@@ -133,7 +133,7 @@ function App() {
 }
 ```
 
-Here is a [complete list](https://github.com/excalidraw/excalidraw/blob/master/src/components/mainMenu/DefaultItems.tsx) of the default items.
+Here is a [complete list](https://github.com/excalidraw/excalidraw/blob/master/src/components/main-menu/DefaultItems.tsx) of the default items.
 
 ### MainMenu.Group
 


### PR DESCRIPTION
Fix a broken link in [MainMenu](https://docs.excalidraw.com/docs/@excalidraw/excalidraw/api/children-components/main-menu) page.
