### PR TITLE
chore: remove deprecated docker-compose version field

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 services:
   excalidraw:
     build:


### PR DESCRIPTION
Docker Compose V2+ no longer requires the version field