### PR TITLE
fix: text disappearing on edit (#8558)

### DIFF
--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -4737,10 +4737,13 @@ class App extends React.Component<AppProps, AppState> {
           this.store.shouldCaptureIncrement();
         }
 
-        this.setState({
-          newElement: null,
-          editingTextElement: null,
+        flushSync(() => {
+          this.setState({
+            newElement: null,
+            editingTextElement: null,
+          });
         });
+
         if (this.state.activeTool.locked) {
           setCursorForShape(this.interactiveCanvas, this.state);
         }


### PR DESCRIPTION
This PR fixes #8558 (due to race condition)

The issue was consistently happening on MacOS and safari.

I use the same strategy that is use before, with the use of `flushSync()`. We should update this in finalize action, like with via keyboard trigger