### PR TITLE
fix: add missing properties to new nodes in flowchart element

### DIFF
--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -531,6 +531,7 @@ let isDraggingScrollBar: boolean = false;
 let currentScrollBars: ScrollBars = { horizontal: null, vertical: null };
 let touchTimeout = 0;
 let invalidateContextMenu = false;
+let elementStartedMoving = false;
 
 /**
  * Map of youtube embed video states
@@ -7900,6 +7901,31 @@ class App extends React.Component<AppProps, AppState> {
           !this.state.editingTextElement &&
           this.state.activeEmbeddable?.state !== "active"
         ) {
+
+        if(!this.state.editingLinearElement && !this.state.editingFrame && !this.state.resizingElement){
+
+          // this determines the threshold for dragging the element initially
+          const MOVEMENT_BUFFER = 4;
+
+          // this calculates the buffer for the movement based on the zoom level
+          const ZOOM_RELETIVE_MOVEMENT_BUFFER = MOVEMENT_BUFFER / this.state.zoom.value;
+          
+          if(typeof(ZOOM_RELETIVE_MOVEMENT_BUFFER) === 'number'){
+
+            if (
+              pointDistance(
+                pointFrom(pointerCoords.x, pointerCoords.y),
+                pointFrom(pointerDownState.origin.x, pointerDownState.origin.y),
+              ) < ZOOM_RELETIVE_MOVEMENT_BUFFER && !elementStartedMoving
+            ) {
+              return;
+            }
+          }
+
+          // sets the elementStartedMoving to true so that the buffer is only used once
+          elementStartedMoving = true;
+        }
+
           const dragOffset = {
             x: pointerCoords.x - pointerDownState.origin.x,
             y: pointerCoords.y - pointerDownState.origin.y,
@@ -8407,6 +8433,9 @@ class App extends React.Component<AppProps, AppState> {
         isRotating,
         isCropping,
       } = this.state;
+
+      // sets the elementStartedMoving to false so that the buffer can be used again
+      elementStartedMoving = false;
 
       this.setState((prevState) => ({
         isResizing: false,

--- a/packages/excalidraw/element/flowchart.ts
+++ b/packages/excalidraw/element/flowchart.ts
@@ -254,6 +254,12 @@ const addNewNode = (
     backgroundColor: element.backgroundColor,
     strokeColor: element.strokeColor,
     strokeWidth: element.strokeWidth,
+    strokeStyle: element.strokeStyle,
+    fillStyle: element.fillStyle,
+    opacity: element.opacity,
+    link: element.link,
+    locked: element.locked,
+    customData: element.customData
   });
 
   invariant(
@@ -329,6 +335,12 @@ export const addNewNodes = (
       backgroundColor: startNode.backgroundColor,
       strokeColor: startNode.strokeColor,
       strokeWidth: startNode.strokeWidth,
+      strokeStyle: startNode.strokeStyle,
+      fillStyle: startNode.fillStyle,
+      opacity: startNode.opacity,
+      link: startNode.link,
+      locked: startNode.locked,
+      customData: startNode.customData,
     });
 
     invariant(


### PR DESCRIPTION
issue : https://github.com/excalidraw/excalidraw/issues/8672

This creates an exact copy of the previous node when we add a new node in the flowchart, making the flowchart consistent.

https://github.com/user-attachments/assets/3aba9cc8-d8a1-4942-bb8f-ae717e5927ac


![Screenshot 2024-10-23 150444](https://github.com/user-attachments/assets/477ca959-b5a1-44bd-bd32-a89dc8681f9a)

![Screenshot 2024-10-23 150413](https://github.com/user-attachments/assets/c0acf393-d718-4cac-8fbc-65d9d86e77cf)