### PR TITLE
fix: update VITE_PKG_VERSION reference in assetPath

### DIFF
--- a/packages/excalidraw/scene/export.ts
+++ b/packages/excalidraw/scene/export.ts
@@ -364,7 +364,7 @@ export const exportToSvg = async (
     assetPath =
       window.EXCALIDRAW_ASSET_PATH ||
       `https://unpkg.com/${import.meta.env.VITE_PKG_NAME}@${
-        import.meta.env.PKG_VERSION
+        import.meta.env.VITE_PKG_VERSION
       }`;
 
     if (assetPath?.startsWith("/")) {


### PR DESCRIPTION
Changed the reference from import.meta.env.PKG_VERSION to import.meta.env.VITE_PKG_VERSION to correctly use the VITE environment variable for package version in the assetPath.