### PR TITLE
replace nginx image with official rootless version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ARG NODE_ENV=production
 
 RUN yarn build:app:docker
 
-FROM nginx:1.24-alpine
+FROM nginxinc/nginx-unprivileged:alpine3.19
 
 COPY --from=build /opt/node_app/excalidraw-app/build /usr/share/nginx/html
 


### PR DESCRIPTION
In order to run excalidraw in restricted environments conveniently (without having to make an effort to build a rootless image just for that use case) i propose to use the official nginx unprivileged image. 

I don't think there are any drawbacks, with exception to the image being slightly larger.