### PR TITLE
refactor: simplify type definitions with record

### DIFF
--- a/excalidraw-app/sentry.ts
+++ b/excalidraw-app/sentry.ts
@@ -1,7 +1,7 @@
 import * as Sentry from "@sentry/browser";
 import * as SentryIntegrations from "@sentry/integrations";
 
-const SentryEnvHostnameMap: { [key: string]: string } = {
+const SentryEnvHostnameMap: Record<string, string> = {
   "excalidraw.com": "production",
   "vercel.app": "staging",
 };

--- a/packages/excalidraw/actions/actionGroup.tsx
+++ b/packages/excalidraw/actions/actionGroup.tsx
@@ -237,15 +237,12 @@ export const actionUngroup = register({
     // remove binded text elements from selection
     updateAppState.selectedElementIds = Object.entries(
       updateAppState.selectedElementIds,
-    ).reduce(
-      (acc: { [key: ExcalidrawElement["id"]]: true }, [id, selected]) => {
-        if (selected && !boundTextElementIds.includes(id)) {
-          acc[id] = true;
-        }
-        return acc;
-      },
-      {},
-    );
+    ).reduce((acc: Record<ExcalidrawElement["id"], true>, [id, selected]) => {
+      if (selected && !boundTextElementIds.includes(id)) {
+        acc[id] = true;
+      }
+      return acc;
+    }, {});
 
     return {
       appState: { ...appState, ...updateAppState },

--- a/packages/excalidraw/colors.ts
+++ b/packages/excalidraw/colors.ts
@@ -25,7 +25,7 @@ export type ColorPalette = Merge<
 >;
 
 // used general type instead of specific type (ColorPalette) to support custom colors
-export type ColorPaletteCustom = { [key: string]: ColorTuple | string };
+export type ColorPaletteCustom = Record<string, ColorTuple | string>;
 export type ColorShadesIndexes = [number, number, number, number, number];
 
 export const MAX_CUSTOM_COLORS_USED_IN_CANVAS = 5;

--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -5272,9 +5272,9 @@ class App extends React.Component<AppProps, AppState> {
           selectedElementIds: makeNextSelectedElementIds(
             Object.keys(this.state.selectedElementIds)
               .filter((key) => key !== element.id)
-              .reduce((obj: { [id: string]: true }, key) => {
-                obj[key] = this.state.selectedElementIds[key];
-                return obj;
+              .reduce((object: { [id: string]: true }, key) => {
+                object[key] = this.state.selectedElementIds[key];
+                return object;
               }, {}),
             this.state,
           ),

--- a/packages/excalidraw/element/textElement.ts
+++ b/packages/excalidraw/element/textElement.ts
@@ -577,7 +577,7 @@ export const wrapText = (text: string, font: FontString, maxWidth: number) => {
 };
 
 export const charWidth = (() => {
-  const cachedCharWidth: { [key: FontString]: Array<number> } = {};
+  const cachedCharWidth: Record<FontString, Array<number>> = {};
 
   const calculate = (char: string, font: FontString) => {
     const ascii = char.charCodeAt(0);

--- a/packages/excalidraw/i18n.ts
+++ b/packages/excalidraw/i18n.ts
@@ -126,7 +126,7 @@ const findPartsForData = (data: any, parts: string[]) => {
 
 export const t = (
   path: NestedKeyOf<typeof fallbackLangData>,
-  replacement?: { [key: string]: string | number } | null,
+  replacement?: Record<string, string | number> | null,
   fallback?: string,
 ) => {
   if (currentLang.code.startsWith(TEST_LANG_CODE)) {

--- a/packages/excalidraw/snapping.ts
+++ b/packages/excalidraw/snapping.ts
@@ -774,8 +774,8 @@ const createPointSnapLines = (
   nearestSnapsX: Snaps,
   nearestSnapsY: Snaps,
 ): PointSnapLine[] => {
-  const snapsX = {} as { [key: string]: Point[] };
-  const snapsY = {} as { [key: string]: Point[] };
+  const snapsX = {} as Record<string, Point[]>;
+  const snapsY = {} as Record<string, Point[]>;
 
   if (nearestSnapsX.length > 0) {
     for (const snap of nearestSnapsX) {


### PR DESCRIPTION
### What I Did
I refactored the existing codebase, replacing the { [key: string]: string } type notation with the more concise and TypeScript-specific Record<string, string> type. This change is aimed at enhancing code readability and leveraging TypeScript's advanced type capabilities for better type checking and maintainability.

### Proposal
I propose that this refactor be merged into our main codebase. The use of Record<string, string> not only simplifies our type definitions but also aligns with best practices in TypeScript for handling homogenous types. This change will make our code more robust and easier to understand, especially for new developers joining the project. Additionally, this modification paves the way for further improvements in our type system and overall code quality.