### PR TITLE
feat:  quick color selection using number keys (1-5) while using the drawing tool

### DIFF
--- a/packages/excalidraw/components/ColorPicker/TopPicks.tsx
+++ b/packages/excalidraw/components/ColorPicker/TopPicks.tsx
@@ -46,19 +46,21 @@ export const TopPicks = ({
   }
 
   return (
-    <div className="color-picker__top-picks"
-    onKeyDown={(event) => {
-      const handled = topPicksColorPickerKeyNavHandler({
-        event,
-        onChange,
-        colors,
-      });
+    <div
+      className="color-picker__top-picks"
+      onKeyDown={(event) => {
+        const handled = topPicksColorPickerKeyNavHandler({
+          event,
+          onChange,
+          colors,
+        });
 
-      if (handled) {
-        event.preventDefault();
-        event.stopPropagation();
-      }
-    }}>
+        if (handled) {
+          event.preventDefault();
+          event.stopPropagation();
+        }
+      }}
+    >
       {colors.map((color: string, index: number) => (
         <button
           className={clsx("color-picker__button", {

--- a/packages/excalidraw/components/ColorPicker/TopPicks.tsx
+++ b/packages/excalidraw/components/ColorPicker/TopPicks.tsx
@@ -1,11 +1,13 @@
 import clsx from "clsx";
-import type { ColorPickerType } from "./colorPickerUtils";
+import { activeColorPickerSectionAtom, type ColorPickerType } from "./colorPickerUtils";
 import {
   DEFAULT_CANVAS_BACKGROUND_PICKS,
   DEFAULT_ELEMENT_BACKGROUND_PICKS,
   DEFAULT_ELEMENT_STROKE_PICKS,
 } from "../../colors";
 import HotkeyLabel from "./HotkeyLabel";
+import { colorPickerKeyNavHandler } from "./keyboardNavHandlers";
+import { useAtom } from "jotai";
 
 interface TopPicksProps {
   onChange: (color: string) => void;
@@ -43,8 +45,32 @@ export const TopPicks = ({
     return null;
   }
 
+  const [activeColorPickerSection, setActiveColorPickerSection] = useAtom(
+    activeColorPickerSectionAtom,
+  );
+
   return (
-    <div className="color-picker__top-picks">
+    <div className="color-picker__top-picks"
+    onKeyDown={(event) => {
+      const handled = colorPickerKeyNavHandler({
+        event,
+        activeColorPickerSection,
+        null,
+        color,
+        onChange,
+        onEyeDropperToggle,
+        customColors,
+        setActiveColorPickerSection,
+        updateData,
+        activeShade,
+        onEscape,
+      });
+
+      if (handled) {
+        event.preventDefault();
+        event.stopPropagation();
+      }
+    }}>
       {colors.map((color: string, index: number) => (
         <button
           className={clsx("color-picker__button", {

--- a/packages/excalidraw/components/ColorPicker/TopPicks.tsx
+++ b/packages/excalidraw/components/ColorPicker/TopPicks.tsx
@@ -5,6 +5,7 @@ import {
   DEFAULT_ELEMENT_BACKGROUND_PICKS,
   DEFAULT_ELEMENT_STROKE_PICKS,
 } from "../../colors";
+import HotkeyLabel from "./HotkeyLabel";
 
 interface TopPicksProps {
   onChange: (color: string) => void;
@@ -44,7 +45,7 @@ export const TopPicks = ({
 
   return (
     <div className="color-picker__top-picks">
-      {colors.map((color: string) => (
+      {colors.map((color: string, index: number) => (
         <button
           className={clsx("color-picker__button", {
             active: color === activeColor,
@@ -58,6 +59,7 @@ export const TopPicks = ({
           data-testid={`color-top-pick-${color}`}
         >
           <div className="color-picker__button-outline" />
+          <HotkeyLabel color={color} keyLabel={index + 1} />
         </button>
       ))}
     </div>

--- a/packages/excalidraw/components/ColorPicker/TopPicks.tsx
+++ b/packages/excalidraw/components/ColorPicker/TopPicks.tsx
@@ -1,13 +1,13 @@
 import clsx from "clsx";
-import { activeColorPickerSectionAtom, type ColorPickerType } from "./colorPickerUtils";
+import { type ColorPickerType } from "./colorPickerUtils";
 import {
+  ColorTuple,
   DEFAULT_CANVAS_BACKGROUND_PICKS,
   DEFAULT_ELEMENT_BACKGROUND_PICKS,
   DEFAULT_ELEMENT_STROKE_PICKS,
 } from "../../colors";
 import HotkeyLabel from "./HotkeyLabel";
-import { colorPickerKeyNavHandler } from "./keyboardNavHandlers";
-import { useAtom } from "jotai";
+import { topPicksColorPickerKeyNavHandler } from "./keyboardNavHandlers";
 
 interface TopPicksProps {
   onChange: (color: string) => void;
@@ -22,7 +22,7 @@ export const TopPicks = ({
   activeColor,
   topPicks,
 }: TopPicksProps) => {
-  let colors;
+  let colors: ColorTuple | readonly string[] | undefined;
   if (type === "elementStroke") {
     colors = DEFAULT_ELEMENT_STROKE_PICKS;
   }
@@ -45,25 +45,13 @@ export const TopPicks = ({
     return null;
   }
 
-  const [activeColorPickerSection, setActiveColorPickerSection] = useAtom(
-    activeColorPickerSectionAtom,
-  );
-
   return (
     <div className="color-picker__top-picks"
     onKeyDown={(event) => {
-      const handled = colorPickerKeyNavHandler({
+      const handled = topPicksColorPickerKeyNavHandler({
         event,
-        activeColorPickerSection,
-        null,
-        color,
         onChange,
-        onEyeDropperToggle,
-        customColors,
-        setActiveColorPickerSection,
-        updateData,
-        activeShade,
-        onEscape,
+        colors,
       });
 
       if (handled) {

--- a/packages/excalidraw/components/ColorPicker/keyboardNavHandlers.ts
+++ b/packages/excalidraw/components/ColorPicker/keyboardNavHandlers.ts
@@ -181,8 +181,8 @@ export const colorPickerKeyNavHandler = ({
       activeSectionIndex + indexOffset > sections.length - 1
         ? 0
         : activeSectionIndex + indexOffset < 0
-          ? sections.length - 1
-          : activeSectionIndex + indexOffset;
+        ? sections.length - 1
+        : activeSectionIndex + indexOffset;
 
     const nextSection = sections[nextSectionIndex];
 
@@ -286,11 +286,10 @@ export const colorPickerKeyNavHandler = ({
   return false;
 };
 
-
 interface TopPicksColorPickerKeyNavHandlerProps {
   event: React.KeyboardEvent;
   onChange: (color: string) => void;
-  colors: ColorTuple | readonly string[] | undefined
+  colors: ColorTuple | readonly string[] | undefined;
 }
 /**
  * @returns true if the event was handled
@@ -299,9 +298,9 @@ export const topPicksColorPickerKeyNavHandler = ({
   event,
   onChange,
   colors,
-}: TopPicksColorPickerKeyNavHandlerProps): boolean => {  
+}: TopPicksColorPickerKeyNavHandlerProps): boolean => {
   if (!colors) {
-    return false
+    return false;
   }
   if (["1", "2", "3", "4", "5"].includes(event.key)) {
     const c = colors[Number(event.key) - 1];

--- a/packages/excalidraw/components/ColorPicker/keyboardNavHandlers.ts
+++ b/packages/excalidraw/components/ColorPicker/keyboardNavHandlers.ts
@@ -3,6 +3,7 @@ import type {
   ColorPickerColor,
   ColorPalette,
   ColorPaletteCustom,
+  ColorTuple,
 } from "../../colors";
 import { COLORS_PER_ROW, COLOR_PALETTE } from "../../colors";
 import type { ValueOf } from "../../utility-types";
@@ -180,8 +181,8 @@ export const colorPickerKeyNavHandler = ({
       activeSectionIndex + indexOffset > sections.length - 1
         ? 0
         : activeSectionIndex + indexOffset < 0
-        ? sections.length - 1
-        : activeSectionIndex + indexOffset;
+          ? sections.length - 1
+          : activeSectionIndex + indexOffset;
 
     const nextSection = sections[nextSectionIndex];
 
@@ -282,5 +283,32 @@ export const colorPickerKeyNavHandler = ({
     }
   }
 
+  return false;
+};
+
+
+interface TopPicksColorPickerKeyNavHandlerProps {
+  event: React.KeyboardEvent;
+  onChange: (color: string) => void;
+  colors: ColorTuple | readonly string[] | undefined
+}
+/**
+ * @returns true if the event was handled
+ */
+export const topPicksColorPickerKeyNavHandler = ({
+  event,
+  onChange,
+  colors,
+}: TopPicksColorPickerKeyNavHandlerProps): boolean => {  
+  if (!colors) {
+    return false
+  }
+  if (["1", "2", "3", "4", "5"].includes(event.key)) {
+    const c = colors[Number(event.key) - 1];
+    if (c) {
+      onChange(colors[Number(event.key) - 1]);
+      return true;
+    }
+  }
   return false;
 };


### PR DESCRIPTION
# Description
Following the description of #8726 , I added hotkeys for color selection (stroke and background). 

## Screenshots
![image](https://github.com/user-attachments/assets/4fe0d97d-2d6f-4666-a3e0-986f5f818952)

