### PR TITLE
feat: upgrade mermaid-to-excalidraw to v1.1.0

### DIFF
--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -3056,7 +3056,9 @@ class App extends React.Component<AppProps, AppState> {
           try {
             const { elements: skeletonElements, files } =
               await api.parseMermaidToExcalidraw(data.text, {
-                fontSize: DEFAULT_FONT_SIZE,
+                themeVariables: {
+                  fontSize: DEFAULT_FONT_SIZE,
+                },
               });
 
             const elements = convertToExcalidrawElements(skeletonElements, {

--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -3055,11 +3055,7 @@ class App extends React.Component<AppProps, AppState> {
 
           try {
             const { elements: skeletonElements, files } =
-              await api.parseMermaidToExcalidraw(data.text, {
-                themeVariables: {
-                  fontSize: DEFAULT_FONT_SIZE,
-                },
-              });
+              await api.parseMermaidToExcalidraw(data.text);
 
             const elements = convertToExcalidrawElements(skeletonElements, {
               regenerateIds: true,

--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -49,7 +49,6 @@ import {
 import type { PastedMixedContent } from "../clipboard";
 import { copyTextToSystemClipboard, parseClipboard } from "../clipboard";
 import type { EXPORT_IMAGE_TYPES } from "../constants";
-import { DEFAULT_FONT_SIZE } from "../constants";
 import {
   APP_NAME,
   CURSOR_TYPE,

--- a/packages/excalidraw/components/TTDDialog/common.ts
+++ b/packages/excalidraw/components/TTDDialog/common.ts
@@ -1,10 +1,6 @@
 import type { MermaidConfig } from "@excalidraw/mermaid-to-excalidraw";
 import type { MermaidToExcalidrawResult } from "@excalidraw/mermaid-to-excalidraw/dist/interfaces";
-import {
-  DEFAULT_EXPORT_PADDING,
-  DEFAULT_FONT_SIZE,
-  EDITOR_LS_KEYS,
-} from "../../constants";
+import { DEFAULT_EXPORT_PADDING, EDITOR_LS_KEYS } from "../../constants";
 import { convertToExcalidrawElements, exportToCanvas } from "../../index";
 import type { NonDeletedExcalidrawElement } from "../../element/types";
 import type { AppClassProperties, BinaryFiles } from "../../types";

--- a/packages/excalidraw/components/TTDDialog/common.ts
+++ b/packages/excalidraw/components/TTDDialog/common.ts
@@ -78,17 +78,10 @@ export const convertMermaidToExcalidraw = async ({
 
     let ret;
     try {
-      ret = await api.parseMermaidToExcalidraw(mermaidDefinition, {
-        themeVariables: {
-          fontSize: `${DEFAULT_FONT_SIZE}px`,
-        },
-      });
+      ret = await api.parseMermaidToExcalidraw(mermaidDefinition);
     } catch (err: any) {
       ret = await api.parseMermaidToExcalidraw(
         mermaidDefinition.replace(/"/g, "'"),
-        {
-          themeVariables: { fontSize: `${DEFAULT_FONT_SIZE}px` },
-        },
       );
     }
     const { elements, files } = ret;

--- a/packages/excalidraw/components/TTDDialog/common.ts
+++ b/packages/excalidraw/components/TTDDialog/common.ts
@@ -38,7 +38,7 @@ export interface MermaidToExcalidrawLibProps {
   api: Promise<{
     parseMermaidToExcalidraw: (
       definition: string,
-      options: MermaidConfig,
+      config?: MermaidConfig,
     ) => Promise<MermaidToExcalidrawResult>;
   }>;
 }
@@ -80,14 +80,14 @@ export const convertMermaidToExcalidraw = async ({
     try {
       ret = await api.parseMermaidToExcalidraw(mermaidDefinition, {
         themeVariables: {
-          fontSize: DEFAULT_FONT_SIZE,
+          fontSize: `${DEFAULT_FONT_SIZE}px`,
         },
       });
     } catch (err: any) {
       ret = await api.parseMermaidToExcalidraw(
         mermaidDefinition.replace(/"/g, "'"),
         {
-          themeVariables: { fontSize: DEFAULT_FONT_SIZE },
+          themeVariables: { fontSize: `${DEFAULT_FONT_SIZE}px` },
         },
       );
     }

--- a/packages/excalidraw/components/TTDDialog/common.ts
+++ b/packages/excalidraw/components/TTDDialog/common.ts
@@ -1,4 +1,4 @@
-import type { MermaidOptions } from "@excalidraw/mermaid-to-excalidraw";
+import type { MermaidConfig } from "@excalidraw/mermaid-to-excalidraw";
 import type { MermaidToExcalidrawResult } from "@excalidraw/mermaid-to-excalidraw/dist/interfaces";
 import {
   DEFAULT_EXPORT_PADDING,
@@ -38,7 +38,7 @@ export interface MermaidToExcalidrawLibProps {
   api: Promise<{
     parseMermaidToExcalidraw: (
       definition: string,
-      options: MermaidOptions,
+      options: MermaidConfig,
     ) => Promise<MermaidToExcalidrawResult>;
   }>;
 }
@@ -79,13 +79,15 @@ export const convertMermaidToExcalidraw = async ({
     let ret;
     try {
       ret = await api.parseMermaidToExcalidraw(mermaidDefinition, {
-        fontSize: DEFAULT_FONT_SIZE,
+        themeVariables: {
+          fontSize: DEFAULT_FONT_SIZE,
+        },
       });
     } catch (err: any) {
       ret = await api.parseMermaidToExcalidraw(
         mermaidDefinition.replace(/"/g, "'"),
         {
-          fontSize: DEFAULT_FONT_SIZE,
+          themeVariables: { fontSize: DEFAULT_FONT_SIZE },
         },
       );
     }

--- a/packages/excalidraw/package.json
+++ b/packages/excalidraw/package.json
@@ -58,7 +58,7 @@
   "dependencies": {
     "@braintree/sanitize-url": "6.0.2",
     "@excalidraw/laser-pointer": "1.3.1",
-    "@excalidraw/mermaid-to-excalidraw": "1.1.0-next.1",
+    "@excalidraw/mermaid-to-excalidraw": "1.1.0-next.4",
     "@excalidraw/random-username": "1.1.0",
     "@radix-ui/react-popover": "1.0.3",
     "@radix-ui/react-tabs": "1.0.2",

--- a/packages/excalidraw/package.json
+++ b/packages/excalidraw/package.json
@@ -58,7 +58,7 @@
   "dependencies": {
     "@braintree/sanitize-url": "6.0.2",
     "@excalidraw/laser-pointer": "1.3.1",
-    "@excalidraw/mermaid-to-excalidraw": "1.0.0",
+    "@excalidraw/mermaid-to-excalidraw": "1.1.0-next.1",
     "@excalidraw/random-username": "1.1.0",
     "@radix-ui/react-popover": "1.0.3",
     "@radix-ui/react-tabs": "1.0.2",

--- a/packages/excalidraw/package.json
+++ b/packages/excalidraw/package.json
@@ -58,7 +58,7 @@
   "dependencies": {
     "@braintree/sanitize-url": "6.0.2",
     "@excalidraw/laser-pointer": "1.3.1",
-    "@excalidraw/mermaid-to-excalidraw": "1.1.0-next.4",
+    "@excalidraw/mermaid-to-excalidraw": "1.1.0-next.5",
     "@excalidraw/random-username": "1.1.0",
     "@radix-ui/react-popover": "1.0.3",
     "@radix-ui/react-tabs": "1.0.2",

--- a/packages/excalidraw/package.json
+++ b/packages/excalidraw/package.json
@@ -58,7 +58,7 @@
   "dependencies": {
     "@braintree/sanitize-url": "6.0.2",
     "@excalidraw/laser-pointer": "1.3.1",
-    "@excalidraw/mermaid-to-excalidraw": "1.1.0-next.5",
+    "@excalidraw/mermaid-to-excalidraw": "1.1.0",
     "@excalidraw/random-username": "1.1.0",
     "@radix-ui/react-popover": "1.0.3",
     "@radix-ui/react-tabs": "1.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1930,10 +1930,10 @@
   resolved "https://registry.npmjs.org/@excalidraw/markdown-to-text/-/markdown-to-text-0.1.2.tgz#1703705e7da608cf478f17bfe96fb295f55a23eb"
   integrity sha512-1nDXBNAojfi3oSFwJswKREkFm5wrSjqay81QlyRv2pkITG/XYB5v+oChENVBQLcxQwX4IUATWvXM5BcaNhPiIg==
 
-"@excalidraw/mermaid-to-excalidraw@1.1.0-next.1":
-  version "1.1.0-next.1"
-  resolved "https://registry.yarnpkg.com/@excalidraw/mermaid-to-excalidraw/-/mermaid-to-excalidraw-1.1.0-next.1.tgz#8d2c4f3893ac39c3c7ed8b15261b87a2529a5eab"
-  integrity sha512-32QQtDTFP1Zr4Vzdtp0cjG/fdrf5morYLYQaipcFknw5ei5+zCouZ+md7Otc2AqNXdiR1Dn7275+xwyZbBc6FA==
+"@excalidraw/mermaid-to-excalidraw@1.1.0-next.4":
+  version "1.1.0-next.4"
+  resolved "https://registry.yarnpkg.com/@excalidraw/mermaid-to-excalidraw/-/mermaid-to-excalidraw-1.1.0-next.4.tgz#7a71c5bdd3a0f6f4aae1a87c61a745b9c51000e0"
+  integrity sha512-53lQB2OvQE8pmJWVnorQOsK0qHLwGY0MjgIXc/f1BV3nKRubqlOhmnRP7YOqIzLddQcE4ucLNYNnfJaeV+ZhOw==
   dependencies:
     "@excalidraw/markdown-to-text" "0.1.2"
     mermaid "10.9.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1930,10 +1930,10 @@
   resolved "https://registry.npmjs.org/@excalidraw/markdown-to-text/-/markdown-to-text-0.1.2.tgz#1703705e7da608cf478f17bfe96fb295f55a23eb"
   integrity sha512-1nDXBNAojfi3oSFwJswKREkFm5wrSjqay81QlyRv2pkITG/XYB5v+oChENVBQLcxQwX4IUATWvXM5BcaNhPiIg==
 
-"@excalidraw/mermaid-to-excalidraw@1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@excalidraw/mermaid-to-excalidraw/-/mermaid-to-excalidraw-1.0.0.tgz#8c058d2a43230425cba96d01e4a669a2d7c586a2"
-  integrity sha512-RGSoJBY2gFag6mQOIwa3OakTrvAZYx0bwvnr5ojuCZInih8Fxhje4X1WZfsaQx+GATEH8Ioq3O3b1FPDg4nKjQ==
+"@excalidraw/mermaid-to-excalidraw@1.1.0-next.1":
+  version "1.1.0-next.1"
+  resolved "https://registry.yarnpkg.com/@excalidraw/mermaid-to-excalidraw/-/mermaid-to-excalidraw-1.1.0-next.1.tgz#8d2c4f3893ac39c3c7ed8b15261b87a2529a5eab"
+  integrity sha512-32QQtDTFP1Zr4Vzdtp0cjG/fdrf5morYLYQaipcFknw5ei5+zCouZ+md7Otc2AqNXdiR1Dn7275+xwyZbBc6FA==
   dependencies:
     "@excalidraw/markdown-to-text" "0.1.2"
     mermaid "10.9.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1930,10 +1930,10 @@
   resolved "https://registry.npmjs.org/@excalidraw/markdown-to-text/-/markdown-to-text-0.1.2.tgz#1703705e7da608cf478f17bfe96fb295f55a23eb"
   integrity sha512-1nDXBNAojfi3oSFwJswKREkFm5wrSjqay81QlyRv2pkITG/XYB5v+oChENVBQLcxQwX4IUATWvXM5BcaNhPiIg==
 
-"@excalidraw/mermaid-to-excalidraw@1.1.0-next.4":
-  version "1.1.0-next.4"
-  resolved "https://registry.yarnpkg.com/@excalidraw/mermaid-to-excalidraw/-/mermaid-to-excalidraw-1.1.0-next.4.tgz#7a71c5bdd3a0f6f4aae1a87c61a745b9c51000e0"
-  integrity sha512-53lQB2OvQE8pmJWVnorQOsK0qHLwGY0MjgIXc/f1BV3nKRubqlOhmnRP7YOqIzLddQcE4ucLNYNnfJaeV+ZhOw==
+"@excalidraw/mermaid-to-excalidraw@1.1.0-next.5":
+  version "1.1.0-next.5"
+  resolved "https://registry.yarnpkg.com/@excalidraw/mermaid-to-excalidraw/-/mermaid-to-excalidraw-1.1.0-next.5.tgz#9983c1682ae4632ca0c69bc8a459cbdbc5ef85de"
+  integrity sha512-9gBIlZ6XDYcSXg6lfvPdzYYbEdcvnky9fQJBzACkoQRnqrjR6O6rLAi2bmyrPFG6mh0Wz49TwxHS8SY2W69lDA==
   dependencies:
     "@excalidraw/markdown-to-text" "0.1.2"
     mermaid "10.9.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1930,10 +1930,10 @@
   resolved "https://registry.npmjs.org/@excalidraw/markdown-to-text/-/markdown-to-text-0.1.2.tgz#1703705e7da608cf478f17bfe96fb295f55a23eb"
   integrity sha512-1nDXBNAojfi3oSFwJswKREkFm5wrSjqay81QlyRv2pkITG/XYB5v+oChENVBQLcxQwX4IUATWvXM5BcaNhPiIg==
 
-"@excalidraw/mermaid-to-excalidraw@1.1.0-next.5":
-  version "1.1.0-next.5"
-  resolved "https://registry.yarnpkg.com/@excalidraw/mermaid-to-excalidraw/-/mermaid-to-excalidraw-1.1.0-next.5.tgz#9983c1682ae4632ca0c69bc8a459cbdbc5ef85de"
-  integrity sha512-9gBIlZ6XDYcSXg6lfvPdzYYbEdcvnky9fQJBzACkoQRnqrjR6O6rLAi2bmyrPFG6mh0Wz49TwxHS8SY2W69lDA==
+"@excalidraw/mermaid-to-excalidraw@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@excalidraw/mermaid-to-excalidraw/-/mermaid-to-excalidraw-1.1.0.tgz#a24a7aa3ad2e4f671054fdb670a8508bab463814"
+  integrity sha512-YP2roqrImzek1SpUAeToSTNhH5Gfw9ogdI5KHp7c+I/mX7SEW8oNqqX7CP+oHcUgNF6RrYIkqSrnMRN9/3EGLg==
   dependencies:
     "@excalidraw/markdown-to-text" "0.1.2"
     mermaid "10.9.0"


### PR DESCRIPTION
changelog in https://github.com/excalidraw/mermaid-to-excalidraw/pull/68

To summarize

* Now the host can pass a config param to `parseMermaidToExcalidraw` which earlier only support fontSize.
* Additonally fontSize is renamed to `themeVariables.fontSize` and type is changed from `number` to `string` to keep in sync with mermaid config.
* I have removed the config since we already pass default params which are same as passed here.