### PR TITLE
fix: fixed frame dragging by extending selection fox for frames

### DIFF
--- a/packages/utils/geometry/shape.ts
+++ b/packages/utils/geometry/shape.ts
@@ -52,6 +52,8 @@ import type {
 import { pointsOnBezierCurves } from "points-on-curve";
 import type { Drawable, Op } from "roughjs/bin/core";
 import { invariant } from "../../excalidraw/utils";
+import { isFrameLikeElement } from "../../excalidraw/element/typeChecks";
+import { FRAME_STYLE } from "../../excalidraw/constants";
 
 // a polyline (made up term here) is a line consisting of other line segments
 // this corresponds to a straight line element in the editor but it could also
@@ -155,6 +157,12 @@ export const getSelectionBoxShape = <Point extends GlobalPoint | LocalPoint>(
     elementsMap,
     true,
   );
+
+  if (isFrameLikeElement(element)) {
+    const frameNameOffset = FRAME_STYLE.nameOffsetY + FRAME_STYLE.nameFontSize;
+    y1 -= frameNameOffset;
+    y2 -= frameNameOffset;
+  }
 
   x1 -= padding;
   x2 += padding;


### PR DESCRIPTION
Fixes #8915

The issue was caused by the selection element fitting the frame bounds without considering the name; when trying to drag a selected frame the `hitElement` function was returning `false` leading to no object being dragged, because the mouse point wasn't in the selection box.

https://github.com/excalidraw/excalidraw/blob/2af32219740b40633af023b7e8a17cb376f531cf/packages/excalidraw/components/App.tsx#L5077C4-L5089C6

Increasing the frame selection box including the name fixes the issue. @dwelle