### PR TITLE
feat: add color wheel

### DIFF
--- a/packages/excalidraw/components/ColorPicker/ColorInput.tsx
+++ b/packages/excalidraw/components/ColorPicker/ColorInput.tsx
@@ -70,7 +70,13 @@ export const ColorInput = ({
 
   return (
     <div className="color-picker__input-label">
-      <div className="color-picker__input-hash">#</div>
+      <input
+        type="color"
+        onChange={(event) => {
+          changeColor(event.target.value);
+        }}
+        className="color-picker__input"
+      />
       <input
         ref={activeSection === "hex" ? inputRef : undefined}
         style={{ border: 0, padding: 0 }}

--- a/packages/excalidraw/components/ColorPicker/ColorPicker.scss
+++ b/packages/excalidraw/components/ColorPicker/ColorPicker.scss
@@ -368,6 +368,7 @@
     }
   }
 
+  
   .color-picker-label-swatch-container {
     border: 1px solid var(--default-border-color);
     border-radius: var(--border-radius-lg);


### PR DESCRIPTION
Currently you either have to look up online to find hash of a color value or have to select color from just a collection of swatches. This aims to make this process easier by putting a color input box with a color wheel instead to make the change. 

This is currently primitive with default color input box with default sytling and if more changes are needed do let me know.