### PR TITLE
fix: normalizeSVG width and height from viewbox when size includes decimal points

### DIFF
--- a/packages/excalidraw/element/image.ts
+++ b/packages/excalidraw/element/image.ts
@@ -124,7 +124,9 @@ export const normalizeSVG = (SVGString: string) => {
       height = height || "50";
 
       if (viewBox) {
-        const match = viewBox.match(/\d+ +\d+ +(\d+) +(\d+)/);
+        const match = viewBox.match(
+          /\d+ +\d+ +(\d+(?:\.\d+)?) +(\d+(?:\.\d+)?)/,
+        );
         if (match) {
           [, width, height] = match;
         }


### PR DESCRIPTION
In the case of this example image downloaded from flaticon the current normalize function fails to identify width and height resulting in a distorted image upon import.

`viewBox="0 0 209.761 162.085"`

```html
<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 209.761 162.085" fill="#000000">
  <path d="M79.779 72.857a14.494 14.494 0 0 1-.929-1.47c-1.02-1.565-2.043-3.312-2.889-5.216L68.1 94.907l25.256-3.33zm-20.536 52.945c-4.976 0-9.452-2.515-12.144-6.394L19.441 140.01c-5.425 4.042-6.547 11.717-2.506 17.143a12.234 12.234 0 0 0 9.834 4.933 12.2 12.2 0 0 0 7.309-2.427l49-36.5c.188-.14.366-.292.545-.443l-22.429 2.958c-.645.085-1.302.128-1.951.128z"/>
  <circle cx="187.259" cy="27" r="22.5" transform="rotate(-34.51 187.265 26.924)"/>
  <path d="m200.687 85.666-38.051-18.857-.689-27.529-.182-7.26a11.003 11.003 0 0 0-.67-4.451c-2.799-7.473-11.972-14.391-24.784-12.515l9.621 6.35c4.74 3.129 6.051 9.53 2.923 14.271a10.283 10.283 0 0 1-8.604 4.627 10.26 10.26 0 0 1-5.666-1.704l-23.037-15.205c-9.608 4.503-17.962 10.324-28.247 19.319-10.627 10.827-7.237 20.216-2.481 27.486.247.446.513.885.82 1.309l15.845 21.845-39.86 5.256c-6.845.902-11.661 7.183-10.759 14.027.829 6.29 6.2 10.867 12.377 10.867.544 0 1.096-.036 1.649-.109l60.667-8a12.501 12.501 0 0 0 8.485-19.732l-20.533-28.308c11.822-8.026 26.159-13.668 36.678-18.215l.062 2.477.51 20.419a8.001 8.001 0 0 0 4.444 6.968l42.375 21a7.986 7.986 0 0 0 3.547.834 8.003 8.003 0 0 0 7.174-4.449 8 8 0 0 0-3.614-10.721z"/>
  <path d="M135.852 36.678a7.995 7.995 0 0 0 11.084-2.27 8 8 0 0 0-2.27-11.084l-33.333-22a7.984 7.984 0 0 0-5.639-1.228L65.028 6.43a8 8 0 0 0-6.673 9.136c.68 4.365 4.771 7.357 9.136 6.673l37.61-5.856zM34.297 34.477h41.286v2.048H34.297zm-8.601 12.286h41.286v2.048H25.696zM0 40.62h59.241v2.048H0zm129.797 91.357h41.286v2.048h-41.286zm-8.601 12.286h41.286v2.048h-41.286zM95.5 138.12h59.241v2.048H95.5z"/>
</svg>
```
