### PR TITLE
docs: fixed exportToCanvas() doc example using wrong prop

### DIFF
--- a/dev-docs/docs/@excalidraw/excalidraw/api/utils/export.mdx
+++ b/dev-docs/docs/@excalidraw/excalidraw/api/utils/export.mdx
@@ -90,7 +90,7 @@ function App() {
         <img src={canvasUrl} alt="" />
       </div>
       <div style={{ height: "400px" }}>
-        <Excalidraw ref={(api) => setExcalidrawAPI(api)}
+        <Excalidraw excalidrawAPI={(api) => setExcalidrawAPI(api)}
 />
       </div>
     </>


### PR DESCRIPTION
In the exportToCanvas() example, there's a mistake about the prop use to store the excalidrawAPI in the state. Currently, ref is passed to the <Excalidraw /> component and it is wrong because in a bare React project, an error is fired saying you can't pass ref to a function component (React 18). Thus we want to store the excalidrawAPI in a useState object so we need to use the excalidrawAPI prop instead. Else this example won't work for someone who follows the documentation.