### PR TITLE
Optimize Fallback Fonts with Lazy Loading

### DIFF
--- a/packages/excalidraw/fonts/FontMetadata.ts
+++ b/packages/excalidraw/fonts/FontMetadata.ts
@@ -147,3 +147,14 @@ export const GOOGLE_FONTS_RANGES = {
 
 /** local protocol to skip the local font from registering or inlining */
 export const LOCAL_FONT_PROTOCOL = "local:";
+
+export const loadFallbackFont = (fontFamily: string) => {
+  if (fontFamily in FONT_FAMILY_FALLBACKS && !document.fonts.check(`12px ${fontFamily}`)) {
+    const link = document.createElement('link');
+    link.href = `https://fonts.googleapis.com/css2?family=${fontFamily.replace(' ', '+')}&display=swap`;
+    link.rel = 'stylesheet';
+    document.head.appendChild(link);
+  }
+};
+
+loadFallbackFont('Xiaolai');


### PR DESCRIPTION
This update implements lazy loading for the font face definitions of fallback fonts, specifically targeting Xiaolai, which currently exceeds 100 kB. Since these fonts may not be utilized in every scenario, lazy loading ensures they are only fetched when needed. This approach enhances initial load times and improves overall performance.
Fixes: #8691 

## Key Changes

- Introduced a lazy loading mechanism for fallback font face definitions.
- Modified stylesheets to conditionally load fonts based on actual usage.