### PR TITLE
fix: align arrows bound to elements excalidraw#8833

### DIFF
--- a/packages/excalidraw/actions/actionAlign.tsx
+++ b/packages/excalidraw/actions/actionAlign.tsx
@@ -48,6 +48,7 @@ const alignSelectedElements = (
     selectedElements,
     elementsMap,
     alignment,
+    app.scene,
   );
 
   const updatedElementsMap = arrayToMap(updatedElements);

--- a/packages/excalidraw/align.ts
+++ b/packages/excalidraw/align.ts
@@ -1,8 +1,10 @@
 import type { ElementsMap, ExcalidrawElement } from "./element/types";
-import { newElementWith } from "./element/mutateElement";
+import { mutateElement } from "./element/mutateElement";
 import type { BoundingBox } from "./element/bounds";
 import { getCommonBoundingBox } from "./element/bounds";
 import { getMaximumGroups } from "./groups";
+import { updateBoundElements } from "./element/binding";
+import type Scene from "./scene/Scene";
 
 export interface Alignment {
   position: "start" | "center" | "end";
@@ -13,6 +15,7 @@ export const alignElements = (
   selectedElements: ExcalidrawElement[],
   elementsMap: ElementsMap,
   alignment: Alignment,
+  scene: Scene,
 ): ExcalidrawElement[] => {
   const groups: ExcalidrawElement[][] = getMaximumGroups(
     selectedElements,
@@ -26,12 +29,18 @@ export const alignElements = (
       selectionBoundingBox,
       alignment,
     );
-    return group.map((element) =>
-      newElementWith(element, {
+    return group.map((element) => {
+      // update element
+      const updatedEle = mutateElement(element, {
         x: element.x + translation.x,
         y: element.y + translation.y,
-      }),
-    );
+      });
+      // update bound elements
+      updateBoundElements(element, scene.getNonDeletedElementsMap(), {
+        simultaneouslyUpdated: group,
+      });
+      return updatedEle;
+    });
   });
 };
 


### PR DESCRIPTION
- This PR addresses the [issue](https://github.com/excalidraw/excalidraw/issues/8833) of misaligned arrows bound to elements during alignment operations. The solution involves integrating the updateBoundElements method to ensure arrows and their associated elements are aligned correctly.

- Verified alignment behavior for elements and their bound arrows in various scenarios, including grouped elements and overlapping cases.
	
- Let me know if you’d like further refinement or if there’s anything else you’d like to add!


https://github.com/user-attachments/assets/ae05d91a-94ce-44f0-b98f-38a30c1df27d

