### PR TITLE
docs: add tools to UIOptions

### DIFF
--- a/dev-docs/docs/@excalidraw/excalidraw/api/props/ui-options.mdx
+++ b/dev-docs/docs/@excalidraw/excalidraw/api/props/ui-options.mdx
@@ -6,7 +6,7 @@ This prop can be used to customise UI of Excalidraw. Currently we support custom
   &#123;
   <br /> canvasActions?: <a href="https://github.com/excalidraw/excalidraw/blob/master/packages/excalidraw/types.ts#L372">
     CanvasActions
-  </a>, <br /> dockedSidebarBreakpoint?: number, <br /> welcomeScreen?: boolean <br />
+  </a>, <br /> dockedSidebarBreakpoint?: number, <br /> welcomeScreen?: boolean, <br /> tools?: { <br />  image: boolean <br /> } <br />
 
   }
 </pre>


### PR DESCRIPTION
There are 4 properties listed up in the explanation in the top of [UIOptions page](https://docs.excalidraw.com/docs/@excalidraw/excalidraw/api/props/ui-options):

* `canvasActions`
* `dockedSidebarBreakpoint`
* `welcomeScreen`
* `tools`

However, `tools` is not in the code below the explanation. So I added `tools`.

Reference:

https://github.com/excalidraw/excalidraw/blob/65047cc2cb59843a4305f9088d886edd9b933585/packages/excalidraw/types.ts#L517-L525
