### PR TITLE
fix: Do not allow overlapping for new elements with existing siblings in flowcharts

### DIFF
--- a/packages/excalidraw/element/flowchart.ts
+++ b/packages/excalidraw/element/flowchart.ts
@@ -275,6 +275,282 @@ const addNewNode = (
   };
 };
 
+const resolveOverlap = (
+  nodeA: ExcalidrawBindableElement,
+  nodeB: ExcalidrawBindableElement,
+  direction: LinkDirection,
+) => {
+  const margin = 5;
+
+  if (direction === "left" || direction === "right") {
+    const overlapY = Math.min(
+      nodeA.y + nodeA.height - nodeB.y,
+      nodeB.y + nodeB.height - nodeA.y,
+    );
+
+    if (overlapY > 0) {
+      const shiftAmount = overlapY + margin;
+
+      if (nodeA.y < nodeB.y) {
+        const newAY = nodeA.y - shiftAmount;
+        const newBY = nodeB.y + shiftAmount;
+        mutateElement(nodeA, { y: newAY });
+        mutateElement(nodeB, { y: newBY });
+      } else {
+        const newAY = nodeA.y + shiftAmount;
+        const newBY = nodeB.y - shiftAmount;
+        mutateElement(nodeA, { y: newAY });
+        mutateElement(nodeB, { y: newBY });
+      }
+    }
+  } else {
+    const overlapX = Math.min(
+      nodeA.x + nodeA.width - nodeB.x,
+      nodeB.x + nodeB.width - nodeA.x,
+    );
+
+    if (overlapX > 0) {
+      const shiftAmount = overlapX + margin;
+
+      if (nodeA.x < nodeB.x) {
+        const newAX = nodeA.y - shiftAmount;
+        const newBX = nodeB.y + shiftAmount;
+        mutateElement(nodeA, { y: newAX });
+        mutateElement(nodeB, { y: newBX });
+      } else {
+        const newAX = nodeA.y + shiftAmount;
+        const newBX = nodeB.y - shiftAmount;
+        mutateElement(nodeA, { y: newAX });
+        mutateElement(nodeB, { y: newBX });
+      }
+    }
+  }
+};
+
+const nodesOverlap = (
+  nodeA: ExcalidrawBindableElement,
+  nodeB: ExcalidrawBindableElement,
+): boolean => {
+  const horizontallyOverlapping =
+    nodeA.x < nodeB.x + nodeB.width && nodeA.x + nodeA.width > nodeB.x;
+  const verticallyOverlapping =
+    nodeA.y < nodeB.y + nodeB.height && nodeA.y + nodeA.height > nodeB.y;
+
+  return horizontallyOverlapping && verticallyOverlapping;
+};
+
+// export const addNewNodes = (
+//   startNode: ExcalidrawFlowchartNodeElement,
+//   elementsMap: ElementsMap,
+//   appState: AppState,
+//   direction: LinkDirection,
+//   numberOfNodes: number,
+// ) => {
+//   // always start from 0 and distribute evenly
+//   const newNodes: ExcalidrawElement[] = [];
+//   const nextNodelist: ExcalidrawElement[] = [];
+//   const nextbindigArrawlist: ExcalidrawElement[] = [];
+
+//   const successors = getSuccessors(startNode, elementsMap, direction);
+//   const predeccessors = getPredecessors(startNode, elementsMap, direction);
+
+//   for (let i = 0; i < numberOfNodes; i++) {
+//     let nextX: number;
+//     let nextY: number;
+//     if (direction === "left" || direction === "right") {
+//       const totalHeight =
+//         VERTICAL_OFFSET * (numberOfNodes - 1) +
+//         numberOfNodes * startNode.height;
+
+//       const startY = startNode.y + startNode.height / 2 - totalHeight / 2;
+
+//       let offsetX = HORIZONTAL_OFFSET + startNode.width;
+//       if (direction === "left") {
+//         offsetX *= -1;
+//       }
+//       nextX = startNode.x + offsetX;
+//       const offsetY = (VERTICAL_OFFSET + startNode.height) * i;
+//       nextY = startY + offsetY;
+//     } else {
+//       const totalWidth =
+//         HORIZONTAL_OFFSET * (numberOfNodes - 1) +
+//         numberOfNodes * startNode.width;
+//       const startX = startNode.x + startNode.width / 2 - totalWidth / 2;
+//       let offsetY = VERTICAL_OFFSET + startNode.height;
+
+//       if (direction === "up") {
+//         offsetY *= -1;
+//       }
+//       nextY = startNode.y + offsetY;
+//       const offsetX = (HORIZONTAL_OFFSET + startNode.width) * i;
+//       nextX = startX + offsetX;
+//     }
+
+//     const nextNode = newElement({
+//       type: startNode.type,
+//       x: nextX,
+//       y: nextY,
+//       // TODO: extract this to a util
+//       width: startNode.width,
+//       height: startNode.height,
+//       roundness: startNode.roundness,
+//       roughness: startNode.roughness,
+//       backgroundColor: startNode.backgroundColor,
+//       strokeColor: startNode.strokeColor,
+//       strokeWidth: startNode.strokeWidth,
+//     });
+
+//     invariant(
+//       isFlowchartNodeElement(nextNode),
+//       "not an ExcalidrawFlowchartNodeElement",
+//     );
+
+//     const bindingArrow = createBindingArrow(
+//       startNode,
+//       nextNode,
+//       elementsMap,
+//       direction,
+//       appState,
+//     );
+//     nextNodelist.push(nextNode);
+//     nextbindigArrawlist.push(bindingArrow);
+//   }
+
+//   let allNodes = [];
+//   if (direction === "right" || direction === "down") {
+//     allNodes = [...successors, ...nextNodelist];
+//   } else {
+//     allNodes = [...predeccessors, ...nextNodelist];
+//   }
+
+//   for (let i = 0; i < allNodes.length; i++) {
+//     for (let j = i + 1; j < allNodes.length; j++) {
+//       const nodeA = allNodes[i] as ExcalidrawFlowchartNodeElement;
+//       const nodeB = allNodes[j] as ExcalidrawFlowchartNodeElement;
+//       if (nodesOverlap(nodeA, nodeB)) {
+//         resolveOverlap(nodeA, nodeB, direction);
+//       }
+//     }
+//   }
+//   for (let i = 0; i < nextNodelist.length; i++) {
+//     newNodes.push(nextNodelist[i]);
+//     newNodes.push(nextbindigArrawlist[i]);
+//   }
+//   return newNodes;
+// };
+
+// export const addNewNodes = (
+//   startNode: ExcalidrawFlowchartNodeElement,
+//   elementsMap: ElementsMap,
+//   appState: AppState,
+//   direction: LinkDirection,
+//   numberOfNodes: number,
+// ) => {
+//   const newNodes: ExcalidrawElement[] = [];
+
+//   const successors = getSuccessors(startNode, elementsMap, direction);
+//   const predeccessors = getPredecessors(startNode, elementsMap, direction);
+
+//   let existingNodes: ExcalidrawElement[] = [];
+
+//   if (direction === "right" || direction === "down") {
+//     existingNodes = successors;
+//   } else {
+//     existingNodes = predeccessors;
+//   }
+
+//   const totalNodes = existingNodes.length + numberOfNodes;
+
+//   for (let i = 0; i < totalNodes; i++) {
+//     let nextX: number;
+//     let nextY: number;
+
+//     if (direction === "left" || direction === "right") {
+//       const totalHeight =
+//         (VERTICAL_OFFSET + startNode.height) * (totalNodes - 1);
+
+//       const middleOffset =
+//         totalNodes % 2 === 0
+//           ? totalHeight / 2
+//           : Math.floor(totalNodes / 2) * (VERTICAL_OFFSET + startNode.height);
+
+//       const startY = startNode.y + startNode.height / 2 - middleOffset;
+
+//       let offsetX = HORIZONTAL_OFFSET + startNode.width;
+//       if (direction === "left") {
+//         offsetX *= -1;
+//       }
+//       nextX = startNode.x + offsetX;
+
+//       const offsetY = (VERTICAL_OFFSET + startNode.height) * i;
+//       nextY = startY + offsetY;
+//     } else {
+//       const totalWidth =
+//         (HORIZONTAL_OFFSET + startNode.width) * (totalNodes - 1);
+
+//       const middleOffset =
+//         totalNodes % 2 === 0
+//           ? totalWidth / 2
+//           : Math.floor(totalNodes / 2) * (HORIZONTAL_OFFSET + startNode.width);
+
+//       const startX = startNode.x + startNode.width / 2 - middleOffset;
+
+//       let offsetY = VERTICAL_OFFSET + startNode.height;
+//       if (direction === "up") {
+//         offsetY *= -1;
+//       }
+//       nextY = startNode.y + offsetY;
+
+//       const offsetX = (HORIZONTAL_OFFSET + startNode.width) * i;
+//       nextX = startX + offsetX;
+//     }
+
+//     let nextNode: ExcalidrawElement;
+//     if (i < existingNodes.length) {
+//       nextNode = existingNodes[i];
+//       mutateElement(nextNode, { x: nextX, y: nextY });
+//     } else {
+//       nextNode = newElement({
+//         type: startNode.type,
+//         x: nextX,
+//         y: nextY,
+//         width: startNode.width,
+//         height: startNode.height,
+//         roundness: startNode.roundness,
+//         roughness: startNode.roughness,
+//         backgroundColor: startNode.backgroundColor,
+//         strokeColor: startNode.strokeColor,
+//         strokeWidth: startNode.strokeWidth,
+//       });
+
+//       invariant(
+//         isFlowchartNodeElement(nextNode),
+//         "not an ExcalidrawFlowchartNodeElement",
+//       );
+//     }
+
+//     if (
+//       i >= existingNodes.length &&
+//       (nextNode.type === "rectangle" ||
+//         nextNode.type === "diamond" ||
+//         nextNode.type === "ellipse")
+//     ) {
+//       const bindingArrow = createBindingArrow(
+//         startNode,
+//         nextNode,
+//         elementsMap,
+//         direction,
+//         appState,
+//       );
+
+//       newNodes.push(nextNode);
+//       newNodes.push(bindingArrow);
+//     }
+//   }
+
+//   return newNodes;
+// };
+
 export const addNewNodes = (
   startNode: ExcalidrawFlowchartNodeElement,
   elementsMap: ElementsMap,

--- a/packages/excalidraw/element/flowchart.ts
+++ b/packages/excalidraw/element/flowchart.ts
@@ -275,69 +275,69 @@ const addNewNode = (
   };
 };
 
