### PR TITLE
docs: Typo fixes and Improved Readability

### DIFF
--- a/dev-docs/docs/@excalidraw/excalidraw/development.mdx
+++ b/dev-docs/docs/@excalidraw/excalidraw/development.mdx
@@ -46,7 +46,7 @@ To release the next stable version follow the below steps:
 yarn prerelease:excalidraw
 ```
 
-You need to pass the `version` for which you want to create the release. This will make the changes needed before making the release like updating `package.json`, `changelog` and more.
+You need to pass the `version` for which you want to create the release. This will make the necessary changes before the release like updating `package.json`, `changelog` and more.
 
 The next step is to run the `release` script:
 

--- a/dev-docs/docs/@excalidraw/excalidraw/faq.mdx
+++ b/dev-docs/docs/@excalidraw/excalidraw/faq.mdx
@@ -1,14 +1,14 @@
 # FAQ
 
-### Does this package support collaboration ?
+### Does this package support collaboration?
 
-No, Excalidraw package doesn't come with collaboration built in, since the implementation is specific to each host app. We expose APIs which you can use to communicate with Excalidraw which you can use to implement it. You can check our own implementation [here](https://github.com/excalidraw/excalidraw/blob/master/excalidraw-app/index.tsx). Here is a [detailed answer](https://github.com/excalidraw/excalidraw/discussions/3879#discussioncomment-1110524) on how you can achieve the same.
+No, Excalidraw package doesn't come with collaboration built in, since the implementation is specific to each host app. We expose APIs that you can use to communicate with Excalidraw which you can use to implement it. You can check our own implementation [here](https://github.com/excalidraw/excalidraw/blob/master/excalidraw-app/index.tsx). Here is a [detailed answer](https://github.com/excalidraw/excalidraw/discussions/3879#discussioncomment-1110524) on how you can achieve the same.
 
 ### Turning off Aggressive Anti-Fingerprinting in Brave browser
 
 When *Aggressive Anti-Fingerprinting* is turned on, the `measureText` API breaks which in turn breaks the Text Elements in your drawings. Here is more [info](https://github.com/excalidraw/excalidraw/pull/6336) on the same.
 
-We strongly recommend turning it off. You can follow the steps below on how to do so.
+We strongly recommend turning it off. You can follow the steps below to learn how to do so.
 
 
 1. Open [excalidraw.com](https://excalidraw.com) in Brave and click on the **Shield** button
@@ -24,14 +24,14 @@ We strongly recommend turning it off. You can follow the steps below on how to d
 
 ![Block filtering](../../assets/block-fingerprint.png)
 
-4. Thats all. All text elements should be fixed now 🎉
+4. That's all. All text elements should be fixed now 🎉
 
 </div>
 
 If disabling this setting doesn't fix the display of text elements, please consider opening an [issue](https://github.com/excalidraw/excalidraw/issues/new) on our GitHub, or message us on [Discord](https://discord.gg/UexuTaE).
 
 
-### ReferenceError: process is not defined
+### ReferenceError: the process is not defined
 
 When using `vite` or any build tools, you will have to make sure the `process` is accessible as we are accessing `process.env.IS_PREACT` to decide whether to use `preact` build.
 

--- a/dev-docs/docs/@excalidraw/excalidraw/integration.mdx
+++ b/dev-docs/docs/@excalidraw/excalidraw/integration.mdx
@@ -51,7 +51,7 @@ export default function App() {
 
 However the above component only works for named component exports. If you want to import some util / constant or something else apart from Excalidraw, then this approach will not work. Instead you can write a wrapper over Excalidraw and import the wrapper dynamically.
 
-If you are using `pages router` then importing the wrapper dynamically would work, where as if you are using `app router` then you will have to also add `useClient` directive on top of the file in addition to dynamically importing the wrapper as shown :point_down:
+If you are using `pages router` then importing the wrapper dynamically would work, whereas if you are using `app router` then you will have to also add `useClient` directive on top of the file in addition to dynamically importing the wrapper as shown :point_down:
 
 <Tabs>
   <TabItem value="Excalidraw Wrapper" label="Excalidraw Wrapper" >
@@ -85,7 +85,7 @@ If you are using `pages router` then importing the wrapper dynamically would wor
   ```jsx showLineNumbers
   import dynamic from "next/dynamic";
   
