### PR TITLE
fix: FileSave now respects file extensions in windows

### DIFF
--- a/packages/excalidraw/data/filesystem.ts
+++ b/packages/excalidraw/data/filesystem.ts
@@ -93,6 +93,7 @@ export const fileSave = (
       fileName: `${opts.name}.${opts.extension}`,
       description: opts.description,
       extensions: [`.${opts.extension}`],
+      mimeTypes: [MIME_TYPES[opts.extension]],
     },
     opts.fileHandle,
   );


### PR DESCRIPTION
## Description

This pull request addresses the issue where the `fileSave` function in the [browser-fs-access](https://github.com/GoogleChromeLabs/browser-fs-access) library does not respect the `extensions` option. This issue has been previously noted in [#113](https://github.com/GoogleChromeLabs/browser-fs-access/issues/113) . This caused issues with saving file after renaming where a user would expect it to retain the correct extension but did not as shown in the before video below.

The issue has also been noted in issue #7762 

### Note

- I experienced and tested this issue on Windows (ms edge-123.0.2420.81  and chrome-123.0.6312.106 and I don't know if it affects other platforms.
## Fix 

The fix involves adding `mimeTypes` to the `fileSave` function, which ensures that the correct file type is suggested in the save dialog.

## Comparison

 https://github.com/excalidraw/excalidraw/assets/71752651/ec8c4f80-81c0-49e4-ab98-6c5490c3acef



https://github.com/excalidraw/excalidraw/assets/71752651/cc2e9a3c-4509-4580-ae6c-80f4848c50fa

