### PR TITLE
docs: export utils type link added

### DIFF
--- a/dev-docs/docs/@excalidraw/excalidraw/api/utils/export.mdx
+++ b/dev-docs/docs/@excalidraw/excalidraw/api/utils/export.mdx
@@ -26,7 +26,7 @@ exportToCanvas(&#123;<br/>&nbsp;
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
 | `elements` | [Excalidraw Element []](https://github.com/excalidraw/excalidraw/blob/master/packages/excalidraw/element/types.ts#L114) |  | The elements to be exported to canvas. |
-| `appState` | [AppState](https://github.com/excalidraw/excalidraw/blob/master/packages/excalidraw/packages/utils.ts#L23) | [Default App State](https://github.com/excalidraw/excalidraw/blob/master/packages/excalidraw/appState.ts#L17) | The app state of the scene. |
+| `appState` | [AppState](https://github.com/excalidraw/excalidraw/blob/master/packages/excalidraw/types.ts#L185) | [Default App State](https://github.com/excalidraw/excalidraw/blob/master/packages/excalidraw/appState.ts#L17) | The app state of the scene. |
 | [`getDimensions`](#getdimensions) | `function` | _ | A function which returns the `width`, `height`, and optionally `scale` (defaults to  `1`), with which canvas is to be exported. |
 | `maxWidthOrHeight` | `number` | _ | The maximum `width` or `height` of the exported image. If provided, `getDimensions` is ignored. |
 | `files` | [BinaryFiles](https://github.com/excalidraw/excalidraw/blob/master/packages/excalidraw/types.ts#L59) | _ | The files added to the scene. |


### PR DESCRIPTION
Broken link of Utils in the API documentation.
https://www.loom.com/share/a0fb166ded5c4d7b8974789e14b0a68b?sid=d8aa0bd2-ddf4-409e-8577-8eea02cc29a4
![image](https://github.com/excalidraw/excalidraw/assets/111674354/0004267c-6501-4071-8c8f-58cbd028cf1b)
![image](https://github.com/excalidraw/excalidraw/assets/111674354/939dca10-45da-4748-91af-04a3407a76f9)
