### PR TITLE
fix: allow build size gt>2mb

### DIFF
--- a/excalidraw-app/vite.config.mts
+++ b/excalidraw-app/vite.config.mts
@@ -128,6 +128,8 @@ export default defineConfig(({ mode }) => {
         },
 
         workbox: {
+          // allow size build +2MB (default)
+          maximumFileSizeToCacheInBytes: 5000000,
           // don't precache fonts, locales and separate chunks
           globIgnores: [
             "fonts.css",


### PR DESCRIPTION
https://vite-pwa-org.netlify.app/guide/faq.html#missing-assets-from-sw-precache-manifest

Error on build: 
```
2025-Apr-01 13:27:55.264344
#11 97.27 build/assets/index-CSauzfg4.js                                                            2,292.56 kB │ gzip: 648.51 kB │ map: 8,996.52 kB
2025-Apr-01 13:28:02.040508
#11 104.2 
2025-Apr-01 13:28:02.040508
#11 104.2  ERROR  error during build:
2025-Apr-01 13:28:02.040508
#11 104.2 Error: 
2025-Apr-01 13:28:02.040508
#11 104.2   Configure "workbox.maximumFileSizeToCacheInBytes" to change the limit: the default value is 2 MiB.
2025-Apr-01 13:28:02.040508
#11 104.2   Check https://vite-pwa-org.netlify.app/guide/faq.html#missing-assets-from-sw-precache-manifest for more information.
2025-Apr-01 13:28:02.040508
#11 104.2   Assets exceeding the limit:
2025-Apr-01 13:28:02.040508
#11 104.2   - assets/index-CSauzfg4.js is 2.29 MB, and won't be precached.
2025-Apr-01 13:28:02.040508
#11 104.2 
2025-Apr-01 13:28:02.040508
#11 104.2     at logWorkboxResult (file:///opt/node_app/node_modules/vite-plugin-pwa/dist/chunk-G4TAN34B.js:44:13)
2025-Apr-01 13:28:02.040508
#11 104.2     at generateServiceWorker (file:///opt/node_app/node_modules/vite-plugin-pwa/dist/index.js:229:3)
2025-Apr-01 13:28:02.040508
#11 104.2     at async _generateSW (file:///opt/node_app/node_modules/vite-plugin-pwa/dist/index.js:362:5)
2025-Apr-01 13:28:02.040508
#11 104.2     at async Object.handler (file:///opt/node_app/node_modules/vite-plugin-pwa/dist/index.js:526:13)
2025-Apr-01 13:28:02.040508
#11 104.2     at async PluginDriver.hookParallel (file:///opt/node_app/node_modules/vite/node_modules/rollup/dist/es/shared/node-entry.js:21757:17)
2025-Apr-01 13:28:02.040508
#11 104.2     at async Object.close (file:///opt/node_app/node_modules/vite/node_modules/rollup/dist/es/shared/node-entry.js:22741:13)
2025-Apr-01 13:28:02.040508
#11 104.2     at async build (file:///opt/node_app/node_modules/vite/dist/node/chunks/dep-9A4-l-43.js:67191:13)
2025-Apr-01 13:28:02.040508
#11 104.2     at async CAC.<anonymous> (file:///opt/node_app/node_modules/vite/dist/node/cli.js:845:9)
2025-Apr-01 13:28:02.040508
#11 104.2
```