### PR TITLE
fix: remove export-to-clip-as-svg shortcut for now

### DIFF
--- a/packages/excalidraw/actions/actionClipboard.tsx
+++ b/packages/excalidraw/actions/actionClipboard.tsx
@@ -182,7 +182,6 @@ export const actionCopyAsSvg = register({
   predicate: (elements) => {
     return probablySupportsClipboardWriteText && elements.length > 0;
   },
-  keyTest: (event) => event.code === CODES.C && event.ctrlKey && event.shiftKey,
   keywords: ["svg", "clipboard", "copy"],
 });
 

--- a/packages/excalidraw/actions/shortcuts.ts
+++ b/packages/excalidraw/actions/shortcuts.ts
@@ -23,7 +23,6 @@ export type ShortcutName =
       | "sendToBack"
       | "bringToFront"
       | "copyAsPng"
-      | "copyAsSvg"
       | "group"
       | "ungroup"
       | "gridMode"
@@ -88,7 +87,6 @@ const shortcutMap: Record<ShortcutName, string[]> = {
       : getShortcutKey("CtrlOrCmd+Shift+]"),
   ],
   copyAsPng: [getShortcutKey("Shift+Alt+C")],
-  copyAsSvg: [getShortcutKey("Shift+Ctrl+C")],
   group: [getShortcutKey("CtrlOrCmd+G")],
   ungroup: [getShortcutKey("CtrlOrCmd+Shift+G")],
   gridMode: [getShortcutKey("CtrlOrCmd+'")],

--- a/packages/excalidraw/components/HelpDialog.tsx
+++ b/packages/excalidraw/components/HelpDialog.tsx
@@ -375,10 +375,6 @@ export const HelpDialog = ({ onClose }: { onClose?: () => void }) => {
               />
             )}
             <Shortcut
-              label={t("labels.copyAsSvg")}
-              shortcuts={[getShortcutKey("Shift+Ctrl+C")]}
-            />
-            <Shortcut
               label={t("labels.copyStyles")}
               shortcuts={[getShortcutKey("CtrlOrCmd+Alt+C")]}
             />

--- a/packages/excalidraw/tests/__snapshots__/contextmenu.test.tsx.snap
+++ b/packages/excalidraw/tests/__snapshots__/contextmenu.test.tsx.snap
@@ -206,7 +206,6 @@ exports[`contextMenu element > right-clicking on a group should select whole gro
             />
           </g>
         </svg>,
-        "keyTest": [Function],
         "keywords": [
           "svg",
           "clipboard",
@@ -4724,7 +4723,6 @@ exports[`contextMenu element > shows 'Group selection' in context menu for multi
             />
           </g>
         </svg>,
-        "keyTest": [Function],
         "keywords": [
           "svg",
           "clipboard",
@@ -5852,7 +5850,6 @@ exports[`contextMenu element > shows 'Ungroup selection' in context menu for gro
             />
           </g>
         </svg>,
-        "keyTest": [Function],
         "keywords": [
           "svg",
           "clipboard",
@@ -6932,7 +6929,6 @@ exports[`contextMenu element > shows context menu for canvas > [end of test] app
             />
           </g>
         </svg>,
-        "keyTest": [Function],
         "keywords": [
           "svg",
           "clipboard",
@@ -7701,7 +7697,6 @@ exports[`contextMenu element > shows context menu for element > [end of test] ap
             />
           </g>
         </svg>,
-        "keyTest": [Function],
         "keywords": [
           "svg",
           "clipboard",
@@ -8596,7 +8591,6 @@ exports[`contextMenu element > shows context menu for element > [end of test] ap
             />
           </g>
         </svg>,
-        "keyTest": [Function],
         "keywords": [
           "svg",
           "clipboard",


### PR DESCRIPTION
(we need to reconsider this shortcut)