### PR TITLE
fix: file save timing out with big file sizes

### DIFF
--- a/packages/excalidraw/data/filesystem.ts
+++ b/packages/excalidraw/data/filesystem.ts
@@ -76,7 +76,7 @@ export const fileOpen = <M extends boolean | undefined = false>(opts: {
 };
 
 export const fileSave = (
-  blob: Blob,
+  blob: Blob | Promise<Blob>,
   opts: {
     /** supply without the extension */
     name: string;


### PR DESCRIPTION
New filesystem API requires to be called within ~5 second of user action. This results in failure on permissions when the canvas is large enough that the export takes longer.

Can be worked around by passing a promise into the filesystem API instead of awaiting it first.

fix https://github.com/excalidraw/excalidraw/issues/7277
fix https://github.com/excalidraw/excalidraw/issues/7456
fix https://github.com/excalidraw/excalidraw/issues/7646

tested on Chrome, Safari (legacy fs), Brave (legacy fs), Firefox (legacy fs)
