### PR TITLE
docs: type mistake in integration of excalidraw

### DIFF
--- a/dev-docs/docs/@excalidraw/excalidraw/integration.mdx
+++ b/dev-docs/docs/@excalidraw/excalidraw/integration.mdx
@@ -58,7 +58,7 @@ If you are using `pages router` then importing the wrapper dynamically would wor
 
   ```jsx showLineNumbers
   "use client";
-  import { Excalidraw. convertToExcalidrawElements } from "@excalidraw/excalidraw";
+  import { Excalidraw, convertToExcalidrawElements } from "@excalidraw/excalidraw";
 
   import "@excalidraw/excalidraw/index.css";
 


### PR DESCRIPTION
docs: type error in integration documentation.
![WhatsApp Image 2024-02-24 at 8 42 59 PM](https://github.com/excalidraw/excalidraw/assets/111674354/21e7d9b4-dce0-4c2a-8855-ba3f71b910e4)

