### PR TITLE
fix: Upgraded image-blob-reduce library to fix image alpha issue

### DIFF
--- a/packages/excalidraw/package.json
+++ b/packages/excalidraw/package.json
@@ -69,7 +69,7 @@
     "es6-promise-pool": "2.5.0",
     "fractional-indexing": "3.2.0",
     "fuzzy": "0.1.3",
-    "image-blob-reduce": "3.0.1",
+    "image-blob-reduce": "4.1.0",
     "jotai": "1.13.1",
     "lodash.throttle": "4.1.1",
     "nanoid": "3.3.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6851,12 +6851,12 @@ ignore@^5.2.0:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.3.1.tgz#5073e554cd42c5b33b394375f538b8593e34d4ef"
   integrity sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==
 
-image-blob-reduce@3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/image-blob-reduce/-/image-blob-reduce-3.0.1.tgz#812be7655a552031635799ae64e846b106f7a489"
-  integrity sha512-/VmmWgIryG/wcn4TVrV7cC4mlfUC/oyiKIfSg5eVM3Ten/c1c34RJhMYKCWTnoSMHSqXLt3tsrBR4Q2HInvN+Q==
+image-blob-reduce@4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/image-blob-reduce/-/image-blob-reduce-4.1.0.tgz#45f1e146ceaa45079025febe307f9b1e8b6833c9"
+  integrity sha512-iljleP8Fr7tS1ezrAazWi30abNPYXtBGXb9R9oTZDWObqiKq18AQJGTUb0wkBOtdCZ36/IirkuuAIIHTjBJIjA==
   dependencies:
-    pica "^7.1.0"
+    pica "^9.0.0"
 
 immediate@~3.0.5:
   version "3.0.6"
@@ -8580,13 +8580,23 @@ perfect-freehand@1.2.0:
   resolved "https://registry.yarnpkg.com/perfect-freehand/-/perfect-freehand-1.2.0.tgz#706a0f854544f6175772440c51d3b0563eb3988a"
   integrity sha512-h/0ikF1M3phW7CwpZ5MMvKnfpHficWoOEyr//KVNTxV4F6deRK1eYMtHyBKEAKFK0aXIEUK9oBvlF6PNXMDsAw==
 
-pica@7.1.1, pica@^7.1.0:
+pica@7.1.1:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/pica/-/pica-7.1.1.tgz#c68b42f5cfa6cc26eaec5cfa10cc0a5299ef3b7a"
   integrity sha512-WY73tMvNzXWEld2LicT9Y260L43isrZ85tPuqRyvtkljSDLmnNFQmZICt4xUJMVulmcc6L9O7jbBrtx3DOz/YQ==
   dependencies:
     glur "^1.1.2"
     inherits "^2.0.3"
+    multimath "^2.0.0"
+    object-assign "^4.1.1"
+    webworkify "^1.5.0"
+
+pica@^9.0.0:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/pica/-/pica-9.0.1.tgz#9ba5a5e81fc09dca9800abef9fb8388434b18b2f"
+  integrity sha512-v0U4vY6Z3ztz9b4jBIhCD3WYoecGXCQeCsYep+sXRefViL+mVVoTL+wqzdPeE+GpBFsRUtQZb6dltvAt2UkMtQ==
+  dependencies:
+    glur "^1.1.2"
     multimath "^2.0.0"
     object-assign "^4.1.1"
     webworkify "^1.5.0"


### PR DESCRIPTION
Related Bug: #8792

The issue is that the `image-blob-reduce` library relies on a `pica` version that has to specify the `alpha` option to preserve the alpha channel. Specifically the `reduce.toBlob(file, options)` function, should have an `alpha: true` option.

https://github.com/excalidraw/excalidraw/blob/b5652b8e36abcc813478c65cdbe248aae774e5db/packages/excalidraw/data/blob.ts#L332.

Upgrading to `image-blob-reduce` `4.0.1` solves the issue without modifying the code.