### PR TITLE
build: add `rm:build`, `rm:node_modules` & `clean-install` scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "prerelease:excalidraw": "node scripts/prerelease.js",
     "build:preview": "yarn build && vite preview --port 5000",
     "release:excalidraw": "node scripts/release.js",
-    "rm:build": "rm -rf excalidraw-app/{build,dist,dev-dist} && rm -rf packages/*/{dist,build}",
+    "rm:build": "rm -rf excalidraw-app/{build,dist,dev-dist} && rm -rf packages/*/{dist,build} && rm -rf examples/*/*/{build,dist}",
     "rm:node_modules": "rm -rf node_modules && rm -rf excalidraw-app/node_modules && rm -rf packages/*/node_modules",
     "clean-install": "yarn rm:node_modules && yarn install"
   },

--- a/package.json
+++ b/package.json
@@ -76,7 +76,10 @@
     "autorelease": "node scripts/autorelease.js",
     "prerelease:excalidraw": "node scripts/prerelease.js",
     "build:preview": "yarn build && vite preview --port 5000",
-    "release:excalidraw": "node scripts/release.js"
+    "release:excalidraw": "node scripts/release.js",
+    "rm:build": "rm -rf excalidraw-app/{build,dist,dev-dist} && rm -rf packages/*/{dist,build}",
+    "rm:node_modules": "rm -rf node_modules && rm -rf excalidraw-app/node_modules && rm -rf packages/*/node_modules",
+    "clean-install": "yarn rm:node_modules && yarn install"
   },
   "resolutions": {
     "@types/react": "18.2.0"


### PR DESCRIPTION
- `rm:build` - removes build/dist folders from `excalidraw-app` and `packages/*`
- `rm:node_modules` - removes `node_modules` from `excalidraw-app` and `packages/*`
- `clean-install` - runs `rm:node_modules` & `yarn`
 
skips docs, examples etc.

Supporting non-bash compatible enviros was a non-goal.