### PR TITLE
feat: normalize indices on scene init

### DIFF
--- a/excalidraw-app/App.tsx
+++ b/excalidraw-app/App.tsx
@@ -26,6 +26,7 @@ import {
   TTDDialogTrigger,
   StoreAction,
   reconcileElements,
+  normalizeIndices,
 } from "../packages/excalidraw";
 import type {
   AppState,
@@ -305,14 +306,21 @@ const initializeScene = async (opts: {
       key: roomLinkData.roomKey,
     };
   } else if (scene) {
+    const normalizedScene = {
+      ...scene,
+      // non-collab scenes are always always normalized on init
+      // collab scenes are normalized only on "first-in-room" as part of collabAPI
+      elements: normalizeIndices(scene.elements),
+    };
+
     return isExternalScene && jsonBackendMatch
       ? {
-          scene,
+          scene: normalizedScene,
           isExternalScene,
           id: jsonBackendMatch[1],
           key: jsonBackendMatch[2],
         }
-      : { scene, isExternalScene: false };
+      : { scene: normalizedScene, isExternalScene: false };
   }
   return { scene: null, isExternalScene: false };
 };

--- a/excalidraw-app/collab/Collab.tsx
+++ b/excalidraw-app/collab/Collab.tsx
@@ -18,6 +18,7 @@ import {
   restoreElements,
   zoomToFitBounds,
   reconcileElements,
+  normalizeIndices,
 } from "../../packages/excalidraw";
 import type { Collaborator, Gesture } from "../../packages/excalidraw/types";
 import {
@@ -637,7 +638,16 @@ class Collab extends PureComponent<CollabProps, CollabState> {
         fetchScene: true,
         roomLinkData: existingRoomLinkData,
       });
