### PR TITLE
feat: QoL improvement. Debounce context menu if user is resizing an element

### DIFF
--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -6232,7 +6232,7 @@ class App extends React.Component<AppProps, AppState> {
 
   // set touch moving for mobile context menu
   private handleTouchMove = (event: React.TouchEvent<HTMLCanvasElement>) => {
-    invalidateContextMenu = true;
+    this.resetContextMenuTimer();
   };
 
   handleHoverSelectedLinearElement(
@@ -10423,6 +10423,10 @@ class App extends React.Component<AppProps, AppState> {
           event.button !== POINTER_BUTTON.SECONDARY)) &&
       this.state.activeTool.type !== "selection"
     ) {
+      return;
+    }
+
+    if (this.state.isResizing) {
       return;
     }
 


### PR DESCRIPTION
This is an issue on mobile devices. In the current solution when you resize an element with your finger or a pen the context menu constantly pops up as you try to resize. This small change resolves it.