### PR TITLE
feat: disable mouse wheel scroll

### DIFF
--- a/excalidraw-app/App.tsx
+++ b/excalidraw-app/App.tsx
@@ -691,6 +691,10 @@ const ExcalidrawWrapper = () => {
       className={clsx("excalidraw-app", {
         "is-collaborating": isCollaborating,
       })}
+      //TODO - prop to disable wheel event handling
+      onWheelCapture={(e) => {
+        // e.stopPropagation();
+      }}
     >
       <Excalidraw
         excalidrawAPI={excalidrawRefCallback}

--- a/excalidraw-app/app_constants.ts
+++ b/excalidraw-app/app_constants.ts
@@ -41,6 +41,7 @@ export const STORAGE_KEYS = {
   LOCAL_STORAGE_COLLAB: "excalidraw-collab",
   LOCAL_STORAGE_LIBRARY: "excalidraw-library",
   LOCAL_STORAGE_THEME: "excalidraw-theme",
+  LOCAL_STORAGE_SCROLL_BEHAVIOR: "excalidraw-scroll-behavior",
   VERSION_DATA_STATE: "version-dataState",
   VERSION_FILES: "version-files",
 } as const;

--- a/excalidraw-app/components/AppMainMenu.tsx
+++ b/excalidraw-app/components/AppMainMenu.tsx
@@ -8,6 +8,7 @@ export const AppMainMenu: React.FC<{
   isCollaborating: boolean;
   isCollabEnabled: boolean;
 }> = React.memo((props) => {
+  const deviceInfo = useDevice();
   return (
     <MainMenu>
       <MainMenu.DefaultItems.LoadScene />
@@ -36,7 +37,7 @@ export const AppMainMenu: React.FC<{
       <MainMenu.DefaultItems.Socials />
       <MainMenu.Separator />
       <MainMenu.DefaultItems.ToggleTheme />
-      {!useDevice().isTouchScreen && !useDevice().viewport.isMobile && (
+      {!deviceInfo.isTouchScreen && !deviceInfo.viewport.isMobile && (
         <MainMenu.DefaultItems.ToggleScrollWheel />
       )}
       <MainMenu.ItemCustom>

--- a/excalidraw-app/components/AppMainMenu.tsx
+++ b/excalidraw-app/components/AppMainMenu.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { PlusPromoIcon } from "../../packages/excalidraw/components/icons";
-import { MainMenu } from "../../packages/excalidraw/index";
+import { MainMenu, useDevice } from "../../packages/excalidraw/index";
 import { LanguageList } from "./LanguageList";
 
 export const AppMainMenu: React.FC<{
@@ -36,7 +36,9 @@ export const AppMainMenu: React.FC<{
       <MainMenu.DefaultItems.Socials />
       <MainMenu.Separator />
       <MainMenu.DefaultItems.ToggleTheme />
-      <MainMenu.DefaultItems.ToggleScrollWheel />
+      {!useDevice().isTouchScreen && !useDevice().viewport.isMobile && (
+        <MainMenu.DefaultItems.ToggleScrollWheel />
+      )}
       <MainMenu.ItemCustom>
         <LanguageList style={{ width: "100%" }} />
       </MainMenu.ItemCustom>

--- a/excalidraw-app/components/AppMainMenu.tsx
+++ b/excalidraw-app/components/AppMainMenu.tsx
@@ -36,6 +36,7 @@ export const AppMainMenu: React.FC<{
       <MainMenu.DefaultItems.Socials />
       <MainMenu.Separator />
       <MainMenu.DefaultItems.ToggleTheme />
+      <MainMenu.DefaultItems.ToggleScrollWheel />
       <MainMenu.ItemCustom>
         <LanguageList style={{ width: "100%" }} />
       </MainMenu.ItemCustom>

--- a/packages/excalidraw/actions/actionCanvas.tsx
+++ b/packages/excalidraw/actions/actionCanvas.tsx
@@ -1,7 +1,7 @@
 import { ColorPicker } from "../components/ColorPicker/ColorPicker";
 import { ZoomInIcon, ZoomOutIcon } from "../components/icons";
 import { ToolButton } from "../components/ToolButton";
-import { CURSOR_TYPE, MIN_ZOOM, THEME, ZOOM_STEP } from "../constants";
+import { CURSOR_TYPE, MIN_ZOOM, SCROLL_BEHAVIOR, THEME, ZOOM_STEP } from "../constants";
 import { getCommonBounds, getNonDeletedElements } from "../element";
 import { ExcalidrawElement } from "../element/types";
 import { t } from "../i18n";
@@ -420,6 +420,24 @@ export const actionToggleTheme = register({
   keyTest: (event) => event.altKey && event.shiftKey && event.code === CODES.D,
   predicate: (elements, appState, props, app) => {
     return !!app.props.UIOptions.canvasActions.toggleTheme;
+  },
+});
+
+export const actionToggleScrollBehavior = register({
+  name: "toggleScrollBehavior",
+  viewMode: true,
+  trackEvent: { category: "canvas" },
+  perform: (_, appState, value) => {
+    return {
+      appState: {
+        ...appState,
+        scrollBehavior: value || (appState.scrollBehavior === SCROLL_BEHAVIOR.DISABLE ? SCROLL_BEHAVIOR.DEFAULT : SCROLL_BEHAVIOR.DISABLE),
+      },
+      commitToHistory: false,
+    };
+  },
+  predicate: (elements, appState, props, app) => {
+    return !!app.props.UIOptions.canvasActions.toggleScrollBehavior;
   },
 });
 

--- a/packages/excalidraw/actions/types.ts
+++ b/packages/excalidraw/actions/types.ts
@@ -124,7 +124,8 @@ export type ActionName =
   | "setFrameAsActiveTool"
   | "setEmbeddableAsActiveTool"
   | "createContainerFromText"
-  | "wrapTextInContainer";
+  | "wrapTextInContainer"
+  | "toggleScrollBehavior";
 
 export type PanelComponentProps = {
   elements: readonly ExcalidrawElement[];

--- a/packages/excalidraw/appState.ts
+++ b/packages/excalidraw/appState.ts
@@ -5,6 +5,7 @@ import {
   DEFAULT_FONT_SIZE,
   DEFAULT_TEXT_ALIGN,
   EXPORT_SCALES,
+  SCROLL_BEHAVIOR,
   THEME,
 } from "./constants";
 import { t } from "./i18n";
@@ -22,6 +23,7 @@ export const getDefaultAppState = (): Omit<
   return {
     showWelcomeScreen: false,
     theme: THEME.LIGHT,
+    scrollBehavior: SCROLL_BEHAVIOR.DEFAULT,
     collaborators: new Map(),
     currentChartType: "bar",
     currentItemBackgroundColor: DEFAULT_ELEMENT_PROPS.backgroundColor,
@@ -128,6 +130,7 @@ const APP_STATE_STORAGE_CONF = (<
   config)({
   showWelcomeScreen: { browser: true, export: false, server: false },
   theme: { browser: true, export: false, server: false },
+  scrollBehavior: { browser: true, export: false, server: false },
   collaborators: { browser: false, export: false, server: false },
   currentChartType: { browser: true, export: false, server: false },
   currentItemBackgroundColor: { browser: true, export: false, server: false },

--- a/packages/excalidraw/components/icons.tsx
+++ b/packages/excalidraw/components/icons.tsx
@@ -470,6 +470,19 @@ export const ExternalLinkIcon = createIcon(
   modifiedTablerIconProps,
 );
 
+export const MouseIcon = createIcon(
+  <g strokeWidth="1.25">
+    <svg xmlns="http://www.w3.org/2000/svg" className="icon icon-tabler icon-tabler-mouse" width="24" height="24"
+         viewBox="0 0 24 24" stroke-width="1.25" stroke="currentColor" fill="none" stroke-linecap="round"
+         stroke-linejoin="round">
+      <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+      <path d="M6 3m0 4a4 4 0 0 1 4 -4h4a4 4 0 0 1 4 4v10a4 4 0 0 1 -4 4h-4a4 4 0 0 1 -4 -4z" />
+      <path d="M12 7l0 4" />
+    </svg>
+  </g>,
+  tablerIconProps
+);
+
 export const GithubIcon = createIcon(
   <path
     d="M7.5 15.833c-3.583 1.167-3.583-2.083-5-2.5m10 4.167v-2.917c0-.833.083-1.166-.417-1.666 2.334-.25 4.584-1.167 4.584-5a3.833 3.833 0 0 0-1.084-2.667 3.5 3.5 0 0 0-.083-2.667s-.917-.25-2.917 1.084a10.25 10.25 0 0 0-5.166 0C5.417 2.333 4.5 2.583 4.5 2.583a3.5 3.5 0 0 0-.083 2.667 3.833 3.833 0 0 0-1.084 2.667c0 3.833 2.25 4.75 4.584 5-.5.5-.5 1-.417 1.666V17.5"
@@ -1776,7 +1789,8 @@ export const OpenAIIcon = createIcon(
     <path d="M6 7.63c-1.391 -.236 -2.787 .395 -3.534 1.689a3.474 3.474 0 0 0 1.271 4.745l4.263 2.514l6 -3.348" />
     <path d="M12.783 4.616a3.501 3.501 0 0 0 -6.783 1.217v5.067l6 3.45" />
     <path d="M18.786 8.986a3.501 3.501 0 0 0 -4.446 -5.266l-4.34 2.534v6.946" />
-    <path d="M18 16.302c1.391 .236 2.787 -.395 3.534 -1.689a3.474 3.474 0 0 0 -1.271 -4.745l-4.308 -2.514l-5.955 3.42" />
+    <path
+      d="M18 16.302c1.391 .236 2.787 -.395 3.534 -1.689a3.474 3.474 0 0 0 -1.271 -4.745l-4.308 -2.514l-5.955 3.42" />
   </g>,
   tablerIconProps,
 );
@@ -1805,7 +1819,8 @@ export const eyeClosedIcon = createIcon(
   <g stroke="currentColor" fill="none">
     <path stroke="none" d="M0 0h24v24H0z" fill="none" />
     <path d="M10.585 10.587a2 2 0 0 0 2.829 2.828" />
-    <path d="M16.681 16.673a8.717 8.717 0 0 1 -4.681 1.327c-3.6 0 -6.6 -2 -9 -6c1.272 -2.12 2.712 -3.678 4.32 -4.674m2.86 -1.146a9.055 9.055 0 0 1 1.82 -.18c3.6 0 6.6 2 9 6c-.666 1.11 -1.379 2.067 -2.138 2.87" />
+    <path
+      d="M16.681 16.673a8.717 8.717 0 0 1 -4.681 1.327c-3.6 0 -6.6 -2 -9 -6c1.272 -2.12 2.712 -3.678 4.32 -4.674m2.86 -1.146a9.055 9.055 0 0 1 1.82 -.18c3.6 0 6.6 2 9 6c-.666 1.11 -1.379 2.067 -2.138 2.87" />
     <path d="M3 3l18 18" />
   </g>,
   tablerIconProps,

--- a/packages/excalidraw/components/main-menu/DefaultItems.tsx
+++ b/packages/excalidraw/components/main-menu/DefaultItems.tsx
@@ -195,6 +195,32 @@ export const ToggleTheme = () => {
 };
 ToggleTheme.displayName = "ToggleTheme";
 
+export const ToggleScrollWheel = () => {
+  // const { t } = useI18n();
+  // const appState = useUIAppState();
+  const actionManager = useExcalidrawActionManager();
+
+  if (!actionManager.isActionEnabled(actionToggleTheme)) {
+    return null;
+  }
+  return (
+    <DropdownMenuItem
+      onSelect={(event) => {
+        // do not close the menu when changing theme
+        event.preventDefault();
+        return actionManager.executeAction(actionToggleTheme);
+      }}
+      icon={MoonIcon}
+      data-testid="toggle-dark-mode"
+      // shortcut={getShortcutFromShortcutName("toggleTheme")}
+      aria-label={"test"}
+    >
+      Wheel Scroll Disable
+    </DropdownMenuItem>
+  );
+};
+ToggleScrollWheel.displayName = "ToggleScrollWheel";
+
 export const ChangeCanvasBackground = () => {
   const { t } = useI18n();
   const appState = useUIAppState();

--- a/packages/excalidraw/components/main-menu/DefaultItems.tsx
+++ b/packages/excalidraw/components/main-menu/DefaultItems.tsx
@@ -12,10 +12,11 @@ import {
   HelpIcon,
   LoadIcon,
   MoonIcon,
+  MouseIcon,
   save,
   SunIcon,
   TrashIcon,
-  usersIcon,
+  usersIcon
 } from "../icons";
 import { GithubIcon, DiscordIcon, TwitterIcon } from "../icons";
 import DropdownMenuItem from "../dropdownMenu/DropdownMenuItem";
@@ -36,6 +37,10 @@ import { jotaiScope } from "../../jotai";
 import { useUIAppState } from "../../context/ui-appState";
 import { openConfirmModal } from "../OverwriteConfirm/OverwriteConfirmState";
 import Trans from "../Trans";
+import { actionToggleScrollBehavior } from "../../actions/actionCanvas";
+import { values } from "idb-keyval";
+import firebase from "firebase";
+import apps = firebase.apps;
 
 export const LoadScene = () => {
   const { t } = useI18n();
@@ -196,11 +201,12 @@ export const ToggleTheme = () => {
 ToggleTheme.displayName = "ToggleTheme";
 
 export const ToggleScrollWheel = () => {
+  //TODO: Implement after PR is determined to be viable
   // const { t } = useI18n();
-  // const appState = useUIAppState();
+  const appState = useUIAppState();
   const actionManager = useExcalidrawActionManager();
 
-  if (!actionManager.isActionEnabled(actionToggleTheme)) {
+  if (!actionManager.isActionEnabled(actionToggleScrollBehavior)) {
     return null;
   }
   return (
@@ -208,14 +214,12 @@ export const ToggleScrollWheel = () => {
       onSelect={(event) => {
         // do not close the menu when changing theme
         event.preventDefault();
-        return actionManager.executeAction(actionToggleTheme);
+        return actionManager.executeAction(actionToggleScrollBehavior);
       }}
-      icon={MoonIcon}
-      data-testid="toggle-dark-mode"
-      // shortcut={getShortcutFromShortcutName("toggleTheme")}
-      aria-label={"test"}
+      icon={MouseIcon}
+      aria-label=  { appState.scrollBehavior === "default" ? "Scroll disable" : "Scroll default" }
     >
-      Wheel Scroll Disable
+      Scroll {appState.scrollBehavior === "default" ? "disable" : "default"}
     </DropdownMenuItem>
   );
 };

--- a/packages/excalidraw/constants.ts
+++ b/packages/excalidraw/constants.ts
@@ -118,6 +118,11 @@ export const THEME = {
   DARK: "dark",
 } as const;
 
+export const SCROLL_BEHAVIOR = {
+  DISABLE: "disable",
+  DEFAULT: "default",
+} as const;
+
 export const FRAME_STYLE = {
   strokeColor: "#bbb" as ExcalidrawElement["strokeColor"],
   strokeWidth: 2 as ExcalidrawElement["strokeWidth"],
@@ -225,6 +230,7 @@ export const DEFAULT_UI_OPTIONS: AppProps["UIOptions"] = {
     loadScene: true,
     saveToActiveFile: true,
     toggleTheme: null,
+    toggleScrollBehavior: null,
     saveAsImage: true,
   },
   tools: {

--- a/packages/excalidraw/element/types.ts
+++ b/packages/excalidraw/element/types.ts
@@ -4,6 +4,7 @@ import {
   ROUNDNESS,
   TEXT_ALIGN,
   THEME,
+  SCROLL_BEHAVIOR,
   VERTICAL_ALIGN,
 } from "../constants";
 import { MarkNonNullable, ValueOf } from "../utility-types";
@@ -14,6 +15,7 @@ export type FillStyle = "hachure" | "cross-hatch" | "solid" | "zigzag";
 export type FontFamilyKeys = keyof typeof FONT_FAMILY;
 export type FontFamilyValues = typeof FONT_FAMILY[FontFamilyKeys];
 export type Theme = typeof THEME[keyof typeof THEME];
+export type ScrollBehavior = typeof SCROLL_BEHAVIOR[keyof typeof SCROLL_BEHAVIOR];
 export type FontString = string & { _brand: "fontString" };
 export type GroupId = string;
 export type PointerType = "mouse" | "pen" | "touch";

--- a/packages/excalidraw/types.ts
+++ b/packages/excalidraw/types.ts
@@ -19,6 +19,7 @@ import {
   ExcalidrawMagicFrameElement,
   ExcalidrawFrameLikeElement,
   ExcalidrawElementType,
+  ScrollBehavior,
 } from "./element/types";
 import { Action } from "./actions/types";
 import { Point as RoughPoint } from "roughjs/bin/geometry";
@@ -282,6 +283,7 @@ export interface AppState {
   toast: { message: string; closable?: boolean; duration?: number } | null;
   zenModeEnabled: boolean;
   theme: Theme;
+  scrollBehavior: ScrollBehavior;
   gridSize: number | null;
   viewModeEnabled: boolean;
 
@@ -434,6 +436,7 @@ export interface ExcalidrawProps {
   objectsSnapModeEnabled?: boolean;
   libraryReturnUrl?: string;
   theme?: Theme;
+  scrollBehavior?: ScrollBehavior;
   name?: string;
   renderCustomStats?: (
     elements: readonly NonDeletedExcalidrawElement[],
@@ -511,6 +514,7 @@ export type CanvasActions = Partial<{
   loadScene: boolean;
   saveToActiveFile: boolean;
   toggleTheme: boolean | null;
+  toggleScrollBehavior: boolean | null;
   saveAsImage: boolean;
 }>;
 


### PR DESCRIPTION
Added scroll behavior toggle functionality via prop `scrollBehavior`

Introduced a new functionality to toggle scroll behavior between 'default' and 'disable',  focusing on mouse scroll in particular. This PR includes changes in state, actions, and UI elements to provide the option for users. A new icon has also been introduced for this functionality.

1. Created `<MainMenu.DefaultItems.ToggleScrollWheel />`
2. Created `appState.scrollBehavior`
3. Created `SCROLL_BEHAVIOR`
```
export const SCROLL_BEHAVIOR = {
  DISABLE: "disable",
  DEFAULT: "default",
} as const;
```
5. Created `handleWheelCapture`

```
 const handleWheelCapture = (e: React.WheelEvent<HTMLDivElement>) => {
    if (scrollBehavior === 'disable') {
      e.stopPropagation();
    }
 };
```

This is just a stab at implementing #3686. Hopefully it will stimulate some additional discussion and feedback! Also, apologies if this is totally off the mark. I'm kinda new to contributing to open source projects of this scale and technicality. Awesome work on this amazing application! 

![image](https://github.com/excalidraw/excalidraw/assets/64165327/06d3db05-a1ff-4adb-84ea-bff086fca0b0)


![image](https://github.com/excalidraw/excalidraw/assets/64165327/628c543a-e696-4d0c-a976-4305039d60ef)



