### PR TITLE
feat: Upgraded node engine version of excalidraw-monorepo.

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "vitest-canvas-mock": "0.3.2"
   },
   "engines": {
-    "node": "18.0.0 - 20.x.x"
+    "node": "18.0.0 - 21.x.x"
   },
   "homepage": ".",
   "prettier": "@excalidraw/prettier-config",


### PR DESCRIPTION
Upgraded node engine version of excalidraw-monorepo from "18.0.0 - 20.x.x" to "18.0.0 - 21.x.x".

Before this merge, if you have the latest node engine version, you got the error:
`excalidraw-monorepo@: The engine "node" is incompatible with this module. Expected version "18.0.0 - 20.x.x". Got "21.6.1"
`

There is a need to manually switch to compatible version with command before starting development.
`n 18.0.0`

I upgraded maximum compatible node engine version, all tests and build passed without any errors\conflicts.
So there is no need to stick to 20.x.x only, as it creates discomfort expressed in need to switch to not the latest version.