### PR TITLE
fix: drawing from 0-dimension canvas

### DIFF
--- a/packages/excalidraw/renderer/renderElement.ts
+++ b/packages/excalidraw/renderer/renderElement.ts
@@ -199,7 +199,7 @@ const generateElementCanvas = (
   zoom: Zoom,
   renderConfig: StaticCanvasRenderConfig,
   appState: StaticCanvasAppState,
-): ExcalidrawElementWithCanvas => {
+): ExcalidrawElementWithCanvas | null => {
   const canvas = document.createElement("canvas");
   const context = canvas.getContext("2d")!;
   const padding = getCanvasPadding(element);
@@ -209,6 +209,10 @@ const generateElementCanvas = (
     elementsMap,
     zoom,
   );
+
+  if (!width || !height) {
+    return null;
+  }
 
   canvas.width = width;
   canvas.height = height;
@@ -540,6 +544,10 @@ const generateElementWithCanvas = (
       appState,
     );
 
+    if (!elementWithCanvas) {
+      return null;
+    }
+
     elementWithCanvasCache.set(element, elementWithCanvas);
 
     return elementWithCanvas;
@@ -742,6 +750,10 @@ export const renderElement = (
           renderConfig,
           appState,
         );
+        if (!elementWithCanvas) {
+          return;
+        }
+
         drawElementFromCanvas(
           elementWithCanvas,
           context,
@@ -880,6 +892,10 @@ export const renderElement = (
           renderConfig,
           appState,
         );
+
+        if (!elementWithCanvas) {
+          return;
+        }
 
         const currentImageSmoothingStatus = context.imageSmoothingEnabled;
 


### PR DESCRIPTION
When trying to render from a 0-width or 0-height canvas, e.g. for small elements when zoomed out a lot. Right now happens primarily (perhaps exclusively) for container labels.

Instead of just preventing the `drawImage` call, I'm opting to not generate and populate the canvas cache at all so safe on memory and cpu.