### PR TITLE
Fix: Fix rectangle text element padding to be dynamic based on font size. 

### DIFF
--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -333,7 +333,7 @@ import { fileOpen } from "../data/filesystem";
 import {
   bindTextToShapeAfterDuplication,
   getApproxMinLineHeight,
-  getApproxMinLineWidth,
+  getApproxMinContainerWidth,
   getBoundTextElement,
   getContainerCenter,
   getContainerElement,
@@ -5223,7 +5223,7 @@ class App extends React.Component<AppProps, AppState> {
         fontSize,
         fontFamily,
       };
-      const minWidth = getApproxMinLineWidth(
+      const minWidth = getApproxMinContainerWidth(
         getFontString(fontString),
         lineHeight,
       );

--- a/packages/excalidraw/components/Stats/utils.ts
+++ b/packages/excalidraw/components/Stats/utils.ts
@@ -11,7 +11,7 @@ import {
 } from "../../element/resizeElements";
 import {
   getApproxMinLineHeight,
-  getApproxMinLineWidth,
+  getApproxMinContainerWidth,
   getBoundTextElement,
   getBoundTextMaxWidth,
   handleBindTextResize,
@@ -139,7 +139,7 @@ export const resizeElement = (
   const boundTextElement = getBoundTextElement(latestElement, elementsMap);
 
   if (boundTextElement) {
-    const minWidth = getApproxMinLineWidth(
+    const minWidth = getApproxMinContainerWidth(
       getFontString(boundTextElement),
       boundTextElement.lineHeight,
     );

--- a/packages/excalidraw/element/resizeElements.ts
+++ b/packages/excalidraw/element/resizeElements.ts
@@ -40,7 +40,7 @@ import type {
 import type { PointerDownState } from "../types";
 import Scene from "../scene/Scene";
 import {
-  getApproxMinLineWidth,
+  getApproxMinContainerWidth,
   getBoundTextElement,
   getBoundTextElementId,
   getContainerElement,
@@ -571,7 +571,7 @@ export const resizeSingleElement = (
         fontSize: nextFont.size,
       };
     } else {
-      const minWidth = getApproxMinLineWidth(
+      const minWidth = getApproxMinContainerWidth(
         getFontString(boundTextElement),
         boundTextElement.lineHeight,
       );

--- a/packages/excalidraw/element/textElement.ts
+++ b/packages/excalidraw/element/textElement.ts
@@ -443,18 +443,23 @@ export const charWidth = (() => {
 const DUMMY_TEXT = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789".toLocaleUpperCase();
 
 // FIXME rename to getApproxMinContainerWidth
-export const getApproxMinLineWidth = (
+export const getApproxMinContainerWidth = (
   font: FontString,
   lineHeight: ExcalidrawTextElement["lineHeight"],
 ) => {
   const maxCharWidth = getMaxCharWidth(font);
+  const minCharWidth = BOUND_TEXT_PADDING;
+  const fontSize = parseFloat(font) || 16; // Fallback to a default font size if parseFloat fails
+  const padding = Math.max(minCharWidth, fontSize); // Adjust padding based on font size or minCharWidth
+  const baseWidth = minCharWidth || maxCharWidth;
+
   if (maxCharWidth === 0) {
     return (
       measureText(DUMMY_TEXT.split("").join("\n"), font, lineHeight).width +
       BOUND_TEXT_PADDING * 2
     );
   }
-  return maxCharWidth + BOUND_TEXT_PADDING * 2;
+  return baseWidth + padding;
 };
 
 export const getMinCharWidth = (font: FontString) => {


### PR DESCRIPTION
Fixes #4498 , #8834 
Padding size was hardcoded to 5px, so it was changed to be dynamic based on the font size and min padding. 
Update function name and adjust logic to change padding based on font size