### PR TITLE
fix: remove flushSync to fix flickering

### DIFF
--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -8320,9 +8320,7 @@ class App extends React.Component<AppProps, AppState> {
             this.scene.getNonDeletedElementsMap(),
           );
 
-          flushSync(() => {
-            this.setState({ snapLines });
-          });
+          this.setState({ snapLines });
 
           // when we're editing the name of a frame, we want the user to be
           // able to select and interact with the text input


### PR DESCRIPTION
reverts `flushSync` introduced in #8763 to attempt to fix https://github.com/excalidraw/excalidraw/issues/8859