### PR TITLE
fix: Duplicate bound arrow without it's bound elements throws error (#8315)

### DIFF
--- a/packages/excalidraw/element/binding.ts
+++ b/packages/excalidraw/element/binding.ts
@@ -1246,9 +1246,8 @@ export const fixBindingsAfterDuplication = (
     .filter(({ id }) => allBindableElementIds.has(id))
     .forEach((bindableElement) => {
       const oldElementId = duplicateIdToOldId.get(bindableElement.id);
-      const { boundElements } = sceneElements.find(
-        ({ id }) => id === oldElementId,
-      )!;
+      const { boundElements } =
+        sceneElements.find(({ id }) => id === oldElementId) ?? {};
 
       if (boundElements != null && boundElements.length > 0) {
         mutateElement(bindableElement, {


### PR DESCRIPTION
See #8315 for details.