### PR TITLE
[FIX]: copy pasted SVG or PNG cannot be undone

### DIFF
--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -2979,6 +2979,9 @@ class App extends React.Component<AppProps, AppState> {
         const imageElement = this.createImageElement({ sceneX, sceneY });
         this.insertImageElement(imageElement, file);
         this.initializeImageDimensions(imageElement);
+
+        this.store.shouldCaptureIncrement();
+
         this.setState({
           selectedElementIds: makeNextSelectedElementIds(
             {
@@ -2987,6 +2990,8 @@ class App extends React.Component<AppProps, AppState> {
             this.state,
           ),
         });
+
+        this.actionManager.executeAction(actionFinalize);
 
         return;
       }


### PR DESCRIPTION
# Fix 
Copy pasted SVG or PNG cannot be undone 
Issue #8321 

# Video of Fixed bug  

https://github.com/user-attachments/assets/13c289b4-2a85-4462-b4a7-d432af582a89

