### PR TITLE
Toggle pressure stimulation button

### DIFF
--- a/excalidraw-app/App.tsx
+++ b/excalidraw-app/App.tsx
@@ -133,7 +133,7 @@ const shareableLinkConfirmDialog = {
   description: (
     <Trans
       i18nKey="overwriteConfirm.modal.shareableLink.description"
-      bold={(text) => <strong>{text}</strong>}
+      bold={(text: any) => <strong>{text}</strong>}
       br={() => <br />}
     />
   ),

--- a/packages/excalidraw/actions/actionProperties.tsx
+++ b/packages/excalidraw/actions/actionProperties.tsx
@@ -1170,15 +1170,22 @@ export const actionChangeArrowhead = register({
   },
 });
 
-function calculateAdjustedStrokeWidth(speed: any) {
-  return 1 * speed;
+function calculateAdjustedStrokeWidth(
+  speed: any,
+  pressureSimulationEnabled: boolean,
+) {
+  const pressureFactor = pressureSimulationEnabled ? 0.5 : 1;
+  return pressureFactor * speed;
 }
 
 export const actionPressureSensitivity = register({
   name: "pressureSensitivity",
   trackEvent: false,
   perform: (elements, appState, value, drawingSpeed) => {
-    const adjustedStrokeWidth = calculateAdjustedStrokeWidth(drawingSpeed);
+    const adjustedStrokeWidth = calculateAdjustedStrokeWidth(
+      drawingSpeed,
+      appState.pressureSimulationEnabled,
+    );
 
     return {
       elements: changeProperty(elements, appState, (el) =>
@@ -1195,15 +1202,13 @@ export const actionPressureSensitivity = register({
       useState(false);
 
     const togglePressureSimulation = () => {
-      setPressureSimulationEnabled((prev: any) => !prev);
-      const strokeWidth = pressureSimulationEnabled
-        ? 1
+      setPressureSimulationEnabled((prev: boolean) => !prev);
+      const newStrokeWidth = pressureSimulationEnabled
+        ? STROKE_WIDTH.thin
         : appState.currentItemStrokeWidth;
-
       updateData({
         ...appState,
-        pressureSimulationEnabled,
-        currentItemStrokeWidth: strokeWidth,
+        currentItemStrokeWidth: newStrokeWidth,
       });
     };
     return (
@@ -1224,9 +1229,13 @@ export const actionPressureSensitivity = register({
             value={getFormValue(
               elements,
               appState,
-              (element) => calculateAdjustedStrokeWidth(element),
+              (element) =>
+                calculateAdjustedStrokeWidth(
+                  element,
+                  appState.pressureSimulationEnabled,
+                ),
               true,
-              1,
+              appState.currentItemStrokeWidth,
             )}
           ></button>
         </div>

--- a/packages/excalidraw/actions/actionProperties.tsx
+++ b/packages/excalidraw/actions/actionProperties.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { AppState, Primitive } from "../types";
 import {
   DEFAULT_ELEMENT_BACKGROUND_COLOR_PALETTE,
@@ -1165,6 +1166,71 @@ export const actionChangeArrowhead = register({
           />
         </div>
       </fieldset>
+    );
+  },
+});
+
+function calculateAdjustedStrokeWidth(speed: any) {
+  return 1 * speed;
+}
+
+export const actionPressureSensitivity = register({
+  name: "pressureSensitivity",
+  trackEvent: false,
+  perform: (elements, appState, value, drawingSpeed) => {
+    const adjustedStrokeWidth = calculateAdjustedStrokeWidth(drawingSpeed);
+
+    return {
+      elements: changeProperty(elements, appState, (el) =>
+        newElementWith(el, {
+          strokeWidth: adjustedStrokeWidth,
+        }),
+      ),
+      appState: { ...appState, currentItemStrokeWidth: adjustedStrokeWidth },
+      commitToHistory: true,
+    };
+  },
+  PanelComponent: ({ elements, appState, updateData }) => {
+    const [pressureSimulationEnabled, setPressureSimulationEnabled] =
+      useState(false);
+
+    const togglePressureSimulation = () => {
+      setPressureSimulationEnabled((prev: any) => !prev);
+      const strokeWidth = pressureSimulationEnabled
+        ? 1
+        : appState.currentItemStrokeWidth;
+
+      updateData({
+        ...appState,
+        pressureSimulationEnabled,
+        currentItemStrokeWidth: strokeWidth,
+      });
+    };
+    return (
+      <div className="pressure-container">
+        <label className="pressure-label">
+          {t("labels.pressureSensitivity")}
+        </label>
+        <div className="pressure-button-container">
+          <div
+            onClick={togglePressureSimulation}
+            className={`pressure-button-toggle-ball ${
+              pressureSimulationEnabled ? "active" : ""
+            }`}
+          ></div>
+          <button
+            className="pressure-button"
+            onClick={togglePressureSimulation}
+            value={getFormValue(
+              elements,
+              appState,
+              (element) => calculateAdjustedStrokeWidth(element),
+              true,
+              1,
+            )}
+          ></button>
+        </div>
+      </div>
     );
   },
 });

--- a/packages/excalidraw/actions/index.ts
+++ b/packages/excalidraw/actions/index.ts
@@ -18,6 +18,7 @@ export {
   actionChangeFontFamily,
   actionChangeTextAlign,
   actionChangeVerticalAlign,
+  actionPressureSensitivity
 } from "./actionProperties";
 
 export {

--- a/packages/excalidraw/actions/types.ts
+++ b/packages/excalidraw/actions/types.ts
@@ -104,6 +104,7 @@ export type ActionName =
   | "distributeHorizontally"
   | "distributeVertically"
   | "flipHorizontal"
+  | "pressureSensitivity"
   | "flipVertical"
   | "viewMode"
   | "exportWithDarkMode"

--- a/packages/excalidraw/components/Actions.tsx
+++ b/packages/excalidraw/components/Actions.tsx
@@ -148,9 +148,8 @@ export const SelectedShapeActions = ({
         targetElements.some((element) => canHaveArrowheads(element.type))) && (
         <>{renderAction("changeArrowhead")}</>
       )}
-
-      {renderAction("changeOpacity")}
       {renderAction("pressureSensitivity")}
+      {renderAction("changeOpacity")}
 
       <fieldset>
         <legend>{t("labels.layers")}</legend>

--- a/packages/excalidraw/components/Actions.tsx
+++ b/packages/excalidraw/components/Actions.tsx
@@ -150,6 +150,7 @@ export const SelectedShapeActions = ({
       )}
 
       {renderAction("changeOpacity")}
+      {renderAction("pressureSensitivity")}
 
       <fieldset>
         <legend>{t("labels.layers")}</legend>

--- a/packages/excalidraw/css/styles.scss
+++ b/packages/excalidraw/css/styles.scss
@@ -540,6 +540,44 @@
     }
   }
 
+  .pressure-container {
+    display: flex;
+    gap: 0.8em;
+    align-items: center;
+    margin-top: 0.2rem;
+
+    .pressure-label {
+      font-size: 13px;
+    }
+
+    .pressure-button-container {
+      display: flex;
+      position: relative;
+      margin-top: 0.1rem;
+      .pressure-button-toggle-ball {
+        width: 45%;
+        height: 0.58rem;
+        background-color: var(--default-bg-color);
+        border-radius: 50%;
+        transform: translate(0.7rem, 0.1rem);
+        transition: 0.2s ease-in-out;
+      }
+
+      .pressure-button-toggle-ball.active {
+        transform: translate(1.3rem, 0.1rem);
+      }
+
+      .pressure-button {
+        background-color: var(--link-color);
+        border-radius: 35px;
+        border: none;
+        width: 2rem;
+        height: 0.8rem;
+        font-size: 10px;
+      }
+    }
+  }
+
   input.is-redacted {
     // we don't use type=password because browsers (chrome?) prompt
     // you to save it which is annoying

--- a/packages/excalidraw/css/styles.scss
+++ b/packages/excalidraw/css/styles.scss
@@ -559,12 +559,12 @@
         height: 0.58rem;
         background-color: var(--default-bg-color);
         border-radius: 50%;
-        transform: translate(0.7rem, 0.1rem);
+        transform: translate(0.6rem, 0.1rem);
         transition: 0.2s ease-in-out;
       }
 
       .pressure-button-toggle-ball.active {
-        transform: translate(1.3rem, 0.1rem);
+        transform: translate(1.4em, 0.1rem);
       }
 
       .pressure-button {

--- a/packages/excalidraw/locales/en.json
+++ b/packages/excalidraw/locales/en.json
@@ -30,6 +30,7 @@
     "strokeStyle_dotted": "Dotted",
     "sloppiness": "Sloppiness",
     "opacity": "Opacity",
+    "pressureSensitivity": "pressureSensitivity",
     "textAlign": "Text align",
     "edges": "Edges",
     "sharp": "Sharp",

--- a/packages/excalidraw/locales/en.json
+++ b/packages/excalidraw/locales/en.json
@@ -30,7 +30,7 @@
     "strokeStyle_dotted": "Dotted",
     "sloppiness": "Sloppiness",
     "opacity": "Opacity",
-    "pressureSensitivity": "pressureSensitivity",
+    "pressureSensitivity": "Pressure Sensitivity",
     "textAlign": "Text align",
     "edges": "Edges",
     "sharp": "Sharp",

--- a/packages/excalidraw/types.ts
+++ b/packages/excalidraw/types.ts
@@ -223,6 +223,7 @@ export interface AppState {
   currentItemBackgroundColor: string;
   currentItemFillStyle: ExcalidrawElement["fillStyle"];
   currentItemStrokeWidth: number;
+  pressureSimulationEnabled: boolean;
   currentItemStrokeStyle: ExcalidrawElement["strokeStyle"];
   currentItemRoughness: number;
   currentItemOpacity: number;


### PR DESCRIPTION
**Title:**
Add Pressure Sensitivity Toggle Feature

**Description:**
This pull request introduces a pressure sensitivity toggle feature. Users can now control the pressure sensitivity of the drawing tool, resulting in varying stroke thickness based on drawing speed.

**Changes Made:**
-  Added a pressureSimulationEnabled state to control pressure sensitivity.
- Implemented the togglePressureSimulation function to switch the toggle state.
- Updated the drawing tool to adjust stroke width based on pressure sensitivity.
- Integrated the new feature into the UI with a toggle button.

**Testing:**
- Used the drawing tool with a standard mouse to ensure the toggle affects stroke thickness.
- Zoomed in to observe the effects more clearly.
- Tested drawing lines at different speeds to verify varying stroke thickness.

**Screenshots**

<img width="259" alt="Screenshot 2023-12-14 at 10 21 50" src="https://github.com/excalidraw/excalidraw/assets/112406576/f61ff94a-7bbf-45d7-87fc-55bf90d7f0dc">
<img width="641" alt="Screenshot 2023-12-14 at 10 24 43" src="https://github.com/excalidraw/excalidraw/assets/112406576/9b1be52a-7805-4c19-95b3-73fbdac662ff">

