### PR TITLE
chore: remove duplicated meta tag

### DIFF
--- a/excalidraw-app/index.html
+++ b/excalidraw-app/index.html
@@ -54,7 +54,6 @@
       content="https://excalidraw.com/og-image-3.png"
     />
 
-
     <!------------------------------------------------------------------------->
     <!--   to minimize white flash on load when user has dark mode enabled   -->
     <script>

--- a/excalidraw-app/index.html
+++ b/excalidraw-app/index.html
@@ -55,10 +55,6 @@
     />
 
     <!-- General tags -->
-    <meta
-      name="description"
-      content="Excalidraw is a virtual collaborative whiteboard tool that lets you easily sketch diagrams that have a hand-drawn feel to them."
-    />
 
     <!------------------------------------------------------------------------->
     <!--   to minimize white flash on load when user has dark mode enabled   -->

--- a/excalidraw-app/index.html
+++ b/excalidraw-app/index.html
@@ -54,7 +54,6 @@
       content="https://excalidraw.com/og-image-3.png"
     />
 
-    <!-- General tags -->
 
     <!------------------------------------------------------------------------->
     <!--   to minimize white flash on load when user has dark mode enabled   -->


### PR DESCRIPTION
There is already a `<meta name="description" />` tag in the upper **Primary Meta Tags** section, it seems the latter `<meta name="description" />` inside **General tags** section is duplicated.