### PR TITLE
build: add example apps `public` and vite `dev-dist` to eslintignore

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -6,3 +6,5 @@ firebase/
 dist/
 public/workbox
 packages/excalidraw/types
+examples/**/public
+dev-dist


### PR DESCRIPTION
to unstuck eslint checks when example apps are built