### PR TITLE
docs: use excalidrawAPI instead of ref to make examples work

### DIFF
--- a/dev-docs/docs/@excalidraw/excalidraw/api/children-components/live-collaboration-trigger.mdx
+++ b/dev-docs/docs/@excalidraw/excalidraw/api/children-components/live-collaboration-trigger.mdx
@@ -45,7 +45,7 @@ function App() {
         Show Collaborators
       </label>
       <Excalidraw
-        ref={(api) => setExcalidrawAPI(api)}
+        excalidrawAPI={(api) => setExcalidrawAPI(api)}
         renderTopRightUI={() => (
           <LiveCollaborationTrigger
             isCollaborating={isCollaborating}

--- a/dev-docs/docs/@excalidraw/excalidraw/api/props/excalidraw-api.mdx
+++ b/dev-docs/docs/@excalidraw/excalidraw/api/props/excalidraw-api.mdx
@@ -115,7 +115,7 @@ function App() {
       <button className="custom-button" onClick={updateScene}>
         Update Scene
       </button>
-      <Excalidraw ref={(api) => setExcalidrawAPI(api)} />
+      <Excalidraw excalidrawAPI={(api) => setExcalidrawAPI(api)} />
     </div>
   );
 }
@@ -188,7 +188,7 @@ function App() {
         Update Library
       </button>
       <Excalidraw
-        ref={(api) => setExcalidrawAPI(api)}
+        excalidrawAPI={(api) => setExcalidrawAPI(api)}
         // initial data retrieved from https://github.com/excalidraw/excalidraw/blob/master/dev-docs/packages/excalidraw/initialData.js
         initialData={{
           libraryItems: initialData.libraryItems,

--- a/dev-docs/docs/@excalidraw/excalidraw/api/utils/export.mdx
+++ b/dev-docs/docs/@excalidraw/excalidraw/api/utils/export.mdx
@@ -90,7 +90,7 @@ function App() {
         <img src={canvasUrl} alt="" />
       </div>
       <div style={{ height: "400px" }}>
-        <Excalidraw ref={(api) => setExcalidrawAPI(api)}
+        <Excalidraw excalidrawAPI={(api) => setExcalidrawAPI(api)}
 />
       </div>
     </>


### PR DESCRIPTION
For example, clicking "Update Scene" button on the example in [the updateScene API](https://docs.excalidraw.com/docs/@excalidraw/excalidraw/api/props/excalidraw-api#updatescene) on Microsoft Edge didn't update the scene and yielded this error:

```
main.7c1b8420.js:2  Uncaught TypeError: Cannot read properties of null (reading 'updateScene')
    at updateScene (eval at tr (689.82742620.js:2:1393134), <anonymous>:40:19)
    at Object.$e (main.7c1b8420.js:2:223923)
    at Ke (main.7c1b8420.js:2:224077)
    at main.7c1b8420.js:2:242280
    at Ar (main.7c1b8420.js:2:242374)
    at Lr (main.7c1b8420.js:2:242788)
    at main.7c1b8420.js:2:248424
    at Me (main.7c1b8420.js:2:323716)
    at main.7c1b8420.js:2:244247
    at Dr (main.7c1b8420.js:2:244277)
```

I found that replacing the `ref` props with `excalidrawAPI` eliminates this error and makes the examples work.
