### PR TITLE
fix: default sidebar triggers & behavior

### DIFF
--- a/packages/excalidraw/components/DefaultSidebar.tsx
+++ b/packages/excalidraw/components/DefaultSidebar.tsx
@@ -37,14 +37,11 @@ const DefaultSidebarTrigger = withInternalFallback(
 );
 DefaultSidebarTrigger.displayName = "DefaultSidebarTrigger";
 
-const DefaultTabTriggers = ({
-  children,
-  ...rest
-}: { children: React.ReactNode } & React.HTMLAttributes<HTMLDivElement>) => {
+const DefaultTabTriggers = ({ children }: { children: React.ReactNode }) => {
   const { DefaultSidebarTabTriggersTunnel } = useTunnels();
   return (
     <DefaultSidebarTabTriggersTunnel.In>
-      <Sidebar.TabTriggers {...rest}>{children}</Sidebar.TabTriggers>
+      {children}
     </DefaultSidebarTabTriggersTunnel.In>
   );
 };
@@ -76,7 +73,8 @@ export const DefaultSidebar = Object.assign(
       return (
         <Sidebar
           {...rest}
-          name={"default"}
+          name="default"
+          key="default"
           className={clsx("default-sidebar", className)}
           docked={
             isForceDocked || (docked ?? appState.defaultSidebarDockedPreference)
@@ -94,15 +92,15 @@ export const DefaultSidebar = Object.assign(
         >
           <Sidebar.Tabs>
             <Sidebar.Header>
-              <DefaultSidebar.TabTriggers>
+              <Sidebar.TabTriggers>
                 <Sidebar.TabTrigger tab={CANVAS_SEARCH_TAB}>
                   {searchIcon}
                 </Sidebar.TabTrigger>
                 <Sidebar.TabTrigger tab={LIBRARY_SIDEBAR_TAB}>
                   {LibraryIcon}
                 </Sidebar.TabTrigger>
-              </DefaultSidebar.TabTriggers>
-              {rest.__fallback && <DefaultSidebarTabTriggersTunnel.Out />}
+                <DefaultSidebarTabTriggersTunnel.Out />
+              </Sidebar.TabTriggers>
             </Sidebar.Header>
             <Sidebar.Tab tab={LIBRARY_SIDEBAR_TAB}>
               <LibraryMenu />


### PR DESCRIPTION
- fix rendering of `<DefaultSidebar.Triggers/>` (broken by canvas search)
- BREAKING CHANGE: default sidebar triggers are now always merged with host app triggers (rendered through `<DefaultSidebar.Triggers/>`
- BREAKING CHANGE: `<DefaultSidebar.Triggers/>` no longer accepts any props other than `children`