### PR TITLE
fix: z-index change by one causes app to freeze

### DIFF
--- a/packages/excalidraw/tests/zindex.test.tsx
+++ b/packages/excalidraw/tests/zindex.test.tsx
@@ -241,6 +241,20 @@ describe("z-index manipulation", () => {
       ],
     });
 
+    // elements should not duplicate
+    assertZindex({
+      elements: [
+        { id: "A", containerId: "C" },
+        { id: "B" },
+        { id: "C", isSelected: true },
+      ],
+      operations: [
+        [actionSendBackward, ["A", "C", "B"]],
+        // noop
+        [actionSendBackward, ["A", "C", "B"]],
+      ],
+    });
+
     // grouped elements should be atomic
     // -------------------------------------------------------------------------
 

--- a/packages/excalidraw/zindex.ts
+++ b/packages/excalidraw/zindex.ts
@@ -80,29 +80,37 @@ const getTargetIndexAccountingForBinding = (
   direction: "left" | "right",
 ) => {
   if ("containerId" in nextElement && nextElement.containerId) {
-    if (direction === "left") {
-      const containerElement = Scene.getScene(nextElement)!.getElement(
-        nextElement.containerId,
-      );
-      if (containerElement) {
-        return elements.indexOf(containerElement);
-      }
-    } else {
-      return elements.indexOf(nextElement);
+    const containerElement = Scene.getScene(nextElement)!.getElement(
+      nextElement.containerId,
+    );
+    if (containerElement) {
+      return direction === "left"
+        ? Math.min(
+            elements.indexOf(containerElement),
+            elements.indexOf(nextElement),
+          )
+        : Math.max(
+            elements.indexOf(containerElement),
+            elements.indexOf(nextElement),
+          );
     }
   } else {
     const boundElementId = nextElement.boundElements?.find(
       (binding) => binding.type !== "arrow",
     )?.id;
     if (boundElementId) {
-      if (direction === "left") {
-        return elements.indexOf(nextElement);
-      }
-
       const boundTextElement =
         Scene.getScene(nextElement)!.getElement(boundElementId);
       if (boundTextElement) {
-        return elements.indexOf(boundTextElement);
+        return direction === "left"
+          ? Math.min(
+              elements.indexOf(boundTextElement),
+              elements.indexOf(nextElement),
+            )
+          : Math.max(
+              elements.indexOf(boundTextElement),
+              elements.indexOf(nextElement),
+            );
       }
     }
   }


### PR DESCRIPTION
Fix for #8295

Bug occurs because `getTargetIndexAccountingForBinding()` is able to return an index greater than the initial index even when `direction` is `left`, and similarly able to return an index smaller than the initial index even when `direction` is `right`.

This incorrect `targetIndex` causes elements to be duplicated when manipulating the `elements` array in `shiftElementsByOne()`.

First PR so I hope this is helpful and I haven't done anything wrong. Thanks!
