### PR TITLE
fix: Ensure new flowchart nodes match properties of the starting node

### DIFF
--- a/packages/excalidraw/element/flowchart.ts
+++ b/packages/excalidraw/element/flowchart.ts
@@ -227,6 +227,28 @@ const getOffsets = (
   };
 };
 
+const createNode = (
+  node: ExcalidrawFlowchartNodeElement,
+  x: number,
+  y: number
+) => {
+  return newElement({
+    type: node.type,
+    x: x,
+    y: y,
+    width: node.width,
+    height: node.height,
+    roundness: node.roundness,
+    roughness: node.roughness,
+    backgroundColor: node.backgroundColor,
+    strokeColor: node.strokeColor,
+    strokeWidth: node.strokeWidth,
+    strokeStyle: node.strokeStyle,
+    fillStyle: node.fillStyle,
+    opacity: node.opacity,
+  });
+};
+
 const addNewNode = (
   element: ExcalidrawFlowchartNodeElement,
   elementsMap: ElementsMap,
@@ -242,19 +264,7 @@ const addNewNode = (
     direction,
   );
 
-  const nextNode = newElement({
-    type: element.type,
-    x: element.x + offsets.x,
-    y: element.y + offsets.y,
-    // TODO: extract this to a util
-    width: element.width,
-    height: element.height,
-    roundness: element.roundness,
-    roughness: element.roughness,
-    backgroundColor: element.backgroundColor,
-    strokeColor: element.strokeColor,
-    strokeWidth: element.strokeWidth,
-  });
+  const nextNode = createNode(element, element.x + offsets.x, element.y + offsets.y);
 
   invariant(
     isFlowchartNodeElement(nextNode),
@@ -317,19 +327,7 @@ export const addNewNodes = (
       nextX = startX + offsetX;
     }
 
-    const nextNode = newElement({
-      type: startNode.type,
-      x: nextX,
-      y: nextY,
-      // TODO: extract this to a util
-      width: startNode.width,
-      height: startNode.height,
-      roundness: startNode.roundness,
-      roughness: startNode.roughness,
-      backgroundColor: startNode.backgroundColor,
-      strokeColor: startNode.strokeColor,
-      strokeWidth: startNode.strokeWidth,
-    });
+    const nextNode = createNode(startNode, nextX, nextY);
 
     invariant(
       isFlowchartNodeElement(nextNode),


### PR DESCRIPTION
This update ensures that new flowchart nodes created in the application match the properties of the starting node. By introducing a utility function for node creation, we maintain consistency in attributes such as dimensions, styling, and opacity across all flowchart nodes.

This improvement enhances the visual integrity of flowcharts and ensures that the behavior of new nodes is predictable.

Fixes: #8672 
Ensures new flowchart nodes maintain consistent properties with the starting node, improving visual coherence.
![image](https://github.com/user-attachments/assets/5ef48c79-ab4a-4b6c-bd1c-55b712b524d2)

https://github.com/user-attachments/assets/5bcb434a-7d56-4096-98ea-439026f081e0

