### PR TITLE
fix: revert `mapElementIds` flag removal

### DIFF
--- a/packages/excalidraw/scene/export.ts
+++ b/packages/excalidraw/scene/export.ts
@@ -66,7 +66,7 @@ const __createSceneForElementsHack__ = (
   // ids to Scene instances so that we don't override the editor elements
   // mapping.
   // We still need to clone the objects themselves to regen references.
-  scene.replaceAllElements(cloneJSON(elements));
+  scene.replaceAllElements(cloneJSON(elements), false);
   return scene;
 };
 


### PR DESCRIPTION
inexplicably removed in https://github.com/excalidraw/excalidraw/pull/7577