### PR TITLE
feat:prevent unwanted movements of elements on mouse click

### DIFF
--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -531,6 +531,7 @@ let isDraggingScrollBar: boolean = false;
 let currentScrollBars: ScrollBars = { horizontal: null, vertical: null };
 let touchTimeout = 0;
 let invalidateContextMenu = false;
+let elementStartedMoving = false;
 
 /**
  * Map of youtube embed video states
@@ -7900,6 +7901,31 @@ class App extends React.Component<AppProps, AppState> {
           !this.state.editingTextElement &&
           this.state.activeEmbeddable?.state !== "active"
         ) {
+
+          if(!this.state.editingLinearElement && !this.state.editingFrame && !this.state.resizingElement){
+
+            // this determines the threshold for dragging the element initially
+            const MOVEMENT_BUFFER = 4;
+  
+            // this calculates the buffer for the movement based on the zoom level
+            const ZOOM_RELETIVE_MOVEMENT_BUFFER = MOVEMENT_BUFFER / this.state.zoom.value;
+            
+            if(typeof(ZOOM_RELETIVE_MOVEMENT_BUFFER) === 'number'){
+  
+              if (
+                pointDistance(
+                  pointFrom(pointerCoords.x, pointerCoords.y),
+                  pointFrom(pointerDownState.origin.x, pointerDownState.origin.y),
+                ) < ZOOM_RELETIVE_MOVEMENT_BUFFER && !elementStartedMoving
+              ) {
+                return;
+              }
+            }
+  
+            // sets the elementStartedMoving to true so that the buffer is only used once
+            elementStartedMoving = true;
+          }
+
           const dragOffset = {
             x: pointerCoords.x - pointerDownState.origin.x,
             y: pointerCoords.y - pointerDownState.origin.y,
@@ -8407,6 +8433,9 @@ class App extends React.Component<AppProps, AppState> {
         isRotating,
         isCropping,
       } = this.state;
+
+      // sets the elementStartedMoving to false so that the buffer can be used again
+      elementStartedMoving = false;
 
       this.setState((prevState) => ({
         isResizing: false,


### PR DESCRIPTION
issue: https://github.com/excalidraw/excalidraw/issues/8713

This PR addresses the issue of elements moving unintentionally when selected by adding a slight buffer on initial selection. This buffer prevents small, accidental movements when beginning to interact with an element.

Once the element crosses a defined movement threshold, the buffer is fully removed, allowing unrestricted, precise movement without further interference.

Note: The video below may appear laggy. For a smoother experience, please try the Vercel build for this PR to see the changes more accurately.

example:


https://github.com/user-attachments/assets/5f5ed887-032e-4949-b690-42932f77b051

I look forward to your feedback!