### PR TITLE
Change support straight line when shift is pressed

### DIFF
--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -7993,9 +7993,17 @@ class App extends React.Component<AppProps, AppState> {
 
         if (newElement.type === "freedraw") {
           const points = newElement.points;
-          const dx = pointerCoords.x - newElement.x;
-          const dy = pointerCoords.y - newElement.y;
-
+          let dx = pointerCoords.x - newElement.x;
+          let dy = pointerCoords.y - newElement.y;
+          const isShiftPressed = event?.shiftKey || false;
+          if (isShiftPressed) {
+            const angle = Math.atan2(dy, dx) * (180 / Math.PI);
+            const snapAngle = Math.round(angle / 45) * 45;
+            const radians = (snapAngle * Math.PI) / 180;
+            const distance = Math.sqrt(dx * dx + dy * dy);
+            dx = distance * Math.cos(radians);
+            dy = distance * Math.sin(radians);
+          }
           const lastPoint = points.length > 0 && points[points.length - 1];
           const discardPoint =
             lastPoint && lastPoint[0] === dx && lastPoint[1] === dy;


### PR DESCRIPTION
This PR introduces enhancements for angle snapping and smooth transitions when using the free-draw tool. It allows users to maintain a fixed angle while drawing and resets state after the shift key is released, improving the overall user experience. The updates aim to refine the drawing process, ensuring cleaner and more precise lines. Your feedback and suggestions for further improvements are welcome! #8586 