### PR TITLE
refactor: fix todo

### DIFF
--- a/packages/excalidraw/actions/actionDuplicateSelection.tsx
+++ b/packages/excalidraw/actions/actionDuplicateSelection.tsx
@@ -1,11 +1,11 @@
 import { KEYS } from "../keys";
 import { register } from "./register";
-import type { ExcalidrawElement } from "../element/types";
+import type { ExcalidrawElement, SceneElementsMap } from "../element/types";
 import { duplicateElement, getNonDeletedElements } from "../element";
 import { isSomeElementSelected } from "../scene";
 import { ToolButton } from "../components/ToolButton";
 import { t } from "../i18n";
-import { arrayToMap, getShortcutKey } from "../utils";
+import { invariant, arrayToMap, getShortcutKey } from "../utils";
 import { LinearElementEditor } from "../element/linearElementEditor";
 import {
   selectGroupsForSelectedElements,
@@ -39,14 +39,36 @@ export const actionDuplicateSelection = register({
   label: "labels.duplicateSelection",
   icon: DuplicateIcon,
   trackEvent: { category: "element" },
-  perform: (elements, appState, formData, app) => {
+  perform: (elements, appState, app) => {
     // duplicate selected point(s) if editing a line
     if (appState.editingLinearElement) {
-      // TODO: Invariants should be checked here instead of duplicateSelectedPoints()
+      invariant(
+        appState.editingLinearElement,
+        "Not currently editing a linear element",
+      );
+      
+      const elementsMap = app.scene.getNonDeletedElementsMap();
+      const { selectedPointsIndices, elementId } = appState.editingLinearElement;
+      const element = LinearElementEditor.getElement(elementId, elementsMap);
+  
+      invariant(
+        element,
+        "The linear element does not exist in the provided Scene",
+      );
+      invariant(
+        selectedPointsIndices != null,
+        "There are no selected points to duplicate",
+      );
+      invariant(
+        appState.editingLinearElement,
+        "Not currently editing a linear element",
+      );
       try {
         const newAppState = LinearElementEditor.duplicateSelectedPoints(
           appState,
-          app.scene.getNonDeletedElementsMap(),
+          elementsMap,
+          element,
+          selectedPointsIndices,
         );
 
         return {

--- a/packages/excalidraw/element/linearElementEditor.ts
+++ b/packages/excalidraw/element/linearElementEditor.ts
@@ -1139,23 +1139,9 @@ export class LinearElementEditor {
   static duplicateSelectedPoints(
     appState: AppState,
     elementsMap: NonDeletedSceneElementsMap | SceneElementsMap,
+    element: NonDeleted<ExcalidrawLinearElement>,
+    selectedPointsIndices: readonly number[],
   ): AppState {
-    invariant(
-      appState.editingLinearElement,
-      "Not currently editing a linear element",
-    );
-
-    const { selectedPointsIndices, elementId } = appState.editingLinearElement;
-    const element = LinearElementEditor.getElement(elementId, elementsMap);
-
-    invariant(
-      element,
-      "The linear element does not exist in the provided Scene",
-    );
-    invariant(
-      selectedPointsIndices != null,
-      "There are no selected points to duplicate",
-    );
 
     const { points } = element;
 
@@ -1207,7 +1193,7 @@ export class LinearElementEditor {
 
     return {
       ...appState,
-      editingLinearElement: {
+      editingLinearElement: appState.editingLinearElement && {
         ...appState.editingLinearElement,
         selectedPointsIndices: nextSelectedIndices,
       },


### PR DESCRIPTION
Fixed this TODO 
`// TODO: Invariants should be checked here instead of duplicateSelectedPoints()`

Moving these invariant checks outside of `duplicateSelectedPoints()` can make the code ensure that only valid data is passed to the function, which _should_ simplify its implementation and make it more robust.