### PR TITLE
docs: fix serializeAsJSON signature

### DIFF
--- a/dev-docs/docs/@excalidraw/excalidraw/api/utils/utils-intro.md
+++ b/dev-docs/docs/@excalidraw/excalidraw/api/utils/utils-intro.md
@@ -15,9 +15,11 @@ If you want to overwrite the `source` field in the `JSON` string, you can set `w
 **_Signature_**
 
 <pre>
-serializeAsJSON(&#123;<br/>&nbsp;
-  elements: <a href="https://github.com/excalidraw/excalidraw/blob/master/packages/excalidraw/element/types.ts#L114">ExcalidrawElement[]</a>,<br/>&nbsp;
-  appState: <a href="https://github.com/excalidraw/excalidraw/blob/master/packages/excalidraw/types.ts#L95">AppState</a>,<br/>
+serializeAsJSON({
+  elements: <a href="https://github.com/excalidraw/excalidraw/blob/master/packages/excalidraw/element/types.ts#L114">ExcalidrawElement[]</a>,
+  appState: <a href="https://github.com/excalidraw/excalidraw/blob/master/packages/excalidraw/types.ts#L95">AppState</a>,
+  files: <a href="https://github.com/excalidraw/excalidraw/blob/master/packages/excalidraw/types.ts#L97">BinaryFiles</a>,
+  type: "local" | "database"
 }): string
 </pre>
 


### PR DESCRIPTION
serializeAsJSON signature defined as: 
https://github.com/excalidraw/excalidraw/blob/master/packages/excalidraw/data/json.ts#L43-L48

fix #7146 

Before: 
![image](https://github.com/excalidraw/excalidraw/assets/460431/33e48e51-7643-4348-8d8a-e9a765517d20)

After: 
![image](https://github.com/excalidraw/excalidraw/assets/460431/f0f2f4d5-dfde-41cb-9195-868aa46ae77c)
