### PR TITLE
fix: SVG font loading from unpkg.com due to undefined version

### DIFF
--- a/packages/excalidraw/scene/export.ts
+++ b/packages/excalidraw/scene/export.ts
@@ -342,7 +342,7 @@ export const exportToSvg = async (
     assetPath =
       window.EXCALIDRAW_ASSET_PATH ||
       `https://unpkg.com/${import.meta.env.VITE_PKG_NAME}@${
-        import.meta.env.PKG_VERSION
+        import.meta.env.VITE_PKG_VERSION
       }`;
 
     if (assetPath?.startsWith("/")) {


### PR DESCRIPTION
Looks the Vite migration done on https://github.com/excalidraw/excalidraw/commit/48924688c75aada554674b5a2bc3c752d33d3444

Renamed from vars but one was missed.

I found this issue when trying to investigate font that were not loaded from SVG

```
    <style class="style-fonts">
      @font-face {
        font-family: "Virgil";
        src: url("https://unpkg.com/@excalidraw/excalidraw@undefined/dist/excalidraw-assets/Virgil.woff2");
      }
      @font-face {
        font-family: "Cascadia";
        src: url("https://unpkg.com/@excalidraw/excalidraw@undefined/dist/excalidraw-assets/Cascadia.woff2");
      }
      @font-face {
        font-family: "Assistant";
        src: url("https://unpkg.com/@excalidraw/excalidraw@undefined/dist/excalidraw-assets/Assistant-Regular.woff2");
      }
    </style>
```

