### PR TITLE
fix: wysiwyg textarea width when window zoom !== 100%

### DIFF
--- a/packages/excalidraw/element/textWysiwyg.tsx
+++ b/packages/excalidraw/element/textWysiwyg.tsx
@@ -235,7 +235,7 @@ export const textWysiwyg = ({
         font: getFontString(updatedTextElement),
         // must be defined *after* font ¯\_(ツ)_/¯
         lineHeight: updatedTextElement.lineHeight,
-        width: `${textElementWidth}px`,
+        width: `${Math.ceil(textElementWidth)}px`,
         height: `${textElementHeight}px`,
         left: `${viewportX}px`,
         top: `${viewportY}px`,
@@ -333,7 +333,7 @@ export const textWysiwyg = ({
           getBoundTextMaxWidth(container, boundTextElement),
         );
         const width = getTextWidth(wrappedText, font);
-        editable.style.width = `${width}px`;
+        editable.style.width = `${Math.ceil(width)}px`;
       }
     };
 


### PR DESCRIPTION
fixes: #7847

Here's my test container: https://excalidraw-6pc2v020f-excalidraw.vercel.app/#json=aZ4Unb4qtOAVvp-rvjsY-,sj2COn1LEP7E9F0ozvf49Q

If you copy/paste this into excalidraw.com production and change browser zoom to 110% the text jumps on edit.