### PR TITLE
fix: fixed search input cursor position issue

### DIFF
--- a/packages/excalidraw/components/SearchMenu.tsx
+++ b/packages/excalidraw/components/SearchMenu.tsx
@@ -137,6 +137,22 @@ export const SearchMenu = () => {
     }
   };
 
+  const fixInputCursorPosition = () => {
+    requestAnimationFrame(() => {
+      const searchInput = searchInputRef.current;
+      const isFocus = document.activeElement === searchInput;
+      // if input is not focus and input instance is not exist return
+      if (!searchInput || !isFocus) {
+        return;
+      }
+      const cursorPosition = searchInput.selectionStart;
+      const textLength = searchInput.value.length!;
+      if (cursorPosition !== textLength) {
+        searchInput.setSelectionRange(textLength, textLength);
+      }
+    });
+  };
+
   useEffect(() => {
     setAppState((state) => {
       return {
@@ -282,6 +298,7 @@ export const SearchMenu = () => {
           if (event.key === KEYS.ARROW_UP) {
             event.stopPropagation();
             stableState.goToPreviousItem();
+            fixInputCursorPosition();
           } else if (event.key === KEYS.ARROW_DOWN) {
             event.stopPropagation();
             stableState.goToNextItem();


### PR DESCRIPTION
This PR is to fixed this issue #8847 .

the issue only happen in here: 
component path:  `packages/excalidraw/components/SearchMenu.tsx`
```javascript
  if (event.key === KEYS.ARROW_UP) {
    event.stopPropagation();
    stableState.goToPreviousItem();
  }
```

Reason: It may be that the `goToPreviousItem` function changes the focusIndex state, and then the cursor position is updated before the input re-render.

So，we must make the input cursor change after input component re-render. `requestAnimationFrame` is a good way to change input cursor  before redraw, reflow.
```javascript
  const fixInputCursorPosition = () => {
    requestAnimationFrame(() => {
      const searchInput = searchInputRef.current;
      const isFocus = document.activeElement === searchInput;
      // if input is not focus and input instance is not exist return
      if (!searchInput || !isFocus) {
        return;
      }
      const cursorPosition = searchInput.selectionStart;
      const textLength = searchInput.value.length!;
      if (cursorPosition !== textLength) {
        searchInput.setSelectionRange(textLength, textLength);
      }
    });
  };
  ```
  
  

after fixed， the position of input cursor is correct. and keep on the end of input value.
but you can move cursor by keyboard or mouse as well

https://github.com/user-attachments/assets/c140618a-3e0b-43a0-8d29-b78515e4d9b2


