### PR TITLE
docs: clarify description of duration for setToast

### DIFF
--- a/dev-docs/docs/@excalidraw/excalidraw/api/props/excalidraw-api.mdx
+++ b/dev-docs/docs/@excalidraw/excalidraw/api/props/excalidraw-api.mdx
@@ -320,7 +320,7 @@ This API can be used to show the toast with custom message.
 | --- | --- | --- |
 | message | string | The message to be shown on the toast. |
 | closable | boolean | Indicates whether to show the closable button on toast to dismiss the toast. |
-| duration | number | Determines the duration after which the toast should auto dismiss. To prevent autodimiss you can pass `Infinity`. |
+| duration | number | Determines the duration in milliseconds after which the toast should auto dismiss. To prevent autodimiss you can pass `Infinity`. |
 
 To dismiss an existing toast you can simple pass `null`
 


### PR DESCRIPTION
Clarifying that the duration is interpreted as milliseconds.

The duration is passed to the `Toast` component:

https://github.com/excalidraw/excalidraw/blob/10bd08ef19a049abcb4a7da96fc69a052c9520ee/packages/excalidraw/components/App.tsx#L1608-L1613

The duration is passed to `window.setTimeout`:

https://github.com/excalidraw/excalidraw/blob/10bd08ef19a049abcb4a7da96fc69a052c9520ee/packages/excalidraw/components/Toast.tsx#L26

`setTimeout()` accepts the time in milliseconds:

[setTimeout() global function - Web APIs | MDN](https://developer.mozilla.org/en-US/docs/Web/API/setTimeout)
