### PR TITLE
fix: right-click paste for images in clipboard (Issue #8826)

### DIFF
--- a/packages/excalidraw/clipboard.ts
+++ b/packages/excalidraw/clipboard.ts
@@ -331,14 +331,6 @@ const parseClipboardEvent = async (
 
       return mixedContent;
     }
-    const imageType = event.clipboardData?.types.find(type => type.startsWith("image/"));
-    
-    if (imageType) {
-      const image = event.clipboardData?.getData(imageType);
-      if (image) {
-        return { type: "mixedContent", value: [{ type: "imageUrl", value: image }] };
-      }
-    }
 
     const text = event.clipboardData?.getData("text/plain");
 

--- a/packages/excalidraw/constants.ts
+++ b/packages/excalidraw/constants.ts
@@ -214,13 +214,9 @@ export const IMAGE_MIME_TYPES = {
   jfif: "image/jfif",
 } as const;
 
-export const ALLOWED_PASTE_MIME_TYPES = [
-  "text/plain",
-  "text/html",
-  ...Object.values(IMAGE_MIME_TYPES),
-] as const;
-
 export const MIME_TYPES = {
+  text: "text/plain",
+  html: "text/html",
   json: "application/json",
   // excalidraw data
   excalidraw: "application/vnd.excalidraw+json",
@@ -233,6 +229,12 @@ export const MIME_TYPES = {
   // image
   ...IMAGE_MIME_TYPES,
 } as const;
+
+export const ALLOWED_PASTE_MIME_TYPES = [
+  MIME_TYPES.text,
+  MIME_TYPES.html,
+  ...Object.values(IMAGE_MIME_TYPES),
+] as const;
 
 export const EXPORT_IMAGE_TYPES = {
   png: "png",

--- a/packages/excalidraw/constants.ts
+++ b/packages/excalidraw/constants.ts
@@ -214,7 +214,11 @@ export const IMAGE_MIME_TYPES = {
   jfif: "image/jfif",
 } as const;
 
-export const ALLOWED_PASTE_MIME_TYPES = ["text/plain", "text/html"] as const;
+export const ALLOWED_PASTE_MIME_TYPES = [
+  "text/plain",
+  "text/html",
+  ...Object.values(IMAGE_MIME_TYPES),
+] as const;
 
 export const MIME_TYPES = {
   json: "application/json",

--- a/packages/excalidraw/data/blob.ts
+++ b/packages/excalidraw/data/blob.ts
@@ -106,11 +106,15 @@ export const isImageFileHandle = (handle: FileSystemHandle | null) => {
   return type === "png" || type === "svg";
 };
 
+export const isSupportedImageFileType = (type: string | null | undefined) => {
+  return !!type && (Object.values(IMAGE_MIME_TYPES) as string[]).includes(type);
+};
+
 export const isSupportedImageFile = (
   blob: Blob | null | undefined,
 ): blob is Blob & { type: ValueOf<typeof IMAGE_MIME_TYPES> } => {
   const { type } = blob || {};
-  return !!type && (Object.values(IMAGE_MIME_TYPES) as string[]).includes(type);
+  return isSupportedImageFileType(type);
 };
 
 export const loadSceneOrLibraryFromBlob = async (


### PR DESCRIPTION
This PR fixes the issue with pasting images from the clipboard using the right-click context menu. Previously, users were unable to paste copied images from the clipboard when using the right-click action, which hindered the usability of the application. While pasting with `Ctrl + V` was functioning correctly, the right-click custom paste option was not working as intended. This fix addresses that issue and improves the overall user experience.

### Related Issue
Fixes #8826.
