### PR TITLE
Add holding Z and click-drag to zoom

### DIFF
--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -480,7 +480,9 @@ export const useExcalidrawActionManager = () =>
 let didTapTwice: boolean = false;
 let tappedTwiceTimer = 0;
 let isHoldingSpace: boolean = false;
+let isHoldingZ: boolean = false;
 let isPanning: boolean = false;
+let isZooming: boolean = false;
 let isDraggingScrollBar: boolean = false;
 let currentScrollBars: ScrollBars = { horizontal: null, vertical: null };
 let touchTimeout = 0;
@@ -3930,6 +3932,14 @@ class App extends React.Component<AppProps, AppState> {
         event.preventDefault();
       }
 
+      if (event.key === KEYS.Z && gesture.pointers.size === 0) {
+        isHoldingZ = true;
+        if (!isHoldingSpace) {
+          setCursor(this.interactiveCanvas, CURSOR_TYPE.ZOOM_IN);
+        }
+        event.preventDefault();
+      }
+
       if (
         (event.key === KEYS.G || event.key === KEYS.S) &&
         !event.altKey &&
@@ -3998,7 +4008,9 @@ class App extends React.Component<AppProps, AppState> {
 
   private onKeyUp = withBatchedUpdates((event: KeyboardEvent) => {
     if (event.key === KEYS.SPACE) {
-      if (this.state.viewModeEnabled) {
+      if (isHoldingZ === true) {
+        setCursor(this.interactiveCanvas, CURSOR_TYPE.ZOOM_IN);
+      } else if (this.state.viewModeEnabled) {
         setCursor(this.interactiveCanvas, CURSOR_TYPE.GRAB);
       } else if (this.state.activeTool.type === "selection") {
         resetCursor(this.interactiveCanvas);
@@ -4012,6 +4024,22 @@ class App extends React.Component<AppProps, AppState> {
         });
       }
       isHoldingSpace = false;
+    }
+    if (event.key === KEYS.Z) {
+      if (this.state.viewModeEnabled) {
+        setCursor(this.interactiveCanvas, CURSOR_TYPE.GRAB);
+      } else if (this.state.activeTool.type === "selection") {
+        resetCursor(this.interactiveCanvas);
+      } else {
+        setCursorForShape(this.interactiveCanvas, this.state);
+        this.setState({
+          selectedElementIds: makeNextSelectedElementIds({}, this.state),
+          selectedGroupIds: {},
+          editingGroupId: null,
+          activeEmbeddable: null,
+        });
+      }
+      isHoldingZ = false;
     }
     if (!event[KEYS.CTRL_OR_CMD] && !this.state.isBindingEnabled) {
       this.setState({ isBindingEnabled: true });
@@ -4062,7 +4090,7 @@ class App extends React.Component<AppProps, AppState> {
     const nextActiveTool = updateActiveTool(this.state, tool);
     if (nextActiveTool.type === "hand") {
       setCursor(this.interactiveCanvas, CURSOR_TYPE.GRAB);
-    } else if (!isHoldingSpace) {
+    } else if (!isHoldingSpace && !isHoldingZ) {
       setCursorForShape(this.interactiveCanvas, this.state);
     }
     if (isToolIcon(document.activeElement)) {
@@ -4856,6 +4884,8 @@ class App extends React.Component<AppProps, AppState> {
 
     if (
       isHoldingSpace ||
+      isHoldingZ ||
+      isZooming ||
       isPanning ||
       isDraggingScrollBar ||
       isHandToolActive(this.state)
@@ -5496,7 +5526,7 @@ class App extends React.Component<AppProps, AppState> {
       this.device = updateObject(this.device, { isTouchScreen: true });
     }
 
-    if (isPanning) {
+    if (isPanning || isZooming) {
       return;
     }
 
@@ -5506,6 +5536,10 @@ class App extends React.Component<AppProps, AppState> {
     // else it will send pointer state & laser pointer events in collab when
     // panning
     if (this.handleCanvasPanUsingWheelOrSpaceDrag(event)) {
+      return;
+    }
+
+    if (this.handleCanvasZoomWithKeyboard(event)) {
       return;
     }
 
@@ -5926,6 +5960,72 @@ class App extends React.Component<AppProps, AppState> {
       passive: true,
     });
     window.addEventListener(EVENT.POINTER_UP, teardown);
+    return true;
+  };
+
+  // Returns whether the event is a zooming
+  private handleCanvasZoomWithKeyboard = (
+    event: React.PointerEvent<HTMLElement>,
+  ): boolean => {
+    if (event.button === POINTER_BUTTON.WHEEL || !isHoldingZ) {
+      return false;
+    }
+    isZooming = true;
+    event.preventDefault();
+
+    let { clientX: lastX, clientY: lastY } = event;
+    const onPointerMove = withBatchedUpdatesThrottled((event: PointerEvent) => {
+      const deltaX = lastX - event.clientX;
+      const deltaY = lastY - event.clientY;
+
+      lastX = event.clientX;
+      lastY = event.clientY;
+
+      const newZoom =
+        this.state.zoom.value +
+        (deltaY / 500) * this.state.zoom.value -
+        (deltaX / 500) * this.state.zoom.value;
+
+      this.translateCanvas((state) => ({
+        ...getStateForZoom(
+          {
+            viewportX: this.lastViewportPosition.x,
+            viewportY: this.lastViewportPosition.y,
+            nextZoom: getNormalizedZoom(newZoom),
+          },
+          state,
+        ),
+        shouldCacheIgnoreZoom: true,
+      }));
+      this.resetShouldCacheIgnoreZoomDebounced();
+    });
+    const teardown = withBatchedUpdates(
+      (lastPointerUp = () => {
+        lastPointerUp = null;
+        isZooming = false;
+        if (!isHoldingZ) {
+          if (this.state.viewModeEnabled) {
+            setCursor(this.interactiveCanvas, CURSOR_TYPE.GRAB);
+          } else {
+            setCursorForShape(this.interactiveCanvas, this.state);
+          }
+        }
+        this.setState({
+          cursorButton: "up",
+        });
+        this.savePointer(event.clientX, event.clientY, "up");
+        window.removeEventListener(EVENT.POINTER_MOVE, onPointerMove);
+        window.removeEventListener(EVENT.POINTER_UP, teardown);
+        window.removeEventListener(EVENT.BLUR, teardown);
+        onPointerMove.flush();
+      }),
+    );
+    window.addEventListener(EVENT.BLUR, teardown);
+    window.addEventListener(EVENT.POINTER_MOVE, onPointerMove, {
+      passive: true,
+    });
+    window.addEventListener(EVENT.POINTER_UP, teardown);
+
     return true;
   };
 
@@ -9408,7 +9508,7 @@ class App extends React.Component<AppProps, AppState> {
       event: WheelEvent | React.WheelEvent<HTMLDivElement | HTMLCanvasElement>,
     ) => {
       event.preventDefault();
-      if (isPanning) {
+      if (isPanning || isZooming) {
         return;
       }
 

--- a/packages/excalidraw/constants.ts
+++ b/packages/excalidraw/constants.ts
@@ -39,6 +39,7 @@ export const CURSOR_TYPE = {
   GRAB: "grab",
   POINTER: "pointer",
   MOVE: "move",
+  ZOOM_IN: "zoom-in",
   AUTO: "",
 };
 export const POINTER_BUTTON = {


### PR DESCRIPTION
Adds a new zooming method: holding `Z` and click-drag towards right or up to zoom-in and towards left or bottom to zoom-out. This works a bit similar to holding `Space` and click-drag to pan.

Also adds the corresponding zoom cursor icons.

Adds support for zooming without mouse wheel which enhance experience when using a tablet + stylus.

fixes #7801