### PR TITLE
extensions are set when opening files, except in Safari on iOS

### DIFF
--- a/packages/excalidraw/components/LibraryMenuHeaderContent.tsx
+++ b/packages/excalidraw/components/LibraryMenuHeaderContent.tsx
@@ -16,7 +16,7 @@ import {
 } from "./icons";
 import { ToolButton } from "./ToolButton";
 import { fileOpen } from "../data/filesystem";
-import { muteFSAbortError } from "../utils";
+import { muteFSAbortError, isIosSafari } from "../utils";
 import ConfirmDialog from "./ConfirmDialog";
 import PublishLibrary from "./PublishLibrary";
 import { Dialog } from "./Dialog";
@@ -158,9 +158,7 @@ export const LibraryDropdownMenuButton: React.FC<{
           description: "Excalidraw library files",
           // ToDo: Be over-permissive until https://bugs.webkit.org/show_bug.cgi?id=34442
           // gets resolved. Else, iOS users cannot open `.excalidraw` files.
-          /*
-            extensions: [".json", ".excalidrawlib"],
-            */
+          extensions: isIosSafari ? undefined : ["json", "excalidrawlib"],
         }),
         merge: true,
         openLibraryMenu: true,

--- a/packages/excalidraw/data/json.ts
+++ b/packages/excalidraw/data/json.ts
@@ -18,6 +18,7 @@ import type {
   ExportedLibraryData,
   ImportedLibraryData,
 } from "./types";
+import { isIosSafari } from "../utils";
 
 /**
  * Strips out files which are only referenced by deleted elements
@@ -99,7 +100,7 @@ export const loadFromJSON = async (
     description: "Excalidraw files",
     // ToDo: Be over-permissive until https://bugs.webkit.org/show_bug.cgi?id=34442
     // gets resolved. Else, iOS users cannot open `.excalidraw` files.
-    // extensions: ["json", "excalidraw", "png", "svg"],
+    extensions: isIosSafari ? undefined : ["json", "excalidraw", "png", "svg"],
   });
   return loadFromBlob(
     await normalizeFile(file),

--- a/packages/excalidraw/utils.ts
+++ b/packages/excalidraw/utils.ts
@@ -1243,3 +1243,8 @@ export const escapeDoubleQuotes = (str: string) => {
 
 export const castArray = <T>(value: T | T[]): T[] =>
   Array.isArray(value) ? value : [value];
+
+export const isIosSafari =
+  /iP(hone|ad|od)/.test(navigator.userAgent) &&
+  /Safari/.test(navigator.userAgent) &&
+  !/Chrome|CriOS/.test(navigator.userAgent);


### PR DESCRIPTION
While keeping the workaround for the Safari on iOS bug, extensions are set in other environments