### PR TITLE
feat: record freedraw tool selection to history

### DIFF
--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -4167,6 +4167,7 @@ class App extends React.Component<AppProps, AppState> {
         activeEmbeddable: null,
       } as const;
       if (nextActiveTool.type !== "selection") {
+        this.store.shouldCaptureIncrement();
         return {
           ...prevState,
           activeTool: nextActiveTool,

--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -4166,8 +4166,12 @@ class App extends React.Component<AppProps, AppState> {
         originSnapOffset: null,
         activeEmbeddable: null,
       } as const;
-      if (nextActiveTool.type !== "selection") {
+
+      if (nextActiveTool.type === "freedraw") {
         this.store.shouldCaptureIncrement();
+      }
+
+      if (nextActiveTool.type !== "selection") {
         return {
           ...prevState,
           activeTool: nextActiveTool,

--- a/packages/excalidraw/tests/__snapshots__/history.test.tsx.snap
+++ b/packages/excalidraw/tests/__snapshots__/history.test.tsx.snap
@@ -71,13 +71,13 @@ exports[`history > multiplayer undo/redo > conflicts in arrows and their bindabl
   "penMode": false,
   "pendingImageElementId": null,
   "previousSelectedElementIds": {
-    "id155": true,
+    "id158": true,
   },
   "resizingElement": null,
   "scrollX": 0,
   "scrollY": 0,
   "selectedElementIds": {
-    "id155": true,
+    "id158": true,
   },
   "selectedElementsAreBeingDragged": false,
   "selectedGroupIds": {},
@@ -112,7 +112,7 @@ exports[`history > multiplayer undo/redo > conflicts in arrows and their bindabl
   "frameId": null,
   "groupIds": [],
   "height": 100,
-  "id": "id153",
+  "id": "id156",
   "index": "a0",
   "isDeleted": false,
   "link": null,
@@ -144,7 +144,7 @@ exports[`history > multiplayer undo/redo > conflicts in arrows and their bindabl
   "frameId": null,
   "groupIds": [],
   "height": 100,
-  "id": "id154",
+  "id": "id157",
   "index": "a1",
   "isDeleted": false,
   "link": null,
@@ -174,7 +174,7 @@ exports[`history > multiplayer undo/redo > conflicts in arrows and their bindabl
   "customData": undefined,
   "endArrowhead": "arrow",
   "endBinding": {
-    "elementId": "id157",
+    "elementId": "id160",
     "focus": 0,
     "gap": 1,
   },
@@ -182,7 +182,7 @@ exports[`history > multiplayer undo/redo > conflicts in arrows and their bindabl
   "frameId": null,
   "groupIds": [],
   "height": 99.19725525211979,
-  "id": "id155",
+  "id": "id158",
   "index": "a2",
   "isDeleted": false,
   "lastCommittedPoint": null,
@@ -223,7 +223,7 @@ exports[`history > multiplayer undo/redo > conflicts in arrows and their bindabl
   "backgroundColor": "transparent",
   "boundElements": [
     {
-      "id": "id155",
+      "id": "id158",
       "type": "arrow",
     },
   ],
@@ -232,7 +232,7 @@ exports[`history > multiplayer undo/redo > conflicts in arrows and their bindabl
   "frameId": null,
   "groupIds": [],
   "height": 50,
-  "id": "id157",
+  "id": "id160",
   "index": "a3",
   "isDeleted": false,
   "link": null,
@@ -274,36 +274,36 @@ History {
         "added": Map {},
         "removed": Map {},
         "updated": Map {
-          "id153" => Delta {
+          "id156" => Delta {
             "deleted": {
               "boundElements": [],
             },
             "inserted": {
               "boundElements": [
                 {
-                  "id": "id155",
+                  "id": "id158",
                   "type": "arrow",
                 },
               ],
             },
           },
-          "id154" => Delta {
+          "id157" => Delta {
             "deleted": {
               "boundElements": [],
             },
             "inserted": {
               "boundElements": [
                 {
-                  "id": "id155",
+                  "id": "id158",
                   "type": "arrow",
                 },
               ],
             },
           },
-          "id155" => Delta {
+          "id158" => Delta {
             "deleted": {
               "endBinding": {
-                "elementId": "id157",
+                "elementId": "id160",
                 "focus": 0,
                 "gap": 1,
               },
@@ -323,7 +323,7 @@ History {
             },
             "inserted": {
               "endBinding": {
-                "elementId": "id154",
+                "elementId": "id157",
                 "focus": 0.009900990099009901,
                 "gap": 1,
               },
@@ -339,18 +339,18 @@ History {
                 ],
               ],
               "startBinding": {
-                "elementId": "id153",
+                "elementId": "id156",
                 "focus": 0.0297029702970297,
                 "gap": 1,
               },
               "y": 0.9900000000000004,
             },
           },
-          "id157" => Delta {
+          "id160" => Delta {
             "deleted": {
               "boundElements": [
                 {
-                  "id": "id155",
+                  "id": "id158",
                   "type": "arrow",
                 },
               ],
@@ -374,7 +374,7 @@ History {
       "elementsChange": ElementsChange {
         "added": Map {},
         "removed": Map {
-          "id153" => Delta {
+          "id156" => Delta {
             "deleted": {
               "angle": 0,
               "backgroundColor": "transparent",
@@ -405,7 +405,7 @@ History {
               "isDeleted": true,
             },
           },
-          "id154" => Delta {
+          "id157" => Delta {
             "deleted": {
               "angle": 0,
               "backgroundColor": "transparent",
@@ -445,9 +445,9 @@ History {
         "delta": Delta {
           "deleted": {
             "selectedElementIds": {
-              "id155": true,
+              "id158": true,
             },
-            "selectedLinearElementId": "id155",
+            "selectedLinearElementId": "id158",
           },
           "inserted": {
             "selectedElementIds": {},
@@ -458,7 +458,7 @@ History {
       "elementsChange": ElementsChange {
         "added": Map {},
         "removed": Map {
-          "id155" => Delta {
+          "id158" => Delta {
             "deleted": {
               "angle": 0,
               "backgroundColor": "transparent",
@@ -587,13 +587,13 @@ exports[`history > multiplayer undo/redo > conflicts in arrows and their bindabl
   "penMode": false,
   "pendingImageElementId": null,
   "previousSelectedElementIds": {
-    "id151": true,
+    "id154": true,
   },
   "resizingElement": null,
   "scrollX": 0,
   "scrollY": 0,
   "selectedElementIds": {
-    "id151": true,
+    "id154": true,
   },
   "selectedElementsAreBeingDragged": false,
   "selectedGroupIds": {},
@@ -628,7 +628,7 @@ exports[`history > multiplayer undo/redo > conflicts in arrows and their bindabl
   "frameId": null,
   "groupIds": [],
   "height": 100,
-  "id": "id149",
+  "id": "id152",
   "index": "a0",
   "isDeleted": false,
   "link": null,
@@ -660,7 +660,7 @@ exports[`history > multiplayer undo/redo > conflicts in arrows and their bindabl
   "frameId": null,
   "groupIds": [],
   "height": 100,
-  "id": "id150",
+  "id": "id153",
   "index": "a1",
   "isDeleted": false,
   "link": null,
@@ -694,7 +694,7 @@ exports[`history > multiplayer undo/redo > conflicts in arrows and their bindabl
   "frameId": null,
   "groupIds": [],
   "height": 0,
-  "id": "id151",
+  "id": "id154",
   "index": "a2",
   "isDeleted": false,
   "lastCommittedPoint": null,
@@ -749,33 +749,33 @@ History {
         "added": Map {},
         "removed": Map {},
         "updated": Map {
-          "id149" => Delta {
+          "id152" => Delta {
             "deleted": {
               "boundElements": [],
             },
             "inserted": {
               "boundElements": [
                 {
-                  "id": "id151",
+                  "id": "id154",
                   "type": "arrow",
                 },
               ],
             },
           },
-          "id150" => Delta {
+          "id153" => Delta {
             "deleted": {
               "boundElements": [],
             },
             "inserted": {
               "boundElements": [
                 {
-                  "id": "id151",
+                  "id": "id154",
                   "type": "arrow",
                 },
               ],
             },
           },
-          "id151" => Delta {
+          "id154" => Delta {
             "deleted": {
               "endBinding": null,
               "points": [
@@ -792,7 +792,7 @@ History {
             },
             "inserted": {
               "endBinding": {
-                "elementId": "id150",
+                "elementId": "id153",
                 "focus": 0,
                 "gap": 1,
               },
@@ -807,7 +807,7 @@ History {
                 ],
               ],
               "startBinding": {
-                "elementId": "id149",
+                "elementId": "id152",
                 "focus": 0,
                 "gap": 1,
               },
@@ -828,7 +828,7 @@ History {
       "elementsChange": ElementsChange {
         "added": Map {},
         "removed": Map {
-          "id149" => Delta {
+          "id152" => Delta {
             "deleted": {
               "angle": 0,
               "backgroundColor": "transparent",
@@ -859,7 +859,7 @@ History {
               "isDeleted": true,
             },
           },
-          "id150" => Delta {
+          "id153" => Delta {
             "deleted": {
               "angle": 0,
               "backgroundColor": "transparent",
@@ -899,9 +899,9 @@ History {
         "delta": Delta {
           "deleted": {
             "selectedElementIds": {
-              "id151": true,
+              "id154": true,
             },
-            "selectedLinearElementId": "id151",
+            "selectedLinearElementId": "id154",
           },
           "inserted": {
             "selectedElementIds": {},
@@ -912,7 +912,7 @@ History {
       "elementsChange": ElementsChange {
         "added": Map {},
         "removed": Map {
-          "id151" => Delta {
+          "id154" => Delta {
             "deleted": {
               "angle": 0,
               "backgroundColor": "transparent",
@@ -1079,7 +1079,7 @@ exports[`history > multiplayer undo/redo > conflicts in arrows and their bindabl
   "customData": undefined,
   "endArrowhead": null,
   "endBinding": {
-    "elementId": "id159",
+    "elementId": "id162",
     "focus": 0,
     "gap": 1,
   },
@@ -1087,7 +1087,7 @@ exports[`history > multiplayer undo/redo > conflicts in arrows and their bindabl
   "frameId": null,
   "groupIds": [],
   "height": 0.03596020595764898,
-  "id": "id160",
+  "id": "id163",
   "index": "Zz",
   "isDeleted": false,
   "lastCommittedPoint": null,
@@ -1110,7 +1110,7 @@ exports[`history > multiplayer undo/redo > conflicts in arrows and their bindabl
   },
   "startArrowhead": null,
   "startBinding": {
-    "elementId": "id158",
+    "elementId": "id161",
     "focus": 0,
     "gap": 1,
   },
@@ -1132,7 +1132,7 @@ exports[`history > multiplayer undo/redo > conflicts in arrows and their bindabl
   "backgroundColor": "transparent",
   "boundElements": [
     {
-      "id": "id160",
+      "id": "id163",
       "type": "arrow",
     },
   ],
@@ -1141,7 +1141,7 @@ exports[`history > multiplayer undo/redo > conflicts in arrows and their bindabl
   "frameId": null,
   "groupIds": [],
   "height": 100,
-  "id": "id158",
+  "id": "id161",
   "index": "a0",
   "isDeleted": false,
   "link": null,
@@ -1169,7 +1169,7 @@ exports[`history > multiplayer undo/redo > conflicts in arrows and their bindabl
   "backgroundColor": "transparent",
   "boundElements": [
     {
-      "id": "id160",
+      "id": "id163",
       "type": "arrow",
     },
   ],
@@ -1178,7 +1178,7 @@ exports[`history > multiplayer undo/redo > conflicts in arrows and their bindabl
   "frameId": null,
   "groupIds": [],
   "height": 100,
-  "id": "id159",
+  "id": "id162",
   "index": "a1",
   "isDeleted": false,
   "link": null,
@@ -1220,7 +1220,7 @@ History {
       "elementsChange": ElementsChange {
         "added": Map {},
         "removed": Map {
-          "id158" => Delta {
+          "id161" => Delta {
             "deleted": {
               "angle": 0,
               "backgroundColor": "transparent",
@@ -1251,7 +1251,7 @@ History {
               "isDeleted": true,
             },
           },
-          "id159" => Delta {
+          "id162" => Delta {
             "deleted": {
               "angle": 0,
               "backgroundColor": "transparent",
@@ -1284,15 +1284,15 @@ History {
           },
         },
         "updated": Map {
-          "id160" => Delta {
+          "id163" => Delta {
             "deleted": {
               "endBinding": {
-                "elementId": "id159",
+                "elementId": "id162",
                 "focus": 0,
                 "gap": 1,
               },
               "startBinding": {
-                "elementId": "id158",
+                "elementId": "id161",
                 "focus": 0,
                 "gap": 1,
               },
@@ -1422,7 +1422,7 @@ exports[`history > multiplayer undo/redo > conflicts in arrows and their bindabl
   "customData": undefined,
   "endArrowhead": null,
   "endBinding": {
-    "elementId": "id162",
+    "elementId": "id165",
     "focus": 0,
     "gap": 1,
   },
@@ -1430,7 +1430,7 @@ exports[`history > multiplayer undo/redo > conflicts in arrows and their bindabl
   "frameId": null,
   "groupIds": [],
   "height": 0.03596020595764898,
-  "id": "id163",
+  "id": "id166",
   "index": "a0",
   "isDeleted": false,
   "lastCommittedPoint": null,
@@ -1453,7 +1453,7 @@ exports[`history > multiplayer undo/redo > conflicts in arrows and their bindabl
   },
   "startArrowhead": null,
   "startBinding": {
-    "elementId": "id161",
+    "elementId": "id164",
     "focus": 0,
     "gap": 1,
   },
@@ -1475,7 +1475,7 @@ exports[`history > multiplayer undo/redo > conflicts in arrows and their bindabl
   "backgroundColor": "transparent",
   "boundElements": [
     {
-      "id": "id163",
+      "id": "id166",
       "type": "arrow",
     },
   ],
@@ -1484,7 +1484,7 @@ exports[`history > multiplayer undo/redo > conflicts in arrows and their bindabl
   "frameId": null,
   "groupIds": [],
   "height": 100,
-  "id": "id161",
+  "id": "id164",
   "index": "a0V",
   "isDeleted": false,
   "link": null,
@@ -1512,7 +1512,7 @@ exports[`history > multiplayer undo/redo > conflicts in arrows and their bindabl
   "backgroundColor": "transparent",
   "boundElements": [
     {
-      "id": "id163",
+      "id": "id166",
       "type": "arrow",
     },
   ],
@@ -1521,7 +1521,7 @@ exports[`history > multiplayer undo/redo > conflicts in arrows and their bindabl
   "frameId": null,
   "groupIds": [],
   "height": 100,
-  "id": "id162",
+  "id": "id165",
   "index": "a1",
   "isDeleted": false,
   "link": null,
@@ -1563,7 +1563,7 @@ History {
       "elementsChange": ElementsChange {
         "added": Map {},
         "removed": Map {
-          "id163" => Delta {
+          "id166" => Delta {
             "deleted": {
               "angle": 0,
               "backgroundColor": "transparent",
@@ -1571,7 +1571,7 @@ History {
               "customData": undefined,
               "endArrowhead": null,
               "endBinding": {
-                "elementId": "id162",
+                "elementId": "id165",
                 "focus": 0,
                 "gap": 1,
               },
@@ -1601,7 +1601,7 @@ History {
               },
               "startArrowhead": null,
               "startBinding": {
-                "elementId": "id161",
+                "elementId": "id164",
                 "focus": 0,
                 "gap": 1,
               },
@@ -1619,11 +1619,11 @@ History {
           },
         },
         "updated": Map {
-          "id161" => Delta {
+          "id164" => Delta {
             "deleted": {
               "boundElements": [
                 {
-                  "id": "id163",
+                  "id": "id166",
                   "type": "arrow",
                 },
               ],
@@ -1632,11 +1632,11 @@ History {
               "boundElements": [],
             },
           },
-          "id162" => Delta {
+          "id165" => Delta {
             "deleted": {
               "boundElements": [
                 {
-                  "id": "id163",
+                  "id": "id166",
                   "type": "arrow",
                 },
               ],
@@ -1767,7 +1767,7 @@ exports[`history > multiplayer undo/redo > conflicts in arrows and their bindabl
   "frameId": null,
   "groupIds": [],
   "height": 100,
-  "id": "id164",
+  "id": "id167",
   "index": "a0",
   "isDeleted": false,
   "link": null,
@@ -1799,7 +1799,7 @@ exports[`history > multiplayer undo/redo > conflicts in arrows and their bindabl
   "frameId": null,
   "groupIds": [],
   "height": 100,
-  "id": "id165",
+  "id": "id168",
   "index": "a1",
   "isDeleted": false,
   "link": null,
@@ -1841,7 +1841,7 @@ History {
       "elementsChange": ElementsChange {
         "added": Map {},
         "removed": Map {
-          "id164" => Delta {
+          "id167" => Delta {
             "deleted": {
               "angle": 0,
               "backgroundColor": "transparent",
@@ -1872,7 +1872,7 @@ History {
               "isDeleted": true,
             },
           },
-          "id165" => Delta {
+          "id168" => Delta {
             "deleted": {
               "angle": 0,
               "backgroundColor": "transparent",
@@ -1990,7 +1990,7 @@ exports[`history > multiplayer undo/redo > conflicts in arrows and their bindabl
   "scrollX": 0,
   "scrollY": 0,
   "selectedElementIds": {
-    "id168": true,
+    "id171": true,
   },
   "selectedElementsAreBeingDragged": false,
   "selectedGroupIds": {},
@@ -2021,7 +2021,7 @@ exports[`history > multiplayer undo/redo > conflicts in arrows and their bindabl
   "backgroundColor": "transparent",
   "boundElements": [
     {
-      "id": "id168",
+      "id": "id171",
       "type": "arrow",
     },
   ],
@@ -2030,7 +2030,7 @@ exports[`history > multiplayer undo/redo > conflicts in arrows and their bindabl
   "frameId": null,
   "groupIds": [],
   "height": 100,
-  "id": "id166",
+  "id": "id169",
   "index": "a0",
   "isDeleted": false,
   "link": null,
@@ -2058,7 +2058,7 @@ exports[`history > multiplayer undo/redo > conflicts in arrows and their bindabl
   "backgroundColor": "transparent",
   "boundElements": [
     {
-      "id": "id168",
+      "id": "id171",
       "type": "arrow",
     },
   ],
@@ -2067,7 +2067,7 @@ exports[`history > multiplayer undo/redo > conflicts in arrows and their bindabl
   "frameId": null,
   "groupIds": [],
   "height": 100,
-  "id": "id167",
+  "id": "id170",
   "index": "a1",
   "isDeleted": false,
   "link": null,
@@ -2097,7 +2097,7 @@ exports[`history > multiplayer undo/redo > conflicts in arrows and their bindabl
   "customData": undefined,
   "endArrowhead": "arrow",
   "endBinding": {
-    "elementId": "id167",
+    "elementId": "id170",
     "focus": 0,
     "gap": 1,
   },
@@ -2105,7 +2105,7 @@ exports[`history > multiplayer undo/redo > conflicts in arrows and their bindabl
   "frameId": null,
   "groupIds": [],
   "height": 373.7994222717614,
-  "id": "id168",
+  "id": "id171",
   "index": "a2",
   "isDeleted": false,
   "lastCommittedPoint": null,
@@ -2128,7 +2128,7 @@ exports[`history > multiplayer undo/redo > conflicts in arrows and their bindabl
   },
   "startArrowhead": null,
   "startBinding": {
-    "elementId": "id166",
+    "elementId": "id169",
     "focus": 0,
     "gap": 1,
   },
@@ -2164,7 +2164,7 @@ History {
       "elementsChange": ElementsChange {
         "added": Map {},
         "removed": Map {
-          "id166" => Delta {
+          "id169" => Delta {
             "deleted": {
               "angle": 0,
               "backgroundColor": "transparent",
@@ -2195,7 +2195,7 @@ History {
               "isDeleted": true,
             },
           },
-          "id167" => Delta {
+          "id170" => Delta {
             "deleted": {
               "angle": 0,
               "backgroundColor": "transparent",
@@ -2235,9 +2235,9 @@ History {
         "delta": Delta {
           "deleted": {
             "selectedElementIds": {
-              "id168": true,
+              "id171": true,
             },
-            "selectedLinearElementId": "id168",
+            "selectedLinearElementId": "id171",
           },
           "inserted": {
             "selectedElementIds": {},
@@ -2248,7 +2248,7 @@ History {
       "elementsChange": ElementsChange {
         "added": Map {},
         "removed": Map {
-          "id168" => Delta {
+          "id171" => Delta {
             "deleted": {
               "angle": 0,
               "backgroundColor": "transparent",
@@ -2256,7 +2256,7 @@ History {
               "customData": undefined,
               "endArrowhead": "arrow",
               "endBinding": {
-                "elementId": "id167",
+                "elementId": "id170",
                 "focus": 0,
                 "gap": 1,
               },
@@ -2286,7 +2286,7 @@ History {
               },
               "startArrowhead": null,
               "startBinding": {
-                "elementId": "id166",
+                "elementId": "id169",
                 "focus": 0,
                 "gap": 1,
               },
@@ -2304,11 +2304,11 @@ History {
           },
         },
         "updated": Map {
-          "id166" => Delta {
+          "id169" => Delta {
             "deleted": {
               "boundElements": [
                 {
-                  "id": "id168",
+                  "id": "id171",
                   "type": "arrow",
                 },
               ],
@@ -2317,11 +2317,11 @@ History {
               "boundElements": [],
             },
           },
-          "id167" => Delta {
+          "id170" => Delta {
             "deleted": {
               "boundElements": [
                 {
-                  "id": "id168",
+                  "id": "id171",
                   "type": "arrow",
                 },
               ],
@@ -2448,7 +2448,7 @@ exports[`history > multiplayer undo/redo > conflicts in bound text elements and 
   "backgroundColor": "transparent",
   "boundElements": [
     {
-      "id": "id137",
+      "id": "id140",
       "type": "text",
     },
   ],
@@ -2457,7 +2457,7 @@ exports[`history > multiplayer undo/redo > conflicts in bound text elements and 
   "frameId": null,
   "groupIds": [],
   "height": 100,
-  "id": "id135",
+  "id": "id138",
   "index": "a0",
   "isDeleted": false,
   "link": null,
@@ -2492,7 +2492,7 @@ exports[`history > multiplayer undo/redo > conflicts in bound text elements and 
   "frameId": null,
   "groupIds": [],
   "height": 100,
-  "id": "id136",
+  "id": "id139",
   "index": "a1",
   "isDeleted": false,
   "lineHeight": 1.25,
@@ -2524,7 +2524,7 @@ exports[`history > multiplayer undo/redo > conflicts in bound text elements and 
   "angle": 0,
   "backgroundColor": "transparent",
   "boundElements": null,
-  "containerId": "id135",
+  "containerId": "id138",
   "customData": undefined,
   "fillStyle": "solid",
   "fontFamily": 1,
@@ -2532,7 +2532,7 @@ exports[`history > multiplayer undo/redo > conflicts in bound text elements and 
   "frameId": null,
   "groupIds": [],
   "height": 25,
-  "id": "id137",
+  "id": "id140",
   "index": "a2",
   "isDeleted": false,
   "lineHeight": 1.25,
@@ -2579,7 +2579,7 @@ History {
         "added": Map {},
         "removed": Map {},
         "updated": Map {
-          "id135" => Delta {
+          "id138" => Delta {
             "deleted": {
               "isDeleted": false,
             },
@@ -2610,7 +2610,7 @@ History {
               "y": 10,
             },
           },
-          "id136" => Delta {
+          "id139" => Delta {
             "deleted": {
               "containerId": null,
             },
@@ -2737,7 +2737,7 @@ exports[`history > multiplayer undo/redo > conflicts in bound text elements and 
   "backgroundColor": "transparent",
   "boundElements": [
     {
-      "id": "id140",
+      "id": "id143",
       "type": "text",
     },
   ],
@@ -2746,7 +2746,7 @@ exports[`history > multiplayer undo/redo > conflicts in bound text elements and 
   "frameId": null,
   "groupIds": [],
   "height": 100,
-  "id": "id138",
+  "id": "id141",
   "index": "Zz",
   "isDeleted": false,
   "link": null,
@@ -2773,7 +2773,7 @@ exports[`history > multiplayer undo/redo > conflicts in bound text elements and 
   "angle": 0,
   "backgroundColor": "transparent",
   "boundElements": null,
-  "containerId": "id138",
+  "containerId": "id141",
   "customData": undefined,
   "fillStyle": "solid",
   "fontFamily": 1,
@@ -2781,7 +2781,7 @@ exports[`history > multiplayer undo/redo > conflicts in bound text elements and 
   "frameId": null,
   "groupIds": [],
   "height": 100,
-  "id": "id139",
+  "id": "id142",
   "index": "a0",
   "isDeleted": true,
   "lineHeight": 1.25,
@@ -2813,7 +2813,7 @@ exports[`history > multiplayer undo/redo > conflicts in bound text elements and 
   "angle": 0,
   "backgroundColor": "transparent",
   "boundElements": null,
-  "containerId": "id138",
+  "containerId": "id141",
   "customData": undefined,
   "fillStyle": "solid",
   "fontFamily": 1,
@@ -2821,7 +2821,7 @@ exports[`history > multiplayer undo/redo > conflicts in bound text elements and 
   "frameId": null,
   "groupIds": [],
   "height": 25,
-  "id": "id140",
+  "id": "id143",
   "index": "a1",
   "isDeleted": false,
   "lineHeight": 1.25,
@@ -2866,9 +2866,9 @@ History {
       },
       "elementsChange": ElementsChange {
         "added": Map {
-          "id139" => Delta {
+          "id142" => Delta {
             "deleted": {
-              "containerId": "id138",
+              "containerId": "id141",
               "isDeleted": true,
             },
             "inserted": {
@@ -2879,14 +2879,14 @@ History {
         },
         "removed": Map {},
         "updated": Map {
-          "id138" => Delta {
+          "id141" => Delta {
             "deleted": {
               "boundElements": [],
             },
             "inserted": {
               "boundElements": [
                 {
-                  "id": "id139",
+                  "id": "id142",
                   "type": "text",
                 },
               ],
@@ -3011,7 +3011,7 @@ exports[`history > multiplayer undo/redo > conflicts in bound text elements and 
   "backgroundColor": "transparent",
   "boundElements": [
     {
-      "id": "id127",
+      "id": "id130",
       "type": "text",
     },
   ],
@@ -3020,7 +3020,7 @@ exports[`history > multiplayer undo/redo > conflicts in bound text elements and 
   "frameId": null,
   "groupIds": [],
   "height": 100,
-  "id": "id125",
+  "id": "id128",
   "index": "a0",
   "isDeleted": false,
   "link": null,
@@ -3047,7 +3047,7 @@ exports[`history > multiplayer undo/redo > conflicts in bound text elements and 
   "angle": 0,
   "backgroundColor": "transparent",
   "boundElements": null,
-  "containerId": "id125",
+  "containerId": "id128",
   "customData": undefined,
   "fillStyle": "solid",
   "fontFamily": 1,
@@ -3055,7 +3055,7 @@ exports[`history > multiplayer undo/redo > conflicts in bound text elements and 
   "frameId": null,
   "groupIds": [],
   "height": 25,
-  "id": "id127",
+  "id": "id130",
   "index": "a0V",
   "isDeleted": false,
   "lineHeight": 1.25,
@@ -3095,7 +3095,7 @@ exports[`history > multiplayer undo/redo > conflicts in bound text elements and 
   "frameId": null,
   "groupIds": [],
   "height": 25,
-  "id": "id126",
+  "id": "id129",
   "index": "a1",
   "isDeleted": false,
   "lineHeight": 1.25,
@@ -3142,11 +3142,11 @@ History {
         "added": Map {},
         "removed": Map {},
         "updated": Map {
-          "id125" => Delta {
+          "id128" => Delta {
             "deleted": {
               "boundElements": [
                 {
-                  "id": "id127",
+                  "id": "id130",
                   "type": "text",
                 },
               ],
@@ -3154,23 +3154,23 @@ History {
             "inserted": {
               "boundElements": [
                 {
-                  "id": "id126",
+                  "id": "id129",
                   "type": "text",
                 },
               ],
             },
           },
-          "id126" => Delta {
+          "id129" => Delta {
             "deleted": {
               "containerId": null,
             },
             "inserted": {
-              "containerId": "id125",
+              "containerId": "id128",
             },
           },
-          "id127" => Delta {
+          "id130" => Delta {
             "deleted": {
-              "containerId": "id125",
+              "containerId": "id128",
             },
             "inserted": {
               "containerId": null,
@@ -3299,7 +3299,7 @@ exports[`history > multiplayer undo/redo > conflicts in bound text elements and 
   "frameId": null,
   "groupIds": [],
   "height": 100,
-  "id": "id128",
+  "id": "id131",
   "index": "a0",
   "isDeleted": false,
   "link": null,
@@ -3327,7 +3327,7 @@ exports[`history > multiplayer undo/redo > conflicts in bound text elements and 
   "backgroundColor": "transparent",
   "boundElements": [
     {
-      "id": "id129",
+      "id": "id132",
       "type": "text",
     },
   ],
@@ -3336,7 +3336,7 @@ exports[`history > multiplayer undo/redo > conflicts in bound text elements and 
   "frameId": null,
   "groupIds": [],
   "height": 60,
-  "id": "id130",
+  "id": "id133",
   "index": "a0V",
   "isDeleted": false,
   "link": null,
@@ -3363,7 +3363,7 @@ exports[`history > multiplayer undo/redo > conflicts in bound text elements and 
   "angle": 0,
   "backgroundColor": "transparent",
   "boundElements": null,
-  "containerId": "id130",
+  "containerId": "id133",
   "customData": undefined,
   "fillStyle": "solid",
   "fontFamily": 1,
@@ -3371,7 +3371,7 @@ exports[`history > multiplayer undo/redo > conflicts in bound text elements and 
   "frameId": null,
   "groupIds": [],
   "height": 50,
-  "id": "id129",
+  "id": "id132",
   "index": "a1",
   "isDeleted": false,
   "lineHeight": 1.25,
@@ -3419,32 +3419,32 @@ History {
         "added": Map {},
         "removed": Map {},
         "updated": Map {
-          "id128" => Delta {
+          "id131" => Delta {
             "deleted": {
               "boundElements": [],
             },
             "inserted": {
               "boundElements": [
                 {
-                  "id": "id129",
+                  "id": "id132",
                   "type": "text",
                 },
               ],
             },
           },
-          "id129" => Delta {
+          "id132" => Delta {
             "deleted": {
-              "containerId": "id130",
+              "containerId": "id133",
             },
             "inserted": {
-              "containerId": "id128",
+              "containerId": "id131",
             },
           },
-          "id130" => Delta {
+          "id133" => Delta {
             "deleted": {
               "boundElements": [
                 {
-                  "id": "id129",
+                  "id": "id132",
                   "type": "text",
                 },
               ],
@@ -3576,7 +3576,7 @@ exports[`history > multiplayer undo/redo > conflicts in bound text elements and 
   "frameId": null,
   "groupIds": [],
   "height": 100,
-  "id": "id123",
+  "id": "id126",
   "index": "a0",
   "isDeleted": false,
   "link": null,
@@ -3611,7 +3611,7 @@ exports[`history > multiplayer undo/redo > conflicts in bound text elements and 
   "frameId": null,
   "groupIds": [],
   "height": 25,
-  "id": "id124",
+  "id": "id127",
   "index": "a1",
   "isDeleted": false,
   "lineHeight": 1.25,
@@ -3658,25 +3658,25 @@ History {
         "added": Map {},
         "removed": Map {},
         "updated": Map {
-          "id123" => Delta {
+          "id126" => Delta {
             "deleted": {
               "boundElements": [],
             },
             "inserted": {
               "boundElements": [
                 {
-                  "id": "id124",
+                  "id": "id127",
                   "type": "text",
                 },
               ],
             },
           },
-          "id124" => Delta {
+          "id127" => Delta {
             "deleted": {
               "containerId": null,
             },
             "inserted": {
-              "containerId": "id123",
+              "containerId": "id126",
             },
           },
         },
@@ -3798,7 +3798,7 @@ exports[`history > multiplayer undo/redo > conflicts in bound text elements and 
   "backgroundColor": "transparent",
   "boundElements": [
     {
-      "id": "id132",
+      "id": "id135",
       "type": "text",
     },
   ],
@@ -3807,7 +3807,7 @@ exports[`history > multiplayer undo/redo > conflicts in bound text elements and 
   "frameId": null,
   "groupIds": [],
   "height": 100,
-  "id": "id131",
+  "id": "id134",
   "index": "a0",
   "isDeleted": false,
   "link": null,
@@ -3834,7 +3834,7 @@ exports[`history > multiplayer undo/redo > conflicts in bound text elements and 
   "angle": 0,
   "backgroundColor": "transparent",
   "boundElements": null,
-  "containerId": "id131",
+  "containerId": "id134",
   "customData": undefined,
   "fillStyle": "solid",
   "fontFamily": 1,
@@ -3842,7 +3842,7 @@ exports[`history > multiplayer undo/redo > conflicts in bound text elements and 
   "frameId": null,
   "groupIds": [],
   "height": 25,
-  "id": "id132",
+  "id": "id135",
   "index": "a1",
   "isDeleted": false,
   "lineHeight": 1.25,
@@ -3889,7 +3889,7 @@ History {
       "elementsChange": ElementsChange {
         "added": Map {},
         "removed": Map {
-          "id131" => Delta {
+          "id134" => Delta {
             "deleted": {
               "angle": 0,
               "backgroundColor": "transparent",
@@ -3922,9 +3922,9 @@ History {
           },
         },
         "updated": Map {
-          "id132" => Delta {
+          "id135" => Delta {
             "deleted": {
-              "containerId": "id131",
+              "containerId": "id134",
             },
             "inserted": {
               "containerId": null,
@@ -4048,7 +4048,7 @@ exports[`history > multiplayer undo/redo > conflicts in bound text elements and 
   "backgroundColor": "transparent",
   "boundElements": [
     {
-      "id": "id134",
+      "id": "id137",
       "type": "text",
     },
   ],
@@ -4057,7 +4057,7 @@ exports[`history > multiplayer undo/redo > conflicts in bound text elements and 
   "frameId": null,
   "groupIds": [],
   "height": 100,
-  "id": "id133",
+  "id": "id136",
   "index": "Zz",
   "isDeleted": false,
   "link": null,
@@ -4084,7 +4084,7 @@ exports[`history > multiplayer undo/redo > conflicts in bound text elements and 
   "angle": 0,
   "backgroundColor": "transparent",
   "boundElements": null,
-  "containerId": "id133",
+  "containerId": "id136",
   "customData": undefined,
   "fillStyle": "solid",
   "fontFamily": 1,
@@ -4092,7 +4092,7 @@ exports[`history > multiplayer undo/redo > conflicts in bound text elements and 
   "frameId": null,
   "groupIds": [],
   "height": 25,
-  "id": "id134",
+  "id": "id137",
   "index": "a0",
   "isDeleted": false,
   "lineHeight": 1.25,
@@ -4139,12 +4139,12 @@ History {
       "elementsChange": ElementsChange {
         "added": Map {},
         "removed": Map {
-          "id134" => Delta {
+          "id137" => Delta {
             "deleted": {
               "angle": 0,
               "backgroundColor": "transparent",
               "boundElements": null,
-              "containerId": "id133",
+              "containerId": "id136",
               "customData": undefined,
               "fillStyle": "solid",
               "fontFamily": 1,
@@ -4180,11 +4180,11 @@ History {
           },
         },
         "updated": Map {
-          "id133" => Delta {
+          "id136" => Delta {
             "deleted": {
               "boundElements": [
                 {
-                  "id": "id134",
+                  "id": "id137",
                   "type": "text",
                 },
               ],
@@ -4311,7 +4311,7 @@ exports[`history > multiplayer undo/redo > conflicts in bound text elements and 
   "backgroundColor": "transparent",
   "boundElements": [
     {
-      "id": "id148",
+      "id": "id151",
       "type": "text",
     },
   ],
@@ -4320,7 +4320,7 @@ exports[`history > multiplayer undo/redo > conflicts in bound text elements and 
   "frameId": null,
   "groupIds": [],
   "height": 100,
-  "id": "id147",
+  "id": "id150",
   "index": "Zz",
   "isDeleted": false,
   "link": null,
@@ -4347,7 +4347,7 @@ exports[`history > multiplayer undo/redo > conflicts in bound text elements and 
   "angle": 0,
   "backgroundColor": "transparent",
   "boundElements": null,
-  "containerId": "id147",
+  "containerId": "id150",
   "customData": undefined,
   "fillStyle": "solid",
   "fontFamily": 1,
@@ -4355,7 +4355,7 @@ exports[`history > multiplayer undo/redo > conflicts in bound text elements and 
   "frameId": null,
   "groupIds": [],
   "height": 25,
-  "id": "id148",
+  "id": "id151",
   "index": "a0",
   "isDeleted": false,
   "lineHeight": 1.25,
@@ -4402,7 +4402,7 @@ History {
         "added": Map {},
         "removed": Map {},
         "updated": Map {
-          "id148" => Delta {
+          "id151" => Delta {
             "deleted": {
               "angle": 0,
               "x": 15,
@@ -4533,7 +4533,7 @@ exports[`history > multiplayer undo/redo > conflicts in bound text elements and 
   "backgroundColor": "transparent",
   "boundElements": [
     {
-      "id": "id146",
+      "id": "id149",
       "type": "text",
     },
   ],
@@ -4542,7 +4542,7 @@ exports[`history > multiplayer undo/redo > conflicts in bound text elements and 
   "frameId": null,
   "groupIds": [],
   "height": 100,
-  "id": "id145",
+  "id": "id148",
   "index": "a0",
   "isDeleted": false,
   "link": null,
@@ -4569,7 +4569,7 @@ exports[`history > multiplayer undo/redo > conflicts in bound text elements and 
   "angle": 90,
   "backgroundColor": "transparent",
   "boundElements": null,
-  "containerId": "id145",
+  "containerId": "id148",
   "customData": undefined,
   "fillStyle": "solid",
   "fontFamily": 1,
@@ -4577,7 +4577,7 @@ exports[`history > multiplayer undo/redo > conflicts in bound text elements and 
   "frameId": null,
   "groupIds": [],
   "height": 25,
-  "id": "id146",
+  "id": "id149",
   "index": "a1",
   "isDeleted": false,
   "lineHeight": 1.25,
@@ -4625,7 +4625,7 @@ History {
         "added": Map {},
         "removed": Map {},
         "updated": Map {
-          "id145" => Delta {
+          "id148" => Delta {
             "deleted": {
               "angle": 90,
               "x": 200,
@@ -4759,7 +4759,7 @@ exports[`history > multiplayer undo/redo > conflicts in bound text elements and 
   "frameId": null,
   "groupIds": [],
   "height": 100,
-  "id": "id141",
+  "id": "id144",
   "index": "a0",
   "isDeleted": false,
   "link": null,
@@ -4786,7 +4786,7 @@ exports[`history > multiplayer undo/redo > conflicts in bound text elements and 
   "angle": 0,
   "backgroundColor": "transparent",
   "boundElements": null,
-  "containerId": "id141",
+  "containerId": "id144",
   "customData": undefined,
   "fillStyle": "solid",
   "fontFamily": 1,
@@ -4794,7 +4794,7 @@ exports[`history > multiplayer undo/redo > conflicts in bound text elements and 
   "frameId": null,
   "groupIds": [],
   "height": 100,
-  "id": "id142",
+  "id": "id145",
   "index": "a1",
   "isDeleted": true,
   "lineHeight": 1.25,
@@ -4841,7 +4841,7 @@ History {
       "elementsChange": ElementsChange {
         "added": Map {},
         "removed": Map {
-          "id141" => Delta {
+          "id144" => Delta {
             "deleted": {
               "boundElements": [],
               "isDeleted": false,
@@ -4849,7 +4849,7 @@ History {
             "inserted": {
               "boundElements": [
                 {
-                  "id": "id142",
+                  "id": "id145",
                   "type": "text",
                 },
               ],
@@ -4975,7 +4975,7 @@ exports[`history > multiplayer undo/redo > conflicts in bound text elements and 
   "backgroundColor": "transparent",
   "boundElements": [
     {
-      "id": "id144",
+      "id": "id147",
       "type": "text",
     },
   ],
@@ -4984,7 +4984,7 @@ exports[`history > multiplayer undo/redo > conflicts in bound text elements and 
   "frameId": null,
   "groupIds": [],
   "height": 100,
-  "id": "id143",
+  "id": "id146",
   "index": "Zz",
   "isDeleted": true,
   "link": null,
@@ -5019,7 +5019,7 @@ exports[`history > multiplayer undo/redo > conflicts in bound text elements and 
   "frameId": null,
   "groupIds": [],
   "height": 100,
-  "id": "id144",
+  "id": "id147",
   "index": "a0",
   "isDeleted": false,
   "lineHeight": 1.25,
@@ -5066,13 +5066,13 @@ History {
       "elementsChange": ElementsChange {
         "added": Map {},
         "removed": Map {
-          "id144" => Delta {
+          "id147" => Delta {
             "deleted": {
               "containerId": null,
               "isDeleted": false,
             },
             "inserted": {
-              "containerId": "id143",
+              "containerId": "id146",
               "isDeleted": true,
             },
           },
@@ -5199,7 +5199,7 @@ exports[`history > multiplayer undo/redo > conflicts in frames and their childre
   "frameId": null,
   "groupIds": [],
   "height": 100,
-  "id": "id170",
+  "id": "id173",
   "index": "Zz",
   "isDeleted": false,
   "link": null,
@@ -5231,7 +5231,7 @@ exports[`history > multiplayer undo/redo > conflicts in frames and their childre
   "frameId": null,
   "groupIds": [],
   "height": 500,
-  "id": "id169",
+  "id": "id172",
   "index": "a0",
   "isDeleted": true,
   "link": null,
@@ -5274,7 +5274,7 @@ History {
       "elementsChange": ElementsChange {
         "added": Map {},
         "removed": Map {
-          "id170" => Delta {
+          "id173" => Delta {
             "deleted": {
               "angle": 0,
               "backgroundColor": "transparent",
@@ -5320,9 +5320,9 @@ History {
         "added": Map {},
         "removed": Map {},
         "updated": Map {
-          "id170" => Delta {
+          "id173" => Delta {
             "deleted": {
-              "frameId": "id169",
+              "frameId": "id172",
             },
             "inserted": {
               "frameId": null,
@@ -5410,7 +5410,7 @@ exports[`history > multiplayer undo/redo > should iterate through the history wh
   "penMode": false,
   "pendingImageElementId": null,
   "previousSelectedElementIds": {
-    "id100": true,
+    "id103": true,
   },
   "resizingElement": null,
   "scrollX": 0,
@@ -5451,7 +5451,7 @@ exports[`history > multiplayer undo/redo > should iterate through the history wh
     "A",
   ],
   "height": 100,
-  "id": "id99",
+  "id": "id102",
   "index": "a0",
   "isDeleted": false,
   "link": null,
@@ -5485,7 +5485,7 @@ exports[`history > multiplayer undo/redo > should iterate through the history wh
     "A",
   ],
   "height": 100,
-  "id": "id100",
+  "id": "id103",
   "index": "a1",
   "isDeleted": true,
   "link": null,
@@ -5522,8 +5522,8 @@ History {
         "delta": Delta {
           "deleted": {
             "selectedElementIds": {
-              "id100": true,
-              "id99": true,
+              "id102": true,
+              "id103": true,
             },
             "selectedGroupIds": {
               "A": true,
@@ -5539,7 +5539,7 @@ History {
         "added": Map {},
         "removed": Map {},
         "updated": Map {
-          "id99" => Delta {
+          "id102" => Delta {
             "deleted": {
               "angle": 0,
               "backgroundColor": "transparent",
@@ -5572,7 +5572,7 @@ History {
               "isDeleted": true,
             },
           },
-          "id100" => Delta {
+          "id103" => Delta {
             "deleted": {
               "angle": 0,
               "backgroundColor": "transparent",
@@ -5619,7 +5619,7 @@ History {
           "inserted": {
             "editingGroupId": null,
             "selectedElementIds": {
-              "id99": true,
+              "id102": true,
             },
             "selectedGroupIds": {
               "A": true,
@@ -5643,7 +5643,7 @@ History {
           "inserted": {
             "editingGroupId": "A",
             "selectedElementIds": {
-              "id100": true,
+              "id103": true,
             },
           },
         },
@@ -5733,7 +5733,7 @@ exports[`history > multiplayer undo/redo > should iterate through the history wh
   "penMode": false,
   "pendingImageElementId": null,
   "previousSelectedElementIds": {
-    "id87": true,
+    "id90": true,
   },
   "resizingElement": null,
   "scrollX": 0,
@@ -5772,7 +5772,7 @@ exports[`history > multiplayer undo/redo > should iterate through the history wh
   "frameId": null,
   "groupIds": [],
   "height": 10,
-  "id": "id85",
+  "id": "id88",
   "index": "a0",
   "isDeleted": false,
   "link": null,
@@ -5804,7 +5804,7 @@ exports[`history > multiplayer undo/redo > should iterate through the history wh
   "frameId": null,
   "groupIds": [],
   "height": 10,
-  "id": "id86",
+  "id": "id89",
   "index": "a1",
   "isDeleted": true,
   "link": null,
@@ -5836,7 +5836,7 @@ exports[`history > multiplayer undo/redo > should iterate through the history wh
   "frameId": null,
   "groupIds": [],
   "height": 10,
-  "id": "id87",
+  "id": "id90",
   "index": "a2",
   "isDeleted": true,
   "link": null,
@@ -5873,7 +5873,7 @@ History {
         "delta": Delta {
           "deleted": {
             "selectedElementIds": {
-              "id85": true,
+              "id88": true,
             },
           },
           "inserted": {
@@ -5884,7 +5884,7 @@ History {
       "elementsChange": ElementsChange {
         "added": Map {},
         "removed": Map {
-          "id85" => Delta {
+          "id88" => Delta {
             "deleted": {
               "angle": 0,
               "backgroundColor": "transparent",
@@ -5924,12 +5924,12 @@ History {
         "delta": Delta {
           "deleted": {
             "selectedElementIds": {
-              "id86": true,
+              "id89": true,
             },
           },
           "inserted": {
             "selectedElementIds": {
-              "id85": true,
+              "id88": true,
             },
           },
         },
@@ -5938,7 +5938,7 @@ History {
         "added": Map {},
         "removed": Map {},
         "updated": Map {
-          "id86" => Delta {
+          "id89" => Delta {
             "deleted": {
               "angle": 0,
               "backgroundColor": "#ffc9c9",
@@ -5983,7 +5983,7 @@ History {
         "added": Map {},
         "removed": Map {},
         "updated": Map {
-          "id86" => Delta {
+          "id89" => Delta {
             "deleted": {
               "backgroundColor": "#ffc9c9",
             },
@@ -5999,12 +5999,12 @@ History {
         "delta": Delta {
           "deleted": {
             "selectedElementIds": {
-              "id87": true,
+              "id90": true,
             },
           },
           "inserted": {
             "selectedElementIds": {
-              "id86": true,
+              "id89": true,
             },
           },
         },
@@ -6013,7 +6013,7 @@ History {
         "added": Map {},
         "removed": Map {},
         "updated": Map {
-          "id87" => Delta {
+          "id90" => Delta {
             "deleted": {
               "angle": 0,
               "backgroundColor": "#ffc9c9",
@@ -6058,7 +6058,7 @@ History {
         "added": Map {},
         "removed": Map {},
         "updated": Map {
-          "id87" => Delta {
+          "id90" => Delta {
             "deleted": {
               "x": 50,
               "y": 50,
@@ -6150,14 +6150,14 @@ exports[`history > multiplayer undo/redo > should iterate through the history wh
   "penMode": false,
   "pendingImageElementId": null,
   "previousSelectedElementIds": {
-    "id90": true,
+    "id93": true,
   },
   "resizingElement": null,
   "scrollX": 0,
   "scrollY": 0,
   "selectedElementIds": {
-    "id90": true,
-    "id91": true,
+    "id93": true,
+    "id94": true,
   },
   "selectedElementsAreBeingDragged": false,
   "selectedGroupIds": {},
@@ -6192,7 +6192,7 @@ exports[`history > multiplayer undo/redo > should iterate through the history wh
   "frameId": null,
   "groupIds": [],
   "height": 100,
-  "id": "id89",
+  "id": "id92",
   "index": "a0",
   "isDeleted": false,
   "link": null,
@@ -6224,7 +6224,7 @@ exports[`history > multiplayer undo/redo > should iterate through the history wh
   "frameId": null,
   "groupIds": [],
   "height": 100,
-  "id": "id90",
+  "id": "id93",
   "index": "a1",
   "isDeleted": false,
   "link": null,
@@ -6256,7 +6256,7 @@ exports[`history > multiplayer undo/redo > should iterate through the history wh
   "frameId": null,
   "groupIds": [],
   "height": 100,
-  "id": "id91",
+  "id": "id94",
   "index": "a2",
   "isDeleted": false,
   "link": null,
@@ -6293,7 +6293,7 @@ History {
         "delta": Delta {
           "deleted": {
             "selectedElementIds": {
-              "id89": true,
+              "id92": true,
             },
           },
           "inserted": {
@@ -6304,7 +6304,7 @@ History {
       "elementsChange": ElementsChange {
         "added": Map {},
         "removed": Map {
-          "id89" => Delta {
+          "id92" => Delta {
             "deleted": {
               "angle": 0,
               "backgroundColor": "transparent",
@@ -6335,7 +6335,7 @@ History {
               "isDeleted": true,
             },
           },
-          "id90" => Delta {
+          "id93" => Delta {
             "deleted": {
               "angle": 0,
               "backgroundColor": "transparent",
@@ -6366,7 +6366,7 @@ History {
               "isDeleted": true,
             },
           },
-          "id91" => Delta {
+          "id94" => Delta {
             "deleted": {
               "angle": 0,
               "backgroundColor": "transparent",
@@ -6406,12 +6406,12 @@ History {
         "delta": Delta {
           "deleted": {
             "selectedElementIds": {
-              "id90": true,
+              "id93": true,
             },
           },
           "inserted": {
             "selectedElementIds": {
-              "id89": true,
+              "id92": true,
             },
           },
         },
@@ -6427,7 +6427,7 @@ History {
         "delta": Delta {
           "deleted": {
             "selectedElementIds": {
-              "id91": true,
+              "id94": true,
             },
           },
           "inserted": {
@@ -6527,10 +6527,10 @@ exports[`history > multiplayer undo/redo > should iterate through the history wh
   "scrollX": 0,
   "scrollY": 0,
   "selectedElementIds": {
-    "id95": true,
-    "id96": true,
-    "id97": true,
+    "id100": true,
+    "id101": true,
     "id98": true,
+    "id99": true,
   },
   "selectedElementsAreBeingDragged": false,
   "selectedGroupIds": {
@@ -6570,7 +6570,7 @@ exports[`history > multiplayer undo/redo > should iterate through the history wh
     "A",
   ],
   "height": 100,
-  "id": "id95",
+  "id": "id98",
   "index": "a0",
   "isDeleted": false,
   "link": null,
@@ -6604,7 +6604,7 @@ exports[`history > multiplayer undo/redo > should iterate through the history wh
     "A",
   ],
   "height": 100,
-  "id": "id96",
+  "id": "id99",
   "index": "a1",
   "isDeleted": false,
   "link": null,
@@ -6638,7 +6638,7 @@ exports[`history > multiplayer undo/redo > should iterate through the history wh
     "B",
   ],
   "height": 100,
-  "id": "id97",
+  "id": "id100",
   "index": "a2",
   "isDeleted": false,
   "link": null,
@@ -6672,7 +6672,7 @@ exports[`history > multiplayer undo/redo > should iterate through the history wh
     "B",
   ],
   "height": 100,
-  "id": "id98",
+  "id": "id101",
   "index": "a3",
   "isDeleted": false,
   "link": null,
@@ -6709,8 +6709,8 @@ History {
         "delta": Delta {
           "deleted": {
             "selectedElementIds": {
-              "id95": true,
-              "id96": true,
+              "id98": true,
+              "id99": true,
             },
             "selectedGroupIds": {
               "A": true,
@@ -6733,8 +6733,8 @@ History {
         "delta": Delta {
           "deleted": {
             "selectedElementIds": {
-              "id97": true,
-              "id98": true,
+              "id100": true,
+              "id101": true,
             },
             "selectedGroupIds": {
               "B": true,
@@ -6870,7 +6870,7 @@ exports[`history > multiplayer undo/redo > should iterate through the history wh
   "frameId": null,
   "groupIds": [],
   "height": 10,
-  "id": "id103",
+  "id": "id106",
   "index": "a0",
   "isDeleted": true,
   "lastCommittedPoint": [
@@ -6923,7 +6923,7 @@ History {
         "delta": Delta {
           "deleted": {
             "selectedElementIds": {
-              "id103": true,
+              "id106": true,
             },
           },
           "inserted": {
@@ -6935,7 +6935,7 @@ History {
         "added": Map {},
         "removed": Map {},
         "updated": Map {
-          "id103" => Delta {
+          "id106" => Delta {
             "deleted": {
               "angle": 0,
               "backgroundColor": "transparent",
@@ -6991,7 +6991,7 @@ History {
       "appStateChange": AppStateChange {
         "delta": Delta {
           "deleted": {
-            "selectedLinearElementId": "id103",
+            "selectedLinearElementId": "id106",
           },
           "inserted": {
             "selectedLinearElementId": null,
@@ -7008,7 +7008,7 @@ History {
       "appStateChange": AppStateChange {
         "delta": Delta {
           "deleted": {
-            "editingLinearElementId": "id103",
+            "editingLinearElementId": "id106",
           },
           "inserted": {
             "editingLinearElementId": null,
@@ -7029,8 +7029,8 @@ History {
             "selectedLinearElementId": null,
           },
           "inserted": {
-            "editingLinearElementId": "id103",
-            "selectedLinearElementId": "id103",
+            "editingLinearElementId": "id106",
+            "selectedLinearElementId": "id106",
           },
         },
       },
@@ -7156,7 +7156,7 @@ exports[`history > multiplayer undo/redo > should iterate through the history wh
   "frameId": null,
   "groupIds": [],
   "height": 10,
-  "id": "id84",
+  "id": "id87",
   "index": "a0",
   "isDeleted": true,
   "link": null,
@@ -7193,7 +7193,7 @@ History {
         "delta": Delta {
           "deleted": {
             "selectedElementIds": {
-              "id84": true,
+              "id87": true,
             },
           },
           "inserted": {
@@ -7205,7 +7205,7 @@ History {
         "added": Map {},
         "removed": Map {},
         "updated": Map {
-          "id84" => Delta {
+          "id87" => Delta {
             "deleted": {
               "angle": 0,
               "backgroundColor": "#ffec99",
@@ -7250,7 +7250,7 @@ History {
         "added": Map {},
         "removed": Map {},
         "updated": Map {
-          "id84" => Delta {
+          "id87" => Delta {
             "deleted": {
               "backgroundColor": "#ffec99",
             },
@@ -7377,7 +7377,7 @@ exports[`history > multiplayer undo/redo > should iterate through the history wh
   "frameId": null,
   "groupIds": [],
   "height": 100,
-  "id": "id109",
+  "id": "id112",
   "index": "a1",
   "isDeleted": true,
   "link": null,
@@ -7409,7 +7409,7 @@ exports[`history > multiplayer undo/redo > should iterate through the history wh
   "frameId": null,
   "groupIds": [],
   "height": 100,
-  "id": "id110",
+  "id": "id113",
   "index": "a3V",
   "isDeleted": true,
   "link": null,
@@ -7441,7 +7441,7 @@ exports[`history > multiplayer undo/redo > should iterate through the history wh
   "frameId": null,
   "groupIds": [],
   "height": 100,
-  "id": "id108",
+  "id": "id111",
   "index": "a4",
   "isDeleted": true,
   "link": null,
@@ -7483,7 +7483,7 @@ History {
         "added": Map {},
         "removed": Map {},
         "updated": Map {
-          "id109" => Delta {
+          "id112" => Delta {
             "deleted": {
               "index": "a1",
             },
@@ -7502,14 +7502,14 @@ History {
           },
           "inserted": {
             "selectedElementIds": {
-              "id109": true,
+              "id112": true,
             },
           },
         },
       },
       "elementsChange": ElementsChange {
         "added": Map {
-          "id108" => Delta {
+          "id111" => Delta {
             "deleted": {
               "isDeleted": true,
             },
@@ -7540,7 +7540,7 @@ History {
               "y": 10,
             },
           },
-          "id109" => Delta {
+          "id112" => Delta {
             "deleted": {
               "isDeleted": true,
             },
@@ -7571,7 +7571,7 @@ History {
               "y": 20,
             },
           },
-          "id110" => Delta {
+          "id113" => Delta {
             "deleted": {
               "isDeleted": true,
             },
@@ -7724,7 +7724,7 @@ exports[`history > multiplayer undo/redo > should iterate through the history wh
   "frameId": null,
   "groupIds": [],
   "height": 100,
-  "id": "id104",
+  "id": "id107",
   "index": "Zx",
   "isDeleted": true,
   "link": null,
@@ -7756,7 +7756,7 @@ exports[`history > multiplayer undo/redo > should iterate through the history wh
   "frameId": null,
   "groupIds": [],
   "height": 100,
-  "id": "id106",
+  "id": "id109",
   "index": "Zy",
   "isDeleted": true,
   "link": null,
@@ -7788,7 +7788,7 @@ exports[`history > multiplayer undo/redo > should iterate through the history wh
   "frameId": null,
   "groupIds": [],
   "height": 100,
-  "id": "id105",
+  "id": "id108",
   "index": "a1",
   "isDeleted": true,
   "link": null,
@@ -7830,7 +7830,7 @@ History {
         "added": Map {},
         "removed": Map {},
         "updated": Map {
-          "id105" => Delta {
+          "id108" => Delta {
             "deleted": {
               "index": "a1",
             },
@@ -7849,14 +7849,14 @@ History {
           },
           "inserted": {
             "selectedElementIds": {
-              "id105": true,
+              "id108": true,
             },
           },
         },
       },
       "elementsChange": ElementsChange {
         "added": Map {
-          "id104" => Delta {
+          "id107" => Delta {
             "deleted": {
               "isDeleted": true,
             },
@@ -7887,7 +7887,7 @@ History {
               "y": 10,
             },
           },
-          "id105" => Delta {
+          "id108" => Delta {
             "deleted": {
               "isDeleted": true,
             },
@@ -7918,7 +7918,7 @@ History {
               "y": 20,
             },
           },
-          "id106" => Delta {
+          "id109" => Delta {
             "deleted": {
               "isDeleted": true,
             },
@@ -8034,15 +8034,15 @@ exports[`history > multiplayer undo/redo > should not let remote changes to inte
   "penMode": false,
   "pendingImageElementId": null,
   "previousSelectedElementIds": {
-    "id117": true,
-    "id118": true,
+    "id120": true,
+    "id121": true,
   },
   "resizingElement": null,
   "scrollX": 0,
   "scrollY": 0,
   "selectedElementIds": {
-    "id117": true,
-    "id118": true,
+    "id120": true,
+    "id121": true,
   },
   "selectedElementsAreBeingDragged": false,
   "selectedGroupIds": {},
@@ -8077,7 +8077,7 @@ exports[`history > multiplayer undo/redo > should not let remote changes to inte
   "frameId": null,
   "groupIds": [],
   "height": 10,
-  "id": "id117",
+  "id": "id120",
   "index": "a0",
   "isDeleted": false,
   "link": null,
@@ -8109,7 +8109,7 @@ exports[`history > multiplayer undo/redo > should not let remote changes to inte
   "frameId": null,
   "groupIds": [],
   "height": 10,
-  "id": "id118",
+  "id": "id121",
   "index": "a1",
   "isDeleted": false,
   "link": null,
@@ -8141,7 +8141,7 @@ exports[`history > multiplayer undo/redo > should not let remote changes to inte
   "frameId": null,
   "groupIds": [],
   "height": 100,
-  "id": "id122",
+  "id": "id125",
   "index": "a2",
   "isDeleted": false,
   "link": null,
@@ -8178,7 +8178,7 @@ History {
         "delta": Delta {
           "deleted": {
             "selectedElementIds": {
-              "id117": true,
+              "id120": true,
             },
           },
           "inserted": {
@@ -8189,7 +8189,7 @@ History {
       "elementsChange": ElementsChange {
         "added": Map {},
         "removed": Map {
-          "id117" => Delta {
+          "id120" => Delta {
             "deleted": {
               "angle": 0,
               "backgroundColor": "transparent",
@@ -8229,12 +8229,12 @@ History {
         "delta": Delta {
           "deleted": {
             "selectedElementIds": {
-              "id118": true,
+              "id121": true,
             },
           },
           "inserted": {
             "selectedElementIds": {
-              "id117": true,
+              "id120": true,
             },
           },
         },
@@ -8242,7 +8242,7 @@ History {
       "elementsChange": ElementsChange {
         "added": Map {},
         "removed": Map {
-          "id118" => Delta {
+          "id121" => Delta {
             "deleted": {
               "angle": 0,
               "backgroundColor": "transparent",
@@ -8282,12 +8282,12 @@ History {
         "delta": Delta {
           "deleted": {
             "selectedElementIds": {
-              "id117": true,
+              "id120": true,
             },
           },
           "inserted": {
             "selectedElementIds": {
-              "id118": true,
+              "id121": true,
             },
           },
         },
@@ -8303,7 +8303,7 @@ History {
         "delta": Delta {
           "deleted": {
             "selectedElementIds": {
-              "id118": true,
+              "id121": true,
             },
           },
           "inserted": {
@@ -8328,7 +8328,7 @@ History {
         "added": Map {},
         "removed": Map {},
         "updated": Map {
-          "id117" => Delta {
+          "id120" => Delta {
             "deleted": {
               "x": 90,
               "y": 90,
@@ -8338,7 +8338,7 @@ History {
               "y": 10,
             },
           },
-          "id118" => Delta {
+          "id121" => Delta {
             "deleted": {
               "x": 110,
               "y": 110,
@@ -8467,7 +8467,7 @@ exports[`history > multiplayer undo/redo > should not let remote changes to inte
   "frameId": null,
   "groupIds": [],
   "height": 50,
-  "id": "id112",
+  "id": "id115",
   "index": "a0",
   "isDeleted": false,
   "lastCommittedPoint": [
@@ -8526,7 +8526,7 @@ exports[`history > multiplayer undo/redo > should not let remote changes to inte
   "frameId": null,
   "groupIds": [],
   "height": 100,
-  "id": "id113",
+  "id": "id116",
   "index": "a1",
   "isDeleted": false,
   "link": null,
@@ -8568,7 +8568,7 @@ History {
       "elementsChange": ElementsChange {
         "added": Map {},
         "removed": Map {
-          "id112" => Delta {
+          "id115" => Delta {
             "deleted": {
               "angle": 0,
               "backgroundColor": "transparent",
@@ -8713,7 +8713,7 @@ exports[`history > multiplayer undo/redo > should not let remote changes to inte
   "scrollX": 0,
   "scrollY": 0,
   "selectedElementIds": {
-    "id114": true,
+    "id117": true,
   },
   "selectedElementsAreBeingDragged": false,
   "selectedGroupIds": {},
@@ -8748,7 +8748,7 @@ exports[`history > multiplayer undo/redo > should not let remote changes to inte
   "frameId": null,
   "groupIds": [],
   "height": 90,
-  "id": "id114",
+  "id": "id117",
   "index": "a0",
   "isDeleted": false,
   "link": null,
@@ -8780,7 +8780,7 @@ exports[`history > multiplayer undo/redo > should not let remote changes to inte
   "frameId": null,
   "groupIds": [],
   "height": 100,
-  "id": "id116",
+  "id": "id119",
   "index": "a1",
   "isDeleted": false,
   "link": null,
@@ -8817,7 +8817,7 @@ History {
         "delta": Delta {
           "deleted": {
             "selectedElementIds": {
-              "id114": true,
+              "id117": true,
             },
           },
           "inserted": {
@@ -8828,7 +8828,7 @@ History {
       "elementsChange": ElementsChange {
         "added": Map {},
         "removed": Map {
-          "id114" => Delta {
+          "id117" => Delta {
             "deleted": {
               "angle": 0,
               "backgroundColor": "transparent",
@@ -8874,7 +8874,7 @@ History {
         "added": Map {},
         "removed": Map {},
         "updated": Map {
-          "id114" => Delta {
+          "id117" => Delta {
             "deleted": {
               "height": 90,
               "width": 90,
@@ -8970,7 +8970,7 @@ exports[`history > multiplayer undo/redo > should not override remote changes on
   "scrollX": 0,
   "scrollY": 0,
   "selectedElementIds": {
-    "id74": true,
+    "id77": true,
   },
   "selectedElementsAreBeingDragged": false,
   "selectedGroupIds": {},
@@ -9005,7 +9005,7 @@ exports[`history > multiplayer undo/redo > should not override remote changes on
   "frameId": null,
   "groupIds": [],
   "height": 10,
-  "id": "id74",
+  "id": "id77",
   "index": "a0",
   "isDeleted": false,
   "link": null,
@@ -9037,7 +9037,7 @@ exports[`history > multiplayer undo/redo > should not override remote changes on
   "frameId": null,
   "groupIds": [],
   "height": 100,
-  "id": "id75",
+  "id": "id78",
   "index": "a1",
   "isDeleted": false,
   "link": null,
@@ -9079,7 +9079,7 @@ History {
         "added": Map {},
         "removed": Map {},
         "updated": Map {
-          "id74" => Delta {
+          "id77" => Delta {
             "deleted": {
               "backgroundColor": "transparent",
             },
@@ -9097,7 +9097,7 @@ History {
         "delta": Delta {
           "deleted": {
             "selectedElementIds": {
-              "id74": true,
+              "id77": true,
             },
           },
           "inserted": {
@@ -9108,7 +9108,7 @@ History {
       "elementsChange": ElementsChange {
         "added": Map {},
         "removed": Map {
-          "id74" => Delta {
+          "id77" => Delta {
             "deleted": {
               "angle": 0,
               "backgroundColor": "transparent",
@@ -9226,7 +9226,7 @@ exports[`history > multiplayer undo/redo > should not override remote changes on
   "scrollX": 0,
   "scrollY": 0,
   "selectedElementIds": {
-    "id76": true,
+    "id79": true,
   },
   "selectedElementsAreBeingDragged": false,
   "selectedGroupIds": {},
@@ -9261,7 +9261,7 @@ exports[`history > multiplayer undo/redo > should not override remote changes on
   "frameId": null,
   "groupIds": [],
   "height": 10,
-  "id": "id76",
+  "id": "id79",
   "index": "a0",
   "isDeleted": false,
   "link": null,
@@ -9298,7 +9298,7 @@ History {
         "delta": Delta {
           "deleted": {
             "selectedElementIds": {
-              "id76": true,
+              "id79": true,
             },
           },
           "inserted": {
@@ -9309,7 +9309,7 @@ History {
       "elementsChange": ElementsChange {
         "added": Map {},
         "removed": Map {
-          "id76" => Delta {
+          "id79" => Delta {
             "deleted": {
               "angle": 0,
               "backgroundColor": "transparent",
@@ -9355,7 +9355,7 @@ History {
         "added": Map {},
         "removed": Map {},
         "updated": Map {
-          "id76" => Delta {
+          "id79" => Delta {
             "deleted": {
               "backgroundColor": "#ffc9c9",
             },
@@ -9488,7 +9488,7 @@ exports[`history > multiplayer undo/redo > should override remotely added groups
     "B",
   ],
   "height": 100,
-  "id": "id78",
+  "id": "id81",
   "index": "a0",
   "isDeleted": false,
   "link": null,
@@ -9523,7 +9523,7 @@ exports[`history > multiplayer undo/redo > should override remotely added groups
     "B",
   ],
   "height": 100,
-  "id": "id79",
+  "id": "id82",
   "index": "a1",
   "isDeleted": false,
   "link": null,
@@ -9557,7 +9557,7 @@ exports[`history > multiplayer undo/redo > should override remotely added groups
     "B",
   ],
   "height": 100,
-  "id": "id80",
+  "id": "id83",
   "index": "a2",
   "isDeleted": false,
   "link": null,
@@ -9591,7 +9591,7 @@ exports[`history > multiplayer undo/redo > should override remotely added groups
     "B",
   ],
   "height": 100,
-  "id": "id81",
+  "id": "id84",
   "index": "a3",
   "isDeleted": false,
   "link": null,
@@ -9634,7 +9634,7 @@ History {
         "added": Map {},
         "removed": Map {},
         "updated": Map {
-          "id78" => Delta {
+          "id81" => Delta {
             "deleted": {
               "groupIds": [
                 "A",
@@ -9645,7 +9645,7 @@ History {
               "groupIds": [],
             },
           },
-          "id79" => Delta {
+          "id82" => Delta {
             "deleted": {
               "groupIds": [
                 "A",
@@ -9742,7 +9742,7 @@ exports[`history > multiplayer undo/redo > should override remotely added points
   "scrollX": 0,
   "scrollY": 0,
   "selectedElementIds": {
-    "id82": true,
+    "id85": true,
   },
   "selectedElementsAreBeingDragged": false,
   "selectedGroupIds": {},
@@ -9779,7 +9779,7 @@ exports[`history > multiplayer undo/redo > should override remotely added points
   "frameId": null,
   "groupIds": [],
   "height": 20,
-  "id": "id82",
+  "id": "id85",
   "index": "a0",
   "isDeleted": false,
   "lastCommittedPoint": [
@@ -9844,7 +9844,7 @@ History {
         "delta": Delta {
           "deleted": {
             "selectedElementIds": {
-              "id82": true,
+              "id85": true,
             },
           },
           "inserted": {
@@ -9855,7 +9855,7 @@ History {
       "elementsChange": ElementsChange {
         "added": Map {},
         "removed": Map {
-          "id82" => Delta {
+          "id85" => Delta {
             "deleted": {
               "angle": 0,
               "backgroundColor": "transparent",
@@ -9919,7 +9919,7 @@ History {
         "added": Map {},
         "removed": Map {},
         "updated": Map {
-          "id82" => Delta {
+          "id85" => Delta {
             "deleted": {
               "height": 30,
               "lastCommittedPoint": [
@@ -9976,7 +9976,7 @@ History {
       "appStateChange": AppStateChange {
         "delta": Delta {
           "deleted": {
-            "selectedLinearElementId": "id82",
+            "selectedLinearElementId": "id85",
           },
           "inserted": {
             "selectedLinearElementId": null,
@@ -10105,7 +10105,7 @@ exports[`history > multiplayer undo/redo > should redistribute deltas when eleme
   "frameId": null,
   "groupIds": [],
   "height": 10,
-  "id": "id83",
+  "id": "id86",
   "index": "a0",
   "isDeleted": false,
   "link": null,
@@ -10142,7 +10142,7 @@ History {
         "delta": Delta {
           "deleted": {
             "selectedElementIds": {
-              "id83": true,
+              "id86": true,
             },
           },
           "inserted": {
@@ -10153,7 +10153,7 @@ History {
       "elementsChange": ElementsChange {
         "added": Map {},
         "removed": Map {
-          "id83" => Delta {
+          "id86" => Delta {
             "deleted": {
               "angle": 0,
               "backgroundColor": "#ffec99",
@@ -10196,7 +10196,7 @@ History {
           },
           "inserted": {
             "selectedElementIds": {
-              "id83": true,
+              "id86": true,
             },
           },
         },
@@ -10205,7 +10205,7 @@ History {
         "added": Map {},
         "removed": Map {},
         "updated": Map {
-          "id83" => Delta {
+          "id86" => Delta {
             "deleted": {
               "isDeleted": false,
             },
@@ -10299,7 +10299,7 @@ exports[`history > multiplayer undo/redo > should update history entries after r
   "scrollX": 0,
   "scrollY": 0,
   "selectedElementIds": {
-    "id77": true,
+    "id80": true,
   },
   "selectedElementsAreBeingDragged": false,
   "selectedGroupIds": {},
@@ -10334,7 +10334,7 @@ exports[`history > multiplayer undo/redo > should update history entries after r
   "frameId": null,
   "groupIds": [],
   "height": 10,
-  "id": "id77",
+  "id": "id80",
   "index": "a0",
   "isDeleted": false,
   "link": null,
@@ -10376,7 +10376,7 @@ History {
         "added": Map {},
         "removed": Map {},
         "updated": Map {
-          "id77" => Delta {
+          "id80" => Delta {
             "deleted": {
               "backgroundColor": "#d0bfff",
             },
@@ -10398,7 +10398,7 @@ History {
         "added": Map {},
         "removed": Map {},
         "updated": Map {
-          "id77" => Delta {
+          "id80" => Delta {
             "deleted": {
               "backgroundColor": "transparent",
             },
@@ -10416,7 +10416,7 @@ History {
         "delta": Delta {
           "deleted": {
             "selectedElementIds": {
-              "id77": true,
+              "id80": true,
             },
           },
           "inserted": {
@@ -10427,7 +10427,7 @@ History {
       "elementsChange": ElementsChange {
         "added": Map {},
         "removed": Map {
-          "id77" => Delta {
+          "id80" => Delta {
             "deleted": {
               "angle": 0,
               "backgroundColor": "transparent",
@@ -10702,6 +10702,399 @@ History {
 exports[`history > singleplayer undo/redo > should clear the redo stack on elements change > [end of test] number of elements 1`] = `2`;
 
 exports[`history > singleplayer undo/redo > should clear the redo stack on elements change > [end of test] number of renders 1`] = `10`;
+
+exports[`history > singleplayer undo/redo > should create entry when selecting freedraw > [end of test] appState 1`] = `
+{
+  "activeEmbeddable": null,
+  "activeTool": {
+    "customType": null,
+    "lastActiveTool": null,
+    "locked": false,
+    "type": "freedraw",
+  },
+  "collaborators": Map {},
+  "contextMenu": null,
+  "currentChartType": "bar",
+  "currentItemBackgroundColor": "transparent",
+  "currentItemEndArrowhead": "arrow",
+  "currentItemFillStyle": "solid",
+  "currentItemFontFamily": 1,
+  "currentItemFontSize": 20,
+  "currentItemOpacity": 100,
+  "currentItemRoughness": 1,
+  "currentItemRoundness": "round",
+  "currentItemStartArrowhead": null,
+  "currentItemStrokeColor": "#e03131",
+  "currentItemStrokeStyle": "solid",
+  "currentItemStrokeWidth": 2,
+  "currentItemTextAlign": "left",
+  "cursorButton": "up",
+  "defaultSidebarDockedPreference": false,
+  "draggingElement": null,
+  "editingElement": null,
+  "editingFrame": null,
+  "editingGroupId": null,
+  "editingLinearElement": null,
+  "elementsToHighlight": null,
+  "errorMessage": null,
+  "exportBackground": true,
+  "exportEmbedScene": false,
+  "exportScale": 1,
+  "exportWithDarkMode": false,
+  "fileHandle": null,
+  "followedBy": Set {},
+  "frameRendering": {
+    "clip": true,
+    "enabled": true,
+    "name": true,
+    "outline": true,
+  },
+  "frameToHighlight": null,
+  "gridSize": null,
+  "height": 0,
+  "isBindingEnabled": true,
+  "isLoading": false,
+  "isResizing": false,
+  "isRotating": false,
+  "lastPointerDownWith": "mouse",
+  "multiElement": null,
+  "objectsSnapModeEnabled": false,
+  "offsetLeft": 0,
+  "offsetTop": 0,
+  "openDialog": null,
+  "openMenu": null,
+  "openPopup": "elementStroke",
+  "openSidebar": null,
+  "originSnapOffset": null,
+  "pasteDialog": {
+    "data": null,
+    "shown": false,
+  },
+  "penDetected": false,
+  "penMode": false,
+  "pendingImageElementId": null,
+  "previousSelectedElementIds": {},
+  "resizingElement": null,
+  "scrollX": 0,
+  "scrollY": 0,
+  "selectedElementIds": {},
+  "selectedElementsAreBeingDragged": false,
+  "selectedGroupIds": {},
+  "selectionElement": null,
+  "shouldCacheIgnoreZoom": false,
+  "showHyperlinkPopup": false,
+  "showStats": false,
+  "showWelcomeScreen": true,
+  "snapLines": [],
+  "startBoundElement": null,
+  "suggestedBindings": [],
+  "theme": "light",
+  "toast": null,
+  "userToFollow": null,
+  "viewBackgroundColor": "#ffffff",
+  "viewModeEnabled": false,
+  "width": 0,
+  "zenModeEnabled": false,
+  "zoom": {
+    "value": 1,
+  },
+}
+`;
+
+exports[`history > singleplayer undo/redo > should create entry when selecting freedraw > [end of test] element 0 1`] = `
+{
+  "angle": 0,
+  "backgroundColor": "transparent",
+  "boundElements": null,
+  "customData": undefined,
+  "fillStyle": "solid",
+  "frameId": null,
+  "groupIds": [],
+  "height": 10,
+  "id": "id32",
+  "index": "a0",
+  "isDeleted": false,
+  "link": null,
+  "locked": false,
+  "opacity": 100,
+  "roughness": 1,
+  "roundness": {
+    "type": 3,
+  },
+  "strokeColor": "#1e1e1e",
+  "strokeStyle": "solid",
+  "strokeWidth": 2,
+  "type": "rectangle",
+  "updated": 1,
+  "version": 3,
+  "width": 10,
+  "x": 10,
+  "y": 10,
+}
+`;
+
+exports[`history > singleplayer undo/redo > should create entry when selecting freedraw > [end of test] element 1 1`] = `
+{
+  "angle": 0,
+  "backgroundColor": "transparent",
+  "boundElements": null,
+  "customData": undefined,
+  "fillStyle": "solid",
+  "frameId": null,
+  "groupIds": [],
+  "height": 10,
+  "id": "id33",
+  "index": "a1",
+  "isDeleted": true,
+  "lastCommittedPoint": [
+    50,
+    10,
+  ],
+  "link": null,
+  "locked": false,
+  "opacity": 100,
+  "points": [
+    [
+      0,
+      0,
+    ],
+    [
+      50,
+      10,
+    ],
+    [
+      50,
+      10,
+    ],
+  ],
+  "pressures": [
+    0,
+    0,
+    0,
+  ],
+  "roughness": 1,
+  "roundness": null,
+  "simulatePressure": false,
+  "strokeColor": "#1e1e1e",
+  "strokeStyle": "solid",
+  "strokeWidth": 2,
+  "type": "freedraw",
+  "updated": 1,
+  "version": 6,
+  "width": 50,
+  "x": 60,
+  "y": 0,
+}
+`;
+
+exports[`history > singleplayer undo/redo > should create entry when selecting freedraw > [end of test] element 2 1`] = `
+{
+  "angle": 0,
+  "backgroundColor": "transparent",
+  "boundElements": null,
+  "customData": undefined,
+  "fillStyle": "solid",
+  "frameId": null,
+  "groupIds": [],
+  "height": 10,
+  "id": "id34",
+  "index": "a2",
+  "isDeleted": false,
+  "lastCommittedPoint": [
+    50,
+    10,
+  ],
+  "link": null,
+  "locked": false,
+  "opacity": 100,
+  "points": [
+    [
+      0,
+      0,
+    ],
+    [
+      50,
+      10,
+    ],
+    [
+      50,
+      10,
+    ],
+  ],
+  "pressures": [
+    0,
+    0,
+    0,
+  ],
+  "roughness": 1,
+  "roundness": null,
+  "simulatePressure": false,
+  "strokeColor": "#e03131",
+  "strokeStyle": "solid",
+  "strokeWidth": 2,
+  "type": "freedraw",
+  "updated": 1,
+  "version": 5,
+  "width": 50,
+  "x": 150,
+  "y": -10,
+}
+`;
+
+exports[`history > singleplayer undo/redo > should create entry when selecting freedraw > [end of test] history 1`] = `
+History {
+  "onHistoryChangedEmitter": Emitter {
+    "subscribers": [
+      [Function],
+      [Function],
+    ],
+  },
+  "redoStack": [],
+  "undoStack": [
+    HistoryEntry {
+      "appStateChange": AppStateChange {
+        "delta": Delta {
+          "deleted": {
+            "selectedElementIds": {
+              "id32": true,
+            },
+          },
+          "inserted": {
+            "selectedElementIds": {},
+          },
+        },
+      },
+      "elementsChange": ElementsChange {
+        "added": Map {},
+        "removed": Map {
+          "id32" => Delta {
+            "deleted": {
+              "angle": 0,
+              "backgroundColor": "transparent",
+              "boundElements": null,
+              "customData": undefined,
+              "fillStyle": "solid",
+              "frameId": null,
+              "groupIds": [],
+              "height": 10,
+              "index": "a0",
+              "isDeleted": false,
+              "link": null,
+              "locked": false,
+              "opacity": 100,
+              "roughness": 1,
+              "roundness": {
+                "type": 3,
+              },
+              "strokeColor": "#1e1e1e",
+              "strokeStyle": "solid",
+              "strokeWidth": 2,
+              "type": "rectangle",
+              "width": 10,
+              "x": 10,
+              "y": 10,
+            },
+            "inserted": {
+              "isDeleted": true,
+            },
+          },
+        },
+        "updated": Map {},
+      },
+    },
+    HistoryEntry {
+      "appStateChange": AppStateChange {
+        "delta": Delta {
+          "deleted": {
+            "selectedElementIds": {},
+          },
+          "inserted": {
+            "selectedElementIds": {
+              "id32": true,
+            },
+          },
+        },
+      },
+      "elementsChange": ElementsChange {
+        "added": Map {},
+        "removed": Map {},
+        "updated": Map {},
+      },
+    },
+    HistoryEntry {
+      "appStateChange": AppStateChange {
+        "delta": Delta {
+          "deleted": {},
+          "inserted": {},
+        },
+      },
+      "elementsChange": ElementsChange {
+        "added": Map {},
+        "removed": Map {
+          "id34" => Delta {
+            "deleted": {
+              "angle": 0,
+              "backgroundColor": "transparent",
+              "boundElements": null,
+              "customData": undefined,
+              "fillStyle": "solid",
+              "frameId": null,
+              "groupIds": [],
+              "height": 10,
+              "index": "a2",
+              "isDeleted": false,
+              "lastCommittedPoint": [
+                50,
+                10,
+              ],
+              "link": null,
+              "locked": false,
+              "opacity": 100,
+              "points": [
+                [
+                  0,
+                  0,
+                ],
+                [
+                  50,
+                  10,
+                ],
+                [
+                  50,
+                  10,
+                ],
+              ],
+              "pressures": [
+                0,
+                0,
+                0,
+              ],
+              "roughness": 1,
+              "roundness": null,
+              "simulatePressure": false,
+              "strokeColor": "#e03131",
+              "strokeStyle": "solid",
+              "strokeWidth": 2,
+              "type": "freedraw",
+              "width": 50,
+              "x": 150,
+              "y": -10,
+            },
+            "inserted": {
+              "isDeleted": true,
+            },
+          },
+        },
+        "updated": Map {},
+      },
+    },
+  ],
+}
+`;
+
+exports[`history > singleplayer undo/redo > should create entry when selecting freedraw > [end of test] number of elements 1`] = `3`;
+
+exports[`history > singleplayer undo/redo > should create entry when selecting freedraw > [end of test] number of renders 1`] = `15`;
 
 exports[`history > singleplayer undo/redo > should create new history entry on scene import via drag&drop > [end of test] appState 1`] = `
 {
@@ -12932,13 +13325,13 @@ exports[`history > singleplayer undo/redo > should support bidirectional binding
   "penMode": false,
   "pendingImageElementId": null,
   "previousSelectedElementIds": {
-    "id47": true,
+    "id50": true,
   },
   "resizingElement": null,
   "scrollX": 0,
   "scrollY": 0,
   "selectedElementIds": {
-    "id52": true,
+    "id55": true,
   },
   "selectedElementsAreBeingDragged": false,
   "selectedGroupIds": {},
@@ -12969,11 +13362,11 @@ exports[`history > singleplayer undo/redo > should support bidirectional binding
   "backgroundColor": "transparent",
   "boundElements": [
     {
-      "id": "id48",
+      "id": "id51",
       "type": "text",
     },
     {
-      "id": "id52",
+      "id": "id55",
       "type": "arrow",
     },
   ],
@@ -12982,7 +13375,7 @@ exports[`history > singleplayer undo/redo > should support bidirectional binding
   "frameId": null,
   "groupIds": [],
   "height": 100,
-  "id": "id47",
+  "id": "id50",
   "index": "a0",
   "isDeleted": false,
   "link": null,
@@ -13009,7 +13402,7 @@ exports[`history > singleplayer undo/redo > should support bidirectional binding
   "angle": 0,
   "backgroundColor": "transparent",
   "boundElements": null,
-  "containerId": "id47",
+  "containerId": "id50",
   "customData": undefined,
   "fillStyle": "solid",
   "fontFamily": 1,
@@ -13017,7 +13410,7 @@ exports[`history > singleplayer undo/redo > should support bidirectional binding
   "frameId": null,
   "groupIds": [],
   "height": 25,
-  "id": "id48",
+  "id": "id51",
   "index": "a1",
   "isDeleted": false,
   "lineHeight": 1.25,
@@ -13050,7 +13443,7 @@ exports[`history > singleplayer undo/redo > should support bidirectional binding
   "backgroundColor": "transparent",
   "boundElements": [
     {
-      "id": "id52",
+      "id": "id55",
       "type": "arrow",
     },
   ],
@@ -13059,7 +13452,7 @@ exports[`history > singleplayer undo/redo > should support bidirectional binding
   "frameId": null,
   "groupIds": [],
   "height": 100,
-  "id": "id49",
+  "id": "id52",
   "index": "a2",
   "isDeleted": false,
   "link": null,
@@ -13089,7 +13482,7 @@ exports[`history > singleplayer undo/redo > should support bidirectional binding
   "customData": undefined,
   "endArrowhead": "arrow",
   "endBinding": {
-    "elementId": "id49",
+    "elementId": "id52",
     "focus": 0,
     "gap": 1,
   },
@@ -13097,7 +13490,7 @@ exports[`history > singleplayer undo/redo > should support bidirectional binding
   "frameId": null,
   "groupIds": [],
   "height": 0,
-  "id": "id52",
+  "id": "id55",
   "index": "a3",
   "isDeleted": false,
   "lastCommittedPoint": null,
@@ -13120,7 +13513,7 @@ exports[`history > singleplayer undo/redo > should support bidirectional binding
   },
   "startArrowhead": null,
   "startBinding": {
-    "elementId": "id47",
+    "elementId": "id50",
     "focus": 0,
     "gap": 1,
   },
@@ -13150,7 +13543,7 @@ History {
         "delta": Delta {
           "deleted": {
             "selectedElementIds": {
-              "id52": true,
+              "id55": true,
             },
           },
           "inserted": {
@@ -13161,7 +13554,7 @@ History {
       "elementsChange": ElementsChange {
         "added": Map {},
         "removed": Map {
-          "id52" => Delta {
+          "id55" => Delta {
             "deleted": {
               "isDeleted": false,
               "points": [
@@ -13191,11 +13584,11 @@ History {
           },
         },
         "updated": Map {
-          "id47" => Delta {
+          "id50" => Delta {
             "deleted": {
               "boundElements": [
                 {
-                  "id": "id52",
+                  "id": "id55",
                   "type": "arrow",
                 },
               ],
@@ -13204,11 +13597,11 @@ History {
               "boundElements": [],
             },
           },
-          "id49" => Delta {
+          "id52" => Delta {
             "deleted": {
               "boundElements": [
                 {
-                  "id": "id52",
+                  "id": "id55",
                   "type": "arrow",
                 },
               ],
@@ -13232,7 +13625,7 @@ History {
       "elementsChange": ElementsChange {
         "added": Map {},
         "removed": Map {
-          "id47" => Delta {
+          "id50" => Delta {
             "deleted": {
               "angle": 0,
               "backgroundColor": "transparent",
@@ -13263,7 +13656,7 @@ History {
               "isDeleted": true,
             },
           },
-          "id48" => Delta {
+          "id51" => Delta {
             "deleted": {
               "angle": 0,
               "backgroundColor": "transparent",
@@ -13302,7 +13695,7 @@ History {
               "isDeleted": true,
             },
           },
-          "id49" => Delta {
+          "id52" => Delta {
             "deleted": {
               "angle": 0,
               "backgroundColor": "transparent",
@@ -13342,7 +13735,7 @@ History {
         "delta": Delta {
           "deleted": {
             "selectedElementIds": {
-              "id47": true,
+              "id50": true,
             },
           },
           "inserted": {
@@ -13361,7 +13754,7 @@ History {
         "delta": Delta {
           "deleted": {
             "selectedElementIds": {
-              "id48": true,
+              "id51": true,
             },
           },
           "inserted": {
@@ -13383,7 +13776,7 @@ History {
           },
           "inserted": {
             "selectedElementIds": {
-              "id48": true,
+              "id51": true,
             },
           },
         },
@@ -13392,11 +13785,11 @@ History {
         "added": Map {},
         "removed": Map {},
         "updated": Map {
-          "id47" => Delta {
+          "id50" => Delta {
             "deleted": {
               "boundElements": [
                 {
-                  "id": "id48",
+                  "id": "id51",
                   "type": "text",
                 },
               ],
@@ -13405,9 +13798,9 @@ History {
               "boundElements": [],
             },
           },
-          "id48" => Delta {
+          "id51" => Delta {
             "deleted": {
-              "containerId": "id47",
+              "containerId": "id50",
               "height": 25,
               "textAlign": "center",
               "verticalAlign": "middle",
@@ -13433,13 +13826,13 @@ History {
         "delta": Delta {
           "deleted": {
             "selectedElementIds": {
-              "id52": true,
+              "id55": true,
             },
-            "selectedLinearElementId": "id52",
+            "selectedLinearElementId": "id55",
           },
           "inserted": {
             "selectedElementIds": {
-              "id47": true,
+              "id50": true,
             },
             "selectedLinearElementId": null,
           },
@@ -13448,7 +13841,7 @@ History {
       "elementsChange": ElementsChange {
         "added": Map {},
         "removed": Map {
-          "id52" => Delta {
+          "id55" => Delta {
             "deleted": {
               "angle": 0,
               "backgroundColor": "transparent",
@@ -13456,7 +13849,7 @@ History {
               "customData": undefined,
               "endArrowhead": "arrow",
               "endBinding": {
-                "elementId": "id49",
+                "elementId": "id52",
                 "focus": 0,
                 "gap": 1,
               },
@@ -13486,7 +13879,7 @@ History {
               },
               "startArrowhead": null,
               "startBinding": {
-                "elementId": "id47",
+                "elementId": "id50",
                 "focus": 0,
                 "gap": 1,
               },
@@ -13504,11 +13897,11 @@ History {
           },
         },
         "updated": Map {
-          "id47" => Delta {
+          "id50" => Delta {
             "deleted": {
               "boundElements": [
                 {
-                  "id": "id52",
+                  "id": "id55",
                   "type": "arrow",
                 },
               ],
@@ -13517,11 +13910,11 @@ History {
               "boundElements": [],
             },
           },
-          "id49" => Delta {
+          "id52" => Delta {
             "deleted": {
               "boundElements": [
                 {
-                  "id": "id52",
+                  "id": "id55",
                   "type": "arrow",
                 },
               ],
@@ -13612,13 +14005,13 @@ exports[`history > singleplayer undo/redo > should support bidirectional binding
   "penMode": false,
   "pendingImageElementId": null,
   "previousSelectedElementIds": {
-    "id41": true,
+    "id44": true,
   },
   "resizingElement": null,
   "scrollX": 0,
   "scrollY": 0,
   "selectedElementIds": {
-    "id46": true,
+    "id49": true,
   },
   "selectedElementsAreBeingDragged": false,
   "selectedGroupIds": {},
@@ -13649,11 +14042,11 @@ exports[`history > singleplayer undo/redo > should support bidirectional binding
   "backgroundColor": "transparent",
   "boundElements": [
     {
-      "id": "id42",
+      "id": "id45",
       "type": "text",
     },
     {
-      "id": "id46",
+      "id": "id49",
       "type": "arrow",
     },
   ],
@@ -13662,7 +14055,7 @@ exports[`history > singleplayer undo/redo > should support bidirectional binding
   "frameId": null,
   "groupIds": [],
   "height": 100,
-  "id": "id41",
+  "id": "id44",
   "index": "a0",
   "isDeleted": false,
   "link": null,
@@ -13689,7 +14082,7 @@ exports[`history > singleplayer undo/redo > should support bidirectional binding
   "angle": 0,
   "backgroundColor": "transparent",
   "boundElements": null,
-  "containerId": "id41",
+  "containerId": "id44",
   "customData": undefined,
   "fillStyle": "solid",
   "fontFamily": 1,
@@ -13697,7 +14090,7 @@ exports[`history > singleplayer undo/redo > should support bidirectional binding
   "frameId": null,
   "groupIds": [],
   "height": 25,
-  "id": "id42",
+  "id": "id45",
   "index": "a1",
   "isDeleted": false,
   "lineHeight": 1.25,
@@ -13730,7 +14123,7 @@ exports[`history > singleplayer undo/redo > should support bidirectional binding
   "backgroundColor": "transparent",
   "boundElements": [
     {
-      "id": "id46",
+      "id": "id49",
       "type": "arrow",
     },
   ],
@@ -13739,7 +14132,7 @@ exports[`history > singleplayer undo/redo > should support bidirectional binding
   "frameId": null,
   "groupIds": [],
   "height": 100,
-  "id": "id43",
+  "id": "id46",
   "index": "a2",
   "isDeleted": false,
   "link": null,
@@ -13769,7 +14162,7 @@ exports[`history > singleplayer undo/redo > should support bidirectional binding
   "customData": undefined,
   "endArrowhead": "arrow",
   "endBinding": {
-    "elementId": "id43",
+    "elementId": "id46",
     "focus": 0,
     "gap": 1,
   },
@@ -13777,7 +14170,7 @@ exports[`history > singleplayer undo/redo > should support bidirectional binding
   "frameId": null,
   "groupIds": [],
   "height": 0,
-  "id": "id46",
+  "id": "id49",
   "index": "a3",
   "isDeleted": false,
   "lastCommittedPoint": null,
@@ -13800,7 +14193,7 @@ exports[`history > singleplayer undo/redo > should support bidirectional binding
   },
   "startArrowhead": null,
   "startBinding": {
-    "elementId": "id41",
+    "elementId": "id44",
     "focus": 0,
     "gap": 1,
   },
@@ -13836,7 +14229,7 @@ History {
       "elementsChange": ElementsChange {
         "added": Map {},
         "removed": Map {
-          "id41" => Delta {
+          "id44" => Delta {
             "deleted": {
               "angle": 0,
               "backgroundColor": "transparent",
@@ -13867,7 +14260,7 @@ History {
               "isDeleted": true,
             },
           },
-          "id42" => Delta {
+          "id45" => Delta {
             "deleted": {
               "angle": 0,
               "backgroundColor": "transparent",
@@ -13906,7 +14299,7 @@ History {
               "isDeleted": true,
             },
           },
-          "id43" => Delta {
+          "id46" => Delta {
             "deleted": {
               "angle": 0,
               "backgroundColor": "transparent",
@@ -13946,7 +14339,7 @@ History {
         "delta": Delta {
           "deleted": {
             "selectedElementIds": {
-              "id41": true,
+              "id44": true,
             },
           },
           "inserted": {
@@ -13965,7 +14358,7 @@ History {
         "delta": Delta {
           "deleted": {
             "selectedElementIds": {
-              "id42": true,
+              "id45": true,
             },
           },
           "inserted": {
@@ -13987,7 +14380,7 @@ History {
           },
           "inserted": {
             "selectedElementIds": {
-              "id42": true,
+              "id45": true,
             },
           },
         },
@@ -13996,11 +14389,11 @@ History {
         "added": Map {},
         "removed": Map {},
         "updated": Map {
-          "id41" => Delta {
+          "id44" => Delta {
             "deleted": {
               "boundElements": [
                 {
-                  "id": "id42",
+                  "id": "id45",
                   "type": "text",
                 },
               ],
@@ -14009,9 +14402,9 @@ History {
               "boundElements": [],
             },
           },
-          "id42" => Delta {
+          "id45" => Delta {
             "deleted": {
-              "containerId": "id41",
+              "containerId": "id44",
               "height": 25,
               "textAlign": "center",
               "verticalAlign": "middle",
@@ -14037,13 +14430,13 @@ History {
         "delta": Delta {
           "deleted": {
             "selectedElementIds": {
-              "id46": true,
+              "id49": true,
             },
-            "selectedLinearElementId": "id46",
+            "selectedLinearElementId": "id49",
           },
           "inserted": {
             "selectedElementIds": {
-              "id41": true,
+              "id44": true,
             },
             "selectedLinearElementId": null,
           },
@@ -14052,7 +14445,7 @@ History {
       "elementsChange": ElementsChange {
         "added": Map {},
         "removed": Map {
-          "id46" => Delta {
+          "id49" => Delta {
             "deleted": {
               "angle": 0,
               "backgroundColor": "transparent",
@@ -14060,7 +14453,7 @@ History {
               "customData": undefined,
               "endArrowhead": "arrow",
               "endBinding": {
-                "elementId": "id43",
+                "elementId": "id46",
                 "focus": 0,
                 "gap": 1,
               },
@@ -14090,7 +14483,7 @@ History {
               },
               "startArrowhead": null,
               "startBinding": {
-                "elementId": "id41",
+                "elementId": "id44",
                 "focus": 0,
                 "gap": 1,
               },
@@ -14108,11 +14501,11 @@ History {
           },
         },
         "updated": Map {
-          "id41" => Delta {
+          "id44" => Delta {
             "deleted": {
               "boundElements": [
                 {
-                  "id": "id46",
+                  "id": "id49",
                   "type": "arrow",
                 },
               ],
@@ -14121,11 +14514,11 @@ History {
               "boundElements": [],
             },
           },
-          "id43" => Delta {
+          "id46" => Delta {
             "deleted": {
               "boundElements": [
                 {
-                  "id": "id46",
+                  "id": "id49",
                   "type": "arrow",
                 },
               ],
@@ -14216,13 +14609,13 @@ exports[`history > singleplayer undo/redo > should support bidirectional binding
   "penMode": false,
   "pendingImageElementId": null,
   "previousSelectedElementIds": {
-    "id53": true,
+    "id56": true,
   },
   "resizingElement": null,
   "scrollX": 0,
   "scrollY": 0,
   "selectedElementIds": {
-    "id58": true,
+    "id61": true,
   },
   "selectedElementsAreBeingDragged": false,
   "selectedGroupIds": {},
@@ -14253,11 +14646,11 @@ exports[`history > singleplayer undo/redo > should support bidirectional binding
   "backgroundColor": "transparent",
   "boundElements": [
     {
-      "id": "id54",
+      "id": "id57",
       "type": "text",
     },
     {
-      "id": "id58",
+      "id": "id61",
       "type": "arrow",
     },
   ],
@@ -14266,7 +14659,7 @@ exports[`history > singleplayer undo/redo > should support bidirectional binding
   "frameId": null,
   "groupIds": [],
   "height": 100,
-  "id": "id53",
+  "id": "id56",
   "index": "a0",
   "isDeleted": false,
   "link": null,
@@ -14293,7 +14686,7 @@ exports[`history > singleplayer undo/redo > should support bidirectional binding
   "angle": 0,
   "backgroundColor": "transparent",
   "boundElements": null,
-  "containerId": "id53",
+  "containerId": "id56",
   "customData": undefined,
   "fillStyle": "solid",
   "fontFamily": 1,
@@ -14301,7 +14694,7 @@ exports[`history > singleplayer undo/redo > should support bidirectional binding
   "frameId": null,
   "groupIds": [],
   "height": 25,
-  "id": "id54",
+  "id": "id57",
   "index": "a1",
   "isDeleted": false,
   "lineHeight": 1.25,
@@ -14334,7 +14727,7 @@ exports[`history > singleplayer undo/redo > should support bidirectional binding
   "backgroundColor": "transparent",
   "boundElements": [
     {
-      "id": "id58",
+      "id": "id61",
       "type": "arrow",
     },
   ],
@@ -14343,7 +14736,7 @@ exports[`history > singleplayer undo/redo > should support bidirectional binding
   "frameId": null,
   "groupIds": [],
   "height": 100,
-  "id": "id55",
+  "id": "id58",
   "index": "a2",
   "isDeleted": false,
   "link": null,
@@ -14373,7 +14766,7 @@ exports[`history > singleplayer undo/redo > should support bidirectional binding
   "customData": undefined,
   "endArrowhead": "arrow",
   "endBinding": {
-    "elementId": "id55",
+    "elementId": "id58",
     "focus": 0,
     "gap": 1,
   },
@@ -14381,7 +14774,7 @@ exports[`history > singleplayer undo/redo > should support bidirectional binding
   "frameId": null,
   "groupIds": [],
   "height": 0,
-  "id": "id58",
+  "id": "id61",
   "index": "a3",
   "isDeleted": false,
   "lastCommittedPoint": null,
@@ -14404,7 +14797,7 @@ exports[`history > singleplayer undo/redo > should support bidirectional binding
   },
   "startArrowhead": null,
   "startBinding": {
-    "elementId": "id53",
+    "elementId": "id56",
     "focus": 0,
     "gap": 1,
   },
@@ -14440,7 +14833,7 @@ History {
       "elementsChange": ElementsChange {
         "added": Map {},
         "removed": Map {
-          "id53" => Delta {
+          "id56" => Delta {
             "deleted": {
               "angle": 0,
               "backgroundColor": "transparent",
@@ -14471,7 +14864,7 @@ History {
               "isDeleted": true,
             },
           },
-          "id54" => Delta {
+          "id57" => Delta {
             "deleted": {
               "angle": 0,
               "backgroundColor": "transparent",
@@ -14510,7 +14903,7 @@ History {
               "isDeleted": true,
             },
           },
-          "id55" => Delta {
+          "id58" => Delta {
             "deleted": {
               "angle": 0,
               "backgroundColor": "transparent",
@@ -14550,7 +14943,7 @@ History {
         "delta": Delta {
           "deleted": {
             "selectedElementIds": {
-              "id53": true,
+              "id56": true,
             },
           },
           "inserted": {
@@ -14569,7 +14962,7 @@ History {
         "delta": Delta {
           "deleted": {
             "selectedElementIds": {
-              "id54": true,
+              "id57": true,
             },
           },
           "inserted": {
@@ -14591,7 +14984,7 @@ History {
           },
           "inserted": {
             "selectedElementIds": {
-              "id54": true,
+              "id57": true,
             },
           },
         },
@@ -14600,11 +14993,11 @@ History {
         "added": Map {},
         "removed": Map {},
         "updated": Map {
-          "id53" => Delta {
+          "id56" => Delta {
             "deleted": {
               "boundElements": [
                 {
-                  "id": "id54",
+                  "id": "id57",
                   "type": "text",
                 },
               ],
@@ -14613,9 +15006,9 @@ History {
               "boundElements": [],
             },
           },
-          "id54" => Delta {
+          "id57" => Delta {
             "deleted": {
-              "containerId": "id53",
+              "containerId": "id56",
               "height": 25,
               "textAlign": "center",
               "verticalAlign": "middle",
@@ -14641,13 +15034,13 @@ History {
         "delta": Delta {
           "deleted": {
             "selectedElementIds": {
-              "id58": true,
+              "id61": true,
             },
-            "selectedLinearElementId": "id58",
+            "selectedLinearElementId": "id61",
           },
           "inserted": {
             "selectedElementIds": {
-              "id53": true,
+              "id56": true,
             },
             "selectedLinearElementId": null,
           },
@@ -14656,7 +15049,7 @@ History {
       "elementsChange": ElementsChange {
         "added": Map {},
         "removed": Map {
-          "id58" => Delta {
+          "id61" => Delta {
             "deleted": {
               "angle": 0,
               "backgroundColor": "transparent",
@@ -14664,7 +15057,7 @@ History {
               "customData": undefined,
               "endArrowhead": "arrow",
               "endBinding": {
-                "elementId": "id55",
+                "elementId": "id58",
                 "focus": 0,
                 "gap": 1,
               },
@@ -14694,7 +15087,7 @@ History {
               },
               "startArrowhead": null,
               "startBinding": {
-                "elementId": "id53",
+                "elementId": "id56",
                 "focus": 0,
                 "gap": 1,
               },
@@ -14712,11 +15105,11 @@ History {
           },
         },
         "updated": Map {
-          "id53" => Delta {
+          "id56" => Delta {
             "deleted": {
               "boundElements": [
                 {
-                  "id": "id58",
+                  "id": "id61",
                   "type": "arrow",
                 },
               ],
@@ -14725,11 +15118,11 @@ History {
               "boundElements": [],
             },
           },
-          "id55" => Delta {
+          "id58" => Delta {
             "deleted": {
               "boundElements": [
                 {
-                  "id": "id58",
+                  "id": "id61",
                   "type": "arrow",
                 },
               ],
@@ -14824,7 +15217,7 @@ exports[`history > singleplayer undo/redo > should support bidirectional binding
   "scrollX": 0,
   "scrollY": 0,
   "selectedElementIds": {
-    "id59": true,
+    "id62": true,
   },
   "selectedElementsAreBeingDragged": false,
   "selectedGroupIds": {},
@@ -14855,11 +15248,11 @@ exports[`history > singleplayer undo/redo > should support bidirectional binding
   "backgroundColor": "transparent",
   "boundElements": [
     {
-      "id": "id64",
+      "id": "id67",
       "type": "arrow",
     },
     {
-      "id": "id60",
+      "id": "id63",
       "type": "text",
     },
   ],
@@ -14868,7 +15261,7 @@ exports[`history > singleplayer undo/redo > should support bidirectional binding
   "frameId": null,
   "groupIds": [],
   "height": 100,
-  "id": "id59",
+  "id": "id62",
   "index": "a0",
   "isDeleted": false,
   "link": null,
@@ -14895,7 +15288,7 @@ exports[`history > singleplayer undo/redo > should support bidirectional binding
   "angle": 0,
   "backgroundColor": "transparent",
   "boundElements": null,
-  "containerId": "id59",
+  "containerId": "id62",
   "customData": undefined,
   "fillStyle": "solid",
   "fontFamily": 1,
@@ -14903,7 +15296,7 @@ exports[`history > singleplayer undo/redo > should support bidirectional binding
   "frameId": null,
   "groupIds": [],
   "height": 25,
-  "id": "id60",
+  "id": "id63",
   "index": "a1",
   "isDeleted": false,
   "lineHeight": 1.25,
@@ -14936,7 +15329,7 @@ exports[`history > singleplayer undo/redo > should support bidirectional binding
   "backgroundColor": "transparent",
   "boundElements": [
     {
-      "id": "id64",
+      "id": "id67",
       "type": "arrow",
     },
   ],
@@ -14945,7 +15338,7 @@ exports[`history > singleplayer undo/redo > should support bidirectional binding
   "frameId": null,
   "groupIds": [],
   "height": 100,
-  "id": "id61",
+  "id": "id64",
   "index": "a2",
   "isDeleted": false,
   "link": null,
@@ -14975,7 +15368,7 @@ exports[`history > singleplayer undo/redo > should support bidirectional binding
   "customData": undefined,
   "endArrowhead": "arrow",
   "endBinding": {
-    "elementId": "id61",
+    "elementId": "id64",
     "focus": 0,
     "gap": 1,
   },
@@ -14983,7 +15376,7 @@ exports[`history > singleplayer undo/redo > should support bidirectional binding
   "frameId": null,
   "groupIds": [],
   "height": 0,
-  "id": "id64",
+  "id": "id67",
   "index": "a3",
   "isDeleted": false,
   "lastCommittedPoint": null,
@@ -15006,7 +15399,7 @@ exports[`history > singleplayer undo/redo > should support bidirectional binding
   },
   "startArrowhead": null,
   "startBinding": {
-    "elementId": "id59",
+    "elementId": "id62",
     "focus": 0,
     "gap": 1,
   },
@@ -15036,7 +15429,7 @@ History {
         "delta": Delta {
           "deleted": {
             "selectedElementIds": {
-              "id59": true,
+              "id62": true,
             },
           },
           "inserted": {
@@ -15047,7 +15440,7 @@ History {
       "elementsChange": ElementsChange {
         "added": Map {},
         "removed": Map {
-          "id59" => Delta {
+          "id62" => Delta {
             "deleted": {
               "isDeleted": false,
             },
@@ -15055,7 +15448,7 @@ History {
               "isDeleted": true,
             },
           },
-          "id60" => Delta {
+          "id63" => Delta {
             "deleted": {
               "isDeleted": false,
             },
@@ -15065,7 +15458,7 @@ History {
           },
         },
         "updated": Map {
-          "id64" => Delta {
+          "id67" => Delta {
             "deleted": {
               "points": [
                 [
@@ -15078,7 +15471,7 @@ History {
                 ],
               ],
               "startBinding": {
-                "elementId": "id59",
+                "elementId": "id62",
                 "focus": 0,
                 "gap": 1,
               },
@@ -15112,7 +15505,7 @@ History {
       "elementsChange": ElementsChange {
         "added": Map {},
         "removed": Map {
-          "id59" => Delta {
+          "id62" => Delta {
             "deleted": {
               "angle": 0,
               "backgroundColor": "transparent",
@@ -15143,7 +15536,7 @@ History {
               "isDeleted": true,
             },
           },
-          "id60" => Delta {
+          "id63" => Delta {
             "deleted": {
               "angle": 0,
               "backgroundColor": "transparent",
@@ -15182,7 +15575,7 @@ History {
               "isDeleted": true,
             },
           },
-          "id61" => Delta {
+          "id64" => Delta {
             "deleted": {
               "angle": 0,
               "backgroundColor": "transparent",
@@ -15222,7 +15615,7 @@ History {
         "delta": Delta {
           "deleted": {
             "selectedElementIds": {
-              "id59": true,
+              "id62": true,
             },
           },
           "inserted": {
@@ -15241,7 +15634,7 @@ History {
         "delta": Delta {
           "deleted": {
             "selectedElementIds": {
-              "id60": true,
+              "id63": true,
             },
           },
           "inserted": {
@@ -15263,7 +15656,7 @@ History {
           },
           "inserted": {
             "selectedElementIds": {
-              "id60": true,
+              "id63": true,
             },
           },
         },
@@ -15272,11 +15665,11 @@ History {
         "added": Map {},
         "removed": Map {},
         "updated": Map {
-          "id59" => Delta {
+          "id62" => Delta {
             "deleted": {
               "boundElements": [
                 {
-                  "id": "id60",
+                  "id": "id63",
                   "type": "text",
                 },
               ],
@@ -15285,9 +15678,9 @@ History {
               "boundElements": [],
             },
           },
-          "id60" => Delta {
+          "id63" => Delta {
             "deleted": {
-              "containerId": "id59",
+              "containerId": "id62",
               "height": 25,
               "textAlign": "center",
               "verticalAlign": "middle",
@@ -15313,13 +15706,13 @@ History {
         "delta": Delta {
           "deleted": {
             "selectedElementIds": {
-              "id64": true,
+              "id67": true,
             },
-            "selectedLinearElementId": "id64",
+            "selectedLinearElementId": "id67",
           },
           "inserted": {
             "selectedElementIds": {
-              "id59": true,
+              "id62": true,
             },
             "selectedLinearElementId": null,
           },
@@ -15328,7 +15721,7 @@ History {
       "elementsChange": ElementsChange {
         "added": Map {},
         "removed": Map {
-          "id64" => Delta {
+          "id67" => Delta {
             "deleted": {
               "angle": 0,
               "backgroundColor": "transparent",
@@ -15336,7 +15729,7 @@ History {
               "customData": undefined,
               "endArrowhead": "arrow",
               "endBinding": {
-                "elementId": "id61",
+                "elementId": "id64",
                 "focus": 0,
                 "gap": 1,
               },
@@ -15366,7 +15759,7 @@ History {
               },
               "startArrowhead": null,
               "startBinding": {
-                "elementId": "id59",
+                "elementId": "id62",
                 "focus": 0,
                 "gap": 1,
               },
@@ -15384,11 +15777,11 @@ History {
           },
         },
         "updated": Map {
-          "id59" => Delta {
+          "id62" => Delta {
             "deleted": {
               "boundElements": [
                 {
-                  "id": "id64",
+                  "id": "id67",
                   "type": "arrow",
                 },
               ],
@@ -15397,11 +15790,11 @@ History {
               "boundElements": [],
             },
           },
-          "id61" => Delta {
+          "id64" => Delta {
             "deleted": {
               "boundElements": [
                 {
-                  "id": "id64",
+                  "id": "id67",
                   "type": "arrow",
                 },
               ],
@@ -15418,15 +15811,15 @@ History {
         "delta": Delta {
           "deleted": {
             "selectedElementIds": {
-              "id59": true,
+              "id62": true,
             },
             "selectedLinearElementId": null,
           },
           "inserted": {
             "selectedElementIds": {
-              "id64": true,
+              "id67": true,
             },
-            "selectedLinearElementId": "id64",
+            "selectedLinearElementId": "id67",
           },
         },
       },
@@ -15515,14 +15908,14 @@ exports[`history > singleplayer undo/redo > should support bidirectional binding
   "penMode": false,
   "pendingImageElementId": null,
   "previousSelectedElementIds": {
-    "id66": true,
+    "id69": true,
   },
   "resizingElement": null,
   "scrollX": 0,
   "scrollY": 0,
   "selectedElementIds": {
-    "id66": true,
-    "id68": true,
+    "id69": true,
+    "id71": true,
   },
   "selectedElementsAreBeingDragged": false,
   "selectedGroupIds": {},
@@ -15553,11 +15946,11 @@ exports[`history > singleplayer undo/redo > should support bidirectional binding
   "backgroundColor": "transparent",
   "boundElements": [
     {
-      "id": "id71",
+      "id": "id74",
       "type": "arrow",
     },
     {
-      "id": "id67",
+      "id": "id70",
       "type": "text",
     },
   ],
@@ -15566,7 +15959,7 @@ exports[`history > singleplayer undo/redo > should support bidirectional binding
   "frameId": null,
   "groupIds": [],
   "height": 100,
-  "id": "id66",
+  "id": "id69",
   "index": "a0",
   "isDeleted": false,
   "link": null,
@@ -15593,7 +15986,7 @@ exports[`history > singleplayer undo/redo > should support bidirectional binding
   "angle": 0,
   "backgroundColor": "transparent",
   "boundElements": null,
-  "containerId": "id66",
+  "containerId": "id69",
   "customData": undefined,
   "fillStyle": "solid",
   "fontFamily": 1,
@@ -15601,7 +15994,7 @@ exports[`history > singleplayer undo/redo > should support bidirectional binding
   "frameId": null,
   "groupIds": [],
   "height": 25,
-  "id": "id67",
+  "id": "id70",
   "index": "a1",
   "isDeleted": false,
   "lineHeight": 1.25,
@@ -15634,7 +16027,7 @@ exports[`history > singleplayer undo/redo > should support bidirectional binding
   "backgroundColor": "transparent",
   "boundElements": [
     {
-      "id": "id71",
+      "id": "id74",
       "type": "arrow",
     },
   ],
@@ -15643,7 +16036,7 @@ exports[`history > singleplayer undo/redo > should support bidirectional binding
   "frameId": null,
   "groupIds": [],
   "height": 100,
-  "id": "id68",
+  "id": "id71",
   "index": "a2",
   "isDeleted": false,
   "link": null,
@@ -15673,7 +16066,7 @@ exports[`history > singleplayer undo/redo > should support bidirectional binding
   "customData": undefined,
   "endArrowhead": "arrow",
   "endBinding": {
-    "elementId": "id68",
+    "elementId": "id71",
     "focus": 0,
     "gap": 1,
   },
@@ -15681,7 +16074,7 @@ exports[`history > singleplayer undo/redo > should support bidirectional binding
   "frameId": null,
   "groupIds": [],
   "height": 0,
-  "id": "id71",
+  "id": "id74",
   "index": "a3",
   "isDeleted": false,
   "lastCommittedPoint": null,
@@ -15704,7 +16097,7 @@ exports[`history > singleplayer undo/redo > should support bidirectional binding
   },
   "startArrowhead": null,
   "startBinding": {
-    "elementId": "id66",
+    "elementId": "id69",
     "focus": 0,
     "gap": 1,
   },
@@ -15734,8 +16127,8 @@ History {
         "delta": Delta {
           "deleted": {
             "selectedElementIds": {
-              "id66": true,
-              "id68": true,
+              "id69": true,
+              "id71": true,
             },
           },
           "inserted": {
@@ -15746,7 +16139,7 @@ History {
       "elementsChange": ElementsChange {
         "added": Map {},
         "removed": Map {
-          "id66" => Delta {
+          "id69" => Delta {
             "deleted": {
               "isDeleted": false,
             },
@@ -15754,7 +16147,7 @@ History {
               "isDeleted": true,
             },
           },
-          "id67" => Delta {
+          "id70" => Delta {
             "deleted": {
               "isDeleted": false,
             },
@@ -15762,7 +16155,7 @@ History {
               "isDeleted": true,
             },
           },
-          "id68" => Delta {
+          "id71" => Delta {
             "deleted": {
               "isDeleted": false,
             },
@@ -15772,10 +16165,10 @@ History {
           },
         },
         "updated": Map {
-          "id71" => Delta {
+          "id74" => Delta {
             "deleted": {
               "endBinding": {
-                "elementId": "id68",
+                "elementId": "id71",
                 "focus": 0,
                 "gap": 1,
               },
@@ -15790,7 +16183,7 @@ History {
                 ],
               ],
               "startBinding": {
-                "elementId": "id66",
+                "elementId": "id69",
                 "focus": 0,
                 "gap": 1,
               },
@@ -15825,7 +16218,7 @@ History {
       "elementsChange": ElementsChange {
         "added": Map {},
         "removed": Map {
-          "id66" => Delta {
+          "id69" => Delta {
             "deleted": {
               "angle": 0,
               "backgroundColor": "transparent",
@@ -15856,7 +16249,7 @@ History {
               "isDeleted": true,
             },
           },
-          "id67" => Delta {
+          "id70" => Delta {
             "deleted": {
               "angle": 0,
               "backgroundColor": "transparent",
@@ -15895,7 +16288,7 @@ History {
               "isDeleted": true,
             },
           },
-          "id68" => Delta {
+          "id71" => Delta {
             "deleted": {
               "angle": 0,
               "backgroundColor": "transparent",
@@ -15935,7 +16328,7 @@ History {
         "delta": Delta {
           "deleted": {
             "selectedElementIds": {
-              "id66": true,
+              "id69": true,
             },
           },
           "inserted": {
@@ -15954,7 +16347,7 @@ History {
         "delta": Delta {
           "deleted": {
             "selectedElementIds": {
-              "id67": true,
+              "id70": true,
             },
           },
           "inserted": {
@@ -15976,7 +16369,7 @@ History {
           },
           "inserted": {
             "selectedElementIds": {
-              "id67": true,
+              "id70": true,
             },
           },
         },
@@ -15985,11 +16378,11 @@ History {
         "added": Map {},
         "removed": Map {},
         "updated": Map {
-          "id66" => Delta {
+          "id69" => Delta {
             "deleted": {
               "boundElements": [
                 {
-                  "id": "id67",
+                  "id": "id70",
                   "type": "text",
                 },
               ],
@@ -15998,9 +16391,9 @@ History {
               "boundElements": [],
             },
           },
-          "id67" => Delta {
+          "id70" => Delta {
             "deleted": {
-              "containerId": "id66",
+              "containerId": "id69",
               "height": 25,
               "textAlign": "center",
               "verticalAlign": "middle",
@@ -16026,13 +16419,13 @@ History {
         "delta": Delta {
           "deleted": {
             "selectedElementIds": {
-              "id71": true,
+              "id74": true,
             },
-            "selectedLinearElementId": "id71",
+            "selectedLinearElementId": "id74",
           },
           "inserted": {
             "selectedElementIds": {
-              "id66": true,
+              "id69": true,
             },
             "selectedLinearElementId": null,
           },
@@ -16041,7 +16434,7 @@ History {
       "elementsChange": ElementsChange {
         "added": Map {},
         "removed": Map {
-          "id71" => Delta {
+          "id74" => Delta {
             "deleted": {
               "angle": 0,
               "backgroundColor": "transparent",
@@ -16049,7 +16442,7 @@ History {
               "customData": undefined,
               "endArrowhead": "arrow",
               "endBinding": {
-                "elementId": "id68",
+                "elementId": "id71",
                 "focus": 0,
                 "gap": 1,
               },
@@ -16079,7 +16472,7 @@ History {
               },
               "startArrowhead": null,
               "startBinding": {
-                "elementId": "id66",
+                "elementId": "id69",
                 "focus": 0,
                 "gap": 1,
               },
@@ -16097,11 +16490,11 @@ History {
           },
         },
         "updated": Map {
-          "id66" => Delta {
+          "id69" => Delta {
             "deleted": {
               "boundElements": [
                 {
-                  "id": "id71",
+                  "id": "id74",
                   "type": "arrow",
                 },
               ],
@@ -16110,11 +16503,11 @@ History {
               "boundElements": [],
             },
           },
-          "id68" => Delta {
+          "id71" => Delta {
             "deleted": {
               "boundElements": [
                 {
-                  "id": "id71",
+                  "id": "id74",
                   "type": "arrow",
                 },
               ],
@@ -16131,15 +16524,15 @@ History {
         "delta": Delta {
           "deleted": {
             "selectedElementIds": {
-              "id66": true,
+              "id69": true,
             },
             "selectedLinearElementId": null,
           },
           "inserted": {
             "selectedElementIds": {
-              "id71": true,
+              "id74": true,
             },
-            "selectedLinearElementId": "id71",
+            "selectedLinearElementId": "id74",
           },
         },
       },
@@ -16154,7 +16547,7 @@ History {
         "delta": Delta {
           "deleted": {
             "selectedElementIds": {
-              "id68": true,
+              "id71": true,
             },
           },
           "inserted": {
@@ -16247,14 +16640,14 @@ exports[`history > singleplayer undo/redo > should support changes in elements' 
   "penMode": false,
   "pendingImageElementId": null,
   "previousSelectedElementIds": {
-    "id36": true,
+    "id39": true,
   },
   "resizingElement": null,
   "scrollX": 0,
   "scrollY": 0,
   "selectedElementIds": {
-    "id36": true,
-    "id38": true,
+    "id39": true,
+    "id41": true,
   },
   "selectedElementsAreBeingDragged": false,
   "selectedGroupIds": {},
@@ -16289,7 +16682,7 @@ exports[`history > singleplayer undo/redo > should support changes in elements' 
   "frameId": null,
   "groupIds": [],
   "height": 10,
-  "id": "id37",
+  "id": "id40",
   "index": "a1",
   "isDeleted": false,
   "link": null,
@@ -16321,7 +16714,7 @@ exports[`history > singleplayer undo/redo > should support changes in elements' 
   "frameId": null,
   "groupIds": [],
   "height": 10,
-  "id": "id36",
+  "id": "id39",
   "index": "a2",
   "isDeleted": false,
   "link": null,
@@ -16353,7 +16746,7 @@ exports[`history > singleplayer undo/redo > should support changes in elements' 
   "frameId": null,
   "groupIds": [],
   "height": 10,
-  "id": "id38",
+  "id": "id41",
   "index": "a3",
   "isDeleted": false,
   "link": null,
@@ -16390,7 +16783,7 @@ History {
         "delta": Delta {
           "deleted": {
             "selectedElementIds": {
-              "id36": true,
+              "id39": true,
             },
           },
           "inserted": {
@@ -16401,7 +16794,7 @@ History {
       "elementsChange": ElementsChange {
         "added": Map {},
         "removed": Map {
-          "id36" => Delta {
+          "id39" => Delta {
             "deleted": {
               "angle": 0,
               "backgroundColor": "transparent",
@@ -16441,12 +16834,12 @@ History {
         "delta": Delta {
           "deleted": {
             "selectedElementIds": {
-              "id37": true,
+              "id40": true,
             },
           },
           "inserted": {
             "selectedElementIds": {
-              "id36": true,
+              "id39": true,
             },
           },
         },
@@ -16454,7 +16847,7 @@ History {
       "elementsChange": ElementsChange {
         "added": Map {},
         "removed": Map {
-          "id37" => Delta {
+          "id40" => Delta {
             "deleted": {
               "angle": 0,
               "backgroundColor": "transparent",
@@ -16494,12 +16887,12 @@ History {
         "delta": Delta {
           "deleted": {
             "selectedElementIds": {
-              "id38": true,
+              "id41": true,
             },
           },
           "inserted": {
             "selectedElementIds": {
-              "id37": true,
+              "id40": true,
             },
           },
         },
@@ -16507,7 +16900,7 @@ History {
       "elementsChange": ElementsChange {
         "added": Map {},
         "removed": Map {
-          "id38" => Delta {
+          "id41" => Delta {
             "deleted": {
               "angle": 0,
               "backgroundColor": "transparent",
@@ -16553,7 +16946,7 @@ History {
         "added": Map {},
         "removed": Map {},
         "updated": Map {
-          "id38" => Delta {
+          "id41" => Delta {
             "deleted": {
               "index": "a0V",
             },
@@ -16569,12 +16962,12 @@ History {
         "delta": Delta {
           "deleted": {
             "selectedElementIds": {
-              "id36": true,
+              "id39": true,
             },
           },
           "inserted": {
             "selectedElementIds": {
-              "id38": true,
+              "id41": true,
             },
           },
         },
@@ -16590,7 +16983,7 @@ History {
         "delta": Delta {
           "deleted": {
             "selectedElementIds": {
-              "id38": true,
+              "id41": true,
             },
           },
           "inserted": {
@@ -16615,7 +17008,7 @@ History {
         "added": Map {},
         "removed": Map {},
         "updated": Map {
-          "id36" => Delta {
+          "id39" => Delta {
             "deleted": {
               "index": "a2",
             },
@@ -16623,7 +17016,7 @@ History {
               "index": "a0",
             },
           },
-          "id38" => Delta {
+          "id41" => Delta {
             "deleted": {
               "index": "a3",
             },
@@ -16713,14 +17106,14 @@ exports[`history > singleplayer undo/redo > should support duplication of groups
   "penMode": false,
   "pendingImageElementId": null,
   "previousSelectedElementIds": {
-    "id33": true,
+    "id36": true,
   },
   "resizingElement": null,
   "scrollX": 0,
   "scrollY": 0,
   "selectedElementIds": {
-    "id32_copy_copy": true,
-    "id33_copy_copy": true,
+    "id35_copy_copy": true,
+    "id36_copy_copy": true,
   },
   "selectedElementsAreBeingDragged": false,
   "selectedGroupIds": {
@@ -16759,7 +17152,7 @@ exports[`history > singleplayer undo/redo > should support duplication of groups
     "A",
   ],
   "height": 100,
-  "id": "id32",
+  "id": "id35",
   "index": "a0",
   "isDeleted": false,
   "link": null,
@@ -16793,7 +17186,7 @@ exports[`history > singleplayer undo/redo > should support duplication of groups
     "A",
   ],
   "height": 100,
-  "id": "id33",
+  "id": "id36",
   "index": "a1",
   "isDeleted": false,
   "link": null,
@@ -16827,7 +17220,7 @@ exports[`history > singleplayer undo/redo > should support duplication of groups
     "A_copy",
   ],
   "height": 100,
-  "id": "id32_copy_copy",
+  "id": "id35_copy_copy",
   "index": "a1G",
   "isDeleted": false,
   "link": null,
@@ -16861,7 +17254,7 @@ exports[`history > singleplayer undo/redo > should support duplication of groups
     "A_copy",
   ],
   "height": 100,
-  "id": "id33_copy_copy",
+  "id": "id36_copy_copy",
   "index": "a1V",
   "isDeleted": false,
   "link": null,
@@ -16895,7 +17288,7 @@ exports[`history > singleplayer undo/redo > should support duplication of groups
     "A_copy",
   ],
   "height": 100,
-  "id": "id32_copy",
+  "id": "id35_copy",
   "index": "a2",
   "isDeleted": true,
   "link": null,
@@ -16929,7 +17322,7 @@ exports[`history > singleplayer undo/redo > should support duplication of groups
     "A_copy",
   ],
   "height": 100,
-  "id": "id33_copy",
+  "id": "id36_copy",
   "index": "a3",
   "isDeleted": true,
   "link": null,
@@ -16966,8 +17359,8 @@ History {
         "delta": Delta {
           "deleted": {
             "selectedElementIds": {
-              "id32": true,
-              "id33": true,
+              "id35": true,
+              "id36": true,
             },
             "selectedGroupIds": {
               "A": true,
@@ -16982,7 +17375,7 @@ History {
       "elementsChange": ElementsChange {
         "added": Map {},
         "removed": Map {
-          "id32" => Delta {
+          "id35" => Delta {
             "deleted": {
               "angle": 0,
               "backgroundColor": "transparent",
@@ -17015,7 +17408,7 @@ History {
               "isDeleted": true,
             },
           },
-          "id33" => Delta {
+          "id36" => Delta {
             "deleted": {
               "angle": 0,
               "backgroundColor": "transparent",
@@ -17057,8 +17450,8 @@ History {
         "delta": Delta {
           "deleted": {
             "selectedElementIds": {
-              "id32_copy_copy": true,
-              "id33_copy_copy": true,
+              "id35_copy_copy": true,
+              "id36_copy_copy": true,
             },
             "selectedGroupIds": {
               "A_copy": true,
@@ -17066,8 +17459,8 @@ History {
           },
           "inserted": {
             "selectedElementIds": {
-              "id32": true,
-              "id33": true,
+              "id35": true,
+              "id36": true,
             },
             "selectedGroupIds": {
               "A": true,
@@ -17078,7 +17471,7 @@ History {
       "elementsChange": ElementsChange {
         "added": Map {},
         "removed": Map {
-          "id32_copy_copy" => Delta {
+          "id35_copy_copy" => Delta {
             "deleted": {
               "angle": 0,
               "backgroundColor": "transparent",
@@ -17111,7 +17504,7 @@ History {
               "isDeleted": true,
             },
           },
-          "id33_copy_copy" => Delta {
+          "id36_copy_copy" => Delta {
             "deleted": {
               "angle": 0,
               "backgroundColor": "transparent",

--- a/packages/excalidraw/tests/__snapshots__/regressionTests.test.tsx.snap
+++ b/packages/excalidraw/tests/__snapshots__/regressionTests.test.tsx.snap
@@ -6570,12 +6570,27 @@ History {
         "delta": Delta {
           "deleted": {
             "selectedElementIds": {},
-            "selectedLinearElementId": null,
           },
           "inserted": {
             "selectedElementIds": {
               "id6": true,
             },
+          },
+        },
+      },
+      "elementsChange": ElementsChange {
+        "added": Map {},
+        "removed": Map {},
+        "updated": Map {},
+      },
+    },
+    HistoryEntry {
+      "appStateChange": AppStateChange {
+        "delta": Delta {
+          "deleted": {
+            "selectedLinearElementId": null,
+          },
+          "inserted": {
             "selectedLinearElementId": "id6",
           },
         },


### PR DESCRIPTION
Selecting freedraw tool is recorded, so that undo does not select previously selected elements, for details check #5437.

fix https://github.com/excalidraw/excalidraw/issues/5437