### PR TITLE
add props for handleGestureGlobally

### DIFF
--- a/dev-docs/docs/@excalidraw/excalidraw/api/props/props.mdx
+++ b/dev-docs/docs/@excalidraw/excalidraw/api/props/props.mdx
@@ -27,6 +27,7 @@ All `props` are _optional_.
 | [`UIOptions`](/docs/@excalidraw/excalidraw/api/props/ui-options) | `object` | [DEFAULT UI OPTIONS](https://github.com/excalidraw/excalidraw/blob/master/packages/excalidraw/constants.ts#L151) | To customise UI options. Currently we support customising [`canvas actions`](/docs/@excalidraw/excalidraw/api/props/ui-options#canvasactions) |
 | [`detectScroll`](#detectscroll) | `boolean` | `true` | Indicates whether to update the offsets when nearest ancestor is scrolled. |
 | [`handleKeyboardGlobally`](#handlekeyboardglobally) | `boolean` | `false` | Indicates whether to bind the keyboard events to document. |
+| [`handleGestureGlobally`](#handleGestureGlobally) | `boolean` | `true` | Indicates whether to bind the gesture events to document.(Safari only) |
 | [`autoFocus`](#autofocus) | `boolean` | `false` | Indicates whether to focus the Excalidraw component on page load |
 | [`generateIdForFile`](#generateidforfile) | `function` | \_ | Allows you to override `id` generation for files added on canvas |
 | [`validateEmbeddable`](#validateEmbeddable) | string[] | `boolean | RegExp | RegExp[] | ((link: string) => boolean | undefined)` | \_ | use for custom src url validation |

--- a/excalidraw-app/App.tsx
+++ b/excalidraw-app/App.tsx
@@ -834,6 +834,7 @@ const ExcalidrawWrapper = () => {
         renderCustomStats={renderCustomStats}
         detectScroll={false}
         handleKeyboardGlobally={true}
+        handleGestureGlobally={true}
         autoFocus={true}
         theme={editorTheme}
         renderTopRightUI={(isMobile) => {

--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -4778,6 +4778,12 @@ class App extends React.Component<AppProps, AppState> {
 
   // fires only on Safari
   private onGestureStart = withBatchedUpdates((event: GestureEvent) => {
+    if (
+      !this.props.handleGestureGlobally &&
+      this.excalidrawContainerRef.current?.contains(event.target as Node)
+    ) {
+      return;
+    }
     event.preventDefault();
 
     // we only want to deselect on touch screens because user may have selected
@@ -4793,6 +4799,12 @@ class App extends React.Component<AppProps, AppState> {
 
   // fires only on Safari
   private onGestureChange = withBatchedUpdates((event: GestureEvent) => {
+    if (
+      !this.props.handleGestureGlobally &&
+      this.excalidrawContainerRef.current?.contains(event.target as Node)
+    ) {
+      return;
+    }
     event.preventDefault();
 
     // onGestureChange only has zoom factor but not the center.
@@ -4825,6 +4837,12 @@ class App extends React.Component<AppProps, AppState> {
 
   // fires only on Safari
   private onGestureEnd = withBatchedUpdates((event: GestureEvent) => {
+    if (
+      !this.props.handleGestureGlobally &&
+      this.excalidrawContainerRef.current?.contains(event.target as Node)
+    ) {
+      return;
+    }
     event.preventDefault();
     // reselect elements only on touch screens (see onGestureStart)
     if (this.isTouchScreenMultiTouchGesture()) {

--- a/packages/excalidraw/index.tsx
+++ b/packages/excalidraw/index.tsx
@@ -38,6 +38,7 @@ const ExcalidrawBase = (props: ExcalidrawProps) => {
     onPaste,
     detectScroll = true,
     handleKeyboardGlobally = false,
+    handleGestureGlobally = true,
     onLibraryChange,
     autoFocus = false,
     generateIdForFile,
@@ -128,6 +129,7 @@ const ExcalidrawBase = (props: ExcalidrawProps) => {
           onPaste={onPaste}
           detectScroll={detectScroll}
           handleKeyboardGlobally={handleKeyboardGlobally}
+          handleGestureGlobally={handleGestureGlobally}
           onLibraryChange={onLibraryChange}
           autoFocus={autoFocus}
           generateIdForFile={generateIdForFile}

--- a/packages/excalidraw/types.ts
+++ b/packages/excalidraw/types.ts
@@ -532,6 +532,7 @@ export interface ExcalidrawProps {
   UIOptions?: Partial<UIOptions>;
   detectScroll?: boolean;
   handleKeyboardGlobally?: boolean;
+  handleGestureGlobally?: boolean;
   onLibraryChange?: (libraryItems: LibraryItems) => void | Promise<any>;
   autoFocus?: boolean;
   generateIdForFile?: (file: File) => string | Promise<string>;


### PR DESCRIPTION
In Safari, when multiple instances were created, gestures such as pinch-to-zoom only worked on the first instance created. By setting this to false, gesture event handlers are registered to local elements instead of globally, allowing individual gestures for each instance.