### PR TITLE
chore: Add lcov coverage output to vitest

### DIFF
--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -6,7 +6,7 @@ export default defineConfig({
     globals: true,
     environment: "jsdom",
     coverage: {
-      reporter: ["text", "json-summary", "json", "html"],
+      reporter: ["text", "json-summary", "json", "html", "lcovonly"],
       thresholds: {
         lines: 70,
         branches: 70,


### PR DESCRIPTION
This addition would allow code coverage plugins in most IDEs to pick up the results. Having a visual indicator in IDEs should nudge people toward covering their code with tests.