### PR TITLE
`docs:` Update UI style at some pages and update indented space

### DIFF
--- a/dev-docs/docs/@excalidraw/excalidraw/api/children-components/live-collaboration-trigger.mdx
+++ b/dev-docs/docs/@excalidraw/excalidraw/api/children-components/live-collaboration-trigger.mdx
@@ -14,7 +14,7 @@ function App() {
   const [excalidrawAPI, setExcalidrawAPI] = useState(null);
   const [isCollaborating, setIsCollaborating] = useState(false);
   return (
-    <div style={{ height: "500px" }}>
+    <div>
       <p style={{ fontSize: "16px" }}>
         Selecting the checkbox to see the collaborator count
       </p>
@@ -44,18 +44,20 @@ function App() {
         />
         Show Collaborators
       </label>
-      <Excalidraw
-        ref={(api) => setExcalidrawAPI(api)}
-        renderTopRightUI={() => (
-          <LiveCollaborationTrigger
-            isCollaborating={isCollaborating}
-            onSelect={() => {
-              window.alert("You clicked on collab button");
-              setIsCollaborating(true);
-            }}
-          />
-        )}
-      ></Excalidraw>
+      <div style={{ height: "500px" }}>
+        <Excalidraw
+          ref={(api) => setExcalidrawAPI(api)}
+          renderTopRightUI={() => (
+            <LiveCollaborationTrigger
+              isCollaborating={isCollaborating}
+              onSelect={() => {
+                window.alert("You clicked on collab button");
+                setIsCollaborating(true);
+              }}
+            />
+          )}
+        />
+      </div>
     </div>
   );
 }

--- a/dev-docs/docs/@excalidraw/excalidraw/api/props/excalidraw-api.mdx
+++ b/dev-docs/docs/@excalidraw/excalidraw/api/props/excalidraw-api.mdx
@@ -13,7 +13,7 @@ Once the callback is triggered, you will need to store the api in state to acces
 ```jsx showLineNumbers
 export default function App() {
   const [excalidrawAPI, setExcalidrawAPI] = useState(null);
-  return <Excalidraw excalidrawAPI={(api)=> setExcalidrawAPI(api)} />;
+  return <Excalidraw excalidrawAPI={(api) => setExcalidrawAPI(api)} />;
 }
 ```
 
@@ -110,12 +110,14 @@ function App() {
   };
   const [excalidrawAPI, setExcalidrawAPI] = useState(null);
   return (
-    <div style={{ height: "500px" }}>
+    <div>
       <p style={{ fontSize: "16px" }}> Click to update the scene</p>
       <button className="custom-button" onClick={updateScene}>
         Update Scene
       </button>
-      <Excalidraw excalidrawAPI={(api) => setExcalidrawAPI(api)} />
+      <div style={{ height: "500px" }}>
+        <Excalidraw excalidrawAPI={(api) => setExcalidrawAPI(api)} />
+      </div>
     </div>
   );
 }
@@ -160,7 +162,7 @@ function App() {
   }, [excalidrawAPI]);
 
   return (
-    <div style={{ height: "500px" }}>
+    <div>
       <p style={{ fontSize: "16px" }}> Click to update the library items</p>
       <button
         className="custom-button"
@@ -187,14 +189,16 @@ function App() {
       >
         Update Library
       </button>
-      <Excalidraw
-        excalidrawAPI={(api) => setExcalidrawAPI(api)}
-        // initial data retrieved from https://github.com/excalidraw/excalidraw/blob/master/dev-docs/packages/excalidraw/initialData.js
-        initialData={{
-          libraryItems: initialData.libraryItems,
-          appState: { openSidebar: "library" },
-        }}
-      />
+      <div style={{ height: "500px" }}>
+        <Excalidraw
+          excalidrawAPI={(api) => setExcalidrawAPI(api)}
+          // initial data retrieved from https://github.com/excalidraw/excalidraw/blob/master/dev-docs/packages/excalidraw/initialData.js
+          initialData={{
+            libraryItems: initialData.libraryItems,
+            appState: { openSidebar: "library" },
+          }}
+        />
+      </div>
     </div>
   );
 }

