### PR TITLE
fix: Check for roundness undefined in restore.ts

### DIFF
--- a/packages/excalidraw/data/restore.ts
+++ b/packages/excalidraw/data/restore.ts
@@ -140,7 +140,7 @@ const restoreElementWithProperties = <
     seed: element.seed ?? 1,
     groupIds: element.groupIds ?? [],
     frameId: element.frameId ?? null,
-    roundness: element.roundness
+    roundness: typeof element.roundness !== "undefined"
       ? element.roundness
       : element.strokeSharpness === "round"
       ? {


### PR DESCRIPTION
null is a valid value for roundness. The current code treats null as "to-be restored".