### PR TITLE
Fix WYSIWYG pointerdown event listener leak

### DIFF
--- a/packages/excalidraw/element/textWysiwyg.tsx
+++ b/packages/excalidraw/element/textWysiwyg.tsx
@@ -591,7 +591,7 @@ export const textWysiwyg = ({
 
     window.removeEventListener("resize", updateWysiwygStyle);
     window.removeEventListener("wheel", stopEvent, true);
-    window.removeEventListener("pointerdown", onPointerDown);
+    window.removeEventListener("pointerdown", onPointerDown, { capture: true });
     window.removeEventListener("pointerup", bindBlurEvent);
     window.removeEventListener("blur", handleSubmit);
     window.removeEventListener("beforeunload", handleSubmit);


### PR DESCRIPTION
`addEventListener("pointerdown", ...` is called with the `{capture: true}` option but when removing it, this option is not provided, hence not effectively removing it.