-const resolveOverlap = (
-  nodeA: ExcalidrawBindableElement,
-  nodeB: ExcalidrawBindableElement,
-  direction: LinkDirection,
-) => {
-  const margin = 5;
+// const resolveOverlap = (
+//   nodeA: ExcalidrawBindableElement,
+//   nodeB: ExcalidrawBindableElement,
+//   direction: LinkDirection,
+// ) => {
+//   const margin = 5;
 
-  if (direction === "left" || direction === "right") {
-    const overlapY = Math.min(
-      nodeA.y + nodeA.height - nodeB.y,
-      nodeB.y + nodeB.height - nodeA.y,
-    );
+//   if (direction === "left" || direction === "right") {
+//     const overlapY = Math.min(
+//       nodeA.y + nodeA.height - nodeB.y,
+//       nodeB.y + nodeB.height - nodeA.y,
+//     );
 
-    if (overlapY > 0) {
-      const shiftAmount = overlapY + margin;
+//     if (overlapY > 0) {
+//       const shiftAmount = overlapY + margin;
 
-      if (nodeA.y < nodeB.y) {
-        const newAY = nodeA.y - shiftAmount;
-        const newBY = nodeB.y + shiftAmount;
-        mutateElement(nodeA, { y: newAY });
-        mutateElement(nodeB, { y: newBY });
-      } else {
-        const newAY = nodeA.y + shiftAmount;
-        const newBY = nodeB.y - shiftAmount;
-        mutateElement(nodeA, { y: newAY });
-        mutateElement(nodeB, { y: newBY });
-      }
-    }
-  } else {
-    const overlapX = Math.min(
-      nodeA.x + nodeA.width - nodeB.x,
-      nodeB.x + nodeB.width - nodeA.x,
-    );
+//       if (nodeA.y < nodeB.y) {
+//         const newAY = nodeA.y - shiftAmount;
+//         const newBY = nodeB.y + shiftAmount;
+//         mutateElement(nodeA, { y: newAY });
+//         mutateElement(nodeB, { y: newBY });
+//       } else {
+//         const newAY = nodeA.y + shiftAmount;
+//         const newBY = nodeB.y - shiftAmount;
+//         mutateElement(nodeA, { y: newAY });
+//         mutateElement(nodeB, { y: newBY });
+//       }
+//     }
+//   } else {
+//     const overlapX = Math.min(
+//       nodeA.x + nodeA.width - nodeB.x,
+//       nodeB.x + nodeB.width - nodeA.x,
+//     );
 
-    if (overlapX > 0) {
-      const shiftAmount = overlapX + margin;
+//     if (overlapX > 0) {
+//       const shiftAmount = overlapX + margin;
 
-      if (nodeA.x < nodeB.x) {
-        const newAX = nodeA.y - shiftAmount;
-        const newBX = nodeB.y + shiftAmount;
-        mutateElement(nodeA, { y: newAX });
-        mutateElement(nodeB, { y: newBX });
-      } else {
-        const newAX = nodeA.y + shiftAmount;
-        const newBX = nodeB.y - shiftAmount;
-        mutateElement(nodeA, { y: newAX });
-        mutateElement(nodeB, { y: newBX });
-      }
-    }
-  }
-};
+//       if (nodeA.x < nodeB.x) {
+//         const newAX = nodeA.y - shiftAmount;
+//         const newBX = nodeB.y + shiftAmount;
+//         mutateElement(nodeA, { y: newAX });
+//         mutateElement(nodeB, { y: newBX });
+//       } else {
+//         const newAX = nodeA.y + shiftAmount;
+//         const newBX = nodeB.y - shiftAmount;
+//         mutateElement(nodeA, { y: newAX });
+//         mutateElement(nodeB, { y: newBX });
+//       }
+//     }
+//   }
+// };
 
