### PR TITLE
fix: Point duplication in LEE on ALT+click (#8346)

### DIFF
--- a/packages/excalidraw/element/linearElementEditor.ts
+++ b/packages/excalidraw/element/linearElementEditor.ts
@@ -741,7 +741,7 @@ export class LinearElementEditor {
     }
     if (event.altKey && appState.editingLinearElement) {
       if (
-        linearElementEditor.lastUncommittedPoint == null &&
+        linearElementEditor.lastUncommittedPoint === null &&
         !isElbowArrow(element)
       ) {
         mutateElement(element, {


### PR DESCRIPTION
Fixes #8346.
Making null check strict.
I do not understand why #8350 broke the fix implemented in #8347, but making the null check strict seems to have solved the issue (at least in my testing)





