### PR TITLE
fix: z-index clash in mobile UI

### DIFF
--- a/packages/excalidraw/components/FixedSideContainer.scss
+++ b/packages/excalidraw/components/FixedSideContainer.scss
@@ -15,7 +15,6 @@
     top: var(--editor-container-padding);
     right: var(--editor-container-padding);
     bottom: var(--editor-container-padding);
-    z-index: 2;
   }
 
   .FixedSideContainer_side_top.zen-mode {


### PR DESCRIPTION
fix https://github.com/excalidraw/excalidraw/issues/8983

Regressed in https://github.com/excalidraw/excalidraw/pull/8942 due to random CSS concatenation issue on build or something.