### PR TITLE
Updated with correct translation for sv-se

### DIFF
--- a/packages/excalidraw/locales/sv-SE.json
+++ b/packages/excalidraw/locales/sv-SE.json
@@ -166,7 +166,7 @@
     "edit": "Redigera",
     "undo": "Ångra",
     "redo": "Gör om",
-    "resetLibrary": "Återställ bibliotek",
+    "resetLibrary": "Rensa bibliotek",
     "createNewRoom": "Skapa ett nytt rum",
     "fullScreen": "Helskärm",
     "darkMode": "Mörkt läge",


### PR DESCRIPTION
Changed from "Återställ bibliotek" till "Rensa bibliotek".