### PR TITLE
fix: text content with tab characters act different in view/edit

### DIFF
--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -328,6 +328,7 @@ import {
   isMeasureTextSupported,
   isValidTextContainer,
   measureText,
+  normalizeText,
   wrapText,
 } from "../element/textElement";
 import {
@@ -3397,7 +3398,7 @@ class App extends React.Component<AppProps, AppState> {
     const lines = isPlainPaste ? [text] : text.split("\n");
     const textElements = lines.reduce(
       (acc: ExcalidrawTextElement[], line, idx) => {
-        const originalText = line.trim();
+        const originalText = normalizeText(line).trim();
         if (originalText.length) {
           const topLayerFrame = this.getTopLayerFrameAtSceneCoords({
             x,

--- a/packages/excalidraw/element/textWysiwyg.tsx
+++ b/packages/excalidraw/element/textWysiwyg.tsx
@@ -357,7 +357,15 @@ export const textWysiwyg = ({
     };
 
     editable.oninput = () => {
-      editable.value = normalizeText(editable.value);
+      const normalized = normalizeText(editable.value);
+      if (editable.value !== normalized) {
+        const selectionStart = editable.selectionStart;
+        editable.value = normalized;
+        // put the cursor at some position close to where it was before
+        // normalization (otherwise it'll end up at the end of the text)
+        editable.selectionStart = selectionStart;
+        editable.selectionEnd = selectionStart;
+      }
       onChange(editable.value);
     };
   }

--- a/packages/excalidraw/element/textWysiwyg.tsx
+++ b/packages/excalidraw/element/textWysiwyg.tsx
@@ -357,7 +357,8 @@ export const textWysiwyg = ({
     };
 
     editable.oninput = () => {
-      onChange(normalizeText(editable.value));
+      editable.value = normalizeText(editable.value);
+      onChange(editable.value);
     };
   }
 


### PR DESCRIPTION
Fix #7947

There doesn't seem to be a nice way to incorporate tab stops in the Canvas API, so this replaces tab characters with spaces when editing an existing text element, and also when creating new text elements via pasting (non-Excalidraw-JSON) text.