-const nodesOverlap = (
-  nodeA: ExcalidrawBindableElement,
-  nodeB: ExcalidrawBindableElement,
-): boolean => {
-  const horizontallyOverlapping =
-    nodeA.x < nodeB.x + nodeB.width && nodeA.x + nodeA.width > nodeB.x;
-  const verticallyOverlapping =
-    nodeA.y < nodeB.y + nodeB.height && nodeA.y + nodeA.height > nodeB.y;
+// const nodesOverlap = (
+//   nodeA: ExcalidrawBindableElement,
+//   nodeB: ExcalidrawBindableElement,
+// ): boolean => {
+//   const horizontallyOverlapping =
+//     nodeA.x < nodeB.x + nodeB.width && nodeA.x + nodeA.width > nodeB.x;
+//   const verticallyOverlapping =
+//     nodeA.y < nodeB.y + nodeB.height && nodeA.y + nodeA.height > nodeB.y;
 
-  return horizontallyOverlapping && verticallyOverlapping;
-};
+//   return horizontallyOverlapping && verticallyOverlapping;
+// };
 
 // export const addNewNodes = (
 //   startNode: ExcalidrawFlowchartNodeElement,
@@ -508,6 +508,8 @@ const nodesOverlap = (
 //     let nextNode: ExcalidrawElement;
 //     if (i < existingNodes.length) {
 //       nextNode = existingNodes[i];
+//       const arrow = existingNodes[i+1];
+//       console.log(arrow)
 //       mutateElement(nextNode, { x: nextX, y: nextY });
 //     } else {
 //       nextNode = newElement({
@@ -551,53 +553,132 @@ const nodesOverlap = (
 //   return newNodes;
 // };
 
-export const addNewNodes = (
+// export const addNewNodes = (
+//   startNode: ExcalidrawFlowchartNodeElement,
+//   elementsMap: ElementsMap,
+//   appState: AppState,
+//   direction: LinkDirection,
+//   numberOfNodes: number,
+// ) => {
+//   // always start from 0 and distribute evenly
+//   const newNodes: ExcalidrawElement[] = [];
+
+//   for (let i = 0; i < numberOfNodes; i++) {
+//     let nextX: number;
+//     let nextY: number;
+//     if (direction === "left" || direction === "right") {
+//       const totalHeight =
+//         VERTICAL_OFFSET * (numberOfNodes - 1) +
+//         numberOfNodes * startNode.height;
+
+//       const startY = startNode.y + startNode.height / 2 - totalHeight / 2;
+
+//       let offsetX = HORIZONTAL_OFFSET + startNode.width;
+//       if (direction === "left") {
+//         offsetX *= -1;
+//       }
+//       nextX = startNode.x + offsetX;
+//       const offsetY = (VERTICAL_OFFSET + startNode.height) * i;
+//       nextY = startY + offsetY;
+//     } else {
+//       const totalWidth =
+//         HORIZONTAL_OFFSET * (numberOfNodes - 1) +
+//         numberOfNodes * startNode.width;
+//       const startX = startNode.x + startNode.width / 2 - totalWidth / 2;
+//       let offsetY = VERTICAL_OFFSET + startNode.height;
+
+//       if (direction === "up") {
+//         offsetY *= -1;
+//       }
+//       nextY = startNode.y + offsetY;
+//       const offsetX = (HORIZONTAL_OFFSET + startNode.width) * i;
+//       nextX = startX + offsetX;
+//     }
+
+//     const nextNode = newElement({
+//       type: startNode.type,
+//       x: nextX,
+//       y: nextY,
+//       // TODO: extract this to a util
+//       width: startNode.width,
+//       height: startNode.height,
+//       roundness: startNode.roundness,
+//       roughness: startNode.roughness,
+//       backgroundColor: startNode.backgroundColor,
+//       strokeColor: startNode.strokeColor,
+//       strokeWidth: startNode.strokeWidth,
+//     });
+
+//     invariant(
+//       isFlowchartNodeElement(nextNode),
+//       "not an ExcalidrawFlowchartNodeElement",
+//     );
+
+//     const bindingArrow = createBindingArrow(
+//       startNode,
+//       nextNode,
+//       elementsMap,
+//       direction,
+//       appState,
+//     );
+
+//     newNodes.push(nextNode);
+//     newNodes.push(bindingArrow);
+//   }
+
+//   return newNodes;
+// };
+
+// export const addNewNodes = (
+//   startNode: ExcalidrawFlowchartNodeElement,
+//   elementsMap: ElementsMap,
+//   appState: AppState,
+//   direction: LinkDirection,
+//   numberOfNodes: number,
+// ) => {
+//   const newNodes: ExcalidrawElement[] = [];
+//   let newElementMap = elementsMap; // Initialize with existing elements map
+
+//   for (let i = 0; i < numberOfNodes; i++) {
+//     const { nextNode, bindingArrow } = addNewNode(
+//       startNode,
+//       newElementMap,
+//       appState,
+//       direction,
+//     );
+//     newNodes.push(nextNode);
+//     newNodes.push(bindingArrow);
+
+//     // Update newElementMap to include new nodes
+//     newElementMap = {
+//       ...newElementMap,
+//       ...newNodes.reduce((acc, node) => ({ ...acc, [node.id]: node }), {}),
+//     };
+//   }
+
+//   return newNodes;
+// };
+
+const addNewNodes = (
   startNode: ExcalidrawFlowchartNodeElement,
   elementsMap: ElementsMap,
   appState: AppState,
   direction: LinkDirection,
   numberOfNodes: number,
 ) => {
-  // always start from 0 and distribute evenly
   const newNodes: ExcalidrawElement[] = [];
 
+  const successors = getSuccessors(startNode, elementsMap, direction);
+  const predeccessors = getPredecessors(startNode, elementsMap, direction);
+  const linkedNodes = [...successors, ...predeccessors];
+
   for (let i = 0; i < numberOfNodes; i++) {
-    let nextX: number;
-    let nextY: number;
-    if (direction === "left" || direction === "right") {
-      const totalHeight =
-        VERTICAL_OFFSET * (numberOfNodes - 1) +
-        numberOfNodes * startNode.height;
-
-      const startY = startNode.y + startNode.height / 2 - totalHeight / 2;
-
-      let offsetX = HORIZONTAL_OFFSET + startNode.width;
-      if (direction === "left") {
-        offsetX *= -1;
-      }
-      nextX = startNode.x + offsetX;
-      const offsetY = (VERTICAL_OFFSET + startNode.height) * i;
-      nextY = startY + offsetY;
-    } else {
-      const totalWidth =
-        HORIZONTAL_OFFSET * (numberOfNodes - 1) +
-        numberOfNodes * startNode.width;
-      const startX = startNode.x + startNode.width / 2 - totalWidth / 2;
-      let offsetY = VERTICAL_OFFSET + startNode.height;
-
-      if (direction === "up") {
-        offsetY *= -1;
-      }
-      nextY = startNode.y + offsetY;
-      const offsetX = (HORIZONTAL_OFFSET + startNode.width) * i;
-      nextX = startX + offsetX;
-    }
+    const offsets = getOffsets(startNode, linkedNodes, direction);
 
     const nextNode = newElement({
       type: startNode.type,
-      x: nextX,
-      y: nextY,
-      // TODO: extract this to a util
+      x: startNode.x + offsets.x,
+      y: startNode.y + offsets.y,
       width: startNode.width,
       height: startNode.height,
       roundness: startNode.roundness,
@@ -607,11 +688,13 @@ export const addNewNodes = (
       strokeWidth: startNode.strokeWidth,
     });
 
+    // Invariant check for node type (optional)
     invariant(
       isFlowchartNodeElement(nextNode),
       "not an ExcalidrawFlowchartNodeElement",
     );
 
+    // Create the binding arrow to connect nodes
     const bindingArrow = createBindingArrow(
       startNode,
       nextNode,
@@ -622,6 +705,8 @@ export const addNewNodes = (
 
     newNodes.push(nextNode);
     newNodes.push(bindingArrow);
+
+    linkedNodes.push(nextNode);
   }
 
   return newNodes;

--- a/packages/excalidraw/element/flowchart.ts
+++ b/packages/excalidraw/element/flowchart.ts
@@ -191,11 +191,39 @@ export const getPredecessors = (
   return getNodeRelatives("predecessors", node, elementsMap, direction);
 };
 
+function getIndividualYOffset(nodes: ExcalidrawElement[]): number[] {
+  const offsets = [];
+
+  for (let i = 0; i < nodes.length - 1; i++) {
+    const nodeA = nodes[i];
+    const nodeB = nodes[i + 1];
+
+    const offset = nodeB.y - (nodeA.y + nodeA.height);
+    offsets.push(offset);
+  }
+
+  return offsets;
+}
+function getIndividualXOffset(nodes: ExcalidrawElement[]): number[] {
+  const offsets = [];
+
+  for (let i = 0; i < nodes.length - 1; i++) {
+    const nodeA = nodes[i];
+    const nodeB = nodes[i + 1];
+
+    const offset = nodeB.y - (nodeA.y + nodeA.height);
+    offsets.push(offset);
+  }
+
+  return offsets;
+}
+
 const getOffsets = (
   element: ExcalidrawFlowchartNodeElement,
   linkedNodes: ExcalidrawElement[],
   direction: LinkDirection,
 ) => {
+  console.log("code0")
   if (direction === "up" || direction === "down") {
     const _VERTICAL_OFFSET = VERTICAL_OFFSET + element.height;
     // check vertical space
@@ -215,6 +243,7 @@ const getOffsets = (
       };
     }
   } else if (direction === "right" || direction === "left") {
+    console.log("code1")
     const minY = element.y;
     const maxY = element.y + element.height;
 
@@ -231,7 +260,7 @@ const getOffsets = (
       };
     }
   }
-
+  console.log("code2")
   const { minX, maxX } = getMinMaxX(linkedNodes);
   if (direction === "up" || direction === "down") {
     const _VERTICAL_OFFSET = VERTICAL_OFFSET + element.height;
@@ -256,8 +285,11 @@ const getOffsets = (
       y,
     };
   }
-
+  console.log("code3")
   const { minY, maxY } = getMinMaxY(linkedNodes);
+  const offsets = getIndividualYOffset(linkedNodes);
+  const absoluteOffsets = offsets.map((offset) => Math.abs(offset));
+  const minAbsoluteOffset = Math.min(...absoluteOffsets, 0); // it's because the nodes can be offseted away from each outher with a large number which we dont want
 
   const x =
     (linkedNodes.length === 0 ? HORIZONTAL_OFFSET : HORIZONTAL_OFFSET) +
@@ -267,9 +299,9 @@ const getOffsets = (
     linkedNodes.length === 0
       ? 0
       : (linkedNodes.length + 1) % 2 === 0
-      ? Math.abs(maxY - minY) / 2 + element.height
-      : (Math.abs(maxY - minY) / 2 + element.height) * -1;
-
+      ? Math.abs(maxY - minY) / 2 + element.height + minAbsoluteOffset
+      : (Math.abs(maxY - minY) / 2 + element.height + minAbsoluteOffset) * -1;
+    
   if (direction === "left") {
     return {
       x: x * -1,
@@ -287,54 +319,53 @@ const getOffsets = (
 //   linkedNodes: ExcalidrawElement[],
 //   direction: LinkDirection,
 // ) => {
-//   const _HORIZONTAL_OFFSET = HORIZONTAL_OFFSET + element.width;
+//   if (direction === "up" || direction === "down") {
+//     const _VERTICAL_OFFSET = VERTICAL_OFFSET + element.height;
+//     // check vertical space
+//     const minX = element.x;
+//     const maxX = element.x + element.width;
 
-//   if (direction === "right" || direction === "left") {
+//     // vertical space is available
+//     if (
+//       linkedNodes.every(
+//         (linkedNode) =>
+//           linkedNode.x + linkedNode.width < minX || linkedNode.x > maxX,
+//       )
+//     ) {
+//       return {
+//         x: 0,
+//         y: _VERTICAL_OFFSET * (direction === "up" ? -1 : 1),
+//       };
+//     }
+//   } else if (direction === "right" || direction === "left") {
 //     const minY = element.y;
 //     const maxY = element.y + element.height;
 
-//     // Check for vertical overlap with any linked nodes
 //     if (
 //       linkedNodes.every(
 //         (linkedNode) =>
 //           linkedNode.y + linkedNode.height < minY || linkedNode.y > maxY,
 //       )
 //     ) {
-//       // If no vertical overlap, place node as usual
 //       return {
 //         x:
 //           (HORIZONTAL_OFFSET + element.width) * (direction === "left" ? -1 : 1),
 //         y: 0,
 //       };
-//     } else {
-//       // If there is vertical overlap, adjust the y-position
-//       // Find the closest node above or below and place the new node with enough space
-//       let maxLinkedY = Math.max(
-//         ...linkedNodes.map((node) => node.y + node.height),
-//       );
-//       let minLinkedY = Math.min(...linkedNodes.map((node) => node.y));
-
-//       // Choose whether to place the node above or below the closest linked node
-//       const newY = maxLinkedY + VERTICAL_OFFSET;
-
-//       return {
-//         x:
-//           (HORIZONTAL_OFFSET + element.width) * (direction === "left" ? -1 : 1),
-//         y: newY,
-//       };
 //     }
 //   }
 
-// Handle vertical placement (same as before)
+//   const { minX, maxX } = getMinMaxX(linkedNodes);
 //   if (direction === "up" || direction === "down") {
 //     const _VERTICAL_OFFSET = VERTICAL_OFFSET + element.height;
 //     const y = linkedNodes.length === 0 ? _VERTICAL_OFFSET : _VERTICAL_OFFSET;
+
 //     const x =
 //       linkedNodes.length === 0
 //         ? 0
 //         : (linkedNodes.length + 1) % 2 === 0
-//         ? ((linkedNodes.length + 1) / 2) * _HORIZONTAL_OFFSET
-//         : (linkedNodes.length / 2) * _HORIZONTAL_OFFSET * -1;
+//         ? Math.abs(maxX - minX) / 2 + element.width
+//         : (Math.abs(maxX - minX) / 2 + element.width) * -1;
 
 //     if (direction === "up") {
 //       return {
@@ -348,6 +379,30 @@ const getOffsets = (
 //       y,
 //     };
 //   }
+
+//   const { minY, maxY } = getMinMaxY(linkedNodes);
+
+//   const x =
+//     (linkedNodes.length === 0 ? HORIZONTAL_OFFSET : HORIZONTAL_OFFSET) +
+//     element.width;
+
+//   const y =
+//     linkedNodes.length === 0
+//       ? 0
+//       : (linkedNodes.length + 1) % 2 === 0
+//       ? Math.abs(maxY - minY) / 2 + element.height
+//       : (Math.abs(maxY - minY) / 2 + element.height) * -1;
+
+//   if (direction === "left") {
+//     return {
+//       x: x * -1,
+//       y,
+//     };
+//   }
+//   return {
+//     x,
+//     y,
+//   };
 // };
 
 const addNewNode = (


### PR DESCRIPTION
issue :  #8518
Hi @mtolmacs  
The code isn’t complete yet, so please bear with me.

I’ve created some functions similar to addNodes(), but none of them work properly, so I’ve commented them out. You can uncomment them and check for yourself.

The first function tries to resolve overlapping nodes, but it’s not working, and I have no idea why. I’m not sure if the getSuccessors() and getPredecessors() functions are working correctly. In my opinion, the logic seems right, but I still can’t figure out why it’s failing.

The second version moves existing elements to make space, and that part works. However, when many nodes are interconnected, it doesn’t resolve the overlap properly.

The current code also creates overlap. For example, if you create one node next to an existing one, and then add an odd number of nodes, it always results in overlap.

So, I need your help to figure out which direction I should take. Any guidance would be appreciated!