### PR TITLE
fix: don't update locked items

### DIFF
--- a/packages/excalidraw/actions/actionProperties.tsx
+++ b/packages/excalidraw/actions/actionProperties.tsx
@@ -113,8 +113,9 @@ export const changeProperty = (
 
   return elements.map((element) => {
     if (
-      selectedElementIds.get(element.id) ||
-      element.id === appState.editingElement?.id
+      (selectedElementIds.get(element.id) ||
+      element.id === appState.editingElement?.id)
+      && !element.locked
     ) {
       return callback(element);
     }


### PR DESCRIPTION
Don't allow editing of locked items
Issue: #7831 