### PR TITLE
chore: Consolidate i18n import in LanguageList component

### DIFF
--- a/excalidraw-app/components/LanguageList.tsx
+++ b/excalidraw-app/components/LanguageList.tsx
@@ -1,8 +1,7 @@
 import { useSetAtom } from "jotai";
 import React from "react";
 import { appLangCodeAtom } from "../App";
-import { useI18n } from "../../packages/excalidraw/i18n";
-import { languages } from "../../packages/excalidraw/i18n";
+import { useI18n, languages } from "../../packages/excalidraw/i18n";
 
 export const LanguageList = ({ style }: { style?: React.CSSProperties }) => {
   const { t, langCode } = useI18n();


### PR DESCRIPTION
Found a small code smell, the import of " ../../packages/excalidraw/i18n" was duplicated.

![image](https://github.com/excalidraw/excalidraw/assets/43703884/6614ada5-dc2b-4687-946c-5d60a823c19d)
