### PR TITLE
memoize rendering actions in sidebar to improve performance

### DIFF
--- a/src/components/LayerUI.tsx
+++ b/src/components/LayerUI.tsx
@@ -239,12 +239,14 @@ const LayerUI = ({
       elements,
     );
 
+    const actionsMemoized = useMemo(renderSelectedShapeActions, [appState.selectedElementIds]);
+
     return (
       <FixedSideContainer side="top">
         <div className="App-menu App-menu_top">
           <Stack.Col gap={6} className={clsx("App-menu_top__left")}>
             {renderCanvasActions()}
-            {shouldRenderSelectedShapeActions && renderSelectedShapeActions()}
+            {shouldRenderSelectedShapeActions && actionsMemoized}
           </Stack.Col>
           {!appState.viewModeEnabled && (
             <Section heading="shapes" className="shapes-section">


### PR DESCRIPTION
Before it was re-rendering all the actions in sidebar while moving the cursor around the canvas, and it's actually quite expensive operation because it iterates across elements many times to compute it's state

Here we avoid unnecessary rendering until user selects other elements

All elements such as transparency scrollbar still work rerendering themselves on interactions