### PR TITLE
fix: package build fails on worker chunks 

### DIFF
--- a/scripts/buildPackage.js
+++ b/scripts/buildPackage.js
@@ -158,5 +158,8 @@ const createESMRawBuild = async () => {
   await buildProd(rawConfigChunks);
 };
 
-createESMRawBuild();
-createESMBrowserBuild();
+// otherwise throws "ERROR: Could not resolve "./subset-worker.chunk"
+(async () => {
+  await createESMRawBuild();
+  await createESMBrowserBuild();
+})();


### PR DESCRIPTION
- re-added top level await for each package build 
- unknown what recently caused this to fail?