### PR TITLE
fix: Fix elbow arrow fixed binding on restore

### DIFF
--- a/packages/excalidraw/element/binding.ts
+++ b/packages/excalidraw/element/binding.ts
@@ -2206,9 +2206,13 @@ export const normalizeFixedPoint = <T extends FixedPoint | null>(
 ): T extends null ? null : FixedPoint => {
   // Do not allow a precise 0.5 for fixed point ratio
   // to avoid jumping arrow heading due to floating point imprecision
-  if (fixedPoint && (fixedPoint[0] === 0.5 || fixedPoint[1] === 0.5)) {
+  if (
+    fixedPoint &&
+    (Math.abs(fixedPoint[0] - 0.5) < 0.0001 ||
+      Math.abs(fixedPoint[1] - 0.5) < 0.0001)
+  ) {
     return fixedPoint.map((ratio) =>
-      ratio === 0.5 ? 0.5001 : ratio,
+      Math.abs(ratio - 0.5) < 0.0001 ? 0.5001 : ratio,
     ) as T extends null ? null : FixedPoint;
   }
   return fixedPoint as any as T extends null ? null : FixedPoint;


### PR DESCRIPTION
If a `fixedPoint` binding is too close to 0.5 in some edge cases it can oscillate between positions at every frame. This PR fixes that by adding an offset to the binding points at element restore (reload)