### PR TITLE
feat: rerender canvas on focus

### DIFF
--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -2594,6 +2594,9 @@ class App extends React.Component<AppProps, AppState> {
       ),
       addEventListener(window, EVENT.FOCUS, () => {
         this.maybeCleanupAfterMissingPointerUp(null);
+        // browsers (chrome?) tend to free up memory a lot, which results
+        // in canvas context being cleared. Thus re-render on focus.
+        this.triggerRender(true);
       }),
     );
 
@@ -3729,8 +3732,15 @@ class App extends React.Component<AppProps, AppState> {
     },
   );
 
-  private triggerRender = () => {
-    this.setState({});
+  private triggerRender = (
+    /** force always re-renders canvas even if no change */
+    force?: boolean,
+  ) => {
+    if (force === true) {
+      this.scene.triggerUpdate();
+    } else {
+      this.setState({});
+    }
   };
 
   /**


### PR DESCRIPTION
Honestly not sure if this is the root cause of the problem and thus will fix it, but it makes sense to me. We'll see.

Assumption: chrome frees up memory wherever it can (they're quite aggressive lately), and one such thing is clearing the canvas context when the tab is inactive.

If true, this PR rerender the canvas on focus.