### PR TITLE
fix: Fixed issue where shape details were pasted in text areas instead of actual shape

### DIFF
--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -2903,8 +2903,10 @@ class App extends React.Component<AppProps, AppState> {
         this.lastViewportPosition.x,
         this.lastViewportPosition.y,
       );
+
+      const data = await parseClipboard(event, isPlainPaste);
       if (
-        event &&
+        event && data.text &&
         (!(elementUnderCursor instanceof HTMLCanvasElement) ||
           isWritableElement(target))
       ) {
@@ -2923,7 +2925,6 @@ class App extends React.Component<AppProps, AppState> {
       // event else some browsers (FF...) will clear the clipboardData
       // (something something security)
       let file = event?.clipboardData?.files[0];
-      const data = await parseClipboard(event, isPlainPaste);
       if (!file && !isPlainPaste) {
         if (data.mixedContent) {
           return this.addElementsFromMixedContentPaste(data.mixedContent, {
@@ -2991,12 +2992,18 @@ class App extends React.Component<AppProps, AppState> {
             : data.elements
         ) as readonly ExcalidrawElement[];
         // TODO remove formatting from elements if isPlainPaste
+        const position = isWritableElement(target) && this.lastPointerDownEvent
+        ? { clientX: this.lastPointerDownEvent.pageX, clientY: this.lastPointerDownEvent.pageY }
+        : "cursor";
         this.addElementsFromPasteOrLibrary({
           elements,
           files: data.files || null,
-          position: "cursor",
+          position,
           retainSeed: isPlainPaste,
         });
+        if(isWritableElement(target)){
+          this.focusContainer();
+        }
       } else if (data.text) {
         if (data.text && isMaybeMermaidDefinition(data.text)) {
           const api = await import("@excalidraw/mermaid-to-excalidraw");


### PR DESCRIPTION
### Summary
This pull request resolves the issue occurred when copying a shape and pasting it into a text area, resulting in the copied shape's information being inserted.

### Changes Made
- Updated the `pasteFromClipboard` function in `packages/excalidraw/components/App.tsx` to handle paste operations more accurately.
- Modified the logic to correctly identify whether the copied content is a shape or text, and to paste the appropriate content into the text area.

### Steps to Reproduce (before fix)
1. Create a shape and copy it.
2. Double-click to open a text area.
3. Paste the copied content.
4. Observe that shape details (not the actual shape) are pasted.

### Steps to Reproduce (after fix)
1. Create a shape and copy it.
2. Double-click to open a text area.
3. Paste the copied content.
4. Verify that the shape is pasted instead of it's information.

### Issue Reference
Fixes #8410.

### Testing
- Manually tested by performing the steps to reproduce the issue both before and after applying the fix.
- Confirmed that the issue is resolved and the behavior is as expected.

Please review and let me know if there are any further changes or tests required. Thank you!