### PR TITLE
fix: external link not opening

### DIFF
--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -4953,11 +4953,7 @@ class App extends React.Component<AppProps, AppState> {
         }
         if (!customEvent?.defaultPrevented) {
           const target = isLocalLink(url) ? "_self" : "_blank";
-          const newWindow = window.open(
-            undefined,
-            target,
-            "noopener noreferrer",
-          );
+          const newWindow = window.open(undefined, target);
           // https://mathiasbynens.github.io/rel-noopener/
           if (newWindow) {
             newWindow.opener = null;


### PR DESCRIPTION
fixes: #7858 
....
problem was when using "noopener noreferrer", window.open returns null
...
according to this: https://mathiasbynens.github.io/rel-noopener
doing newWindow.opener = null; should do same as adding "noopener noreferrer"

or maybe we can do window.open(url, target, "noopener noreferrer");