### PR TITLE
Seperated imports from packages and local imports

### DIFF
--- a/excalidraw-app/App.tsx
+++ b/excalidraw-app/App.tsx
@@ -1,6 +1,9 @@
-import polyfill from "../packages/excalidraw/polyfill";
-import LanguageDetector from "i18next-browser-languagedetector";
 import { useEffect, useRef, useState } from "react";
+import clsx from "clsx";
+import { atom, Provider, useAtom, useAtomValue } from "jotai";
+import LanguageDetector from "i18next-browser-languagedetector";
+
+import polyfill from "../packages/excalidraw/polyfill";
 import { trackEvent } from "../packages/excalidraw/analytics";
 import { getDefaultAppState } from "../packages/excalidraw/appState";
 import { ErrorDialog } from "../packages/excalidraw/components/ErrorDialog";
@@ -85,7 +88,6 @@ import { isInitializedImageElement } from "../packages/excalidraw/element/typeCh
 import { loadFilesFromFirebase } from "./data/firebase";
 import { LocalData } from "./data/LocalData";
 import { isBrowserStorageStateNewer } from "./data/tabSync";
-import clsx from "clsx";
 import { reconcileElements } from "./collab/reconciliation";
 import {
   parseLibraryTokensFromUrl,
@@ -94,16 +96,16 @@ import {
 import { AppMainMenu } from "./components/AppMainMenu";
 import { AppWelcomeScreen } from "./components/AppWelcomeScreen";
 import { AppFooter } from "./components/AppFooter";
-import { atom, Provider, useAtom, useAtomValue } from "jotai";
-import { useAtomWithInitialValue } from "../packages/excalidraw/jotai";
 import { appJotaiStore } from "./app-jotai";
 
-import "./index.scss";
+import { useAtomWithInitialValue } from "../packages/excalidraw/jotai";
 import { ResolutionType } from "../packages/excalidraw/utility-types";
 import { ShareableLinkDialog } from "../packages/excalidraw/components/ShareableLinkDialog";
 import { openConfirmModal } from "../packages/excalidraw/components/OverwriteConfirm/OverwriteConfirmState";
 import { OverwriteConfirmDialog } from "../packages/excalidraw/components/OverwriteConfirm/OverwriteConfirm";
 import Trans from "../packages/excalidraw/components/Trans";
+
+import "./index.scss";
 
 polyfill();
 

--- a/excalidraw-app/data/FileManager.ts
+++ b/excalidraw-app/data/FileManager.ts
@@ -8,7 +8,8 @@ import {
   InitializedExcalidrawImageElement,
 } from "../../packages/excalidraw/element/types";
 import { t } from "../../packages/excalidraw/i18n";
-import {
+
+import type {
   BinaryFileData,
   BinaryFileMetadata,
   ExcalidrawImperativeAPI,

--- a/excalidraw-app/data/firebase.ts
+++ b/excalidraw-app/data/firebase.ts
@@ -1,7 +1,5 @@
-import {
-  ExcalidrawElement,
-  FileId,
-} from "../../packages/excalidraw/element/types";
+import type { Socket } from "socket.io-client";
+
 import { getSceneVersion } from "../../packages/excalidraw/element";
 import Portal from "../collab/Portal";
 import { restoreElements } from "../../packages/excalidraw/data/restore";
@@ -20,8 +18,13 @@ import {
 import { MIME_TYPES } from "../../packages/excalidraw/constants";
 import { reconcileElements } from "../collab/reconciliation";
 import { getSyncableElements, SyncableExcalidrawElement } from ".";
-import { ResolutionType } from "../../packages/excalidraw/utility-types";
-import type { Socket } from "socket.io-client";
+
+// local types
+import type {
+  ExcalidrawElement,
+  FileId,
+} from "../../packages/excalidraw/element/types";
+import type { ResolutionType } from "../../packages/excalidraw/utility-types";
 
 // private
 // -----------------------------------------------------------------------------

--- a/excalidraw-app/data/index.ts
+++ b/excalidraw-app/data/index.ts
@@ -13,18 +13,7 @@ import { ImportedDataState } from "../../packages/excalidraw/data/types";
 import { SceneBounds } from "../../packages/excalidraw/element/bounds";
 import { isInvisiblySmallElement } from "../../packages/excalidraw/element/sizeHelpers";
 import { isInitializedImageElement } from "../../packages/excalidraw/element/typeChecks";
-import {
-  ExcalidrawElement,
-  FileId,
-} from "../../packages/excalidraw/element/types";
 import { t } from "../../packages/excalidraw/i18n";
-import {
-  AppState,
-  BinaryFileData,
-  BinaryFiles,
-  SocketId,
-  UserIdleState,
-} from "../../packages/excalidraw/types";
 import { bytesToHexString } from "../../packages/excalidraw/utils";
 import {
   DELETED_ELEMENT_TIMEOUT,
@@ -34,6 +23,18 @@ import {
 } from "../app_constants";
 import { encodeFilesForUpload } from "./FileManager";
 import { saveFilesToFirebase } from "./firebase";
+
+import {
+  ExcalidrawElement,
+  FileId,
+} from "../../packages/excalidraw/element/types";
+import {
+  AppState,
+  BinaryFileData,
+  BinaryFiles,
+  SocketId,
+  UserIdleState,
+} from "../../packages/excalidraw/types";
 
 export type SyncableExcalidrawElement = ExcalidrawElement & {
   _brand: "SyncableExcalidrawElement";

--- a/excalidraw-app/data/localStorage.ts
+++ b/excalidraw-app/data/localStorage.ts
@@ -1,3 +1,4 @@
+import { STORAGE_KEYS } from "../app_constants";
 import { ExcalidrawElement } from "../../packages/excalidraw/element/types";
 import { AppState } from "../../packages/excalidraw/types";
 import {
@@ -5,7 +6,6 @@ import {
   getDefaultAppState,
 } from "../../packages/excalidraw/appState";
 import { clearElementsForLocalStorage } from "../../packages/excalidraw/element";
-import { STORAGE_KEYS } from "../app_constants";
 import { ImportedDataState } from "../../packages/excalidraw/data/types";
 
 export const saveUsernameToLocalStorage = (username: string) => {


### PR DESCRIPTION
### **1. Improved Readability:**
   - **External Packages:** Placing external package imports at the beginning of the file makes it clear which external dependencies the module relies on. This enhances readability by providing a quick overview of the external components used in the code.

   - **Local Imports:** Grouping local imports together helps to distinguish between external dependencies and internal modules or utilities. This separation contributes to a cleaner and more organized appearance, making the code easier to follow.

### **2. Clarity in Dependencies:**
   - **External Packages:** Having external package imports in a separate section emphasizes the external dependencies that the module relies on. This separation allows developers to quickly identify and understand the external libraries or frameworks being utilized.

   - **Local Imports:** Local imports, which refer to modules or utilities within the same codebase, are often closely related to the internal logic of the module. Grouping them together emphasizes the internal dependencies, providing clarity on the structure of the codebase.

### **3. Easier Maintenance:**
   - **External Packages:** When new external dependencies are added or existing ones are updated, having them listed separately makes it easier for developers to identify changes in the external dependencies without scrolling through the entire file.

   - **Local Imports:** Similarly, when there are changes in internal dependencies or module relationships, developers can quickly locate and understand the local imports in a dedicated section. This separation simplifies the maintenance process.

### **4. Consistency Across Files:**
   - **External Packages:** Following a consistent pattern of importing external packages at the beginning of the file aligns with common practices in many programming languages and frameworks. This consistency makes it easier for developers to navigate unfamiliar code.

   - **Local Imports:** Consistently placing local imports in a specific section within the file establishes a clear pattern. This consistency is particularly helpful when developers work with multiple files or modules within the same project.

### **5. IDE and Tool Support:**
   - **External Packages:** Many integrated development environments (IDEs) and code analysis tools recognize and organize external package imports separately. This separation can enhance the functionality of auto-completion and code navigation features.

   - **Local Imports:** IDEs often provide features for navigating local imports within a file. By having a dedicated section for local imports, developers can leverage these IDE features more effectively.

### **6. Scalability and Collaboration:**
   - **External Packages:** As the codebase scales and more external dependencies are introduced, separating external package imports can prevent clutter and maintain a clear structure. This is particularly beneficial for collaborative development.

   - **Local Imports:** In a collaborative environment, where multiple developers may contribute to the same codebase, consistent organization of local imports facilitates collaboration by providing a standard structure that team members can follow.

(If my this pull request merges then I will try to organize imports in all of the files in terms of packages, names and utilities)