### PR TITLE
fix:excalidraw#7421 : changed tooltip style of zoom out, in and reset…

### DIFF
--- a/packages/excalidraw/actions/actionCanvas.tsx
+++ b/packages/excalidraw/actions/actionCanvas.tsx
@@ -115,16 +115,16 @@ export const actionZoomIn = register({
     };
   },
   PanelComponent: ({ updateData }) => (
-    <ToolButton
+    <Tooltip label={t("buttons.zoomIn") + " — " + getShortcutKey("CtrlOrCmd++")} style={{ height: "100%", width: "100%" }} children={<ToolButton
       type="button"
       className="zoom-in-button zoom-button"
       icon={ZoomInIcon}
-      title={`${t("buttons.zoomIn")} — ${getShortcutKey("CtrlOrCmd++")}`}
       aria-label={t("buttons.zoomIn")}
       onClick={() => {
         updateData(null);
       }}
-    />
+    />} />
+
   ),
   keyTest: (event) =>
     (event.code === CODES.EQUAL || event.code === CODES.NUM_ADD) &&
@@ -153,16 +153,16 @@ export const actionZoomOut = register({
     };
   },
   PanelComponent: ({ updateData }) => (
-    <ToolButton
-      type="button"
-      className="zoom-out-button zoom-button"
-      icon={ZoomOutIcon}
-      title={`${t("buttons.zoomOut")} — ${getShortcutKey("CtrlOrCmd+-")}`}
-      aria-label={t("buttons.zoomOut")}
-      onClick={() => {
-        updateData(null);
-      }}
-    />
+    <Tooltip label={t("buttons.zoomOut") + " — " + getShortcutKey("CtrlOrCmd+-")} style={{ height: "100%", width: "100%" }} children={
+      <ToolButton
+        type="button"
+        className="zoom-out-button zoom-button"
+        icon={ZoomOutIcon}
+        aria-label={t("buttons.zoomOut")}
+        onClick={() => {
+          updateData(null);
+        }}
+      />} />
   ),
   keyTest: (event) =>
     (event.code === CODES.MINUS || event.code === CODES.NUM_SUBTRACT) &&
@@ -191,11 +191,10 @@ export const actionResetZoom = register({
     };
   },
   PanelComponent: ({ updateData, appState }) => (
-    <Tooltip label={t("buttons.resetZoom")} style={{ height: "100%" }}>
+    <Tooltip label={t("buttons.resetZoom")} style={{ height: "100%" }} children={
       <ToolButton
         type="button"
         className="reset-zoom-button zoom-button"
-        title={t("buttons.resetZoom")}
         aria-label={t("buttons.resetZoom")}
         onClick={() => {
           updateData(null);
@@ -203,7 +202,7 @@ export const actionResetZoom = register({
       >
         {(appState.zoom.value * 100).toFixed(0)}%
       </ToolButton>
-    </Tooltip>
+    } />
   ),
   keyTest: (event) =>
     (event.code === CODES.ZERO || event.code === CODES.NUM_ZERO) &&


### PR DESCRIPTION
tooltip for  zoom in , out and reset button was missing with issue #7421 
fix: #7421 : tooltip style added to the zoom in , out and reset button 
