### PR TITLE
Fix/issue 8834 Increase text element horizontal padding in rectangle

### DIFF
--- a/packages/excalidraw/constants.ts
+++ b/packages/excalidraw/constants.ts
@@ -323,6 +323,7 @@ export const VERSIONS = {
 } as const;
 
 export const BOUND_TEXT_PADDING = 5;
+export const INCREASED_BOUND_TEXT_PADDING = 5;
 export const ARROW_LABEL_WIDTH_FRACTION = 0.7;
 export const ARROW_LABEL_FONT_SIZE_TO_MIN_WIDTH_RATIO = 11;
 

--- a/packages/excalidraw/element/textElement.test.ts
+++ b/packages/excalidraw/element/textElement.test.ts
@@ -31,7 +31,7 @@ describe("Test measureText", () => {
         ...params,
       });
       expect(getContainerCoords(element)).toEqual({
-        x: 15,
+        x: 20,
         y: 25,
       });
     });
@@ -93,7 +93,7 @@ describe("Test measureText", () => {
 
     it("should return max width when container is rectangle", () => {
       const container = API.createElement({ type: "rectangle", ...params });
-      expect(getBoundTextMaxWidth(container, null)).toBe(168);
+      expect(getBoundTextMaxWidth(container, null)).toBe(158);
     });
 
     it("should return max width when container is ellipse", () => {

--- a/packages/excalidraw/element/textElement.ts
+++ b/packages/excalidraw/element/textElement.ts
@@ -13,6 +13,7 @@ import {
   ARROW_LABEL_FONT_SIZE_TO_MIN_WIDTH_RATIO,
   ARROW_LABEL_WIDTH_FRACTION,
   BOUND_TEXT_PADDING,
+  INCREASED_BOUND_TEXT_PADDING,
   DEFAULT_FONT_SIZE,
   TEXT_ALIGN,
   VERTICAL_ALIGN,
@@ -360,6 +361,12 @@ export const getContainerCoords = (container: NonDeletedExcalidrawElement) => {
     offsetX += container.width / 4;
     offsetY += container.height / 4;
   }
+
+  if (container.type === "rectangle") {
+    //Increase horizontal padding without modifying BOUND_TEXT_PADDING.
+    offsetX = BOUND_TEXT_PADDING + INCREASED_BOUND_TEXT_PADDING;
+  }
+
   return {
     x: container.x + offsetX,
     y: container.y + offsetY,
@@ -475,6 +482,12 @@ export const getBoundTextMaxWidth = (
     // Math.round(width / 2) - https://github.com/excalidraw/excalidraw/pull/6265
     return Math.round(width / 2) - BOUND_TEXT_PADDING * 2;
   }
+
+  if (container.type === "rectangle") {
+    //Adjust width to accommodate increased horizontal padding in getContainerCoords() .
+    return width - (BOUND_TEXT_PADDING + INCREASED_BOUND_TEXT_PADDING) * 2;
+  }
+
   return width - BOUND_TEXT_PADDING * 2;
 };
 


### PR DESCRIPTION
## DESCRIPTION
This PR is increase horizontal padding to bound text elements for rectangles without affecting the already existing diagrams.

## CHANGES MADE:
 
Added INCREASED_BOUND_TEXT_PADDING (5) to BOUND_TEXT_PADDING for rectangles to apply extra padding while keeping the existing padding logic.

## RELATED ISSUES:
#8834 

## DEMO

https://github.com/user-attachments/assets/13475c10-9266-4feb-9cdc-505285b24e75

## Suggestions
It would be good to add a created timestamp or some versioning method for new elements.

Right now, existing diagrams won’t be affected by the new padding unless they are edited. But once edited, the new padding will apply, which might change the container size as shown in the image below. This is not a problem for our case, but having a created timestamp could make things more flexible in the future.

This was discussed in issue #8834.
![Screenshot 2025-02-28 074812](https://github.com/user-attachments/assets/bc3733bf-37bf-45c6-be53-30964b054c74)

