### PR TITLE
feat: grouped together Undo and Redo buttons on mobile

### DIFF
--- a/packages/excalidraw/components/MobileMenu.tsx
+++ b/packages/excalidraw/components/MobileMenu.tsx
@@ -145,8 +145,10 @@ export const MobileMenu = ({
       <div className="App-toolbar-content">
         <MainMenuTunnel.Out />
         {actionManager.renderAction("toggleEditMenu")}
-        {actionManager.renderAction("undo")}
-        {actionManager.renderAction("redo")}
+        <div>
+          {actionManager.renderAction("undo")}
+          {actionManager.renderAction("redo")}
+        </div>
         {actionManager.renderAction(
           appState.multiElement ? "finalize" : "duplicateSelection",
         )}

--- a/packages/excalidraw/components/MobileMenu.tsx
+++ b/packages/excalidraw/components/MobileMenu.tsx
@@ -145,14 +145,14 @@ export const MobileMenu = ({
       <div className="App-toolbar-content">
         <MainMenuTunnel.Out />
         {actionManager.renderAction("toggleEditMenu")}
-        <div>
-          {actionManager.renderAction("undo")}
-          {actionManager.renderAction("redo")}
-        </div>
         {actionManager.renderAction(
           appState.multiElement ? "finalize" : "duplicateSelection",
         )}
         {actionManager.renderAction("deleteSelectedElements")}
+        <div>
+          {actionManager.renderAction("undo")}
+          {actionManager.renderAction("redo")}
+        </div>
       </div>
     );
   };


### PR DESCRIPTION
# Description
This PR puts the redo and undo button under the same div and fixes their position to the right in mobile view so that they look grouped together and stay on the same spot

# Before: 
![image](https://github.com/user-attachments/assets/c0a508ec-6ea5-4b67-9533-453c66d47ab1)

![image](https://github.com/user-attachments/assets/5d0c98fd-bf07-4553-ba55-8d6b783758fc)


# After: 
![image](https://github.com/user-attachments/assets/67ada1d7-2d88-48ce-b7a3-826424b8d67e)
![image](https://github.com/user-attachments/assets/28edea56-423a-4ef8-b7af-813a98851b8b)


# How to Test
1. Open the Excalidraw board on mobile or open the mobile view via inspector.
2. Look at the bottom bar
# Checklist
[✅ ] Code follows the project’s coding style.
[✅ ] Tested the feature in different scenarios.
[✅ ] No console errors or warnings.

# Linked Issue
fixes #9110