### PR TITLE
feat: add install-PWA to command palette

### DIFF
--- a/packages/excalidraw/locales/en.json
+++ b/packages/excalidraw/locales/en.json
@@ -148,7 +148,8 @@
     "discordChat": "Discord chat",
     "zoomToFitViewport": "Zoom to fit in viewport",
     "zoomToFitSelection": "Zoom to fit selection",
-    "zoomToFit": "Zoom to fit all elements"
+    "zoomToFit": "Zoom to fit all elements",
+    "installPWA": "Install Excalidraw locally (PWA)"
   },
   "library": {
     "noItems": "No items added yet...",


### PR DESCRIPTION
Adds "Install Excalidraw locally (PWA)" command to the command palette for better discoveribility.

Docs: https://developer.mozilla.org/en-US/docs/Web/API/Window/beforeinstallprompt_event

Note that the command will appear to users only if certain PWA install criteria are met (see https://web.dev/articles/install-criteria).

![image](https://github.com/excalidraw/excalidraw/assets/5153846/1f545836-889f-43b0-babc-636614299b67)
