### PR TITLE
toggel searchMenu updated

### DIFF
--- a/packages/excalidraw/actions/actionToggleSearchMenu.ts
+++ b/packages/excalidraw/actions/actionToggleSearchMenu.ts
@@ -51,5 +51,6 @@ export const actionToggleSearchMenu = register({
   predicate: (element, appState, props) => {
     return props.gridModeEnabled === undefined;
   },
-  keyTest: (event) => event[KEYS.CTRL_OR_CMD] && event.key === KEYS.F,
+  keyTest: (event) =>
+    event[KEYS.CTRL_OR_CMD] && event.altKey && event.key === KEYS.F,
 });

--- a/packages/excalidraw/actions/shortcuts.ts
+++ b/packages/excalidraw/actions/shortcuts.ts
@@ -113,7 +113,7 @@ const shortcutMap: Record<ShortcutName, string[]> = {
   saveFileToDisk: [getShortcutKey("CtrlOrCmd+S")],
   saveToActiveFile: [getShortcutKey("CtrlOrCmd+S")],
   toggleShortcuts: [getShortcutKey("?")],
-  searchMenu: [getShortcutKey("CtrlOrCmd+F")],
+  searchMenu: [getShortcutKey("CtrlOrCmd+Alt+F")],
 };
 
 export const getShortcutFromShortcutName = (name: ShortcutName, idx = 0) => {

--- a/packages/excalidraw/components/SearchMenu.tsx
+++ b/packages/excalidraw/components/SearchMenu.tsx
@@ -250,7 +250,7 @@ export const SearchMenu = () => {
         return;
       }
 
-      if (event[KEYS.CTRL_OR_CMD] && event.key === KEYS.F) {
+      if (event[KEYS.CTRL_OR_CMD] && event.altKey && event.key === KEYS.F) {
         event.preventDefault();
         event.stopPropagation();
 


### PR DESCRIPTION
issue: #8534
toggel search menu updated press [Ctrl+Alt+F] to toggel the "find in canvas" insted of "Ctrl+F"
