### PR TITLE
fix: undo/redo when exiting view mode

### DIFF
--- a/packages/excalidraw/actions/actionHistory.tsx
+++ b/packages/excalidraw/actions/actionHistory.tsx
@@ -79,6 +79,7 @@ export const createUndoAction: ActionCreator = (history, store) => ({
         onClick={updateData}
         size={data?.size || "medium"}
         disabled={isUndoStackEmpty}
+        data-testid="button-undo"
       />
     );
   },
@@ -120,6 +121,7 @@ export const createRedoAction: ActionCreator = (history, store) => ({
         onClick={updateData}
         size={data?.size || "medium"}
         disabled={isRedoStackEmpty}
+        data-testid="button-redo"
       />
     );
   },

--- a/packages/excalidraw/actions/actionHistory.tsx
+++ b/packages/excalidraw/actions/actionHistory.tsx
@@ -65,7 +65,10 @@ export const createUndoAction: ActionCreator = (history, store) => ({
   PanelComponent: ({ updateData, data }) => {
     const { isUndoStackEmpty } = useEmitter<HistoryChangedEvent>(
       history.onHistoryChangedEmitter,
-      new HistoryChangedEvent(),
+      new HistoryChangedEvent(
+        history.isUndoStackEmpty,
+        history.isRedoStackEmpty,
+      ),
     );
 
     return (
@@ -103,7 +106,10 @@ export const createRedoAction: ActionCreator = (history, store) => ({
   PanelComponent: ({ updateData, data }) => {
     const { isRedoStackEmpty } = useEmitter(
       history.onHistoryChangedEmitter,
-      new HistoryChangedEvent(),
+      new HistoryChangedEvent(
+        history.isUndoStackEmpty,
+        history.isRedoStackEmpty,
+      ),
     );
 
     return (

--- a/packages/excalidraw/tests/__snapshots__/history.test.tsx.snap
+++ b/packages/excalidraw/tests/__snapshots__/history.test.tsx.snap
@@ -71,13 +71,13 @@ exports[`history > multiplayer undo/redo > conflicts in arrows and their bindabl
   "penMode": false,
   "pendingImageElementId": null,
   "previousSelectedElementIds": {
-    "id159": true,
+    "id163": true,
   },
   "resizingElement": null,
   "scrollX": 0,
   "scrollY": 0,
   "selectedElementIds": {
-    "id159": true,
+    "id163": true,
   },
   "selectedElementsAreBeingDragged": false,
   "selectedGroupIds": {},
@@ -112,7 +112,7 @@ exports[`history > multiplayer undo/redo > conflicts in arrows and their bindabl
   "frameId": null,
   "groupIds": [],
   "height": 100,
-  "id": "id157",
+  "id": "id161",
   "index": "a0",
   "isDeleted": false,
   "link": null,
@@ -144,7 +144,7 @@ exports[`history > multiplayer undo/redo > conflicts in arrows and their bindabl
   "frameId": null,
   "groupIds": [],
   "height": 100,
-  "id": "id158",
+  "id": "id162",
   "index": "a1",
   "isDeleted": false,
   "link": null,
@@ -174,7 +174,7 @@ exports[`history > multiplayer undo/redo > conflicts in arrows and their bindabl
   "customData": undefined,
   "endArrowhead": "arrow",
   "endBinding": {
-    "elementId": "id162",
+    "elementId": "id166",
     "focus": 0,
     "gap": 1,
   },
@@ -182,7 +182,7 @@ exports[`history > multiplayer undo/redo > conflicts in arrows and their bindabl
   "frameId": null,
   "groupIds": [],
   "height": 99.19725525211979,
-  "id": "id159",
+  "id": "id163",
   "index": "a2",
   "isDeleted": false,
   "lastCommittedPoint": null,
@@ -223,7 +223,7 @@ exports[`history > multiplayer undo/redo > conflicts in arrows and their bindabl
   "backgroundColor": "transparent",
   "boundElements": [
     {
-      "id": "id159",
+      "id": "id163",
       "type": "arrow",
     },
   ],
@@ -232,7 +232,7 @@ exports[`history > multiplayer undo/redo > conflicts in arrows and their bindabl
   "frameId": null,
   "groupIds": [],
   "height": 50,
-  "id": "id162",
+  "id": "id166",
   "index": "a3",
   "isDeleted": false,
   "link": null,
@@ -274,10 +274,10 @@ History {
         "added": Map {},
         "removed": Map {},
         "updated": Map {
-          "id159" => Delta {
+          "id163" => Delta {
             "deleted": {
               "endBinding": {
-                "elementId": "id158",
+                "elementId": "id162",
                 "focus": 0.009900990099009901,
                 "gap": 1,
               },
@@ -293,14 +293,14 @@ History {
                 ],
               ],
               "startBinding": {
-                "elementId": "id157",
+                "elementId": "id161",
                 "focus": 0.0297029702970297,
                 "gap": 1,
               },
             },
             "inserted": {
               "endBinding": {
-                "elementId": "id158",
+                "elementId": "id162",
                 "focus": -0.02,
                 "gap": 1,
               },
@@ -316,7 +316,7 @@ History {
                 ],
               ],
               "startBinding": {
-                "elementId": "id157",
+                "elementId": "id161",
                 "focus": 0.02,
                 "gap": 1,
               },
@@ -336,36 +336,36 @@ History {
         "added": Map {},
         "removed": Map {},
         "updated": Map {
-          "id157" => Delta {
+          "id161" => Delta {
             "deleted": {
               "boundElements": [],
             },
             "inserted": {
               "boundElements": [
                 {
-                  "id": "id159",
+                  "id": "id163",
                   "type": "arrow",
                 },
               ],
             },
           },
-          "id158" => Delta {
+          "id162" => Delta {
             "deleted": {
               "boundElements": [],
             },
             "inserted": {
               "boundElements": [
                 {
-                  "id": "id159",
+                  "id": "id163",
                   "type": "arrow",
                 },
               ],
             },
           },
-          "id159" => Delta {
+          "id163" => Delta {
             "deleted": {
               "endBinding": {
-                "elementId": "id162",
+                "elementId": "id166",
                 "focus": 0,
                 "gap": 1,
               },
@@ -385,7 +385,7 @@ History {
             },
             "inserted": {
               "endBinding": {
-                "elementId": "id158",
+                "elementId": "id162",
                 "focus": 0.009900990099009901,
                 "gap": 1,
               },
@@ -401,18 +401,18 @@ History {
                 ],
               ],
               "startBinding": {
-                "elementId": "id157",
+                "elementId": "id161",
                 "focus": 0.0297029702970297,
                 "gap": 1,
               },
               "y": 0.9903686540602428,
             },
           },
-          "id162" => Delta {
+          "id166" => Delta {
             "deleted": {
               "boundElements": [
                 {
-                  "id": "id159",
+                  "id": "id163",
                   "type": "arrow",
                 },
               ],
@@ -436,7 +436,7 @@ History {
       "elementsChange": ElementsChange {
         "added": Map {},
         "removed": Map {
-          "id157" => Delta {
+          "id161" => Delta {
             "deleted": {
               "angle": 0,
               "backgroundColor": "transparent",
@@ -467,7 +467,7 @@ History {
               "isDeleted": true,
             },
           },
-          "id158" => Delta {
+          "id162" => Delta {
             "deleted": {
               "angle": 0,
               "backgroundColor": "transparent",
@@ -507,9 +507,9 @@ History {
         "delta": Delta {
           "deleted": {
             "selectedElementIds": {
-              "id159": true,
+              "id163": true,
             },
-            "selectedLinearElementId": "id159",
+            "selectedLinearElementId": "id163",
           },
           "inserted": {
             "selectedElementIds": {},
@@ -520,7 +520,7 @@ History {
       "elementsChange": ElementsChange {
         "added": Map {},
         "removed": Map {
-          "id159" => Delta {
+          "id163" => Delta {
             "deleted": {
               "angle": 0,
               "backgroundColor": "transparent",
@@ -649,13 +649,13 @@ exports[`history > multiplayer undo/redo > conflicts in arrows and their bindabl
   "penMode": false,
   "pendingImageElementId": null,
   "previousSelectedElementIds": {
-    "id154": true,
+    "id158": true,
   },
   "resizingElement": null,
   "scrollX": 0,
   "scrollY": 0,
   "selectedElementIds": {
-    "id154": true,
+    "id158": true,
   },
   "selectedElementsAreBeingDragged": false,
   "selectedGroupIds": {},
@@ -690,7 +690,7 @@ exports[`history > multiplayer undo/redo > conflicts in arrows and their bindabl
   "frameId": null,
   "groupIds": [],
   "height": 100,
-  "id": "id152",
+  "id": "id156",
   "index": "a0",
   "isDeleted": false,
   "link": null,
@@ -722,7 +722,7 @@ exports[`history > multiplayer undo/redo > conflicts in arrows and their bindabl
   "frameId": null,
   "groupIds": [],
   "height": 100,
-  "id": "id153",
+  "id": "id157",
   "index": "a1",
   "isDeleted": false,
   "link": null,
@@ -756,7 +756,7 @@ exports[`history > multiplayer undo/redo > conflicts in arrows and their bindabl
   "frameId": null,
   "groupIds": [],
   "height": 0,
-  "id": "id154",
+  "id": "id158",
   "index": "a2",
   "isDeleted": false,
   "lastCommittedPoint": null,
@@ -811,7 +811,7 @@ History {
         "added": Map {},
         "removed": Map {},
         "updated": Map {
-          "id154" => Delta {
+          "id158" => Delta {
             "deleted": {
               "points": [
                 [
@@ -851,33 +851,33 @@ History {
         "added": Map {},
         "removed": Map {},
         "updated": Map {
-          "id152" => Delta {
+          "id156" => Delta {
             "deleted": {
               "boundElements": [],
             },
             "inserted": {
               "boundElements": [
                 {
-                  "id": "id154",
+                  "id": "id158",
                   "type": "arrow",
                 },
               ],
             },
           },
-          "id153" => Delta {
+          "id157" => Delta {
             "deleted": {
               "boundElements": [],
             },
             "inserted": {
               "boundElements": [
                 {
-                  "id": "id154",
+                  "id": "id158",
                   "type": "arrow",
                 },
               ],
             },
           },
-          "id154" => Delta {
+          "id158" => Delta {
             "deleted": {
               "endBinding": null,
               "points": [
@@ -894,7 +894,7 @@ History {
             },
             "inserted": {
               "endBinding": {
-                "elementId": "id153",
+                "elementId": "id157",
                 "focus": 0,
                 "gap": 1,
               },
@@ -909,7 +909,7 @@ History {
                 ],
               ],
               "startBinding": {
-                "elementId": "id152",
+                "elementId": "id156",
                 "focus": 0,
                 "gap": 1,
               },
@@ -930,7 +930,7 @@ History {
       "elementsChange": ElementsChange {
         "added": Map {},
         "removed": Map {
-          "id152" => Delta {
+          "id156" => Delta {
             "deleted": {
               "angle": 0,
               "backgroundColor": "transparent",
@@ -961,7 +961,7 @@ History {
               "isDeleted": true,
             },
           },
-          "id153" => Delta {
+          "id157" => Delta {
             "deleted": {
               "angle": 0,
               "backgroundColor": "transparent",
@@ -1001,9 +1001,9 @@ History {
         "delta": Delta {
           "deleted": {
             "selectedElementIds": {
-              "id154": true,
+              "id158": true,
             },
-            "selectedLinearElementId": "id154",
+            "selectedLinearElementId": "id158",
           },
           "inserted": {
             "selectedElementIds": {},
@@ -1014,7 +1014,7 @@ History {
       "elementsChange": ElementsChange {
         "added": Map {},
         "removed": Map {
-          "id154" => Delta {
+          "id158" => Delta {
             "deleted": {
               "angle": 0,
               "backgroundColor": "transparent",
@@ -1181,7 +1181,7 @@ exports[`history > multiplayer undo/redo > conflicts in arrows and their bindabl
   "customData": undefined,
   "endArrowhead": null,
   "endBinding": {
-    "elementId": "id164",
+    "elementId": "id168",
     "focus": 0,
     "gap": 1,
   },
@@ -1189,7 +1189,7 @@ exports[`history > multiplayer undo/redo > conflicts in arrows and their bindabl
   "frameId": null,
   "groupIds": [],
   "height": 0.03596020595764898,
-  "id": "id165",
+  "id": "id169",
   "index": "Zz",
   "isDeleted": false,
   "lastCommittedPoint": null,
@@ -1212,7 +1212,7 @@ exports[`history > multiplayer undo/redo > conflicts in arrows and their bindabl
   },
   "startArrowhead": null,
   "startBinding": {
-    "elementId": "id163",
+    "elementId": "id167",
     "focus": 0,
     "gap": 1,
   },
@@ -1234,7 +1234,7 @@ exports[`history > multiplayer undo/redo > conflicts in arrows and their bindabl
   "backgroundColor": "transparent",
   "boundElements": [
     {
-      "id": "id165",
+      "id": "id169",
       "type": "arrow",
     },
   ],
@@ -1243,7 +1243,7 @@ exports[`history > multiplayer undo/redo > conflicts in arrows and their bindabl
   "frameId": null,
   "groupIds": [],
   "height": 100,
-  "id": "id163",
+  "id": "id167",
   "index": "a0",
   "isDeleted": false,
   "link": null,
@@ -1271,7 +1271,7 @@ exports[`history > multiplayer undo/redo > conflicts in arrows and their bindabl
   "backgroundColor": "transparent",
   "boundElements": [
     {
-      "id": "id165",
+      "id": "id169",
       "type": "arrow",
     },
   ],
@@ -1280,7 +1280,7 @@ exports[`history > multiplayer undo/redo > conflicts in arrows and their bindabl
   "frameId": null,
   "groupIds": [],
   "height": 100,
-  "id": "id164",
+  "id": "id168",
   "index": "a1",
   "isDeleted": false,
   "link": null,
@@ -1322,7 +1322,7 @@ History {
       "elementsChange": ElementsChange {
         "added": Map {},
         "removed": Map {
-          "id163" => Delta {
+          "id167" => Delta {
             "deleted": {
               "angle": 0,
               "backgroundColor": "transparent",
@@ -1353,7 +1353,7 @@ History {
               "isDeleted": true,
             },
           },
-          "id164" => Delta {
+          "id168" => Delta {
             "deleted": {
               "angle": 0,
               "backgroundColor": "transparent",
@@ -1386,15 +1386,15 @@ History {
           },
         },
         "updated": Map {
-          "id165" => Delta {
+          "id169" => Delta {
             "deleted": {
               "endBinding": {
-                "elementId": "id164",
+                "elementId": "id168",
                 "focus": 0,
                 "gap": 1,
               },
               "startBinding": {
-                "elementId": "id163",
+                "elementId": "id167",
                 "focus": 0,
                 "gap": 1,
               },
@@ -1524,7 +1524,7 @@ exports[`history > multiplayer undo/redo > conflicts in arrows and their bindabl
   "customData": undefined,
   "endArrowhead": null,
   "endBinding": {
-    "elementId": "id167",
+    "elementId": "id171",
     "focus": 0,
     "gap": 1,
   },
@@ -1532,7 +1532,7 @@ exports[`history > multiplayer undo/redo > conflicts in arrows and their bindabl
   "frameId": null,
   "groupIds": [],
   "height": 0.03596020595764898,
-  "id": "id168",
+  "id": "id172",
   "index": "a0",
   "isDeleted": false,
   "lastCommittedPoint": null,
@@ -1555,7 +1555,7 @@ exports[`history > multiplayer undo/redo > conflicts in arrows and their bindabl
   },
   "startArrowhead": null,
   "startBinding": {
-    "elementId": "id166",
+    "elementId": "id170",
     "focus": 0,
     "gap": 1,
   },
@@ -1577,7 +1577,7 @@ exports[`history > multiplayer undo/redo > conflicts in arrows and their bindabl
   "backgroundColor": "transparent",
   "boundElements": [
     {
-      "id": "id168",
+      "id": "id172",
       "type": "arrow",
     },
   ],
@@ -1586,7 +1586,7 @@ exports[`history > multiplayer undo/redo > conflicts in arrows and their bindabl
   "frameId": null,
   "groupIds": [],
   "height": 100,
-  "id": "id166",
+  "id": "id170",
   "index": "a0V",
   "isDeleted": false,
   "link": null,
@@ -1614,7 +1614,7 @@ exports[`history > multiplayer undo/redo > conflicts in arrows and their bindabl
   "backgroundColor": "transparent",
   "boundElements": [
     {
-      "id": "id168",
+      "id": "id172",
       "type": "arrow",
     },
   ],
@@ -1623,7 +1623,7 @@ exports[`history > multiplayer undo/redo > conflicts in arrows and their bindabl
   "frameId": null,
   "groupIds": [],
   "height": 100,
-  "id": "id167",
+  "id": "id171",
   "index": "a1",
   "isDeleted": false,
   "link": null,
@@ -1665,7 +1665,7 @@ History {
       "elementsChange": ElementsChange {
         "added": Map {},
         "removed": Map {
-          "id168" => Delta {
+          "id172" => Delta {
             "deleted": {
               "angle": 0,
               "backgroundColor": "transparent",
@@ -1673,7 +1673,7 @@ History {
               "customData": undefined,
               "endArrowhead": null,
               "endBinding": {
-                "elementId": "id167",
+                "elementId": "id171",
                 "focus": 0,
                 "gap": 1,
               },
@@ -1703,7 +1703,7 @@ History {
               },
               "startArrowhead": null,
               "startBinding": {
-                "elementId": "id166",
+                "elementId": "id170",
                 "focus": 0,
                 "gap": 1,
               },
@@ -1721,11 +1721,11 @@ History {
           },
         },
         "updated": Map {
-          "id166" => Delta {
+          "id170" => Delta {
             "deleted": {
               "boundElements": [
                 {
-                  "id": "id168",
+                  "id": "id172",
                   "type": "arrow",
                 },
               ],
@@ -1734,11 +1734,11 @@ History {
               "boundElements": [],
             },
           },
-          "id167" => Delta {
+          "id171" => Delta {
             "deleted": {
               "boundElements": [
                 {
-                  "id": "id168",
+                  "id": "id172",
                   "type": "arrow",
                 },
               ],
@@ -1869,7 +1869,7 @@ exports[`history > multiplayer undo/redo > conflicts in arrows and their bindabl
   "frameId": null,
   "groupIds": [],
   "height": 100,
-  "id": "id169",
+  "id": "id173",
   "index": "a0",
   "isDeleted": false,
   "link": null,
@@ -1901,7 +1901,7 @@ exports[`history > multiplayer undo/redo > conflicts in arrows and their bindabl
   "frameId": null,
   "groupIds": [],
   "height": 100,
-  "id": "id170",
+  "id": "id174",
   "index": "a1",
   "isDeleted": false,
   "link": null,
@@ -1943,7 +1943,7 @@ History {
       "elementsChange": ElementsChange {
         "added": Map {},
         "removed": Map {
-          "id169" => Delta {
+          "id173" => Delta {
             "deleted": {
               "angle": 0,
               "backgroundColor": "transparent",
@@ -1974,7 +1974,7 @@ History {
               "isDeleted": true,
             },
           },
-          "id170" => Delta {
+          "id174" => Delta {
             "deleted": {
               "angle": 0,
               "backgroundColor": "transparent",
@@ -2092,7 +2092,7 @@ exports[`history > multiplayer undo/redo > conflicts in arrows and their bindabl
   "scrollX": 0,
   "scrollY": 0,
   "selectedElementIds": {
-    "id173": true,
+    "id177": true,
   },
   "selectedElementsAreBeingDragged": false,
   "selectedGroupIds": {},
@@ -2123,7 +2123,7 @@ exports[`history > multiplayer undo/redo > conflicts in arrows and their bindabl
   "backgroundColor": "transparent",
   "boundElements": [
     {
-      "id": "id173",
+      "id": "id177",
       "type": "arrow",
     },
   ],
@@ -2132,7 +2132,7 @@ exports[`history > multiplayer undo/redo > conflicts in arrows and their bindabl
   "frameId": null,
   "groupIds": [],
   "height": 100,
-  "id": "id171",
+  "id": "id175",
   "index": "a0",
   "isDeleted": false,
   "link": null,
@@ -2160,7 +2160,7 @@ exports[`history > multiplayer undo/redo > conflicts in arrows and their bindabl
   "backgroundColor": "transparent",
   "boundElements": [
     {
-      "id": "id173",
+      "id": "id177",
       "type": "arrow",
     },
   ],
@@ -2169,7 +2169,7 @@ exports[`history > multiplayer undo/redo > conflicts in arrows and their bindabl
   "frameId": null,
   "groupIds": [],
   "height": 100,
-  "id": "id172",
+  "id": "id176",
   "index": "a1",
   "isDeleted": false,
   "link": null,
@@ -2199,7 +2199,7 @@ exports[`history > multiplayer undo/redo > conflicts in arrows and their bindabl
   "customData": undefined,
   "endArrowhead": "arrow",
   "endBinding": {
-    "elementId": "id172",
+    "elementId": "id176",
     "focus": 0,
     "gap": 1,
   },
@@ -2207,7 +2207,7 @@ exports[`history > multiplayer undo/redo > conflicts in arrows and their bindabl
   "frameId": null,
   "groupIds": [],
   "height": 373.7994222717614,
-  "id": "id173",
+  "id": "id177",
   "index": "a2",
   "isDeleted": false,
   "lastCommittedPoint": null,
@@ -2230,7 +2230,7 @@ exports[`history > multiplayer undo/redo > conflicts in arrows and their bindabl
   },
   "startArrowhead": null,
   "startBinding": {
-    "elementId": "id171",
+    "elementId": "id175",
     "focus": 0,
     "gap": 1,
   },
@@ -2266,7 +2266,7 @@ History {
       "elementsChange": ElementsChange {
         "added": Map {},
         "removed": Map {
-          "id171" => Delta {
+          "id175" => Delta {
             "deleted": {
               "angle": 0,
               "backgroundColor": "transparent",
@@ -2297,7 +2297,7 @@ History {
               "isDeleted": true,
             },
           },
-          "id172" => Delta {
+          "id176" => Delta {
             "deleted": {
               "angle": 0,
               "backgroundColor": "transparent",
@@ -2337,9 +2337,9 @@ History {
         "delta": Delta {
           "deleted": {
             "selectedElementIds": {
-              "id173": true,
+              "id177": true,
             },
-            "selectedLinearElementId": "id173",
+            "selectedLinearElementId": "id177",
           },
           "inserted": {
             "selectedElementIds": {},
@@ -2350,7 +2350,7 @@ History {
       "elementsChange": ElementsChange {
         "added": Map {},
         "removed": Map {
-          "id173" => Delta {
+          "id177" => Delta {
             "deleted": {
               "angle": 0,
               "backgroundColor": "transparent",
@@ -2358,7 +2358,7 @@ History {
               "customData": undefined,
               "endArrowhead": "arrow",
               "endBinding": {
-                "elementId": "id172",
+                "elementId": "id176",
                 "focus": 0,
                 "gap": 1,
               },
@@ -2388,7 +2388,7 @@ History {
               },
               "startArrowhead": null,
               "startBinding": {
-                "elementId": "id171",
+                "elementId": "id175",
                 "focus": 0,
                 "gap": 1,
               },
@@ -2406,11 +2406,11 @@ History {
           },
         },
         "updated": Map {
-          "id171" => Delta {
+          "id175" => Delta {
             "deleted": {
               "boundElements": [
                 {
-                  "id": "id173",
+                  "id": "id177",
                   "type": "arrow",
                 },
               ],
@@ -2419,11 +2419,11 @@ History {
               "boundElements": [],
             },
           },
-          "id172" => Delta {
+          "id176" => Delta {
             "deleted": {
               "boundElements": [
                 {
-                  "id": "id173",
+                  "id": "id177",
                   "type": "arrow",
                 },
               ],
@@ -2550,7 +2550,7 @@ exports[`history > multiplayer undo/redo > conflicts in bound text elements and 
   "backgroundColor": "transparent",
   "boundElements": [
     {
-      "id": "id140",
+      "id": "id144",
       "type": "text",
     },
   ],
@@ -2559,7 +2559,7 @@ exports[`history > multiplayer undo/redo > conflicts in bound text elements and 
   "frameId": null,
   "groupIds": [],
   "height": 100,
-  "id": "id138",
+  "id": "id142",
   "index": "a0",
   "isDeleted": false,
   "link": null,
@@ -2595,7 +2595,7 @@ exports[`history > multiplayer undo/redo > conflicts in bound text elements and 
   "frameId": null,
   "groupIds": [],
   "height": 100,
-  "id": "id139",
+  "id": "id143",
   "index": "a1",
   "isDeleted": false,
   "lineHeight": 1.25,
@@ -2628,7 +2628,7 @@ exports[`history > multiplayer undo/redo > conflicts in bound text elements and 
   "autoResize": true,
   "backgroundColor": "transparent",
   "boundElements": null,
-  "containerId": "id138",
+  "containerId": "id142",
   "customData": undefined,
   "fillStyle": "solid",
   "fontFamily": 1,
@@ -2636,7 +2636,7 @@ exports[`history > multiplayer undo/redo > conflicts in bound text elements and 
   "frameId": null,
   "groupIds": [],
   "height": 25,
-  "id": "id140",
+  "id": "id144",
   "index": "a2",
   "isDeleted": false,
   "lineHeight": 1.25,
@@ -2683,7 +2683,7 @@ History {
         "added": Map {},
         "removed": Map {},
         "updated": Map {
-          "id138" => Delta {
+          "id142" => Delta {
             "deleted": {
               "isDeleted": false,
             },
@@ -2714,7 +2714,7 @@ History {
               "y": 10,
             },
           },
-          "id139" => Delta {
+          "id143" => Delta {
             "deleted": {
               "containerId": null,
             },
@@ -2841,7 +2841,7 @@ exports[`history > multiplayer undo/redo > conflicts in bound text elements and 
   "backgroundColor": "transparent",
   "boundElements": [
     {
-      "id": "id143",
+      "id": "id147",
       "type": "text",
     },
   ],
@@ -2850,7 +2850,7 @@ exports[`history > multiplayer undo/redo > conflicts in bound text elements and 
   "frameId": null,
   "groupIds": [],
   "height": 100,
-  "id": "id141",
+  "id": "id145",
   "index": "Zz",
   "isDeleted": false,
   "link": null,
@@ -2878,7 +2878,7 @@ exports[`history > multiplayer undo/redo > conflicts in bound text elements and 
   "autoResize": true,
   "backgroundColor": "transparent",
   "boundElements": null,
-  "containerId": "id141",
+  "containerId": "id145",
   "customData": undefined,
   "fillStyle": "solid",
   "fontFamily": 1,
@@ -2886,7 +2886,7 @@ exports[`history > multiplayer undo/redo > conflicts in bound text elements and 
   "frameId": null,
   "groupIds": [],
   "height": 100,
-  "id": "id142",
+  "id": "id146",
   "index": "a0",
   "isDeleted": true,
   "lineHeight": 1.25,
@@ -2919,7 +2919,7 @@ exports[`history > multiplayer undo/redo > conflicts in bound text elements and 
   "autoResize": true,
   "backgroundColor": "transparent",
   "boundElements": null,
-  "containerId": "id141",
+  "containerId": "id145",
   "customData": undefined,
   "fillStyle": "solid",
   "fontFamily": 1,
@@ -2927,7 +2927,7 @@ exports[`history > multiplayer undo/redo > conflicts in bound text elements and 
   "frameId": null,
   "groupIds": [],
   "height": 25,
-  "id": "id143",
+  "id": "id147",
   "index": "a1",
   "isDeleted": false,
   "lineHeight": 1.25,
@@ -2972,9 +2972,9 @@ History {
       },
       "elementsChange": ElementsChange {
         "added": Map {
-          "id142" => Delta {
+          "id146" => Delta {
             "deleted": {
-              "containerId": "id141",
+              "containerId": "id145",
               "isDeleted": true,
             },
             "inserted": {
@@ -2985,14 +2985,14 @@ History {
         },
         "removed": Map {},
         "updated": Map {
-          "id141" => Delta {
+          "id145" => Delta {
             "deleted": {
               "boundElements": [],
             },
             "inserted": {
               "boundElements": [
                 {
-                  "id": "id142",
+                  "id": "id146",
                   "type": "text",
                 },
               ],
@@ -3117,7 +3117,7 @@ exports[`history > multiplayer undo/redo > conflicts in bound text elements and 
   "backgroundColor": "transparent",
   "boundElements": [
     {
-      "id": "id130",
+      "id": "id134",
       "type": "text",
     },
   ],
@@ -3126,7 +3126,7 @@ exports[`history > multiplayer undo/redo > conflicts in bound text elements and 
   "frameId": null,
   "groupIds": [],
   "height": 100,
-  "id": "id128",
+  "id": "id132",
   "index": "a0",
   "isDeleted": false,
   "link": null,
@@ -3154,7 +3154,7 @@ exports[`history > multiplayer undo/redo > conflicts in bound text elements and 
   "autoResize": true,
   "backgroundColor": "transparent",
   "boundElements": null,
-  "containerId": "id128",
+  "containerId": "id132",
   "customData": undefined,
   "fillStyle": "solid",
   "fontFamily": 1,
@@ -3162,7 +3162,7 @@ exports[`history > multiplayer undo/redo > conflicts in bound text elements and 
   "frameId": null,
   "groupIds": [],
   "height": 25,
-  "id": "id130",
+  "id": "id134",
   "index": "a0V",
   "isDeleted": false,
   "lineHeight": 1.25,
@@ -3203,7 +3203,7 @@ exports[`history > multiplayer undo/redo > conflicts in bound text elements and 
   "frameId": null,
   "groupIds": [],
   "height": 25,
-  "id": "id129",
+  "id": "id133",
   "index": "a1",
   "isDeleted": false,
   "lineHeight": 1.25,
@@ -3250,11 +3250,11 @@ History {
         "added": Map {},
         "removed": Map {},
         "updated": Map {
-          "id128" => Delta {
+          "id132" => Delta {
             "deleted": {
               "boundElements": [
                 {
-                  "id": "id130",
+                  "id": "id134",
                   "type": "text",
                 },
               ],
@@ -3262,23 +3262,23 @@ History {
             "inserted": {
               "boundElements": [
                 {
-                  "id": "id129",
+                  "id": "id133",
                   "type": "text",
                 },
               ],
             },
           },
-          "id129" => Delta {
+          "id133" => Delta {
             "deleted": {
               "containerId": null,
             },
             "inserted": {
-              "containerId": "id128",
+              "containerId": "id132",
             },
           },
-          "id130" => Delta {
+          "id134" => Delta {
             "deleted": {
-              "containerId": "id128",
+              "containerId": "id132",
             },
             "inserted": {
               "containerId": null,
@@ -3407,7 +3407,7 @@ exports[`history > multiplayer undo/redo > conflicts in bound text elements and 
   "frameId": null,
   "groupIds": [],
   "height": 100,
-  "id": "id131",
+  "id": "id135",
   "index": "a0",
   "isDeleted": false,
   "link": null,
@@ -3435,7 +3435,7 @@ exports[`history > multiplayer undo/redo > conflicts in bound text elements and 
   "backgroundColor": "transparent",
   "boundElements": [
     {
-      "id": "id132",
+      "id": "id136",
       "type": "text",
     },
   ],
@@ -3444,7 +3444,7 @@ exports[`history > multiplayer undo/redo > conflicts in bound text elements and 
   "frameId": null,
   "groupIds": [],
   "height": 60,
-  "id": "id133",
+  "id": "id137",
   "index": "a0V",
   "isDeleted": false,
   "link": null,
@@ -3472,7 +3472,7 @@ exports[`history > multiplayer undo/redo > conflicts in bound text elements and 
   "autoResize": true,
   "backgroundColor": "transparent",
   "boundElements": null,
-  "containerId": "id133",
+  "containerId": "id137",
   "customData": undefined,
   "fillStyle": "solid",
   "fontFamily": 1,
@@ -3480,7 +3480,7 @@ exports[`history > multiplayer undo/redo > conflicts in bound text elements and 
   "frameId": null,
   "groupIds": [],
   "height": 50,
-  "id": "id132",
+  "id": "id136",
   "index": "a1",
   "isDeleted": false,
   "lineHeight": 1.25,
@@ -3528,32 +3528,32 @@ History {
         "added": Map {},
         "removed": Map {},
         "updated": Map {
-          "id131" => Delta {
+          "id135" => Delta {
             "deleted": {
               "boundElements": [],
             },
             "inserted": {
               "boundElements": [
                 {
-                  "id": "id132",
+                  "id": "id136",
                   "type": "text",
                 },
               ],
             },
           },
-          "id132" => Delta {
+          "id136" => Delta {
             "deleted": {
-              "containerId": "id133",
+              "containerId": "id137",
             },
             "inserted": {
-              "containerId": "id131",
+              "containerId": "id135",
             },
           },
-          "id133" => Delta {
+          "id137" => Delta {
             "deleted": {
               "boundElements": [
                 {
-                  "id": "id132",
+                  "id": "id136",
                   "type": "text",
                 },
               ],
@@ -3685,7 +3685,7 @@ exports[`history > multiplayer undo/redo > conflicts in bound text elements and 
   "frameId": null,
   "groupIds": [],
   "height": 100,
-  "id": "id126",
+  "id": "id130",
   "index": "a0",
   "isDeleted": false,
   "link": null,
@@ -3721,7 +3721,7 @@ exports[`history > multiplayer undo/redo > conflicts in bound text elements and 
   "frameId": null,
   "groupIds": [],
   "height": 25,
-  "id": "id127",
+  "id": "id131",
   "index": "a1",
   "isDeleted": false,
   "lineHeight": 1.25,
@@ -3768,25 +3768,25 @@ History {
         "added": Map {},
         "removed": Map {},
         "updated": Map {
-          "id126" => Delta {
+          "id130" => Delta {
             "deleted": {
               "boundElements": [],
             },
             "inserted": {
               "boundElements": [
                 {
-                  "id": "id127",
+                  "id": "id131",
                   "type": "text",
                 },
               ],
             },
           },
-          "id127" => Delta {
+          "id131" => Delta {
             "deleted": {
               "containerId": null,
             },
             "inserted": {
-              "containerId": "id126",
+              "containerId": "id130",
             },
           },
         },
@@ -3908,7 +3908,7 @@ exports[`history > multiplayer undo/redo > conflicts in bound text elements and 
   "backgroundColor": "transparent",
   "boundElements": [
     {
-      "id": "id135",
+      "id": "id139",
       "type": "text",
     },
   ],
@@ -3917,7 +3917,7 @@ exports[`history > multiplayer undo/redo > conflicts in bound text elements and 
   "frameId": null,
   "groupIds": [],
   "height": 100,
-  "id": "id134",
+  "id": "id138",
   "index": "a0",
   "isDeleted": false,
   "link": null,
@@ -3945,7 +3945,7 @@ exports[`history > multiplayer undo/redo > conflicts in bound text elements and 
   "autoResize": true,
   "backgroundColor": "transparent",
   "boundElements": null,
-  "containerId": "id134",
+  "containerId": "id138",
   "customData": undefined,
   "fillStyle": "solid",
   "fontFamily": 1,
@@ -3953,7 +3953,7 @@ exports[`history > multiplayer undo/redo > conflicts in bound text elements and 
   "frameId": null,
   "groupIds": [],
   "height": 25,
-  "id": "id135",
+  "id": "id139",
   "index": "a1",
   "isDeleted": false,
   "lineHeight": 1.25,
@@ -4000,7 +4000,7 @@ History {
       "elementsChange": ElementsChange {
         "added": Map {},
         "removed": Map {
-          "id134" => Delta {
+          "id138" => Delta {
             "deleted": {
               "angle": 0,
               "backgroundColor": "transparent",
@@ -4033,9 +4033,9 @@ History {
           },
         },
         "updated": Map {
-          "id135" => Delta {
+          "id139" => Delta {
             "deleted": {
-              "containerId": "id134",
+              "containerId": "id138",
             },
             "inserted": {
               "containerId": null,
@@ -4159,7 +4159,7 @@ exports[`history > multiplayer undo/redo > conflicts in bound text elements and 
   "backgroundColor": "transparent",
   "boundElements": [
     {
-      "id": "id137",
+      "id": "id141",
       "type": "text",
     },
   ],
@@ -4168,7 +4168,7 @@ exports[`history > multiplayer undo/redo > conflicts in bound text elements and 
   "frameId": null,
   "groupIds": [],
   "height": 100,
-  "id": "id136",
+  "id": "id140",
   "index": "Zz",
   "isDeleted": false,
   "link": null,
@@ -4196,7 +4196,7 @@ exports[`history > multiplayer undo/redo > conflicts in bound text elements and 
   "autoResize": true,
   "backgroundColor": "transparent",
   "boundElements": null,
-  "containerId": "id136",
+  "containerId": "id140",
   "customData": undefined,
   "fillStyle": "solid",
   "fontFamily": 1,
@@ -4204,7 +4204,7 @@ exports[`history > multiplayer undo/redo > conflicts in bound text elements and 
   "frameId": null,
   "groupIds": [],
   "height": 25,
-  "id": "id137",
+  "id": "id141",
   "index": "a0",
   "isDeleted": false,
   "lineHeight": 1.25,
@@ -4251,13 +4251,13 @@ History {
       "elementsChange": ElementsChange {
         "added": Map {},
         "removed": Map {
-          "id137" => Delta {
+          "id141" => Delta {
             "deleted": {
               "angle": 0,
               "autoResize": true,
               "backgroundColor": "transparent",
               "boundElements": null,
-              "containerId": "id136",
+              "containerId": "id140",
               "customData": undefined,
               "fillStyle": "solid",
               "fontFamily": 1,
@@ -4293,11 +4293,11 @@ History {
           },
         },
         "updated": Map {
-          "id136" => Delta {
+          "id140" => Delta {
             "deleted": {
               "boundElements": [
                 {
-                  "id": "id137",
+                  "id": "id141",
                   "type": "text",
                 },
               ],
@@ -4424,7 +4424,7 @@ exports[`history > multiplayer undo/redo > conflicts in bound text elements and 
   "backgroundColor": "transparent",
   "boundElements": [
     {
-      "id": "id151",
+      "id": "id155",
       "type": "text",
     },
   ],
@@ -4433,7 +4433,7 @@ exports[`history > multiplayer undo/redo > conflicts in bound text elements and 
   "frameId": null,
   "groupIds": [],
   "height": 100,
-  "id": "id150",
+  "id": "id154",
   "index": "Zz",
   "isDeleted": false,
   "link": null,
@@ -4461,7 +4461,7 @@ exports[`history > multiplayer undo/redo > conflicts in bound text elements and 
   "autoResize": true,
   "backgroundColor": "transparent",
   "boundElements": null,
-  "containerId": "id150",
+  "containerId": "id154",
   "customData": undefined,
   "fillStyle": "solid",
   "fontFamily": 1,
@@ -4469,7 +4469,7 @@ exports[`history > multiplayer undo/redo > conflicts in bound text elements and 
   "frameId": null,
   "groupIds": [],
   "height": 25,
-  "id": "id151",
+  "id": "id155",
   "index": "a0",
   "isDeleted": false,
   "lineHeight": 1.25,
@@ -4516,7 +4516,7 @@ History {
         "added": Map {},
         "removed": Map {},
         "updated": Map {
-          "id151" => Delta {
+          "id155" => Delta {
             "deleted": {
               "angle": 0,
               "x": 15,
@@ -4647,7 +4647,7 @@ exports[`history > multiplayer undo/redo > conflicts in bound text elements and 
   "backgroundColor": "transparent",
   "boundElements": [
     {
-      "id": "id149",
+      "id": "id153",
       "type": "text",
     },
   ],
@@ -4656,7 +4656,7 @@ exports[`history > multiplayer undo/redo > conflicts in bound text elements and 
   "frameId": null,
   "groupIds": [],
   "height": 100,
-  "id": "id148",
+  "id": "id152",
   "index": "a0",
   "isDeleted": false,
   "link": null,
@@ -4684,7 +4684,7 @@ exports[`history > multiplayer undo/redo > conflicts in bound text elements and 
   "autoResize": true,
   "backgroundColor": "transparent",
   "boundElements": null,
-  "containerId": "id148",
+  "containerId": "id152",
   "customData": undefined,
   "fillStyle": "solid",
   "fontFamily": 1,
@@ -4692,7 +4692,7 @@ exports[`history > multiplayer undo/redo > conflicts in bound text elements and 
   "frameId": null,
   "groupIds": [],
   "height": 25,
-  "id": "id149",
+  "id": "id153",
   "index": "a1",
   "isDeleted": false,
   "lineHeight": 1.25,
@@ -4740,7 +4740,7 @@ History {
         "added": Map {},
         "removed": Map {},
         "updated": Map {
-          "id148" => Delta {
+          "id152" => Delta {
             "deleted": {
               "angle": 90,
               "x": 200,
@@ -4874,7 +4874,7 @@ exports[`history > multiplayer undo/redo > conflicts in bound text elements and 
   "frameId": null,
   "groupIds": [],
   "height": 100,
-  "id": "id144",
+  "id": "id148",
   "index": "a0",
   "isDeleted": false,
   "link": null,
@@ -4902,7 +4902,7 @@ exports[`history > multiplayer undo/redo > conflicts in bound text elements and 
   "autoResize": true,
   "backgroundColor": "transparent",
   "boundElements": null,
-  "containerId": "id144",
+  "containerId": "id148",
   "customData": undefined,
   "fillStyle": "solid",
   "fontFamily": 1,
@@ -4910,7 +4910,7 @@ exports[`history > multiplayer undo/redo > conflicts in bound text elements and 
   "frameId": null,
   "groupIds": [],
   "height": 100,
-  "id": "id145",
+  "id": "id149",
   "index": "a1",
   "isDeleted": true,
   "lineHeight": 1.25,
@@ -4957,7 +4957,7 @@ History {
       "elementsChange": ElementsChange {
         "added": Map {},
         "removed": Map {
-          "id144" => Delta {
+          "id148" => Delta {
             "deleted": {
               "boundElements": [],
               "isDeleted": false,
@@ -4965,7 +4965,7 @@ History {
             "inserted": {
               "boundElements": [
                 {
-                  "id": "id145",
+                  "id": "id149",
                   "type": "text",
                 },
               ],
@@ -5091,7 +5091,7 @@ exports[`history > multiplayer undo/redo > conflicts in bound text elements and 
   "backgroundColor": "transparent",
   "boundElements": [
     {
-      "id": "id147",
+      "id": "id151",
       "type": "text",
     },
   ],
@@ -5100,7 +5100,7 @@ exports[`history > multiplayer undo/redo > conflicts in bound text elements and 
   "frameId": null,
   "groupIds": [],
   "height": 100,
-  "id": "id146",
+  "id": "id150",
   "index": "Zz",
   "isDeleted": true,
   "link": null,
@@ -5136,7 +5136,7 @@ exports[`history > multiplayer undo/redo > conflicts in bound text elements and 
   "frameId": null,
   "groupIds": [],
   "height": 100,
-  "id": "id147",
+  "id": "id151",
   "index": "a0",
   "isDeleted": false,
   "lineHeight": 1.25,
@@ -5183,13 +5183,13 @@ History {
       "elementsChange": ElementsChange {
         "added": Map {},
         "removed": Map {
-          "id147" => Delta {
+          "id151" => Delta {
             "deleted": {
               "containerId": null,
               "isDeleted": false,
             },
             "inserted": {
-              "containerId": "id146",
+              "containerId": "id150",
               "isDeleted": true,
             },
           },
@@ -5316,7 +5316,7 @@ exports[`history > multiplayer undo/redo > conflicts in frames and their childre
   "frameId": null,
   "groupIds": [],
   "height": 100,
-  "id": "id175",
+  "id": "id179",
   "index": "Zz",
   "isDeleted": false,
   "link": null,
@@ -5348,7 +5348,7 @@ exports[`history > multiplayer undo/redo > conflicts in frames and their childre
   "frameId": null,
   "groupIds": [],
   "height": 500,
-  "id": "id174",
+  "id": "id178",
   "index": "a0",
   "isDeleted": true,
   "link": null,
@@ -5391,7 +5391,7 @@ History {
       "elementsChange": ElementsChange {
         "added": Map {},
         "removed": Map {
-          "id175" => Delta {
+          "id179" => Delta {
             "deleted": {
               "angle": 0,
               "backgroundColor": "transparent",
@@ -5437,9 +5437,9 @@ History {
         "added": Map {},
         "removed": Map {},
         "updated": Map {
-          "id175" => Delta {
+          "id179" => Delta {
             "deleted": {
-              "frameId": "id174",
+              "frameId": "id178",
             },
             "inserted": {
               "frameId": null,
@@ -5527,7 +5527,7 @@ exports[`history > multiplayer undo/redo > should iterate through the history wh
   "penMode": false,
   "pendingImageElementId": null,
   "previousSelectedElementIds": {
-    "id103": true,
+    "id107": true,
   },
   "resizingElement": null,
   "scrollX": 0,
@@ -5568,7 +5568,7 @@ exports[`history > multiplayer undo/redo > should iterate through the history wh
     "A",
   ],
   "height": 100,
-  "id": "id102",
+  "id": "id106",
   "index": "a0",
   "isDeleted": false,
   "link": null,
@@ -5602,7 +5602,7 @@ exports[`history > multiplayer undo/redo > should iterate through the history wh
     "A",
   ],
   "height": 100,
-  "id": "id103",
+  "id": "id107",
   "index": "a1",
   "isDeleted": true,
   "link": null,
@@ -5639,8 +5639,8 @@ History {
         "delta": Delta {
           "deleted": {
             "selectedElementIds": {
-              "id102": true,
-              "id103": true,
+              "id106": true,
+              "id107": true,
             },
             "selectedGroupIds": {
               "A": true,
@@ -5656,7 +5656,7 @@ History {
         "added": Map {},
         "removed": Map {},
         "updated": Map {
-          "id102" => Delta {
+          "id106" => Delta {
             "deleted": {
               "angle": 0,
               "backgroundColor": "transparent",
@@ -5689,7 +5689,7 @@ History {
               "isDeleted": true,
             },
           },
-          "id103" => Delta {
+          "id107" => Delta {
             "deleted": {
               "angle": 0,
               "backgroundColor": "transparent",
@@ -5736,7 +5736,7 @@ History {
           "inserted": {
             "editingGroupId": null,
             "selectedElementIds": {
-              "id102": true,
+              "id106": true,
             },
             "selectedGroupIds": {
               "A": true,
@@ -5760,7 +5760,7 @@ History {
           "inserted": {
             "editingGroupId": "A",
             "selectedElementIds": {
-              "id103": true,
+              "id107": true,
             },
           },
         },
@@ -5850,7 +5850,7 @@ exports[`history > multiplayer undo/redo > should iterate through the history wh
   "penMode": false,
   "pendingImageElementId": null,
   "previousSelectedElementIds": {
-    "id90": true,
+    "id94": true,
   },
   "resizingElement": null,
   "scrollX": 0,
@@ -5889,7 +5889,7 @@ exports[`history > multiplayer undo/redo > should iterate through the history wh
   "frameId": null,
   "groupIds": [],
   "height": 10,
-  "id": "id88",
+  "id": "id92",
   "index": "a0",
   "isDeleted": false,
   "link": null,
@@ -5921,7 +5921,7 @@ exports[`history > multiplayer undo/redo > should iterate through the history wh
   "frameId": null,
   "groupIds": [],
   "height": 10,
-  "id": "id89",
+  "id": "id93",
   "index": "a1",
   "isDeleted": true,
   "link": null,
@@ -5953,7 +5953,7 @@ exports[`history > multiplayer undo/redo > should iterate through the history wh
   "frameId": null,
   "groupIds": [],
   "height": 10,
-  "id": "id90",
+  "id": "id94",
   "index": "a2",
   "isDeleted": true,
   "link": null,
@@ -5990,7 +5990,7 @@ History {
         "delta": Delta {
           "deleted": {
             "selectedElementIds": {
-              "id88": true,
+              "id92": true,
             },
           },
           "inserted": {
@@ -6001,7 +6001,7 @@ History {
       "elementsChange": ElementsChange {
         "added": Map {},
         "removed": Map {
-          "id88" => Delta {
+          "id92" => Delta {
             "deleted": {
               "angle": 0,
               "backgroundColor": "transparent",
@@ -6041,12 +6041,12 @@ History {
         "delta": Delta {
           "deleted": {
             "selectedElementIds": {
-              "id89": true,
+              "id93": true,
             },
           },
           "inserted": {
             "selectedElementIds": {
-              "id88": true,
+              "id92": true,
             },
           },
         },
@@ -6055,7 +6055,7 @@ History {
         "added": Map {},
         "removed": Map {},
         "updated": Map {
-          "id89" => Delta {
+          "id93" => Delta {
             "deleted": {
               "angle": 0,
               "backgroundColor": "#ffc9c9",
@@ -6100,7 +6100,7 @@ History {
         "added": Map {},
         "removed": Map {},
         "updated": Map {
-          "id89" => Delta {
+          "id93" => Delta {
             "deleted": {
               "backgroundColor": "#ffc9c9",
             },
@@ -6116,12 +6116,12 @@ History {
         "delta": Delta {
           "deleted": {
             "selectedElementIds": {
-              "id90": true,
+              "id94": true,
             },
           },
           "inserted": {
             "selectedElementIds": {
-              "id89": true,
+              "id93": true,
             },
           },
         },
@@ -6130,7 +6130,7 @@ History {
         "added": Map {},
         "removed": Map {},
         "updated": Map {
-          "id90" => Delta {
+          "id94" => Delta {
             "deleted": {
               "angle": 0,
               "backgroundColor": "#ffc9c9",
@@ -6175,7 +6175,7 @@ History {
         "added": Map {},
         "removed": Map {},
         "updated": Map {
-          "id90" => Delta {
+          "id94" => Delta {
             "deleted": {
               "x": 50,
               "y": 50,
@@ -6267,14 +6267,14 @@ exports[`history > multiplayer undo/redo > should iterate through the history wh
   "penMode": false,
   "pendingImageElementId": null,
   "previousSelectedElementIds": {
-    "id93": true,
+    "id97": true,
   },
   "resizingElement": null,
   "scrollX": 0,
   "scrollY": 0,
   "selectedElementIds": {
-    "id93": true,
-    "id94": true,
+    "id97": true,
+    "id98": true,
   },
   "selectedElementsAreBeingDragged": false,
   "selectedGroupIds": {},
@@ -6309,7 +6309,7 @@ exports[`history > multiplayer undo/redo > should iterate through the history wh
   "frameId": null,
   "groupIds": [],
   "height": 100,
-  "id": "id92",
+  "id": "id96",
   "index": "a0",
   "isDeleted": false,
   "link": null,
@@ -6341,7 +6341,7 @@ exports[`history > multiplayer undo/redo > should iterate through the history wh
   "frameId": null,
   "groupIds": [],
   "height": 100,
-  "id": "id93",
+  "id": "id97",
   "index": "a1",
   "isDeleted": false,
   "link": null,
@@ -6373,7 +6373,7 @@ exports[`history > multiplayer undo/redo > should iterate through the history wh
   "frameId": null,
   "groupIds": [],
   "height": 100,
-  "id": "id94",
+  "id": "id98",
   "index": "a2",
   "isDeleted": false,
   "link": null,
@@ -6410,7 +6410,7 @@ History {
         "delta": Delta {
           "deleted": {
             "selectedElementIds": {
-              "id92": true,
+              "id96": true,
             },
           },
           "inserted": {
@@ -6421,7 +6421,7 @@ History {
       "elementsChange": ElementsChange {
         "added": Map {},
         "removed": Map {
-          "id92" => Delta {
+          "id96" => Delta {
             "deleted": {
               "angle": 0,
               "backgroundColor": "transparent",
@@ -6452,7 +6452,7 @@ History {
               "isDeleted": true,
             },
           },
-          "id93" => Delta {
+          "id97" => Delta {
             "deleted": {
               "angle": 0,
               "backgroundColor": "transparent",
@@ -6483,7 +6483,7 @@ History {
               "isDeleted": true,
             },
           },
-          "id94" => Delta {
+          "id98" => Delta {
             "deleted": {
               "angle": 0,
               "backgroundColor": "transparent",
@@ -6523,12 +6523,12 @@ History {
         "delta": Delta {
           "deleted": {
             "selectedElementIds": {
-              "id93": true,
+              "id97": true,
             },
           },
           "inserted": {
             "selectedElementIds": {
-              "id92": true,
+              "id96": true,
             },
           },
         },
@@ -6544,7 +6544,7 @@ History {
         "delta": Delta {
           "deleted": {
             "selectedElementIds": {
-              "id94": true,
+              "id98": true,
             },
           },
           "inserted": {
@@ -6644,10 +6644,10 @@ exports[`history > multiplayer undo/redo > should iterate through the history wh
   "scrollX": 0,
   "scrollY": 0,
   "selectedElementIds": {
-    "id100": true,
-    "id101": true,
-    "id98": true,
-    "id99": true,
+    "id102": true,
+    "id103": true,
+    "id104": true,
+    "id105": true,
   },
   "selectedElementsAreBeingDragged": false,
   "selectedGroupIds": {
@@ -6687,7 +6687,7 @@ exports[`history > multiplayer undo/redo > should iterate through the history wh
     "A",
   ],
   "height": 100,
-  "id": "id98",
+  "id": "id102",
   "index": "a0",
   "isDeleted": false,
   "link": null,
@@ -6721,7 +6721,7 @@ exports[`history > multiplayer undo/redo > should iterate through the history wh
     "A",
   ],
   "height": 100,
-  "id": "id99",
+  "id": "id103",
   "index": "a1",
   "isDeleted": false,
   "link": null,
@@ -6755,7 +6755,7 @@ exports[`history > multiplayer undo/redo > should iterate through the history wh
     "B",
   ],
   "height": 100,
-  "id": "id100",
+  "id": "id104",
   "index": "a2",
   "isDeleted": false,
   "link": null,
@@ -6789,7 +6789,7 @@ exports[`history > multiplayer undo/redo > should iterate through the history wh
     "B",
   ],
   "height": 100,
-  "id": "id101",
+  "id": "id105",
   "index": "a3",
   "isDeleted": false,
   "link": null,
@@ -6826,8 +6826,8 @@ History {
         "delta": Delta {
           "deleted": {
             "selectedElementIds": {
-              "id98": true,
-              "id99": true,
+              "id102": true,
+              "id103": true,
             },
             "selectedGroupIds": {
               "A": true,
@@ -6850,8 +6850,8 @@ History {
         "delta": Delta {
           "deleted": {
             "selectedElementIds": {
-              "id100": true,
-              "id101": true,
+              "id104": true,
+              "id105": true,
             },
             "selectedGroupIds": {
               "B": true,
@@ -6987,7 +6987,7 @@ exports[`history > multiplayer undo/redo > should iterate through the history wh
   "frameId": null,
   "groupIds": [],
   "height": 10,
-  "id": "id106",
+  "id": "id110",
   "index": "a0",
   "isDeleted": true,
   "lastCommittedPoint": [
@@ -7040,7 +7040,7 @@ History {
         "delta": Delta {
           "deleted": {
             "selectedElementIds": {
-              "id106": true,
+              "id110": true,
             },
           },
           "inserted": {
@@ -7052,7 +7052,7 @@ History {
         "added": Map {},
         "removed": Map {},
         "updated": Map {
-          "id106" => Delta {
+          "id110" => Delta {
             "deleted": {
               "angle": 0,
               "backgroundColor": "transparent",
@@ -7108,7 +7108,7 @@ History {
       "appStateChange": AppStateChange {
         "delta": Delta {
           "deleted": {
-            "selectedLinearElementId": "id106",
+            "selectedLinearElementId": "id110",
           },
           "inserted": {
             "selectedLinearElementId": null,
@@ -7125,7 +7125,7 @@ History {
       "appStateChange": AppStateChange {
         "delta": Delta {
           "deleted": {
-            "editingLinearElementId": "id106",
+            "editingLinearElementId": "id110",
           },
           "inserted": {
             "editingLinearElementId": null,
@@ -7146,8 +7146,8 @@ History {
             "selectedLinearElementId": null,
           },
           "inserted": {
-            "editingLinearElementId": "id106",
-            "selectedLinearElementId": "id106",
+            "editingLinearElementId": "id110",
+            "selectedLinearElementId": "id110",
           },
         },
       },
@@ -7273,7 +7273,7 @@ exports[`history > multiplayer undo/redo > should iterate through the history wh
   "frameId": null,
   "groupIds": [],
   "height": 10,
-  "id": "id87",
+  "id": "id91",
   "index": "a0",
   "isDeleted": true,
   "link": null,
@@ -7310,7 +7310,7 @@ History {
         "delta": Delta {
           "deleted": {
             "selectedElementIds": {
-              "id87": true,
+              "id91": true,
             },
           },
           "inserted": {
@@ -7322,7 +7322,7 @@ History {
         "added": Map {},
         "removed": Map {},
         "updated": Map {
-          "id87" => Delta {
+          "id91" => Delta {
             "deleted": {
               "angle": 0,
               "backgroundColor": "#ffec99",
@@ -7367,7 +7367,7 @@ History {
         "added": Map {},
         "removed": Map {},
         "updated": Map {
-          "id87" => Delta {
+          "id91" => Delta {
             "deleted": {
               "backgroundColor": "#ffec99",
             },
@@ -7494,7 +7494,7 @@ exports[`history > multiplayer undo/redo > should iterate through the history wh
   "frameId": null,
   "groupIds": [],
   "height": 100,
-  "id": "id112",
+  "id": "id116",
   "index": "a1",
   "isDeleted": true,
   "link": null,
@@ -7526,7 +7526,7 @@ exports[`history > multiplayer undo/redo > should iterate through the history wh
   "frameId": null,
   "groupIds": [],
   "height": 100,
-  "id": "id113",
+  "id": "id117",
   "index": "a3V",
   "isDeleted": true,
   "link": null,
@@ -7558,7 +7558,7 @@ exports[`history > multiplayer undo/redo > should iterate through the history wh
   "frameId": null,
   "groupIds": [],
   "height": 100,
-  "id": "id111",
+  "id": "id115",
   "index": "a4",
   "isDeleted": true,
   "link": null,
@@ -7600,7 +7600,7 @@ History {
         "added": Map {},
         "removed": Map {},
         "updated": Map {
-          "id112" => Delta {
+          "id116" => Delta {
             "deleted": {
               "index": "a1",
             },
@@ -7619,14 +7619,14 @@ History {
           },
           "inserted": {
             "selectedElementIds": {
-              "id112": true,
+              "id116": true,
             },
           },
         },
       },
       "elementsChange": ElementsChange {
         "added": Map {
-          "id111" => Delta {
+          "id115" => Delta {
             "deleted": {
               "isDeleted": true,
             },
@@ -7657,7 +7657,7 @@ History {
               "y": 10,
             },
           },
-          "id112" => Delta {
+          "id116" => Delta {
             "deleted": {
               "isDeleted": true,
             },
@@ -7688,7 +7688,7 @@ History {
               "y": 20,
             },
           },
-          "id113" => Delta {
+          "id117" => Delta {
             "deleted": {
               "isDeleted": true,
             },
@@ -7841,7 +7841,7 @@ exports[`history > multiplayer undo/redo > should iterate through the history wh
   "frameId": null,
   "groupIds": [],
   "height": 100,
-  "id": "id107",
+  "id": "id111",
   "index": "Zx",
   "isDeleted": true,
   "link": null,
@@ -7873,7 +7873,7 @@ exports[`history > multiplayer undo/redo > should iterate through the history wh
   "frameId": null,
   "groupIds": [],
   "height": 100,
-  "id": "id109",
+  "id": "id113",
   "index": "Zy",
   "isDeleted": true,
   "link": null,
@@ -7905,7 +7905,7 @@ exports[`history > multiplayer undo/redo > should iterate through the history wh
   "frameId": null,
   "groupIds": [],
   "height": 100,
-  "id": "id108",
+  "id": "id112",
   "index": "a1",
   "isDeleted": true,
   "link": null,
@@ -7947,7 +7947,7 @@ History {
         "added": Map {},
         "removed": Map {},
         "updated": Map {
-          "id108" => Delta {
+          "id112" => Delta {
             "deleted": {
               "index": "a1",
             },
@@ -7966,14 +7966,14 @@ History {
           },
           "inserted": {
             "selectedElementIds": {
-              "id108": true,
+              "id112": true,
             },
           },
         },
       },
       "elementsChange": ElementsChange {
         "added": Map {
-          "id107" => Delta {
+          "id111" => Delta {
             "deleted": {
               "isDeleted": true,
             },
@@ -8004,7 +8004,7 @@ History {
               "y": 10,
             },
           },
-          "id108" => Delta {
+          "id112" => Delta {
             "deleted": {
               "isDeleted": true,
             },
@@ -8035,7 +8035,7 @@ History {
               "y": 20,
             },
           },
-          "id109" => Delta {
+          "id113" => Delta {
             "deleted": {
               "isDeleted": true,
             },
@@ -8151,15 +8151,15 @@ exports[`history > multiplayer undo/redo > should not let remote changes to inte
   "penMode": false,
   "pendingImageElementId": null,
   "previousSelectedElementIds": {
-    "id120": true,
-    "id121": true,
+    "id124": true,
+    "id125": true,
   },
   "resizingElement": null,
   "scrollX": 0,
   "scrollY": 0,
   "selectedElementIds": {
-    "id120": true,
-    "id121": true,
+    "id124": true,
+    "id125": true,
   },
   "selectedElementsAreBeingDragged": false,
   "selectedGroupIds": {},
@@ -8194,7 +8194,7 @@ exports[`history > multiplayer undo/redo > should not let remote changes to inte
   "frameId": null,
   "groupIds": [],
   "height": 10,
-  "id": "id120",
+  "id": "id124",
   "index": "a0",
   "isDeleted": false,
   "link": null,
@@ -8226,7 +8226,7 @@ exports[`history > multiplayer undo/redo > should not let remote changes to inte
   "frameId": null,
   "groupIds": [],
   "height": 10,
-  "id": "id121",
+  "id": "id125",
   "index": "a1",
   "isDeleted": false,
   "link": null,
@@ -8258,7 +8258,7 @@ exports[`history > multiplayer undo/redo > should not let remote changes to inte
   "frameId": null,
   "groupIds": [],
   "height": 100,
-  "id": "id125",
+  "id": "id129",
   "index": "a2",
   "isDeleted": false,
   "link": null,
@@ -8295,7 +8295,7 @@ History {
         "delta": Delta {
           "deleted": {
             "selectedElementIds": {
-              "id120": true,
+              "id124": true,
             },
           },
           "inserted": {
@@ -8306,7 +8306,7 @@ History {
       "elementsChange": ElementsChange {
         "added": Map {},
         "removed": Map {
-          "id120" => Delta {
+          "id124" => Delta {
             "deleted": {
               "angle": 0,
               "backgroundColor": "transparent",
@@ -8346,12 +8346,12 @@ History {
         "delta": Delta {
           "deleted": {
             "selectedElementIds": {
-              "id121": true,
+              "id125": true,
             },
           },
           "inserted": {
             "selectedElementIds": {
-              "id120": true,
+              "id124": true,
             },
           },
         },
@@ -8359,7 +8359,7 @@ History {
       "elementsChange": ElementsChange {
         "added": Map {},
         "removed": Map {
-          "id121" => Delta {
+          "id125" => Delta {
             "deleted": {
               "angle": 0,
               "backgroundColor": "transparent",
@@ -8399,12 +8399,12 @@ History {
         "delta": Delta {
           "deleted": {
             "selectedElementIds": {
-              "id120": true,
+              "id124": true,
             },
           },
           "inserted": {
             "selectedElementIds": {
-              "id121": true,
+              "id125": true,
             },
           },
         },
@@ -8420,7 +8420,7 @@ History {
         "delta": Delta {
           "deleted": {
             "selectedElementIds": {
-              "id121": true,
+              "id125": true,
             },
           },
           "inserted": {
@@ -8445,7 +8445,7 @@ History {
         "added": Map {},
         "removed": Map {},
         "updated": Map {
-          "id120" => Delta {
+          "id124" => Delta {
             "deleted": {
               "x": 90,
               "y": 90,
@@ -8455,7 +8455,7 @@ History {
               "y": 10,
             },
           },
-          "id121" => Delta {
+          "id125" => Delta {
             "deleted": {
               "x": 110,
               "y": 110,
@@ -8584,7 +8584,7 @@ exports[`history > multiplayer undo/redo > should not let remote changes to inte
   "frameId": null,
   "groupIds": [],
   "height": 50,
-  "id": "id115",
+  "id": "id119",
   "index": "a0",
   "isDeleted": false,
   "lastCommittedPoint": [
@@ -8643,7 +8643,7 @@ exports[`history > multiplayer undo/redo > should not let remote changes to inte
   "frameId": null,
   "groupIds": [],
   "height": 100,
-  "id": "id116",
+  "id": "id120",
   "index": "a1",
   "isDeleted": false,
   "link": null,
@@ -8685,7 +8685,7 @@ History {
       "elementsChange": ElementsChange {
         "added": Map {},
         "removed": Map {
-          "id115" => Delta {
+          "id119" => Delta {
             "deleted": {
               "angle": 0,
               "backgroundColor": "transparent",
@@ -8830,7 +8830,7 @@ exports[`history > multiplayer undo/redo > should not let remote changes to inte
   "scrollX": 0,
   "scrollY": 0,
   "selectedElementIds": {
-    "id117": true,
+    "id121": true,
   },
   "selectedElementsAreBeingDragged": false,
   "selectedGroupIds": {},
@@ -8865,7 +8865,7 @@ exports[`history > multiplayer undo/redo > should not let remote changes to inte
   "frameId": null,
   "groupIds": [],
   "height": 90,
-  "id": "id117",
+  "id": "id121",
   "index": "a0",
   "isDeleted": false,
   "link": null,
@@ -8897,7 +8897,7 @@ exports[`history > multiplayer undo/redo > should not let remote changes to inte
   "frameId": null,
   "groupIds": [],
   "height": 100,
-  "id": "id119",
+  "id": "id123",
   "index": "a1",
   "isDeleted": false,
   "link": null,
@@ -8934,7 +8934,7 @@ History {
         "delta": Delta {
           "deleted": {
             "selectedElementIds": {
-              "id117": true,
+              "id121": true,
             },
           },
           "inserted": {
@@ -8945,7 +8945,7 @@ History {
       "elementsChange": ElementsChange {
         "added": Map {},
         "removed": Map {
-          "id117" => Delta {
+          "id121" => Delta {
             "deleted": {
               "angle": 0,
               "backgroundColor": "transparent",
@@ -8991,7 +8991,7 @@ History {
         "added": Map {},
         "removed": Map {},
         "updated": Map {
-          "id117" => Delta {
+          "id121" => Delta {
             "deleted": {
               "height": 90,
               "width": 90,
@@ -9087,7 +9087,7 @@ exports[`history > multiplayer undo/redo > should not override remote changes on
   "scrollX": 0,
   "scrollY": 0,
   "selectedElementIds": {
-    "id77": true,
+    "id81": true,
   },
   "selectedElementsAreBeingDragged": false,
   "selectedGroupIds": {},
@@ -9122,7 +9122,7 @@ exports[`history > multiplayer undo/redo > should not override remote changes on
   "frameId": null,
   "groupIds": [],
   "height": 10,
-  "id": "id77",
+  "id": "id81",
   "index": "a0",
   "isDeleted": false,
   "link": null,
@@ -9154,7 +9154,7 @@ exports[`history > multiplayer undo/redo > should not override remote changes on
   "frameId": null,
   "groupIds": [],
   "height": 100,
-  "id": "id78",
+  "id": "id82",
   "index": "a1",
   "isDeleted": false,
   "link": null,
@@ -9196,7 +9196,7 @@ History {
         "added": Map {},
         "removed": Map {},
         "updated": Map {
-          "id77" => Delta {
+          "id81" => Delta {
             "deleted": {
               "backgroundColor": "transparent",
             },
@@ -9214,7 +9214,7 @@ History {
         "delta": Delta {
           "deleted": {
             "selectedElementIds": {
-              "id77": true,
+              "id81": true,
             },
           },
           "inserted": {
@@ -9225,7 +9225,7 @@ History {
       "elementsChange": ElementsChange {
         "added": Map {},
         "removed": Map {
-          "id77" => Delta {
+          "id81" => Delta {
             "deleted": {
               "angle": 0,
               "backgroundColor": "transparent",
@@ -9343,7 +9343,7 @@ exports[`history > multiplayer undo/redo > should not override remote changes on
   "scrollX": 0,
   "scrollY": 0,
   "selectedElementIds": {
-    "id79": true,
+    "id83": true,
   },
   "selectedElementsAreBeingDragged": false,
   "selectedGroupIds": {},
@@ -9378,7 +9378,7 @@ exports[`history > multiplayer undo/redo > should not override remote changes on
   "frameId": null,
   "groupIds": [],
   "height": 10,
-  "id": "id79",
+  "id": "id83",
   "index": "a0",
   "isDeleted": false,
   "link": null,
@@ -9415,7 +9415,7 @@ History {
         "delta": Delta {
           "deleted": {
             "selectedElementIds": {
-              "id79": true,
+              "id83": true,
             },
           },
           "inserted": {
@@ -9426,7 +9426,7 @@ History {
       "elementsChange": ElementsChange {
         "added": Map {},
         "removed": Map {
-          "id79" => Delta {
+          "id83" => Delta {
             "deleted": {
               "angle": 0,
               "backgroundColor": "transparent",
@@ -9472,7 +9472,7 @@ History {
         "added": Map {},
         "removed": Map {},
         "updated": Map {
-          "id79" => Delta {
+          "id83" => Delta {
             "deleted": {
               "backgroundColor": "#ffc9c9",
             },
@@ -9605,7 +9605,7 @@ exports[`history > multiplayer undo/redo > should override remotely added groups
     "B",
   ],
   "height": 100,
-  "id": "id81",
+  "id": "id85",
   "index": "a0",
   "isDeleted": false,
   "link": null,
@@ -9640,7 +9640,7 @@ exports[`history > multiplayer undo/redo > should override remotely added groups
     "B",
   ],
   "height": 100,
-  "id": "id82",
+  "id": "id86",
   "index": "a1",
   "isDeleted": false,
   "link": null,
@@ -9674,7 +9674,7 @@ exports[`history > multiplayer undo/redo > should override remotely added groups
     "B",
   ],
   "height": 100,
-  "id": "id83",
+  "id": "id87",
   "index": "a2",
   "isDeleted": false,
   "link": null,
@@ -9708,7 +9708,7 @@ exports[`history > multiplayer undo/redo > should override remotely added groups
     "B",
   ],
   "height": 100,
-  "id": "id84",
+  "id": "id88",
   "index": "a3",
   "isDeleted": false,
   "link": null,
@@ -9751,7 +9751,7 @@ History {
         "added": Map {},
         "removed": Map {},
         "updated": Map {
-          "id81" => Delta {
+          "id85" => Delta {
             "deleted": {
               "groupIds": [
                 "A",
@@ -9762,7 +9762,7 @@ History {
               "groupIds": [],
             },
           },
-          "id82" => Delta {
+          "id86" => Delta {
             "deleted": {
               "groupIds": [
                 "A",
@@ -9859,7 +9859,7 @@ exports[`history > multiplayer undo/redo > should override remotely added points
   "scrollX": 0,
   "scrollY": 0,
   "selectedElementIds": {
-    "id85": true,
+    "id89": true,
   },
   "selectedElementsAreBeingDragged": false,
   "selectedGroupIds": {},
@@ -9896,7 +9896,7 @@ exports[`history > multiplayer undo/redo > should override remotely added points
   "frameId": null,
   "groupIds": [],
   "height": 20,
-  "id": "id85",
+  "id": "id89",
   "index": "a0",
   "isDeleted": false,
   "lastCommittedPoint": [
@@ -9961,7 +9961,7 @@ History {
         "delta": Delta {
           "deleted": {
             "selectedElementIds": {
-              "id85": true,
+              "id89": true,
             },
           },
           "inserted": {
@@ -9972,7 +9972,7 @@ History {
       "elementsChange": ElementsChange {
         "added": Map {},
         "removed": Map {
-          "id85" => Delta {
+          "id89" => Delta {
             "deleted": {
               "angle": 0,
               "backgroundColor": "transparent",
@@ -10036,7 +10036,7 @@ History {
         "added": Map {},
         "removed": Map {},
         "updated": Map {
-          "id85" => Delta {
+          "id89" => Delta {
             "deleted": {
               "height": 30,
               "lastCommittedPoint": [
@@ -10093,7 +10093,7 @@ History {
       "appStateChange": AppStateChange {
         "delta": Delta {
           "deleted": {
-            "selectedLinearElementId": "id85",
+            "selectedLinearElementId": "id89",
           },
           "inserted": {
             "selectedLinearElementId": null,
@@ -10222,7 +10222,7 @@ exports[`history > multiplayer undo/redo > should redistribute deltas when eleme
   "frameId": null,
   "groupIds": [],
   "height": 10,
-  "id": "id86",
+  "id": "id90",
   "index": "a0",
   "isDeleted": false,
   "link": null,
@@ -10259,7 +10259,7 @@ History {
         "delta": Delta {
           "deleted": {
             "selectedElementIds": {
-              "id86": true,
+              "id90": true,
             },
           },
           "inserted": {
@@ -10270,7 +10270,7 @@ History {
       "elementsChange": ElementsChange {
         "added": Map {},
         "removed": Map {
-          "id86" => Delta {
+          "id90" => Delta {
             "deleted": {
               "angle": 0,
               "backgroundColor": "#ffec99",
@@ -10313,7 +10313,7 @@ History {
           },
           "inserted": {
             "selectedElementIds": {
-              "id86": true,
+              "id90": true,
             },
           },
         },
@@ -10322,7 +10322,7 @@ History {
         "added": Map {},
         "removed": Map {},
         "updated": Map {
-          "id86" => Delta {
+          "id90" => Delta {
             "deleted": {
               "isDeleted": false,
             },
@@ -10416,7 +10416,7 @@ exports[`history > multiplayer undo/redo > should update history entries after r
   "scrollX": 0,
   "scrollY": 0,
   "selectedElementIds": {
-    "id80": true,
+    "id84": true,
   },
   "selectedElementsAreBeingDragged": false,
   "selectedGroupIds": {},
@@ -10451,7 +10451,7 @@ exports[`history > multiplayer undo/redo > should update history entries after r
   "frameId": null,
   "groupIds": [],
   "height": 10,
-  "id": "id80",
+  "id": "id84",
   "index": "a0",
   "isDeleted": false,
   "link": null,
@@ -10493,7 +10493,7 @@ History {
         "added": Map {},
         "removed": Map {},
         "updated": Map {
-          "id80" => Delta {
+          "id84" => Delta {
             "deleted": {
               "backgroundColor": "#d0bfff",
             },
@@ -10515,7 +10515,7 @@ History {
         "added": Map {},
         "removed": Map {},
         "updated": Map {
-          "id80" => Delta {
+          "id84" => Delta {
             "deleted": {
               "backgroundColor": "transparent",
             },
@@ -10533,7 +10533,7 @@ History {
         "delta": Delta {
           "deleted": {
             "selectedElementIds": {
-              "id80": true,
+              "id84": true,
             },
           },
           "inserted": {
@@ -10544,7 +10544,7 @@ History {
       "elementsChange": ElementsChange {
         "added": Map {},
         "removed": Map {
-          "id80" => Delta {
+          "id84" => Delta {
             "deleted": {
               "angle": 0,
               "backgroundColor": "transparent",
@@ -10586,6 +10586,237 @@ History {
 exports[`history > multiplayer undo/redo > should update history entries after remote changes on the same properties > [end of test] number of elements 1`] = `1`;
 
 exports[`history > multiplayer undo/redo > should update history entries after remote changes on the same properties > [end of test] number of renders 1`] = `16`;
+
+exports[`history > singleplayer undo/redo > remounting undo/redo buttons should initialize undo/redo state correctly > [end of test] appState 1`] = `
+{
+  "activeEmbeddable": null,
+  "activeTool": {
+    "customType": null,
+    "lastActiveTool": null,
+    "locked": false,
+    "type": "selection",
+  },
+  "collaborators": Map {},
+  "contextMenu": null,
+  "currentChartType": "bar",
+  "currentItemBackgroundColor": "transparent",
+  "currentItemEndArrowhead": "arrow",
+  "currentItemFillStyle": "solid",
+  "currentItemFontFamily": 1,
+  "currentItemFontSize": 20,
+  "currentItemOpacity": 100,
+  "currentItemRoughness": 1,
+  "currentItemRoundness": "round",
+  "currentItemStartArrowhead": null,
+  "currentItemStrokeColor": "#1e1e1e",
+  "currentItemStrokeStyle": "solid",
+  "currentItemStrokeWidth": 2,
+  "currentItemTextAlign": "left",
+  "cursorButton": "up",
+  "defaultSidebarDockedPreference": false,
+  "draggingElement": null,
+  "editingElement": null,
+  "editingFrame": null,
+  "editingGroupId": null,
+  "editingLinearElement": null,
+  "elementsToHighlight": null,
+  "errorMessage": null,
+  "exportBackground": true,
+  "exportEmbedScene": false,
+  "exportScale": 1,
+  "exportWithDarkMode": false,
+  "fileHandle": null,
+  "followedBy": Set {},
+  "frameRendering": {
+    "clip": true,
+    "enabled": true,
+    "name": true,
+    "outline": true,
+  },
+  "frameToHighlight": null,
+  "gridSize": null,
+  "height": 0,
+  "isBindingEnabled": true,
+  "isLoading": false,
+  "isResizing": false,
+  "isRotating": false,
+  "lastPointerDownWith": "mouse",
+  "multiElement": null,
+  "objectsSnapModeEnabled": false,
+  "offsetLeft": 0,
+  "offsetTop": 0,
+  "openDialog": null,
+  "openMenu": null,
+  "openPopup": null,
+  "openSidebar": null,
+  "originSnapOffset": null,
+  "pasteDialog": {
+    "data": null,
+    "shown": false,
+  },
+  "penDetected": false,
+  "penMode": false,
+  "pendingImageElementId": null,
+  "previousSelectedElementIds": {},
+  "resizingElement": null,
+  "scrollX": 0,
+  "scrollY": 0,
+  "selectedElementIds": {},
+  "selectedElementsAreBeingDragged": false,
+  "selectedGroupIds": {},
+  "selectionElement": null,
+  "shouldCacheIgnoreZoom": false,
+  "showHyperlinkPopup": false,
+  "showStats": false,
+  "showWelcomeScreen": false,
+  "snapLines": [],
+  "startBoundElement": null,
+  "suggestedBindings": [],
+  "theme": "light",
+  "toast": null,
+  "userToFollow": null,
+  "viewBackgroundColor": "#ffffff",
+  "viewModeEnabled": false,
+  "width": 0,
+  "zenModeEnabled": false,
+  "zoom": {
+    "value": 1,
+  },
+}
+`;
+
+exports[`history > singleplayer undo/redo > remounting undo/redo buttons should initialize undo/redo state correctly > [end of test] element 0 1`] = `
+{
+  "angle": 0,
+  "backgroundColor": "transparent",
+  "boundElements": [],
+  "customData": undefined,
+  "fillStyle": "solid",
+  "frameId": null,
+  "groupIds": [],
+  "height": 100,
+  "id": "A",
+  "index": "a0",
+  "isDeleted": false,
+  "link": null,
+  "locked": false,
+  "opacity": 100,
+  "roughness": 1,
+  "roundness": {
+    "type": 3,
+  },
+  "strokeColor": "#1e1e1e",
+  "strokeStyle": "solid",
+  "strokeWidth": 2,
+  "type": "rectangle",
+  "updated": 1,
+  "version": 2,
+  "width": 100,
+  "x": 0,
+  "y": 0,
+}
+`;
+
+exports[`history > singleplayer undo/redo > remounting undo/redo buttons should initialize undo/redo state correctly > [end of test] element 1 1`] = `
+{
+  "angle": 0,
+  "backgroundColor": "transparent",
+  "boundElements": null,
+  "customData": undefined,
+  "fillStyle": "solid",
+  "frameId": null,
+  "groupIds": [],
+  "height": 10,
+  "id": "id80",
+  "index": "a1",
+  "isDeleted": true,
+  "link": null,
+  "locked": false,
+  "opacity": 100,
+  "roughness": 1,
+  "roundness": {
+    "type": 3,
+  },
+  "strokeColor": "#1e1e1e",
+  "strokeStyle": "solid",
+  "strokeWidth": 2,
+  "type": "rectangle",
+  "updated": 1,
+  "version": 4,
+  "width": 10,
+  "x": 0,
+  "y": 0,
+}
+`;
+
+exports[`history > singleplayer undo/redo > remounting undo/redo buttons should initialize undo/redo state correctly > [end of test] history 1`] = `
+History {
+  "onHistoryChangedEmitter": Emitter {
+    "subscribers": [
+      [Function],
+      [Function],
+    ],
+  },
+  "redoStack": [
+    HistoryEntry {
+      "appStateChange": AppStateChange {
+        "delta": Delta {
+          "deleted": {
+            "selectedElementIds": {},
+          },
+          "inserted": {
+            "selectedElementIds": {
+              "id80": true,
+            },
+          },
+        },
+      },
+      "elementsChange": ElementsChange {
+        "added": Map {
+          "id80" => Delta {
+            "deleted": {
+              "isDeleted": true,
+            },
+            "inserted": {
+              "angle": 0,
+              "backgroundColor": "transparent",
+              "boundElements": null,
+              "customData": undefined,
+              "fillStyle": "solid",
+              "frameId": null,
+              "groupIds": [],
+              "height": 10,
+              "index": "a1",
+              "isDeleted": false,
+              "link": null,
+              "locked": false,
+              "opacity": 100,
+              "roughness": 1,
+              "roundness": {
+                "type": 3,
+              },
+              "strokeColor": "#1e1e1e",
+              "strokeStyle": "solid",
+              "strokeWidth": 2,
+              "type": "rectangle",
+              "width": 10,
+              "x": 0,
+              "y": 0,
+            },
+          },
+        },
+        "removed": Map {},
+        "updated": Map {},
+      },
+    },
+  ],
+  "undoStack": [],
+}
+`;
+
+exports[`history > singleplayer undo/redo > remounting undo/redo buttons should initialize undo/redo state correctly > [end of test] number of elements 1`] = `2`;
+
+exports[`history > singleplayer undo/redo > remounting undo/redo buttons should initialize undo/redo state correctly > [end of test] number of renders 1`] = `12`;
 
 exports[`history > singleplayer undo/redo > should clear the redo stack on elements change > [end of test] appState 1`] = `
 {
@@ -11451,6 +11682,239 @@ History {
 exports[`history > singleplayer undo/redo > should create new history entry on scene import via drag&drop > [end of test] number of elements 1`] = `2`;
 
 exports[`history > singleplayer undo/redo > should create new history entry on scene import via drag&drop > [end of test] number of renders 1`] = `6`;
+
+exports[`history > singleplayer undo/redo > should disable undo/redo buttons when stacks empty > [end of test] appState 1`] = `
+{
+  "activeEmbeddable": null,
+  "activeTool": {
+    "customType": null,
+    "lastActiveTool": null,
+    "locked": false,
+    "type": "selection",
+  },
+  "collaborators": Map {},
+  "contextMenu": null,
+  "currentChartType": "bar",
+  "currentItemBackgroundColor": "transparent",
+  "currentItemEndArrowhead": "arrow",
+  "currentItemFillStyle": "solid",
+  "currentItemFontFamily": 1,
+  "currentItemFontSize": 20,
+  "currentItemOpacity": 100,
+  "currentItemRoughness": 1,
+  "currentItemRoundness": "round",
+  "currentItemStartArrowhead": null,
+  "currentItemStrokeColor": "#1e1e1e",
+  "currentItemStrokeStyle": "solid",
+  "currentItemStrokeWidth": 2,
+  "currentItemTextAlign": "left",
+  "cursorButton": "up",
+  "defaultSidebarDockedPreference": false,
+  "draggingElement": null,
+  "editingElement": null,
+  "editingFrame": null,
+  "editingGroupId": null,
+  "editingLinearElement": null,
+  "elementsToHighlight": null,
+  "errorMessage": null,
+  "exportBackground": true,
+  "exportEmbedScene": false,
+  "exportScale": 1,
+  "exportWithDarkMode": false,
+  "fileHandle": null,
+  "followedBy": Set {},
+  "frameRendering": {
+    "clip": true,
+    "enabled": true,
+    "name": true,
+    "outline": true,
+  },
+  "frameToHighlight": null,
+  "gridSize": null,
+  "height": 0,
+  "isBindingEnabled": true,
+  "isLoading": false,
+  "isResizing": false,
+  "isRotating": false,
+  "lastPointerDownWith": "mouse",
+  "multiElement": null,
+  "objectsSnapModeEnabled": false,
+  "offsetLeft": 0,
+  "offsetTop": 0,
+  "openDialog": null,
+  "openMenu": null,
+  "openPopup": null,
+  "openSidebar": null,
+  "originSnapOffset": null,
+  "pasteDialog": {
+    "data": null,
+    "shown": false,
+  },
+  "penDetected": false,
+  "penMode": false,
+  "pendingImageElementId": null,
+  "previousSelectedElementIds": {},
+  "resizingElement": null,
+  "scrollX": 0,
+  "scrollY": 0,
+  "selectedElementIds": {
+    "id78": true,
+  },
+  "selectedElementsAreBeingDragged": false,
+  "selectedGroupIds": {},
+  "selectionElement": null,
+  "shouldCacheIgnoreZoom": false,
+  "showHyperlinkPopup": false,
+  "showStats": false,
+  "showWelcomeScreen": false,
+  "snapLines": [],
+  "startBoundElement": null,
+  "suggestedBindings": [],
+  "theme": "light",
+  "toast": null,
+  "userToFollow": null,
+  "viewBackgroundColor": "#ffffff",
+  "viewModeEnabled": false,
+  "width": 0,
+  "zenModeEnabled": false,
+  "zoom": {
+    "value": 1,
+  },
+}
+`;
+
+exports[`history > singleplayer undo/redo > should disable undo/redo buttons when stacks empty > [end of test] element 0 1`] = `
+{
+  "angle": 0,
+  "backgroundColor": "transparent",
+  "boundElements": [],
+  "customData": undefined,
+  "fillStyle": "solid",
+  "frameId": null,
+  "groupIds": [],
+  "height": 100,
+  "id": "A",
+  "index": "a0",
+  "isDeleted": false,
+  "link": null,
+  "locked": false,
+  "opacity": 100,
+  "roughness": 1,
+  "roundness": {
+    "type": 3,
+  },
+  "strokeColor": "#1e1e1e",
+  "strokeStyle": "solid",
+  "strokeWidth": 2,
+  "type": "rectangle",
+  "updated": 1,
+  "version": 2,
+  "width": 100,
+  "x": 0,
+  "y": 0,
+}
+`;
+
+exports[`history > singleplayer undo/redo > should disable undo/redo buttons when stacks empty > [end of test] element 1 1`] = `
+{
+  "angle": 0,
+  "backgroundColor": "transparent",
+  "boundElements": null,
+  "customData": undefined,
+  "fillStyle": "solid",
+  "frameId": null,
+  "groupIds": [],
+  "height": 10,
+  "id": "id78",
+  "index": "a1",
+  "isDeleted": false,
+  "link": null,
+  "locked": false,
+  "opacity": 100,
+  "roughness": 1,
+  "roundness": {
+    "type": 3,
+  },
+  "strokeColor": "#1e1e1e",
+  "strokeStyle": "solid",
+  "strokeWidth": 2,
+  "type": "rectangle",
+  "updated": 1,
+  "version": 5,
+  "width": 10,
+  "x": 0,
+  "y": 0,
+}
+`;
+
+exports[`history > singleplayer undo/redo > should disable undo/redo buttons when stacks empty > [end of test] history 1`] = `
+History {
+  "onHistoryChangedEmitter": Emitter {
+    "subscribers": [
+      [Function],
+      [Function],
+    ],
+  },
+  "redoStack": [],
+  "undoStack": [
+    HistoryEntry {
+      "appStateChange": AppStateChange {
+        "delta": Delta {
+          "deleted": {
+            "selectedElementIds": {
+              "id78": true,
+            },
+          },
+          "inserted": {
+            "selectedElementIds": {},
+          },
+        },
+      },
+      "elementsChange": ElementsChange {
+        "added": Map {},
+        "removed": Map {
+          "id78" => Delta {
+            "deleted": {
+              "angle": 0,
+              "backgroundColor": "transparent",
+              "boundElements": null,
+              "customData": undefined,
+              "fillStyle": "solid",
+              "frameId": null,
+              "groupIds": [],
+              "height": 10,
+              "index": "a1",
+              "isDeleted": false,
+              "link": null,
+              "locked": false,
+              "opacity": 100,
+              "roughness": 1,
+              "roundness": {
+                "type": 3,
+              },
+              "strokeColor": "#1e1e1e",
+              "strokeStyle": "solid",
+              "strokeWidth": 2,
+              "type": "rectangle",
+              "width": 10,
+              "x": 0,
+              "y": 0,
+            },
+            "inserted": {
+              "isDeleted": true,
+            },
+          },
+        },
+        "updated": Map {},
+      },
+    },
+  ],
+}
+`;
+
+exports[`history > singleplayer undo/redo > should disable undo/redo buttons when stacks empty > [end of test] number of elements 1`] = `2`;
+
+exports[`history > singleplayer undo/redo > should disable undo/redo buttons when stacks empty > [end of test] number of renders 1`] = `8`;
 
 exports[`history > singleplayer undo/redo > should end up with no history entry after initializing scene > [end of test] appState 1`] = `
 {


### PR DESCRIPTION
### Description
This PR addresses the bug: When exiting view mode the undo/redo buttons are disabled even though their stacks aren't empty.

### Fix
Fixes https://github.com/excalidraw/excalidraw/issues/7948.
The default constructor is getting called which has values `isUndoStackEmpty` equal to `true` and `isRedoStackEmpty` equal to `true`.
Passing the function(from class `History`) which checks for whether the stacks are empty or not fixes the issue.

## Comparison
### Before

https://github.com/excalidraw/excalidraw/assets/53573748/ff57b133-8d9b-4574-8e69-e59b60177b85

### After

https://github.com/excalidraw/excalidraw/assets/53573748/329588d3-b6bb-4eea-8fe8-d9faa6810da1

