### PR TITLE
build: specify `packageManager` field

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "private": true,
   "name": "excalidraw-monorepo",
+  "packageManager": "yarn@1.22.22",
   "workspaces": [
     "excalidraw-app",
     "packages/excalidraw",


### PR DESCRIPTION
For `corepack` https://nodejs.org/api/corepack.html.

Won't affect those not using corepack, though it should still yell at people if they try to use non-v1 yarn in a project with `packageManger` specifying v1 yarn, which is good.

We should also investigate migrating to yarn v4.