### PR TITLE
chore: Correct Typos in Code Comments

### DIFF
--- a/excalidraw-app/app-language/language-detector.ts
+++ b/excalidraw-app/app-language/language-detector.ts
@@ -17,7 +17,7 @@ export const getPreferredLanguage = () => {
   const initialLanguage =
     (detectedLanguage
       ? // region code may not be defined if user uses generic preferred language
-        // (e.g. chinese vs instead of chienese-simplified)
+        // (e.g. chinese vs instead of chinese-simplified)
         languages.find((lang) => lang.code.startsWith(detectedLanguage))?.code
       : null) || defaultLang.code;
 

--- a/packages/excalidraw/fractionalIndex.ts
+++ b/packages/excalidraw/fractionalIndex.ts
@@ -11,15 +11,15 @@ import { InvalidFractionalIndexError } from "./errors";
  * Envisioned relation between array order and fractional indices:
  *
  * 1) Array (or array-like ordered data structure) should be used as a cache of elements order, hiding the internal fractional indices implementation.
- * - it's undesirable to to perform reorder for each related operation, thefeore it's necessary to cache the order defined by fractional indices into an ordered data structure
+ * - it's undesirable to perform reorder for each related operation, therefore it's necessary to cache the order defined by fractional indices into an ordered data structure
  * - it's easy enough to define the order of the elements from the outside (boundaries), without worrying about the underlying structure of fractional indices (especially for the host apps)
  * - it's necessary to always keep the array support for backwards compatibility (restore) - old scenes, old libraries, supporting multiple excalidraw versions etc.
  * - it's necessary to always keep the fractional indices in sync with the array order
  * - elements with invalid indices should be detected and synced, without altering the already valid indices
  *
  * 2) Fractional indices should be used to reorder the elements, whenever the cached order is expected to be invalidated.
- * - as the fractional indices are encoded as part of the elements, it opens up possibilties for incremental-like APIs
- * - re-order based on fractional indices should be part of (multiplayer) operations such as reconcillitation & undo/redo
+ * - as the fractional indices are encoded as part of the elements, it opens up possibilities for incremental-like APIs
+ * - re-order based on fractional indices should be part of (multiplayer) operations such as reconciliation & undo/redo
  * - technically all the z-index actions could perform also re-order based on fractional indices,but in current state it would not bring much benefits,
  *   as it's faster & more efficient to perform re-order based on array manipulation and later synchronisation of moved indices with the array order
  */


### PR DESCRIPTION
Thanks for PR #8205, it effectively resolved my previous issue. However, there was a minor typo. 
This PR also addresses other minor corrections I discovered over the past few days.

![image](https://github.com/user-attachments/assets/0ea3d82e-fcc1-4ab7-bfbd-d183e08cb68e)
