### PR TITLE
fix: throttle fractional indices validation

### DIFF
--- a/packages/excalidraw/fractionalIndex.ts
+++ b/packages/excalidraw/fractionalIndex.ts
@@ -37,10 +37,12 @@ export const validateFractionalIndices = (
   {
     shouldThrow = false,
     includeBoundTextValidation = false,
+    ignoreLogs,
     reconciliationContext,
   }: {
     shouldThrow: boolean;
     includeBoundTextValidation: boolean;
+    ignoreLogs?: true;
     reconciliationContext?: {
       localElements: ReadonlyArray<ExcalidrawElement>;
       remoteElements: ReadonlyArray<ExcalidrawElement>;
@@ -95,13 +97,15 @@ export const validateFractionalIndices = (
       );
     }
 
-    // report just once and with the stacktrace
-    console.error(
-      errorMessages.join("\n\n"),
-      error.stack,
-      elements.map((x) => stringifyElement(x)),
-      ...additionalContext,
-    );
+    if (!ignoreLogs) {
+      // report just once and with the stacktrace
+      console.error(
+        errorMessages.join("\n\n"),
+        error.stack,
+        elements.map((x) => stringifyElement(x)),
+        ...additionalContext,
+      );
+    }
 
     if (shouldThrow) {
       // if enabled, gather all the errors first, throw once
@@ -157,7 +161,11 @@ export const syncMovedIndices = (
     validateFractionalIndices(
       elementsCandidates,
       // we don't autofix invalid bound text indices, hence don't include it in the validation
-      { includeBoundTextValidation: false, shouldThrow: true },
+      {
+        includeBoundTextValidation: false,
+        shouldThrow: true,
+        ignoreLogs: true,
+      },
     );
 
     // split mutation so we don't end up in an incosistent state

--- a/packages/excalidraw/tests/fractionalIndex.test.ts
+++ b/packages/excalidraw/tests/fractionalIndex.test.ts
@@ -766,6 +766,7 @@ function test(
         validateFractionalIndices(elements, {
           shouldThrow: true,
           includeBoundTextValidation: true,
+          ignoreLogs: true,
         }),
       ).toThrowError(InvalidFractionalIndexError);
     }
@@ -783,6 +784,7 @@ function test(
       validateFractionalIndices(syncedElements, {
         shouldThrow: true,
         includeBoundTextValidation: true,
+        ignoreLogs: true,
       }),
     ).not.toThrowError(InvalidFractionalIndexError);
 


### PR DESCRIPTION
- throttle the validation on scene updates and during reconciliation, to be performed at most once every minute (so that we could sleep a bit more calmly)
- ignore error logs when it's expected to fail (~ in `tests` and `syncMovedIndices`) 