### PR TITLE
feat: ability to debug the state of fractional indices

### DIFF
--- a/packages/excalidraw/data/reconcile.ts
+++ b/packages/excalidraw/data/reconcile.ts
@@ -82,25 +82,20 @@ export const reconcileElements = (
     import.meta.env.MODE === ENV.TEST ||
     window?.DEBUG_FRACTIONAL_INDICES
   ) {
-    try {
-      const elements = syncInvalidIndices(
-        // create new instances due to the mutation
-        orderedElements.map((x) => ({ ...x })),
-      );
+    const elements = syncInvalidIndices(
+      // create new instances due to the mutation
+      orderedElements.map((x) => ({ ...x })),
+    );
 
-      validateFractionalIndices(elements, {
-        shouldThrow: true,
-        includeBoundTextValidation: true,
-      });
-    } catch (e) {
-      console.error("Local elements:", localElements);
-      console.error("Remote elements:", remoteElements);
-
-      if (import.meta.env.DEV || import.meta.env.MODE === ENV.TEST) {
-        // re-throw only in dev & test, to remain functional on `DEBUG_FRACTIONAL_INDICES`
-        throw e;
-      }
-    }
+    validateFractionalIndices(elements, {
+      // throw in dev & test only, to remain functional on `DEBUG_FRACTIONAL_INDICES`
+      shouldThrow: import.meta.env.DEV || import.meta.env.MODE === ENV.TEST,
+      includeBoundTextValidation: true,
+      reconciliationContext: {
+        localElements,
+        remoteElements,
+      },
+    });
   }
 
   // de-duplicate indices

--- a/packages/excalidraw/global.d.ts
+++ b/packages/excalidraw/global.d.ts
@@ -4,6 +4,7 @@ interface Window {
   EXCALIDRAW_ASSET_PATH: string | undefined;
   EXCALIDRAW_EXPORT_SOURCE: string;
   EXCALIDRAW_THROTTLE_RENDER: boolean | undefined;
+  DEBUG_FRACTIONAL_INDICES: boolean | undefined;
   gtag: Function;
   sa_event: Function;
   fathom: { trackEvent: Function };

--- a/packages/excalidraw/scene/Scene.ts
+++ b/packages/excalidraw/scene/Scene.ts
@@ -274,9 +274,17 @@ class Scene {
         : Array.from(nextElements.values());
     const nextFrameLikes: ExcalidrawFrameLikeElement[] = [];
 
-    if (import.meta.env.DEV || import.meta.env.MODE === ENV.TEST) {
-      // throw on invalid indices in test / dev to potentially detect cases were we forgot to sync moved elements
-      validateFractionalIndices(_nextElements.map((x) => x.index));
+    if (
+      import.meta.env.DEV ||
+      import.meta.env.MODE === ENV.TEST ||
+      window?.DEBUG_FRACTIONAL_INDICES
+    ) {
+      validateFractionalIndices(_nextElements, {
+        // validate everything
+        includeBoundTextValidation: true,
+        // throw only in dev & test, to remain functional on `DEBUG_FRACTIONAL_INDICES`
+        shouldThrow: import.meta.env.DEV || import.meta.env.MODE === ENV.TEST,
+      });
     }
 
     this.elements = syncInvalidIndices(_nextElements);

--- a/packages/excalidraw/tests/fractionalIndex.test.ts
+++ b/packages/excalidraw/tests/fractionalIndex.test.ts
@@ -763,7 +763,10 @@ function test(
     // ensure the input is invalid (unless the flag is on)
     if (!expectValidInput) {
       expect(() =>
-        validateFractionalIndices(elements.map((x) => x.index)),
+        validateFractionalIndices(elements, {
+          shouldThrow: true,
+          includeBoundTextValidation: true,
+        }),
       ).toThrowError(InvalidFractionalIndexError);
     }
 
@@ -777,7 +780,10 @@ function test(
 
     expect(syncedElements.length).toBe(elements.length);
     expect(() =>
-      validateFractionalIndices(syncedElements.map((x) => x.index)),
+      validateFractionalIndices(syncedElements, {
+        shouldThrow: true,
+        includeBoundTextValidation: true,
+      }),
     ).not.toThrowError(InvalidFractionalIndexError);
 
     syncedElements.forEach((synced, index) => {


### PR DESCRIPTION
- hidden behind `window.DEBUG_FRACTIONAL_INDICES`
- disabled by default for OSS (should get enabled for E+)