### PR TITLE
fix: fixed image transparency by adding alpha option to preserve image alpha channel

### DIFF
--- a/packages/excalidraw/data/blob.ts
+++ b/packages/excalidraw/data/blob.ts
@@ -329,7 +329,7 @@ export const resizeImageFile = async (
   }
 
   return new File(
-    [await reduce.toBlob(file, { max: opts.maxWidthOrHeight })],
+    [await reduce.toBlob(file, { max: opts.maxWidthOrHeight, alpha: true })],
     file.name,
     {
       type: opts.outputType || file.type,


### PR DESCRIPTION
Fixes: #8792

The issue is that the `image-blob-reduce` library relies on a `pica` version that has to specify the `alpha` option to preserve the alpha channel. Specifically the `reduce.toBlob(file, options)` function, should have an `alpha: true` option.

https://github.com/excalidraw/excalidraw/blob/b5652b8e36abcc813478c65cdbe248aae774e5db/packages/excalidraw/data/blob.ts#L332.

@Mrazator 