### PR TITLE
Issue #7177 Changed selectionColors: [oc.black] to  selectionColors:…

### DIFF
--- a/packages/excalidraw/renderer/renderScene.ts
+++ b/packages/excalidraw/renderer/renderScene.ts
@@ -639,7 +639,7 @@ const _renderInteractiveScene = ({
           elementX2,
           elementY1,
           elementY2,
-          selectionColors: [oc.black],
+          selectionColors: [selectionColor],
           dashed: true,
           cx: elementX1 + (elementX2 - elementX1) / 2,
           cy: elementY1 + (elementY2 - elementY1) / 2,


### PR DESCRIPTION
Issue #7177 : not visible grouping line on a dark background in a light theme

Changed `selectionColors: [oc.black]` to  `selectionColors: [selectionColor]`

This changed the selection colors of groups (the dotted one in case of groups) to the default primary color (purple).

### Before Changing:
![image](https://github.com/excalidraw/excalidraw/assets/63807168/97a7701f-e357-4ce7-ad3d-939dcdf5937f)

### After Changing:
![image](https://github.com/excalidraw/excalidraw/assets/63807168/160992d3-e923-4d3d-af01-d03957c74364)
