### PR TITLE
Fix: Docker build (#7582)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
 *
+!excalidraw-app/
 !.env.development
 !.env.production
 !.eslintrc.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,14 @@
 FROM node:18 AS build
 
-WORKDIR /opt/node_app
-
-COPY package.json yarn.lock ./
-RUN yarn --ignore-optional --network-timeout 600000
-
-ARG NODE_ENV=production
+WORKDIR /home/node/app
 
 COPY . .
-RUN yarn build:app:docker
+
+RUN npm install
+RUN cd excalidraw-app && npm run build:app:docker
 
 FROM nginx:1.21-alpine
 
-COPY --from=build /opt/node_app/build /usr/share/nginx/html
+COPY --from=build /home/node/app/excalidraw-app/build /usr/share/nginx/html
 
 HEALTHCHECK CMD wget -q -O /dev/null http://localhost || exit 1


### PR DESCRIPTION
Corrected the Dockerfile and .dockerignore to successfully build the excalidraw Docker image locally.

Tested locally by
* building the Docker image
* running the image using docker-compose
* connecting to Excalidraw and using some features
