### PR TITLE
fix: Do not rebind undragged elbow arrow endpoint

### DIFF
--- a/packages/excalidraw/element/binding.ts
+++ b/packages/excalidraw/element/binding.ts
@@ -283,7 +283,7 @@ const getBindingStrategyForDraggingArrowEndpoints = (
         elements,
         zoom,
       )
-    : null;
+    : "keep";
   const end = endDragged
     ? isBindingEnabled
       ? getElligibleElementForBindingElement(
@@ -303,7 +303,7 @@ const getBindingStrategyForDraggingArrowEndpoints = (
         elements,
         zoom,
       )
-    : null;
+    : "keep";
 
   return [start, end];
 };

--- a/packages/excalidraw/element/binding.ts
+++ b/packages/excalidraw/element/binding.ts
@@ -73,6 +73,8 @@ import {
   vectorCross,
   pointsEqual,
   lineSegmentIntersectionPoints,
+  round,
+  PRECISION,
 } from "@excalidraw/math";
 import { intersectElementWithLineSegment } from "./collision";
 import { distanceToBindableElement } from "./distance";
@@ -954,13 +956,17 @@ export const bindPointToSnapToElementOutline = (
     const currentDistance = pointDistance(p, center);
     const fullDistance = Math.max(
       pointDistance(intersection ?? p, center),
-      1e-5,
+      PRECISION,
     );
-    const ratio = currentDistance / fullDistance;
+    const ratio = round(currentDistance / fullDistance, 6);
 
     switch (true) {
       case ratio > 0.9:
-        if (currentDistance - fullDistance > FIXED_BINDING_DISTANCE) {
+        if (
+          currentDistance - fullDistance > FIXED_BINDING_DISTANCE ||
+          // Too close to determine vector from intersection to p
+          pointDistanceSq(p, intersection) < PRECISION
+        ) {
           return p;
         }
 

--- a/packages/excalidraw/element/binding.ts
+++ b/packages/excalidraw/element/binding.ts
@@ -272,14 +272,16 @@ const getBindingStrategyForDraggingArrowEndpoints = (
           zoom,
         )
       : null // If binding is disabled and start is dragged, break all binds
-    : // We have to update the focus and gap of the binding, so let's rebind
+    : !isElbowArrow(selectedElement)
+    ? // We have to update the focus and gap of the binding, so let's rebind
       getElligibleElementForBindingElement(
         selectedElement,
         "start",
         elementsMap,
         elements,
         zoom,
-      );
+      )
+    : null;
   const end = endDragged
     ? isBindingEnabled
       ? getElligibleElementForBindingElement(
@@ -290,14 +292,16 @@ const getBindingStrategyForDraggingArrowEndpoints = (
           zoom,
         )
       : null // If binding is disabled and end is dragged, break all binds
-    : // We have to update the focus and gap of the binding, so let's rebind
+    : !isElbowArrow(selectedElement)
+    ? // We have to update the focus and gap of the binding, so let's rebind
       getElligibleElementForBindingElement(
         selectedElement,
         "end",
         elementsMap,
         elements,
         zoom,
-      );
+      )
+    : null;
 
   return [start, end];
 };
@@ -309,6 +313,11 @@ const getBindingStrategyForDraggingArrowOrJoints = (
   isBindingEnabled: boolean,
   zoom?: AppState["zoom"],
 ): (NonDeleted<ExcalidrawBindableElement> | null | "keep")[] => {
+  // Elbow arrows don't bind when dragged as a whole
+  if (isElbowArrow(selectedElement)) {
+    return [null, null];
+  }
+
   const [startIsClose, endIsClose] = getOriginalBindingsIfStillCloseToArrowEnds(
     selectedElement,
     elementsMap,

--- a/packages/excalidraw/element/binding.ts
+++ b/packages/excalidraw/element/binding.ts
@@ -315,7 +315,7 @@ const getBindingStrategyForDraggingArrowOrJoints = (
 ): (NonDeleted<ExcalidrawBindableElement> | null | "keep")[] => {
   // Elbow arrows don't bind when dragged as a whole
   if (isElbowArrow(selectedElement)) {
-    return [null, null];
+    return ["keep", "keep"];
   }
 
   const [startIsClose, endIsClose] = getOriginalBindingsIfStillCloseToArrowEnds(

--- a/packages/excalidraw/element/elbowArrow.test.tsx
+++ b/packages/excalidraw/element/elbowArrow.test.tsx
@@ -71,9 +71,9 @@ describe("elbow arrow segment move", () => {
 
     expect(arrow.points).toCloselyEqualPoints([
       [0, 0],
-      [115, 0],
-      [115, 199.9],
-      [195, 199.9],
+      [110, 0],
+      [110, 200],
+      [190, 200],
     ]);
 
     mouse.reset();
@@ -82,9 +82,9 @@ describe("elbow arrow segment move", () => {
 
     expect(arrow.points).toCloselyEqualPoints([
       [0, 0],
-      [115, 0],
-      [115, 199.9],
-      [195, 199.9],
+      [110, 0],
+      [110, 200],
+      [190, 200],
     ]);
   });
 
@@ -248,9 +248,9 @@ describe("elbow arrow ui", () => {
     expect(arrow.elbowed).toBe(true);
     expect(arrow.points).toEqual([
       [0, 0],
-      [43, 0],
-      [43, 198.9],
-      [88, 198.9],
+      [45, 0],
+      [45, 200],
+      [90, 200],
     ]);
   });
 
@@ -290,9 +290,9 @@ describe("elbow arrow ui", () => {
 
     expect(arrow.points.map((point) => point.map(Math.round))).toEqual([
       [0, 0],
-      [33, 0],
-      [33, 164],
-      [101, 164],
+      [35, 0],
+      [35, 165],
+      [103, 165],
     ]);
   });
 
@@ -346,9 +346,9 @@ describe("elbow arrow ui", () => {
     expect(duplicatedArrow.elbowed).toBe(true);
     expect(duplicatedArrow.points).toEqual([
       [0, 0],
-      [43, 0],
-      [43, 198.9],
-      [88, 198.9],
+      [45, 0],
+      [45, 200],
+      [90, 200],
     ]);
     expect(arrow.startBinding).not.toBe(null);
     expect(arrow.endBinding).not.toBe(null);
@@ -400,9 +400,9 @@ describe("elbow arrow ui", () => {
     expect(duplicatedArrow.elbowed).toBe(true);
     expect(duplicatedArrow.points).toEqual([
       [0, 0],
-      [43, 0],
-      [43, 198.9],
-      [88, 198.9],
+      [45, 0],
+      [45, 200],
+      [90, 200],
     ]);
   });
 });

--- a/packages/excalidraw/element/elbowArrow.test.tsx
+++ b/packages/excalidraw/element/elbowArrow.test.tsx
@@ -71,9 +71,9 @@ describe("elbow arrow segment move", () => {
 
     expect(arrow.points).toCloselyEqualPoints([
       [0, 0],
-      [110, 0],
-      [110, 200],
-      [190, 200],
+      [115, 0],
+      [115, 199.9],
+      [195, 199.9],
     ]);
 
     mouse.reset();
@@ -82,9 +82,9 @@ describe("elbow arrow segment move", () => {
 
     expect(arrow.points).toCloselyEqualPoints([
       [0, 0],
-      [110, 0],
-      [110, 200],
-      [190, 200],
+      [115, 0],
+      [115, 199.9],
+      [195, 199.9],
     ]);
   });
 
@@ -248,9 +248,9 @@ describe("elbow arrow ui", () => {
     expect(arrow.elbowed).toBe(true);
     expect(arrow.points).toEqual([
       [0, 0],
-      [45, 0],
-      [45, 200],
-      [90, 200],
+      [43, 0],
+      [43, 198.9],
+      [88, 198.9],
     ]);
   });
 
@@ -290,9 +290,9 @@ describe("elbow arrow ui", () => {
 
     expect(arrow.points.map((point) => point.map(Math.round))).toEqual([
       [0, 0],
-      [35, 0],
-      [35, 165],
-      [103, 165],
+      [33, 0],
+      [33, 164],
+      [101, 164],
     ]);
   });
 
@@ -346,9 +346,9 @@ describe("elbow arrow ui", () => {
     expect(duplicatedArrow.elbowed).toBe(true);
     expect(duplicatedArrow.points).toEqual([
       [0, 0],
-      [45, 0],
-      [45, 200],
-      [90, 200],
+      [43, 0],
+      [43, 198.9],
+      [88, 198.9],
     ]);
     expect(arrow.startBinding).not.toBe(null);
     expect(arrow.endBinding).not.toBe(null);
@@ -400,9 +400,9 @@ describe("elbow arrow ui", () => {
     expect(duplicatedArrow.elbowed).toBe(true);
     expect(duplicatedArrow.points).toEqual([
       [0, 0],
-      [45, 0],
-      [45, 200],
-      [90, 200],
+      [43, 0],
+      [43, 198.9],
+      [88, 198.9],
     ]);
   });
 });

--- a/packages/excalidraw/element/elbowArrow.ts
+++ b/packages/excalidraw/element/elbowArrow.ts
@@ -1201,34 +1201,21 @@ const getElbowArrowData = (
   let hoveredStartElement = startElement;
   let hoveredEndElement = endElement;
   if (options?.isDragging) {
-    const isEndDragged =
-      Math.abs(
-        arrow.x +
-          arrow.points[arrow.points.length - 1][0] -
-          (arrow.x + nextPoints[nextPoints.length - 1][0]),
-      ) > 0 ||
-      Math.abs(
-        arrow.y +
-          arrow.points[arrow.points.length - 1][1] -
-          (arrow.y + nextPoints[nextPoints.length - 1][1]),
-      ) > 0;
     const elements = Array.from(elementsMap.values());
-    if (!isEndDragged) {
-      hoveredStartElement = getHoveredElement(
+    hoveredStartElement =
+      getHoveredElement(
         origStartGlobalPoint,
         elementsMap,
         elements,
         options?.zoom,
-      );
-    }
-    if (isEndDragged) {
-      hoveredEndElement = getHoveredElement(
+      ) || startElement;
+    hoveredEndElement =
+      getHoveredElement(
         origEndGlobalPoint,
         elementsMap,
         elements,
         options?.zoom,
-      );
-    }
+      ) || endElement;
   }
 
   const startGlobalPoint = getGlobalPoint(

--- a/packages/excalidraw/element/elbowArrow.ts
+++ b/packages/excalidraw/element/elbowArrow.ts
@@ -235,6 +235,16 @@ const handleSegmentRenormalization = (
                 nextPoints.map((p) =>
                   pointFrom<LocalPoint>(p[0] - arrow.x, p[1] - arrow.y),
                 ),
+                arrow.startBinding &&
+                  getBindableElementForId(
+                    arrow.startBinding.elementId,
+                    elementsMap,
+                  ),
+                arrow.endBinding &&
+                  getBindableElementForId(
+                    arrow.endBinding.elementId,
+                    elementsMap,
+                  ),
               ),
             ) ?? [],
           ),
@@ -296,6 +306,8 @@ const handleSegmentRelease = (
   // We need to render a sub-arrow path to restore deleted segments
   const x = arrow.x + (prevSegment ? prevSegment.end[0] : 0);
   const y = arrow.y + (prevSegment ? prevSegment.end[1] : 0);
+  const startBinding = prevSegment ? null : arrow.startBinding;
+  const endBinding = nextSegment ? null : arrow.endBinding;
   const {
     startHeading,
     endHeading,
@@ -308,8 +320,8 @@ const handleSegmentRelease = (
     {
       x,
       y,
-      startBinding: prevSegment ? null : arrow.startBinding,
-      endBinding: nextSegment ? null : arrow.endBinding,
+      startBinding,
+      endBinding,
       startArrowhead: null,
       endArrowhead: null,
       points: arrow.points,
@@ -326,6 +338,9 @@ const handleSegmentRelease = (
           y,
       ),
     ],
+    startBinding &&
+      getBindableElementForId(startBinding.elementId, elementsMap),
+    endBinding && getBindableElementForId(endBinding.elementId, elementsMap),
     { isDragging: false },
   );
 
@@ -988,8 +1003,11 @@ export const updateElbowArrowPoints = (
     typeof updates.endBinding !== "undefined"
       ? updates.endBinding
       : arrow.endBinding;
-  const startElement = startBinding && elementsMap.get(startBinding.elementId);
-  const endElement = endBinding && elementsMap.get(endBinding.elementId);
+  const startElement =
+    startBinding &&
+    getBindableElementForId(startBinding.elementId, elementsMap);
+  const endElement =
+    endBinding && getBindableElementForId(endBinding.elementId, elementsMap);
   if (
     (elementsMap.size === 0 && validateElbowPoints(updatedPoints)) ||
     startElement?.id !== startBinding?.elementId ||
@@ -1025,6 +1043,8 @@ export const updateElbowArrowPoints = (
     },
     elementsMap,
     updatedPoints,
+    startElement,
+    endElement,
     options,
   );
 
@@ -1162,6 +1182,8 @@ const getElbowArrowData = (
   },
   elementsMap: NonDeletedSceneElementsMap,
   nextPoints: readonly LocalPoint[],
+  startElement: ExcalidrawBindableElement | null,
+  endElement: ExcalidrawBindableElement | null,
   options?: {
     isDragging?: boolean;
     zoom?: AppState["zoom"];
@@ -1175,12 +1197,6 @@ const getElbowArrowData = (
     LocalPoint,
     GlobalPoint
   >(nextPoints[nextPoints.length - 1], vector(arrow.x, arrow.y));
-  const startElement =
-    arrow.startBinding &&
-    getBindableElementForId(arrow.startBinding.elementId, elementsMap);
-  const endElement =
-    arrow.endBinding &&
-    getBindableElementForId(arrow.endBinding.elementId, elementsMap);
 
   let hoveredStartElement = startElement;
   let hoveredEndElement = endElement;

--- a/packages/excalidraw/element/elbowArrow.ts
+++ b/packages/excalidraw/element/elbowArrow.ts
@@ -15,7 +15,7 @@ import {
 import BinaryHeap from "../binaryheap";
 import { getSizeFromPoints } from "../points";
 import { aabbForElement, pointInsideBounds } from "../shapes";
-import { invariant, isAnyTrue, toBrandedType, tupleToCoors } from "../utils";
+import { invariant, isAnyTrue, tupleToCoors } from "../utils";
 import type { AppState } from "../types";
 import {
   bindPointToSnapToElementOutline,
@@ -52,6 +52,7 @@ import type {
   ExcalidrawBindableElement,
   FixedPointBinding,
   FixedSegment,
+  NonDeletedExcalidrawElement,
 } from "./types";
 import { distanceToBindableElement } from "./distance";
 
@@ -101,7 +102,7 @@ export const BASE_PADDING = 40;
 
 const handleSegmentRenormalization = (
   arrow: ExcalidrawElbowArrowElement,
-  elementsMap: NonDeletedSceneElementsMap | SceneElementsMap,
+  elementsMap: NonDeletedSceneElementsMap,
 ) => {
   const nextFixedSegments: FixedSegment[] | null = arrow.fixedSegments
     ? arrow.fixedSegments.slice()
@@ -271,7 +272,7 @@ const handleSegmentRenormalization = (
 const handleSegmentRelease = (
   arrow: ExcalidrawElbowArrowElement,
   fixedSegments: readonly FixedSegment[],
-  elementsMap: NonDeletedSceneElementsMap | SceneElementsMap,
+  elementsMap: NonDeletedSceneElementsMap,
 ) => {
   const newFixedSegmentIndices = fixedSegments.map((segment) => segment.index);
   const oldFixedSegmentIndices =
@@ -311,6 +312,7 @@ const handleSegmentRelease = (
       endBinding: nextSegment ? null : arrow.endBinding,
       startArrowhead: null,
       endArrowhead: null,
+      points: arrow.points,
     },
     elementsMap,
     [
@@ -870,7 +872,7 @@ const MAX_POS = 1e6;
  */
 export const updateElbowArrowPoints = (
   arrow: Readonly<ExcalidrawElbowArrowElement>,
-  elementsMap: NonDeletedSceneElementsMap | SceneElementsMap,
+  elementsMap: NonDeletedSceneElementsMap,
   updates: {
     points?: readonly LocalPoint[];
     fixedSegments?: FixedSegment[] | null;
@@ -1019,6 +1021,7 @@ export const updateElbowArrowPoints = (
       endBinding,
       startArrowhead: arrow.startArrowhead,
       endArrowhead: arrow.endArrowhead,
+      points: arrow.points,
     },
     elementsMap,
     updatedPoints,
@@ -1155,8 +1158,9 @@ const getElbowArrowData = (
     endBinding: FixedPointBinding | null;
     startArrowhead: Arrowhead | null;
     endArrowhead: Arrowhead | null;
+    points: readonly LocalPoint[];
   },
-  elementsMap: NonDeletedSceneElementsMap | SceneElementsMap,
+  elementsMap: NonDeletedSceneElementsMap,
   nextPoints: readonly LocalPoint[],
   options?: {
     isDragging?: boolean;
@@ -1177,14 +1181,40 @@ const getElbowArrowData = (
   const endElement =
     arrow.endBinding &&
     getBindableElementForId(arrow.endBinding.elementId, elementsMap);
-  const [hoveredStartElement, hoveredEndElement] = options?.isDragging
-    ? getHoveredElements(
+
+  let hoveredStartElement = startElement;
+  let hoveredEndElement = endElement;
+  if (options?.isDragging) {
+    const isEndDragged =
+      Math.abs(
+        arrow.x +
+          arrow.points[arrow.points.length - 1][0] -
+          (arrow.x + nextPoints[nextPoints.length - 1][0]),
+      ) > 0 ||
+      Math.abs(
+        arrow.y +
+          arrow.points[arrow.points.length - 1][1] -
+          (arrow.y + nextPoints[nextPoints.length - 1][1]),
+      ) > 0;
+    const elements = Array.from(elementsMap.values());
+    if (!isEndDragged) {
+      hoveredStartElement = getHoveredElement(
         origStartGlobalPoint,
+        elementsMap,
+        elements,
+        options?.zoom,
+      );
+    }
+    if (isEndDragged) {
+      hoveredEndElement = getHoveredElement(
         origEndGlobalPoint,
         elementsMap,
+        elements,
         options?.zoom,
-      )
-    : [startElement, endElement];
+      );
+    }
+  }
+
   const startGlobalPoint = getGlobalPoint(
     {
       ...arrow,
@@ -2214,36 +2244,20 @@ const getBindPointHeading = (
     origPoint,
   );
 
-const getHoveredElements = (
-  origStartGlobalPoint: GlobalPoint,
-  origEndGlobalPoint: GlobalPoint,
-  elementsMap: NonDeletedSceneElementsMap | SceneElementsMap,
+const getHoveredElement = (
+  origPoint: GlobalPoint,
+  elementsMap: NonDeletedSceneElementsMap,
+  elements: readonly NonDeletedExcalidrawElement[],
   zoom?: AppState["zoom"],
 ) => {
-  // TODO: Might be a performance bottleneck and the Map type
-  // remembers the insertion order anyway...
-  const nonDeletedSceneElementsMap = toBrandedType<NonDeletedSceneElementsMap>(
-    new Map([...elementsMap].filter((el) => !el[1].isDeleted)),
+  return getHoveredElementForBinding(
+    tupleToCoors(origPoint),
+    elements,
+    elementsMap,
+    zoom,
+    true,
+    true,
   );
-  const elements = Array.from(elementsMap.values());
-  return [
-    getHoveredElementForBinding(
-      tupleToCoors(origStartGlobalPoint),
-      elements,
-      nonDeletedSceneElementsMap,
-      zoom,
-      true,
-      true,
-    ),
-    getHoveredElementForBinding(
-      tupleToCoors(origEndGlobalPoint),
-      elements,
-      nonDeletedSceneElementsMap,
-      zoom,
-      true,
-      true,
-    ),
-  ];
 };
 
 const gridAddressesEqual = (a: GridAddress, b: GridAddress): boolean =>

--- a/packages/excalidraw/element/flowchart.ts
+++ b/packages/excalidraw/element/flowchart.ts
@@ -10,7 +10,6 @@ import {
 import { bindLinearElement } from "./binding";
 import { LinearElementEditor } from "./linearElementEditor";
 import { newArrowElement, newElement } from "./newElement";
-import type { SceneElementsMap } from "./types";
 import {
   type ElementsMap,
   type ExcalidrawBindableElement,
@@ -472,7 +471,7 @@ const createBindingArrow = (
 
   const update = updateElbowArrowPoints(
     bindingArrow,
-    toBrandedType<SceneElementsMap>(
+    toBrandedType<NonDeletedSceneElementsMap>(
       new Map([
         ...elementsMap.entries(),
         [startBindingElement.id, startBindingElement],

--- a/packages/excalidraw/element/mutateElement.ts
+++ b/packages/excalidraw/element/mutateElement.ts
@@ -1,4 +1,4 @@
-import type { ExcalidrawElement, SceneElementsMap } from "./types";
+import type { ExcalidrawElement, NonDeletedSceneElementsMap } from "./types";
 import Scene from "../scene/Scene";
 import { getSizeFromPoints } from "../points";
 import { randomInteger } from "../random";
@@ -44,7 +44,7 @@ export const mutateElement = <TElement extends Mutable<ExcalidrawElement>>(
       typeof startBinding !== "undefined" ||
       typeof endBinding !== "undefined") // manual binding to element
   ) {
-    const elementsMap = toBrandedType<SceneElementsMap>(
+    const elementsMap = toBrandedType<NonDeletedSceneElementsMap>(
       Scene.getScene(element)?.getNonDeletedElementsMap() ?? new Map(),
     );
 

--- a/packages/excalidraw/tests/resize.test.tsx
+++ b/packages/excalidraw/tests/resize.test.tsx
@@ -533,9 +533,8 @@ describe("arrow element", () => {
     expect(arrow.startBinding?.fixedPoint?.[1]).toBeCloseTo(0.75);
 
     UI.resize([rectangle, arrow], "nw", [300, 350]);
-
-    expect(arrow.startBinding?.fixedPoint?.[0]).toBeCloseTo(-0.13);
-    expect(arrow.startBinding?.fixedPoint?.[1]).toBeCloseTo(0.11);
+    expect(arrow.startBinding?.fixedPoint?.[0]).toBeCloseTo(0);
+    expect(arrow.startBinding?.fixedPoint?.[1]).toBeCloseTo(0.25);
   });
 });
 


### PR DESCRIPTION
Currently dragging elbow arrows (not start or end points!) still attempts to bind, which this PR changes to no binding in drag.

Currently elbow arrows also re-bind the opposite endpoint when the other endpoint is dragged, which can rebind to the incorrect element with overlapping binding gaps.

Also fixes #9130