### PR TITLE
docs: fix Browser integration example React import

### DIFF
--- a/dev-docs/docs/@excalidraw/excalidraw/integration.mdx
+++ b/dev-docs/docs/@excalidraw/excalidraw/integration.mdx
@@ -208,7 +208,7 @@ import TabItem from "@theme/TabItem";
 // See https://www.npmjs.com/package/@excalidraw/excalidraw documentation.
 import * as ExcalidrawLib from 'https://esm.sh/@excalidraw/excalidraw@0.18.0/dist/dev/index.js?external=react,react-dom';
 import React from "https://esm.sh/react@19.0.0";
-import ReactDOM from "https://esm.sh/react-dom@19.0.0"
+import { createRoot } from "https://esm.sh/react-dom@19.0.0/client";
 
 window.ExcalidrawLib = ExcalidrawLib;
 console.log("Excalidraw library", ExcalidrawLib);
@@ -228,7 +228,7 @@ const App = () => {
 };
 
 const excalidrawWrapper = document.getElementById("app");
-const root = ReactDOM.createRoot(excalidrawWrapper);
+const root = createRoot(excalidrawWrapper);
 root.render(React.createElement(App));
 ```
 


### PR DESCRIPTION
The previous version did not work for me.

Changed import and usage to match React documentation: https://react.dev/reference/react-dom/client/createRoot