--- a/dev-docs/docs/@excalidraw/excalidraw/api/utils/export.mdx
+++ b/dev-docs/docs/@excalidraw/excalidraw/api/utils/export.mdx
@@ -14,35 +14,44 @@ We're working on much improved export utilities. Stay tuned!
 **_Signature_**
 
 <pre>
-exportToCanvas(&#123;<br/>&nbsp;
-  elements,<br/>&nbsp;
-  appState<br/>&nbsp;
-  getDimensions,<br/>&nbsp;
-  files,<br/>&nbsp;
-  exportPadding?: number;<br/>
-&#125;: <a href="https://github.com/excalidraw/excalidraw/blob/master/packages/excalidraw/packages/utils.ts#L21">ExportOpts</a>
+  exportToCanvas(&#123;
+  <br />
+  &nbsp; elements,
+  <br />
+  &nbsp; appState
+  <br />
+  &nbsp; getDimensions,
+  <br />
+  &nbsp; files,
+  <br />
+  &nbsp; exportPadding?: number;
+  <br />
+  &#125;:{" "}
+  <a href="https://github.com/excalidraw/excalidraw/blob/master/packages/excalidraw/packages/utils.ts#L21">
+    ExportOpts
+  </a>
 </pre>
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
 | `elements` | [Excalidraw Element []](https://github.com/excalidraw/excalidraw/blob/master/packages/excalidraw/element/types.ts#L114) |  | The elements to be exported to canvas. |
 | `appState` | [AppState](https://github.com/excalidraw/excalidraw/blob/master/packages/excalidraw/packages/utils.ts#L23) | [Default App State](https://github.com/excalidraw/excalidraw/blob/master/packages/excalidraw/appState.ts#L17) | The app state of the scene. |
-| [`getDimensions`](#getdimensions) | `function` | _ | A function which returns the `width`, `height`, and optionally `scale` (defaults to  `1`), with which canvas is to be exported. |
-| `maxWidthOrHeight` | `number` | _ | The maximum `width` or `height` of the exported image. If provided, `getDimensions` is ignored. |
-| `files` | [BinaryFiles](https://github.com/excalidraw/excalidraw/blob/master/packages/excalidraw/types.ts#L59) | _ | The files added to the scene. |
+| [`getDimensions`](#getdimensions) | `function` | \_ | A function which returns the `width`, `height`, and optionally `scale` (defaults to `1`), with which canvas is to be exported. |
+| `maxWidthOrHeight` | `number` | \_ | The maximum `width` or `height` of the exported image. If provided, `getDimensions` is ignored. |
+| `files` | [BinaryFiles](https://github.com/excalidraw/excalidraw/blob/master/packages/excalidraw/types.ts#L59) | \_ | The files added to the scene. |
 | `exportPadding` | `number` | `10` | The `padding` to be added on canvas. |
-
 
 #### getDimensions
 
 ```tsx
-(width: number, height: number) => { 
+(width: number, height: number) => {
   width: number,
-  height: number, 
-  scale?: number 
+  height: number,
+  scale?: number
 }
 ```
-A function which returns the `width`, `height`, and optionally `scale` (defaults to  `1`), with which canvas is to be exported.
+
+A function which returns the `width`, `height`, and optionally `scale` (defaults to `1`), with which canvas is to be exported.
 
 **How to use**
 
@@ -57,17 +66,17 @@ function App() {
   const [canvasUrl, setCanvasUrl] = useState("");
   const [excalidrawAPI, setExcalidrawAPI] = useState(null);
 
-  return  (
+  return (
     <>
       <button
         className="custom-button"
         onClick={async () => {
           if (!excalidrawAPI) {
-            return
+            return;
           }
           const elements = excalidrawAPI.getSceneElements();
           if (!elements || !elements.length) {
-            return
+            return;
           }
           const canvas = await exportToCanvas({
             elements,
@@ -76,7 +85,9 @@ function App() {
               exportWithDarkMode: false,
             },
             files: excalidrawAPI.getFiles(),
-            getDimensions: () => { return {width: 350, height: 350}}
+            getDimensions: () => {
+              return { width: 350, height: 350 };
+            },
           });
           const ctx = canvas.getContext("2d");
           ctx.font = "30px Virgil";
@@ -90,31 +101,38 @@ function App() {
         <img src={canvasUrl} alt="" />
       </div>
       <div style={{ height: "400px" }}>
-        <Excalidraw ref={(api) => setExcalidrawAPI(api)}
-/>
+        <Excalidraw ref={(api) => setExcalidrawAPI(api)} />
       </div>
     </>
-  )
+  );
 }
 ```
-
 
 ### exportToBlob
 
 **_Signature_**
 
 <pre>
-exportToBlob(<br/>&nbsp;
-  opts: <a href="https://github.com/excalidraw/excalidraw/blob/master/packages/excalidraw/packages/utils.ts#L14">ExportOpts</a> & &#123;<br/>&nbsp;
-  mimeType?: string,<br/>&nbsp;
-  quality?: number,<br/>&nbsp;
-  exportPadding?: number;<br/>
-})
+  exportToBlob(
+  <br />
+  &nbsp; opts:{" "}
+  <a href="https://github.com/excalidraw/excalidraw/blob/master/packages/excalidraw/packages/utils.ts#L14">
+    ExportOpts
+  </a>{" "}
+  & &#123;
+  <br />
+  &nbsp; mimeType?: string,
+  <br />
+  &nbsp; quality?: number,
+  <br />
+  &nbsp; exportPadding?: number;
+  <br />
+  })
 </pre>
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
-| `opts` | `object` | _ | This param is passed to `exportToCanvas`. You can refer to [`exportToCanvas`](#exporttocanvas) |
+| `opts` | `object` | \_ | This param is passed to `exportToCanvas`. You can refer to [`exportToCanvas`](#exporttocanvas) |
 | `mimeType` | `string` | `image/png` | Indicates the image format. |
 | `quality` | `number` | `0.92` | A value between `0` and `1` indicating the [image quality](https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/toBlob#parameters). Applies only to `image/jpeg`/`image/webp` MIME types. |
 | `exportPadding` | `number` | `10` | The padding to be added on canvas. |
@@ -132,26 +150,31 @@ Returns a promise which resolves with a [blob](https://developer.mozilla.org/en-
 **_Signature_**
 
 <pre>
-exportToSvg(&#123;<br/>&nbsp;
-  elements:&nbsp; 
-    <a href="https://github.com/excalidraw/excalidraw/blob/master/packages/excalidraw/element/types.ts#L114">
-      ExcalidrawElement[]
-    </a>,<br/>&nbsp;
-  appState:
-    <a href="https://github.com/excalidraw/excalidraw/blob/master/packages/excalidraw/types.ts#L95"> AppState
-    </a>,<br/>&nbsp;
-  exportPadding: number,<br/>&nbsp;
-  metadata: string,<br/>&nbsp;
-  files:&nbsp;
+  exportToSvg(&#123;
+  <br />
+  &nbsp; elements:&nbsp;
+  <a href="https://github.com/excalidraw/excalidraw/blob/master/packages/excalidraw/element/types.ts#L114">
+    ExcalidrawElement[]
+  </a>,<br />
+  &nbsp; appState:
+  <a href="https://github.com/excalidraw/excalidraw/blob/master/packages/excalidraw/types.ts#L95">
+    {" "}
+    AppState
+  </a>,<br />
+  &nbsp; exportPadding: number,
+  <br />
+  &nbsp; metadata: string,
+  <br />
+  &nbsp; files:&nbsp;
   <a href="https://github.com/excalidraw/excalidraw/blob/master/packages/excalidraw/types.ts#L59">
-      BinaryFiles
-    </a>,<br/>
-&#125;);
+    BinaryFiles
+  </a>,<br />
+  &#125;);
 </pre>
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
-| elements | [Excalidraw Element []](https://github.com/excalidraw/excalidraw/blob/master/packages/excalidraw/element/types.ts#L114) |  | The elements to exported as `svg `|
+| elements | [Excalidraw Element []](https://github.com/excalidraw/excalidraw/blob/master/packages/excalidraw/element/types.ts#L114) |  | The elements to exported as `svg ` |
 | appState | [AppState](https://github.com/excalidraw/excalidraw/blob/master/packages/excalidraw/types.ts#L95) | [defaultAppState](https://github.com/excalidraw/excalidraw/blob/master/packages/excalidraw/appState.ts#L11) | The `appState` of the scene |
 | exportPadding | number | 10 | The `padding` to be added on canvas |
 | files | [BinaryFiles](https://github.com/excalidraw/excalidraw/blob/master/packages/excalidraw/types.ts#L64) | undefined | The `files` added to the scene. |
@@ -163,12 +186,21 @@ This function returns a promise which resolves to `svg` of the exported drawing.
 **_Signature_**
 
 <pre>
-exportToClipboard(<br/>&nbsp;
-  opts: <a href="https://github.com/excalidraw/excalidraw/blob/master/packages/excalidraw/packages/utils.ts#L21">ExportOpts</a> & &#123;<br/>&nbsp;
-  mimeType?: string,<br/>&nbsp;
-  quality?: number;<br/>&nbsp;
-  type: 'png' | 'svg' |'json'<br/>
-})
+  exportToClipboard(
+  <br />
+  &nbsp; opts:{" "}
+  <a href="https://github.com/excalidraw/excalidraw/blob/master/packages/excalidraw/packages/utils.ts#L21">
+    ExportOpts
+  </a>{" "}
+  & &#123;
+  <br />
+  &nbsp; mimeType?: string,
+  <br />
+  &nbsp; quality?: number;
+  <br />
+  &nbsp; type: 'png' | 'svg' |'json'
+  <br />
+  })
 </pre>
 
 | Name | Type | Default | Description |
@@ -176,7 +208,7 @@ exportToClipboard(<br/>&nbsp;
 | `opts` |  |  | This param is same as the params passed to `exportToCanvas`. You can refer to [`exportToCanvas`](#exporttocanvas). |
 | `mimeType` | `string` | `image/png` | Indicates the image format, this will be used when exporting as `png`. |
 | `quality` | `number` | `0.92` | A value between `0` and `1` indicating the [image quality](https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/toBlob#parameters). Applies only to `image/jpeg` / `image/webp` MIME types. This will be used when exporting as `png`. |
-| `type` | 'png' &#124; 'svg' &#124; 'json' | _ | This determines the format to which the scene data should be `exported`. |
+| `type` | 'png' &#124; 'svg' &#124; 'json' | \_ | This determines the format to which the scene data should be `exported`. |
 
 **How to use**
 

--- a/dev-docs/docs/@excalidraw/excalidraw/api/utils/restore.mdx
+++ b/dev-docs/docs/@excalidraw/excalidraw/api/utils/restore.mdx
@@ -8,7 +8,21 @@ id: "restore"
 **_Signature_**
 
 <pre>
-restoreAppState(appState: <a href="https://github.com/excalidraw/excalidraw/blob/master/packages/excalidraw/data/types.ts#L34">ImportedDataState["appState"]</a>,<br/>&nbsp; localAppState: Partial&lt;<a href="https://github.com/excalidraw/excalidraw/blob/master/packages/excalidraw/types.ts#L95">AppState</a>> | null): <a href="https://github.com/excalidraw/excalidraw/blob/master/packages/excalidraw/types.ts#L95">AppState</a>
+  restoreAppState (
+  <br />
+  &nbsp; appState:{" "}
+  <a href="https://github.com/excalidraw/excalidraw/blob/master/packages/excalidraw/data/types.ts#L34">
+    ImportedDataState["appState"]
+  </a>
+  ,<br />
+  &nbsp; localAppState: Partial&lt;
+  <a href="https://github.com/excalidraw/excalidraw/blob/master/packages/excalidraw/types.ts#L95">
+    AppState
+  </a>> | null
+  <br />
+  ): <a href="https://github.com/excalidraw/excalidraw/blob/master/packages/excalidraw/types.ts#L95">
+    AppState
+  </a>
 </pre>
 
 **_How to use_**
@@ -20,26 +34,38 @@ import { restoreAppState } from "@excalidraw/excalidraw";
 This function will make sure all the `keys` have appropriate `values` in [appState](https://github.com/excalidraw/excalidraw/blob/master/packages/excalidraw/types.ts#L95) and if any key is missing, it will be set to its `default` value.
 
 When `localAppState` is supplied, it's used in place of values that are missing (`undefined`) in `appState` instead of the defaults.  
-Use this as a way to not override user's defaults if you persist them.
-You can pass `null` / `undefined` if not applicable.
+Use this as a way to not override user's defaults if you persist them. You can pass `null` / `undefined` if not applicable.
 
 ### restoreElements
 
 **_Signature_**
 
 <pre>
-restoreElements(
-  elements: <a href="https://github.com/excalidraw/excalidraw/blob/master/packages/excalidraw/element/types.ts#L114">ImportedDataState["elements"]</a>,<br/>&nbsp;
-  localElements: <a href="https://github.com/excalidraw/excalidraw/blob/master/packages/excalidraw/element/types.ts#L114">ExcalidrawElement[]</a> | null | undefined): <a href="https://github.com/excalidraw/excalidraw/blob/master/packages/excalidraw/element/types.ts#L114">ExcalidrawElement[]</a>,<br/>&nbsp;
-  opts: &#123; refreshDimensions?: boolean, repairBindings?: boolean }<br/>
-)
+  restoreElements (
+  <br />
+  &nbsp; elements:{" "}
+  <a href="https://github.com/excalidraw/excalidraw/blob/master/packages/excalidraw/element/types.ts#L114">
+    ImportedDataState["elements"]
+  </a>
+  ,<br />
+  &nbsp; localElements:{" "}
+  <a href="https://github.com/excalidraw/excalidraw/blob/master/packages/excalidraw/element/types.ts#L114">
+    ExcalidrawElement[]
+  </a>{" "}
+  | null | undefined):{" "}
+  <a href="https://github.com/excalidraw/excalidraw/blob/master/packages/excalidraw/element/types.ts#L114">
+    ExcalidrawElement[]
+  </a>
+  ,<br />
+  &nbsp; opts: &#123; refreshDimensions?: boolean, repairBindings?: boolean }
+  <br />)
 </pre>
 
 | Prop | Type | Description |
-| ---- | ---- | ---- |
+| --- | --- | --- |
 | `elements` | <a href="https://github.com/excalidraw/excalidraw/blob/master/packages/excalidraw/element/types.ts#L114">ImportedDataState["elements"]</a> | The `elements` to be restored |
-| [`localElements`](#localelements) | <a href="https://github.com/excalidraw/excalidraw/blob/master/packages/excalidraw/element/types.ts#L114">ExcalidrawElement[]</a> &#124; null &#124; undefined |  When `localElements` are supplied, they are used to ensure that existing restored elements reuse `version` (and increment it), and regenerate `versionNonce`. |
-| [`opts`](#opts) | `Object` | The extra optional parameter to configure restored elements
+| [`localElements`](#localelements) | <a href="https://github.com/excalidraw/excalidraw/blob/master/packages/excalidraw/element/types.ts#L114">ExcalidrawElement[]</a> &#124; null &#124; undefined | When `localElements` are supplied, they are used to ensure that existing restored elements reuse `version` (and increment it), and regenerate `versionNonce`. |
+| [`opts`](#opts) | `Object` | The extra optional parameter to configure restored elements |
 
 #### localElements
 
@@ -47,12 +73,13 @@ When `localElements` are supplied, they are used to ensure that existing restore
 Use this when you `import` elements which may already be present in the scene to ensure that you do not disregard the newly imported elements if you're using element version to detect the update
 
 #### opts
+
 The extra optional parameter to configure restored elements. It has the following attributes
 
-| Prop | Type | Description|
-| --- | --- | ------|
+| Prop | Type | Description |
+| --- | --- | --- |
 | `refreshDimensions` | `boolean` | Indicates whether we should also `recalculate` text element dimensions. Since this is a potentially costly operation, you may want to disable it if you restore elements in tight loops, such as during collaboration. |
-| `repairBindings` |`boolean` | Indicates whether the `bindings` for the elements should be repaired. This is to make sure there are no containers with non existent bound text element id and no bound text elements with non existent container id. |
+| `repairBindings` | `boolean` | Indicates whether the `bindings` for the elements should be repaired. This is to make sure there are no containers with non existent bound text element id and no bound text elements with non existent container id. |
 
 **_How to use_**
 
@@ -69,13 +96,31 @@ Parameter `refreshDimensions` indicates whether we should also `recalculate` tex
 **_Signature_**
 
 <pre>
-restore(
-  data: <a href="https://github.com/excalidraw/excalidraw/blob/master/packages/excalidraw/data/types.ts#L34">ImportedDataState</a>,<br/>&nbsp;
-  localAppState: Partial&lt;<a href="https://github.com/excalidraw/excalidraw/blob/master/packages/excalidraw/types.ts#L95">AppState</a>> | null | undefined,<br/>&nbsp;
-  localElements: <a href="https://github.com/excalidraw/excalidraw/blob/master/packages/excalidraw/element/types.ts#L114">ExcalidrawElement[]</a> | null | undefined<br/>): <a href="https://github.com/excalidraw/excalidraw/blob/master/packages/excalidraw/data/types.ts#L4">DataState</a><br/>
-  opts: &#123; refreshDimensions?: boolean, repairBindings?: boolean }<br/>
-
-)
+  restore (
+  <br />
+  &nbsp; data:{" "}
+  <a href="https://github.com/excalidraw/excalidraw/blob/master/packages/excalidraw/data/types.ts#L34">
+    ImportedDataState
+  </a>
+  ,<br />
+  &nbsp; localAppState: Partial&lt;
+  <a href="https://github.com/excalidraw/excalidraw/blob/master/packages/excalidraw/types.ts#L95">
+    AppState
+  </a>
+  > | null | undefined,
+  <br />
+  &nbsp; localElements:{" "}
+  <a href="https://github.com/excalidraw/excalidraw/blob/master/packages/excalidraw/element/types.ts#L114">
+    ExcalidrawElement[]
+  </a>{" "}
+  | null | undefined
+  <br />
+  ):{" "}
+  <a href="https://github.com/excalidraw/excalidraw/blob/master/packages/excalidraw/data/types.ts#L4">
+    DataState
+  </a>
+  <br />
+  opts: &#123; refreshDimensions?: boolean, repairBindings?: boolean &#125;
 </pre>
 
 See [`restoreAppState()`](https://github.com/excalidraw/excalidraw/blob/master/packages/excalidraw/packages/excalidraw/README.md#restoreAppState) about `localAppState`, and [`restoreElements()`](https://github.com/excalidraw/excalidraw/blob/master/packages/excalidraw/packages/excalidraw/README.md#restoreElements) about `localElements`.
@@ -93,8 +138,15 @@ This function makes sure elements and state is set to appropriate values and set
 **_Signature_**
 
 <pre>
-restoreLibraryItems(libraryItems: <a href="https://github.com/excalidraw/excalidraw/blob/master/packages/excalidraw/data/types.ts#L34">ImportedDataState["libraryItems"]</a>,<br/>&nbsp;
-defaultStatus: "published" | "unpublished")
+  restoreLibraryItems (
+  <br />
+  &nbsp; libraryItems:{" "}
+  <a href="https://github.com/excalidraw/excalidraw/blob/master/packages/excalidraw/data/types.ts#L34">
+    ImportedDataState["libraryItems"]
+  </a>
+  ,<br />
+  &nbsp; defaultStatus: "published" | "unpublished"
+  <br />)
 </pre>
 
 **_How to use_**

--- a/dev-docs/docs/@excalidraw/excalidraw/faq.mdx
+++ b/dev-docs/docs/@excalidraw/excalidraw/faq.mdx
@@ -6,30 +6,23 @@ No, Excalidraw package doesn't come with collaboration built in, since the imple
 
 ### Turning off Aggressive Anti-Fingerprinting in Brave browser
 
-When *Aggressive Anti-Fingerprinting* is turned on, the `measureText` API breaks which in turn breaks the Text Elements in your drawings. Here is more [info](https://github.com/excalidraw/excalidraw/pull/6336) on the same.
+When _Aggressive Anti-Fingerprinting_ is turned on, the `measureText` API breaks which in turn breaks the Text Elements in your drawings. Here is more [info](https://github.com/excalidraw/excalidraw/pull/6336) on the same.
 
 We strongly recommend turning it off. You can follow the steps below on how to do so.
 
-
-1. Open [excalidraw.com](https://excalidraw.com) in Brave and click on the **Shield** button
-![Shield button](../../assets/brave-shield.png)
+1. Open [excalidraw.com](https://excalidraw.com) in Brave and click on the **Shield** button ![Shield button](../../assets/brave-shield.png)
 
 <div style={{width:'30rem'}}>
 
-2. Once opened, look for **Aggressively Block Fingerprinting**
+2. Once opened, look for **Aggressively Block Fingerprinting** ![Aggressive block fingerprinting](../../assets/aggressive-block-fingerprint.png)
 
-![Aggressive block fingerprinting](../../assets/aggressive-block-fingerprint.png)
-
-3. Switch to **Block Fingerprinting**
-
-![Block filtering](../../assets/block-fingerprint.png)
+3. Switch to **Block Fingerprinting** ![Block filtering](../../assets/block-fingerprint.png)
 
 4. Thats all. All text elements should be fixed now 🎉
 
 </div>
 
 If disabling this setting doesn't fix the display of text elements, please consider opening an [issue](https://github.com/excalidraw/excalidraw/issues/new) on our GitHub, or message us on [Discord](https://discord.gg/UexuTaE).
-
 
 ### ReferenceError: process is not defined
 

--- a/dev-docs/docusaurus.config.js
+++ b/dev-docs/docusaurus.config.js
@@ -120,7 +120,7 @@ const config = {
             ],
           },
         ],
-        copyright: `Copyright © 2023 Excalidraw community. Built with Docusaurus ❤️`,
+        copyright: `Copyright © ${new Date().getFullYear()} Excalidraw community. Built with Docusaurus ❤️`,
       },
       prism: {
         theme: require("prism-react-renderer/themes/dracula"),


### PR DESCRIPTION
## `style:` update UI

- [_/dev-docs/docs/@excalidraw/excalidraw/api/children-components/live-collaboration-trigger.mdx_](https://docs.excalidraw.com/docs/@excalidraw/excalidraw/api/children-components/live-collaboration-trigger)
- [_/dev-docs/docs/@excalidraw/excalidraw/api/props/excalidraw-api.mdx_](https://docs.excalidraw.com/docs/@excalidraw/excalidraw/api/props/excalidraw-api)

## `style:` update indented space

- [_/dev-docs/docs/@excalidraw/excalidraw/api/utils/export.mdx_](https://docs.excalidraw.com/docs/@excalidraw/excalidraw/api/utils/export)
- [_/dev-docs/docs/@excalidraw/excalidraw/api/utils/restore.mdx_](https://docs.excalidraw.com/docs/@excalidraw/excalidraw/api/utils/restore)
- [_/dev-docs/docs/@excalidraw/excalidraw/faq.mdx_](https://docs.excalidraw.com/docs/@excalidraw/excalidraw/faq)

## `refactor:` update footer _Copyright_ line

- add method that fetch **current year**

  ```js
    new Date().getFullYear()
  ```
