### PR TITLE
perf: cache getElementShape() result

### DIFF
--- a/packages/excalidraw/element/bounds.ts
+++ b/packages/excalidraw/element/bounds.ts
@@ -482,7 +482,7 @@ export const getBoundsFromPoints = (
   return [minX, minY, maxX, maxY];
 };
 
-const getFreeDrawElementAbsoluteCoords = (
+export const getFreeDrawElementAbsoluteCoords = (
   element: ExcalidrawFreeDrawElement,
 ): [number, number, number, number, number, number] => {
   const [minX, minY, maxX, maxY] = getBoundsFromPoints(element.points);


### PR DESCRIPTION
Closes #8070 

This PR caches `getElementShape()` result if possible.

`getElementShape()` is what takes up most time when using the eraser, and for pointer move handler. This PR improves performance for eraser tool drastically.

## Result

On a canvas with 13k freedraw elements in Chrome (Macbook M1), this improves `handleEraser()` from 110ms to 35ms, and `handleCanvasPointerMove()` from 80ms to 15ms. 

On Firefox with 3k freedraw elements, `handleEraser()` from 150ms to 7ms, and `handleCanvasPointerMove()` from 150ms to 15ms.



