### PR TITLE
fix: Can't click on anything if I close linear editor by clicking on canvas.

### DIFF
--- a/packages/excalidraw/actions/actionFinalize.tsx
+++ b/packages/excalidraw/actions/actionFinalize.tsx
@@ -16,6 +16,7 @@ import { isBindingElement, isLinearElement } from "../element/typeChecks";
 import type { AppState } from "../types";
 import { resetCursor } from "../cursor";
 import { StoreAction } from "../store";
+import { makeNextSelectedElementIds } from "../scene/selection";
 
 export const actionFinalize = register({
   name: "finalize",
@@ -51,6 +52,8 @@ export const actionFinalize = register({
             cursorButton: "up",
             editingLinearElement: null,
             selectedLinearElement: null,
+            //selectedElementIds: makeNextSelectedElementIds({}, appState),
+            selectionElement: null,
           },
           storeAction: StoreAction.CAPTURE,
         };

--- a/packages/excalidraw/actions/actionLinearEditor.tsx
+++ b/packages/excalidraw/actions/actionLinearEditor.tsx
@@ -27,9 +27,10 @@ export const actionToggleLinearEditor = register({
   predicate: (elements, appState, _, app) => {
     const selectedElements = app.scene.getSelectedElements(appState);
     if (
-      !appState.editingLinearElement &&
       selectedElements.length === 1 &&
       isLinearElement(selectedElements[0]) &&
+      (!appState.editingLinearElement ||
+        appState.editingLinearElement.elementId !== selectedElements[0].id) &&
       !isElbowArrow(selectedElements[0])
     ) {
       return true;

--- a/packages/excalidraw/actions/actionProperties.tsx
+++ b/packages/excalidraw/actions/actionProperties.tsx
@@ -1571,7 +1571,8 @@ export const actionChangeArrowType = register({
         if (isElbowArrow(newElement)) {
           const elementsMap = app.scene.getNonDeletedElementsMap();
 
-          app.dismissLinearEditor();
+          //defer so that previous changes don't get overwritten
+          setTimeout(() => app.dismissLinearEditor());
 
           const startGlobalPoint =
             LinearElementEditor.getPointAtIndexGlobalCoordinates(

--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -2146,11 +2146,8 @@ class App extends React.Component<AppProps, AppState> {
   };
 
   public dismissLinearEditor = () => {
-    setTimeout(() => {
-      this.setState({
-        editingLinearElement: null,
-      });
-    });
+    this.state.editingLinearElement &&
+      this.actionManager.executeAction(actionFinalize);
   };
 
   public syncActionResult = withBatchedUpdates((actionResult: ActionResult) => {
@@ -2792,13 +2789,7 @@ class App extends React.Component<AppProps, AppState> {
       !this.state.selectedElementIds[this.state.editingLinearElement.elementId]
     ) {
       // defer so that the storeAction flag isn't reset via current update
-      setTimeout(() => {
-        // execute only if the condition still holds when the deferred callback
-        // executes (it can be scheduled multiple times depending on how
-        // many times the component renders)
-        this.state.editingLinearElement &&
-          this.actionManager.executeAction(actionFinalize);
-      });
+      setTimeout(() => this.dismissLinearEditor());
     }
 
     // failsafe in case the state is being updated in incorrect order resulting
@@ -4197,22 +4188,11 @@ class App extends React.Component<AppProps, AppState> {
         if (selectedElements.length === 1) {
           const selectedElement = selectedElements[0];
           if (event[KEYS.CTRL_OR_CMD]) {
-            if (isLinearElement(selectedElement)) {
-              if (
-                !this.state.editingLinearElement ||
-                this.state.editingLinearElement.elementId !==
-                  selectedElements[0].id
-              ) {
-                this.store.shouldCaptureIncrement();
-                if (!isElbowArrow(selectedElement)) {
-                  this.setState({
-                    editingLinearElement: new LinearElementEditor(
-                      selectedElement,
-                    ),
-                  });
-                }
-              }
-            }
+            this.actionManager.isActionEnabled(actionToggleLinearEditor) &&
+              this.actionManager.executeAction(
+                actionToggleLinearEditor,
+                "keyboard",
+              );
           } else if (
             isTextElement(selectedElement) ||
             isValidTextContainer(selectedElement)
@@ -5139,22 +5119,10 @@ class App extends React.Component<AppProps, AppState> {
       return;
     }
 
-    const selectedElements = this.scene.getSelectedElements(this.state);
-
-    if (selectedElements.length === 1 && isLinearElement(selectedElements[0])) {
-      if (
-        event[KEYS.CTRL_OR_CMD] &&
-        (!this.state.editingLinearElement ||
-          this.state.editingLinearElement.elementId !==
-            selectedElements[0].id) &&
-        !isElbowArrow(selectedElements[0])
-      ) {
-        this.store.shouldCaptureIncrement();
-        this.setState({
-          editingLinearElement: new LinearElementEditor(selectedElements[0]),
-        });
-        return;
-      }
+    if (event[KEYS.CTRL_OR_CMD]) {
+      this.actionManager.isActionEnabled(actionToggleLinearEditor) &&
+        this.actionManager.executeAction(actionToggleLinearEditor, "keyboard");
+      return;
     }
 
     resetCursor(this.interactiveCanvas);
@@ -8200,7 +8168,7 @@ class App extends React.Component<AppProps, AppState> {
           pointerDownState.hit?.element?.id !==
             this.state.editingLinearElement.elementId
         ) {
-          this.actionManager.executeAction(actionFinalize);
+          this.dismissLinearEditor();
         } else {
           const editingLinearElement = LinearElementEditor.handlePointerUp(
             childEvent,
@@ -8873,7 +8841,7 @@ class App extends React.Component<AppProps, AppState> {
             pointerDownState.hit.hasHitCommonBoundingBoxOfSelectedElements))
       ) {
         if (this.state.editingLinearElement) {
-          this.setState({ editingLinearElement: null });
+          this.dismissLinearEditor();
         } else {
           // Deselect selected elements
           this.setState({


### PR DESCRIPTION
## Fixes for problems 1 and 3 stated in this issue: #8401

### Before:


https://github.com/user-attachments/assets/74c43987-95f6-4817-a97c-92d2bbc8fed8



### After: 


https://github.com/user-attachments/assets/9c31c450-f4ac-401b-8c25-d1a596e262d4

## Problem 2.:

I've tried fixing problem 2 in two ways.
1. Don't set `selectedLinearElement` to `null` (this is my preferred way)
2. Also set `selectedElementIds` to `{}` (`selectedElementIds: makeNextSelectedElementIds({}, appState)`)

In either case I had around 30 failing tests and I'm not sure how to fix that...

