### PR TITLE
fix: use Reflect API (2016) instead of Object.hasOwn (2021)

### DIFF
--- a/packages/excalidraw/store.ts
+++ b/packages/excalidraw/store.ts
@@ -22,7 +22,7 @@ export const getObservedAppState = (appState: AppState): ObservedAppState => {
     selectedLinearElementId: appState.selectedLinearElement?.elementId || null,
   };
 
-  Object.defineProperty(observedAppState, hiddenObservedAppStateProp, {
+  Reflect.defineProperty(observedAppState, hiddenObservedAppStateProp, {
     value: true,
     enumerable: false,
   });
@@ -33,7 +33,7 @@ export const getObservedAppState = (appState: AppState): ObservedAppState => {
 const isObservedAppState = (
   appState: AppState | ObservedAppState,
 ): appState is ObservedAppState =>
-  Object.hasOwn(appState, hiddenObservedAppStateProp);
+  !!Reflect.get(appState, hiddenObservedAppStateProp);
 
 export type StoreActionType = "capture" | "update" | "none";
 


### PR DESCRIPTION
Use a more stable Reflect API (since 2016 in major browsers) for handling `observedAppState`, instead of `Object.hasOwn` (since 2021 in major browsers).

The next step is possibly polyfilling the APIs (such as Reflect) through `@vitejs/plugin-legacy` and it's specifiers https://www.npmjs.com/package/@vitejs/plugin-legacy#polyfill-specifiers.

Can I use Reflect? https://caniuse.com/mdn-javascript_builtins_reflect

Fixes #7957