### PR TITLE
fix: CTRL/CMD & arrow point drag unbinds both sides (#6459)

### DIFF
--- a/packages/excalidraw/actions/actionFlip.ts
+++ b/packages/excalidraw/actions/actionFlip.ts
@@ -14,7 +14,7 @@ import { getCommonBoundingBox } from "../element/bounds";
 import {
   bindOrUnbindSelectedElements,
   isBindingEnabled,
-  unbindLinearElements,
+  filterBindingElementsAndPossiblyUnbind,
 } from "../element/binding";
 import { updateFrameMembershipOfSelectedElements } from "../frame";
 import { flipHorizontal, flipVertical } from "../components/icons";
@@ -124,7 +124,7 @@ const flipElements = (
 
   isBindingEnabled(appState)
     ? bindOrUnbindSelectedElements(selectedElements, app)
-    : unbindLinearElements(selectedElements, elementsMap);
+    : filterBindingElementsAndPossiblyUnbind(selectedElements, elementsMap);
 
   return selectedElements;
 };

--- a/packages/excalidraw/actions/actionFlip.ts
+++ b/packages/excalidraw/actions/actionFlip.ts
@@ -14,7 +14,7 @@ import { getCommonBoundingBox } from "../element/bounds";
 import {
   bindOrUnbindSelectedElements,
   isBindingEnabled,
-  filterBindingElementsAndPossiblyUnbind,
+  unbindLinearElements,
 } from "../element/binding";
 import { updateFrameMembershipOfSelectedElements } from "../frame";
 import { flipHorizontal, flipVertical } from "../components/icons";
@@ -124,7 +124,7 @@ const flipElements = (
 
   isBindingEnabled(appState)
     ? bindOrUnbindSelectedElements(selectedElements, app)
-    : filterBindingElementsAndPossiblyUnbind(selectedElements, elementsMap);
+    : unbindLinearElements(selectedElements, elementsMap);
 
   return selectedElements;
 };

--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -8396,7 +8396,7 @@ class App extends React.Component<AppProps, AppState> {
               this,
             )
           : unbindLinearElements(
-              this.scene.getNonDeletedElements(),
+              this.scene.getSelectedElements(this.state),
               elementsMap,
             );
       }

--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -130,7 +130,7 @@ import {
   isLinearElementSimpleAndAlreadyBound,
   maybeBindLinearElement,
   shouldEnableBindingForPointerEvent,
-  unbindLinearElements,
+  filterBindingElementsAndPossiblyUnbind,
   updateBoundElements,
 } from "../element/binding";
 import { LinearElementEditor } from "../element/linearElementEditor";
@@ -4051,7 +4051,7 @@ class App extends React.Component<AppProps, AppState> {
       const elementsMap = this.scene.getNonDeletedElementsMap();
       isBindingEnabled(this.state)
         ? bindOrUnbindSelectedElements(selectedElements, this)
-        : unbindLinearElements(selectedElements, elementsMap);
+        : filterBindingElementsAndPossiblyUnbind(selectedElements, elementsMap);
       this.setState({ suggestedBindings: [] });
     }
   });
@@ -8395,7 +8395,7 @@ class App extends React.Component<AppProps, AppState> {
               this.scene.getSelectedElements(this.state),
               this,
             )
-          : unbindLinearElements(
+          : filterBindingElementsAndPossiblyUnbind(
               this.scene.getSelectedElements(this.state),
               elementsMap,
             );

--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -130,7 +130,7 @@ import {
   isLinearElementSimpleAndAlreadyBound,
   maybeBindLinearElement,
   shouldEnableBindingForPointerEvent,
-  filterBindingElementsAndPossiblyUnbind,
+  unbindLinearElements,
   updateBoundElements,
 } from "../element/binding";
 import { LinearElementEditor } from "../element/linearElementEditor";
@@ -4051,7 +4051,7 @@ class App extends React.Component<AppProps, AppState> {
       const elementsMap = this.scene.getNonDeletedElementsMap();
       isBindingEnabled(this.state)
         ? bindOrUnbindSelectedElements(selectedElements, this)
-        : filterBindingElementsAndPossiblyUnbind(selectedElements, elementsMap);
+        : unbindLinearElements(selectedElements, elementsMap);
       this.setState({ suggestedBindings: [] });
     }
   });
@@ -8395,7 +8395,7 @@ class App extends React.Component<AppProps, AppState> {
               this.scene.getSelectedElements(this.state),
               this,
             )
