### PR TITLE
fix: Add DOCTYPE and XML preamble in exported SVG documents

### DIFF
--- a/packages/common/src/constants.ts
+++ b/packages/common/src/constants.ts
@@ -319,6 +319,9 @@ export const DEFAULT_MAX_IMAGE_WIDTH_OR_HEIGHT = 1440;
 export const MAX_ALLOWED_FILE_BYTES = 4 * 1024 * 1024;
 
 export const SVG_NS = "http://www.w3.org/2000/svg";
+export const SVG_DOCUMENT_PREAMBLE = `<?xml version="1.0" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+`;
 
 export const ENCRYPTION_KEY_BITS = 128;
 

--- a/packages/excalidraw/data/index.ts
+++ b/packages/excalidraw/data/index.ts
@@ -5,6 +5,7 @@ import {
   isFirefox,
   MIME_TYPES,
   cloneJSON,
+  SVG_DOCUMENT_PREAMBLE,
 } from "@excalidraw/common";
 
 import { getNonDeletedElements } from "@excalidraw/element";
@@ -134,7 +135,9 @@ export const exportCanvas = async (
     if (type === "svg") {
       return fileSave(
         svgPromise.then((svg) => {
-          return new Blob([svg.outerHTML], { type: MIME_TYPES.svg });
+          return new Blob([SVG_DOCUMENT_PREAMBLE + svg.outerHTML], {
+            type: MIME_TYPES.svg,
+          });
         }),
         {
           description: "Export to SVG",

--- a/packages/excalidraw/data/index.ts
+++ b/packages/excalidraw/data/index.ts
@@ -135,6 +135,8 @@ export const exportCanvas = async (
     if (type === "svg") {
       return fileSave(
         svgPromise.then((svg) => {
+          // adding SVG preamble so that older software parse the SVG file
+          // properly
           return new Blob([SVG_DOCUMENT_PREAMBLE + svg.outerHTML], {
             type: MIME_TYPES.svg,
           });


### PR DESCRIPTION
SVG images exported by Excalidraw contain only the `<svg>` element representing the image, without specifying a DOCTYPE or the XML preamble for older tools to recognize and render images correctly.

This adds that preamble to increase compatibility, following recommendations from SVG 1.1: https://www.w3.org/TR/SVG11/struct.html

I tested this E2E. Exported image:

* Before:

```
<svg version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 856.1042326312408 424.0772977941177"  ...
```

* After:
```
<?xml version="1.0" standalone="no"?>
<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
<svg version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 856.1042326312408 424.0772977941177"  ...
```

Also verified that loading the new SVG document files both in existing Excalidraw version and in the new version works correctly.