### PR TITLE
fix: Add Link feature changed my redicrect to link 

### DIFF
--- a/packages/excalidraw/data/url.ts
+++ b/packages/excalidraw/data/url.ts
@@ -6,7 +6,7 @@ export const normalizeLink = (link: string) => {
   if (!link) {
     return link;
   }
-  return sanitizeUrl(sanitizeHTMLAttribute(link));
+  return sanitizeUrl(link);
 };
 
 export const isLocalLink = (link: string | null) => {


### PR DESCRIPTION
removed sanitizeHTMLAttribute  from normalizeLink to prevent conversion of & in link to "&amp"; in attempt to fix https://github.com/excalidraw/excalidraw/issues/9051