### PR TITLE
feat: export duplicateElements function to excalidraw API

### DIFF
--- a/packages/excalidraw/element/index.ts
+++ b/packages/excalidraw/element/index.ts
@@ -14,6 +14,7 @@ export {
   newArrowElement,
   newImageElement,
   duplicateElement,
+  duplicateElements,
 } from "./newElement";
 export {
   getElementAbsoluteCoords,

--- a/packages/excalidraw/index.tsx
+++ b/packages/excalidraw/index.tsx
@@ -214,6 +214,7 @@ export {
   isInvisiblySmallElement,
   getNonDeletedElements,
   getTextFromElements,
+  duplicateElements,
 } from "./element";
 export { defaultLang, useI18n, languages } from "./i18n";
 export {


### PR DESCRIPTION
Hi folks!

I'm using excalidraw for a project and it turns out there are several functions that would be amazing to be able to use in my project. DuplicateElements is one of them. This PR exposes this function to the public module.

Cheers!