### PR TITLE
fix: make getEmbedLink independent of t function

### DIFF
--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -6501,7 +6501,7 @@ class App extends React.Component<AppProps, AppState> {
       return;
     }
 
-    if (embedLink.warning) {
+    if (embedLink.error instanceof URIError) {
       this.setToast({
         message: t("toast.unrecognizedLinkFormat"),
         closable: true,

--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -6502,7 +6502,10 @@ class App extends React.Component<AppProps, AppState> {
     }
 
     if (embedLink.warning) {
-      this.setToast({ message: embedLink.warning, closable: true });
+      this.setToast({
+        message: t("toast.unrecognizedLinkFormat"),
+        closable: true,
+      });
     }
 
     const element = newEmbeddableElement({

--- a/packages/excalidraw/element/Hyperlink.tsx
+++ b/packages/excalidraw/element/Hyperlink.tsx
@@ -121,7 +121,10 @@ export const Hyperlink = ({
         const { width, height } = element;
         const embedLink = getEmbedLink(link);
         if (embedLink?.warning) {
-          setToast({ message: embedLink.warning, closable: true });
+          setToast({
+            message: t("toast.unrecognizedLinkFormat"),
+            closable: true,
+          });
         }
         const ar = embedLink
           ? embedLink.intrinsicSize.w / embedLink.intrinsicSize.h

--- a/packages/excalidraw/element/Hyperlink.tsx
+++ b/packages/excalidraw/element/Hyperlink.tsx
@@ -120,7 +120,7 @@ export const Hyperlink = ({
       } else {
         const { width, height } = element;
         const embedLink = getEmbedLink(link);
-        if (embedLink?.warning) {
+        if (embedLink?.error instanceof URIError) {
           setToast({
             message: t("toast.unrecognizedLinkFormat"),
             closable: true,

--- a/packages/excalidraw/element/embeddable.ts
+++ b/packages/excalidraw/element/embeddable.ts
@@ -106,7 +106,9 @@ export const getEmbedLink = (
   const vimeoLink = link.match(RE_VIMEO);
   if (vimeoLink?.[1]) {
     const target = vimeoLink?.[1];
-    const warning = !/^\d+$/.test(target);
+    const error = !/^\d+$/.test(target)
+      ? new URIError("Invalid embed link format")
+      : undefined;
     type = "video";
     link = `https://player.vimeo.com/video/${target}?api=1`;
     aspectRatio = { w: 560, h: 315 };
@@ -117,7 +119,7 @@ export const getEmbedLink = (
       intrinsicSize: aspectRatio,
       type,
     });
-    return { link, intrinsicSize: aspectRatio, type, warning };
+    return { link, intrinsicSize: aspectRatio, type, error };
   }
 
   const figmaLink = link.match(RE_FIGMA);

--- a/packages/excalidraw/element/embeddable.ts
+++ b/packages/excalidraw/element/embeddable.ts
@@ -1,6 +1,5 @@
 import { register } from "../actions/register";
 import { FONT_FAMILY, VERTICAL_ALIGN } from "../constants";
-import { t } from "../i18n";
 import { ExcalidrawProps } from "../types";
 import { getFontString, updateActiveTool } from "../utils";
 import { setCursorForShape } from "../cursor";
@@ -107,9 +106,7 @@ export const getEmbedLink = (
   const vimeoLink = link.match(RE_VIMEO);
   if (vimeoLink?.[1]) {
     const target = vimeoLink?.[1];
-    const warning = !/^\d+$/.test(target)
-      ? t("toast.unrecognizedLinkFormat")
-      : undefined;
+    const warning = !/^\d+$/.test(target);
     type = "video";
     link = `https://player.vimeo.com/video/${target}?api=1`;
     aspectRatio = { w: 560, h: 315 };

--- a/packages/excalidraw/element/types.ts
+++ b/packages/excalidraw/element/types.ts
@@ -104,7 +104,7 @@ export type ExcalidrawIframeLikeElement =
 export type IframeData =
   | {
       intrinsicSize: { w: number; h: number };
-      warning?: boolean;
+      error?: Error;
     } & (
       | { type: "video" | "generic"; link: string }
       | { type: "document"; srcdoc: (theme: Theme) => string }

--- a/packages/excalidraw/element/types.ts
+++ b/packages/excalidraw/element/types.ts
@@ -104,7 +104,7 @@ export type ExcalidrawIframeLikeElement =
 export type IframeData =
   | {
       intrinsicSize: { w: number; h: number };
-      warning?: string;
+      warning?: boolean;
     } & (
       | { type: "video" | "generic"; link: string }
       | { type: "document"; srcdoc: (theme: Theme) => string }


### PR DESCRIPTION
for #7500 

```js
import {getEmbedLink} from "../element/embeddable";
```
The above import results in :point_down: 
![uploaded image](https://i.imgur.com/16bw9V9.png)

So `getEmbedLink` uses `t` function which results in importing `react`, `jotai` and all the locales. Since its a pure JS util, it shouldn't be dependent on `t`, instead the function should just return whether to show warning and the caller will be responsible to show the warning. 

Hence I have moved the responsibility of showing `warning` to caller and instead just return `warning` as a boolean. Should `warning` be renamed to `showWarning` so its more semantic ? 