-          : filterBindingElementsAndPossiblyUnbind(
+          : unbindLinearElements(
               this.scene.getSelectedElements(this.state),
               elementsMap,
             );

--- a/packages/excalidraw/element/binding.ts
+++ b/packages/excalidraw/element/binding.ts
@@ -289,14 +289,16 @@ export const filterBindingElementsAndPossiblyUnbind = (
 ): void => {
   elements.forEach((element) => {
     if (isBindingElement(element)) {
-      const startBindingElement = element.startBinding ? "keep" : null;
-      const endBindingElement = element.endBinding ? "keep" : null;
-      bindOrUnbindLinearElement(
-        element,
-        startBindingElement,
-        endBindingElement,
-        elementsMap,
-      );
+      if (element.startBinding !== null && element.endBinding !== null) {
+        bindOrUnbindLinearElement(element, null, null, elementsMap);
+      } else {
+        bindOrUnbindLinearElement(
+          element,
+          element.startBinding ? "keep" : null,
+          element.endBinding ? "keep" : null,
+          elementsMap,
+        );
+      }
     }
   });
 };

--- a/packages/excalidraw/element/binding.ts
+++ b/packages/excalidraw/element/binding.ts
@@ -283,7 +283,7 @@ export const isLinearElementSimpleAndAlreadyBound = (
   );
 };
 
-export const filterBindingElementsAndPossiblyUnbind = (
+export const unbindLinearElements = (
   elements: readonly NonDeleted<ExcalidrawElement>[],
   elementsMap: NonDeletedSceneElementsMap,
 ): void => {

--- a/packages/excalidraw/element/binding.ts
+++ b/packages/excalidraw/element/binding.ts
@@ -283,13 +283,20 @@ export const isLinearElementSimpleAndAlreadyBound = (
   );
 };
 
-export const unbindLinearElements = (
+export const filterBindingElementsAndPossiblyUnbind = (
   elements: readonly NonDeleted<ExcalidrawElement>[],
   elementsMap: NonDeletedSceneElementsMap,
 ): void => {
   elements.forEach((element) => {
     if (isBindingElement(element)) {
-      bindOrUnbindLinearElement(element, null, null, elementsMap);
+      const startBindingElement = element.startBinding ? "keep" : null;
+      const endBindingElement = element.endBinding ? "keep" : null;
+      bindOrUnbindLinearElement(
+        element,
+        startBindingElement,
+        endBindingElement,
+        elementsMap,
+      );
     }
   });
 };

--- a/packages/excalidraw/tests/binding.test.tsx
+++ b/packages/excalidraw/tests/binding.test.tsx
@@ -369,4 +369,44 @@ describe("element binding", () => {
     expect(arrow2.startBinding?.elementId).toBe(container.id);
     expect(arrow2.endBinding?.elementId).toBe(rectangle1.id);
   });
+
+  // #6459
+  it("should unbind arrow only from the latest element", () => {
+    const rectLeft = UI.createElement("rectangle", {
+      x: 0,
+      width: 200,
+      height: 500,
+    });
+    const rectRight = UI.createElement("rectangle", {
+      x: 400,
+      width: 200,
+      height: 500,
+    });
+    const arrow = UI.createElement("arrow", {
+      x: 210,
+      y: 250,
+      width: 180,
+      height: 1,
+    });
+    expect(arrow.startBinding?.elementId).toBe(rectLeft.id);
+    expect(arrow.endBinding?.elementId).toBe(rectRight.id);
+
+    // Drag arrow off of bound rectangle range
+    const handles = getTransformHandles(
+      arrow,
+      h.state.zoom,
+      arrayToMap(h.elements),
+      "mouse",
+    ).se!;
+
+    Keyboard.keyDown(KEYS.CTRL_OR_CMD);
+    const elX = handles[0] + handles[2] / 2;
+    const elY = handles[1] + handles[3] / 2;
+    mouse.downAt(elX, elY);
+    mouse.moveTo(300, 400);
+    mouse.up();
+
+    expect(arrow.startBinding).not.toBe(null);
+    expect(arrow.endBinding).toBe(null);
+  });
 });


### PR DESCRIPTION
fix https://github.com/excalidraw/excalidraw/issues/6459

This PR fixes not just #6459 but also addresses the related issue of CTRL/CMD & dragging arrow drag points disconnect ALL arrows in the scene.

## How to test the effect of the PR

### Setup
Create two diamonds and two boxes, then connect one diamond to the other diamond via an arrow, followed by connecting one box to the other via another arrow.

### Before
1) Press the CTRL/CMD key and drag the end marker of the arrow connecting the boxes somewhere ✅ 
2) The box previously connected to the end of the arrow is now disconnected ✅ 
3) When the box connected with the start of the arrow is drag moved, it can be seen that the arrow did not remain connected ❌ 
4) When any of the diamonds are drag moved, the arrow connected to them did not remain connected to either of them ❌ 

### After
1) Press the CTRL/CMD key and drag the end marker of the arrow connecting the boxes somewhere ✅ 
2) The box previously connected to the end of the arrow is now disconnected ✅ 
3) When the box connected with the start of the arrow is drag moved, it remains connected to the arrow ✅ 
4) When the box connected with the end of the arrow is drag moved, it remains connected to the arrow ✅ 
5) When any of the diamonds are moved, the arrow remains connected to both of them ✅ 

## Refactor
In this PR I also propose a function rename in `element/binding.ts`, specifically the `unbindLinearElements` to `filterBindingElementsAndPossiblyUnbind` in order to better reflect what the actual function does. Please let me know if this is inappropriate or need to be proposed in another context.