### PR TITLE
fix: make utils and constants treeshakeable

### DIFF
--- a/packages/excalidraw/colors.ts
+++ b/packages/excalidraw/colors.ts
@@ -167,4 +167,14 @@ export const getAllColorsSpecificShade = (index: 0 | 1 | 2 | 3 | 4) =>
 export const rgbToHex = (r: number, g: number, b: number) =>
   `#${((1 << 24) + (r << 16) + (g << 8) + b).toString(16).slice(1)}`;
 
+export const isTransparent = (color: string) => {
+  const isRGBTransparent = color.length === 5 && color.substr(4, 1) === "0";
+  const isRRGGBBTransparent = color.length === 9 && color.substr(7, 2) === "00";
+  return (
+    isRGBTransparent ||
+    isRRGGBBTransparent ||
+    color === COLOR_PALETTE.transparent
+  );
+};
+
 // -----------------------------------------------------------------------------

--- a/packages/excalidraw/components/Actions.tsx
+++ b/packages/excalidraw/components/Actions.tsx
@@ -14,7 +14,7 @@ import {
 } from "../scene";
 import { SHAPES } from "../shapes";
 import { AppClassProperties, AppProps, UIAppState, Zoom } from "../types";
-import { capitalizeString, isTransparent } from "../utils";
+import { capitalizeString } from "../utils";
 import Stack from "./Stack";
 import { ToolButton } from "./ToolButton";
 import { hasStrokeColor } from "../scene/comparisons";
@@ -41,6 +41,7 @@ import {
 } from "./icons";
 import { KEYS } from "../keys";
 import { useTunnels } from "../context/tunnels";
