### PR TITLE
feat: close dialog and show toast for Export image

### DIFF
--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -1777,12 +1777,19 @@ class App extends React.Component<AppProps, AppState> {
         this.setState({ errorMessage: error.message });
       });
 
-    if (
-      this.state.exportEmbedScene &&
-      fileHandle &&
-      isImageFileHandle(fileHandle)
-    ) {
-      this.setState({ fileHandle });
+    if (fileHandle && isImageFileHandle(fileHandle)) {
+      this.setState({
+        fileHandle: this.state.exportEmbedScene ? fileHandle : null,
+        openDialog: null,
+        toast: {
+          message: fileHandle?.name
+            ? t("toast.fileSavedToFilename").replace(
+                "{filename}",
+                `"${fileHandle.name}"`,
+              )
+            : t("toast.fileSaved"),
+        },
+      });
     }
   };
 


### PR DESCRIPTION
Save to feature closes dialog and showed toast message after exporting successful.
Export image feature better follow the same flow.