### PR TITLE
fix: remove jsx-runtime from bundle

### DIFF
--- a/src/packages/excalidraw/webpack.dev.config.js
+++ b/src/packages/excalidraw/webpack.dev.config.js
@@ -104,5 +104,17 @@ module.exports = {
       commonjs: "react-dom",
       amd: "react-dom",
     },
+    "react-dom/client": {
+      root: "ReactDOMClient",
+      commonjs2: "react-dom/client",
+      commonjs: "react-dom/client",
+      amd: "react-dom/client",
+    },
+    "react/jsx-runtime": {
+      root: "ReactJSXRuntime",
+      commonjs2: "react/jsx-runtime",
+      commonjs: "react/jsx-runtime",
+      amd: "react/jsx-runtime",
+    },
   },
 };

--- a/src/packages/excalidraw/webpack.prod.config.js
+++ b/src/packages/excalidraw/webpack.prod.config.js
@@ -127,5 +127,17 @@ module.exports = {
       commonjs: "react-dom",
       amd: "react-dom",
     },
+    "react-dom/client": {
+      root: "ReactDOMClient",
+      commonjs2: "react-dom/client",
+      commonjs: "react-dom/client",
+      amd: "react-dom/client",
+    },
+    "react/jsx-runtime": {
+      root: "ReactJSXRuntime",
+      commonjs2: "react/jsx-runtime",
+      commonjs: "react/jsx-runtime",
+      amd: "react/jsx-runtime",
+    },
   },
 };


### PR DESCRIPTION
1. remove jsx-runtime from bundle

related issue https://github.com/excalidraw/excalidraw/issues/8923

@dwelle PTAL
