### PR TITLE
fix: Prevent the library label from being collapsed

### DIFF
--- a/packages/excalidraw/components/Sidebar/SidebarTrigger.scss
+++ b/packages/excalidraw/components/Sidebar/SidebarTrigger.scss
@@ -29,6 +29,7 @@
 
   .default-sidebar-trigger .sidebar-trigger__label {
     display: block;
+    white-space: nowrap;
   }
 
   &.excalidraw--mobile .default-sidebar-trigger .sidebar-trigger__label {


### PR DESCRIPTION
In some language and some component width, characters in the upper right "library" label become overlapped and they look bad.

![screenshot (before)](https://github.com/excalidraw/excalidraw/assets/6667599/98207c77-3b36-4b51-ae4e-1ad337c30320)

I added `white-space: nowrap;` style to prevent this and make the full word be shown.

![screenshot (after)](https://github.com/excalidraw/excalidraw/assets/6667599/f17c6ab1-61ea-4ca2-8108-6b2776f35e98)
