### PR TITLE
fix: enable undo/redo support for image elements

### DIFF
--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -8387,6 +8387,8 @@ class App extends React.Component<AppProps, AppState> {
     imageElement: ExcalidrawImageElement,
     forceNaturalSize = false,
   ) => {
+    this.history.resumeRecording();
+
     const image =
       isInitializedImageElement(imageElement) &&
       this.imageCache.get(imageElement.fileId)?.image;

--- a/packages/excalidraw/history.ts
+++ b/packages/excalidraw/history.ts
@@ -1,6 +1,6 @@
 import { AppState } from "./types";
 import { ExcalidrawElement } from "./element/types";
-import { isLinearElement } from "./element/typeChecks";
+import { isLinearElement, isImageElement } from "./element/typeChecks";
 import { deepCopyElement } from "./element/newElement";
 import { Mutable } from "./utility-types";
 
@@ -128,6 +128,12 @@ class History {
                 ? element.points.slice(0, -1)
                 : element.points,
           });
+        } else if (isImageElement(element)) {
+          // don't store uninitialized image
+          if (!element.fileId) {
+            return elements;
+          }
+          elements.push(element);
         } else {
           elements.push(element);
         }


### PR DESCRIPTION

![20240103154322_rec_](https://github.com/excalidraw/excalidraw/assets/6285483/2b1f86a9-c427-43e7-99f8-1ae6b2cf59db)

Image elements added to scene cannot be deleted/re-added immediately using undo/redo. 

This PR is for this problem.