### PR TITLE
docs: add missing closing angle bracket in integration.mdx 

### DIFF
--- a/dev-docs/docs/@excalidraw/excalidraw/integration.mdx
+++ b/dev-docs/docs/@excalidraw/excalidraw/integration.mdx
@@ -70,7 +70,7 @@ If you are using `pages router` then importing the wrapper dynamically would wor
       height: 141.9765625,
     },]));
     return (
-      <div style={{height:"500px", width:"500px"}}  
+      <div style={{height:"500px", width:"500px"}}>  
         <Excalidraw />
       </div> 
     );


### PR DESCRIPTION
 A closing angle bracket was missing in a code sample.

### Original code:

```javascript 
<div style={{height:"500px", width:"500px"}}
    <Excalidraw />
</div>
```

### After adding the ">"

```javascript 
<div style={{height:"500px", width:"500px"}}>
    <Excalidraw />
</div>
```