### PR TITLE
feat: Expose clear canvas shortcut in main menu

### DIFF
--- a/packages/excalidraw/components/main-menu/DefaultItems.tsx
+++ b/packages/excalidraw/components/main-menu/DefaultItems.tsx
@@ -205,6 +205,7 @@ export const ClearCanvas = () => {
       onSelect={() => setActiveConfirmDialog("clearCanvas")}
       data-testid="clear-canvas-button"
       aria-label={t("buttons.clearReset")}
+      shortcut={getShortcutFromShortcutName("clearCanvas")}
     >
       {t("buttons.clearReset")}
     </DropdownMenuItem>


### PR DESCRIPTION
### Context
Closes: https://github.com/excalidraw/excalidraw/issues/8572

### Changes
- Adds command shortcut to Main Menu for the clear canvas functionality.
- Similar to Open, export, etc. options

### Before
<img width="356" alt="image" src="https://github.com/user-attachments/assets/b883820a-4c93-43e0-8165-d45cc6d56bb3">

### After
<img width="309" alt="image" src="https://github.com/user-attachments/assets/279dda06-94e6-4ded-926e-4e2656535492">
