### PR TITLE
fix: revert default element canvas padding change

### DIFF
--- a/packages/excalidraw/renderer/renderElement.ts
+++ b/packages/excalidraw/renderer/renderElement.ts
@@ -90,7 +90,7 @@ const shouldResetImageFilter = (
 };
 
 const getCanvasPadding = (element: ExcalidrawElement) =>
-  element.type === "freedraw" ? element.strokeWidth * 12 : 200;
+  element.type === "freedraw" ? element.strokeWidth * 12 : 20;
 
 export const getRenderOpacity = (
   element: ExcalidrawElement,


### PR DESCRIPTION
Mistakenly introduced in https://github.com/excalidraw/excalidraw/pull/8177

Worsens perf especially during zoom.

via @zsviczian