### PR TITLE
fix: move default to last so its compatible with nextjs

### DIFF
--- a/packages/excalidraw/package.json
+++ b/packages/excalidraw/package.json
@@ -7,8 +7,8 @@
   "exports": {
     ".": {
       "development": "./dist/dev/index.js",
-      "default": "./dist/prod/index.js",
-      "types": "./dist/excalidraw/index.d.ts"
+      "types": "./dist/excalidraw/index.d.ts",
+      "default": "./dist/prod/index.js"
     },
     "./index.css": {
       "development": "./dist/dev/index.css",


### PR DESCRIPTION
`nextjs` build fails as it expects the default export should be last one