### PR TITLE
fix: Linear element complete button disabled

### DIFF
--- a/packages/excalidraw/actions/actionFinalize.tsx
+++ b/packages/excalidraw/actions/actionFinalize.tsx
@@ -217,7 +217,7 @@ export const actionFinalize = register({
       onClick={updateData}
       visible={appState.multiElement != null}
       size={data?.size || "medium"}
-      style={{pointerEvents: "all"}}
+      style={{ pointerEvents: "all" }}
     />
   ),
 });

--- a/packages/excalidraw/actions/actionFinalize.tsx
+++ b/packages/excalidraw/actions/actionFinalize.tsx
@@ -217,6 +217,7 @@ export const actionFinalize = register({
       onClick={updateData}
       visible={appState.multiElement != null}
       size={data?.size || "medium"}
+      style={{pointerEvents: "all"}}
     />
   ),
 });

--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -1489,8 +1489,7 @@ class App extends React.Component<AppProps, AppState> {
 
     const isNewElementNotLinearOnTouchScreen =
       this.state.newElement &&
-      !isLinearElement(this.state.newElement) &&
-      this.device.isTouchScreen;
+      (!isLinearElement(this.state.newElement) || !this.device.isTouchScreen);
 
     const shouldBlockPointerEvents =
       this.state.selectionElement ||

--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -1487,13 +1487,9 @@ class App extends React.Component<AppProps, AppState> {
 
     const allElementsMap = this.scene.getNonDeletedElementsMap();
 
-    const isNewElementNotLinearOnTouchScreen =
-      this.state.newElement &&
-      (!isLinearElement(this.state.newElement) || !this.device.isTouchScreen);
-
     const shouldBlockPointerEvents =
       this.state.selectionElement ||
-      isNewElementNotLinearOnTouchScreen ||
+      this.state.newElement ||
       this.state.selectedElementsAreBeingDragged ||
       this.state.resizingElement ||
       (this.state.activeTool.type === "laser" &&

--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -1490,7 +1490,7 @@ class App extends React.Component<AppProps, AppState> {
     const isNewElementNotLinearOnTouchScreen =
       this.state.newElement &&
       !isLinearElement(this.state.newElement) &&
-      (this.device.isTouchScreen || this.state.penDetected);
+      this.device.isTouchScreen;
 
     const shouldBlockPointerEvents =
       this.state.selectionElement ||

--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -1489,7 +1489,7 @@ class App extends React.Component<AppProps, AppState> {
 
     const isNewElementNotLinearOnTouchScreen =
       this.state.newElement &&
-      !["line", "arrow"].includes(this.state.newElement.type) &&
+      isLinearElement(this.state.newElement) &&
       (this.device.isTouchScreen || this.state.penDetected);
 
     const shouldBlockPointerEvents =

--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -1487,9 +1487,14 @@ class App extends React.Component<AppProps, AppState> {
 
     const allElementsMap = this.scene.getNonDeletedElementsMap();
 
+    const isNewElementNotLinearOnTouchScreen =
+      this.state.newElement &&
+      !["line", "arrow"].includes(this.state.newElement.type) &&
+      (this.device.isTouchScreen || this.state.penDetected);
+
     const shouldBlockPointerEvents =
       this.state.selectionElement ||
-      this.state.newElement ||
+      isNewElementNotLinearOnTouchScreen ||
       this.state.selectedElementsAreBeingDragged ||
       this.state.resizingElement ||
       (this.state.activeTool.type === "laser" &&

--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -1489,7 +1489,7 @@ class App extends React.Component<AppProps, AppState> {
 
     const isNewElementNotLinearOnTouchScreen =
       this.state.newElement &&
-      isLinearElement(this.state.newElement) &&
+      !isLinearElement(this.state.newElement) &&
       (this.device.isTouchScreen || this.state.penDetected);
 
     const shouldBlockPointerEvents =


### PR DESCRIPTION
Fixes: [#2006](https://github.com/zsviczian/obsidian-excalidraw-plugin/issues/2006)

If you touch the screen with two fingers when creating a new linear element you can create a multipoint line by adding additional points. There is a complete edit button, but this is disabled during editing of the new element. On a mobile device there is simply no way to exit the line edit mode (unless by chance you find the beginning of the line and you are able to close the loop (if you know about this trick and if you can tap precisely enough). This can be an extremely frustrating UX experience when it happens.

![image](https://github.com/user-attachments/assets/625073bb-887e-4d9d-9c78-dc2aacc6e3fa)
