### PR TITLE
fix: image rendering issue when passed in `initialData` 

### DIFF
--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -2295,6 +2295,9 @@ class App extends React.Component<AppProps, AppState> {
       storeAction: StoreAction.UPDATE,
     });
 
+    // clear the shape and image cache so that any images in initialData
+    // can be loaded fresh
+    this.clearImageShapeCache();
     // FontFaceSet loadingdone event we listen on may not always
     // fire (looking at you Safari), so on init we manually load all
     // fonts and rerender scene text elements once done. This also
@@ -2359,6 +2362,15 @@ class App extends React.Component<AppProps, AppState> {
     }
     return false;
   };
+
+  private clearImageShapeCache() {
+    this.scene.getNonDeletedElements().forEach((element) => {
+      if (isInitializedImageElement(element) && this.files[element.fileId]) {
+        this.imageCache.delete(element.fileId);
+        ShapeCache.delete(element);
+      }
+    });
+  }
 
   public async componentDidMount() {
     this.unmounted = false;
@@ -3674,15 +3686,7 @@ class App extends React.Component<AppProps, AppState> {
 
       this.files = { ...this.files, ...Object.fromEntries(filesMap) };
 
-      this.scene.getNonDeletedElements().forEach((element) => {
-        if (
-          isInitializedImageElement(element) &&
-          filesMap.has(element.fileId)
-        ) {
-          this.imageCache.delete(element.fileId);
-          ShapeCache.delete(element);
-        }
-      });
+      this.clearImageShapeCache();
       this.scene.triggerUpdate();
 
       this.addNewImagesToImageCache();


### PR DESCRIPTION
### What?
When passing files in `initialData` to the `@excalidraw/excalidraw` package, the images do not render the first time unless the screen is resized or a scene update is triggered by other actions.

### Linked issue:
Fixes #8419

### Reproduction steps
Clone the repo and run the following command:
```bash
cd examples/excalidraw/with-script-in-browser && yarn start
```

Observe the `rocket` image not being rendered unless the window is resized or some other action is done on the image.

### How?
By creating a `clearImageShapeCache` function and calling it in 2 places: `addFiles` and `initializeScene` fixes this issue. The problem with the original code was that the image cache was not being cleared in the `addFiles` function because `this.scene.getNonDeletedElements()` was returning an empty list. Referenced code:
https://github.com/excalidraw/excalidraw/blob/51ea184938d57637faa345de85028aa8a0930ed2/packages/excalidraw/components/App.tsx#L3668-L3690