### PR TITLE
Added `renderTopLeftUI` render prop

### DIFF
--- a/dev-docs/docs/@excalidraw/excalidraw/api/props/props.mdx
+++ b/dev-docs/docs/@excalidraw/excalidraw/api/props/props.mdx
@@ -16,7 +16,8 @@ All `props` are _optional_.
 | [`generateLinkForSelection`](#generateLinkForSelection) | `function` | \_ | Allows you to override `url` generation when linking to Excalidraw elements. |
 | [`onLinkOpen`](#onlinkopen) | `function` | \_ | The callback if supplied is triggered when any link is opened. |
 | [`langCode`](#langcode) | `string` | `en` | Language code string to be used in Excalidraw |
-| [`renderTopRightUI`](/docs/@excalidraw/excalidraw/api/props/render-props#rendertoprightui) | `function` | \_ | Render function that renders custom UI in top right corner |
+| [`renderTopRightUI`](/docs/@excalidraw/excalidraw/api/props/render-props#rendertoprightui) | `function` | \_ | Render function that renders custom UI in top right corner next to the main menu |
+| [`renderTopLeftUI`](/docs/@excalidraw/excalidraw/api/props/render-props#rendertopleftui) | `function` | \_ | Render function that renders custom UI in top left corner |
 | [`renderCustomStats`](/docs/@excalidraw/excalidraw/api/props/render-props#rendercustomstats) | `function` | \_ | Render function that can be used to render custom stats on the stats dialog. |
 | [`viewModeEnabled`](#viewmodeenabled) | `boolean` | \_ | This indicates if the app is in `view` mode. |
 | [`zenModeEnabled`](#zenmodeenabled) | `boolean` | \_ | This indicates if the `zen` mode is enabled |

--- a/dev-docs/docs/@excalidraw/excalidraw/api/props/render-props.mdx
+++ b/dev-docs/docs/@excalidraw/excalidraw/api/props/render-props.mdx
@@ -1,5 +1,43 @@
 # Render Props
 
+## renderTopLeftUI
+
+<pre>
+  (isMobile: boolean, appState:
+  <a href="https://github.com/excalidraw/excalidraw/blob/master/packages/excalidraw/types.ts#L95">
+    AppState
+  </a>) => JSX | null
+</pre>
+
+A function returning `JSX` to render `custom` UI in the top left corner of the app. The element will render next to the main menu trigger.
+
+```jsx live
+function App() {
+  return (
+    <div style={{ height: "500px" }}>
+      <Excalidraw
+        renderTopLeftUI={() => {
+          return (
+            <button
+              style={{
+                background: "#70b1ec",
+                border: "none",
+                color: "#fff",
+                width: "max-content",
+                fontWeight: "bold",
+              }}
+              onClick={() => window.alert("This is dummy top left UI")}
+            >
+              Click me
+            </button>
+          );
+        }}
+      />
+    </div>
+  );
+}
+```
+
 ## renderTopRightUI
 
 <pre>

--- a/examples/excalidraw/components/ExampleApp.tsx
+++ b/examples/excalidraw/components/ExampleApp.tsx
@@ -203,6 +203,7 @@ export default function ExampleApp({
           tools: { image: !disableImageTool },
         },
         renderTopRightUI,
+        renderTopLeftUI,
         onLinkOpen,
         onPointerDown,
         onScrollChange: rerenderCommentIcons,
@@ -274,6 +275,26 @@ export default function ExampleApp({
         )}
         <button
           onClick={() => alert("This is an empty top right UI")}
+          style={{ height: "2.5rem" }}
+        >
+          Click me
+        </button>
+      </>
+    );
+  };
+  const renderTopLeftUI = (isMobile: boolean) => {
+    return (
+      <>
+        {!isMobile && (
+          <LiveCollaborationTrigger
+            isCollaborating={isCollaborating}
+            onSelect={() => {
+              window.alert("Collab dialog clicked");
+            }}
+          />
+        )}
+        <button
+          onClick={() => alert("This is an empty top left UI")}
           style={{ height: "2.5rem" }}
         >
           Click me

--- a/excalidraw-app/App.tsx
+++ b/excalidraw-app/App.tsx
@@ -834,17 +834,38 @@ const ExcalidrawWrapper = () => {
         autoFocus={true}
         theme={editorTheme}
         renderTopRightUI={(isMobile) => {
-          if (isMobile || !collabAPI || isCollabDisabled) {
+          if (!collabAPI || isCollabDisabled) {
             return null;
           }
           return (
-            <div className="top-right-ui">
+            <div className={isMobile ? "top-right-ui_mobile" : "top-right-ui"}>
+              <button
+                className="custom-top-button"
+                onClick={() => alert("This is an empty top right UI")}
+                title="Click"
+                aria-label="click"
+              />
               {collabError.message && <CollabError collabError={collabError} />}
               <LiveCollaborationTrigger
                 isCollaborating={isCollaborating}
                 onSelect={() =>
                   setShareDialogState({ isOpen: true, type: "share" })
                 }
+              />
+            </div>
+          );
+        }}
+        renderTopLeftUI={(isMobile) => {
+          if (!collabAPI || isCollabDisabled) {
+            return null;
+          }
+          return (
+            <div className={isMobile ? "top-left-ui_mobile" : "top-left-ui"}>
+              <button
+                className="custom-top-button"
+                onClick={() => alert("This is an empty top left UI")}
+                title="Custom Top Left"
+                aria-label="Custom Top Left"
               />
             </div>
           );

--- a/excalidraw-app/index.scss
+++ b/excalidraw-app/index.scss
@@ -5,10 +5,61 @@
     --color-primary-contrast-offset: #726dff; // to offset Chubb illusion
   }
 
+  .custom-top-button{
+    padding: .5rem 1rem;
+    border-radius: .25rem;
+    min-width: 44px;
+    min-height: 44px;
+    background-color: var(--color-primary);
+    border-color: var(--color-primary);
+    color: var(--color-surface-lowest);
+    box-shadow: 0;
+
+    &:hover{
+      background-color: var(--color-primary-darker);
+      border-color: var(--color-primary-darker);
+    }
+  }
+
   .top-right-ui {
     display: flex;
-    justify-content: center;
-    align-items: flex-start;
+    align-items: center;
+    gap: .25rem;
+    .custom-top-button{
+      &::before{
+        content:"poke";
+      }
+    }
+    &_mobile {
+      flex-direction: column;
+      
+      .custom-top-button{
+        padding: .5rem .5rem;
+        margin-bottom: .5rem;
+        &::before{
+        content:"☞";
+      }
+    }
+  }
+
+  }
+  .top-left-ui{
+    min-width: 10rem;
+    .custom-top-button{
+      &::before{
+        content:"Custom Top Left";
+      }
+    }
+    &_mobile {
+      flex-direction: column;
+      .custom-top-button{
+        padding: .5rem .5rem;
+        margin: .5rem 0;
+        &::before{
+        content:"♥︎";
+        }
+      }
+    }
   }
 
   .footer-center {

--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -1493,7 +1493,7 @@ class App extends React.Component<AppProps, AppState> {
 
   public render() {
     const selectedElements = this.scene.getSelectedElements(this.state);
-    const { renderTopRightUI, renderCustomStats } = this.props;
+    const { renderTopLeftUI, renderTopRightUI, renderCustomStats } = this.props;
 
     const sceneNonce = this.scene.getSceneNonce();
     const { elementsMap, visibleElements } =
@@ -1573,6 +1573,7 @@ class App extends React.Component<AppProps, AppState> {
                           onHandToolToggle={this.onHandToolToggle}
                           langCode={getLanguage().code}
                           renderTopRightUI={renderTopRightUI}
+                          renderTopLeftUI={renderTopLeftUI}
                           renderCustomStats={renderCustomStats}
                           showExitZenModeBtn={
                             typeof this.props?.zenModeEnabled === "undefined" &&

--- a/packages/excalidraw/components/LayerUI.tsx
+++ b/packages/excalidraw/components/LayerUI.tsx
@@ -78,6 +78,7 @@ interface LayerUIProps {
   showExitZenModeBtn: boolean;
   langCode: Language["code"];
   renderTopRightUI?: ExcalidrawProps["renderTopRightUI"];
+  renderTopLeftUI?: ExcalidrawProps["renderTopLeftUI"];
   renderCustomStats?: ExcalidrawProps["renderCustomStats"];
   UIOptions: AppProps["UIOptions"];
   onExportImage: AppClassProperties["onExportImage"];
@@ -136,6 +137,7 @@ const LayerUI = ({
   onPenModeToggle,
   showExitZenModeBtn,
   renderTopRightUI,
+  renderTopLeftUI,
   renderCustomStats,
   UIOptions,
   onExportImage,
@@ -242,7 +244,11 @@ const LayerUI = ({
       <FixedSideContainer side="top">
         <div className="App-menu App-menu_top">
           <Stack.Col gap={6} className={clsx("App-menu_top__left")}>
-            {renderCanvasActions()}
+            <Stack.Row gap={1}>
+              {renderCanvasActions()}
+              {renderTopLeftUI?.(device.editor.isMobile, appState)}
+            </Stack.Row>
+
             {shouldRenderSelectedShapeActions && renderSelectedShapeActions()}
           </Stack.Col>
           {!appState.viewModeEnabled &&
@@ -517,6 +523,7 @@ const LayerUI = ({
           onHandToolToggle={onHandToolToggle}
           onPenModeToggle={onPenModeToggle}
           renderTopRightUI={renderTopRightUI}
+          renderTopLeftUI={renderTopLeftUI}
           renderCustomStats={renderCustomStats}
           renderSidebars={renderSidebars}
           device={device}

--- a/packages/excalidraw/components/MobileMenu.tsx
+++ b/packages/excalidraw/components/MobileMenu.tsx
@@ -40,6 +40,10 @@ type MobileMenuProps = {
     isMobile: boolean,
     appState: UIAppState,
   ) => JSX.Element | null;
+  renderTopLeftUI?: (
+    isMobile: boolean,
+    appState: UIAppState,
+  ) => JSX.Element | null;
   renderCustomStats?: ExcalidrawProps["renderCustomStats"];
   renderSidebars: () => JSX.Element | null;
   device: Device;
@@ -56,7 +60,7 @@ export const MobileMenu = ({
   onLockToggle,
   onHandToolToggle,
   onPenModeToggle,
-
+  renderTopLeftUI,
   renderTopRightUI,
   renderCustomStats,
   renderSidebars,
@@ -89,7 +93,6 @@ export const MobileMenu = ({
                     />
                   </Stack.Row>
                 </Island>
-                {renderTopRightUI && renderTopRightUI(true, appState)}
                 <div className="mobile-misc-tools-container">
                   {!appState.viewModeEnabled &&
                     appState.openDialog?.name !== "elementLinkSelector" && (
@@ -114,6 +117,8 @@ export const MobileMenu = ({
                     title={t("toolBar.hand")}
                     isMobile
                   />
+                  {renderTopLeftUI && renderTopLeftUI(true, appState)}
+                  {renderTopRightUI && renderTopRightUI(true, appState)}
                 </div>
               </Stack.Row>
             </Stack.Col>
@@ -145,8 +150,10 @@ export const MobileMenu = ({
       <div className="App-toolbar-content">
         <MainMenuTunnel.Out />
         {actionManager.renderAction("toggleEditMenu")}
-        {actionManager.renderAction("undo")}
-        {actionManager.renderAction("redo")}
+        <div className="undo-redo-buttons_mobile">
+          {actionManager.renderAction("undo")}
+          {actionManager.renderAction("redo")}
+        </div>
         {actionManager.renderAction(
           appState.multiElement ? "finalize" : "duplicateSelection",
         )}

--- a/packages/excalidraw/css/styles.scss
+++ b/packages/excalidraw/css/styles.scss
@@ -344,6 +344,14 @@ body.excalidraw-cursor-resize * {
     justify-self: flex-end;
   }
 
+  .App-menu_top__left{
+    .Stack{
+      &_horizontal{
+        align-items: center;
+      }
+    }
+  }
+
   .App-menu_bottom {
     position: absolute;
     bottom: 1rem;
@@ -495,6 +503,18 @@ body.excalidraw-cursor-resize * {
     margin-top: auto;
     margin-bottom: auto;
     margin-inline-start: 0.6em;
+  }
+
+  .undo-redo-buttons_mobile{
+    display: flex;
+    gap: .5rem;
+    button{
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      min-width: 44px;
+      min-height: 44px;
+    }
   }
 
   @include isMobile {

--- a/packages/excalidraw/index.tsx
+++ b/packages/excalidraw/index.tsx
@@ -28,6 +28,7 @@ const ExcalidrawBase = (props: ExcalidrawProps) => {
     isCollaborating = false,
     onPointerUpdate,
     renderTopRightUI,
+    renderTopLeftUI,
     langCode = defaultLang.code,
     viewModeEnabled,
     zenModeEnabled,
@@ -117,6 +118,7 @@ const ExcalidrawBase = (props: ExcalidrawProps) => {
           isCollaborating={isCollaborating}
           onPointerUpdate={onPointerUpdate}
           renderTopRightUI={renderTopRightUI}
+          renderTopLeftUI={renderTopLeftUI}
           langCode={langCode}
           viewModeEnabled={viewModeEnabled}
           zenModeEnabled={zenModeEnabled}

--- a/packages/excalidraw/types.ts
+++ b/packages/excalidraw/types.ts
@@ -516,6 +516,10 @@ export interface ExcalidrawProps {
     isMobile: boolean,
     appState: UIAppState,
   ) => JSX.Element | null;
+  renderTopLeftUI?: (
+    isMobile: boolean,
+    appState: UIAppState,
+  ) => JSX.Element | null;
   langCode?: Language["code"];
   viewModeEnabled?: boolean;
   zenModeEnabled?: boolean;


### PR DESCRIPTION
## Summary
Adds a render function for a custom JSX element in the top left corner.  It renders to the right of the main menu trigger.
- In the case where `isMobile` is true:
    - If the custom JSX is set to render in the mobile view, the rendering occurs in the `mobile-misc-tools-container` in `packages/excalidraw/components/MobileMenu.tsx`
 - A few small style updates  
   - Accommodation for the JSX element being added to the `App-menu_top__left`
   - A small update to fix the weird spacing of the undo/redo action buttons in the mobile view when nothing is selected
     - Adjusted button size to meet [WCAG 2.2 :: SC 2.5.8 Target Size (Minimum) (Level AA)](https://www.w3.org/WAI/WCAG22/Understanding/target-size-minimum.html)
 