### PR TITLE
fix: load font faces in Safari manually

### DIFF
--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -48,7 +48,7 @@ import {
 } from "../appState";
 import type { PastedMixedContent } from "../clipboard";
 import { copyTextToSystemClipboard, parseClipboard } from "../clipboard";
-import { ARROW_TYPE, type EXPORT_IMAGE_TYPES } from "../constants";
+import { ARROW_TYPE, isSafari, type EXPORT_IMAGE_TYPES } from "../constants";
 import {
   APP_NAME,
   CURSOR_TYPE,
@@ -2306,10 +2306,6 @@ class App extends React.Component<AppProps, AppState> {
     // clear the shape and image cache so that any images in initialData
     // can be loaded fresh
     this.clearImageShapeCache();
-    // FontFaceSet loadingdone event we listen on may not always
-    // fire (looking at you Safari), so on init we manually load all
-    // fonts and rerender scene text elements once done. This also
-    // seems faster even in browsers that do fire the loadingdone event.
     this.fonts.loadSceneFonts();
   };
 
@@ -3221,6 +3217,11 @@ class App extends React.Component<AppProps, AppState> {
         );
       }
     });
+
+    if (isSafari) {
+      // paste event may not fire font loading even on safari, so let's load the fonts manually
+      this.fonts.loadSceneFonts();
+    }
 
     if (opts.files) {
       this.files = { ...this.files, ...opts.files };

--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -2306,7 +2306,11 @@ class App extends React.Component<AppProps, AppState> {
     // clear the shape and image cache so that any images in initialData
     // can be loaded fresh
     this.clearImageShapeCache();
-    this.fonts.loadSceneFonts();
+
+    // manually loading the font faces seems faster even in browsers that do fire the loadingdone event
+    this.fonts.loadSceneFonts().then((fontFaces) => {
+      this.fonts.onLoaded(fontFaces);
+    });
   };
 
   private isMobileBreakpoint = (width: number, height: number) => {
@@ -2549,8 +2553,8 @@ class App extends React.Component<AppProps, AppState> {
       ),
       // rerender text elements on font load to fix #637 && #1553
       addEventListener(document.fonts, "loadingdone", (event) => {
-        const loadedFontFaces = (event as FontFaceSetLoadEvent).fontfaces;
-        this.fonts.onLoaded(loadedFontFaces);
+        const fontFaces = (event as FontFaceSetLoadEvent).fontfaces;
+        this.fonts.onLoaded(fontFaces);
       }),
       // Safari-only desktop pinch zoom
       addEventListener(
@@ -3218,9 +3222,11 @@ class App extends React.Component<AppProps, AppState> {
       }
     });
 
+    // paste event may not fire FontFace loadingdone event in Safari, hence loading font faces manually
     if (isSafari) {
-      // paste event may not fire font loading even on safari, so let's load the fonts manually
-      this.fonts.loadSceneFonts();
+      Fonts.loadElementsFonts(newElements).then((fontFaces) => {
+        this.fonts.onLoaded(fontFaces);
+      });
     }
 
     if (opts.files) {

--- a/packages/excalidraw/constants.ts
+++ b/packages/excalidraw/constants.ts
@@ -2,6 +2,7 @@ import cssVariables from "./css/variables.module.scss";
 import type { AppProps, AppState } from "./types";
 import type { ExcalidrawElement, FontFamilyValues } from "./element/types";
 import { COLOR_PALETTE } from "./colors";
+
 export const isDarwin = /Mac|iPod|iPhone|iPad/.test(navigator.platform);
 export const isWindows = /^Win/.test(navigator.platform);
 export const isAndroid = /\b(android)\b/i.test(navigator.userAgent);

--- a/packages/excalidraw/scene/export.ts
+++ b/packages/excalidraw/scene/export.ts
@@ -44,7 +44,7 @@ import {
 import { newTextElement } from "../element";
 import { type Mutable } from "../utility-types";
 import { newElementWith } from "../element/mutateElement";
-import { isFrameLikeElement, isTextElement } from "../element/typeChecks";
+import { isFrameLikeElement } from "../element/typeChecks";
 import type { RenderableElementsMap } from "./types";
 import { syncInvalidIndices } from "../fractionalIndex";
 import { renderStaticScene } from "../renderer/staticScene";
@@ -483,11 +483,10 @@ const getFontFaces = async (
     }
   }
 
-  const iterator = fontFacesIterator(orderedFamilies, charsPerFamily);
-
   // don't trigger hundreds of concurrent requests (each performing fetch, creating a worker, etc.),
   // instead go three requests at a time, in a controlled manner, without completely blocking the main thread
   // and avoiding potential issues such as rate limits
+  const iterator = fontFacesStylesGenerator(orderedFamilies, charsPerFamily);
   const concurrency = 3;
   const fontFaces = await new PromisePool(iterator, concurrency).all();
 
@@ -495,7 +494,7 @@ const getFontFaces = async (
   return Array.from(new Set(fontFaces));
 };
 
-function* fontFacesIterator(
+function* fontFacesStylesGenerator(
   families: Array<number>,
   charsPerFamily: Record<number, Set<string>>,
 ): Generator<Promise<void | readonly [number, string]>> {


### PR DESCRIPTION
Safari does not always trigger "loadingdone" event (actually it rarely does) and thus in most cases we end up with unloaded fonts on init and paste. It's especially annoying when there are tons of font faces to load, such as with the recent CJK support and half or even less characters remain unloaded.

The solution is loading all the necessary font faces manually in Safari, both on init and when pasting elements.

Fixes https://github.com/excalidraw/excalidraw/issues/3229

_Other improvements_
- Consolidates font faces logic in export under the `Fonts` class
- Concurrently loads 10 font faces at a time (loading all 250 font faces at the same time likely isn't a good idea)

_TODO_
- [x] Regression test export
- [x] Double-check font faces are not loaded twice or more times
- [x] Double-check we don't load font faces which shouldn't be loaded
- [x] Load only font faces for pasted elements

Follows #8530