### PR TITLE
fix: Dont lose text editing focus on switching windows

### DIFF
--- a/packages/excalidraw/element/textWysiwyg.tsx
+++ b/packages/excalidraw/element/textWysiwyg.tsx
@@ -576,6 +576,12 @@ export const textWysiwyg = ({
     });
   };
 
+  const handleBlur = () => {
+    if (document.activeElement !== editable) {
+      handleSubmit();
+    }
+  };
+
   const cleanup = () => {
     // remove events to ensure they don't late-fire
     editable.onblur = null;
@@ -610,7 +616,7 @@ export const textWysiwyg = ({
       target.classList.contains("properties-trigger");
 
     setTimeout(() => {
-      editable.onblur = handleSubmit;
+      editable.onblur = handleBlur;
 
       // case: clicking on the same property → no change → no update → no focus
       if (!isPropertiesTrigger) {

--- a/packages/excalidraw/element/textWysiwyg.tsx
+++ b/packages/excalidraw/element/textWysiwyg.tsx
@@ -582,10 +582,6 @@ export const textWysiwyg = ({
     }
   };
 
-  const handleBlurDuringMenuClick = () => {
-    bindBlurEvent();
-  };
-
   const cleanup = () => {
     // remove events to ensure they don't late-fire
     editable.onblur = null;
@@ -599,8 +595,6 @@ export const textWysiwyg = ({
     window.removeEventListener("resize", updateWysiwygStyle);
     window.removeEventListener("wheel", stopEvent, true);
     window.removeEventListener("pointerdown", onPointerDown, { capture: true });
-    window.removeEventListener("pointerup", bindBlurEvent);
-    window.removeEventListener("blur", handleSubmit);
     window.removeEventListener("beforeunload", handleSubmit);
     unbindUpdate();
 
@@ -608,8 +602,6 @@ export const textWysiwyg = ({
   };
 
   const bindBlurEvent = (event?: MouseEvent) => {
-    window.removeEventListener("pointerup", bindBlurEvent);
-    window.removeEventListener("blur", handleBlurDuringMenuClick);
     // Deferred so that the pointerdown that initiates the wysiwyg doesn't
     // trigger the blur on ensuing pointerup.
     // Also to handle cases such as picking a color which would trigger a blur
@@ -645,11 +637,10 @@ export const textWysiwyg = ({
         !isWritableElement(event.target)) ||
       isPropertiesTrigger
     ) {
-      editable.onblur = null;
-      window.addEventListener("pointerup", bindBlurEvent);
-      // handle edge-case where pointerup doesn't fire e.g. due to user
-      // alt-tabbing away
-      window.addEventListener("blur", handleBlurDuringMenuClick);
+      // blurring shall reset the blur handler instead of invoking it
+      editable.onblur = () => {
+        editable.onblur = onBlur;
+      };
     } else if (
       event.target instanceof HTMLElement &&
       event.target instanceof HTMLCanvasElement &&

--- a/packages/excalidraw/element/textWysiwyg.tsx
+++ b/packages/excalidraw/element/textWysiwyg.tsx
@@ -576,10 +576,14 @@ export const textWysiwyg = ({
     });
   };
 
-  const handleBlur = () => {
+  const onBlur = () => {
     if (document.activeElement !== editable) {
       handleSubmit();
     }
+  };
+
+  const handleBlurDuringMenuClick = () => {
+    bindBlurEvent();
   };
 
   const cleanup = () => {
@@ -605,6 +609,7 @@ export const textWysiwyg = ({
 
   const bindBlurEvent = (event?: MouseEvent) => {
     window.removeEventListener("pointerup", bindBlurEvent);
+    window.removeEventListener("blur", handleBlurDuringMenuClick);
     // Deferred so that the pointerdown that initiates the wysiwyg doesn't
     // trigger the blur on ensuing pointerup.
     // Also to handle cases such as picking a color which would trigger a blur
@@ -616,7 +621,7 @@ export const textWysiwyg = ({
       target.classList.contains("properties-trigger");
 
     setTimeout(() => {
-      editable.onblur = handleBlur;
+      editable.onblur = onBlur;
 
       // case: clicking on the same property → no change → no update → no focus
       if (!isPropertiesTrigger) {
@@ -644,7 +649,7 @@ export const textWysiwyg = ({
       window.addEventListener("pointerup", bindBlurEvent);
       // handle edge-case where pointerup doesn't fire e.g. due to user
       // alt-tabbing away
-      window.addEventListener("blur", handleSubmit);
+      window.addEventListener("blur", handleBlurDuringMenuClick);
     } else if (
       event.target instanceof HTMLElement &&
       event.target instanceof HTMLCanvasElement &&

--- a/packages/excalidraw/element/textWysiwyg.tsx
+++ b/packages/excalidraw/element/textWysiwyg.tsx
@@ -594,7 +594,7 @@ export const textWysiwyg = ({
 
     window.removeEventListener("resize", updateWysiwygStyle);
     window.removeEventListener("wheel", stopEvent, true);
-    window.removeEventListener("pointerdown", onPointerDown);
+    window.removeEventListener("pointerdown", onPointerDown, { capture: true });
     window.removeEventListener("pointerup", bindBlurEvent);
     window.removeEventListener("blur", handleSubmit);
     window.removeEventListener("beforeunload", handleSubmit);


### PR DESCRIPTION
Fixes #5182. This bug was probably the most disruptive to my experience while using Excalidraw.

The PR also fixes an event listeners leak: the "pointerdown" event removal function call did not have the `capture: true` option so the event was not effectively removed.

- `30483ff95a47f75c0d1a91135fe82920a308c5c5`: before submitting on blur, it makes sure the `editable` is not the active element (happens when the window is switched while the `editable` is active).
- `893b1dbbf02750cadb41f0ec8f20163bc9a22a6e`: handles the text options menu click edge case
- `63c269d852adbcb76ac7f877c4466ca016811a7c`: introduces a simpler way of not invoking onblur on text options menu click.

Let me know if you think there is a better way to fix this.

Tested on Firefox 128.0.