### PR TITLE
chore: renamed the Align section to Align & Distribute

### DIFF
--- a/packages/excalidraw/locales/en.json
+++ b/packages/excalidraw/locales/en.json
@@ -98,7 +98,7 @@
     "libraries": "Browse libraries",
     "loadingScene": "Loading scene…",
     "loadScene": "Load scene from file",
-    "align": "Align",
+    "align": "Align & Distribute",
     "alignTop": "Align top",
     "alignBottom": "Align bottom",
     "alignLeft": "Align left",


### PR DESCRIPTION
This PR fixes #8657

Renamed the "Align" section to "Align & Distribute" to improve discoverability.

![labels-align-distribute](https://github.com/user-attachments/assets/01d3d840-cb14-44be-9bdd-cf75e4d28d89)
