### PR TITLE
fix: remove dependency of t from appState.name

### DIFF
--- a/packages/excalidraw/actions/actionExport.tsx
+++ b/packages/excalidraw/actions/actionExport.tsx
@@ -19,7 +19,6 @@ import { nativeFileSystemSupported } from "../data/filesystem";
 import { Theme } from "../element/types";
 
 import "../components/ToolIcon.scss";
-import { getDateTime } from "../utils";
 
 export const actionChangeProjectName = register({
   name: "changeProjectName",
@@ -30,7 +29,7 @@ export const actionChangeProjectName = register({
   PanelComponent: ({ appState, updateData, appProps, data }) => (
     <ProjectName
       label={t("labels.fileTitle")}
-      value={appState.name || `${t("labels.untitled")}-${getDateTime()}`}
+      value={appState.name}
       onChange={(name: string) => updateData(name)}
       isNameEditable={
         typeof appProps.name === "undefined" && !appState.viewModeEnabled

--- a/packages/excalidraw/actions/actionExport.tsx
+++ b/packages/excalidraw/actions/actionExport.tsx
@@ -19,6 +19,7 @@ import { nativeFileSystemSupported } from "../data/filesystem";
 import { Theme } from "../element/types";
 
 import "../components/ToolIcon.scss";
+import { getDateTime } from "../utils";
 
 export const actionChangeProjectName = register({
   name: "changeProjectName",
@@ -29,7 +30,7 @@ export const actionChangeProjectName = register({
   PanelComponent: ({ appState, updateData, appProps, data }) => (
     <ProjectName
       label={t("labels.fileTitle")}
-      value={appState.name || "Unnamed"}
+      value={appState.name || `${t("labels.untitled")}-${getDateTime()}`}
       onChange={(name: string) => updateData(name)}
       isNameEditable={
         typeof appProps.name === "undefined" && !appState.viewModeEnabled

--- a/packages/excalidraw/appState.ts
+++ b/packages/excalidraw/appState.ts
@@ -7,9 +7,7 @@ import {
   EXPORT_SCALES,
   THEME,
 } from "./constants";
-import { t } from "./i18n";
 import { AppState, NormalizedZoomValue } from "./types";
-import { getDateTime } from "./utils";
 
 const defaultExportScale = EXPORT_SCALES.includes(devicePixelRatio)
   ? devicePixelRatio
@@ -65,7 +63,7 @@ export const getDefaultAppState = (): Omit<
     isRotating: false,
     lastPointerDownWith: "mouse",
     multiElement: null,
-    name: `${t("labels.untitled")}-${getDateTime()}`,
+    name: "",
     contextMenu: null,
     openMenu: null,
     openPopup: null,

--- a/packages/excalidraw/components/ImageExportDialog.tsx
+++ b/packages/excalidraw/components/ImageExportDialog.tsx
@@ -34,7 +34,7 @@ import { Tooltip } from "./Tooltip";
 import "./ImageExportDialog.scss";
 import { useAppProps } from "./App";
 import { FilledButton } from "./FilledButton";
-import { cloneJSON } from "../utils";
+import { cloneJSON, getDateTime } from "../utils";
 import { prepareElementsForExport } from "../data";
 
 const supportsContextFilters =
@@ -73,7 +73,9 @@ const ImageExportModal = ({
   );
 
   const appProps = useAppProps();
-  const [projectName, setProjectName] = useState(appStateSnapshot.name);
+  const [projectName, setProjectName] = useState(
+    appStateSnapshot.name || `${t("labels.untitled")}-${getDateTime()}`,
+  );
   const [exportSelectionOnly, setExportSelectionOnly] = useState(hasSelection);
   const [exportWithBackground, setExportWithBackground] = useState(
     appStateSnapshot.exportBackground,

--- a/packages/excalidraw/components/ProjectName.tsx
+++ b/packages/excalidraw/components/ProjectName.tsx
@@ -1,11 +1,12 @@
 import "./TextInput.scss";
 
 import React, { useState } from "react";
-import { focusNearestParent } from "../utils";
+import { focusNearestParent, getDateTime } from "../utils";
 
 import "./ProjectName.scss";
 import { useExcalidrawContainer } from "./App";
 import { KEYS } from "../keys";
+import { t } from "../i18n";
 
 type Props = {
   value: string;

--- a/packages/excalidraw/components/ProjectName.tsx
+++ b/packages/excalidraw/components/ProjectName.tsx
@@ -18,7 +18,9 @@ type Props = {
 
 export const ProjectName = (props: Props) => {
   const { id } = useExcalidrawContainer();
-  const [fileName, setFileName] = useState<string>(props.value);
+  const [fileName, setFileName] = useState<string>(
+    props.value || `${t("labels.untitled")}-${getDateTime()}`,
+  );
 
   const handleBlur = (event: any) => {
     if (!props.ignoreFocus) {

--- a/packages/excalidraw/tests/__snapshots__/contextmenu.test.tsx.snap
+++ b/packages/excalidraw/tests/__snapshots__/contextmenu.test.tsx.snap
@@ -328,7 +328,7 @@ exports[`contextMenu element > right-clicking on a group should select whole gro
   "isRotating": false,
   "lastPointerDownWith": "mouse",
   "multiElement": null,
-  "name": "Untitled-201933152653",
+  "name": "",
   "objectsSnapModeEnabled": false,
   "offsetLeft": 20,
   "offsetTop": 10,
@@ -459,7 +459,7 @@ exports[`contextMenu element > right-clicking on a group should select whole gro
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {},
         "selectedGroupIds": {},
         "viewBackgroundColor": "#ffffff",
@@ -529,7 +529,7 @@ exports[`contextMenu element > selecting 'Add to library' in context menu adds e
   "isRotating": false,
   "lastPointerDownWith": "mouse",
   "multiElement": null,
-  "name": "Untitled-201933152653",
+  "name": "",
   "objectsSnapModeEnabled": false,
   "offsetLeft": 20,
   "offsetTop": 10,
@@ -620,7 +620,7 @@ exports[`contextMenu element > selecting 'Add to library' in context menu adds e
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {},
         "selectedGroupIds": {},
         "viewBackgroundColor": "#ffffff",
@@ -631,7 +631,7 @@ exports[`contextMenu element > selecting 'Add to library' in context menu adds e
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id0": true,
         },
@@ -733,7 +733,7 @@ exports[`contextMenu element > selecting 'Bring forward' in context menu brings 
   "isRotating": false,
   "lastPointerDownWith": "mouse",
   "multiElement": null,
-  "name": "Untitled-201933152653",
+  "name": "",
   "objectsSnapModeEnabled": false,
   "offsetLeft": 20,
   "offsetTop": 10,
@@ -854,7 +854,7 @@ exports[`contextMenu element > selecting 'Bring forward' in context menu brings 
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {},
         "selectedGroupIds": {},
         "viewBackgroundColor": "#ffffff",
@@ -865,7 +865,7 @@ exports[`contextMenu element > selecting 'Bring forward' in context menu brings 
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id0": true,
         },
@@ -908,7 +908,7 @@ exports[`contextMenu element > selecting 'Bring forward' in context menu brings 
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id1": true,
         },
@@ -980,7 +980,7 @@ exports[`contextMenu element > selecting 'Bring forward' in context menu brings 
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id0": true,
         },
@@ -1111,7 +1111,7 @@ exports[`contextMenu element > selecting 'Bring to front' in context menu brings
   "isRotating": false,
   "lastPointerDownWith": "mouse",
   "multiElement": null,
-  "name": "Untitled-201933152653",
+  "name": "",
   "objectsSnapModeEnabled": false,
   "offsetLeft": 20,
   "offsetTop": 10,
@@ -1232,7 +1232,7 @@ exports[`contextMenu element > selecting 'Bring to front' in context menu brings
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {},
         "selectedGroupIds": {},
         "viewBackgroundColor": "#ffffff",
@@ -1243,7 +1243,7 @@ exports[`contextMenu element > selecting 'Bring to front' in context menu brings
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id0": true,
         },
@@ -1286,7 +1286,7 @@ exports[`contextMenu element > selecting 'Bring to front' in context menu brings
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id1": true,
         },
@@ -1358,7 +1358,7 @@ exports[`contextMenu element > selecting 'Bring to front' in context menu brings
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id0": true,
         },
@@ -1489,7 +1489,7 @@ exports[`contextMenu element > selecting 'Copy styles' in context menu copies st
   "isRotating": false,
   "lastPointerDownWith": "mouse",
   "multiElement": null,
-  "name": "Untitled-201933152653",
+  "name": "",
   "objectsSnapModeEnabled": false,
   "offsetLeft": 20,
   "offsetTop": 10,
@@ -1580,7 +1580,7 @@ exports[`contextMenu element > selecting 'Copy styles' in context menu copies st
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {},
         "selectedGroupIds": {},
         "viewBackgroundColor": "#ffffff",
@@ -1591,7 +1591,7 @@ exports[`contextMenu element > selecting 'Copy styles' in context menu copies st
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id0": true,
         },
@@ -1693,7 +1693,7 @@ exports[`contextMenu element > selecting 'Delete' in context menu deletes elemen
   "isRotating": false,
   "lastPointerDownWith": "mouse",
   "multiElement": null,
-  "name": "Untitled-201933152653",
+  "name": "",
   "objectsSnapModeEnabled": false,
   "offsetLeft": 20,
   "offsetTop": 10,
@@ -1780,7 +1780,7 @@ exports[`contextMenu element > selecting 'Delete' in context menu deletes elemen
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {},
         "selectedGroupIds": {},
         "viewBackgroundColor": "#ffffff",
@@ -1791,7 +1791,7 @@ exports[`contextMenu element > selecting 'Delete' in context menu deletes elemen
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id0": true,
         },
@@ -1834,7 +1834,7 @@ exports[`contextMenu element > selecting 'Delete' in context menu deletes elemen
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {},
         "selectedGroupIds": {},
         "viewBackgroundColor": "#ffffff",
@@ -1934,7 +1934,7 @@ exports[`contextMenu element > selecting 'Duplicate' in context menu duplicates 
   "isRotating": false,
   "lastPointerDownWith": "mouse",
   "multiElement": null,
-  "name": "Untitled-201933152653",
+  "name": "",
   "objectsSnapModeEnabled": false,
   "offsetLeft": 20,
   "offsetTop": 10,
@@ -2055,7 +2055,7 @@ exports[`contextMenu element > selecting 'Duplicate' in context menu duplicates 
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {},
         "selectedGroupIds": {},
         "viewBackgroundColor": "#ffffff",
@@ -2066,7 +2066,7 @@ exports[`contextMenu element > selecting 'Duplicate' in context menu duplicates 
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id0": true,
         },
@@ -2109,7 +2109,7 @@ exports[`contextMenu element > selecting 'Duplicate' in context menu duplicates 
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id0_copy": true,
         },
@@ -2240,7 +2240,7 @@ exports[`contextMenu element > selecting 'Group selection' in context menu group
   "isRotating": false,
   "lastPointerDownWith": "mouse",
   "multiElement": null,
-  "name": "Untitled-201933152653",
+  "name": "",
   "objectsSnapModeEnabled": false,
   "offsetLeft": 20,
   "offsetTop": 10,
@@ -2370,7 +2370,7 @@ exports[`contextMenu element > selecting 'Group selection' in context menu group
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {},
         "selectedGroupIds": {},
         "viewBackgroundColor": "#ffffff",
@@ -2381,7 +2381,7 @@ exports[`contextMenu element > selecting 'Group selection' in context menu group
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id0": true,
         },
@@ -2424,7 +2424,7 @@ exports[`contextMenu element > selecting 'Group selection' in context menu group
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id1": true,
         },
@@ -2496,7 +2496,7 @@ exports[`contextMenu element > selecting 'Group selection' in context menu group
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id0": true,
           "id1": true,
@@ -2634,7 +2634,7 @@ exports[`contextMenu element > selecting 'Paste styles' in context menu pastes s
   "isRotating": false,
   "lastPointerDownWith": "mouse",
   "multiElement": null,
-  "name": "Untitled-201933152653",
+  "name": "",
   "objectsSnapModeEnabled": false,
   "offsetLeft": 20,
   "offsetTop": 10,
@@ -2757,7 +2757,7 @@ exports[`contextMenu element > selecting 'Paste styles' in context menu pastes s
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {},
         "selectedGroupIds": {},
         "viewBackgroundColor": "#ffffff",
@@ -2768,7 +2768,7 @@ exports[`contextMenu element > selecting 'Paste styles' in context menu pastes s
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id0": true,
         },
@@ -2811,7 +2811,7 @@ exports[`contextMenu element > selecting 'Paste styles' in context menu pastes s
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id1": true,
         },
@@ -2883,7 +2883,7 @@ exports[`contextMenu element > selecting 'Paste styles' in context menu pastes s
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id1": true,
         },
@@ -2955,7 +2955,7 @@ exports[`contextMenu element > selecting 'Paste styles' in context menu pastes s
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id1": true,
         },
@@ -3027,7 +3027,7 @@ exports[`contextMenu element > selecting 'Paste styles' in context menu pastes s
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id1": true,
         },
@@ -3099,7 +3099,7 @@ exports[`contextMenu element > selecting 'Paste styles' in context menu pastes s
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id1": true,
         },
@@ -3171,7 +3171,7 @@ exports[`contextMenu element > selecting 'Paste styles' in context menu pastes s
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id1": true,
         },
@@ -3243,7 +3243,7 @@ exports[`contextMenu element > selecting 'Paste styles' in context menu pastes s
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id1": true,
         },
@@ -3315,7 +3315,7 @@ exports[`contextMenu element > selecting 'Paste styles' in context menu pastes s
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id0": true,
         },
@@ -3446,7 +3446,7 @@ exports[`contextMenu element > selecting 'Send backward' in context menu sends e
   "isRotating": false,
   "lastPointerDownWith": "mouse",
   "multiElement": null,
-  "name": "Untitled-201933152653",
+  "name": "",
   "objectsSnapModeEnabled": false,
   "offsetLeft": 20,
   "offsetTop": 10,
@@ -3567,7 +3567,7 @@ exports[`contextMenu element > selecting 'Send backward' in context menu sends e
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {},
         "selectedGroupIds": {},
         "viewBackgroundColor": "#ffffff",
@@ -3578,7 +3578,7 @@ exports[`contextMenu element > selecting 'Send backward' in context menu sends e
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id0": true,
         },
@@ -3621,7 +3621,7 @@ exports[`contextMenu element > selecting 'Send backward' in context menu sends e
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id1": true,
         },
@@ -3693,7 +3693,7 @@ exports[`contextMenu element > selecting 'Send backward' in context menu sends e
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id1": true,
         },
@@ -3824,7 +3824,7 @@ exports[`contextMenu element > selecting 'Send to back' in context menu sends el
   "isRotating": false,
   "lastPointerDownWith": "mouse",
   "multiElement": null,
-  "name": "Untitled-201933152653",
+  "name": "",
   "objectsSnapModeEnabled": false,
   "offsetLeft": 20,
   "offsetTop": 10,
@@ -3945,7 +3945,7 @@ exports[`contextMenu element > selecting 'Send to back' in context menu sends el
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {},
         "selectedGroupIds": {},
         "viewBackgroundColor": "#ffffff",
@@ -3956,7 +3956,7 @@ exports[`contextMenu element > selecting 'Send to back' in context menu sends el
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id0": true,
         },
@@ -3999,7 +3999,7 @@ exports[`contextMenu element > selecting 'Send to back' in context menu sends el
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id1": true,
         },
@@ -4071,7 +4071,7 @@ exports[`contextMenu element > selecting 'Send to back' in context menu sends el
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id1": true,
         },
@@ -4202,7 +4202,7 @@ exports[`contextMenu element > selecting 'Ungroup selection' in context menu ung
   "isRotating": false,
   "lastPointerDownWith": "mouse",
   "multiElement": null,
-  "name": "Untitled-201933152653",
+  "name": "",
   "objectsSnapModeEnabled": false,
   "offsetLeft": 20,
   "offsetTop": 10,
@@ -4326,7 +4326,7 @@ exports[`contextMenu element > selecting 'Ungroup selection' in context menu ung
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {},
         "selectedGroupIds": {},
         "viewBackgroundColor": "#ffffff",
@@ -4337,7 +4337,7 @@ exports[`contextMenu element > selecting 'Ungroup selection' in context menu ung
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id0": true,
         },
@@ -4380,7 +4380,7 @@ exports[`contextMenu element > selecting 'Ungroup selection' in context menu ung
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id1": true,
         },
@@ -4452,7 +4452,7 @@ exports[`contextMenu element > selecting 'Ungroup selection' in context menu ung
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id0": true,
           "id1": true,
@@ -4531,7 +4531,7 @@ exports[`contextMenu element > selecting 'Ungroup selection' in context menu ung
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id0": true,
           "id1": true,
@@ -4936,7 +4936,7 @@ exports[`contextMenu element > shows 'Group selection' in context menu for multi
   "isRotating": false,
   "lastPointerDownWith": "mouse",
   "multiElement": null,
-  "name": "Untitled-201933152653",
+  "name": "",
   "objectsSnapModeEnabled": false,
   "offsetLeft": 20,
   "offsetTop": 10,
@@ -5060,7 +5060,7 @@ exports[`contextMenu element > shows 'Group selection' in context menu for multi
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {},
         "selectedGroupIds": {},
         "viewBackgroundColor": "#ffffff",
@@ -5071,7 +5071,7 @@ exports[`contextMenu element > shows 'Group selection' in context menu for multi
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id0": true,
         },
@@ -5114,7 +5114,7 @@ exports[`contextMenu element > shows 'Group selection' in context menu for multi
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id1": true,
         },
@@ -5518,7 +5518,7 @@ exports[`contextMenu element > shows 'Ungroup selection' in context menu for gro
   "isRotating": false,
   "lastPointerDownWith": "mouse",
   "multiElement": null,
-  "name": "Untitled-201933152653",
+  "name": "",
   "objectsSnapModeEnabled": false,
   "offsetLeft": 20,
   "offsetTop": 10,
@@ -5648,7 +5648,7 @@ exports[`contextMenu element > shows 'Ungroup selection' in context menu for gro
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {},
         "selectedGroupIds": {},
         "viewBackgroundColor": "#ffffff",
@@ -5659,7 +5659,7 @@ exports[`contextMenu element > shows 'Ungroup selection' in context menu for gro
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id0": true,
         },
@@ -5702,7 +5702,7 @@ exports[`contextMenu element > shows 'Ungroup selection' in context menu for gro
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id1": true,
         },
@@ -5774,7 +5774,7 @@ exports[`contextMenu element > shows 'Ungroup selection' in context menu for gro
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id0": true,
           "id1": true,
@@ -6039,7 +6039,7 @@ exports[`contextMenu element > shows context menu for canvas > [end of test] app
   "isRotating": false,
   "lastPointerDownWith": "mouse",
   "multiElement": null,
-  "name": "Untitled-201933152653",
+  "name": "",
   "objectsSnapModeEnabled": false,
   "offsetLeft": 20,
   "offsetTop": 10,
@@ -6097,7 +6097,7 @@ exports[`contextMenu element > shows context menu for canvas > [end of test] his
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {},
         "selectedGroupIds": {},
         "viewBackgroundColor": "#ffffff",
@@ -6440,7 +6440,7 @@ exports[`contextMenu element > shows context menu for element > [end of test] ap
   "isRotating": false,
   "lastPointerDownWith": "mouse",
   "multiElement": null,
-  "name": "Untitled-201933152653",
+  "name": "",
   "objectsSnapModeEnabled": false,
   "offsetLeft": 20,
   "offsetTop": 10,
@@ -6816,7 +6816,7 @@ exports[`contextMenu element > shows context menu for element > [end of test] ap
   "isRotating": false,
   "lastPointerDownWith": "mouse",
   "multiElement": null,
-  "name": "Untitled-201933152653",
+  "name": "",
   "objectsSnapModeEnabled": false,
   "offsetLeft": 20,
   "offsetTop": 10,
@@ -6972,7 +6972,7 @@ exports[`contextMenu element > shows context menu for element > [end of test] hi
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {},
         "selectedGroupIds": {},
         "viewBackgroundColor": "#ffffff",
@@ -6983,7 +6983,7 @@ exports[`contextMenu element > shows context menu for element > [end of test] hi
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id0": true,
         },
@@ -7035,7 +7035,7 @@ exports[`contextMenu element > shows context menu for element > [end of test] hi
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {},
         "selectedGroupIds": {},
         "viewBackgroundColor": "#ffffff",

--- a/packages/excalidraw/tests/__snapshots__/regressionTests.test.tsx.snap
+++ b/packages/excalidraw/tests/__snapshots__/regressionTests.test.tsx.snap
@@ -55,7 +55,7 @@ exports[`given element A and group of elements B and given both are selected whe
   "isRotating": false,
   "lastPointerDownWith": "mouse",
   "multiElement": null,
-  "name": "Untitled-201933152653",
+  "name": "",
   "objectsSnapModeEnabled": false,
   "offsetLeft": 0,
   "offsetTop": 0,
@@ -119,7 +119,7 @@ exports[`given element A and group of elements B and given both are selected whe
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {},
         "selectedGroupIds": {},
         "viewBackgroundColor": "#ffffff",
@@ -130,7 +130,7 @@ exports[`given element A and group of elements B and given both are selected whe
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id0": true,
         },
@@ -173,7 +173,7 @@ exports[`given element A and group of elements B and given both are selected whe
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id1": true,
         },
@@ -245,7 +245,7 @@ exports[`given element A and group of elements B and given both are selected whe
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id2": true,
         },
@@ -346,7 +346,7 @@ exports[`given element A and group of elements B and given both are selected whe
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id0": true,
           "id2": true,
@@ -513,7 +513,7 @@ exports[`given element A and group of elements B and given both are selected whe
   "isRotating": false,
   "lastPointerDownWith": "mouse",
   "multiElement": null,
-  "name": "Untitled-201933152653",
+  "name": "",
   "objectsSnapModeEnabled": false,
   "offsetLeft": 0,
   "offsetTop": 0,
@@ -579,7 +579,7 @@ exports[`given element A and group of elements B and given both are selected whe
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {},
         "selectedGroupIds": {},
         "viewBackgroundColor": "#ffffff",
@@ -590,7 +590,7 @@ exports[`given element A and group of elements B and given both are selected whe
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id0": true,
         },
@@ -633,7 +633,7 @@ exports[`given element A and group of elements B and given both are selected whe
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id1": true,
         },
@@ -705,7 +705,7 @@ exports[`given element A and group of elements B and given both are selected whe
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id2": true,
         },
@@ -806,7 +806,7 @@ exports[`given element A and group of elements B and given both are selected whe
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id0": true,
           "id2": true,
@@ -973,7 +973,7 @@ exports[`regression tests > Cmd/Ctrl-click exclusively select element under poin
   "isRotating": false,
   "lastPointerDownWith": "mouse",
   "multiElement": null,
-  "name": "Untitled-201933152653",
+  "name": "",
   "objectsSnapModeEnabled": false,
   "offsetLeft": 0,
   "offsetTop": 0,
@@ -1030,7 +1030,7 @@ exports[`regression tests > Cmd/Ctrl-click exclusively select element under poin
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {},
         "selectedGroupIds": {},
         "viewBackgroundColor": "#ffffff",
@@ -1041,7 +1041,7 @@ exports[`regression tests > Cmd/Ctrl-click exclusively select element under poin
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id0": true,
         },
@@ -1084,7 +1084,7 @@ exports[`regression tests > Cmd/Ctrl-click exclusively select element under poin
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id1": true,
         },
@@ -1156,7 +1156,7 @@ exports[`regression tests > Cmd/Ctrl-click exclusively select element under poin
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id0": true,
           "id1": true,
@@ -1235,7 +1235,7 @@ exports[`regression tests > Cmd/Ctrl-click exclusively select element under poin
       "appState": {
         "editingGroupId": "id4",
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id0": true,
         },
@@ -1311,7 +1311,7 @@ exports[`regression tests > Cmd/Ctrl-click exclusively select element under poin
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id7": true,
         },
@@ -1416,7 +1416,7 @@ exports[`regression tests > Cmd/Ctrl-click exclusively select element under poin
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id0": true,
           "id1": true,
@@ -1529,7 +1529,7 @@ exports[`regression tests > Cmd/Ctrl-click exclusively select element under poin
       "appState": {
         "editingGroupId": "id4",
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id0": true,
         },
@@ -1638,7 +1638,7 @@ exports[`regression tests > Cmd/Ctrl-click exclusively select element under poin
       "appState": {
         "editingGroupId": "id10",
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id7": true,
         },
@@ -1806,7 +1806,7 @@ exports[`regression tests > Drags selected element when hitting only bounding bo
   "isRotating": false,
   "lastPointerDownWith": "mouse",
   "multiElement": null,
-  "name": "Untitled-201933152653",
+  "name": "",
   "objectsSnapModeEnabled": false,
   "offsetLeft": 0,
   "offsetTop": 0,
@@ -1865,7 +1865,7 @@ exports[`regression tests > Drags selected element when hitting only bounding bo
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {},
         "selectedGroupIds": {},
         "viewBackgroundColor": "#ffffff",
@@ -1876,7 +1876,7 @@ exports[`regression tests > Drags selected element when hitting only bounding bo
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id0": true,
         },
@@ -1919,7 +1919,7 @@ exports[`regression tests > Drags selected element when hitting only bounding bo
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id0": true,
         },
@@ -2021,7 +2021,7 @@ exports[`regression tests > adjusts z order when grouping > [end of test] appSta
   "isRotating": false,
   "lastPointerDownWith": "mouse",
   "multiElement": null,
-  "name": "Untitled-201933152653",
+  "name": "",
   "objectsSnapModeEnabled": false,
   "offsetLeft": 0,
   "offsetTop": 0,
@@ -2083,7 +2083,7 @@ exports[`regression tests > adjusts z order when grouping > [end of test] histor
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {},
         "selectedGroupIds": {},
         "viewBackgroundColor": "#ffffff",
@@ -2094,7 +2094,7 @@ exports[`regression tests > adjusts z order when grouping > [end of test] histor
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id0": true,
         },
@@ -2137,7 +2137,7 @@ exports[`regression tests > adjusts z order when grouping > [end of test] histor
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id1": true,
         },
@@ -2209,7 +2209,7 @@ exports[`regression tests > adjusts z order when grouping > [end of test] histor
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id2": true,
         },
@@ -2310,7 +2310,7 @@ exports[`regression tests > adjusts z order when grouping > [end of test] histor
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id0": true,
           "id2": true,
@@ -2477,7 +2477,7 @@ exports[`regression tests > alt-drag duplicates an element > [end of test] appSt
   "isRotating": false,
   "lastPointerDownWith": "mouse",
   "multiElement": null,
-  "name": "Untitled-201933152653",
+  "name": "",
   "objectsSnapModeEnabled": false,
   "offsetLeft": 0,
   "offsetTop": 0,
@@ -2536,7 +2536,7 @@ exports[`regression tests > alt-drag duplicates an element > [end of test] histo
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {},
         "selectedGroupIds": {},
         "viewBackgroundColor": "#ffffff",
@@ -2547,7 +2547,7 @@ exports[`regression tests > alt-drag duplicates an element > [end of test] histo
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id0": true,
         },
@@ -2590,7 +2590,7 @@ exports[`regression tests > alt-drag duplicates an element > [end of test] histo
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id0": true,
         },
@@ -2721,7 +2721,7 @@ exports[`regression tests > arrow keys > [end of test] appState 1`] = `
   "isRotating": false,
   "lastPointerDownWith": "mouse",
   "multiElement": null,
-  "name": "Untitled-201933152653",
+  "name": "",
   "objectsSnapModeEnabled": false,
   "offsetLeft": 0,
   "offsetTop": 0,
@@ -2778,7 +2778,7 @@ exports[`regression tests > arrow keys > [end of test] history 1`] = `
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {},
         "selectedGroupIds": {},
         "viewBackgroundColor": "#ffffff",
@@ -2789,7 +2789,7 @@ exports[`regression tests > arrow keys > [end of test] history 1`] = `
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id0": true,
         },
@@ -2891,7 +2891,7 @@ exports[`regression tests > can drag element that covers another element, while 
   "isRotating": false,
   "lastPointerDownWith": "mouse",
   "multiElement": null,
-  "name": "Untitled-201933152653",
+  "name": "",
   "objectsSnapModeEnabled": false,
   "offsetLeft": 0,
   "offsetTop": 0,
@@ -2950,7 +2950,7 @@ exports[`regression tests > can drag element that covers another element, while 
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {},
         "selectedGroupIds": {},
         "viewBackgroundColor": "#ffffff",
@@ -2961,7 +2961,7 @@ exports[`regression tests > can drag element that covers another element, while 
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id0": true,
         },
@@ -3004,7 +3004,7 @@ exports[`regression tests > can drag element that covers another element, while 
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id1": true,
         },
@@ -3076,7 +3076,7 @@ exports[`regression tests > can drag element that covers another element, while 
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id2": true,
         },
@@ -3177,7 +3177,7 @@ exports[`regression tests > can drag element that covers another element, while 
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id1": true,
         },
@@ -3337,7 +3337,7 @@ exports[`regression tests > change the properties of a shape > [end of test] app
   "isRotating": false,
   "lastPointerDownWith": "mouse",
   "multiElement": null,
-  "name": "Untitled-201933152653",
+  "name": "",
   "objectsSnapModeEnabled": false,
   "offsetLeft": 0,
   "offsetTop": 0,
@@ -3394,7 +3394,7 @@ exports[`regression tests > change the properties of a shape > [end of test] his
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {},
         "selectedGroupIds": {},
         "viewBackgroundColor": "#ffffff",
@@ -3405,7 +3405,7 @@ exports[`regression tests > change the properties of a shape > [end of test] his
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id0": true,
         },
@@ -3448,7 +3448,7 @@ exports[`regression tests > change the properties of a shape > [end of test] his
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id0": true,
         },
@@ -3491,7 +3491,7 @@ exports[`regression tests > change the properties of a shape > [end of test] his
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id0": true,
         },
@@ -3534,7 +3534,7 @@ exports[`regression tests > change the properties of a shape > [end of test] his
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id0": true,
         },
@@ -3636,7 +3636,7 @@ exports[`regression tests > click on an element and drag it > [dragged] appState
   "isRotating": false,
   "lastPointerDownWith": "mouse",
   "multiElement": null,
-  "name": "Untitled-201933152653",
+  "name": "",
   "objectsSnapModeEnabled": false,
   "offsetLeft": 0,
   "offsetTop": 0,
@@ -3727,7 +3727,7 @@ exports[`regression tests > click on an element and drag it > [dragged] history 
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {},
         "selectedGroupIds": {},
         "viewBackgroundColor": "#ffffff",
@@ -3738,7 +3738,7 @@ exports[`regression tests > click on an element and drag it > [dragged] history 
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id0": true,
         },
@@ -3781,7 +3781,7 @@ exports[`regression tests > click on an element and drag it > [dragged] history 
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id0": true,
         },
@@ -3883,7 +3883,7 @@ exports[`regression tests > click on an element and drag it > [end of test] appS
   "isRotating": false,
   "lastPointerDownWith": "mouse",
   "multiElement": null,
-  "name": "Untitled-201933152653",
+  "name": "",
   "objectsSnapModeEnabled": false,
   "offsetLeft": 0,
   "offsetTop": 0,
@@ -3942,7 +3942,7 @@ exports[`regression tests > click on an element and drag it > [end of test] hist
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {},
         "selectedGroupIds": {},
         "viewBackgroundColor": "#ffffff",
@@ -3953,7 +3953,7 @@ exports[`regression tests > click on an element and drag it > [end of test] hist
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id0": true,
         },
@@ -3996,7 +3996,7 @@ exports[`regression tests > click on an element and drag it > [end of test] hist
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id0": true,
         },
@@ -4039,7 +4039,7 @@ exports[`regression tests > click on an element and drag it > [end of test] hist
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id0": true,
         },
@@ -4141,7 +4141,7 @@ exports[`regression tests > click to select a shape > [end of test] appState 1`]
   "isRotating": false,
   "lastPointerDownWith": "mouse",
   "multiElement": null,
-  "name": "Untitled-201933152653",
+  "name": "",
   "objectsSnapModeEnabled": false,
   "offsetLeft": 0,
   "offsetTop": 0,
@@ -4200,7 +4200,7 @@ exports[`regression tests > click to select a shape > [end of test] history 1`] 
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {},
         "selectedGroupIds": {},
         "viewBackgroundColor": "#ffffff",
@@ -4211,7 +4211,7 @@ exports[`regression tests > click to select a shape > [end of test] history 1`] 
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id0": true,
         },
@@ -4254,7 +4254,7 @@ exports[`regression tests > click to select a shape > [end of test] history 1`] 
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id1": true,
         },
@@ -4385,7 +4385,7 @@ exports[`regression tests > click-drag to select a group > [end of test] appStat
   "isRotating": false,
   "lastPointerDownWith": "mouse",
   "multiElement": null,
-  "name": "Untitled-201933152653",
+  "name": "",
   "objectsSnapModeEnabled": false,
   "offsetLeft": 0,
   "offsetTop": 0,
@@ -4445,7 +4445,7 @@ exports[`regression tests > click-drag to select a group > [end of test] history
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {},
         "selectedGroupIds": {},
         "viewBackgroundColor": "#ffffff",
@@ -4456,7 +4456,7 @@ exports[`regression tests > click-drag to select a group > [end of test] history
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id0": true,
         },
@@ -4499,7 +4499,7 @@ exports[`regression tests > click-drag to select a group > [end of test] history
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id1": true,
         },
@@ -4571,7 +4571,7 @@ exports[`regression tests > click-drag to select a group > [end of test] history
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id2": true,
         },
@@ -4731,7 +4731,7 @@ exports[`regression tests > deleting last but one element in editing group shoul
   "isRotating": false,
   "lastPointerDownWith": "mouse",
   "multiElement": null,
-  "name": "Untitled-201933152653",
+  "name": "",
   "objectsSnapModeEnabled": false,
   "offsetLeft": 0,
   "offsetTop": 0,
@@ -4790,7 +4790,7 @@ exports[`regression tests > deleting last but one element in editing group shoul
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {},
         "selectedGroupIds": {},
         "viewBackgroundColor": "#ffffff",
@@ -4801,7 +4801,7 @@ exports[`regression tests > deleting last but one element in editing group shoul
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id0": true,
         },
@@ -4844,7 +4844,7 @@ exports[`regression tests > deleting last but one element in editing group shoul
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id1": true,
         },
@@ -4916,7 +4916,7 @@ exports[`regression tests > deleting last but one element in editing group shoul
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id0": true,
           "id1": true,
@@ -4995,7 +4995,7 @@ exports[`regression tests > deleting last but one element in editing group shoul
       "appState": {
         "editingGroupId": "id4",
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id1": true,
         },
@@ -5071,7 +5071,7 @@ exports[`regression tests > deleting last but one element in editing group shoul
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id1": true,
         },
@@ -5236,7 +5236,7 @@ exports[`regression tests > deselects group of selected elements on pointer down
   "isRotating": false,
   "lastPointerDownWith": "mouse",
   "multiElement": null,
-  "name": "Untitled-201933152653",
+  "name": "",
   "objectsSnapModeEnabled": false,
   "offsetLeft": 0,
   "offsetTop": 0,
@@ -5322,7 +5322,7 @@ exports[`regression tests > deselects group of selected elements on pointer down
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {},
         "selectedGroupIds": {},
         "viewBackgroundColor": "#ffffff",
@@ -5333,7 +5333,7 @@ exports[`regression tests > deselects group of selected elements on pointer down
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id0": true,
         },
@@ -5376,7 +5376,7 @@ exports[`regression tests > deselects group of selected elements on pointer down
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id1": true,
         },
@@ -5535,7 +5535,7 @@ exports[`regression tests > deselects group of selected elements on pointer up w
   "isRotating": false,
   "lastPointerDownWith": "mouse",
   "multiElement": null,
-  "name": "Untitled-201933152653",
+  "name": "",
   "objectsSnapModeEnabled": false,
   "offsetLeft": 0,
   "offsetTop": 0,
@@ -5593,7 +5593,7 @@ exports[`regression tests > deselects group of selected elements on pointer up w
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {},
         "selectedGroupIds": {},
         "viewBackgroundColor": "#ffffff",
@@ -5604,7 +5604,7 @@ exports[`regression tests > deselects group of selected elements on pointer up w
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id0": true,
         },
@@ -5647,7 +5647,7 @@ exports[`regression tests > deselects group of selected elements on pointer up w
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id1": true,
         },
@@ -5806,7 +5806,7 @@ exports[`regression tests > deselects selected element on pointer down when poin
   "isRotating": false,
   "lastPointerDownWith": "mouse",
   "multiElement": null,
-  "name": "Untitled-201933152653",
+  "name": "",
   "objectsSnapModeEnabled": false,
   "offsetLeft": 0,
   "offsetTop": 0,
@@ -5891,7 +5891,7 @@ exports[`regression tests > deselects selected element on pointer down when poin
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {},
         "selectedGroupIds": {},
         "viewBackgroundColor": "#ffffff",
@@ -5902,7 +5902,7 @@ exports[`regression tests > deselects selected element on pointer down when poin
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id0": true,
         },
@@ -6004,7 +6004,7 @@ exports[`regression tests > deselects selected element, on pointer up, when clic
   "isRotating": false,
   "lastPointerDownWith": "mouse",
   "multiElement": null,
-  "name": "Untitled-201933152653",
+  "name": "",
   "objectsSnapModeEnabled": false,
   "offsetLeft": 0,
   "offsetTop": 0,
@@ -6061,7 +6061,7 @@ exports[`regression tests > deselects selected element, on pointer up, when clic
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {},
         "selectedGroupIds": {},
         "viewBackgroundColor": "#ffffff",
@@ -6072,7 +6072,7 @@ exports[`regression tests > deselects selected element, on pointer up, when clic
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id0": true,
         },
@@ -6174,7 +6174,7 @@ exports[`regression tests > double click to edit a group > [end of test] appStat
   "isRotating": false,
   "lastPointerDownWith": "mouse",
   "multiElement": null,
-  "name": "Untitled-201933152653",
+  "name": "",
   "objectsSnapModeEnabled": false,
   "offsetLeft": 0,
   "offsetTop": 0,
@@ -6231,7 +6231,7 @@ exports[`regression tests > double click to edit a group > [end of test] history
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {},
         "selectedGroupIds": {},
         "viewBackgroundColor": "#ffffff",
@@ -6242,7 +6242,7 @@ exports[`regression tests > double click to edit a group > [end of test] history
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id0": true,
         },
@@ -6285,7 +6285,7 @@ exports[`regression tests > double click to edit a group > [end of test] history
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id1": true,
         },
@@ -6357,7 +6357,7 @@ exports[`regression tests > double click to edit a group > [end of test] history
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id2": true,
         },
@@ -6458,7 +6458,7 @@ exports[`regression tests > double click to edit a group > [end of test] history
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id0": true,
           "id1": true,
@@ -6628,7 +6628,7 @@ exports[`regression tests > drags selected elements from point inside common bou
   "isRotating": false,
   "lastPointerDownWith": "mouse",
   "multiElement": null,
-  "name": "Untitled-201933152653",
+  "name": "",
   "objectsSnapModeEnabled": false,
   "offsetLeft": 0,
   "offsetTop": 0,
@@ -6689,7 +6689,7 @@ exports[`regression tests > drags selected elements from point inside common bou
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {},
         "selectedGroupIds": {},
         "viewBackgroundColor": "#ffffff",
@@ -6700,7 +6700,7 @@ exports[`regression tests > drags selected elements from point inside common bou
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id0": true,
         },
@@ -6743,7 +6743,7 @@ exports[`regression tests > drags selected elements from point inside common bou
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id1": true,
         },
@@ -6815,7 +6815,7 @@ exports[`regression tests > drags selected elements from point inside common bou
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id0": true,
           "id1": true,
@@ -6947,7 +6947,7 @@ exports[`regression tests > draw every type of shape > [end of test] appState 1`
   "isRotating": false,
   "lastPointerDownWith": "mouse",
   "multiElement": null,
-  "name": "Untitled-201933152653",
+  "name": "",
   "objectsSnapModeEnabled": false,
   "offsetLeft": 0,
   "offsetTop": 0,
@@ -7002,7 +7002,7 @@ exports[`regression tests > draw every type of shape > [end of test] history 1`]
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {},
         "selectedGroupIds": {},
         "viewBackgroundColor": "#ffffff",
@@ -7013,7 +7013,7 @@ exports[`regression tests > draw every type of shape > [end of test] history 1`]
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id0": true,
         },
@@ -7056,7 +7056,7 @@ exports[`regression tests > draw every type of shape > [end of test] history 1`]
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id1": true,
         },
@@ -7128,7 +7128,7 @@ exports[`regression tests > draw every type of shape > [end of test] history 1`]
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id2": true,
         },
@@ -7229,7 +7229,7 @@ exports[`regression tests > draw every type of shape > [end of test] history 1`]
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id3": true,
         },
@@ -7374,7 +7374,7 @@ exports[`regression tests > draw every type of shape > [end of test] history 1`]
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id4": true,
         },
@@ -7563,7 +7563,7 @@ exports[`regression tests > draw every type of shape > [end of test] history 1`]
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id5": true,
         },
@@ -7799,7 +7799,7 @@ exports[`regression tests > draw every type of shape > [end of test] history 1`]
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id5": true,
         },
@@ -8039,7 +8039,7 @@ exports[`regression tests > draw every type of shape > [end of test] history 1`]
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id6": true,
         },
@@ -8326,7 +8326,7 @@ exports[`regression tests > draw every type of shape > [end of test] history 1`]
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id6": true,
         },
@@ -8617,7 +8617,7 @@ exports[`regression tests > draw every type of shape > [end of test] history 1`]
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {},
         "selectedGroupIds": {},
         "viewBackgroundColor": "#ffffff",
@@ -9016,7 +9016,7 @@ exports[`regression tests > given a group of selected elements with an element t
   "isRotating": false,
   "lastPointerDownWith": "mouse",
   "multiElement": null,
-  "name": "Untitled-201933152653",
+  "name": "",
   "objectsSnapModeEnabled": false,
   "offsetLeft": 0,
   "offsetTop": 0,
@@ -9076,7 +9076,7 @@ exports[`regression tests > given a group of selected elements with an element t
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {},
         "selectedGroupIds": {},
         "viewBackgroundColor": "#ffffff",
@@ -9087,7 +9087,7 @@ exports[`regression tests > given a group of selected elements with an element t
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id0": true,
         },
@@ -9130,7 +9130,7 @@ exports[`regression tests > given a group of selected elements with an element t
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id1": true,
         },
@@ -9202,7 +9202,7 @@ exports[`regression tests > given a group of selected elements with an element t
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id2": true,
         },
@@ -9362,7 +9362,7 @@ exports[`regression tests > given a selected element A and a not selected elemen
   "isRotating": false,
   "lastPointerDownWith": "mouse",
   "multiElement": null,
-  "name": "Untitled-201933152653",
+  "name": "",
   "objectsSnapModeEnabled": false,
   "offsetLeft": 0,
   "offsetTop": 0,
@@ -9422,7 +9422,7 @@ exports[`regression tests > given a selected element A and a not selected elemen
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {},
         "selectedGroupIds": {},
         "viewBackgroundColor": "#ffffff",
@@ -9433,7 +9433,7 @@ exports[`regression tests > given a selected element A and a not selected elemen
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id0": true,
         },
@@ -9476,7 +9476,7 @@ exports[`regression tests > given a selected element A and a not selected elemen
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id1": true,
         },
@@ -9607,7 +9607,7 @@ exports[`regression tests > given selected element A with lower z-index than uns
   "isRotating": false,
   "lastPointerDownWith": "mouse",
   "multiElement": null,
-  "name": "Untitled-201933152653",
+  "name": "",
   "objectsSnapModeEnabled": false,
   "offsetLeft": 0,
   "offsetTop": 0,
@@ -9666,7 +9666,7 @@ exports[`regression tests > given selected element A with lower z-index than uns
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {},
         "selectedGroupIds": {},
         "viewBackgroundColor": "#ffffff",
@@ -9677,7 +9677,7 @@ exports[`regression tests > given selected element A with lower z-index than uns
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id0": true,
         },
@@ -9808,7 +9808,7 @@ exports[`regression tests > given selected element A with lower z-index than uns
   "isRotating": false,
   "lastPointerDownWith": "mouse",
   "multiElement": null,
-  "name": "Untitled-201933152653",
+  "name": "",
   "objectsSnapModeEnabled": false,
   "offsetLeft": 0,
   "offsetTop": 0,
@@ -9867,7 +9867,7 @@ exports[`regression tests > given selected element A with lower z-index than uns
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {},
         "selectedGroupIds": {},
         "viewBackgroundColor": "#ffffff",
@@ -9878,7 +9878,7 @@ exports[`regression tests > given selected element A with lower z-index than uns
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id0": true,
         },
@@ -9950,7 +9950,7 @@ exports[`regression tests > given selected element A with lower z-index than uns
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id0": true,
         },
@@ -10081,7 +10081,7 @@ exports[`regression tests > key 2 selects rectangle tool > [end of test] appStat
   "isRotating": false,
   "lastPointerDownWith": "mouse",
   "multiElement": null,
-  "name": "Untitled-201933152653",
+  "name": "",
   "objectsSnapModeEnabled": false,
   "offsetLeft": 0,
   "offsetTop": 0,
@@ -10138,7 +10138,7 @@ exports[`regression tests > key 2 selects rectangle tool > [end of test] history
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {},
         "selectedGroupIds": {},
         "viewBackgroundColor": "#ffffff",
@@ -10149,7 +10149,7 @@ exports[`regression tests > key 2 selects rectangle tool > [end of test] history
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id0": true,
         },
@@ -10251,7 +10251,7 @@ exports[`regression tests > key 3 selects diamond tool > [end of test] appState 
   "isRotating": false,
   "lastPointerDownWith": "mouse",
   "multiElement": null,
-  "name": "Untitled-201933152653",
+  "name": "",
   "objectsSnapModeEnabled": false,
   "offsetLeft": 0,
   "offsetTop": 0,
@@ -10308,7 +10308,7 @@ exports[`regression tests > key 3 selects diamond tool > [end of test] history 1
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {},
         "selectedGroupIds": {},
         "viewBackgroundColor": "#ffffff",
@@ -10319,7 +10319,7 @@ exports[`regression tests > key 3 selects diamond tool > [end of test] history 1
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id0": true,
         },
@@ -10421,7 +10421,7 @@ exports[`regression tests > key 4 selects ellipse tool > [end of test] appState 
   "isRotating": false,
   "lastPointerDownWith": "mouse",
   "multiElement": null,
-  "name": "Untitled-201933152653",
+  "name": "",
   "objectsSnapModeEnabled": false,
   "offsetLeft": 0,
   "offsetTop": 0,
@@ -10478,7 +10478,7 @@ exports[`regression tests > key 4 selects ellipse tool > [end of test] history 1
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {},
         "selectedGroupIds": {},
         "viewBackgroundColor": "#ffffff",
@@ -10489,7 +10489,7 @@ exports[`regression tests > key 4 selects ellipse tool > [end of test] history 1
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id0": true,
         },
@@ -10591,7 +10591,7 @@ exports[`regression tests > key 5 selects arrow tool > [end of test] appState 1`
   "isRotating": false,
   "lastPointerDownWith": "mouse",
   "multiElement": null,
-  "name": "Untitled-201933152653",
+  "name": "",
   "objectsSnapModeEnabled": false,
   "offsetLeft": 0,
   "offsetTop": 0,
@@ -10671,7 +10671,7 @@ exports[`regression tests > key 5 selects arrow tool > [end of test] history 1`]
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {},
         "selectedGroupIds": {},
         "viewBackgroundColor": "#ffffff",
@@ -10682,7 +10682,7 @@ exports[`regression tests > key 5 selects arrow tool > [end of test] history 1`]
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id0": true,
         },
@@ -10799,7 +10799,7 @@ exports[`regression tests > key 6 selects line tool > [end of test] appState 1`]
   "isRotating": false,
   "lastPointerDownWith": "mouse",
   "multiElement": null,
-  "name": "Untitled-201933152653",
+  "name": "",
   "objectsSnapModeEnabled": false,
   "offsetLeft": 0,
   "offsetTop": 0,
@@ -10879,7 +10879,7 @@ exports[`regression tests > key 6 selects line tool > [end of test] history 1`] 
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {},
         "selectedGroupIds": {},
         "viewBackgroundColor": "#ffffff",
@@ -10890,7 +10890,7 @@ exports[`regression tests > key 6 selects line tool > [end of test] history 1`] 
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id0": true,
         },
@@ -11007,7 +11007,7 @@ exports[`regression tests > key 7 selects freedraw tool > [end of test] appState
   "isRotating": false,
   "lastPointerDownWith": "mouse",
   "multiElement": null,
-  "name": "Untitled-201933152653",
+  "name": "",
   "objectsSnapModeEnabled": false,
   "offsetLeft": 0,
   "offsetTop": 0,
@@ -11062,7 +11062,7 @@ exports[`regression tests > key 7 selects freedraw tool > [end of test] history 
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {},
         "selectedGroupIds": {},
         "viewBackgroundColor": "#ffffff",
@@ -11073,7 +11073,7 @@ exports[`regression tests > key 7 selects freedraw tool > [end of test] history 
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {},
         "selectedGroupIds": {},
         "viewBackgroundColor": "#ffffff",
@@ -11195,7 +11195,7 @@ exports[`regression tests > key a selects arrow tool > [end of test] appState 1`
   "isRotating": false,
   "lastPointerDownWith": "mouse",
   "multiElement": null,
-  "name": "Untitled-201933152653",
+  "name": "",
   "objectsSnapModeEnabled": false,
   "offsetLeft": 0,
   "offsetTop": 0,
@@ -11275,7 +11275,7 @@ exports[`regression tests > key a selects arrow tool > [end of test] history 1`]
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {},
         "selectedGroupIds": {},
         "viewBackgroundColor": "#ffffff",
@@ -11286,7 +11286,7 @@ exports[`regression tests > key a selects arrow tool > [end of test] history 1`]
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id0": true,
         },
@@ -11403,7 +11403,7 @@ exports[`regression tests > key d selects diamond tool > [end of test] appState 
   "isRotating": false,
   "lastPointerDownWith": "mouse",
   "multiElement": null,
-  "name": "Untitled-201933152653",
+  "name": "",
   "objectsSnapModeEnabled": false,
   "offsetLeft": 0,
   "offsetTop": 0,
@@ -11460,7 +11460,7 @@ exports[`regression tests > key d selects diamond tool > [end of test] history 1
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {},
         "selectedGroupIds": {},
         "viewBackgroundColor": "#ffffff",
@@ -11471,7 +11471,7 @@ exports[`regression tests > key d selects diamond tool > [end of test] history 1
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id0": true,
         },
@@ -11573,7 +11573,7 @@ exports[`regression tests > key l selects line tool > [end of test] appState 1`]
   "isRotating": false,
   "lastPointerDownWith": "mouse",
   "multiElement": null,
-  "name": "Untitled-201933152653",
+  "name": "",
   "objectsSnapModeEnabled": false,
   "offsetLeft": 0,
   "offsetTop": 0,
@@ -11653,7 +11653,7 @@ exports[`regression tests > key l selects line tool > [end of test] history 1`] 
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {},
         "selectedGroupIds": {},
         "viewBackgroundColor": "#ffffff",
@@ -11664,7 +11664,7 @@ exports[`regression tests > key l selects line tool > [end of test] history 1`] 
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id0": true,
         },
@@ -11781,7 +11781,7 @@ exports[`regression tests > key o selects ellipse tool > [end of test] appState 
   "isRotating": false,
   "lastPointerDownWith": "mouse",
   "multiElement": null,
-  "name": "Untitled-201933152653",
+  "name": "",
   "objectsSnapModeEnabled": false,
   "offsetLeft": 0,
   "offsetTop": 0,
@@ -11838,7 +11838,7 @@ exports[`regression tests > key o selects ellipse tool > [end of test] history 1
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {},
         "selectedGroupIds": {},
         "viewBackgroundColor": "#ffffff",
@@ -11849,7 +11849,7 @@ exports[`regression tests > key o selects ellipse tool > [end of test] history 1
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id0": true,
         },
@@ -11951,7 +11951,7 @@ exports[`regression tests > key p selects freedraw tool > [end of test] appState
   "isRotating": false,
   "lastPointerDownWith": "mouse",
   "multiElement": null,
-  "name": "Untitled-201933152653",
+  "name": "",
   "objectsSnapModeEnabled": false,
   "offsetLeft": 0,
   "offsetTop": 0,
@@ -12006,7 +12006,7 @@ exports[`regression tests > key p selects freedraw tool > [end of test] history 
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {},
         "selectedGroupIds": {},
         "viewBackgroundColor": "#ffffff",
@@ -12017,7 +12017,7 @@ exports[`regression tests > key p selects freedraw tool > [end of test] history 
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {},
         "selectedGroupIds": {},
         "viewBackgroundColor": "#ffffff",
@@ -12139,7 +12139,7 @@ exports[`regression tests > key r selects rectangle tool > [end of test] appStat
   "isRotating": false,
   "lastPointerDownWith": "mouse",
   "multiElement": null,
-  "name": "Untitled-201933152653",
+  "name": "",
   "objectsSnapModeEnabled": false,
   "offsetLeft": 0,
   "offsetTop": 0,
@@ -12196,7 +12196,7 @@ exports[`regression tests > key r selects rectangle tool > [end of test] history
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {},
         "selectedGroupIds": {},
         "viewBackgroundColor": "#ffffff",
@@ -12207,7 +12207,7 @@ exports[`regression tests > key r selects rectangle tool > [end of test] history
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id0": true,
         },
@@ -12309,7 +12309,7 @@ exports[`regression tests > make a group and duplicate it > [end of test] appSta
   "isRotating": false,
   "lastPointerDownWith": "mouse",
   "multiElement": null,
-  "name": "Untitled-201933152653",
+  "name": "",
   "objectsSnapModeEnabled": false,
   "offsetLeft": 0,
   "offsetTop": 0,
@@ -12374,7 +12374,7 @@ exports[`regression tests > make a group and duplicate it > [end of test] histor
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {},
         "selectedGroupIds": {},
         "viewBackgroundColor": "#ffffff",
@@ -12385,7 +12385,7 @@ exports[`regression tests > make a group and duplicate it > [end of test] histor
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id0": true,
         },
@@ -12428,7 +12428,7 @@ exports[`regression tests > make a group and duplicate it > [end of test] histor
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id1": true,
         },
@@ -12500,7 +12500,7 @@ exports[`regression tests > make a group and duplicate it > [end of test] histor
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id2": true,
         },
@@ -12601,7 +12601,7 @@ exports[`regression tests > make a group and duplicate it > [end of test] histor
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id0": true,
           "id1": true,
@@ -12712,7 +12712,7 @@ exports[`regression tests > make a group and duplicate it > [end of test] histor
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id0": true,
           "id1": true,
@@ -12975,7 +12975,7 @@ exports[`regression tests > noop interaction after undo shouldn't create history
   "isRotating": false,
   "lastPointerDownWith": "mouse",
   "multiElement": null,
-  "name": "Untitled-201933152653",
+  "name": "",
   "objectsSnapModeEnabled": false,
   "offsetLeft": 0,
   "offsetTop": 0,
@@ -13034,7 +13034,7 @@ exports[`regression tests > noop interaction after undo shouldn't create history
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {},
         "selectedGroupIds": {},
         "viewBackgroundColor": "#ffffff",
@@ -13045,7 +13045,7 @@ exports[`regression tests > noop interaction after undo shouldn't create history
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id0": true,
         },
@@ -13088,7 +13088,7 @@ exports[`regression tests > noop interaction after undo shouldn't create history
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id1": true,
         },
@@ -13219,7 +13219,7 @@ exports[`regression tests > pinch-to-zoom works > [end of test] appState 1`] = `
   "isRotating": false,
   "lastPointerDownWith": "touch",
   "multiElement": null,
-  "name": "Untitled-201933152653",
+  "name": "",
   "objectsSnapModeEnabled": false,
   "offsetLeft": 0,
   "offsetTop": 0,
@@ -13274,7 +13274,7 @@ exports[`regression tests > pinch-to-zoom works > [end of test] history 1`] = `
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {},
         "selectedGroupIds": {},
         "viewBackgroundColor": "#ffffff",
@@ -13344,7 +13344,7 @@ exports[`regression tests > shift click on selected element should deselect it o
   "isRotating": false,
   "lastPointerDownWith": "mouse",
   "multiElement": null,
-  "name": "Untitled-201933152653",
+  "name": "",
   "objectsSnapModeEnabled": false,
   "offsetLeft": 0,
   "offsetTop": 0,
@@ -13401,7 +13401,7 @@ exports[`regression tests > shift click on selected element should deselect it o
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {},
         "selectedGroupIds": {},
         "viewBackgroundColor": "#ffffff",
@@ -13412,7 +13412,7 @@ exports[`regression tests > shift click on selected element should deselect it o
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id0": true,
         },
@@ -13514,7 +13514,7 @@ exports[`regression tests > shift-click to multiselect, then drag > [end of test
   "isRotating": false,
   "lastPointerDownWith": "mouse",
   "multiElement": null,
-  "name": "Untitled-201933152653",
+  "name": "",
   "objectsSnapModeEnabled": false,
   "offsetLeft": 0,
   "offsetTop": 0,
@@ -13575,7 +13575,7 @@ exports[`regression tests > shift-click to multiselect, then drag > [end of test
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {},
         "selectedGroupIds": {},
         "viewBackgroundColor": "#ffffff",
@@ -13586,7 +13586,7 @@ exports[`regression tests > shift-click to multiselect, then drag > [end of test
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id0": true,
         },
@@ -13629,7 +13629,7 @@ exports[`regression tests > shift-click to multiselect, then drag > [end of test
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id1": true,
         },
@@ -13701,7 +13701,7 @@ exports[`regression tests > shift-click to multiselect, then drag > [end of test
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id0": true,
           "id1": true,
@@ -13833,7 +13833,7 @@ exports[`regression tests > should group elements and ungroup them > [end of tes
   "isRotating": false,
   "lastPointerDownWith": "mouse",
   "multiElement": null,
-  "name": "Untitled-201933152653",
+  "name": "",
   "objectsSnapModeEnabled": false,
   "offsetLeft": 0,
   "offsetTop": 0,
@@ -13896,7 +13896,7 @@ exports[`regression tests > should group elements and ungroup them > [end of tes
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {},
         "selectedGroupIds": {},
         "viewBackgroundColor": "#ffffff",
@@ -13907,7 +13907,7 @@ exports[`regression tests > should group elements and ungroup them > [end of tes
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id0": true,
         },
@@ -13950,7 +13950,7 @@ exports[`regression tests > should group elements and ungroup them > [end of tes
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id1": true,
         },
@@ -14022,7 +14022,7 @@ exports[`regression tests > should group elements and ungroup them > [end of tes
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id2": true,
         },
@@ -14123,7 +14123,7 @@ exports[`regression tests > should group elements and ungroup them > [end of tes
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id0": true,
           "id1": true,
@@ -14234,7 +14234,7 @@ exports[`regression tests > should group elements and ungroup them > [end of tes
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id0": true,
           "id1": true,
@@ -14396,7 +14396,7 @@ exports[`regression tests > single-clicking on a subgroup of a selected group sh
   "isRotating": false,
   "lastPointerDownWith": "mouse",
   "multiElement": null,
-  "name": "Untitled-201933152653",
+  "name": "",
   "objectsSnapModeEnabled": false,
   "offsetLeft": 0,
   "offsetTop": 0,
@@ -14463,7 +14463,7 @@ exports[`regression tests > single-clicking on a subgroup of a selected group sh
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {},
         "selectedGroupIds": {},
         "viewBackgroundColor": "#ffffff",
@@ -14474,7 +14474,7 @@ exports[`regression tests > single-clicking on a subgroup of a selected group sh
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id0": true,
         },
@@ -14517,7 +14517,7 @@ exports[`regression tests > single-clicking on a subgroup of a selected group sh
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id1": true,
         },
@@ -14589,7 +14589,7 @@ exports[`regression tests > single-clicking on a subgroup of a selected group sh
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id0": true,
           "id1": true,
@@ -14668,7 +14668,7 @@ exports[`regression tests > single-clicking on a subgroup of a selected group sh
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id5": true,
         },
@@ -14773,7 +14773,7 @@ exports[`regression tests > single-clicking on a subgroup of a selected group sh
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id6": true,
         },
@@ -14907,7 +14907,7 @@ exports[`regression tests > single-clicking on a subgroup of a selected group sh
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id5": true,
           "id6": true,
@@ -15048,7 +15048,7 @@ exports[`regression tests > single-clicking on a subgroup of a selected group sh
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id0": true,
           "id1": true,
@@ -15254,7 +15254,7 @@ exports[`regression tests > spacebar + drag scrolls the canvas > [end of test] a
   "isRotating": false,
   "lastPointerDownWith": "mouse",
   "multiElement": null,
-  "name": "Untitled-201933152653",
+  "name": "",
   "objectsSnapModeEnabled": false,
   "offsetLeft": 0,
   "offsetTop": 0,
@@ -15312,7 +15312,7 @@ exports[`regression tests > spacebar + drag scrolls the canvas > [end of test] h
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {},
         "selectedGroupIds": {},
         "viewBackgroundColor": "#ffffff",
@@ -15382,7 +15382,7 @@ exports[`regression tests > supports nested groups > [end of test] appState 1`] 
   "isRotating": false,
   "lastPointerDownWith": "mouse",
   "multiElement": null,
-  "name": "Untitled-201933152653",
+  "name": "",
   "objectsSnapModeEnabled": false,
   "offsetLeft": 0,
   "offsetTop": 0,
@@ -15441,7 +15441,7 @@ exports[`regression tests > supports nested groups > [end of test] history 1`] =
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {},
         "selectedGroupIds": {},
         "viewBackgroundColor": "#ffffff",
@@ -15452,7 +15452,7 @@ exports[`regression tests > supports nested groups > [end of test] history 1`] =
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id0": true,
         },
@@ -15495,7 +15495,7 @@ exports[`regression tests > supports nested groups > [end of test] history 1`] =
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id1": true,
         },
@@ -15567,7 +15567,7 @@ exports[`regression tests > supports nested groups > [end of test] history 1`] =
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id2": true,
         },
@@ -15668,7 +15668,7 @@ exports[`regression tests > supports nested groups > [end of test] history 1`] =
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id0": true,
           "id1": true,
@@ -15779,7 +15779,7 @@ exports[`regression tests > supports nested groups > [end of test] history 1`] =
       "appState": {
         "editingGroupId": "id3",
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id0": true,
           "id2": true,
@@ -15887,7 +15887,7 @@ exports[`regression tests > supports nested groups > [end of test] history 1`] =
       "appState": {
         "editingGroupId": "id3",
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id0": true,
           "id2": true,
@@ -15999,7 +15999,7 @@ exports[`regression tests > supports nested groups > [end of test] history 1`] =
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id0": true,
           "id1": true,
@@ -16199,7 +16199,7 @@ exports[`regression tests > switches from group of selected elements to another 
   "isRotating": false,
   "lastPointerDownWith": "mouse",
   "multiElement": null,
-  "name": "Untitled-201933152653",
+  "name": "",
   "objectsSnapModeEnabled": false,
   "offsetLeft": 0,
   "offsetTop": 0,
@@ -16287,7 +16287,7 @@ exports[`regression tests > switches from group of selected elements to another 
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {},
         "selectedGroupIds": {},
         "viewBackgroundColor": "#ffffff",
@@ -16298,7 +16298,7 @@ exports[`regression tests > switches from group of selected elements to another 
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id0": true,
         },
@@ -16341,7 +16341,7 @@ exports[`regression tests > switches from group of selected elements to another 
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id1": true,
         },
@@ -16413,7 +16413,7 @@ exports[`regression tests > switches from group of selected elements to another 
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id2": true,
         },
@@ -16601,7 +16601,7 @@ exports[`regression tests > switches selected element on pointer down > [end of 
   "isRotating": false,
   "lastPointerDownWith": "mouse",
   "multiElement": null,
-  "name": "Untitled-201933152653",
+  "name": "",
   "objectsSnapModeEnabled": false,
   "offsetLeft": 0,
   "offsetTop": 0,
@@ -16688,7 +16688,7 @@ exports[`regression tests > switches selected element on pointer down > [end of 
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {},
         "selectedGroupIds": {},
         "viewBackgroundColor": "#ffffff",
@@ -16699,7 +16699,7 @@ exports[`regression tests > switches selected element on pointer down > [end of 
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id0": true,
         },
@@ -16742,7 +16742,7 @@ exports[`regression tests > switches selected element on pointer down > [end of 
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id1": true,
         },
@@ -16873,7 +16873,7 @@ exports[`regression tests > two-finger scroll works > [end of test] appState 1`]
   "isRotating": false,
   "lastPointerDownWith": "touch",
   "multiElement": null,
-  "name": "Untitled-201933152653",
+  "name": "",
   "objectsSnapModeEnabled": false,
   "offsetLeft": 0,
   "offsetTop": 0,
@@ -16928,7 +16928,7 @@ exports[`regression tests > two-finger scroll works > [end of test] history 1`] 
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {},
         "selectedGroupIds": {},
         "viewBackgroundColor": "#ffffff",
@@ -16998,7 +16998,7 @@ exports[`regression tests > undo/redo drawing an element > [end of test] appStat
   "isRotating": false,
   "lastPointerDownWith": "mouse",
   "multiElement": null,
-  "name": "Untitled-201933152653",
+  "name": "",
   "objectsSnapModeEnabled": false,
   "offsetLeft": 0,
   "offsetTop": 0,
@@ -17054,7 +17054,7 @@ exports[`regression tests > undo/redo drawing an element > [end of test] history
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id2": true,
         },
@@ -17177,7 +17177,7 @@ exports[`regression tests > undo/redo drawing an element > [end of test] history
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id2": true,
         },
@@ -17298,7 +17298,7 @@ exports[`regression tests > undo/redo drawing an element > [end of test] history
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {},
         "selectedGroupIds": {},
         "viewBackgroundColor": "#ffffff",
@@ -17309,7 +17309,7 @@ exports[`regression tests > undo/redo drawing an element > [end of test] history
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id0": true,
         },
@@ -17352,7 +17352,7 @@ exports[`regression tests > undo/redo drawing an element > [end of test] history
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {
           "id1": true,
         },
@@ -17483,7 +17483,7 @@ exports[`regression tests > updates fontSize & fontFamily appState > [end of tes
   "isRotating": false,
   "lastPointerDownWith": "mouse",
   "multiElement": null,
-  "name": "Untitled-201933152653",
+  "name": "",
   "objectsSnapModeEnabled": false,
   "offsetLeft": 0,
   "offsetTop": 0,
@@ -17538,7 +17538,7 @@ exports[`regression tests > updates fontSize & fontFamily appState > [end of tes
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {},
         "selectedGroupIds": {},
         "viewBackgroundColor": "#ffffff",
@@ -17608,7 +17608,7 @@ exports[`regression tests > zoom hotkeys > [end of test] appState 1`] = `
   "isRotating": false,
   "lastPointerDownWith": "mouse",
   "multiElement": null,
-  "name": "Untitled-201933152653",
+  "name": "",
   "objectsSnapModeEnabled": false,
   "offsetLeft": 0,
   "offsetTop": 0,
@@ -17666,7 +17666,7 @@ exports[`regression tests > zoom hotkeys > [end of test] history 1`] = `
       "appState": {
         "editingGroupId": null,
         "editingLinearElement": null,
-        "name": "Untitled-201933152653",
+        "name": "",
         "selectedElementIds": {},
         "selectedGroupIds": {},
         "viewBackgroundColor": "#ffffff",


### PR DESCRIPTION
```js
import { getDefaultAppState } from "../appState";
```
The above import results in 👇

for #7500 
![uploaded image](https://i.imgur.com/t5mNb01.png)

Since `getDefaultAppState` is using `t` for computing default value of `name`, it ends up importing all `locales`, `react` and `jotai` as well. 

This is a default state and should be independent of `t`. So we can stop using `t` in `getDefaultAppState` and instead fallback to the same value in the component where `name` is being used -> `ImageExport` and `ProjectName` dialogs.

We can remove the appState.name prop completely, I will be raising a separate PR for it and and might have to test backward compact as well