### PR TITLE
fix: Fix inconsistency in resizing while maintaining aspect ratio

### DIFF
--- a/packages/excalidraw/element/resizeElements.ts
+++ b/packages/excalidraw/element/resizeElements.ts
@@ -771,8 +771,8 @@ const getResizedOrigin = (
         x: x + ((prevWidth - newWidth) / 2) * (Math.cos(angle) + 1),
         y:
           y +
-          (newHeight - prevHeight) / 2 +
-          ((prevWidth - newWidth) / 2) * Math.sin(angle),
+          ((prevWidth - newWidth) / 2) * Math.sin(angle) +
+          (prevHeight - newHeight) / 2,
       };
     case "west-side":
       return {


### PR DESCRIPTION
Resizing while maintaining the aspect ratio behaved differently only when manipulating the left edge. I think that these behaviors should be consistent, so I've fixed.

### before

<img src="https://github.com/user-attachments/assets/1779b07c-5be2-4560-8c7a-bc44fde5e86e" width=500>

### after

<img src="https://github.com/user-attachments/assets/ad7e517d-b9c2-4b58-ba29-b96a2b583d38" width=500>
