### PR TITLE
#8586: Add Angle-Constrained Freedraw (Shift + Draw Straight Lines in Discrete Angles)

### DIFF
--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -7993,8 +7993,19 @@ class App extends React.Component<AppProps, AppState> {
 
         if (newElement.type === "freedraw") {
           const points = newElement.points;
-          const dx = pointerCoords.x - newElement.x;
-          const dy = pointerCoords.y - newElement.y;
+          let dx = pointerCoords.x - newElement.x;
+          let dy = pointerCoords.y - newElement.y;
+
+          if(event.shiftKey) {
+            const angle = Math.atan2(dy, dx);
+
+            const step = Math.PI / 4;
+            const snappedAngle = Math.round(angle / step) * step;
+
+            const distance = Math.sqrt(dx * dx + dy * dy);
+            dx = Math.cos(snappedAngle) * distance;
+            dy = Math.sin(snappedAngle) * distance;
+          }
 
           const lastPoint = points.length > 0 && points[points.length - 1];
           const discardPoint =


### PR DESCRIPTION
This update adds angle-constrained drawing to the freedraw tool. By holding the Shift key, users can draw straight lines locked to discrete angles, mimicking the behavior of the line tool. This improvement enhances precision and control during freehand drawing.
Fixes: #8586 
Support angle constrained freedraw (Shift + draw straight line in discrete angles) just like with the line tool



https://github.com/user-attachments/assets/722a2b7d-3fb1-4207-b023-7c96af61f8a9

