### PR TITLE
perf: Improved pointer events related performance when the sidebar is docked with a large library open

### DIFF
--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -1524,7 +1524,7 @@ class App extends React.Component<AppProps, AppState> {
     const shouldBlockPointerEvents =
       // default back to `--ui-pointerEvents` flow if setPointerCapture
       // not supported
-      "setPointerCapture" in HTMLElement.prototype.setPointerCapture
+      "setPointerCapture" in HTMLElement.prototype
         ? false
         : this.state.selectionElement ||
           this.state.newElement ||

--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -1521,15 +1521,6 @@ class App extends React.Component<AppProps, AppState> {
 
     const allElementsMap = this.scene.getNonDeletedElementsMap();
 
-    const shouldBlockPointerEvents =
-      this.state.selectionElement ||
-      this.state.newElement ||
-      this.state.selectedElementsAreBeingDragged ||
-      this.state.resizingElement ||
-      (this.state.activeTool.type === "laser" &&
-        // technically we can just test on this once we make it more safe
-        this.state.cursorButton === "down");
-
     const firstSelectedElement = selectedElements[0];
 
     return (
@@ -1541,9 +1532,7 @@ class App extends React.Component<AppProps, AppState> {
           "excalidraw--mobile": this.device.editor.isMobile,
         })}
         style={{
-          ["--ui-pointerEvents" as any]: shouldBlockPointerEvents
-            ? POINTER_EVENTS.disabled
-            : POINTER_EVENTS.enabled,
+          ["--ui-pointerEvents" as any]: POINTER_EVENTS.enabled,
         }}
         ref={this.excalidrawContainerRef}
         onDrop={this.handleAppOnDrop}
@@ -6295,6 +6284,11 @@ class App extends React.Component<AppProps, AppState> {
   private handleCanvasPointerDown = (
     event: React.PointerEvent<HTMLElement>,
   ) => {
+    // capture subsequent pointer events to the canvas
+    // this makes other elements non-interactive until pointer up
+    const target = event.target as HTMLElement;
+    target.setPointerCapture(event.pointerId);
+
     this.maybeCleanupAfterMissingPointerUp(event.nativeEvent);
     this.maybeUnfollowRemoteUser();
 

--- a/packages/excalidraw/components/LibraryMenu.tsx
+++ b/packages/excalidraw/components/LibraryMenu.tsx
@@ -4,6 +4,7 @@ import React, {
   useMemo,
   useRef,
   useEffect,
+  memo,
 } from "react";
 import type Library from "../data/library";
 import {
@@ -17,6 +18,7 @@ import type {
   LibraryItem,
   ExcalidrawProps,
   UIAppState,
+  AppState,
 } from "../types";
 import LibraryMenuItems from "./LibraryMenuItems";
 import { trackEvent } from "../analytics";
@@ -43,170 +45,193 @@ const LibraryMenuWrapper = ({ children }: { children: React.ReactNode }) => {
   return <div className="layer-ui__library">{children}</div>;
 };
 
-export const LibraryMenuContent = ({
-  onInsertLibraryItems,
-  pendingElements,
-  onAddToLibrary,
-  setAppState,
-  libraryReturnUrl,
-  library,
-  id,
-  theme,
-  selectedItems,
-  onSelectItems,
-}: {
-  pendingElements: LibraryItem["elements"];
-  onInsertLibraryItems: (libraryItems: LibraryItems) => void;
-  onAddToLibrary: () => void;
-  setAppState: React.Component<any, UIAppState>["setState"];
-  libraryReturnUrl: ExcalidrawProps["libraryReturnUrl"];
-  library: Library;
-  id: string;
-  theme: UIAppState["theme"];
-  selectedItems: LibraryItem["id"][];
-  onSelectItems: (id: LibraryItem["id"][]) => void;
-}) => {
-  const [libraryItemsData] = useAtom(libraryItemsAtom);
+const LibraryMenuContent = memo(
+  ({
+    onInsertLibraryItems,
+    pendingElements,
+    onAddToLibrary,
+    setAppState,
+    libraryReturnUrl,
+    library,
+    id,
+    theme,
+    selectedItems,
+    onSelectItems,
+  }: {
+    pendingElements: LibraryItem["elements"];
+    onInsertLibraryItems: (libraryItems: LibraryItems) => void;
+    onAddToLibrary: () => void;
+    setAppState: React.Component<any, UIAppState>["setState"];
+    libraryReturnUrl: ExcalidrawProps["libraryReturnUrl"];
+    library: Library;
+    id: string;
+    theme: UIAppState["theme"];
+    selectedItems: LibraryItem["id"][];
+    onSelectItems: (id: LibraryItem["id"][]) => void;
+  }) => {
+    const [libraryItemsData] = useAtom(libraryItemsAtom);
 
-  const _onAddToLibrary = useCallback(
-    (elements: LibraryItem["elements"]) => {
-      const addToLibrary = async (
-        processedElements: LibraryItem["elements"],
-        libraryItems: LibraryItems,
-      ) => {
-        trackEvent("element", "addToLibrary", "ui");
-        for (const type of LIBRARY_DISABLED_TYPES) {
-          if (processedElements.some((element) => element.type === type)) {
-            return setAppState({
-              errorMessage: t(`errors.libraryElementTypeError.${type}`),
-            });
+    const _onAddToLibrary = useCallback(
+      (elements: LibraryItem["elements"]) => {
+        const addToLibrary = async (
+          processedElements: LibraryItem["elements"],
+          libraryItems: LibraryItems,
+        ) => {
+          trackEvent("element", "addToLibrary", "ui");
+          for (const type of LIBRARY_DISABLED_TYPES) {
+            if (processedElements.some((element) => element.type === type)) {
+              return setAppState({
+                errorMessage: t(`errors.libraryElementTypeError.${type}`),
+              });
+            }
           }
-        }
-        const nextItems: LibraryItems = [
-          {
-            status: "unpublished",
-            elements: processedElements,
-            id: randomId(),
-            created: Date.now(),
-          },
-          ...libraryItems,
-        ];
-        onAddToLibrary();
-        library.setLibrary(nextItems).catch(() => {
-          setAppState({ errorMessage: t("alerts.errorAddingToLibrary") });
-        });
-      };
-      addToLibrary(elements, libraryItemsData.libraryItems);
-    },
-    [onAddToLibrary, library, setAppState, libraryItemsData.libraryItems],
-  );
+          const nextItems: LibraryItems = [
+            {
+              status: "unpublished",
+              elements: processedElements,
+              id: randomId(),
+              created: Date.now(),
+            },
+            ...libraryItems,
+          ];
+          onAddToLibrary();
+          library.setLibrary(nextItems).catch(() => {
+            setAppState({ errorMessage: t("alerts.errorAddingToLibrary") });
+          });
+        };
+        addToLibrary(elements, libraryItemsData.libraryItems);
+      },
+      [onAddToLibrary, library, setAppState, libraryItemsData.libraryItems],
+    );
 
-  const libraryItems = useMemo(
-    () => libraryItemsData.libraryItems,
-    [libraryItemsData],
-  );
+    const libraryItems = useMemo(
+      () => libraryItemsData.libraryItems,
+      [libraryItemsData],
+    );
 
-  if (
-    libraryItemsData.status === "loading" &&
-    !libraryItemsData.isInitialized
-  ) {
+    if (
+      libraryItemsData.status === "loading" &&
+      !libraryItemsData.isInitialized
+    ) {
+      return (
+        <LibraryMenuWrapper>
+          <div className="layer-ui__library-message">
+            <div>
+              <Spinner size="2em" />
+              <span>{t("labels.libraryLoadingMessage")}</span>
+            </div>
+          </div>
+        </LibraryMenuWrapper>
+      );
+    }
+
+    const showBtn =
+      libraryItemsData.libraryItems.length > 0 || pendingElements.length > 0;
+
     return (
       <LibraryMenuWrapper>
-        <div className="layer-ui__library-message">
-          <div>
-            <Spinner size="2em" />
-            <span>{t("labels.libraryLoadingMessage")}</span>
-          </div>
-        </div>
-      </LibraryMenuWrapper>
-    );
-  }
-
-  const showBtn =
-    libraryItemsData.libraryItems.length > 0 || pendingElements.length > 0;
-
-  return (
-    <LibraryMenuWrapper>
-      <LibraryMenuItems
-        isLoading={libraryItemsData.status === "loading"}
-        libraryItems={libraryItems}
-        onAddToLibrary={_onAddToLibrary}
-        onInsertLibraryItems={onInsertLibraryItems}
-        pendingElements={pendingElements}
-        id={id}
-        libraryReturnUrl={libraryReturnUrl}
-        theme={theme}
-        onSelectItems={onSelectItems}
-        selectedItems={selectedItems}
-      />
-      {showBtn && (
-        <LibraryMenuControlButtons
-          className="library-menu-control-buttons--at-bottom"
-          style={{ padding: "16px 12px 0 12px" }}
+        <LibraryMenuItems
+          isLoading={libraryItemsData.status === "loading"}
+          libraryItems={libraryItems}
+          onAddToLibrary={_onAddToLibrary}
+          onInsertLibraryItems={onInsertLibraryItems}
+          pendingElements={pendingElements}
           id={id}
           libraryReturnUrl={libraryReturnUrl}
           theme={theme}
+          onSelectItems={onSelectItems}
+          selectedItems={selectedItems}
         />
-      )}
-    </LibraryMenuWrapper>
-  );
-};
+        {showBtn && (
+          <LibraryMenuControlButtons
+            className="library-menu-control-buttons--at-bottom"
+            style={{ padding: "16px 12px 0 12px" }}
+            id={id}
+            libraryReturnUrl={libraryReturnUrl}
+            theme={theme}
+          />
+        )}
+      </LibraryMenuWrapper>
+    );
+  },
+);
 
-const usePendingElementsMemo = (
-  appState: UIAppState,
+const getPendingElements = (
   elements: readonly NonDeletedExcalidrawElement[],
-) => {
-  const create = useCallback(
-    (appState: UIAppState, elements: readonly NonDeletedExcalidrawElement[]) =>
-      getSelectedElements(elements, appState, {
-        includeBoundTextElement: true,
-        includeElementsInFrames: true,
-      }),
-    [],
+  selectedElementIds: UIAppState["selectedElementIds"],
+) => ({
+  elements,
+  pending: getSelectedElements(
+    elements,
+    { selectedElementIds },
+    {
+      includeBoundTextElement: true,
+      includeElementsInFrames: true,
+    },
+  ),
+  selectedElementIds,
+});
+
+const usePendingElementsMemo = (appState: UIAppState) => {
+  const elements = useExcalidrawElements();
+  const hasSelectedChangedRef = useRef(false);
+
+  const [state, setState] = useState(() =>
+    getPendingElements(elements, appState.selectedElementIds),
   );
 
-  const val = useRef(create(appState, elements));
-  const prevAppState = useRef<UIAppState>(appState);
-  const prevElements = useRef(elements);
+  const cursorButton =
+    "cursorButton" in appState
+      ? (appState.cursorButton as AppState["cursorButton"])
+      : "up";
+  const activeToolType = appState.activeTool.type;
+  const edititingTextElement = appState.editingTextElement;
 
-  const update = useCallback(() => {
-    if (
-      !isShallowEqual(
-        appState.selectedElementIds,
-        prevAppState.current.selectedElementIds,
-      ) ||
-      !isShallowEqual(elements, prevElements.current)
-    ) {
-      val.current = create(appState, elements);
-      prevAppState.current = appState;
-      prevElements.current = elements;
+  useEffect(() => {
+    if (cursorButton === "up" && activeToolType === "selection") {
+      if (edititingTextElement) {
+        setState({
+          pending: [],
+          elements,
+          selectedElementIds: appState.selectedElementIds,
+        });
+        return;
+      }
+      const hasChanged = hasSelectedChangedRef.current;
+      setState((prev) =>
+        !hasChanged &&
+        isShallowEqual(prev.selectedElementIds, appState.selectedElementIds)
+          ? prev
+          : getPendingElements(elements, appState.selectedElementIds),
+      );
     }
-  }, [create, appState, elements]);
+    hasSelectedChangedRef.current = appState.isRotating || appState.isResizing;
+  }, [
+    appState.selectedElementIds,
+    elements,
+    cursorButton,
+    activeToolType,
+    appState.isRotating,
+    appState.isResizing,
+    edititingTextElement,
+  ]);
 
-  return useMemo(
-    () => ({
-      update,
-      value: val.current,
-    }),
-    [update, val],
-  );
+  return state.pending;
 };
 
 /**
  * This component is meant to be rendered inside <Sidebar.Tab/> inside our
  * <DefaultSidebar/> or host apps Sidebar components.
  */
-export const LibraryMenu = () => {
+export const LibraryMenu = memo(() => {
   const { library, id, onInsertElements } = useApp();
   const appProps = useAppProps();
   const appState = useUIAppState();
-  const app = useApp();
   const setAppState = useExcalidrawSetAppState();
-  const elements = useExcalidrawElements();
   const [selectedItems, setSelectedItems] = useState<LibraryItem["id"][]>([]);
   const memoizedLibrary = useMemo(() => library, [library]);
   // BUG: pendingElements are still causing some unnecessary rerenders because clicking into canvas returns some ids even when no element is selected.
-  const pendingElements = usePendingElementsMemo(appState, elements);
+  const pendingElements = usePendingElementsMemo(appState);
 
   const onInsertLibraryItems = useCallback(
     (libraryItems: LibraryItems) => {
@@ -223,13 +248,9 @@ export const LibraryMenu = () => {
     });
   }, [setAppState]);
 
-  useEffect(() => {
-    return app.onPointerUpEmitter.on(() => pendingElements.update());
-  }, [app, pendingElements]);
-
   return (
     <LibraryMenuContent
-      pendingElements={pendingElements.value}
+      pendingElements={pendingElements}
       onInsertLibraryItems={onInsertLibraryItems}
       onAddToLibrary={deselectItems}
       setAppState={setAppState}
@@ -241,4 +262,4 @@ export const LibraryMenu = () => {
       onSelectItems={setSelectedItems}
     />
   );
-};
+});

--- a/setupTests.ts
+++ b/setupTests.ts
@@ -7,6 +7,9 @@ import polyfill from "./packages/excalidraw/polyfill";
 import { testPolyfills } from "./packages/excalidraw/tests/helpers/polyfills";
 import { yellow } from "./packages/excalidraw/tests/helpers/colorize";
 
+// mock for pep.js not working with setPointerCapture()
+HTMLElement.prototype.setPointerCapture = vi.fn();
+
 Object.assign(globalThis, testPolyfills);
 
 require("fake-indexeddb/auto");


### PR DESCRIPTION
When the sidebar is docked with a sufficiently large library open, there is some perceptible lag and choppiness during canvas interaction. This PR aims to improve performance and UX in this scenario.

My first impulse + our offline discussion led me to investigate any unnecessary re-renders. Something that both `LibraryMenu` and `LibraryMenuContent` are guilty of. By memoizing both components, I managed to mitigate this. With it, I also improved the `pending elements calculation`, as in the current version, rotation and resizing do not update the preview element correctly. These optimizations helped somewhat, but did not fully resolve the performance issue.

My next thought was that it might be the large number of (potentially) complex SVGs in the sidebar that may be the culprit. One approach I tried was lazy loading them with `IntersectionObserver`. The idea was to only insert the currently visible ones into the DOM. This showed some promise and definitely seemed to result in noticeably improved performance, but it still did not match the sidebar-less version.

However, this detour helped me identify the real bottleneck. I noticed that although pointer events no longer triggered React re-renders, there was still some unusual behavior. After some more investigation, I found that the App component frequently changes the `--ui-pointerEvent` CSS variable to block other elements' interactivity, and applying these changes was the root cause of the lags.

My proposed solution is to remove these changes while maintaining the same UX (i.e., no interaction with outside elements during canvas interaction). During a canvas pointer up event, we capture the pointer events to the canvas itself. This ensures that all other outside elements will be non-interactive until a pointer up event. I tested this solution and it provides the same UX as before, though there could be some edge cases I'm not aware of. Unfortunately, I have noticed the tests are failing because `pepjs`, the library that polyfills pointer events to `jsdom` does not properly support the capturing phase for pointer events. Still, I think this idea is worth considering at least.

Here is a short video comparing prod vs PR performance with the fix applied:

https://github.com/user-attachments/assets/e01138a5-d182-4850-ae63-8d934dd32b0e