### PR TITLE
Adding one-click installation template

### DIFF
--- a/dev-docs/docs/@excalidraw/excalidraw/installation.mdx
+++ b/dev-docs/docs/@excalidraw/excalidraw/installation.mdx
@@ -41,3 +41,7 @@ Excalidraw takes _100%_ of `width` and `height` of the containing block so make 
 ### Demo
 
 [Try here](https://codesandbox.io/s/excalidraw-ehlz3).
+
+### One-Click Deployment
+
+[![Deploy on RepoCloud](https://d16t0pc4846x52.cloudfront.net/deploy.png)](https://repocloud.io/details/?app_id=143)


### PR DESCRIPTION
Added link to the excalidraw installation page enabling one-click deployment at repocloud.io. This addition simplifies the process for users to quickly deploy and scale excalidraw using repocloud's efficient cloud hosting services.