### PR TITLE
fix: addFiles clears the whole image cache when each file is added - regression from #8471

### DIFF
--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -2367,9 +2367,10 @@ class App extends React.Component<AppProps, AppState> {
     return false;
   };
 
-  private clearImageShapeCache() {
+  private clearImageShapeCache(filesMap?: BinaryFiles) {
+    const files = filesMap ?? this.files;
     this.scene.getNonDeletedElements().forEach((element) => {
-      if (isInitializedImageElement(element) && this.files[element.fileId]) {
+      if (isInitializedImageElement(element) && files[element.fileId]) {
         this.imageCache.delete(element.fileId);
         ShapeCache.delete(element);
       }
@@ -3690,7 +3691,7 @@ class App extends React.Component<AppProps, AppState> {
 
       this.files = { ...this.files, ...Object.fromEntries(filesMap) };
 
-      this.clearImageShapeCache();
+      this.clearImageShapeCache(Object.fromEntries(filesMap));
       this.scene.triggerUpdate();
 
       this.addNewImagesToImageCache();


### PR DESCRIPTION
fixes: #8489
The solution in #8471 leads to flickering and slow performance when sequentially adding files to a scene.