### PR TITLE
fix: Arrowhead scroll & color picker max-height

### DIFF
--- a/packages/excalidraw/components/ColorPicker/Picker.tsx
+++ b/packages/excalidraw/components/ColorPicker/Picker.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { t } from "../../i18n";
 
 import type { ExcalidrawElement } from "../../element/types";
@@ -80,6 +80,19 @@ export const Picker = ({
           : "baseColors",
       );
     }
+
+    // handle overflow of ColorPicker from viewport
+    if(colorPickerRef.current){
+    const popup = colorPickerRef.current;
+    if(window.innerHeight < 380){
+      popup.style.maxHeight = `${Math.max(window.innerHeight - 200, 140)}px`;
+      popup.style.overflowY = "scroll";
+    }
+    else{
+      popup.style.maxHeight = "fit-content";
+    } 
+  }
+  
   }, [
     activeColorPickerSection,
     color,
@@ -113,9 +126,11 @@ export const Picker = ({
   }, [colorObj, onEyeDropperToggle]);
 
   const pickerRef = React.useRef<HTMLDivElement>(null);
+  const colorPickerRef = useRef<HTMLDivElement | null>(null)
+    
 
   return (
-    <div role="dialog" aria-modal="true" aria-label={t("labels.colorPicker")}>
+    <div role="dialog" aria-modal="true" aria-label={t("labels.colorPicker")} ref={colorPickerRef}>
       <div
         ref={pickerRef}
         onKeyDown={(event) => {

--- a/packages/excalidraw/components/IconPicker.scss
+++ b/packages/excalidraw/components/IconPicker.scss
@@ -11,7 +11,6 @@
     :root[dir="rtl"] & {
       padding: 0.4rem;
     }
-    transform: translateX(90%) translateY(-100%);
   }
 
   .picker-container button,


### PR DESCRIPTION
addressed issue: #8992 

This PR addresses both the issues by implementing following changes : 

1. changing the position such that pop up never goes out of bounds 
![Screenshot 2025-01-12 004526](https://github.com/user-attachments/assets/14259185-e568-43af-9088-bc85a681ca9e)

2. giving a max-height and introducing scroll for color pickers
![Screenshot 2025-01-12 004554](https://github.com/user-attachments/assets/61a4483c-e150-4034-93c9-e229f0185169)
