### PR TITLE
chore: remove unused parameter

### DIFF
--- a/packages/excalidraw/components/Stats/Dimension.tsx
+++ b/packages/excalidraw/components/Stats/Dimension.tsx
@@ -23,7 +23,6 @@ const handleDimensionChange: DragInputCallbackType<
 > = ({
   accumulatedChange,
   originalElements,
-  originalElementsMap,
   shouldKeepAspectRatio,
   shouldChangeByStepSize,
   nextValue,


### PR DESCRIPTION
remove unused `originalElementsMap` parameter in `packages\excalidraw\components\Stats\Dimension.tsx`