### PR TITLE
Arrow tool breaks if switching to selection tool while drawing arrow. #9257

### DIFF
--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -3576,7 +3576,7 @@ class App extends React.Component<AppProps, AppState> {
           ...prevState.activeTool,
           ...updateActiveTool(
             this.state,
-            prevState.activeTool.locked
+            prevState.activeTool.locked && !prevState.newElement
               ? { type: "selection" }
               : prevState.activeTool,
           ),
@@ -4690,6 +4690,11 @@ class App extends React.Component<AppProps, AppState> {
         `"${tool.type}" tool is disabled via "UIOptions.canvasActions.tools.${tool.type}"`,
       );
       return;
+    }
+
+    //cancel adding linearElement if tool is switched
+    if (this.state.newElement && isLinearElement(this.state.newElement)) {
+      this.actionManager.executeAction(actionFinalize);
     }
 
     const nextActiveTool = updateActiveTool(this.state, tool);


### PR DESCRIPTION
See #9257 for the issue, this commit fixes a small part of the problem. 

The bigger problem is that by setting `shouldBlockPointerEvents` to false you can also access all menus while drawing a linear element which can cause many issues including: 

https://github.com/user-attachments/assets/256b0054-e05f-4f42-aae0-c61f57d609f3

I'm not sure if it's possible to block pointer events for all menus except the `ShapesSelection` menu.