### PR TITLE
fix: Flush pending DOM updates before .focus()

### DIFF
--- a/packages/excalidraw/components/ConfirmDialog.tsx
+++ b/packages/excalidraw/components/ConfirmDialog.tsx
@@ -1,3 +1,4 @@
+import { flushSync } from "react-dom";
 import { t } from "../i18n";
 import type { DialogProps } from "./Dialog";
 import { Dialog } from "./Dialog";
@@ -43,7 +44,14 @@ const ConfirmDialog = (props: Props) => {
           onClick={() => {
             setAppState({ openMenu: null });
             setIsLibraryMenuOpen(false);
-            onCancel();
+            // flush any pending updates synchronously,
+            // otherwise it could lead to crash in some chromium versions (131.0.6778.86),
+            // when `.focus` is invoked with container in some intermediate state
+            // (container seems mounted in DOM, but focus still causes a crash)
+            flushSync(() => {
+              onCancel();
+            });
+
             container?.focus();
           }}
         />
@@ -52,7 +60,14 @@ const ConfirmDialog = (props: Props) => {
           onClick={() => {
             setAppState({ openMenu: null });
             setIsLibraryMenuOpen(false);
-            onConfirm();
+            // flush any pending updates synchronously,
+            // otherwise it leads to crash in some chromium versions (131.0.6778.86),
+            // when `.focus` is invoked with container in some intermediate state
+            // (container seems mounted in DOM, but focus still causes a crash)
+            flushSync(() => {
+              onConfirm();
+            });
+
             container?.focus();
           }}
           actionType="danger"


### PR DESCRIPTION
fixes #8840

**Questions**
- ~Could we do even better? (without forcing sync update). We likely don't want all functions on the DOM elements to wait for `flushSync`.~ unsure, we would need to find out what is the intermediate step causing this, but there are no usable chrome logs when running in debug
- ~Why is the container not yet fully mounted (might be non-intentional)?~ seems mounted in the DOM, but still crashes
- ~Why does it happen only on Chromium & macOS?~ might be some specific chromium bug (does not crash in newer 132.0.6796.0), though didn't find anything similar reported (weird)
- ~Why does not React automatically queue the call instead of crashing in the middle?~ likely for better granularity / control, though IMO it shouldn't just crash the tab



