### PR TITLE
fix: freedraw jittering

### DIFF
--- a/packages/excalidraw/renderer/renderElement.ts
+++ b/packages/excalidraw/renderer/renderElement.ts
@@ -471,16 +471,7 @@ const drawElementFromCanvas = (
   const element = elementWithCanvas.element;
   const padding = getCanvasPadding(element);
   const zoom = elementWithCanvas.scale;
-  let [x1, y1, x2, y2] = getElementAbsoluteCoords(element, allElementsMap);
-
-  // Free draw elements will otherwise "shuffle" as the min x and y change
-  if (isFreeDrawElement(element)) {
-    x1 = Math.floor(x1);
-    x2 = Math.ceil(x2);
-    y1 = Math.floor(y1);
-    y2 = Math.ceil(y2);
-  }
-
+  const [x1, y1, x2, y2] = getElementAbsoluteCoords(element, allElementsMap);
   const cx = ((x1 + x2) / 2 + appState.scrollX) * window.devicePixelRatio;
   const cy = ((y1 + y2) / 2 + appState.scrollY) * window.devicePixelRatio;
 


### PR DESCRIPTION
Fixes #8234

The problematic code was introduced in #3512 to fix 'shuffle' bug. (https://github.com/excalidraw/excalidraw/pull/3512/commits/d9af6099f54587102fc57a8e069eb1797b783b21) 

At the time, the code was fine. The commit also had corresponding code in `generateElementCanvas()` that generated canvas drawing with floored x and y as base. Which was why `x1 = Math.floor(x1)` needed to be used in `drawElementFromCanvas()`,  when copying over the rendered element from that canvas.

But in #4357, the `Math.floor` code in `generatedElementCanvas()` was removed, yet it did not remove the matching code from `drawElementFromCanvas()` as well. Which resulted in the freehand drawing being rendered to a slightly wrong position.