### PR TITLE
fix: svg and png frame clipping cases

### DIFF
--- a/packages/excalidraw/scene/export.ts
+++ b/packages/excalidraw/scene/export.ts
@@ -356,6 +356,11 @@ export const exportToSvg = async (
     }) rotate(${frame.angle} ${cx} ${cy})"
           width="${frame.width}"
           height="${frame.height}"
+          ${
+            exportingFrame
+              ? ""
+              : `rx=${FRAME_STYLE.radius} ry=${FRAME_STYLE.radius}`
+          }
           >
           </rect>
         </clipPath>`;

--- a/packages/excalidraw/scene/export.ts
+++ b/packages/excalidraw/scene/export.ts
@@ -185,6 +185,11 @@ export const exportToCanvas = async (
     exportingFrame ?? null,
     appState.frameRendering ?? null,
   );
+  // for canvas export, don't clip if exporting a specific frame as it would
+  // clip the corners of the content
+  if (exportingFrame) {
+    frameRendering.clip = false;
+  }
 
   const elementsForRender = prepareElementsForRender({
     elements,


### PR DESCRIPTION
1. When exporting a single frame to PNG, we're effectively exporting with 0 padding, so we shouldn't clip content as it would clip the edges since the frames have a radius.

  before: 
  
  ![image](https://github.com/user-attachments/assets/850ab7af-3c7f-4a9e-baf4-cba74375d76d)
  
  after:
  
  ![image](https://github.com/user-attachments/assets/4c7788d3-081f-4fba-ac0d-9698b9364daf)

2. When exporting to SVG, we were previously not adding radius at all, so we're doing that now in non-single-frame-export cases