+import { isTransparent } from "../colors";
 
 export const SelectedShapeActions = ({
   appState,

--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -263,7 +263,6 @@ import {
   updateObject,
   updateActiveTool,
   getShortcutKey,
-  isTransparent,
   easeToValuesRAF,
   muteFSAbortError,
   isTestEnv,
@@ -396,7 +395,7 @@ import { Emitter } from "../emitter";
 import { ElementCanvasButtons } from "../element/ElementCanvasButtons";
 import { MagicCacheData, diagramToHTML } from "../data/magic";
 import { elementsOverlappingBBox, exportToBlob } from "../../utils/export";
-import { COLOR_PALETTE } from "../colors";
+import { COLOR_PALETTE, isTransparent } from "../colors";
 import { ElementCanvasButton } from "./MagicButton";
 import { MagicIcon, copyIcon, fullscreenIcon } from "./icons";
 import { EditorLocalStorage } from "../data/EditorLocalStorage";

--- a/packages/excalidraw/components/ColorPicker/ColorPicker.tsx
+++ b/packages/excalidraw/components/ColorPicker/ColorPicker.tsx
@@ -1,4 +1,4 @@
-import { isInteractive, isTransparent, isWritableElement } from "../../utils";
+import { isInteractive, isWritableElement } from "../../utils";
 import { ExcalidrawElement } from "../../element/types";
 import { AppState } from "../../types";
 import { TopPicks } from "./TopPicks";

--- a/packages/excalidraw/components/ColorPicker/ColorPicker.tsx
+++ b/packages/excalidraw/components/ColorPicker/ColorPicker.tsx
@@ -10,7 +10,12 @@ import {
   ColorPickerType,
 } from "./colorPickerUtils";
 import { useDevice, useExcalidrawContainer } from "../App";
-import { ColorTuple, COLOR_PALETTE, ColorPaletteCustom } from "../../colors";
+import {
+  ColorTuple,
+  COLOR_PALETTE,
+  ColorPaletteCustom,
+  isTransparent,
+} from "../../colors";
 import PickerHeading from "./PickerHeading";
 import { t } from "../../i18n";
 import clsx from "clsx";

--- a/packages/excalidraw/constants.ts
+++ b/packages/excalidraw/constants.ts
@@ -1,7 +1,6 @@
 import cssVariables from "./css/variables.module.scss";
 import { AppProps } from "./types";
 import { ExcalidrawElement, FontFamilyValues } from "./element/types";
-import { COLOR_PALETTE } from "./colors";
 
 export const isDarwin = /Mac|iPod|iPhone|iPad/.test(navigator.platform);
 export const isWindows = /^Win/.test(navigator.platform);
@@ -333,8 +332,9 @@ export const DEFAULT_ELEMENT_PROPS: {
   opacity: ExcalidrawElement["opacity"];
   locked: ExcalidrawElement["locked"];
 } = {
-  strokeColor: COLOR_PALETTE.black,
-  backgroundColor: COLOR_PALETTE.transparent,
+  // Not importing from color palette as it imports open color package and these colors don't belong to open color package
+  strokeColor: "#1e1e1e",
+  backgroundColor: "transparent",
   fillStyle: "solid",
   strokeWidth: 2,
   strokeStyle: "solid",

--- a/packages/excalidraw/element/collision.ts
+++ b/packages/excalidraw/element/collision.ts
@@ -46,11 +46,11 @@ import {
   isImageElement,
 } from "./typeChecks";
 import { isTextElement } from ".";
-import { isTransparent } from "../utils";
 import { shouldShowBoundingBox } from "./transformHandles";
 import { getBoundTextElement } from "./textElement";
 import { Mutable } from "../utility-types";
 import { ShapeCache } from "../scene/ShapeCache";
+import { isTransparent } from "../colors";
 
 const isElementDraggableFromInside = (
   element: NonDeletedExcalidrawElement,

--- a/packages/excalidraw/scene/Shape.ts
+++ b/packages/excalidraw/scene/Shape.ts
@@ -11,7 +11,7 @@ import type {
 } from "../element/types";
 import { isPathALoop, getCornerRadius } from "../math";
 import { generateFreeDrawShape } from "../renderer/renderElement";
-import { isTransparent, assertNever } from "../utils";
+import { assertNever } from "../utils";
 import { simplify } from "points-on-curve";
 import { ROUGHNESS } from "../constants";
 import {
@@ -21,6 +21,7 @@ import {
   isLinearElement,
 } from "../element/typeChecks";
 import { canChangeRoundness } from "./comparisons";
+import { isTransparent } from "../colors";
 
 const getDashArrayDashed = (strokeWidth: number) => [8, 8 + strokeWidth];
 

--- a/packages/excalidraw/tests/colors.test.ts
+++ b/packages/excalidraw/tests/colors.test.ts
@@ -1,4 +1,4 @@
-import * as utils from "../utils";
+import * as utils from "../colors";
 
 describe("Test isTransparent", () => {
   it("should return true when color is rgb transparent", () => {

--- a/packages/excalidraw/utils.ts
+++ b/packages/excalidraw/utils.ts
@@ -1,4 +1,3 @@
-import { COLOR_PALETTE } from "./colors";
 import {
   DEFAULT_VERSION,
   EVENT,
@@ -525,16 +524,6 @@ export const findLastIndex = <T>(
     }
   }
   return -1;
-};
-
-export const isTransparent = (color: string) => {
-  const isRGBTransparent = color.length === 5 && color.substr(4, 1) === "0";
-  const isRRGGBBTransparent = color.length === 9 && color.substr(7, 2) === "00";
-  return (
-    isRGBTransparent ||
-    isRRGGBBTransparent ||
-    color === COLOR_PALETTE.transparent
-  );
 };
 
 export type ResolvablePromise<T> = Promise<T> & {


### PR DESCRIPTION
Since we are importing `COLOR_PALETTE` in `utils.ts ` and `constants.ts`, and `colors.ts` imports `open-color`, it was getting bundled to all the utilities where `utils.ts` and `constants.ts` is being imported. 

More info - https://keybu.com/l/69d3c20bfdfd76ae6b42/creating-esm-bundle-for-excalidraw-utils
For https://github.com/excalidraw/excalidraw/pull/7500

We are not using any color from `open-color` package so its unnecessary to bundle it with constants and utils and increasing bundle size by `~5kb`. If we want to use `open-color` then those utils should be staying in `colors.ts` file instead of `utils`

Hence I have removed the dependency of `COLOR_PALELTTE` from both and `utils.ts` and `constants.ts`. 

This will result in using all using the utilities from **`typechecks`** eg **`isArrowElement`** without bundling **`open-color`**
