### PR TITLE
feat: add additional arrowheads to the interface

### DIFF
--- a/packages/excalidraw/actions/actionProperties.tsx
+++ b/packages/excalidraw/actions/actionProperties.tsx
@@ -53,6 +53,7 @@ import {
   sharpArrowIcon,
   roundArrowIcon,
   elbowArrowIcon,
+  ArrowheadCrowsFeetIcon,
 } from "../components/icons";
 import {
   ARROW_TYPE,
@@ -1452,6 +1453,12 @@ const getArrowheadOptions = (flip: boolean) => {
       value: "diamond_outline",
       text: t("labels.arrowhead_diamond_outline"),
       icon: <ArrowheadDiamondOutlineIcon flip={flip} />,
+      keyBinding: null,
+    },
+    {
+      value: "crows_feet",
+      text: t("labels.arrowhead_crows_feet"),
+      icon: <ArrowheadCrowsFeetIcon flip={flip} />,
       keyBinding: null,
     },
   ] as const;

--- a/packages/excalidraw/actions/actionProperties.tsx
+++ b/packages/excalidraw/actions/actionProperties.tsx
@@ -1406,6 +1406,12 @@ const getArrowheadOptions = (flip: boolean) => {
       icon: <ArrowheadArrowIcon flip={flip} />,
     },
     {
+      value: "triangle",
+      text: t("labels.arrowhead_triangle"),
+      icon: <ArrowheadTriangleIcon flip={flip} />,
+      keyBinding: "t",
+    },
+    {
       value: "bar",
       text: t("labels.arrowhead_bar"),
       keyBinding: "e",
@@ -1413,51 +1419,40 @@ const getArrowheadOptions = (flip: boolean) => {
     },
     {
       value: "dot",
-      text: t("labels.arrowhead_circle"),
+      text: t("labels.arrowhead_dot"),
       keyBinding: null,
       icon: <ArrowheadCircleIcon flip={flip} />,
-      showInPicker: false,
     },
     {
       value: "circle",
       text: t("labels.arrowhead_circle"),
       keyBinding: "r",
       icon: <ArrowheadCircleIcon flip={flip} />,
-      showInPicker: false,
     },
     {
       value: "circle_outline",
       text: t("labels.arrowhead_circle_outline"),
       keyBinding: null,
       icon: <ArrowheadCircleOutlineIcon flip={flip} />,
-      showInPicker: false,
     },
-    {
-      value: "triangle",
-      text: t("labels.arrowhead_triangle"),
-      icon: <ArrowheadTriangleIcon flip={flip} />,
-      keyBinding: "t",
-    },
+
     {
       value: "triangle_outline",
       text: t("labels.arrowhead_triangle_outline"),
       icon: <ArrowheadTriangleOutlineIcon flip={flip} />,
       keyBinding: null,
-      showInPicker: false,
     },
     {
       value: "diamond",
       text: t("labels.arrowhead_diamond"),
       icon: <ArrowheadDiamondIcon flip={flip} />,
       keyBinding: null,
-      showInPicker: false,
     },
     {
       value: "diamond_outline",
       text: t("labels.arrowhead_diamond_outline"),
       icon: <ArrowheadDiamondOutlineIcon flip={flip} />,
       keyBinding: null,
-      showInPicker: false,
     },
   ] as const;
 };

--- a/packages/excalidraw/components/IconPicker.scss
+++ b/packages/excalidraw/components/IconPicker.scss
@@ -98,6 +98,21 @@
     }
   }
 
