### PR TITLE
fix: elements offset incorrectly when action-duplicated during drag

### DIFF
--- a/packages/excalidraw/actions/actionDuplicateSelection.tsx
+++ b/packages/excalidraw/actions/actionDuplicateSelection.tsx
@@ -52,6 +52,10 @@ export const actionDuplicateSelection = register({
   icon: DuplicateIcon,
   trackEvent: { category: "element" },
   perform: (elements, appState, formData, app) => {
+    if (appState.selectedElementsAreBeingDragged) {
+      return false;
+    }
+
     // duplicate selected point(s) if editing a line
     if (appState.editingLinearElement) {
       // TODO: Invariants should be checked here instead of duplicateSelectedPoints()

--- a/packages/excalidraw/element/dragElements.ts
+++ b/packages/excalidraw/element/dragElements.ts
@@ -17,7 +17,7 @@ import {
 } from "./typeChecks";
 
 import type { Bounds } from "./bounds";
-import type { NonDeletedExcalidrawElement } from "./types";
+import type { ExcalidrawElement, NonDeletedExcalidrawElement } from "./types";
 import type Scene from "../scene/Scene";
 import type {
   AppState,
@@ -78,13 +78,20 @@ export const dragSelectedElements = (
     }
   }
 
-  const commonBounds = getCommonBounds(
-    Array.from(elementsToUpdate).map(
-      (el) => pointerDownState.originalElements.get(el.id) ?? el,
-    ),
-  );
+  const origElements: ExcalidrawElement[] = [];
+
+  for (const element of elementsToUpdate) {
+    const origElement = pointerDownState.originalElements.get(element.id);
+    // if original element is not set (e.g. when you duplicate during a drag
+    // operation), exit to avoid undefined behavior
+    if (!origElement) {
+      return;
+    }
+    origElements.push(origElement);
+  }
+
   const adjustedOffset = calculateOffset(
-    commonBounds,
+    getCommonBounds(origElements),
     offset,
     snapOffset,
     gridSize,


### PR DESCRIPTION
fix https://github.com/excalidraw/excalidraw/issues/9272#issuecomment-2726817896

This isn't really a fix. Instead we prevent dragging if you duplicate via `ctrl-D` during drag. A proper fix would be to update `pointerDownState.originalElements` with the duplicated elements, but it's not easily doable in current implem.

I checked other apps, and they do a mix of preventing drag (figma/figjam/miro) and weird behavior (eraser, tldraw).