### PR TITLE
refactor: unify array type notation

### DIFF
--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -5064,7 +5064,7 @@ class App extends React.Component<AppProps, AppState> {
       });
     };
 
-    const idsToUpdate: Array<string> = [];
+    const idsToUpdate: string[] = [];
 
     const distance = distance2d(
       pointerDownState.lastCoords.x,

--- a/packages/excalidraw/data/ai/types.ts
+++ b/packages/excalidraw/data/ai/types.ts
@@ -42,7 +42,7 @@ export namespace OpenAIInput {
     /**
      * The contents of the user message.
      */
-    content: string | Array<ChatCompletionContentPart> | null;
+    content: string | ChatCompletionContentPart[] | null;
 
     /**
      * The role of the messages author, in this case `user`.
@@ -67,9 +67,10 @@ export namespace OpenAIInput {
      * A list of messages comprising the conversation so far.
      * [Example Python code](https://cookbook.openai.com/examples/how_to_format_inputs_to_chatgpt_models).
      */
-    messages: Array<
-      ChatCompletionUserMessageParam | ChatCompletionSystemMessageParam
-    >;
+    messages: (
+      | ChatCompletionUserMessageParam
+      | ChatCompletionSystemMessageParam
+    )[];
 
     /**
      * ID of the model to use. See the
@@ -149,7 +150,7 @@ export namespace OpenAIInput {
     /**
      * Up to 4 sequences where the API will stop generating further tokens.
      */
-    stop?: string | null | Array<string>;
+    stop?: string | null | string[];
 
     /**
      * If set, partial message deltas will be sent, like in ChatGPT. Tokens will be
@@ -199,7 +200,7 @@ export namespace OpenAIOutput {
      * A list of chat completion choices. Can be more than one if `n` is greater
      * than 1.
      */
-    choices: Array<Choice>;
+    choices: Choice[];
 
     /**
      * The Unix timestamp (in seconds) of when the chat completion was created.

--- a/packages/excalidraw/element/textElement.ts
+++ b/packages/excalidraw/element/textElement.ts
@@ -453,7 +453,7 @@ export const wrapText = (text: string, font: FontString, maxWidth: number) => {
     return text;
   }
 
-  const lines: Array<string> = [];
+  const lines: string[] = [];
   const originalLines = text.split("\n");
   const spaceWidth = getLineWidth(" ", font);
 
@@ -577,7 +577,7 @@ export const wrapText = (text: string, font: FontString, maxWidth: number) => {
 };
 
 export const charWidth = (() => {
-  const cachedCharWidth: { [key: FontString]: Array<number> } = {};
+  const cachedCharWidth: { [key: FontString]: number[] } = {};
 
   const calculate = (char: string, font: FontString) => {
     const ascii = char.charCodeAt(0);

--- a/packages/excalidraw/scene/scroll.ts
+++ b/packages/excalidraw/scene/scroll.ts
@@ -11,7 +11,7 @@ import {
   viewportCoordsToSceneCoords,
 } from "../utils";
 
-const isOutsideViewPort = (appState: AppState, cords: Array<number>) => {
+const isOutsideViewPort = (appState: AppState, cords: number[]) => {
   const [x1, y1, x2, y2] = cords;
   const { x: viewportX1, y: viewportY1 } = sceneCoordsToViewportCoords(
     { sceneX: x1, sceneY: y1 },


### PR DESCRIPTION
### What I Did

In this pull request, I have undertaken a comprehensive refactoring of the codebase, transforming all instances of Array-type declarations (such as Array<number>, Array<string>, etc.) to the shorthand syntax (number[], string[], etc.). This change has been implemented across the board for every applicable type within our project.

### Proposal

I propose the acceptance of this pull request to implement the following changes:

- Every instance of Array-type declarations like `Array<number>`, `Array<string>`, and other similar types have been uniformly converted to their respective shorthand syntax: `number[]`, `string[]`, etc.
- This refactoring extends to the entire codebase, ensuring a consistent style of type declaration throughout.

- There are only four cases where `Array<>` is used.
    <img width="516" alt="Screenshot 2023-12-26 at 3 47 44 PM" src="https://github.com/excalidraw/excalidraw/assets/62178788/de4479c0-7b2b-4adb-80a4-ab32164c7094">


- There are many more instances of `type[]`
    <img width="447" alt="Screenshot 2023-12-26 at 3 48 27 PM" src="https://github.com/excalidraw/excalidraw/assets/62178788/91361b10-3cc0-454f-aad4-ee912f3d9130">

    <img width="486" alt="Screenshot 2023-12-26 at 3 48 19 PM" src="https://github.com/excalidraw/excalidraw/assets/62178788/924c20c6-611b-4521-a3e1-93c843174d49">
    1c-9eab-d8519bd454b9">
