### PR TITLE
fix: double text rendering on edit

### DIFF
--- a/packages/excalidraw/renderer/staticScene.ts
+++ b/packages/excalidraw/renderer/staticScene.ts
@@ -281,7 +281,7 @@ const _renderStaticScene = ({
           );
         }
 
-        const boundTextElement = getBoundTextElement(element, allElementsMap);
+        const boundTextElement = getBoundTextElement(element, elementsMap);
         if (boundTextElement) {
           renderElement(
             boundTextElement,


### PR DESCRIPTION
fix https://github.com/excalidraw/excalidraw/issues/7897

The issue was while we're pre-filtering out the text element being editing, I was retrieving the current container's bound text from the scene elements map, not the filtered elements map, which resulted in always returning the text even if it was not meant to be rendered.