### PR TITLE
feat: improve elbow arrow keyboard move

### DIFF
--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -4146,10 +4146,24 @@ class App extends React.Component<AppProps, AppState> {
           | ExcalidrawArrowElement
           | undefined;
 
-        const step = elbowArrow
-          ? elbowArrow.startBinding || elbowArrow.endBinding
-            ? 0
-            : ELEMENT_TRANSLATE_AMOUNT
+        const preventKeyboardMove = selectedElements
+          .filter(isElbowArrow)
+          .find((arrow) => {
+            const startMissing =
+              arrow.startBinding &&
+              !selectedElements.find(
+                (el) => el.id === arrow.startBinding?.elementId,
+              );
+            const endMissing =
+              arrow.endBinding &&
+              !selectedElements.find(
+                (el) => el.id === arrow.endBinding?.elementId,
+              );
+            return startMissing || endMissing;
+          });
+
+        const step = preventKeyboardMove
+          ? 0
           : (this.getEffectiveGridSize() &&
               (event.shiftKey
                 ? ELEMENT_TRANSLATE_AMOUNT

--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -4148,18 +4148,18 @@ class App extends React.Component<AppProps, AppState> {
 
         const preventKeyboardMove = selectedElements
           .filter(isElbowArrow)
-          .find((arrow) => {
-            const startMissing =
+          .some((arrow) => {
+            const startElementNotInSelection =
               arrow.startBinding &&
               !selectedElements.find(
                 (el) => el.id === arrow.startBinding?.elementId,
               );
-            const endMissing =
+            const endElementNotInSelection =
               arrow.endBinding &&
               !selectedElements.find(
                 (el) => el.id === arrow.endBinding?.elementId,
               );
-            return startMissing || endMissing;
+            return startElementNotInSelection || endElementNotInSelection;
           });
 
         const step = preventKeyboardMove

--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -4150,12 +4150,10 @@ class App extends React.Component<AppProps, AppState> {
           .filter(isElbowArrow)
           .some((arrow) => {
             const startElementNotInSelection =
-              arrow.startBinding &&
               !selectedElements.some(
                 (el) => el.id === arrow.startBinding?.elementId,
               );
             const endElementNotInSelection =
-              arrow.endBinding &&
               !selectedElements.some(
                 (el) => el.id === arrow.endBinding?.elementId,
               );

--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -4149,14 +4149,12 @@ class App extends React.Component<AppProps, AppState> {
         const preventKeyboardMove = selectedElements
           .filter(isElbowArrow)
           .some((arrow) => {
-            const startElementNotInSelection =
-              !selectedElements.some(
-                (el) => el.id === arrow.startBinding?.elementId,
-              );
-            const endElementNotInSelection =
-              !selectedElements.some(
-                (el) => el.id === arrow.endBinding?.elementId,
-              );
+            const startElementNotInSelection = !selectedElements.some(
+              (el) => el.id === arrow.startBinding?.elementId,
+            );
+            const endElementNotInSelection = !selectedElements.some(
+              (el) => el.id === arrow.endBinding?.elementId,
+            );
             return startElementNotInSelection || endElementNotInSelection;
           });
 

--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -4149,12 +4149,16 @@ class App extends React.Component<AppProps, AppState> {
         const preventKeyboardMove = selectedElements
           .filter(isElbowArrow)
           .some((arrow) => {
-            const startElementNotInSelection = !selectedElements.some(
-              (el) => el.id === arrow.startBinding?.elementId,
-            );
-            const endElementNotInSelection = !selectedElements.some(
-              (el) => el.id === arrow.endBinding?.elementId,
-            );
+            const startElementNotInSelection =
+              arrow.startBinding &&
+              !selectedElements.some(
+                (el) => el.id === arrow.startBinding?.elementId,
+              );
+            const endElementNotInSelection =
+              arrow.endBinding &&
+              !selectedElements.some(
+                (el) => el.id === arrow.endBinding?.elementId,
+              );
             return startElementNotInSelection || endElementNotInSelection;
           });
 

--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -4151,12 +4151,12 @@ class App extends React.Component<AppProps, AppState> {
           .some((arrow) => {
             const startElementNotInSelection =
               arrow.startBinding &&
-              !selectedElements.find(
+              !selectedElements.some(
                 (el) => el.id === arrow.startBinding?.elementId,
               );
             const endElementNotInSelection =
               arrow.endBinding &&
-              !selectedElements.find(
+              !selectedElements.some(
                 (el) => el.id === arrow.endBinding?.elementId,
               );
             return startElementNotInSelection || endElementNotInSelection;

--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -4136,7 +4136,7 @@ class App extends React.Component<AppProps, AppState> {
       }
 
       if (isArrowKey(event.key)) {
-        const selectedElements = this.scene.getSelectedElements({
+        let selectedElements = this.scene.getSelectedElements({
           selectedElementIds: this.state.selectedElementIds,
           includeBoundTextElement: true,
           includeElementsInFrames: true,
@@ -4146,9 +4146,11 @@ class App extends React.Component<AppProps, AppState> {
           | ExcalidrawArrowElement
           | undefined;
 
-        const preventKeyboardMove = selectedElements
+        const arrowIdsToRemove = new Set<string>();
+
+        selectedElements
           .filter(isElbowArrow)
-          .some((arrow) => {
+          .filter((arrow) => {
             const startElementNotInSelection =
               arrow.startBinding &&
               !selectedElements.some(
@@ -4160,17 +4162,21 @@ class App extends React.Component<AppProps, AppState> {
                 (el) => el.id === arrow.endBinding?.elementId,
               );
             return startElementNotInSelection || endElementNotInSelection;
-          });
+          })
+          .forEach((arrow) => arrowIdsToRemove.add(arrow.id));
 
-        const step = preventKeyboardMove
-          ? 0
-          : (this.getEffectiveGridSize() &&
-              (event.shiftKey
-                ? ELEMENT_TRANSLATE_AMOUNT
-                : this.getEffectiveGridSize())) ||
+        selectedElements = selectedElements.filter(
+          (el) => !arrowIdsToRemove.has(el.id),
+        );
+
+        const step =
+          (this.getEffectiveGridSize() &&
             (event.shiftKey
-              ? ELEMENT_SHIFT_TRANSLATE_AMOUNT
-              : ELEMENT_TRANSLATE_AMOUNT);
+              ? ELEMENT_TRANSLATE_AMOUNT
+              : this.getEffectiveGridSize())) ||
+          (event.shiftKey
+            ? ELEMENT_SHIFT_TRANSLATE_AMOUNT
+            : ELEMENT_TRANSLATE_AMOUNT);
 
         let offsetX = 0;
         let offsetY = 0;


### PR DESCRIPTION
Fixes: Keyboard arrow keys stop to move elements when the group includes an elbow arrow #8387

Having looked at the code I concluded that this is not a bug, but a too restrictive feature. However, we can make the restriction more targeted/relaxed even without touching the arrow move logic. The keyboard move should only be restricted if the start or end element is not part of the selection. 