### PR TITLE
fix: dont show keyboard related hints when on mobile - they are misleading 

### DIFF
--- a/packages/excalidraw/components/HintViewer.tsx
+++ b/packages/excalidraw/components/HintViewer.tsx
@@ -43,10 +43,14 @@ const getHints = ({
     return null;
   }
 
-  if (isEraserActive(appState)) {
+  if (isEraserActive(appState) && 
+    !isMobile) {
     return t("hints.eraserRevert");
   }
-  if (activeTool.type === "arrow" || activeTool.type === "line") {
+  if (
+    (activeTool.type === "arrow" || activeTool.type === "line") &&
+    !isMobile
+  ) {
     if (multiMode) {
       return t("hints.linearElementMulti");
     }
@@ -56,7 +60,7 @@ const getHints = ({
     return t("hints.linearElement");
   }
 
-  if (activeTool.type === "freedraw") {
+  if (activeTool.type === "freedraw" && !isMobile) {
     return t("hints.freeDraw");
   }
 
@@ -64,11 +68,15 @@ const getHints = ({
     return t("hints.text");
   }
 
-  if (activeTool.type === "embeddable") {
+  if (activeTool.type === "embeddable" && !isMobile) {
     return t("hints.embeddable");
   }
 
-  if (appState.activeTool.type === "image" && appState.pendingImageElementId) {
+  if (
+    appState.activeTool.type === "image" &&
+    appState.pendingImageElementId &&
+    !isMobile
+  ) {
     return t("hints.placeImage");
   }
 
@@ -92,11 +100,15 @@ const getHints = ({
     return t("hints.rotate");
   }
 
-  if (selectedElements.length === 1 && isTextElement(selectedElements[0])) {
+  if (
+    selectedElements.length === 1 &&
+    isTextElement(selectedElements[0]) &&
+    !isMobile
+  ) {
     return t("hints.text_selected");
   }
 
-  if (appState.editingTextElement) {
+  if (appState.editingTextElement && !isMobile) {
     return t("hints.text_editing");
   }
 
@@ -105,7 +117,8 @@ const getHints = ({
       appState.selectionElement &&
       !selectedElements.length &&
       !appState.editingTextElement &&
-      !appState.editingLinearElement
+      !appState.editingLinearElement &&
+      !isMobile
     ) {
       return t("hints.deepBoxSelect");
     }
@@ -119,7 +132,7 @@ const getHints = ({
     }
 
     if (selectedElements.length === 1) {
-      if (isLinearElement(selectedElements[0])) {
+      if (isLinearElement(selectedElements[0]) && !isMobile) {
         if (appState.editingLinearElement) {
           return appState.editingLinearElement.selectedPointsIndices
             ? t("hints.lineEditor_pointSelected")
@@ -130,7 +143,8 @@ const getHints = ({
       if (
         !appState.newElement &&
         !appState.selectedElementsAreBeingDragged &&
-        isTextBindableContainer(selectedElements[0])
+        isTextBindableContainer(selectedElements[0]) &&
+        !isMobile
       ) {
         if (isFlowchartNodeElement(selectedElements[0])) {
           if (


### PR DESCRIPTION
As mentioned in Issue #1007, check if the hints are about to be shown on mobile. 