### PR TITLE
edit group on Enter

### DIFF
--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -190,6 +190,7 @@ import type {
 import { getCenter, getDistance } from "../gesture";
 import {
   editGroupForSelectedElement,
+  elementsAreInSameGroup,
   getElementsInGroup,
   getSelectedGroupIdForElement,
   getSelectedGroupIds,
@@ -4210,6 +4211,7 @@ class App extends React.Component<AppProps, AppState> {
         event.preventDefault();
       } else if (event.key === KEYS.ENTER) {
         const selectedElements = this.scene.getSelectedElements(this.state);
+        const selectedGroupIds = getSelectedGroupIds(this.state);
         if (selectedElements.length === 1) {
           const selectedElement = selectedElements[0];
           if (event[KEYS.CTRL_OR_CMD]) {
@@ -4256,6 +4258,13 @@ class App extends React.Component<AppProps, AppState> {
               editingFrame: selectedElement.id,
             });
           }
+        } else if (
+          selectedGroupIds.length === 1 &&
+          elementsAreInSameGroup(selectedElements)
+        ) {
+          this.setState({
+            editingGroupId: selectedGroupIds[0],
+          });
         }
       } else if (
         !event.ctrlKey &&


### PR DESCRIPTION
closes #8511 

No need to select all elements after pressing Enter, since a group's elements are already all selected once the group is selected 🙂

https://github.com/user-attachments/assets/991948f4-21a8-4c7c-9152-ec1daa8025b2

Is there any additional behavior expected for this? I was thinking to make Escape exit group editing, but maybe that can be a separate PR once this and #7782 are merged.