### PR TITLE
fix: fix trailing line whitespaces layout shift

### DIFF
--- a/packages/excalidraw/element/textElement.test.ts
+++ b/packages/excalidraw/element/textElement.test.ts
@@ -47,6 +47,41 @@ describe("Test wrapText", () => {
     expect(res).toBe("don't wrap this number\n99,100.99");
   });
 
+  it("should trim all trailing whitespaces", () => {
+    const text = "Hello     ";
+    const maxWidth = 50;
+    const res = wrapText(text, font, maxWidth);
+    expect(res).toBe("Hello");
+  });
+
+  it("should trim all but one trailing whitespaces", () => {
+    const text = "Hello     ";
+    const maxWidth = 60;
+    const res = wrapText(text, font, maxWidth);
+    expect(res).toBe("Hello ");
+  });
+
+  it("should keep preceding whitespaces and trim all trailing whitespaces", () => {
+    const text = "  Hello  World";
+    const maxWidth = 90;
+    const res = wrapText(text, font, maxWidth);
+    expect(res).toBe("  Hello\nWorld");
+  });
+
+  it("should keep some preceding whitespaces, trim trailing whitespaces, but kep those that fit in the trailing line", () => {
+    const text = "   Hello  World            ";
+    const maxWidth = 90;
+    const res = wrapText(text, font, maxWidth);
+    expect(res).toBe("   Hello\nWorld    ");
+  });
+
+  it("should trim keep those whitespace that fit in the trailing line", () => {
+    const text = "Hello   Wo rl  d                     ";
+    const maxWidth = 100;
+    const res = wrapText(text, font, maxWidth);
+    expect(res).toBe("Hello   Wo\nrl  d     ");
+  });
+
   it("should support multiple (multi-codepoint) emojis", () => {
     const text = "😀🗺🔥👩🏽‍🦰👨‍👩‍👧‍👦🇨🇿";
     const maxWidth = 1;


### PR DESCRIPTION
Noticed a horizontal layout shift due to browsers not trimming all the whitespaces from the trailing line, but instead trying to fit all that fit into the set width. This PR does just that.

https://github.com/user-attachments/assets/eebab03c-311b-45d6-8d56-31d02e0bdb6a

https://excalidraw-git-mrazator-fix-trailing-line-whi-52f7d9-excalidraw.vercel.app/#json=22W0TOX7IKI0JqoWYwJ7q,efKJZCfTGt0ak8B7cTbF6g

Follows #8530
