### PR TITLE
Fix localStorage overflow and add new toast types

### DIFF
--- a/excalidraw-app/App.tsx
+++ b/excalidraw-app/App.tsx
@@ -374,6 +374,7 @@ const ExcalidrawWrapper = () => {
           message: t("alerts.localStorageOverflow"),
           closable: true,
           duration: Infinity,
+          type: "danger",
         });
       }
     }

--- a/excalidraw-app/App.tsx
+++ b/excalidraw-app/App.tsx
@@ -77,6 +77,7 @@ import { newElementWith } from "../packages/excalidraw/element/mutateElement";
 import { isInitializedImageElement } from "../packages/excalidraw/element/typeChecks";
 import { loadFilesFromFirebase } from "./data/firebase";
 import {
+  isLocalStorageOverflowAtom,
   LibraryIndexedDBAdapter,
   LibraryLocalStorageMigrationAdapter,
   LocalData,
@@ -363,6 +364,20 @@ const ExcalidrawWrapper = () => {
     return isCollaborationLink(window.location.href);
   });
   const collabError = useAtomValue(collabErrorIndicatorAtom);
+
+  const isLocalStorageOverflow = useAtomValue(isLocalStorageOverflowAtom);
+
+  useEffect(() => {
+    if (isLocalStorageOverflow) {
+      if (excalidrawAPI) {
+        excalidrawAPI.setToast({
+          message: t("alerts.localStorageOverflow"),
+          closable: true,
+          duration: Infinity,
+        });
+      }
+    }
+  }, [isLocalStorageOverflow, excalidrawAPI]);
 
   useHandleLibrary({
     excalidrawAPI,

--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -303,6 +303,7 @@ import {
 import type { ContextMenuItems } from "./ContextMenu";
 import { ContextMenu, CONTEXT_MENU_SEPARATOR } from "./ContextMenu";
 import LayerUI from "./LayerUI";
+import type { ToastType } from "./Toast";
 import { Toast } from "./Toast";
 import { actionToggleViewMode } from "../actions/actionToggleViewMode";
 import {
@@ -1695,6 +1696,8 @@ class App extends React.Component<AppProps, AppState> {
                             onClose={() => this.setToast(null)}
                             duration={this.state.toast.duration}
                             closable={this.state.toast.closable}
+                            style={this.state.toast.style}
+                            type={this.state.toast.type}
                           />
                         )}
                         {this.state.contextMenu && (
@@ -3815,6 +3818,8 @@ class App extends React.Component<AppProps, AppState> {
       message: string;
       closable?: boolean;
       duration?: number;
+      style?: React.CSSProperties;
+      type?: ToastType;
     } | null,
   ) => {
     this.setState({ toast });

--- a/packages/excalidraw/components/Toast.scss
+++ b/packages/excalidraw/components/Toast.scss
@@ -1,10 +1,14 @@
 @import "../css/variables.module.scss";
 
 .excalidraw {
+  --bg-toast-message: var(--button-gray-1);
+  --bg-toast-warning: var(--color-warning-background);
+  --bg-toast-danger: var(--color-danger-background);
+  --bg-toast-success: var(--color-success);
+
   .Toast {
     $closeButtonSize: 1.2rem;
     $closeButtonPadding: 0.4rem;
-
     animation: fade-in 0.5s;
     background-color: var(--button-gray-1);
     border-radius: 4px;
@@ -19,10 +23,58 @@
     width: 300px;
     z-index: 999999;
 
+    /* 4 types of toasts: message, warning, danger, success
+     * Close icon styles for toasts override ToolIcon__icon styles
+     * Except for the default message toast
+    /*
+
     .Toast__message {
       padding: 0 $closeButtonSize + ($closeButtonPadding);
       color: var(--popup-text-color);
       white-space: pre-wrap;
+    }
+    /* Default toast uses ToolIcon__icon hover and active states */
+
+    /* Warning Toast */
+    .Toast__warning {
+      padding: 0 $closeButtonSize + ($closeButtonPadding);
+      color: var(--color-text-warning);
+      white-space: pre-wrap;
+    }
+    .Toast__warning__close:hover .ToolIcon__icon,
+    .Toast__warning__close:active .ToolIcon__icon {
+      background-color: var(--color-warning-icon-background);
+    }
+    .Toast__warning__close:active {
+      background-color: var(--bg-warning);
+    }
+
+    /* Danger Toast */
+    .Toast__danger {
+      padding: 0 $closeButtonSize + ($closeButtonPadding);
+      color: var(--color-danger-text);
+      white-space: pre-wrap;
+    }
+    .Toast__danger__close:hover .ToolIcon__icon,
+    .Toast__danger__close:active .ToolIcon__icon {
+      background-color: var(--color-danger-icon-background);
+    }
+    .Toast__danger__close:active {
+      background-color: var(--bg-danger);
+    }
+
+    /* Success Toast */
+    .Toast__success {
+      padding: 0 $closeButtonSize + ($closeButtonPadding);
+      color: var(--color-success-text);
+      white-space: pre-wrap;
+    }
+    .Toast__success__close:hover .ToolIcon__icon,
+    .Toast__success__close:active .ToolIcon__icon {
+      background-color: var(--color-success-darkest);
+    }
+    .Toast__success__close:active {
+      background-color: var(--bg-success);
     }
 
     .close {

--- a/packages/excalidraw/components/Toast.tsx
+++ b/packages/excalidraw/components/Toast.tsx
@@ -6,6 +6,8 @@ import { ToolButton } from "./ToolButton";
 
 const DEFAULT_TOAST_TIMEOUT = 5000;
 
+export type ToastType = "message" | "warning" | "danger" | "success";
+
 export const Toast = ({
   message,
   onClose,
@@ -13,12 +15,14 @@ export const Toast = ({
   // To prevent autoclose, pass duration as Infinity
   duration = DEFAULT_TOAST_TIMEOUT,
   style,
+  type = "message",
 }: {
   message: string;
   onClose: () => void;
   closable?: boolean;
   duration?: number;
   style?: CSSProperties;
+  type?: ToastType;
 }) => {
   const timerRef = useRef<number>(0);
   const shouldAutoClose = duration !== Infinity;
@@ -41,21 +45,29 @@ export const Toast = ({
     ? () => clearTimeout(timerRef?.current)
     : undefined;
   const onMouseLeave = shouldAutoClose ? scheduleTimeout : undefined;
+
+  // Toast classnames: Toast__message, Toast__warning, Toast__danger, Toast__success
+  const className = `Toast__${type}`;
+  const backgroundColor = `var(--bg-toast-${type})`;
+
   return (
     <div
       className="Toast"
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
-      style={style}
+      style={{
+        backgroundColor,
+        ...style,
+      }}
     >
-      <p className="Toast__message">{message}</p>
+      <p className={className}>{message}</p>
       {closable && (
         <ToolButton
           icon={CloseIcon}
           aria-label="close"
           type="icon"
           onClick={onClose}
-          className="close"
+          className={`close ${className}__close`}
         />
       )}
     </div>

--- a/packages/excalidraw/locales/en.json
+++ b/packages/excalidraw/locales/en.json
@@ -238,7 +238,8 @@
     "resetLibrary": "This will clear your library. Are you sure?",
     "removeItemsFromsLibrary": "Delete {{count}} item(s) from library?",
     "invalidEncryptionKey": "Encryption key must be of 22 characters. Live collaboration is disabled.",
-    "collabOfflineWarning": "No internet connection available.\nYour changes will not be saved!"
+    "collabOfflineWarning": "No internet connection available.\nYour changes will not be saved!",
+    "localStorageOverflow": "Save failed. Too many items!"
   },
   "errors": {
     "unsupportedFileType": "Unsupported file type.",

--- a/packages/excalidraw/types.ts
+++ b/packages/excalidraw/types.ts
@@ -41,6 +41,7 @@ import type { ContextMenuItems } from "./components/ContextMenu";
 import type { SnapLine } from "./snapping";
 import type { Merge, MaybePromise, ValueOf, MakeBrand } from "./utility-types";
 import type { StoreActionType } from "./store";
+import type { ToastType } from "./components/Toast";
 
 export type SocketId = string & { _brand: "SocketId" };
 
@@ -352,7 +353,13 @@ export interface AppState {
   previousSelectedElementIds: { [id: string]: true };
   selectedElementsAreBeingDragged: boolean;
   shouldCacheIgnoreZoom: boolean;
-  toast: { message: string; closable?: boolean; duration?: number } | null;
+  toast: {
+    message: string;
+    closable?: boolean;
+    duration?: number;
+    style?: React.CSSProperties;
+    type?: ToastType;
+  } | null;
   zenModeEnabled: boolean;
   theme: Theme;
   /** grid cell px size */


### PR DESCRIPTION

## Fixing Local Storage Overflow
I fixed an issue where users don't get a warning when they exceed the total storage limit. ([Issue 8805](https://github.com/excalidraw/excalidraw/issues/8805)). I removed the overflow error from the console in favor of a toast.

![fix](https://github.com/user-attachments/assets/74c976ea-3ef5-4278-ba58-25616abfd650)

The toast is triggered when the storage capacity is exceeded. After this point, saving is disabled until the user deletes some items.

Initially, I wanted to trigger this at 97% storage capacity. I created a utility function to estimate the usage by summing up the lengths of keys and values. However, it was being called too frequently, and I couldn't find an effective way to memoize it. I ended up just triggering the toast when the error triggers instead.

I did write my error message in `en.json` locale file, which I'm assuming was the right place to put it? Should I open a new issue to get it added to Crowdin?

## New Toast Types

I also expanded the toasting system slightly to include different types of messages. I hovered on the close icon for these screenshots to show the close icon hover color. All colors are from the main theme.

**Warning**
![Screenshot 2024-12-06 at 3 27 52 PM](https://github.com/user-attachments/assets/00d02661-2baf-44d7-9048-52de4adf670f)

**Danger**
![Screenshot 2024-12-06 at 3 28 11 PM](https://github.com/user-attachments/assets/536ddfa0-80d3-491c-9df3-97cd377e1157)

**Success**
![Screenshot 2024-12-06 at 3 29 59 PM](https://github.com/user-attachments/assets/1416591c-6b90-4b9e-a635-11bdde2ce722)
---

This is my first PR here, so I may have missed something. Please let me know what I can do for adjustments. Thanks!
