### PR TITLE
fix: don't bundle react-dom when importing from element

### DIFF
--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -115,7 +115,6 @@ import {
   newLinearElement,
   newTextElement,
   newImageElement,
-  textWysiwyg,
   transformElements,
   updateTextElement,
   redrawTextBoundingBox,
@@ -409,6 +408,7 @@ import { AnimatedTrail } from "../animated-trail";
 import { LaserTrails } from "../laser-trails";
 import { withBatchedUpdates, withBatchedUpdatesThrottled } from "../reactUtils";
 import { getRenderOpacity } from "../renderer/renderElement";
+import { textWysiwyg } from "../element/textWysiwyg";
 
 const AppContext = React.createContext<AppClassProperties>(null!);
 const AppPropsContext = React.createContext<AppProps>(null!);

--- a/packages/excalidraw/element/index.ts
+++ b/packages/excalidraw/element/index.ts
@@ -50,7 +50,6 @@ export {
   dragNewElement,
 } from "./dragElements";
 export { isTextElement, isExcalidrawElement } from "./typeChecks";
-export { textWysiwyg } from "./textWysiwyg";
 export { redrawTextBoundingBox } from "./textElement";
 export {
   getPerfectElementSize,


### PR DESCRIPTION
![uploaded image](https://i.imgur.com/S6aCeEw.png)

`Shape.ts` imports the below functions from "../element"

```js
import { getDiamondPoints, getArrowheadPoints } from "../element";
```

The issue is we are re-exporting lot of functions from `element/index.ts` and it has `textWysiwyg` as well which leads to importing `react-dom` whenever anything is importing from `"../element/index"`.

The first step is to stop re-exporting `textWysiwyg` from `element/index.ts`, however, I think we should stop re-exporting any function and instead import from their original file as it's not a good pattern and re-exporting doesn't make sense unless its converted to a package lets say `@excalidraw/element`, only then it makes sense to re-export.