-      scenePromise.resolve(sceneData);
+
+      if (sceneData) {
+        scenePromise.resolve({
+          ...sceneData,
+          // normalize fractional indices on init for shared scenes, while making sure there are no other collaborators
+          elements: normalizeIndices([...sceneData.elements]),
+        });
+      } else {
+        scenePromise.resolve(null);
+      }
     });
 
     this.portal.socket.on(

--- a/excalidraw-app/data/index.ts
+++ b/excalidraw-app/data/index.ts
@@ -254,7 +254,7 @@ export const loadScene = async (
       await importFromBackend(id, privateKey),
       localDataState?.appState,
       localDataState?.elements,
-      { repairBindings: true, refreshDimensions: false },
+      { repairBindings: true },
     );
   } else {
     data = restore(localDataState || null, null, null, {

--- a/packages/excalidraw/data/blob.ts
+++ b/packages/excalidraw/data/blob.ts
@@ -154,7 +154,11 @@ export const loadSceneOrLibraryFromBlob = async (
           },
           localAppState,
           localElements,
-          { repairBindings: true, refreshDimensions: false },
+          {
+            repairBindings: true,
+            normalizeIndices: true,
+            refreshDimensions: false,
+          },
         ),
       };
     } else if (isValidLibrary(data)) {

--- a/packages/excalidraw/data/restore.ts
+++ b/packages/excalidraw/data/restore.ts
@@ -46,9 +46,9 @@ import { arrayToMap } from "../utils";
 import type { MarkOptional, Mutable } from "../utility-types";
 import { detectLineHeight, getContainerElement } from "../element/textElement";
 import { normalizeLink } from "./url";
-import { syncInvalidIndices } from "../fractionalIndex";
 import { getSizeFromPoints } from "../points";
 import { getLineHeight } from "../fonts";
+import { normalizeIndices, syncInvalidIndices } from "../fractionalIndex";
 
 type RestoredAppState = Omit<
   AppState,
@@ -405,36 +405,41 @@ export const restoreElements = (
   elements: ImportedDataState["elements"],
   /** NOTE doesn't serve for reconciliation */
   localElements: readonly ExcalidrawElement[] | null | undefined,
-  opts?: { refreshDimensions?: boolean; repairBindings?: boolean } | undefined,
+  opts?:
+    | {
+        refreshDimensions?: boolean;
+        repairBindings?: boolean;
+        normalizeIndices?: boolean;
+      }
+    | undefined,
 ): OrderedExcalidrawElement[] => {
   // used to detect duplicate top-level element ids
   const existingIds = new Set<string>();
   const localElementsMap = localElements ? arrayToMap(localElements) : null;
-  const restoredElements = syncInvalidIndices(
-    (elements || []).reduce((elements, element) => {
-      // filtering out selection, which is legacy, no longer kept in elements,
-      // and causing issues if retained
-      if (element.type !== "selection" && !isInvisiblySmallElement(element)) {
-        let migratedElement: ExcalidrawElement | null = restoreElement(element);
-        if (migratedElement) {
-          const localElement = localElementsMap?.get(element.id);
-          if (localElement && localElement.version > migratedElement.version) {
-            migratedElement = bumpVersion(
-              migratedElement,
-              localElement.version,
-            );
-          }
-          if (existingIds.has(migratedElement.id)) {
-            migratedElement = { ...migratedElement, id: randomId() };
-          }
-          existingIds.add(migratedElement.id);
-
-          elements.push(migratedElement);
+  const restoredElementsTemp = (elements || []).reduce((elements, element) => {
+    // filtering out selection, which is legacy, no longer kept in elements,
+    // and causing issues if retained
+    if (element.type !== "selection" && !isInvisiblySmallElement(element)) {
+      let migratedElement: ExcalidrawElement | null = restoreElement(element);
+      if (migratedElement) {
+        const localElement = localElementsMap?.get(element.id);
+        if (localElement && localElement.version > migratedElement.version) {
+          migratedElement = bumpVersion(migratedElement, localElement.version);
         }
+        if (existingIds.has(migratedElement.id)) {
+          migratedElement = { ...migratedElement, id: randomId() };
+        }
+        existingIds.add(migratedElement.id);
+
+        elements.push(migratedElement);
       }
-      return elements;
-    }, [] as ExcalidrawElement[]),
-  );
+    }
+    return elements;
+  }, [] as ExcalidrawElement[]);
+
+  const restoredElements = opts?.normalizeIndices
+    ? normalizeIndices(restoredElementsTemp)
+    : syncInvalidIndices(restoredElementsTemp);
 
   if (!opts?.repairBindings) {
     return restoredElements;
@@ -601,7 +606,11 @@ export const restore = (
    */
   localAppState: Partial<AppState> | null | undefined,
   localElements: readonly ExcalidrawElement[] | null | undefined,
-  elementsConfig?: { refreshDimensions?: boolean; repairBindings?: boolean },
+  elementsConfig?: {
+    refreshDimensions?: boolean;
+    repairBindings?: boolean;
+    normalizeIndices?: boolean;
+  },
 ): RestoredDataState => {
   return {
     elements: restoreElements(data?.elements, localElements, elementsConfig),

--- a/packages/excalidraw/fractionalIndex.ts
+++ b/packages/excalidraw/fractionalIndex.ts
@@ -6,6 +6,14 @@ import type {
   OrderedExcalidrawElement,
 } from "./element/types";
 import { InvalidFractionalIndexError } from "./errors";
+import { arrayToMap } from "./utils";
+
+/**
+ * Normalizes indices for all elements, to prevent possible issues caused by using stale (too old, too long) indices.
+ */
+export const normalizeIndices = (elements: ExcalidrawElement[]) => {
+  return syncMovedIndices(elements, arrayToMap(elements));
+};
 
 /**
  * Envisioned relation between array order and fractional indices:

--- a/packages/excalidraw/index.tsx
+++ b/packages/excalidraw/index.tsx
@@ -222,6 +222,8 @@ export {
   restoreLibraryItems,
 } from "./data/restore";
 
+export { normalizeIndices } from "./fractionalIndex";
+
 export { reconcileElements } from "./data/reconcile";
 
 export {

--- a/packages/excalidraw/tests/data/restore.test.ts
+++ b/packages/excalidraw/tests/data/restore.test.ts
@@ -4,6 +4,7 @@ import type {
   ExcalidrawFreeDrawElement,
   ExcalidrawLinearElement,
   ExcalidrawTextElement,
+  FractionalIndex,
 } from "../../element/types";
 import * as sizeHelpers from "../../element/sizeHelpers";
 import { API } from "../helpers/api";
@@ -574,6 +575,45 @@ describe("restore", () => {
       expect.objectContaining({
         id: ellipse.id,
         version: ellipse.version + 1,
+      }),
+    ]);
+  });
+});
+
+describe("normalize indices", () => {
+  it("shoudl normalize indices of all elements when normalize is true", () => {
+    const ellipse = API.createElement({
+      type: "ellipse",
+      index: "Zz" as FractionalIndex,
+    });
+    const container = API.createElement({
+      type: "rectangle",
+      index: undefined,
+    });
+    const boundElement = API.createElement({
+      type: "text",
+      containerId: container.id,
+      index: "a0000000000000000000000" as FractionalIndex,
+    });
+
+    const restoredElements = restore.restoreElements(
+      [ellipse, container, boundElement],
+      null,
+      { normalizeIndices: true },
+    );
+
+    expect(restoredElements).toEqual([
+      expect.objectContaining({
+        id: ellipse.id,
+        index: "a0",
+      }),
+      expect.objectContaining({
+        id: container.id,
+        index: "a1",
+      }),
+      expect.objectContaining({
+        id: boundElement.id,
+        index: "a2",
       }),
     ]);
   });


### PR DESCRIPTION
Introduce indices normalization for all elements, to prevent possible issues caused by using stale (too old, too long) indices.

### Where and when do we normalize?
1) host app
	- non-shared scenes, on each init
  	- shared scenes, only on the first client init
  	 	~ when a client is "first-in-room"; otherwise it could mess up the history of other clients
  	 	~ when there is already an existing room; otherwise it could mess up the history of the current client
2) editor
	- whenever we load a scene or library from a blob

### Why are we leaving the responsibility to the host apps?
- we cannot normalize on each init as we would possibly mess up with other clients histories, containing z-index changes in the stacks
  - if we ever persist history stacks, we might normalize only when history is empty for non-shared scenes and we will need to figure out something for shared scenes (possibly avoiding migrations of deltas in the stacks for each client)