### PR TITLE
fix: Docker build in CI

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,6 +8,7 @@
 !package.json
 !public/
 !packages/
+!scripts/
 !tsconfig.json
 !yarn.lock
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ARG NODE_ENV=production
 
 RUN yarn build:app:docker
 
-FROM nginx:1.24-alpine
+FROM nginx:1.27-alpine
 
 COPY --from=build /opt/node_app/excalidraw-app/build /usr/share/nginx/html
 

--- a/excalidraw-app/scripts/woff2-vite-plugins.js
+++ b/excalidraw-app/scripts/woff2-vite-plugins.js
@@ -5,7 +5,7 @@ const OSS_FONTS_CDN =
  * Custom vite plugin to convert url woff2 imports into a text.
  * Other woff2 imports are automatically served and resolved as a file uri.
  *
- * @returns {import("vite").PluginOption}
+ * @returns {import("vitest").PluginOption}
  */
 module.exports.woff2BrowserPlugin = () => {
   // for now limited to woff2 only, might be extended to any assets in the future
@@ -58,7 +58,7 @@ module.exports.woff2BrowserPlugin = () => {
         style: normal;
         display: swap;
       }
-      
+
       @font-face {
         font-family: "Assistant";
         src: url(${OSS_FONTS_CDN}Assistant-Medium-DrcxCXg3.woff2)
@@ -68,7 +68,7 @@ module.exports.woff2BrowserPlugin = () => {
         style: normal;
         display: swap;
       }
-      
+
       @font-face {
         font-family: "Assistant";
         src: url(${OSS_FONTS_CDN}Assistant-SemiBold-SCI4bEL9.woff2)
@@ -78,7 +78,7 @@ module.exports.woff2BrowserPlugin = () => {
         style: normal;
         display: swap;
       }
-      
+
       @font-face {
         font-family: "Assistant";
         src: url(${OSS_FONTS_CDN}Assistant-Bold-gm-uSS1B.woff2)

--- a/excalidraw-app/vite.config.mts
+++ b/excalidraw-app/vite.config.mts
@@ -5,7 +5,7 @@ import { ViteEjsPlugin } from "vite-plugin-ejs";
 import { VitePWA } from "vite-plugin-pwa";
 import checker from "vite-plugin-checker";
 import { createHtmlPlugin } from "vite-plugin-html";
-import { woff2BrowserPlugin } from "../scripts/woff2/woff2-vite-plugins";
+import { woff2BrowserPlugin } from "./scripts/woff2-vite-plugins";
 
 // To load .env.local variables
 const envVars = loadEnv("", `../`);

--- a/excalidraw-app/vite.config.mts
+++ b/excalidraw-app/vite.config.mts
@@ -5,7 +5,7 @@ import { ViteEjsPlugin } from "vite-plugin-ejs";
 import { VitePWA } from "vite-plugin-pwa";
 import checker from "vite-plugin-checker";
 import { createHtmlPlugin } from "vite-plugin-html";
-import { woff2BrowserPlugin } from "./scripts/woff2-vite-plugins";
+import { woff2BrowserPlugin } from "../scripts/woff2/woff2-vite-plugins";
 
 // To load .env.local variables
 const envVars = loadEnv("", `../`);
@@ -26,10 +26,10 @@ export default defineConfig({
         assetFileNames(chunkInfo) {
           if (chunkInfo?.name?.endsWith(".woff2")) {
             // put on root so we are flexible about the CDN path
-            return '[name]-[hash][extname]';
+            return "[name]-[hash][extname]";
           }
 
-          return 'assets/[name]-[hash][extname]';
+          return "assets/[name]-[hash][extname]";
         },
         // Creating separate chunk for locales except for en and percentages.json so they
         // can be cached at runtime and not merged with
@@ -44,7 +44,7 @@ export default defineConfig({
             // Taking the substring after "locales/"
             return `locales/${id.substring(index + 8)}`;
           }
-        }
+        },
       },
     },
     sourcemap: true,

--- a/scripts/woff2/woff2-vite-plugins.js
+++ b/scripts/woff2/woff2-vite-plugins.js
@@ -5,7 +5,7 @@ const OSS_FONTS_CDN =
  * Custom vite plugin to convert url woff2 imports into a text.
  * Other woff2 imports are automatically served and resolved as a file uri.
  *
- * @returns {import("vitest").PluginOption}
+ * @returns {import("vite").PluginOption}
  */
 module.exports.woff2BrowserPlugin = () => {
   // for now limited to woff2 only, might be extended to any assets in the future

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -1,5 +1,5 @@
 import { defineConfig } from "vitest/config";
-import { woff2BrowserPlugin } from "./scripts/woff2/woff2-vite-plugins";
+import { woff2BrowserPlugin } from "./excalidraw-app/scripts/woff2-vite-plugins";
 
 export default defineConfig({
   plugins: [

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -1,10 +1,9 @@
 import { defineConfig } from "vitest/config";
-import { woff2BrowserPlugin } from "./excalidraw-app/scripts/woff2-vite-plugins";
+import { woff2BrowserPlugin } from "./scripts/woff2/woff2-vite-plugins";
 
 export default defineConfig({
-  plugins: [
-    woff2BrowserPlugin(),
-  ],
+  // @ts-ignore
+  plugins: [woff2BrowserPlugin()],
   test: {
     setupFiles: ["./setupTests.ts"],
     globals: true,


### PR DESCRIPTION
Docker build is failing CI since the new fonts release
```
#12 0.732 ✘ [ERROR] Could not resolve "../scripts/woff2/woff2-vite-plugins"
#12 0.732 
#12 0.732     vite.config.mts:8:35:
#12 0.732       8 │ ... { woff2BrowserPlugin } from "../scripts/woff2/woff2-vite-plugins";
#12 0.732         ╵                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#12 0.732 
#12 0.747 failed to load config from /opt/node_app/excalidraw-app/vite.config.mts
```

Solution: Moved the script imported from `excalidraw-app/vite.config.mts` into the `excalidraw-app/scripts` directory, thus making it accessible by `yarn --cwd ./excalidraw-app build:app:docker`