### PR TITLE
perf: update openai model name

### DIFF
--- a/packages/excalidraw/data/ai/types.ts
+++ b/packages/excalidraw/data/ai/types.ts
@@ -78,19 +78,18 @@ export namespace OpenAIInput {
      */
     model:
       | (string & {})
+      | "gpt-4o"
+      | "gpt-4o-2024-05-13"
+      | "gpt-4o-mini"
+      | "gpt-4o-mini-2024-07-18"
+      | "gpt-4-turbo"
+      | "gpt-4-turbo-2024-04-09"
+      | "gpt-4-turbo-preview"
+      | "gpt-4-0125-preview"
       | "gpt-4-1106-preview"
-      | "gpt-4-vision-preview"
       | "gpt-4"
-      | "gpt-4-0314"
       | "gpt-4-0613"
-      | "gpt-4-32k"
-      | "gpt-4-32k-0314"
-      | "gpt-4-32k-0613"
-      | "gpt-3.5-turbo"
-      | "gpt-3.5-turbo-16k"
-      | "gpt-3.5-turbo-0301"
-      | "gpt-3.5-turbo-0613"
-      | "gpt-3.5-turbo-16k-0613";
+      | "gpt-4-0314";
 
     /**
      * Number between -2.0 and 2.0. Positive values penalize new tokens based on their

--- a/packages/excalidraw/data/magic.ts
+++ b/packages/excalidraw/data/magic.ts
@@ -48,7 +48,7 @@ export async function diagramToHTML({
   theme?: Theme;
 }) {
   const body: OpenAIInput.ChatCompletionCreateParamsBase = {
-    model: "gpt-4-vision-preview",
+    model: "gpt-4-turbo",
     // 4096 are max output tokens allowed for `gpt-4-vision-preview` currently
     max_tokens: 4096,
     temperature: 0.1,


### PR DESCRIPTION
According to the latest openai documentation, gpt-4-vision-preview has been deprecated, and gpt-3.5 related models are no longer recommended.

## link

- https://platform.openai.com/docs/deprecations/2024-06-06-gpt-4-32k-and-vision-preview-models

- https://platform.openai.com/docs/models