### PR TITLE
docs: Update function call in @excalidraw/mermaid-to-excalidraw 

### DIFF
--- a/dev-docs/docs/@excalidraw/mermaid-to-excalidraw/api.mdx
+++ b/dev-docs/docs/@excalidraw/mermaid-to-excalidraw/api.mdx
@@ -14,7 +14,7 @@ This API receives the mermaid syntax as the input, and resolves to skeleton Exca
 import { parseMermaidToExcalidraw } from "@excalidraw/mermaid-to-excalidraw";
 import { convertToExcalidrawElements}  from "@excalidraw/excalidraw"
 try {
-  const { elements, files } = await parseMermaid(mermaidSyntax: string, {
+  const { elements, files } = await parseMermaidToExcalidraw(mermaidSyntax: string, {
     fontSize: number,
   });
   const excalidrawElements = convertToExcalidrawElements(elements);


### PR DESCRIPTION
# Overview

Script provided [here](https://docs.excalidraw.com/docs/@excalidraw/mermaid-to-excalidraw/installation#usage) contains an error in the function call, which was called `parseMermaid`

## Fix

`parseMermaid` should be `parseMermaidToExcalidraw` as per the imported function.