### PR TITLE
fix: Unintentional Circles in Freehand Strokes

### DIFF
--- a/packages/excalidraw/element/linearElementEditor.ts
+++ b/packages/excalidraw/element/linearElementEditor.ts
@@ -42,7 +42,7 @@ import {
   isBindingEnabled,
 } from "./binding";
 import { tupleToCoors } from "../utils";
-import { isBindingElement } from "./typeChecks";
+import { isBindingElement, isFreeDrawElement } from "./typeChecks";
 import { KEYS, shouldRotateWithDiscreteAngle } from "../keys";
 import { getBoundTextElement, handleBindTextResize } from "./textElement";
 import { DRAGGING_THRESHOLD } from "../constants";
@@ -344,7 +344,10 @@ export class LinearElementEditor {
           selectedPoint === 0 ||
           selectedPoint === element.points.length - 1
         ) {
-          if (isPathALoop(element.points, appState.zoom.value)) {
+          if (
+            !isFreeDrawElement(element) &&
+            isPathALoop(element.points, appState.zoom.value)
+          ) {
             LinearElementEditor.movePoints(element, [
               {
                 index: selectedPoint,


### PR DESCRIPTION
fixes #6303

I decided to retain the fill feature based on LINE_CONFIR_TRESHOLD also for freedraw - because the user can always set the Background color to transparent.