### PR TITLE
feat: store library to IndexedDB & support storage adapters

### DIFF
--- a/excalidraw-app/App.tsx
+++ b/excalidraw-app/App.tsx
@@ -80,7 +80,11 @@ import { updateStaleImageStatuses } from "./data/FileManager";
 import { newElementWith } from "../packages/excalidraw/element/mutateElement";
 import { isInitializedImageElement } from "../packages/excalidraw/element/typeChecks";
 import { loadFilesFromFirebase } from "./data/firebase";
-import { libraryIndexedDBAdapter, LocalData } from "./data/LocalData";
+import {
+  LibraryIndexedDBAdapter,
+  LibraryLocalStorageMigrationAdapter,
+  LocalData,
+} from "./data/LocalData";
 import { isBrowserStorageStateNewer } from "./data/tabSync";
 import clsx from "clsx";
 import { reconcileElements } from "./collab/reconciliation";
@@ -313,7 +317,9 @@ const ExcalidrawWrapper = () => {
 
   useHandleLibrary({
     excalidrawAPI,
-    adapter: libraryIndexedDBAdapter,
+    adapter: LibraryIndexedDBAdapter,
+    // TODO maybe remove this in several months (shipped: 24-02-07)
+    migrateFrom: LibraryLocalStorageMigrationAdapter,
   });
 
   useEffect(() => {
@@ -443,7 +449,7 @@ const ExcalidrawWrapper = () => {
           excalidrawAPI.updateScene({
             ...localDataState,
           });
-          libraryIndexedDBAdapter.load().then((data) => {
+          LibraryIndexedDBAdapter.load().then((data) => {
             if (data) {
               excalidrawAPI.updateLibrary({
                 libraryItems: data.libraryItems,

--- a/excalidraw-app/App.tsx
+++ b/excalidraw-app/App.tsx
@@ -319,7 +319,7 @@ const ExcalidrawWrapper = () => {
     excalidrawAPI,
     adapter: LibraryIndexedDBAdapter,
     // TODO maybe remove this in several months (shipped: 24-02-07)
-    migrateFrom: LibraryLocalStorageMigrationAdapter,
+    migrationAdapter: LibraryLocalStorageMigrationAdapter,
   });
 
   useEffect(() => {

--- a/excalidraw-app/App.tsx
+++ b/excalidraw-app/App.tsx
@@ -446,7 +446,7 @@ const ExcalidrawWrapper = () => {
           libraryIndexedDBAdapter.load().then((data) => {
             if (data) {
               excalidrawAPI.updateLibrary({
-                libraryItems: data,
+                libraryItems: data.libraryItems,
               });
             }
           });

--- a/excalidraw-app/app_constants.ts
+++ b/excalidraw-app/app_constants.ts
@@ -39,10 +39,14 @@ export const STORAGE_KEYS = {
   LOCAL_STORAGE_ELEMENTS: "excalidraw",
   LOCAL_STORAGE_APP_STATE: "excalidraw-state",
   LOCAL_STORAGE_COLLAB: "excalidraw-collab",
-  LOCAL_STORAGE_LIBRARY: "excalidraw-library",
   LOCAL_STORAGE_THEME: "excalidraw-theme",
   VERSION_DATA_STATE: "version-dataState",
   VERSION_FILES: "version-files",
+
+  IDB_LIBRARY: "excalidraw-library",
+
+  // do not use apart from migrations
+  __LEGACY_LOCAL_STORAGE_LIBRARY: "excalidraw-library",
 } as const;
 
 export const COOKIES = {

--- a/excalidraw-app/data/LocalData.ts
+++ b/excalidraw-app/data/LocalData.ts
@@ -234,7 +234,7 @@ export class LibraryLocalStorageMigrationAdapter {
       const libraryItems: ImportedDataState["libraryItems"] =
         JSON.parse(LSData);
       if (libraryItems) {
-        return { libraryItems: libraryItems };
+        return { libraryItems };
       }
     }
     return null;

--- a/excalidraw-app/data/LocalData.ts
+++ b/excalidraw-app/data/LocalData.ts
@@ -224,7 +224,7 @@ class LibraryIndexedDBAdapter implements LibraryPersistenceAdapter {
     this.store = createStore(`${this.name}-db`, `${this.name}-store`);
 
     if (this.migrationLocalStorageKey) {
-      let migrationLocalStorageKey = this.migrationLocalStorageKey;
+      const migrationLocalStorageKey = this.migrationLocalStorageKey;
       this.migrate = () => {
         return {
           load: () => {

--- a/excalidraw-app/data/localStorage.ts
+++ b/excalidraw-app/data/localStorage.ts
@@ -6,7 +6,6 @@ import {
 } from "../../packages/excalidraw/appState";
 import { clearElementsForLocalStorage } from "../../packages/excalidraw/element";
 import { STORAGE_KEYS } from "../app_constants";
-import { ImportedDataState } from "../../packages/excalidraw/data/types";
 
 export const saveUsernameToLocalStorage = (username: string) => {
   try {
@@ -88,28 +87,13 @@ export const getTotalStorageSize = () => {
   try {
     const appState = localStorage.getItem(STORAGE_KEYS.LOCAL_STORAGE_APP_STATE);
     const collab = localStorage.getItem(STORAGE_KEYS.LOCAL_STORAGE_COLLAB);
-    const library = localStorage.getItem(STORAGE_KEYS.LOCAL_STORAGE_LIBRARY);
 
     const appStateSize = appState?.length || 0;
     const collabSize = collab?.length || 0;
-    const librarySize = library?.length || 0;
 
-    return appStateSize + collabSize + librarySize + getElementsStorageSize();
+    return appStateSize + collabSize + getElementsStorageSize();
   } catch (error: any) {
     console.error(error);
     return 0;
-  }
-};
-
-export const getLibraryItemsFromStorage = () => {
-  try {
-    const libraryItems: ImportedDataState["libraryItems"] = JSON.parse(
-      localStorage.getItem(STORAGE_KEYS.LOCAL_STORAGE_LIBRARY) as string,
-    );
-
-    return libraryItems || [];
-  } catch (error) {
-    console.error(error);
-    return [];
   }
 };

--- a/packages/excalidraw/CHANGELOG.md
+++ b/packages/excalidraw/CHANGELOG.md
@@ -16,7 +16,7 @@ Please add the latest change on the top under the correct section.
 ### Features
 
 - Add `useHandleLibrary`'s `opts.adapter` as the new recommended pattern to handle library initialization and persistence on library updates. [#7655](https://github.com/excalidraw/excalidraw/pull/7655)
-- Add `useHandleLibrary`'s `opts.migrateFrom` adapter to handle library migration during init, when migrating from one data store to another (e.g. from LocalStorage to IndexedDB). [#7655](https://github.com/excalidraw/excalidraw/pull/7655)
+- Add `useHandleLibrary`'s `opts.migrationAdapter` adapter to handle library migration during init, when migrating from one data store to another (e.g. from LocalStorage to IndexedDB). [#7655](https://github.com/excalidraw/excalidraw/pull/7655)
 - Soft-deprecate `useHandleLibrary`'s `opts.getInitialLibraryItems` in favor of `opts.getLibraryItems`. [#7655](https://github.com/excalidraw/excalidraw/pull/7655)
 
 - Add `onPointerUp` prop [#7638](https://github.com/excalidraw/excalidraw/pull/7638).

--- a/packages/excalidraw/CHANGELOG.md
+++ b/packages/excalidraw/CHANGELOG.md
@@ -15,6 +15,10 @@ Please add the latest change on the top under the correct section.
 
 ### Features
 
+- Add `useHandleLibrary`'s `opts.adapter` as the new recommended pattern to handle library initialization and persistence on library updates. [#7655](https://github.com/excalidraw/excalidraw/pull/7655)
+- Add `useHandleLibrary`'s `opts.migrateFrom` adapter to handle library migration during init, when migrating from one data store to another (e.g. from LocalStorage to IndexedDB). [#7655](https://github.com/excalidraw/excalidraw/pull/7655)
+- Soft-deprecate `useHandleLibrary`'s `opts.getInitialLibraryItems` in favor of `opts.getLibraryItems`. [#7655](https://github.com/excalidraw/excalidraw/pull/7655)
+
 - Add `onPointerUp` prop [#7638](https://github.com/excalidraw/excalidraw/pull/7638).
 
 - Expose `getVisibleSceneBounds` helper to get scene bounds of visible canvas area. [#7450](https://github.com/excalidraw/excalidraw/pull/7450)

--- a/packages/excalidraw/CHANGELOG.md
+++ b/packages/excalidraw/CHANGELOG.md
@@ -17,7 +17,7 @@ Please add the latest change on the top under the correct section.
 
 - Add `useHandleLibrary`'s `opts.adapter` as the new recommended pattern to handle library initialization and persistence on library updates. [#7655](https://github.com/excalidraw/excalidraw/pull/7655)
 - Add `useHandleLibrary`'s `opts.migrationAdapter` adapter to handle library migration during init, when migrating from one data store to another (e.g. from LocalStorage to IndexedDB). [#7655](https://github.com/excalidraw/excalidraw/pull/7655)
-- Soft-deprecate `useHandleLibrary`'s `opts.getInitialLibraryItems` in favor of `opts.getLibraryItems`. [#7655](https://github.com/excalidraw/excalidraw/pull/7655)
+- Soft-deprecate `useHandleLibrary`'s `opts.getInitialLibraryItems` in favor of `opts.adapter`. [#7655](https://github.com/excalidraw/excalidraw/pull/7655)
 
 - Add `onPointerUp` prop [#7638](https://github.com/excalidraw/excalidraw/pull/7638).
 

--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -91,10 +91,7 @@ import {
   isIOS,
 } from "../constants";
 import { ExportedElements, exportCanvas, loadFromBlob } from "../data";
-import Library, {
-  distributeLibraryItemsOnSquareGrid,
-  LibraryChange,
-} from "../data/library";
+import Library, { distributeLibraryItemsOnSquareGrid } from "../data/library";
 import { restore, restoreElements } from "../data/restore";
 import {
   dragNewElement,
@@ -614,9 +611,6 @@ class App extends React.Component<AppProps, AppState> {
     [event: PointerEvent | null]
   >();
   onRemoveEventListenersEmitter = new Emitter<[]>();
-  onLibraryChangeListenersEmitter = new Emitter<
-    [libraryItems: LibraryItems, change: LibraryChange]
-  >();
 
   constructor(props: AppProps) {
     super(props);
@@ -688,7 +682,6 @@ class App extends React.Component<AppProps, AppState> {
         onPointerUp: (cb) => this.onPointerUpEmitter.on(cb),
         onScrollChange: (cb) => this.onScrollChangeEmitter.on(cb),
         onUserFollow: (cb) => this.onUserFollowEmitter.on(cb),
-        onLibraryChange: (cb) => this.onLibraryChangeListenersEmitter.on(cb),
       } as const;
       if (typeof excalidrawAPI === "function") {
         excalidrawAPI(api);

--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -91,7 +91,10 @@ import {
   isIOS,
 } from "../constants";
 import { ExportedElements, exportCanvas, loadFromBlob } from "../data";
-import Library, { distributeLibraryItemsOnSquareGrid } from "../data/library";
+import Library, {
+  distributeLibraryItemsOnSquareGrid,
+  LibraryChange,
+} from "../data/library";
 import { restore, restoreElements } from "../data/restore";
 import {
   dragNewElement,
@@ -611,6 +614,9 @@ class App extends React.Component<AppProps, AppState> {
     [event: PointerEvent | null]
   >();
   onRemoveEventListenersEmitter = new Emitter<[]>();
+  onLibraryChangeListenersEmitter = new Emitter<
+    [libraryItems: LibraryItems, change: LibraryChange]
+  >();
 
   constructor(props: AppProps) {
     super(props);
@@ -682,6 +688,7 @@ class App extends React.Component<AppProps, AppState> {
         onPointerUp: (cb) => this.onPointerUpEmitter.on(cb),
         onScrollChange: (cb) => this.onScrollChangeEmitter.on(cb),
         onUserFollow: (cb) => this.onUserFollowEmitter.on(cb),
+        onLibraryChange: (cb) => this.onLibraryChangeListenersEmitter.on(cb),
       } as const;
       if (typeof excalidrawAPI === "function") {
         excalidrawAPI(api);

--- a/packages/excalidraw/data/library.ts
+++ b/packages/excalidraw/data/library.ts
@@ -52,8 +52,6 @@ export interface LibraryPersistenceAdapter {
   load(): MaybePromise<{ libraryItems: LibraryItems_anyVersion } | null>;
   /** Should persist to the database as is (do no change the data structure). */
   save(libraryData: LibraryPersistedData): MaybePromise<void>;
-  /** clears entire storage. Currently unused. */
-  clear?(): MaybePromise<void>;
 }
 
 export interface LibraryMigrationAdapter {
@@ -63,7 +61,7 @@ export interface LibraryMigrationAdapter {
    */
   load: LibraryPersistenceAdapter["load"];
   /** clears entire storage afterwards */
-  clear: Required<LibraryPersistenceAdapter>["clear"];
+  clear(): MaybePromise<void>;
 }
 
 export const libraryItemsAtom = atom<{

--- a/packages/excalidraw/data/library.ts
+++ b/packages/excalidraw/data/library.ts
@@ -870,7 +870,7 @@ export const useHandleLibrary = (
                 // exit early, even if actual upstream state ends up being
                 // different (e.g. has more data than we have locally), as it'd
                 // be low-impact scenario.
-                lastSavedLibraryItemsHash !=
+                lastSavedLibraryItemsHash !==
                 getLibraryItemsHash(nextLibraryItems)
               ) {
                 await persistLibraryUpdate(adapter, update);

--- a/packages/excalidraw/data/library.ts
+++ b/packages/excalidraw/data/library.ts
@@ -572,6 +572,9 @@ export const useHandleLibrary = (
         .then((libraryItems) => {
           excalidrawAPI.updateLibrary({
             libraryItems,
+            // merge with current library items because we may have already
+            // populated it (e.g. by installing 3rd party library which can
+            // happen before the DB data is loaded)
             merge: true,
           });
         })
@@ -684,6 +687,9 @@ export const useHandleLibrary = (
       initDataPromise.then(async (data) => {
         excalidrawAPI.updateLibrary({
           libraryItems: data || [],
+          // merge with current library items because we may have already
+          // populated it (e.g. by installing 3rd party library which can
+          // happen before the DB data is loaded)
           merge: true,
         });
       });

--- a/packages/excalidraw/data/library.ts
+++ b/packages/excalidraw/data/library.ts
@@ -525,7 +525,7 @@ class AdapterTransaction {
 let lastSavedLibraryItemsHash = 0;
 let librarySaveCounter = 0;
 
-const getLibraryItemsHash = (items: LibraryItems) => {
+export const getLibraryItemsHash = (items: LibraryItems) => {
   return hashString(
     items
       .map((item) => {

--- a/packages/excalidraw/data/library.ts
+++ b/packages/excalidraw/data/library.ts
@@ -50,7 +50,7 @@ export interface LibraryPersistenceAdapter {
   load(): MaybePromise<{ libraryItems: LibraryItems_anyVersion } | null>;
   /** Should persist to the database as is (do no change the data structure). */
   save(libraryData: LibraryPersistedData): MaybePromise<void>;
-  /** clears entire storage */
+  /** clears entire storage. Currently unused. */
   clear?(): MaybePromise<void>;
 }
 
@@ -604,7 +604,7 @@ export const useHandleLibrary = (
       return restoreLibraryItems(data?.libraryItems || [], "published");
     };
 
-    // ------ (A) data source adapter ------------------------------------------
+    // ------ (B) data source adapter ------------------------------------------
     let unsubOnLibraryChange: () => void | undefined;
 
     if ("adapter" in optsRef.current && optsRef.current.adapter) {

--- a/packages/excalidraw/data/library.ts
+++ b/packages/excalidraw/data/library.ts
@@ -473,7 +473,7 @@ export const useHandleLibrary = (
          *
          * Can be a different LibraryPersistenceAdapter.
          */
-        migrateFrom?: LibraryMigrationAdapter;
+        migrationAdapter?: LibraryMigrationAdapter;
       }
   ),
 ) => {
@@ -609,7 +609,7 @@ export const useHandleLibrary = (
 
     if ("adapter" in optsRef.current && optsRef.current.adapter) {
       const adapter = optsRef.current.adapter;
-      const migrationAdapter = optsRef.current.migrateFrom;
+      const migrationAdapter = optsRef.current.migrationAdapter;
 
       const persistLibraryChange = async (change: LibraryUpdate) => {
         const nextLibraryItemsMap = arrayToMap(await getLibraryItems(adapter));

--- a/packages/excalidraw/data/library.ts
+++ b/packages/excalidraw/data/library.ts
@@ -659,6 +659,10 @@ export const useHandleLibrary = (
       const initDataPromise = resolvablePromise<LibraryItems | null>();
 
       // migrate from old data source if needed
+      // (note, if `migrate` function is defined, we always migrate even
+      //  if the data has already been migrated. In that case it'll be a no-op,
+      //  though with several unnecessary steps — we will still load latest
+      //  DB data during the `persistLibraryChange()` step)
       // -----------------------------------------------------------------------
       if (adapter.migrate) {
         const migration = adapter.migrate();

--- a/packages/excalidraw/data/library.ts
+++ b/packages/excalidraw/data/library.ts
@@ -857,14 +857,14 @@ export const useHandleLibrary = (
       // -----------------------------------------------------------------------
       const unsubOnLibraryUpdate = onLibraryUpdateEmitter.on(
         async (update, nextLibraryItems) => {
-        const isLoaded = isLibraryLoadedRef.current;
-        // we want to operate with the latest adapter, but we don't want this
-        // effect to rerun on every adapter change in case host apps' adapter
-        // isn't stable
-        const adapter =
-          ("adapter" in optsRef.current && optsRef.current.adapter) || null;
-        try {
-          if (adapter) {
+          const isLoaded = isLibraryLoadedRef.current;
+          // we want to operate with the latest adapter, but we don't want this
+          // effect to rerun on every adapter change in case host apps' adapter
+          // isn't stable
+          const adapter =
+            ("adapter" in optsRef.current && optsRef.current.adapter) || null;
+          try {
+            if (adapter) {
               if (
                 // if nextLibraryItems hash identical to previously saved hash,
                 // exit early, even if actual upstream state ends up being
@@ -873,24 +873,24 @@ export const useHandleLibrary = (
                 lastSavedLibraryItemsHash !=
                 getLibraryItemsHash(nextLibraryItems)
               ) {
-            await persistLibraryUpdate(adapter, update);
-          }
+                await persistLibraryUpdate(adapter, update);
+              }
             }
-        } catch (error: any) {
-          console.error(
-            `couldn't persist library update: ${error.message}`,
-            update,
-          );
+          } catch (error: any) {
+            console.error(
+              `couldn't persist library update: ${error.message}`,
+              update,
+            );
 
-          // currently we only show error if an editor is loaded
-          if (isLoaded && optsRef.current.excalidrawAPI) {
-            optsRef.current.excalidrawAPI.updateScene({
-              appState: {
-                errorMessage: t("errors.saveLibraryError"),
-              },
-            });
+            // currently we only show error if an editor is loaded
+            if (isLoaded && optsRef.current.excalidrawAPI) {
+              optsRef.current.excalidrawAPI.updateScene({
+                appState: {
+                  errorMessage: t("errors.saveLibraryError"),
+                },
+              });
+            }
           }
-        }
         },
       );
 

--- a/packages/excalidraw/element/index.ts
+++ b/packages/excalidraw/element/index.ts
@@ -60,8 +60,35 @@ export {
 } from "./sizeHelpers";
 export { showSelectedShapeActions } from "./showSelectedShapeActions";
 
+/**
+ * @deprecated unsafe, use hashElementsVersion instead
+ */
 export const getSceneVersion = (elements: readonly ExcalidrawElement[]) =>
   elements.reduce((acc, el) => acc + el.version, 0);
+
+/**
+ * Hashes elements' versionNonce (using djb2 algo). Order of elements matters.
+ */
+export const hashElementsVersion = (
+  elements: readonly ExcalidrawElement[],
+): number => {
+  let hash = 5381;
+  for (let i = 0; i < elements.length; i++) {
+    hash = (hash << 5) + hash + elements[i].versionNonce;
+  }
+  return hash >>> 0; // Ensure unsigned 32-bit integer
+};
+
+// string hash function (using djb2). Not cryptographically secure, use only
+// for versioning and such.
+export const hashString = (s: string): number => {
+  let hash: number = 5381;
+  for (let i = 0; i < s.length; i++) {
+    const char: number = s.charCodeAt(i);
+    hash = (hash << 5) + hash + char;
+  }
+  return hash >>> 0; // Ensure unsigned 32-bit integer
+};
 
 export const getVisibleElements = (elements: readonly ExcalidrawElement[]) =>
   elements.filter(

--- a/packages/excalidraw/index.tsx
+++ b/packages/excalidraw/index.tsx
@@ -207,6 +207,8 @@ Excalidraw.displayName = "Excalidraw";
 
 export {
   getSceneVersion,
+  hashElementsVersion,
+  hashString,
   isInvisiblySmallElement,
   getNonDeletedElements,
 } from "./element";
@@ -232,7 +234,7 @@ export {
   loadLibraryFromBlob,
 } from "./data/blob";
 export { getFreeDrawSvgPath } from "./renderer/renderElement";
-export { mergeLibraryItems } from "./data/library";
+export { mergeLibraryItems, getLibraryItemsHash } from "./data/library";
 export { isLinearElement } from "./element/typeChecks";
 
 export { FONT_FAMILY, THEME, MIME_TYPES, ROUNDNESS } from "./constants";

--- a/packages/excalidraw/locales/en.json
+++ b/packages/excalidraw/locales/en.json
@@ -216,6 +216,7 @@
     "failedToFetchImage": "Failed to fetch image.",
     "cannotResolveCollabServer": "Couldn't connect to the collab server. Please reload the page and try again.",
     "importLibraryError": "Couldn't load library",
+    "saveLibraryError": "Couldn't save library to storage. Please save your library to a file locally to make sure you don't lose changes.",
     "collabSaveFailed": "Couldn't save to the backend database. If problems persist, you should save your file locally to ensure you don't lose your work.",
     "collabSaveFailed_sizeExceeded": "Couldn't save to the backend database, the canvas seems to be too big. You should save the file locally to ensure you don't lose your work.",
     "imageToolNotSupported": "Images are disabled.",

--- a/packages/excalidraw/queue.test.ts
+++ b/packages/excalidraw/queue.test.ts
@@ -1,0 +1,62 @@
+import { Queue } from "./queue";
+
+describe("Queue", () => {
+  const calls: any[] = [];
+
+  const createJobFactory =
+    <T>(
+      // for purpose of this test, Error object will become a rejection value
+      resolutionOrRejectionValue: T,
+      ms = 1,
+    ) =>
+    () => {
+      return new Promise<T>((resolve, reject) => {
+        setTimeout(() => {
+          if (resolutionOrRejectionValue instanceof Error) {
+            reject(resolutionOrRejectionValue);
+          } else {
+            resolve(resolutionOrRejectionValue);
+          }
+        }, ms);
+      }).then((x) => {
+        calls.push(x);
+        return x;
+      });
+    };
+
+  beforeEach(() => {
+    calls.length = 0;
+  });
+
+  it("should await and resolve values in order of enqueueing", async () => {
+    const queue = new Queue();
+
+    const p1 = queue.push(createJobFactory("A", 50));
+    const p2 = queue.push(createJobFactory("B"));
+    const p3 = queue.push(createJobFactory("C"));
+
+    expect(await p3).toBe("C");
+    expect(await p2).toBe("B");
+    expect(await p1).toBe("A");
+
+    expect(calls).toEqual(["A", "B", "C"]);
+  });
+
+  it("should reject a job if it throws, and not affect other jobs", async () => {
+    const queue = new Queue();
+
+    const err = new Error("B");
+
+    queue.push(createJobFactory("A", 50));
+    const p2 = queue.push(createJobFactory(err));
+    const p3 = queue.push(createJobFactory("C"));
+
+    const p2err = p2.catch((err) => err);
+
+    await p3;
+
+    expect(await p2err).toBe(err);
+
+    expect(calls).toEqual(["A", "C"]);
+  });
+});

--- a/packages/excalidraw/queue.ts
+++ b/packages/excalidraw/queue.ts
@@ -1,0 +1,45 @@
+import { MaybePromise } from "./utility-types";
+import { promiseTry, ResolvablePromise, resolvablePromise } from "./utils";
+
+type Job<T, TArgs extends unknown[]> = (...args: TArgs) => MaybePromise<T>;
+
+type QueueJob<T, TArgs extends unknown[]> = {
+  jobFactory: Job<T, TArgs>;
+  promise: ResolvablePromise<T>;
+  args: TArgs;
+};
+
+export class Queue {
+  private jobs: QueueJob<any, any[]>[] = [];
+  private running = false;
+
+  private tick() {
+    if (this.running) {
+      return;
+    }
+    const job = this.jobs.shift();
+    if (job) {
+      this.running = true;
+      job.promise.resolve(
+        promiseTry(job.jobFactory, ...job.args).finally(() => {
+          this.running = false;
+          this.tick();
+        }),
+      );
+    } else {
+      this.running = false;
+    }
+  }
+
+  push<TValue, TArgs extends unknown[]>(
+    jobFactory: Job<TValue, TArgs>,
+    ...args: TArgs
+  ): Promise<TValue> {
+    const promise = resolvablePromise<TValue>();
+    this.jobs.push({ jobFactory, promise, args });
+
+    this.tick();
+
+    return promise;
+  }
+}

--- a/packages/excalidraw/types.ts
+++ b/packages/excalidraw/types.ts
@@ -33,7 +33,7 @@ import { Language } from "./i18n";
 import { ClipboardData } from "./clipboard";
 import { isOverScrollBars } from "./scene/scrollbars";
 import { MaybeTransformHandleType } from "./element/transformHandles";
-import Library, { LibraryChange } from "./data/library";
+import Library from "./data/library";
 import type { FileSystemHandle } from "./data/filesystem";
 import type { IMAGE_MIME_TYPES, MIME_TYPES } from "./constants";
 import { ContextMenuItems } from "./components/ContextMenu";
@@ -439,10 +439,7 @@ export interface ExcalidrawProps {
   UIOptions?: Partial<UIOptions>;
   detectScroll?: boolean;
   handleKeyboardGlobally?: boolean;
-  onLibraryChange?: (
-    libraryItems: LibraryItems,
-    change: LibraryChange,
-  ) => void | Promise<any>;
+  onLibraryChange?: (libraryItems: LibraryItems) => void | Promise<any>;
   autoFocus?: boolean;
   generateIdForFile?: (file: File) => string | Promise<string>;
   onLinkOpen?: (
@@ -641,7 +638,7 @@ export type PointerDownState = Readonly<{
 
 export type UnsubscribeCallback = () => void;
 
-export type ExcalidrawImperativeAPI = {
+export interface ExcalidrawImperativeAPI {
   updateScene: InstanceType<typeof App>["updateScene"];
   updateLibrary: InstanceType<typeof Library>["updateLibrary"];
   resetScene: InstanceType<typeof App>["resetScene"];
@@ -698,10 +695,7 @@ export type ExcalidrawImperativeAPI = {
   onUserFollow: (
     callback: (payload: OnUserFollowedPayload) => void,
   ) => UnsubscribeCallback;
-  onLibraryChange: (
-    callback: (libraryItems: LibraryItems, change: LibraryChange) => void,
-  ) => UnsubscribeCallback;
-};
+}
 
 export type Device = Readonly<{
   viewport: {

--- a/packages/excalidraw/types.ts
+++ b/packages/excalidraw/types.ts
@@ -33,12 +33,12 @@ import { Language } from "./i18n";
 import { ClipboardData } from "./clipboard";
 import { isOverScrollBars } from "./scene/scrollbars";
 import { MaybeTransformHandleType } from "./element/transformHandles";
-import Library from "./data/library";
+import Library, { LibraryChange } from "./data/library";
 import type { FileSystemHandle } from "./data/filesystem";
 import type { IMAGE_MIME_TYPES, MIME_TYPES } from "./constants";
 import { ContextMenuItems } from "./components/ContextMenu";
 import { SnapLine } from "./snapping";
-import { Merge, ValueOf } from "./utility-types";
+import { Merge, MaybePromise, ValueOf } from "./utility-types";
 
 export type Point = Readonly<RoughPoint>;
 
@@ -392,9 +392,7 @@ export type LibraryItemsSource =
 export type ExcalidrawInitialDataState = Merge<
   ImportedDataState,
   {
-    libraryItems?:
-      | Required<ImportedDataState>["libraryItems"]
-      | Promise<Required<ImportedDataState>["libraryItems"]>;
+    libraryItems?: MaybePromise<Required<ImportedDataState>["libraryItems"]>;
   }
 >;
 
@@ -409,10 +407,7 @@ export interface ExcalidrawProps {
     appState: AppState,
     files: BinaryFiles,
   ) => void;
-  initialData?:
-    | ExcalidrawInitialDataState
-    | null
-    | Promise<ExcalidrawInitialDataState | null>;
+  initialData?: MaybePromise<ExcalidrawInitialDataState | null>;
   excalidrawAPI?: (api: ExcalidrawImperativeAPI) => void;
   isCollaborating?: boolean;
   onPointerUpdate?: (payload: {
@@ -444,7 +439,10 @@ export interface ExcalidrawProps {
   UIOptions?: Partial<UIOptions>;
   detectScroll?: boolean;
   handleKeyboardGlobally?: boolean;
-  onLibraryChange?: (libraryItems: LibraryItems) => void | Promise<any>;
+  onLibraryChange?: (
+    libraryItems: LibraryItems,
+    change: LibraryChange,
+  ) => void | Promise<any>;
   autoFocus?: boolean;
   generateIdForFile?: (file: File) => string | Promise<string>;
   onLinkOpen?: (
@@ -699,6 +697,9 @@ export type ExcalidrawImperativeAPI = {
   ) => UnsubscribeCallback;
   onUserFollow: (
     callback: (payload: OnUserFollowedPayload) => void,
+  ) => UnsubscribeCallback;
+  onLibraryChange: (
+    callback: (libraryItems: LibraryItems, change: LibraryChange) => void,
   ) => UnsubscribeCallback;
 };
 

--- a/packages/excalidraw/types.ts
+++ b/packages/excalidraw/types.ts
@@ -380,13 +380,8 @@ export type LibraryItems_anyVersion = LibraryItems | LibraryItems_v1;
 export type LibraryItemsSource =
   | ((
       currentLibraryItems: LibraryItems,
-    ) =>
-      | Blob
-      | LibraryItems_anyVersion
-      | Promise<LibraryItems_anyVersion | Blob>)
-  | Blob
-  | LibraryItems_anyVersion
-  | Promise<LibraryItems_anyVersion | Blob>;
+    ) => MaybePromise<LibraryItems_anyVersion | Blob>)
+  | MaybePromise<LibraryItems_anyVersion | Blob>;
 // -----------------------------------------------------------------------------
 
 export type ExcalidrawInitialDataState = Merge<

--- a/packages/excalidraw/utility-types.ts
+++ b/packages/excalidraw/utility-types.ts
@@ -62,3 +62,6 @@ export type MakeBrand<T extends string> = {
   /** @private using ~ to sort last in intellisense */
   [K in `~brand~${T}`]: T;
 };
+
+/** Maybe just promise or already fulfilled one! */
+export type MaybePromise<T> = T | Promise<T>;

--- a/packages/excalidraw/utils.ts
+++ b/packages/excalidraw/utils.ts
@@ -1092,3 +1092,13 @@ export const toBrandedType = <BrandedType, CurrentType = BrandedType>(
 };
 
 // -----------------------------------------------------------------------------
+
+// Promise.try, adapted from https://github.com/sindresorhus/p-try
+export const promiseTry = async <TValue, TArgs extends unknown[]>(
+  fn: (...args: TArgs) => PromiseLike<TValue> | TValue,
+  ...args: TArgs
+): Promise<TValue> => {
+  return new Promise((resolve) => {
+    resolve(fn(...args));
+  });
+};

--- a/packages/excalidraw/utils.ts
+++ b/packages/excalidraw/utils.ts
@@ -14,7 +14,7 @@ import {
   UnsubscribeCallback,
   Zoom,
 } from "./types";
-import { ResolutionType } from "./utility-types";
+import { MaybePromise, ResolutionType } from "./utility-types";
 
 let mockDateTime: string | null = null;
 
@@ -538,7 +538,9 @@ export const isTransparent = (color: string) => {
 };
 
 export type ResolvablePromise<T> = Promise<T> & {
-  resolve: [T] extends [undefined] ? (value?: T) => void : (value: T) => void;
+  resolve: [T] extends [undefined]
+    ? (value?: MaybePromise<Awaited<T>>) => void
+    : (value: MaybePromise<Awaited<T>>) => void;
   reject: (error: Error) => void;
 };
 export const resolvablePromise = <T>() => {


### PR DESCRIPTION
# Description

- change library data source from LocalStorage to IndexedDB (to get around the 5MB limit. We could compress instead, but it might be a better idea to future proof this).
- support `useHandleLibrary(opts.adapter)` adapter that handles both loads and saves. Saves are now safer by only adding/removing actually inserted/deleted elements.
- support `useHandleLibrary(opts.migrationAdapter)` to migrate between stores during init.
- on persisting updates to storage, library items are now added/removed individually. This makes data persistence much safer in case of race conditions or initialization issues.
- saves/loads are queued to reduce race conditions.
  - [ ] in the future, can be optimized by reusing previous saved data as the base for reconciliation if the subsequent save is queued directly after the previous one.

unrelated:

- initial library load is now using the `merge` strategy so that there aren't race conditions when installing libraries

# New API

```ts
const useHandleLibrary = (
  opts: {
    adapter: {
      /**
       * Should load data that were previously saved into the database using the
       * `save` method. Should throw if saving fails.
       *
       * Will be used internally in multiple places, such as during save to
       * in order to reconcile changes with latest store data.
       */
      load(metadata: {
        /**
         * Priority 1 indicates we're loading latest data with intent
         * to reconcile with before save.
         * Priority 2 indicates we're loading for read-only purposes, so
         * host app can implement more aggressive caching strategy.
         */
        priority: 1 | 2;
      }): MaybePromise<{ libraryItems: LibraryItems_anyVersion } | null>;
      /** Should persist to the database as is (do no change the data structure). */
      save(libraryData: LibraryPersistedData): MaybePromise<void>;
    };
    /**
     * Adapter that takes care of loading data from legacy data store.
     * Supply this if you want to migrate data on initial load from legacy
     * data store.
     *
     * Can be a different LibraryPersistenceAdapter.
     */
    migrationAdapter?: {
      /**
       * loads data from legacy data source. Returns `null` if no data is
       * to be migrated.
       */
      load(): MaybePromise<{ libraryItems: LibraryItems_anyVersion } | null>;
    
      /** clears entire storage afterwards */
      clear(): MaybePromise<void>;
    };

    // unchanged options

    excalidrawAPI: ExcalidrawImperativeAPI | null;
    /** @deprecated we recommend using `opts.adapter` instead */
    getInitialLibraryItems?: () => MaybePromise<LibraryItemsSource>;
  }
) => void;
```

# todos

- [x] queue save operations
- [x] move beforeunload into the hook, and make sure we prevent unload immediately as we start the update (= load + save). Later, we may wanna add a status emitter so host apps can handle themselves and also update UI based on saving status.

# testing

to test LS migration, you can populate LS with one test item (red rectangle) by using this command:

```
localStorage.setItem('excalidraw-library', JSON.stringify([{"status":"unpublished","elements":[{"type":"rectangle","version":165,"versionNonce":548285778,"isDeleted":false,"id":"sfH8RbI2Qh9ihUzum3ZYR","fillStyle":"solid","strokeWidth":2,"strokeStyle":"solid","roughness":1,"opacity":100,"angle":0,"x":959,"y":-7765,"strokeColor":"#1e1e1e","backgroundColor":"#ffc9c9","width":108,"height":61,"seed":164552463,"groupIds":[],"frameId":null,"roundness":{"type":3},"boundElements":[],"updated":1707140800891,"link":null,"locked":false}],"id":"aJIdcK56UddZ8t7C1lVJC","created":1707141132109}]))
```