### PR TITLE
feat: render embeds lazily

### DIFF
--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -911,13 +911,6 @@ class App extends React.Component<AppProps, AppState> {
           }
           const shouldRender = isVisible || hasBeenInitialized;
 
-          const isActive =
-            this.state.activeEmbeddable?.element === el &&
-            this.state.activeEmbeddable?.state === "active";
-          const isHovered =
-            this.state.activeEmbeddable?.element === el &&
-            this.state.activeEmbeddable?.state === "hover";
-
           if (!shouldRender) {
             return null;
           }
@@ -1062,6 +1055,13 @@ class App extends React.Component<AppProps, AppState> {
           } else {
             src = getEmbedLink(toValidURL(el.link || ""));
           }
+
+          const isActive =
+            this.state.activeEmbeddable?.element === el &&
+            this.state.activeEmbeddable?.state === "active";
+          const isHovered =
+            this.state.activeEmbeddable?.element === el &&
+            this.state.activeEmbeddable?.state === "hover";
 
           return (
             <div

--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -526,6 +526,7 @@ class App extends React.Component<AppProps, AppState> {
   public files: BinaryFiles = {};
   public imageCache: AppClassProperties["imageCache"] = new Map();
   private iFrameRefs = new Map<ExcalidrawElement["id"], HTMLIFrameElement>();
+  private initializedEmbeds = new Set<ExcalidrawIframeLikeElement["id"]>();
 
   hitLinkElement?: NonDeletedExcalidrawElement;
   lastPointerDownEvent: React.PointerEvent<HTMLElement> | null = null;
@@ -1046,12 +1047,23 @@ class App extends React.Component<AppProps, AppState> {
             normalizedHeight,
             this.state,
           );
+          const hasBeenInitialized = this.initializedEmbeds.has(el.id);
+
+          if (isVisible && !hasBeenInitialized) {
+            this.initializedEmbeds.add(el.id);
+          }
+          const shouldRender = isVisible || hasBeenInitialized;
+
           const isActive =
             this.state.activeEmbeddable?.element === el &&
             this.state.activeEmbeddable?.state === "active";
           const isHovered =
             this.state.activeEmbeddable?.element === el &&
             this.state.activeEmbeddable?.state === "hover";
+
+          if (!shouldRender) {
+            return null;
+          }
 
           return (
             <div

--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -898,6 +898,30 @@ class App extends React.Component<AppProps, AppState> {
             this.state,
           );
 
+          const isVisible = isElementInViewport(
+            el,
+            normalizedWidth,
+            normalizedHeight,
+            this.state,
+          );
+          const hasBeenInitialized = this.initializedEmbeds.has(el.id);
+
+          if (isVisible && !hasBeenInitialized) {
+            this.initializedEmbeds.add(el.id);
+          }
+          const shouldRender = isVisible || hasBeenInitialized;
+
+          const isActive =
+            this.state.activeEmbeddable?.element === el &&
+            this.state.activeEmbeddable?.state === "active";
+          const isHovered =
+            this.state.activeEmbeddable?.element === el &&
+            this.state.activeEmbeddable?.state === "hover";
+
+          if (!shouldRender) {
+            return null;
+          }
+
           let src: IframeData | null;
 
           if (isIframeElement(el)) {
@@ -1037,32 +1061,6 @@ class App extends React.Component<AppProps, AppState> {
             }
           } else {
             src = getEmbedLink(toValidURL(el.link || ""));
-          }
-
-          // console.log({ src });
-
-          const isVisible = isElementInViewport(
-            el,
-            normalizedWidth,
-            normalizedHeight,
-            this.state,
-          );
-          const hasBeenInitialized = this.initializedEmbeds.has(el.id);
-
-          if (isVisible && !hasBeenInitialized) {
-            this.initializedEmbeds.add(el.id);
-          }
-          const shouldRender = isVisible || hasBeenInitialized;
-
-          const isActive =
-            this.state.activeEmbeddable?.element === el &&
-            this.state.activeEmbeddable?.state === "active";
-          const isHovered =
-            this.state.activeEmbeddable?.element === el &&
-            this.state.activeEmbeddable?.state === "hover";
-
-          if (!shouldRender) {
-            return null;
           }
 
           return (


### PR DESCRIPTION
This PR makes embeddables render lazily, not rendering them until they first appear in viewport.

Pros:

- faster init load and less traffic in cases where you don't land on canvas where all embeds are immediately visible, or you never even scroll to all the embeds on canvas in a session

Cons:

- Slower initially-visible-to-rendered transition
- in cases where preloading all embeds if desirable (e.g. presentations), this is a deoptimization

If the cons prove too bad, we could investigate hybrid solution to improve both the above while keeping (some of) the benefits.

/cc @zsviczian 