### PR TITLE
Update installation.mdx

### DIFF
--- a/dev-docs/docs/@excalidraw/excalidraw/installation.mdx
+++ b/dev-docs/docs/@excalidraw/excalidraw/installation.mdx
@@ -40,4 +40,4 @@ Excalidraw takes _100%_ of `width` and `height` of the containing block so make 
 
 ### Demo
 
-[Try here](https://codesandbox.io/s/excalidraw-ehlz3).
+[Try Excalidraw in Sandbox.](https://codesandbox.io/s/excalidraw-ehlz3).


### PR DESCRIPTION
documentation should aboid the use of 'here' statement when referencing a link. The text should describe the link it holds. That is the change made to this page