### PR TITLE
fix: Incorrect point offsetting in LinearElementEditor.movePoints()

### DIFF
--- a/packages/excalidraw/element/linearElementEditor.ts
+++ b/packages/excalidraw/element/linearElementEditor.ts
@@ -1165,7 +1165,7 @@ export class LinearElementEditor {
     const nextPoints = points.map((point, idx) => {
       const selectedPointData = targetPoints.find((p) => p.index === idx);
       if (selectedPointData) {
-        if (idx === 0) {
+        if (selectedPointData.index === 0) {
           return point;
         }
 
@@ -1174,7 +1174,10 @@ export class LinearElementEditor {
         const deltaY =
           selectedPointData.point[1] - points[selectedPointData.index][1];
 
-        return [point[0] + deltaX, point[1] + deltaY] as const;
+        return [
+          point[0] + deltaX - offsetX,
+          point[1] + deltaY - offsetY,
+        ] as const;
       }
       return offsetX || offsetY
         ? ([point[0] - offsetX, point[1] - offsetY] as const)

--- a/packages/excalidraw/element/linearElementEditor.ts
+++ b/packages/excalidraw/element/linearElementEditor.ts
@@ -1165,7 +1165,7 @@ export class LinearElementEditor {
     const nextPoints = points.map((point, idx) => {
       const selectedPointData = targetPoints.find((p) => p.index === idx);
       if (selectedPointData) {
-        if (selectedOriginPoint) {
+        if (idx === 0) {
           return point;
         }
 

--- a/packages/excalidraw/tests/linearElementEditor.test.tsx
+++ b/packages/excalidraw/tests/linearElementEditor.test.tsx
@@ -27,6 +27,7 @@ import * as textElementUtils from "../element/textElement";
 import { ROUNDNESS, VERTICAL_ALIGN } from "../constants";
 import { vi } from "vitest";
 import { arrayToMap } from "../utils";
+import React from "react";
 
 const renderInteractiveScene = vi.spyOn(
   InteractiveCanvas,
@@ -972,8 +973,8 @@ describe("Test Linear Elements", () => {
       ]);
       expect((h.elements[1] as ExcalidrawTextElementWithContainer).text)
         .toMatchInlineSnapshot(`
-        "Online whiteboard 
-        collaboration made 
+        "Online whiteboard
+        collaboration made
         easy"
       `);
     });
@@ -1006,8 +1007,8 @@ describe("Test Linear Elements", () => {
       ]);
       expect((h.elements[1] as ExcalidrawTextElementWithContainer).text)
         .toMatchInlineSnapshot(`
-        "Online whiteboard 
-        collaboration made 
+        "Online whiteboard
+        collaboration made
         easy"
       `);
     });
@@ -1057,8 +1058,8 @@ describe("Test Linear Elements", () => {
         }
       `);
       expect(textElement.text).toMatchInlineSnapshot(`
-        "Online whiteboard 
-        collaboration made 
+        "Online whiteboard
+        collaboration made
         easy"
       `);
       expect(
@@ -1102,7 +1103,7 @@ describe("Test Linear Elements", () => {
       `);
       expect((h.elements[1] as ExcalidrawTextElementWithContainer).text)
         .toMatchInlineSnapshot(`
-          "Online whiteboard 
+          "Online whiteboard
           collaboration made easy"
         `);
       expect(
@@ -1141,8 +1142,8 @@ describe("Test Linear Elements", () => {
           }
         `);
       expect(textElement.text).toMatchInlineSnapshot(`
-        "Online whiteboard 
-        collaboration made 
+        "Online whiteboard
+        collaboration made
         easy"
       `);
       const points = LinearElementEditor.getPointsGlobalCoordinates(
@@ -1169,7 +1170,7 @@ describe("Test Linear Elements", () => {
           }
         `);
       expect(textElement.text).toMatchInlineSnapshot(`
-        "Online whiteboard 
+        "Online whiteboard
         collaboration made easy"
       `);
     });
@@ -1221,7 +1222,7 @@ describe("Test Linear Elements", () => {
           getBoundTextMaxWidth(arrow, null),
         ),
       ).toMatchInlineSnapshot(`
-        "Online whiteboard 
+        "Online whiteboard
         collaboration made easy"
       `);
       const handleBindTextResizeSpy = vi.spyOn(
@@ -1250,8 +1251,8 @@ describe("Test Linear Elements", () => {
           getBoundTextMaxWidth(arrow, null),
         ),
       ).toMatchInlineSnapshot(`
-        "Online whiteboard 
-        collaboration made 
+        "Online whiteboard
+        collaboration made
         easy"
       `);
     });
@@ -1347,6 +1348,29 @@ describe("Test Linear Elements", () => {
       expect(arrow.y).toBe(100);
       expect(label.x).toBe(0);
       expect(label.y).toBe(0);
+    });
+  });
+
+  describe("Test moving linear element points", () => {
+    it("should move the endpoint in the negative direction correctly when the start point is also moved in the positive direction", async () => {
+      const line = createThreePointerLinearElement("arrow");
+      const [origStartX, origStartY] = [line.x, line.y];
+
+      LinearElementEditor.movePoints(line, [
+        { index: 0, point: [line.points[0][0] + 10, line.points[0][1] + 10] },
+        {
+          index: line.points.length - 1,
+          point: [
+            line.points[line.points.length - 1][0] - 10,
+            line.points[line.points.length - 1][1] - 10,
+          ],
+        },
+      ]);
+      expect(line.x).toBe(origStartX + 10);
+      expect(line.y).toBe(origStartY + 10);
+
+      expect(line.points[line.points.length - 1][0]).toBe(20);
+      expect(line.points[line.points.length - 1][1]).toBe(-20);
     });
   });
 });

--- a/packages/excalidraw/tests/linearElementEditor.test.tsx
+++ b/packages/excalidraw/tests/linearElementEditor.test.tsx
@@ -973,10 +973,10 @@ describe("Test Linear Elements", () => {
       ]);
       expect((h.elements[1] as ExcalidrawTextElementWithContainer).text)
         .toMatchInlineSnapshot(`
-        "Online whiteboard
-        collaboration made
-        easy"
-      `);
+          "Online whiteboard 
+          collaboration made 
+          easy"
+        `);
     });
 
     it("should bind text to arrow when clicked on arrow and enter pressed", async () => {
@@ -1007,10 +1007,10 @@ describe("Test Linear Elements", () => {
       ]);
       expect((h.elements[1] as ExcalidrawTextElementWithContainer).text)
         .toMatchInlineSnapshot(`
-        "Online whiteboard
-        collaboration made
-        easy"
-      `);
+          "Online whiteboard 
+          collaboration made 
+          easy"
+        `);
     });
 
     it("should not bind text to line when double clicked", async () => {
@@ -1058,8 +1058,8 @@ describe("Test Linear Elements", () => {
         }
       `);
       expect(textElement.text).toMatchInlineSnapshot(`
-        "Online whiteboard
-        collaboration made
+        "Online whiteboard 
+        collaboration made 
         easy"
       `);
       expect(
@@ -1103,7 +1103,7 @@ describe("Test Linear Elements", () => {
       `);
       expect((h.elements[1] as ExcalidrawTextElementWithContainer).text)
         .toMatchInlineSnapshot(`
-          "Online whiteboard
+          "Online whiteboard 
           collaboration made easy"
         `);
       expect(
@@ -1142,8 +1142,8 @@ describe("Test Linear Elements", () => {
           }
         `);
       expect(textElement.text).toMatchInlineSnapshot(`
-        "Online whiteboard
-        collaboration made
+        "Online whiteboard 
+        collaboration made 
         easy"
       `);
       const points = LinearElementEditor.getPointsGlobalCoordinates(
@@ -1170,7 +1170,7 @@ describe("Test Linear Elements", () => {
           }
         `);
       expect(textElement.text).toMatchInlineSnapshot(`
-        "Online whiteboard
+        "Online whiteboard 
         collaboration made easy"
       `);
     });
@@ -1222,7 +1222,7 @@ describe("Test Linear Elements", () => {
           getBoundTextMaxWidth(arrow, null),
         ),
       ).toMatchInlineSnapshot(`
-        "Online whiteboard
+        "Online whiteboard 
         collaboration made easy"
       `);
       const handleBindTextResizeSpy = vi.spyOn(
@@ -1251,8 +1251,8 @@ describe("Test Linear Elements", () => {
           getBoundTextMaxWidth(arrow, null),
         ),
       ).toMatchInlineSnapshot(`
-        "Online whiteboard
-        collaboration made
+        "Online whiteboard 
+        collaboration made 
         easy"
       `);
     });


### PR DESCRIPTION
The `LinearElementEditor.movePoints()` function incorrectly calculates the offset for local linear element points when multiple targetPoints are provided, one of those target points is index === 0 AND the other points are moved in the negative direction, and ending up with negative local coordinates.
