### PR TITLE
don't bundle react and jotai when importing from scene

### DIFF
--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -216,7 +216,6 @@ import {
   getNormalizedZoom,
   getSelectedElements,
   hasBackground,
-  isOverScrollBars,
   isSomeElementSelected,
 } from "../scene";
 import Scene from "../scene/Scene";
@@ -409,6 +408,7 @@ import { LaserTrails } from "../laser-trails";
 import { withBatchedUpdates, withBatchedUpdatesThrottled } from "../reactUtils";
 import { getRenderOpacity } from "../renderer/renderElement";
 import { textWysiwyg } from "../element/textWysiwyg";
+import { isOverScrollBars } from "../scene/scrollbars";
 
 const AppContext = React.createContext<AppClassProperties>(null!);
 const AppPropsContext = React.createContext<AppProps>(null!);

--- a/packages/excalidraw/scene/index.ts
+++ b/packages/excalidraw/scene/index.ts
@@ -1,4 +1,3 @@
-export { isOverScrollBars } from "./scrollbars";
 export {
   isSomeElementSelected,
   getElementsWithinSelection,


### PR DESCRIPTION
![uploaded image](https://i.imgur.com/egElUFU.png)


Importing anything from `i18n` leads tom importing `react` since `i18n` is dependent on `jotai` and `jotai.ts` uses `react` internally.

Additionally `jotai` gets bundled too along with `react` as shown in above image.

In the above image this happens since `scrollbar.ts` gets imported from `scene/index`. 

Quickest way to solve this would be to stop re-exporting `scrollbar.ts` from `scene/index.ts`, which I think we should anyways do. However this would not fix the problem in the root -> importing anything from `i18n` leads to `jotai` and `react` bundling irrespective of whether its used.

We will need to decouple `jotai` stuff completely so the utils are pure as `jotai` isn't needed in the utils. I have some ideas on it, however I would like to first merge this PR.
