### PR TITLE
fix : UI update on Dialog.tsx

### DIFF
--- a/packages/excalidraw/components/Dialog.tsx
+++ b/packages/excalidraw/components/Dialog.tsx
@@ -117,7 +117,6 @@ export const Dialog = (props: DialogProps) => {
             <span className="Dialog__titleContent">{props.title}</span>
           </h2>
         )}
-        {isFullscreen && (
           <button
             className="Dialog__close"
             onClick={onClose}
@@ -127,7 +126,6 @@ export const Dialog = (props: DialogProps) => {
           >
             {CloseIcon}
           </button>
-        )}
         <div className="Dialog__content">{props.children}</div>
       </Island>
     </Modal>


### PR DESCRIPTION
Close icon not visible in desktop mode ,thereby removed the conditional rendering in Dialog.tsx
<img width="1307" alt="Screenshot 2024-08-13 at 7 10 17 AM" src="https://github.com/user-attachments/assets/2a9a052d-78cf-415d-b6ea-c800b51d70e4">