+  .picker-footer {
+    display: flex;
+    justify-content: end;
+    padding: 0.5rem;
+  }
+
+  .picker-footer-link {
+    color: var(--color-promo);
+  }
+
+  .picker-footer-link:hover {
+    text-decoration: underline;
+    cursor: pointer;
+  }
+
   .picker-keybinding {
     position: absolute;
     bottom: 2px;

--- a/packages/excalidraw/components/IconPicker.tsx
+++ b/packages/excalidraw/components/IconPicker.tsx
@@ -132,8 +132,10 @@ function Picker<T>({
               (event.currentTarget as HTMLButtonElement).focus();
               onChange(option.value);
             }}
-            title={`${option.text} ${
-              option.keyBinding && `— ${option.keyBinding.toUpperCase()}`
+            title={`${option.text}${
+              option.keyBinding !== null
+                ? ` — ${option.keyBinding.toUpperCase()}`
+                : ""
             }`}
             aria-label={option.text || "none"}
             aria-keyshortcuts={option.keyBinding || undefined}

--- a/packages/excalidraw/components/icons.tsx
+++ b/packages/excalidraw/components/icons.tsx
@@ -1239,6 +1239,22 @@ export const ArrowheadArrowIcon = React.memo(
     ),
 );
 
+export const ArrowheadCrowsFeetIcon = React.memo(
+  ({ flip = false }: { flip?: boolean }) =>
+    createIcon(
+      <g
+        transform={flip ? "translate(40, 0) scale(-1, 1)" : ""}
+        stroke="currentColor"
+        strokeWidth={2}
+        fill="none"
+      >
+        <path d="M34 10H6M24 10L34 17M24 10L34 3" />
+      </g>,
+      { width: 40, height: 20 },
+    ),
+);
+
+
 export const ArrowheadCircleIcon = React.memo(
   ({ flip = false }: { flip?: boolean }) =>
     createIcon(

--- a/packages/excalidraw/css/styles.scss
+++ b/packages/excalidraw/css/styles.scss
@@ -385,7 +385,7 @@ body.excalidraw-cursor-resize * {
   }
 
   .App-menu__left {
-    overflow-y: auto;
+    overflow-y: visible;
     padding: 0.75rem;
     width: 12.5rem;
     box-sizing: border-box;

--- a/packages/excalidraw/element/bounds.ts
+++ b/packages/excalidraw/element/bounds.ts
@@ -565,6 +565,7 @@ export const getArrowheadSize = (arrowhead: Arrowhead): number => {
 export const getArrowheadAngle = (arrowhead: Arrowhead): Degrees => {
   switch (arrowhead) {
     case "bar":
+    case "crows_feet":
       return 90 as Degrees;
     case "arrow":
       return 20 as Degrees;
@@ -708,6 +709,14 @@ export const getArrowheadPoints = (
     }
 
     return [x2, y2, x3, y3, ox, oy, x4, y4];
+  }
+
+  if (arrowhead === "crows_feet") {
+    // point opposite to the arrowhead point
+    const ox = xs - nx * minSize;
+    const oy = ys - ny * minSize;
+
+    return [ox, oy, x4, y4, x3, y3];
   }
 
   return [x2, y2, x3, y3, x4, y4];

--- a/packages/excalidraw/element/types.ts
+++ b/packages/excalidraw/element/types.ts
@@ -292,7 +292,8 @@ export type Arrowhead =
   | "triangle"
   | "triangle_outline"
   | "diamond"
-  | "diamond_outline";
+  | "diamond_outline"
+  | "crows_feet";
 
 export type ExcalidrawLinearElement = _ExcalidrawElementBase &
   Readonly<{

--- a/packages/excalidraw/locales/en.json
+++ b/packages/excalidraw/locales/en.json
@@ -41,6 +41,7 @@
     "arrowhead_arrow": "Arrow",
     "arrowhead_bar": "Bar",
     "arrowhead_circle": "Circle",
+    "arrowhead_dot": "Dot",
     "arrowhead_circle_outline": "Circle (outline)",
     "arrowhead_triangle": "Triangle",
     "arrowhead_triangle_outline": "Triangle (outline)",

--- a/packages/excalidraw/locales/en.json
+++ b/packages/excalidraw/locales/en.json
@@ -47,6 +47,7 @@
     "arrowhead_triangle_outline": "Triangle (outline)",
     "arrowhead_diamond": "Diamond",
     "arrowhead_diamond_outline": "Diamond (outline)",
+    "arrowhead_crows_feet": "Crow's feet",
     "arrowtypes": "Arrow type",
     "arrowtype_sharp": "Sharp arrow",
     "arrowtype_round": "Curved arrow",


### PR DESCRIPTION
Closes #8611
- [x] Add the show/hide logic to the arrowhead popout
- [x] Add the additionally implemented arrowheads to the conditionally hidden section
- [x] Move the T arrow end to the conditionally hidden section
- [x] Add "crow's feet" arrowhead and put it in the hidden section

![firefox_0LUl1MUZcJ](https://github.com/user-attachments/assets/468e530f-fcfd-4832-b387-278a9dba08ca)