-  // Since client components get prerenderd on server as well hence importing 
+  // Since client components get prerendered on server as well hence importing 
   // the excalidraw stuff dynamically with ssr false
 
   const ExcalidrawWrapper = dynamic(
@@ -108,7 +108,7 @@ If you are using `pages router` then importing the wrapper dynamically would wor
   ```jsx showLineNumbers
   import dynamic from "next/dynamic";
 
-  // Since client components get prerenderd on server as well hence importing 
+  // Since client components get prerendered on server as well hence importing 
   // the excalidraw stuff dynamically with ssr false
 
   const ExcalidrawWrapper = dynamic(
@@ -138,7 +138,7 @@ The `types` are available at `@excalidraw/excalidraw/types`, you can view [examp
 
 Since we support `umd` build ships with `react/jsx-runtime` and `react-dom/client` inlined with the package. This conflicts with `Preact` and hence the build doesn't work directly with `Preact`.
 
-However we have shipped a separate build for `Preact` so if you are using `Preact` you need to set `process.env.IS_PREACT` to `true` to use the `Preact` build.
+However, we have shipped a separate build for `Preact` so if you are using `Preact` you need to set `process.env.IS_PREACT` to `true` to use the `Preact` build.
 
 Once the above `env` variable is set, you will be able to use the package in `Preact` as well.
 

--- a/dev-docs/docs/@excalidraw/mermaid-to-excalidraw/api.mdx
+++ b/dev-docs/docs/@excalidraw/mermaid-to-excalidraw/api.mdx
@@ -26,7 +26,7 @@ try {
 
 ## Supported Diagram Types
 
-Currently only [flowcharts](https://mermaid.js.org/syntax/flowchart.html) are supported. Oother diagram types will be rendered as an image in Excalidraw.
+Currently only [flowcharts](https://mermaid.js.org/syntax/flowchart.html) are supported. Other diagram types will be rendered as images in Excalidraw.
 
 ### Flowchart
 
@@ -103,7 +103,7 @@ flowchart LR
 
 #### Basic FontAwesome fallback to text
 
-The [FontAwesome](https://mermaid.js.org/syntax/flowchart.html#basic-support-for-fontawesome) icons aren't support so they won't be rendered in Excalidraw
+The [FontAwesome](https://mermaid.js.org/syntax/flowchart.html#basic-support-for-fontawesome) icons aren't supported so they won't be rendered in Excalidraw
 
 ```
 flowchart TD

--- a/dev-docs/docs/@excalidraw/mermaid-to-excalidraw/codebase/new-diagram-type.mdx
+++ b/dev-docs/docs/@excalidraw/mermaid-to-excalidraw/codebase/new-diagram-type.mdx
@@ -4,17 +4,17 @@ To add a new diagram type to the parser you can follow the below steps :point_do
 
 All the code for the parser resides in [`src`](https://github.com/excalidraw/mermaid-to-excalidraw/tree/master/src) folder and for playground resides in [`playground`](https://github.com/excalidraw/mermaid-to-excalidraw/tree/master/playground) folder.
 
-lets run the playground server in local :point_down:
+Let's run the playground server in local :point_down:
 
 ```bash
 yarn start
 ```
 
-This will start the playground server in port `1234` and open it in browser so  you start playing with the playground.
+This will start the playground server in port `1234` and open it in the browser so  you start playing with the playground.
 
 ## Update Supported Diagram Types
 
-First step is to add the new diagram type in [`SUPPORTED_DIAGRAM_TYPES`](https://github.com/excalidraw/mermaid-to-excalidraw/blob/master/src/constants.ts#L2).
+The first step is to add the new diagram type in [`SUPPORTED_DIAGRAM_TYPES`](https://github.com/excalidraw/mermaid-to-excalidraw/blob/master/src/constants.ts#L2).
 
 Once this is done the new diagram type won't be rendered as an image but start throwing error since we don't support parsing the data yet.
 
@@ -26,29 +26,29 @@ For this create a file named `{{diagramType}}.ts` in [`src/parser`](https://gith
 
 The main aim of the parser is :point_down:
 
-1. Determine how elements are connected in the diagram and thus finding arrow and text bindings. 
+1. Determine how elements are connected in the diagram and thus find arrow and text bindings. 
 
 For this you might have to dig in to the parser `diagram.parser.yy` and which attributes to parse for the new diagram.
 
 2. Determine the position and dimensions of each element, for this would be using the `svg`
 
-Once the parser is ready, lets start using it. 
+Once the parser is ready, let's start using it. 
 
 Add the diagram type in switch case in [`parseMermaid`](https://github.com/excalidraw/mermaid-to-excalidraw/blob/master/src/parseMermaid.ts#L97) and call the parser for the same.
 
-## Writing the Excalidraw Skeleton Convertor
+## Writing the Excalidraw Skeleton Converter
 
 With the completion of previous step, we have all the data, now we need to transform it so to [ExcalidrawElementSkeleton](https://github.com/excalidraw/excalidraw/blob/master/packages/excalidraw/data/transform.ts#L133) format.
 
 Similar to [`FlowChartToExcalidrawSkeletonConverter`](https://github.com/excalidraw/mermaid-to-excalidraw/blob/master/src/converter/types/flowchart.ts#L24), you have to write the `{{diagramType}}ToExcalidrawSkeletonConverter` which parses the data received in previous step and returns the [ExcalidrawElementSkeleton](https://github.com/excalidraw/excalidraw/blob/master/packages/excalidraw/data/transform.ts#L133).
 
-Thats it, you have added the new diagram type 🥳, now lets test it out!
+That's it, you have added the new diagram type 🥳, now let's test it out!
 
 ## Updating the Playground
 
 1. Create a file named `{{diagramType}}.ts` in [`playround/testcases/`](https://github.com/excalidraw/mermaid-to-excalidraw/tree/master/playground/testcases). For reference you can check [`flowchart.ts`](https://github.com/excalidraw/mermaid-to-excalidraw/blob/master/playground/testcases/flowchart.ts).
 
-2. Incase the new diagram type added is present in [`unsupported.ts`](https://github.com/excalidraw/mermaid-to-excalidraw/blob/master/playground/testcases/unsupported.ts) then remove it from there.
+2. In case the new diagram type added is present in [`unsupported.ts`](https://github.com/excalidraw/mermaid-to-excalidraw/blob/master/playground/testcases/unsupported.ts) then remove it from there.
 
-3. Verify if the test cases are running fine in playground.
+3. Verify if the test cases are running fine in the playground.
 

--- a/dev-docs/docs/@excalidraw/mermaid-to-excalidraw/codebase/parser/flowchart.mdx
+++ b/dev-docs/docs/@excalidraw/mermaid-to-excalidraw/codebase/parser/flowchart.mdx
@@ -94,7 +94,7 @@ Considering the same example this is the response from the API
 ]
 ```
 
-Similarly here the dimensions and position is missing and we compute that from the svg. The [`parseEdge`](https://github.com/excalidraw/mermaid-to-excalidraw/blob/master/src/parseMermaid.ts#L245) takes the above response along with `svg` and computes the position, dimensions and cleans up the response.
+Similarly, here the dimensions and position is missing and we compute that from the svg. The [`parseEdge`](https://github.com/excalidraw/mermaid-to-excalidraw/blob/master/src/parseMermaid.ts#L245) takes the above response along with `svg` and computes the position, dimensions and cleans up the response.
 
  The final output from `parseEdge` looks like :point_down:
 
@@ -128,7 +128,7 @@ Similarly here the dimensions and position is missing and we compute that from t
 
 `Subgraphs` is collection of elements grouped together. The Subgraphs map to `grouping` elements in Excalidraw.
 
-Lets consider the below example :point_down:
+Let's consider the below example :point_down:
 
 ![image](https://github.com/excalidraw/excalidraw/assets/11256141/5243ce4c-beaa-43d2-812a-0577b0a574d7)
 

--- a/dev-docs/docs/@excalidraw/mermaid-to-excalidraw/codebase/parser/parser.mdx
+++ b/dev-docs/docs/@excalidraw/mermaid-to-excalidraw/codebase/parser/parser.mdx
@@ -3,13 +3,13 @@
 [This](https://github.com/excalidraw/mermaid-to-excalidraw/blob/master/src/index.ts) is the entry point of the library.
 
 
-`parseMermaidToExcalidraw` function is the only function exposed which receives mermaid syntax as the input, parses the mermaid syntax and resolves to Excalidraw Skeleton.
+`parseMermaidToExcalidraw` function is the only function exposed that receives mermaid syntax as the input, parses the mermaid syntax and resolves to Excalidraw Skeleton.
 
-Lets look at the high level overview at how the parse works :point_down:
+Let's look at the high-level overview of how the parse works :point_down:
 
 ![image](https://github.com/excalidraw/excalidraw/assets/11256141/8e060de7-b867-44ad-864b-0c1b24466b67)
 
-Lets dive deeper into individual section now to understand better.
+Lets dive deeper into individual sections now to understand better.
 
 ## Parsing Mermaid diagram
 
@@ -33,19 +33,19 @@ If the diagram isn't supported, this svg is converted to `dataURL` and can be re
 
 ### Parsing the mermaid syntax
 
-For this we first need to process the options along with mermaid defination for diagram provided by the user.
+For this, we first need to process the options along with mermaid definition for the diagram provided by the user.
 
-[`processMermaidTextWithOptions`](https://github.com/excalidraw/mermaid-to-excalidraw/blob/master/src/parseMermaid.ts#L13) takes the mermaid defination and options and returns the full defination including the mermaid [directives ](https://mermaid.js.org/config/directives.html).
+[`processMermaidTextWithOptions`](https://github.com/excalidraw/mermaid-to-excalidraw/blob/master/src/parseMermaid.ts#L13) takes the mermaid definition and options and returns the full definition including the mermaid [directives ](https://mermaid.js.org/config/directives.html).
 
 ![image](https://github.com/excalidraw/excalidraw/assets/11256141/3a4825d8-9704-468c-a02f-7e507f4d5b7a)
 
-Next we use mermaid api [getDiagramFromText](https://github.com/mermaid-js/mermaid/blob/00d06c7282a701849793680c1e97da1cfdfcce62/packages/mermaid/src/Diagram.ts#L80) to parse the full defination and get the [Diagram](https://github.com/mermaid-js/mermaid/blob/00d06c7282a701849793680c1e97da1cfdfcce62/packages/mermaid/src/Diagram.ts#L15) json from it.
+Next, we use mermaid api [getDiagramFromText](https://github.com/mermaid-js/mermaid/blob/00d06c7282a701849793680c1e97da1cfdfcce62/packages/mermaid/src/Diagram.ts#L80) to parse the full defination and get the [Diagram](https://github.com/mermaid-js/mermaid/blob/00d06c7282a701849793680c1e97da1cfdfcce62/packages/mermaid/src/Diagram.ts#L15) json from it.
 
 ```js
 const diagram = await mermaid.mermaidAPI.getDiagramFromText(fullDefinition);
 ```
 
-Next we write our own parser to parse this diagram.
+Next, we write our own parser to parse this diagram.
 
 ### Parsing the Diagram
 
@@ -57,7 +57,7 @@ If you want to understand how flowchart parser works, you can navigate to [Flowc
 
 Now we have all the data, we just need to transform it to [ExcalidrawElementSkeleton](https://github.com/excalidraw/excalidraw/blob/master/packages/excalidraw/data/transform.ts#L133C13-L133C38) API so it can be rendered in Excalidraw.
 
-For this we have `converters` which takes the parsed mermaid data and gives back the Excalidraw Skeleton.
+For this, we have `converters` which takes the parsed mermaid data and gives back the Excalidraw Skeleton.
 For Unsupported types, we have already mentioned above that we convert it to `dataURL` and return the ExcalidrawImageSkeleton.
 
 For supported types, currently only flowchart, we have [flowchartConverter](https://github.com/excalidraw/mermaid-to-excalidraw/blob/master/src/converter/types/flowchart.ts#L24) which parses the data and converts to [ExcalidrawElementSkeleton](https://github.com/excalidraw/excalidraw/blob/master/packages/excalidraw/data/transform.ts#L133C13-L133C38).

--- a/dev-docs/docs/@excalidraw/mermaid-to-excalidraw/development.mdx
+++ b/dev-docs/docs/@excalidraw/mermaid-to-excalidraw/development.mdx
@@ -4,7 +4,7 @@ This page relates to developing the `@excalidraw/mermaid-to-excalidraw` package 
 
 ## Setting up in Local
 
-To set up the library in local, follow the below steps 👇🏼
+To set up the library locally, follow the below steps 👇🏼
 
 ### Clone the Repository
 
@@ -39,7 +39,7 @@ This will start the playground server in port `1234` and you start playing with 
 
 ## Creating a test release
 
-We will soon simplify creating release via commenting on GitHub PR similar till then you can create a release by following the below steps
+We will soon simplify creating a release via commenting on GitHub PR till then you can create a release by following the below steps
 
 1. Create the build
 

--- a/dev-docs/docs/@excalidraw/mermaid-to-excalidraw/installation.mdx
+++ b/dev-docs/docs/@excalidraw/mermaid-to-excalidraw/installation.mdx
@@ -16,7 +16,7 @@ yarn add @excalidraw/mermaid-to-excalidraw
 
 ## Usage
 
-Once the library is installed, its ready to use.
+Once the library is installed, it's ready to use.
 
 ```js
 import { parseMermaidToExcalidraw } from "@excalidraw/mermaid-to-excalidraw";


### PR DESCRIPTION
This PR addresses some typos in the documentation and also improves readability by using more clearer and apt phrasing.