### PR TITLE
added a collapsable option for island components

### DIFF
--- a/packages/excalidraw/components/Island.tsx
+++ b/packages/excalidraw/components/Island.tsx
@@ -1,23 +1,64 @@
 import "./Island.scss";
 
-import React from "react";
+import React, { useState }  from "react";
 import clsx from "clsx";
+import { Button } from "./Button";
+import { palette } from "./icons";
 
 type IslandProps = {
   children: React.ReactNode;
   padding?: number;
   className?: string | boolean;
   style?: object;
+  collapsable?: boolean;
 };
 
 export const Island = React.forwardRef<HTMLDivElement, IslandProps>(
-  ({ children, padding, className, style }, ref) => (
-    <div
-      className={clsx("Island", className)}
-      style={{ "--padding": padding, ...style }}
-      ref={ref}
-    >
-      {children}
-    </div>
-  ),
+  ({ children, padding, className, style, collapsable}, ref) => {
+    const [isVisible, setIsVisible] = useState(true);
+
+    const toggleIslandVisibility = () => { setIsVisible(!isVisible) };
+
+    if (collapsable) {
+      if (isVisible) {
+        return (
+          <div
+            className={clsx("Island", className)}
+            style={{ "--padding": padding, ...style }}
+            ref={ref}
+          >
+            <Button
+              onSelect={() => {toggleIslandVisibility()}}
+              className="ToolIcon_type_button"
+            >
+              {palette}
+            </Button><br/>
+            {children}
+          </div>
+        )
+      }
+      else {
+        return (
+          <Button
+            onSelect={() => {toggleIslandVisibility()}}
+            className="dropdown-menu-button"
+          >
+            {palette}
+          </Button>
+        )
+      }
+    }
+
+    else {
+      return (
+        <div
+          className={clsx("Island", className)}
+          style={{ "--padding": padding, ...style }}
+          ref={ref}
+        >
+          {children}
+        </div>
+    )
+  }
+  },
 );

--- a/packages/excalidraw/components/LayerUI.tsx
+++ b/packages/excalidraw/components/LayerUI.tsx
@@ -224,6 +224,7 @@ const LayerUI = ({
           // approximate height of hamburgerMenu + footer
           maxHeight: `${appState.height - 166}px`,
         }}
+        collapsable
       >
         <SelectedShapeActions
           appState={appState}


### PR DESCRIPTION
## Intro ##
Hello! I just graduated from CS, and have been using excalidraw for a long time to help with problem solving. During many of my times using this app, I've tried collapsing the colour palet, but found there was no option to do so. I also considered a draggable option for this, but I think the collapsable solution is better for UX.

## Solution ##
I added an optional collapsable prop to the Island component so that the user can collapse it, and open it as they choose. This fix does not affect the island when it is in the smaller view port as it already has this option. 

**Uncollapsed**
![image](https://github.com/excalidraw/excalidraw/assets/108435887/74d196f1-8ac4-4695-93dc-9803f7d84783)

**Collapsed**
![image](https://github.com/excalidraw/excalidraw/assets/108435887/60d33e9c-f48f-4ddc-908d-5c15c0c51b9d)
