### PR TITLE
feat: Add library items to Command palette on search

### DIFF
--- a/packages/excalidraw/components/CommandPalette/CommandPalette.scss
+++ b/packages/excalidraw/components/CommandPalette/CommandPalette.scss
@@ -132,6 +132,14 @@ $verticalBreakpoint: 861px;
       width: 16px;
       height: 16px;
       margin-right: 6px;
+
+      .library-item-icon {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        height: 100%;
+        width: 100%;
+      }
     }
   }
 }

--- a/packages/excalidraw/components/CommandPalette/CommandPalette.tsx
+++ b/packages/excalidraw/components/CommandPalette/CommandPalette.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import {
   useApp,
   useAppProps,
@@ -31,7 +31,7 @@ import {
 } from "../icons";
 import fuzzy from "fuzzy";
 import { useUIAppState } from "../../context/ui-appState";
-import { AppProps, AppState, UIAppState } from "../../types";
+import { AppProps, AppState, LibraryItem, UIAppState } from "../../types";
 import {
   capitalizeString,
   getShortcutKey,
@@ -45,14 +45,22 @@ import { SHAPES } from "../../shapes";
 import { canChangeBackgroundColor, canChangeStrokeColor } from "../Actions";
 import { useStableCallback } from "../../hooks/useStableCallback";
 import { actionClearCanvas, actionLink } from "../../actions";
-import { jotaiStore } from "../../jotai";
+import { jotaiScope, jotaiStore } from "../../jotai";
 import { activeConfirmDialogAtom } from "../ActiveConfirmDialog";
 import { CommandPaletteItem } from "./types";
 import * as defaultItems from "./defaultCommandPaletteItems";
 import { trackEvent } from "../../analytics";
 import { useStable } from "../../hooks/useStable";
+import {
+  distributeLibraryItemsOnSquareGrid,
+  libraryItemsAtom,
+} from "../../data/library";
 
 import "./CommandPalette.scss";
+import {
+  useLibraryCache,
+  useLibraryItemSvg,
+} from "../../hooks/useLibraryItemSvg";
 
 const lastUsedPaletteItem = atom<CommandPaletteItem | null>(null);
 
@@ -63,6 +71,7 @@ export const DEFAULT_CATEGORIES = {
   editor: "Editor",
   elements: "Elements",
   links: "Links",
+  library: "Library",
 };
 
 const getCategoryOrder = (category: string) => {
@@ -189,6 +198,31 @@ function CommandPaletteInner({
     customCommandPaletteItems,
     appProps,
   });
+
+  const [libraryItemsData] = useAtom(libraryItemsAtom, jotaiScope);
+  const libraryCommands: CommandPaletteItem[] = useMemo(
+    () =>
+      libraryItemsData.libraryItems
+        ?.filter((libraryItem) => !!libraryItem.name)
+        .map((libraryItem) => ({
+          label: libraryItem.name ?? "Unknown Library Item",
+          icon: (
+            <LibraryItemIcon
+              id={libraryItem.id}
+              elements={libraryItem.elements}
+            />
+          ),
+          category: "Library",
+          order: getCategoryOrder("Library"),
+          haystack: deburr(libraryItem.name ?? "Unknown Library Item"),
+          perform: () => {
+            app.onInsertElements(
+              distributeLibraryItemsOnSquareGrid([libraryItem]),
+            );
+          },
+        })) || [],
+    [app, libraryItemsData.libraryItems],
+  );
 
   useEffect(() => {
     // these props change often and we don't want them to re-run the effect
@@ -549,8 +583,9 @@ function CommandPaletteInner({
 
       setAllCommands(allCommands);
       setLastUsed(
-        allCommands.find((command) => command.label === lastUsed?.label) ??
-          null,
+        [...allCommands, ...libraryCommands].find(
+          (command) => command.label === lastUsed?.label,
+        ) ?? null,
       );
     }
   }, [
@@ -561,6 +596,7 @@ function CommandPaletteInner({
     lastUsed?.label,
     setLastUsed,
     setAppState,
+    libraryCommands,
   ]);
 
   const [commandSearch, setCommandSearch] = useState("");
@@ -757,9 +793,12 @@ function CommandPaletteInner({
       return nextCommandsByCategory;
     };
 
-    let matchingCommands = allCommands
-      .filter(isCommandAvailable)
-      .sort((a, b) => a.order - b.order);
+    let matchingCommands =
+      commandSearch?.length > 1
+        ? [...allCommands, ...libraryCommands]
+        : allCommands
+            .filter(isCommandAvailable)
+            .sort((a, b) => a.order - b.order);
 
     const showLastUsed =
       !commandSearch && lastUsed && isCommandAvailable(lastUsed);
@@ -781,14 +820,20 @@ function CommandPaletteInner({
     const _query = deburr(commandSearch.replace(/[<>-_| ]/g, ""));
     matchingCommands = fuzzy
       .filter(_query, matchingCommands, {
-        extract: (command) => command.haystack,
+        extract: (command) => command.haystack ?? "",
       })
       .sort((a, b) => b.score - a.score)
       .map((item) => item.original);
 
     setCommandsByCategory(getNextCommandsByCategory(matchingCommands));
     setCurrentCommand(matchingCommands[0] ?? null);
-  }, [commandSearch, allCommands, isCommandAvailable, lastUsed]);
+  }, [
+    commandSearch,
+    allCommands,
+    isCommandAvailable,
+    lastUsed,
+    libraryCommands,
+  ]);
 
   return (
     <Dialog
@@ -879,6 +924,35 @@ function CommandPaletteInner({
   );
 }
 
+const LibraryItemIcon = ({
+  id,
+  elements,
+}: {
+  id: LibraryItem["id"] | null;
+  elements: LibraryItem["elements"] | undefined;
+}) => {
+  const ref = useRef<HTMLDivElement | null>(null);
+  const { svgCache } = useLibraryCache();
+  const svg = useLibraryItemSvg(id, elements, svgCache);
+
+  useEffect(() => {
+    const node = ref.current;
+
+    if (!node) {
+      return;
+    }
+
+    if (svg) {
+      node.innerHTML = svg.outerHTML;
+    }
+
+    return () => {
+      node.innerHTML = "";
+    };
+  }, [svg]);
+  return <div className="library-item-icon" ref={ref} />;
+};
+
 const CommandItem = ({
   command,
   isSelected,
@@ -918,6 +992,7 @@ const CommandItem = ({
       <div className="name">
         {command.icon && (
           <InlineIcon
+            className="icon"
             icon={
               typeof command.icon === "function"
                 ? command.icon(appState)

--- a/packages/excalidraw/components/InlineIcon.tsx
+++ b/packages/excalidraw/components/InlineIcon.tsx
@@ -1,6 +1,13 @@
-export const InlineIcon = ({ icon }: { icon: React.ReactNode }) => {
+export const InlineIcon = ({
+  className,
+  icon,
+}: {
+  className?: string;
+  icon: React.ReactNode;
+}) => {
   return (
     <span
+      className={className}
       style={{
         width: "1em",
         margin: "0 0.5ex 0 0.5ex",


### PR DESCRIPTION
### Description
- Adds ability to insert items from your library from the Command palette
- Only shows items from library if 2 or more characters are entered into the text prompt

![excalidraw-pr-lib-cmd-plt-1](https://github.com/excalidraw/excalidraw/assets/6342442/26acd88d-2176-4c74-acff-71b2eea6f5c2)

### Motivation
- When creating system diagrams, especially with AWS, having to manually search through the items in the library becomes time consuming (especially when AWS and/or GCP icons are all loaded). Since we now have the handle Command palette feature that can be brought up by hotkeys (cmd + /), it would make it very easy to simply hit the hotkey, then start typing the element you want to add then pressing enter. (example: cmd+/, type "clo", CloudFront appears, press Enter, and it's added).

### Assumptions & Limitations
- All library items are **NOT** added to the Command palette list when nothing is typed in the text input (or less than 2 characters).
  - This is because the Command palette doesn't seem to be the optimal place to visually browse for a list of components (that's what the LibraryMenu is for), but rather it should be just to search for.
  - Adding potentially hundreds of items makes the UI sluggish (we can probably easily solve this, but not worth it given previous point)
- **ONLY** library items published with a `name` metadata field will be included in the search results since there's no other way to identify the older ones
  - So for all previously published Library collections they need to be updated (not sure if this is possible), or republished
- The icons in the Command palette for each library item is so small that it's not clearly visible. However, since this is again meant to be a quick way to add items via hotkey this small icon is really just for quick recognition (esp. in the case there are items with duplicate or very similar names)

### Future work
- It would be great if there was a hosted queryable library of ALL items, and entering this search also queries that service. However, this seems more like a Excalidraw+ feature request. 
- Add a 'name' or 'title' field to published library collections. This way we can have a way to better display the name of the items in the case there are duplicate names (eg. AWS.something, GCP.something)

### Test instructions
Case 1
- Pull up the Command palette using the hotkeys Cmd + / or Cmd + Shift + P
- Start typing the name of a known item in your library
- Once your query is specific enough that it's the first item, press Enter
- It should be added inserted to the canvas

Case 2
- Pull up the Command palette using the hotkeys Cmd + / or Cmd + Shift + P
- Start typing the name of a known item in your library
- Once you see it in the list, use the down arrow to select it and press Enter
- It should be added inserted to the canvas

Case 3
- Pull up the Command palette using the hotkeys Cmd + / or Cmd + Shift + P
- Start typing the name of a known item in your library
- Once you see it in the list, click on it with your mouse
- It should be added inserted to the canvas

Case 4
- Pull up the Command palette using the hotkeys Cmd + / or Cmd + Shift + P
- Your last added item should be first on the list
- Press enter should add it to the canvas