### PR TITLE
feat: improve text baseline measurements

### DIFF
--- a/packages/excalidraw/data/restore.ts
+++ b/packages/excalidraw/data/restore.ts
@@ -207,11 +207,16 @@ const restoreElement = (
           : // no element height likely means programmatic use, so default
             // to a fixed line height
             getDefaultLineHeight(element.fontFamily));
+
       const baseline = measureBaseline(
         element.text,
-        getFontString(element),
-        lineHeight,
+        getFontString({
+          fontSize: element.fontSize,
+          fontFamily: element.fontFamily,
+        }),
+        String(lineHeight),
       );
+
       element = restoreElementWithProperties(element, {
         fontSize,
         fontFamily,


### PR DESCRIPTION
Improved the existing baseline measurements based on DOM, mainly by batching reads & writes to avoid layout thrashing. Also replaced the initial calculation based on `position: absolute` & `span.offsetTop` with `span.getBoundingClientRect().y - container.getBoundingClientRect().y`, as it did not perform well on many elements in Safari.

For now keeping as _Draft_, as even though it reduced the computation time to about 1/3 of the original, it did not really improve the final FPS in hotpaths, such as during resize. The reason is that the main bottleneck remains re-generating the element shape on every single resize, which keeps the GPU busy and delays the browser's plans to schedule a new task.

One way to solve the bottleneck:
- do not regenerate the shapes on hot paths related to text measurements (i.e. resize)
- set a similar flag as we use during zoom
- don't remove the elements from shape cache (i.e. during mutation & height/width change)
- translate the element/s width, height
  - we could even try to copy all the elements in the offscreen canvas, translate them there and copy them back (be aware of canvas limits)
- likely we need to do this also for single elements, otherwise there is always going to be text-bouncing due to the slow baseline calculation
  - seems like the text bounce is now even worse than before!
- UX will in this case favor blurry-precise-fast instead of bouncing-crisp-slow
  - double-check zoom cache ignore on Safari, as it looks like it doesn't always work as expected (gets pretty laggy)
  
Although, even without re-generating the shapes, the DOM baseline calculation is still slow, can we do better?

One way is to take measurements outside the DOM, which might also bring better rendering consistency between browsers, the possibility for server-side rendering and even further perf. improvements. Will investigate before un-drafting this PR.