### PR TITLE
ci: Add metadata tags for Docker image publishing

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -17,9 +17,25 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=sha
+            type=ref,event=branch
+            type=ref,event=pr
+            type=ref,event=tag
+            type=semver,pattern={{version}}
+            type=raw,value={{date 'YYYYMMDD'}}
+          
       - name: Build and push
         uses: docker/build-push-action@v3
         with:
           context: .
           push: true
-          tags: excalidraw/excalidraw:latest
+          tags: |
+            ${{ steps.meta.outputs.tags }}
+            excalidraw/excalidraw:latest


### PR DESCRIPTION
fix issue : #8122

Description
This PR updates the GitHub Actions workflow to publish Docker images with additional tags for easier referencing. The workflow now includes tags based on the version of Excalidraw, the current date, and other relevant metadata.

Changes Made
Modified publish-docker.yml:
Added a step to extract metadata for Docker tags using docker/metadata-action@v5.
Included tags for commit SHA, branch name, PR number, git tag, semantic version, and the current date.
Updated the docker/build-push-action step to use the generated tags.

Workflow Overview
The updated workflow will now:

Tag Docker images with the commit SHA, branch name, PR number, git tag, semantic version, and the current date.
Push images to DockerHub with the latest tag as well as the newly generated tags