### PR TITLE
fix: replaced resizeSingleElements() with resizeMultipleElements() fixes #6832

### DIFF
--- a/packages/excalidraw/element/resizeElements.ts
+++ b/packages/excalidraw/element/resizeElements.ts
@@ -422,6 +422,20 @@ const resizeSingleTextElement = (
   }
 };
 
+function rescalePointsAndTranslateOffset(dimension: 0 | 1, newSize: number, points: readonly Point[]): [translation: number, points: Point[]] {
+    const getPointsMinMax = (points: readonly Point[], dimension: 0 | 1) => {
+      const projectedPoints = points.map(point => point[dimension])
+      const min = Math.min(...projectedPoints);
+      const max = Math.max(...projectedPoints);
+      return {min, max}
+    }
+
+    const origin = getPointsMinMax(points, dimension)
+    const newPoints = rescalePoints(dimension, newSize, points, false)
+    const { min } = getPointsMinMax(newPoints, dimension)
+    return [origin.min - min, newPoints]
+}
+
 export const resizeSingleElement = (
   originalElements: PointerDownState["originalElements"],
   shouldMaintainAspectRatio: boolean,
@@ -638,26 +652,30 @@ export const resizeSingleElement = (
   newOrigin[0] += linearElementXOffset;
   newOrigin[1] += linearElementYOffset;
 
-  const nextX = newOrigin[0];
-  const nextY = newOrigin[1];
+  let nextX = newOrigin[0];
+  let nextY = newOrigin[1];
 
   // Readjust points for linear elements
   let rescaledElementPointsY;
   let rescaledPoints;
   if (isLinearElement(element) || isFreeDrawElement(element)) {
-    rescaledElementPointsY = rescalePoints(
+    let xOffset;
+    let yOffset;
+
+    [yOffset, rescaledElementPointsY] = rescalePointsAndTranslateOffset(
       1,
       eleNewHeight,
       (stateAtResizeStart as ExcalidrawLinearElement).points,
-      true,
     );
 
-    rescaledPoints = rescalePoints(
+    [xOffset, rescaledPoints] = rescalePointsAndTranslateOffset(
       0,
       eleNewWidth,
       rescaledElementPointsY,
-      true,
     );
+
+    nextY += yOffset;
+    nextX += xOffset;
   }
 
   const resizedElement = {


### PR DESCRIPTION
# Brief
I have switched resizeSingleElements() with resizeMultipleElements() and have found some bugs/maybe intentional exceptions that exist with resizeMultipleElements()

# Context
if you use the current code: all the problems/exceptions I am mentioning happen when scaling two elements
if you use my commit: all the problems/exceptions always happen when scaling

# Exceptions 
(maybe in other issues but are relevant right now)
- when you scale diamonds/circles with text in them vertically they start shifting (I guess this is to give the text some room but...)
- when you scale diamonds/circles with text in them horizontally they squish to individual characters then expand when the hitbox is small enough (divide by zero maybe)
- when you scale squares they don't scale horizontally or vertically they always scale both axis

# Question
- What is intended behavior and what isn't?

![image](https://github.com/excalidraw/excalidraw/assets/107800884/90ec0330-8a0f-47ac-b34c-c531ff3a8e0f)
