### PR TITLE
feat: Canvas search zoom to tiny text

### DIFF
--- a/packages/excalidraw/components/SearchMenu.tsx
+++ b/packages/excalidraw/components/SearchMenu.tsx
@@ -167,7 +167,6 @@ export const SearchMenu = () => {
             fitToContent: true,
             animate: true,
             duration: 300,
-            ...(isTinyText ? { viewportZoomFactor: 1 } : {}),
           });
         }
 

--- a/packages/excalidraw/components/SearchMenu.tsx
+++ b/packages/excalidraw/components/SearchMenu.tsx
@@ -6,7 +6,6 @@ import { useApp, useExcalidrawSetAppState } from "./App";
 import { debounce } from "lodash";
 import type { AppClassProperties } from "../types";
 import { isTextElement, newTextElement } from "../element";
-import type { ExcalidrawTextElement } from "../element/types";
 import { measureText } from "../element/textElement";
 import { addEventListener, getFontString } from "../utils";
 import { KEYS } from "../keys";
@@ -135,7 +134,6 @@ export const SearchMenu = () => {
       if (match) {
         const matchAsElement = newTextElement({
           text: match.keyword,
-          rawText: match.keyword,
           x: match.textElement.x + (match.matchedLines[0]?.offsetX ?? 0),
           y: match.textElement.y + (match.matchedLines[0]?.offsetY ?? 0),
           width: match.matchedLines[0]?.width,

--- a/packages/excalidraw/components/SearchMenu.tsx
+++ b/packages/excalidraw/components/SearchMenu.tsx
@@ -135,12 +135,17 @@ export const SearchMenu = () => {
       if (match) {
         const matchAsElement = newTextElement({
           text: match.keyword,
+          rawText: match.keyword,
           x: match.textElement.x + (match.matchedLines[0]?.offsetX ?? 0),
           y: match.textElement.y + (match.matchedLines[0]?.offsetY ?? 0),
           width: match.matchedLines[0]?.width,
           height: match.matchedLines[0]?.height,
         });
 
+        const isTinyText =
+          app.state.zoom.value *
+            searchMatches.items[focusIndex].textElement.fontSize <
+          16;
         if (
           !isElementCompletelyInViewport(
             [matchAsElement],
@@ -155,12 +160,14 @@ export const SearchMenu = () => {
             },
             app.scene.getNonDeletedElementsMap(),
             app.getEditorUIOffsets(),
-          )
+          ) ||
+          isTinyText
         ) {
           app.scrollToContent(matchAsElement, {
             fitToContent: true,
             animate: true,
             duration: 300,
+            ...(isTinyText ? { viewportZoomFactor: 1 } : {}),
           });
         }
 

--- a/packages/excalidraw/components/SearchMenu.tsx
+++ b/packages/excalidraw/components/SearchMenu.tsx
@@ -6,6 +6,7 @@ import { useApp, useExcalidrawSetAppState } from "./App";
 import { debounce } from "lodash";
 import type { AppClassProperties } from "../types";
 import { isTextElement, newTextElement } from "../element";
+import type { ExcalidrawTextElement } from "../element/types";
 import { measureText } from "../element/textElement";
 import { addEventListener, getFontString } from "../utils";
 import { KEYS } from "../keys";


### PR DESCRIPTION
This implements [my proposal](https://github.com/excalidraw/excalidraw/pull/8438#issuecomment-2339878526) in the Canvas Search PR. If the text is tiny search will zoom 100% to make it visible.

See sample canvas: https://excalidraw-ckdr7v1lm-excalidraw.vercel.app/#json=Q0DiGxAM-7frR8GfMO8SO,1zHnvF_m29MNUmv9KJaiuA

https://github.com/user-attachments/assets/c8c678ec-96b3-4051-96ca-7ae65f51b04c
