### PR TITLE
fix: excalidraw issue #9045 flowcharts: align attributes of new node

### DIFF
--- a/packages/excalidraw/element/flowchart.ts
+++ b/packages/excalidraw/element/flowchart.ts
@@ -254,6 +254,9 @@ const addNewNode = (
     backgroundColor: element.backgroundColor,
     strokeColor: element.strokeColor,
     strokeWidth: element.strokeWidth,
+    opacity: element.opacity,
+    fillStyle: element.fillStyle,
+    strokeStyle: element.strokeStyle,
   });
 
   invariant(
@@ -329,6 +332,9 @@ export const addNewNodes = (
       backgroundColor: startNode.backgroundColor,
       strokeColor: startNode.strokeColor,
       strokeWidth: startNode.strokeWidth,
+      opacity: startNode.opacity,
+      fillStyle: startNode.fillStyle,
+      strokeStyle: startNode.strokeStyle,
     });
 
     invariant(

--- a/packages/excalidraw/element/flowchart.ts
+++ b/packages/excalidraw/element/flowchart.ts
@@ -427,6 +427,8 @@ const createBindingArrow = (
     strokeColor: startBindingElement.strokeColor,
     strokeStyle: startBindingElement.strokeStyle,
     strokeWidth: startBindingElement.strokeWidth,
+    opacity: startBindingElement.opacity,
+    roughness: startBindingElement.roughness,
     points: [pointFrom(0, 0), pointFrom(endX, endY)],
     elbowed: true,
   });


### PR DESCRIPTION
### DESCRIPTION
This update addresses Excalidraw issue #9045 by refining the appearance of nodes within the diagram. The changes include adjustments to the stroke style, opacity, and fill style for the new node and the subsequent nodes. These improvements enhance the visual clarity and consistency across the diagram elements.

**Screenshot:**
![Screenshot 2025-01-25 012454](https://github.com/user-attachments/assets/53219c27-806a-4a18-bb73-f25c26f9e0dd)

**Additional Note:** not only rectangle but all the nodes under `ExcalidrawFlowchartNodeElement` type will show same behaviour of consistency

thanks for the opportunity to contribute