### PR TITLE
feat: `command palette` supports searching by shortcut

### DIFF
--- a/packages/excalidraw/components/CommandPalette/CommandPalette.tsx
+++ b/packages/excalidraw/components/CommandPalette/CommandPalette.tsx
@@ -780,12 +780,28 @@ function CommandPaletteInner({
     const _query = deburr(
       commandSearch.toLocaleLowerCase().replace(/[<>_| -]/g, ""),
     );
-    matchingCommands = fuzzy
+
+    const matchingCommandsHaystack = fuzzy
       .filter(_query, matchingCommands, {
         extract: (command) => command.haystack,
       })
       .sort((a, b) => b.score - a.score)
       .map((item) => item.original);
+
+    const matchingCommandsShortcut = fuzzy
+      .filter(_query, matchingCommands, {
+        extract: (command) => command.shortcut || "",
+      })
+      .sort((a, b) => b.score - a.score)
+      .map((item) => item.original)
+      .filter(
+        (item) =>
+          !matchingCommandsHaystack.some((item2) => item.label === item2.label),
+      );
+
+    matchingCommands = matchingCommandsHaystack.concat(
+      matchingCommandsShortcut,
+    );
 
     setCommandsByCategory(getNextCommandsByCategory(matchingCommands));
     setCurrentCommand(matchingCommands[0] ?? null);


### PR DESCRIPTION
### Summary
The search function in the `command palette` supports the shortcut key search

### Preview
![2024-08-15 15 00 43](https://github.com/user-attachments/assets/f1cd36df-95af-419c-8917-9ff50a6bc44e)
