### PR TITLE
feat: add keyboard shortcut to save file in text 

### DIFF
--- a/packages/excalidraw/element/textWysiwyg.tsx
+++ b/packages/excalidraw/element/textWysiwyg.tsx
@@ -393,9 +393,10 @@ export const textWysiwyg = ({
       event.preventDefault();
       submittedViaKeyboard = true;
       handleSubmit();
-    } else if (event.key === KEYS.S && event[KEYS.CTRL_OR_CMD]) {
+    } else if (actionSaveToActiveFile.keyTest(event)) {
       event.preventDefault();
-      app.actionManager.executeAction(actionSaveToActiveFile, "ui");
+      handleSubmit();
+      app.actionManager.executeAction(actionSaveToActiveFile);
     } else if (event.key === KEYS.ENTER && event[KEYS.CTRL_OR_CMD]) {
       event.preventDefault();
       if (event.isComposing || event.keyCode === 229) {

--- a/packages/excalidraw/element/textWysiwyg.tsx
+++ b/packages/excalidraw/element/textWysiwyg.tsx
@@ -18,6 +18,8 @@ import {
   isTestEnv,
 } from "../utils";
 
+import { actionSaveToActiveFile } from "../actions";
+
 import {
   originalContainerCache,
   updateOriginalContainerCache,
@@ -52,7 +54,6 @@ import type {
 } from "./types";
 import type App from "../components/App";
 import type { AppState } from "../types";
-import { actionSaveToActiveFile } from "../actions";
 
 const getTransform = (
   width: number,

--- a/packages/excalidraw/element/textWysiwyg.tsx
+++ b/packages/excalidraw/element/textWysiwyg.tsx
@@ -52,6 +52,7 @@ import type {
 } from "./types";
 import type App from "../components/App";
 import type { AppState } from "../types";
+import { actionSaveFileToDisk } from "../actions";
 
 const getTransform = (
   width: number,
@@ -392,6 +393,9 @@ export const textWysiwyg = ({
       event.preventDefault();
       submittedViaKeyboard = true;
       handleSubmit();
+    } else if (event.key === KEYS.S && event[KEYS.CTRL_OR_CMD]) {
+      event.preventDefault();
+      app.actionManager.executeAction(actionSaveFileToDisk, "ui");
     } else if (event.key === KEYS.ENTER && event[KEYS.CTRL_OR_CMD]) {
       event.preventDefault();
       if (event.isComposing || event.keyCode === 229) {

--- a/packages/excalidraw/element/textWysiwyg.tsx
+++ b/packages/excalidraw/element/textWysiwyg.tsx
@@ -52,7 +52,7 @@ import type {
 } from "./types";
 import type App from "../components/App";
 import type { AppState } from "../types";
-import { actionSaveFileToDisk } from "../actions";
+import { actionSaveToActiveFile } from "../actions";
 
 const getTransform = (
   width: number,
@@ -395,7 +395,7 @@ export const textWysiwyg = ({
       handleSubmit();
     } else if (event.key === KEYS.S && event[KEYS.CTRL_OR_CMD]) {
       event.preventDefault();
-      app.actionManager.executeAction(actionSaveFileToDisk, "ui");
+      app.actionManager.executeAction(actionSaveToActiveFile, "ui");
     } else if (event.key === KEYS.ENTER && event[KEYS.CTRL_OR_CMD]) {
       event.preventDefault();
       if (event.isComposing || event.keyCode === 229) {


### PR DESCRIPTION
fix for - CTRL + S opens browser 'save as html webpage' if a text field is selected instead of saving as .excalidraw #9281 