### PR TITLE
fix: Stop repeated error message popup during a collab #6221

### DIFF
--- a/excalidraw-app/App.tsx
+++ b/excalidraw-app/App.tsx
@@ -568,7 +568,7 @@ const ExcalidrawWrapper = () => {
     setTheme(appState.theme);
 
     // this check is redundant, but since this is a hot path, it's best
-    // not to evaludate the nested expression every time
+    // not to evaluate the nested expression every time
     if (!LocalData.isSavePaused()) {
       LocalData.save(elements, appState, files, () => {
         if (excalidrawAPI) {

--- a/excalidraw-app/App.tsx
+++ b/excalidraw-app/App.tsx
@@ -57,6 +57,7 @@ import Collab, {
   collabDialogShownAtom,
   isCollaboratingAtom,
   isOfflineAtom,
+  maxSizeExceededAtom,
 } from "./collab/Collab";
 import {
   exportToBackend,
@@ -310,6 +311,7 @@ const ExcalidrawWrapper = () => {
   const [isCollaborating] = useAtomWithInitialValue(isCollaboratingAtom, () => {
     return isCollaborationLink(window.location.href);
   });
+  const [maxSizeExceeded] = useAtom(maxSizeExceededAtom);
 
   useHandleLibrary({
     excalidrawAPI,
@@ -774,7 +776,7 @@ const ExcalidrawWrapper = () => {
             </OverwriteConfirmDialog.Action>
           )}
         </OverwriteConfirmDialog>
-        <AppFooter />
+        <AppFooter maxSizeExceeded={maxSizeExceeded} />
         <TTDDialog
           onTextSubmit={async (input) => {
             try {

--- a/excalidraw-app/collab/Collab.tsx
+++ b/excalidraw-app/collab/Collab.tsx
@@ -88,6 +88,7 @@ export const collabAPIAtom = atom<CollabAPI | null>(null);
 export const collabDialogShownAtom = atom(false);
 export const isCollaboratingAtom = atom(false);
 export const isOfflineAtom = atom(false);
+export const maxSizeExceededAtom = atom(false);
 
 interface CollabState {
   errorMessage: string;
@@ -263,29 +264,40 @@ class Collab extends PureComponent<Props, CollabState> {
     }
   });
 
+  maxSizeExceeded = () => appJotaiStore.get(maxSizeExceededAtom);
   saveCollabRoomToFirebase = async (
     syncableElements: readonly SyncableExcalidrawElement[],
   ) => {
-    try {
-      const savedData = await saveToFirebase(
-        this.portal,
-        syncableElements,
-        this.excalidrawAPI.getAppState(),
-      );
-
-      if (this.isCollaborating() && savedData && savedData.reconciledElements) {
-        this.handleRemoteSceneUpdate(
-          this.reconcileElements(savedData.reconciledElements),
+    if (!this.maxSizeExceeded()) {
+      try {
+        const savedData = await saveToFirebase(
+          this.portal,
+          syncableElements,
+          this.excalidrawAPI.getAppState(),
         );
-      }
-    } catch (error: any) {
-      this.setState({
+
+        if (
+          this.isCollaborating() &&
+          savedData &&
+          savedData.reconciledElements
+        ) {
+          this.handleRemoteSceneUpdate(
+            this.reconcileElements(savedData.reconciledElements),
+          );
+        }
+      } catch (error: any) {
         // firestore doesn't return a specific error code when size exceeded
-        errorMessage: /is longer than.*?bytes/.test(error.message)
-          ? t("errors.collabSaveFailed_sizeExceeded")
-          : t("errors.collabSaveFailed"),
-      });
-      console.error(error);
+        const maxSizeExceeded = /is longer than.*?bytes/.test(error.message);
+        this.setState({
+          errorMessage: maxSizeExceeded
+            ? t("errors.collabSaveFailed_sizeExceeded")
+            : t("errors.collabSaveFailed"),
+        });
+        if (maxSizeExceeded) {
+          appJotaiStore.set(maxSizeExceededAtom, true);
+        }
+        console.error(error);
+      }
     }
   };
 

--- a/excalidraw-app/components/AppFooter.tsx
+++ b/excalidraw-app/components/AppFooter.tsx
@@ -1,25 +1,29 @@
 import React from "react";
 import { Footer } from "../../packages/excalidraw/index";
 import { EncryptedIcon } from "./EncryptedIcon";
+import { MaxSizeExceededIcon } from "./MaxSizeExceededIcon";
 import { ExcalidrawPlusAppLink } from "./ExcalidrawPlusAppLink";
 import { isExcalidrawPlusSignedUser } from "../app_constants";
 
-export const AppFooter = React.memo(() => {
-  return (
-    <Footer>
-      <div
-        style={{
-          display: "flex",
-          gap: ".5rem",
-          alignItems: "center",
-        }}
-      >
-        {isExcalidrawPlusSignedUser ? (
-          <ExcalidrawPlusAppLink />
-        ) : (
-          <EncryptedIcon />
-        )}
-      </div>
-    </Footer>
-  );
-});
+export const AppFooter: React.FC<{ maxSizeExceeded: boolean }> = React.memo(
+  (props) => {
+    return (
+      <Footer>
+        <div
+          style={{
+            display: "flex",
+            gap: ".5rem",
+            alignItems: "center",
+          }}
+        >
+          {props.maxSizeExceeded && <MaxSizeExceededIcon />}
+          {isExcalidrawPlusSignedUser ? (
+            <ExcalidrawPlusAppLink />
+          ) : (
+            <EncryptedIcon />
+          )}
+        </div>
+      </Footer>
+    );
+  },
+);

--- a/excalidraw-app/components/MaxSizeExceededIcon.tsx
+++ b/excalidraw-app/components/MaxSizeExceededIcon.tsx
@@ -1,0 +1,15 @@
+import { alert } from "../../packages/excalidraw/components/icons";
+import { Tooltip } from "../../packages/excalidraw/components/Tooltip";
+import { useI18n } from "../../packages/excalidraw/i18n";
+
+export const MaxSizeExceededIcon = () => {
+  const { t } = useI18n();
+
+  return (
+    <div className="max-size-exceeded-icon tooltip">
+      <Tooltip label={t("errors.collabSaveFailed_sizeExceeded")} long={true}>
+        {alert}
+      </Tooltip>
+    </div>
+  );
+};

--- a/excalidraw-app/index.scss
+++ b/excalidraw-app/index.scss
@@ -11,6 +11,7 @@
     margin-inline-start: auto;
   }
 
+  .max-size-exceeded-icon,
   .encrypted-icon {
     border-radius: var(--space-factor);
     color: var(--color-primary);
@@ -23,6 +24,14 @@
       width: 1.2rem;
       height: 1.2rem;
     }
+  }
+
+  .max-size-exceeded-icon {
+    color: var(--color-promo);
+  }
+
+  .encrypted-icon {
+    color: var(--color-primary);
   }
 
   .dropdown-menu-container {

--- a/packages/excalidraw/components/icons.tsx
+++ b/packages/excalidraw/components/icons.tsx
@@ -951,6 +951,11 @@ export const file = createIcon(
   { width: 384, height: 512 },
 );
 
+export const alert = createIcon(
+  "M12 7h1v7h-1zm1.5 9.5a1 1 0 1 0-1 1 1.002 1.002 0 0 0 1-1zm9.3-4A10.3 10.3 0 1 1 12.5 2.2a10.297 10.297 0 0 1 10.3 10.3zm-1 0a9.3 9.3 0 1 0-9.3 9.3 9.31 9.31 0 0 0 9.3-9.3z",
+  { width: 24 },
+);
+
 // TODO barnabasmolnar/editor-redesign
 // couldn't find a new icon for this
 export const GroupIcon = React.memo(({ theme }: { theme: Theme }) =>


### PR DESCRIPTION
Problem:

![image](https://github.com/excalidraw/excalidraw/assets/82120596/1415c72b-49ba-4076-b6d6-601448089779)

When I'm tutoring using the Excalidraw Collaboration, I've had the problem that an error pops up every 1/2 a minute or so when the canvas is too big and can't be saved, which forces me to start a new Excalidraw room, even though I don't need to save anyways. This fix should implement the fix suggested by @dwelle to 'Perhaps show once, and then show a status icon on canvas instead.' 

This is my first contribution here, so if there's anything I did wrong, then I would be happy to take any feedback and change my code. 

P.S. I do not have Font Awesome Pro so I only added a very basic alert icon. I suggest changing it to something better if you have the time.
