### PR TITLE
Fix: Arrow tool breaks if switching to selection tool while drawing arrow.

### DIFF
--- a/packages/excalidraw/actions/actionCanvas.tsx
+++ b/packages/excalidraw/actions/actionCanvas.tsx
@@ -27,8 +27,12 @@ import {
   ZOOM_STEP,
 } from "../constants";
 import { setCursor } from "../cursor";
-import { getCommonBounds, getNonDeletedElements } from "../element";
-import { newElementWith } from "../element/mutateElement";
+import {
+  getCommonBounds,
+  getNonDeletedElements,
+  isInvisiblySmallElement,
+} from "../element";
+import { mutateElement, newElementWith } from "../element/mutateElement";
 import { t } from "../i18n";
 import { CODES, KEYS } from "../keys";
 import { getNormalizedZoom } from "../scene";
@@ -42,6 +46,7 @@ import { register } from "./register";
 import type { SceneBounds } from "../element/bounds";
 import type { ExcalidrawElement } from "../element/types";
 import type { AppState, Offsets } from "../types";
+import { isLinearElement } from "../element/typeChecks";
 
 export const actionChangeViewBackgroundColor = register({
   name: "changeViewBackgroundColor",
@@ -544,13 +549,44 @@ export const actionToggleHandTool = register({
       setCursor(app.interactiveCanvas, CURSOR_TYPE.GRAB);
     }
 
+    let newElements = elements;
+
+    const multiPointElement =
+      appState.multiElement && isLinearElement(appState.multiElement)
+        ? appState.multiElement
+        : null;
+
+    if (multiPointElement) {
+      // pen and mouse have hover
+      if (appState.lastPointerDownWith !== "touch") {
+        const { points, lastCommittedPoint } = multiPointElement;
+        if (
+          !lastCommittedPoint ||
+          points[points.length - 1] !== lastCommittedPoint
+        ) {
+          mutateElement(multiPointElement, {
+            points: multiPointElement.points.slice(0, -1),
+          });
+        }
+      }
+      if (isInvisiblySmallElement(multiPointElement)) {
+        // TODO: #7348 in theory this gets recorded by the store, so the invisible elements could be restored by the undo/redo, which might be not what we would want
+        newElements = newElements.filter(
+          (el) => el.id !== multiPointElement.id,
+        );
+      }
+    }
+
     return {
+      elements: newElements,
       appState: {
         ...appState,
         selectedElementIds: {},
         selectedGroupIds: {},
         activeEmbeddable: null,
         activeTool,
+        newElement: null,
+        multiElement: null,
       },
       captureUpdate: CaptureUpdateAction.IMMEDIATELY,
     };

--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -3579,7 +3579,7 @@ class App extends React.Component<AppProps, AppState> {
           ...prevState.activeTool,
           ...updateActiveTool(
             this.state,
-            prevState.activeTool.locked
+            prevState.activeTool.locked && !prevState.newElement
               ? { type: "selection" }
               : prevState.activeTool,
           ),
@@ -4693,6 +4693,11 @@ class App extends React.Component<AppProps, AppState> {
         `"${tool.type}" tool is disabled via "UIOptions.canvasActions.tools.${tool.type}"`,
       );
       return;
+    }
+
+    //cancel adding linearElement if tool is switched
+    if (this.state.newElement && isLinearElement(this.state.newElement)) {
+      this.actionManager.executeAction(actionFinalize);
     }
 
     const nextActiveTool = updateActiveTool(this.state, tool);


### PR DESCRIPTION
See #9257 for the issue, this commit fixes a small part of the problem.

The bigger problem is that by setting shouldBlockPointerEvents to false you can also access all menus while drawing a linear element which can cause many issues including:

https://github.com/user-attachments/assets/e2f341dc-cd3b-45b9-bb72-4e5a36e00209

In this commit I do 3 things:

1. When switching to another tool, I execute `actionFinalize` so that you don't get stuck drawing the linear element.
2. When switching to the hand tool I just clear the last point from the linearElement (using a bit of code stolen from the `actionFinalize` function)
3. If you unlock the lock button while drawing a linear element the drawing doesn't get cancelled, but after the drawing is finished you will go back to the selection tool.