### PR TITLE
fix: Duplicating arrow without bound elements throws error

### DIFF
--- a/packages/excalidraw/element/binding.ts
+++ b/packages/excalidraw/element/binding.ts
@@ -1246,14 +1246,11 @@ export const fixBindingsAfterDuplication = (
     .filter(({ id }) => allBindableElementIds.has(id))
     .forEach((bindableElement) => {
       const oldElementId = duplicateIdToOldId.get(bindableElement.id);
-      if (!oldElementId) {
-        return; //if no bound element is found
-      }
       const { boundElements } = sceneElements.find(
         ({ id }) => id === oldElementId,
-      )!;
+      ) ?? {};
 
-      if (boundElements != null && boundElements.length > 0) {
+      if (boundElements && boundElements.length > 0) {
         mutateElement(bindableElement, {
           boundElements: boundElements.map((boundElement) =>
             oldIdToDuplicatedId.has(boundElement.id)

--- a/packages/excalidraw/element/binding.ts
+++ b/packages/excalidraw/element/binding.ts
@@ -1246,8 +1246,8 @@ export const fixBindingsAfterDuplication = (
     .filter(({ id }) => allBindableElementIds.has(id))
     .forEach((bindableElement) => {
       const oldElementId = duplicateIdToOldId.get(bindableElement.id);
-      const { boundElements } =
-        sceneElements.find(({ id }) => id === oldElementId) ?? {};
+      const boundElements =
+        sceneElements.find(({ id }) => id === oldElementId)?.boundElements;
 
       if (boundElements && boundElements.length > 0) {
         mutateElement(bindableElement, {

--- a/packages/excalidraw/element/binding.ts
+++ b/packages/excalidraw/element/binding.ts
@@ -1246,9 +1246,8 @@ export const fixBindingsAfterDuplication = (
     .filter(({ id }) => allBindableElementIds.has(id))
     .forEach((bindableElement) => {
       const oldElementId = duplicateIdToOldId.get(bindableElement.id);
-      const { boundElements } = sceneElements.find(
-        ({ id }) => id === oldElementId,
-      ) ?? {};
+      const { boundElements } =
+        sceneElements.find(({ id }) => id === oldElementId) ?? {};
 
       if (boundElements && boundElements.length > 0) {
         mutateElement(bindableElement, {

--- a/packages/excalidraw/element/binding.ts
+++ b/packages/excalidraw/element/binding.ts
@@ -1246,6 +1246,9 @@ export const fixBindingsAfterDuplication = (
     .filter(({ id }) => allBindableElementIds.has(id))
     .forEach((bindableElement) => {
       const oldElementId = duplicateIdToOldId.get(bindableElement.id);
+      if (!oldElementId) {
+        return; //if no bound element is found
+      }
       const { boundElements } = sceneElements.find(
         ({ id }) => id === oldElementId,
       )!;

--- a/packages/excalidraw/element/binding.ts
+++ b/packages/excalidraw/element/binding.ts
@@ -1246,8 +1246,9 @@ export const fixBindingsAfterDuplication = (
     .filter(({ id }) => allBindableElementIds.has(id))
     .forEach((bindableElement) => {
       const oldElementId = duplicateIdToOldId.get(bindableElement.id);
-      const boundElements =
-        sceneElements.find(({ id }) => id === oldElementId)?.boundElements;
+      const boundElements = sceneElements.find(
+        ({ id }) => id === oldElementId,
+      )?.boundElements;
 
       if (boundElements && boundElements.length > 0) {
         mutateElement(bindableElement, {


### PR DESCRIPTION
Resolves #8315, introduced in #8185