### PR TITLE
feat: implementation of non-proportional resize for groups

### DIFF
--- a/packages/element/src/resizeElements.ts
+++ b/packages/element/src/resizeElements.ts
@@ -1378,8 +1378,21 @@ export const resizeMultipleElements = (
       );
 
     if (keepAspectRatio) {
-      scaleX = scale;
-      scaleY = scale;
+      // If the elements are in a group and shouldMaintainAspectRatio is true(meaning user is holding shift),
+      // we need to adjust the scaleX or scaleY based on the handleDirection
+      if(targetElements.some(item => isInGroup(item.latest)) && shouldMaintainAspectRatio) {
+        if(handleDirection.length === 1) {
+          if(handleDirection.includes("e") || handleDirection.includes("w")) {
+            scaleX = scale;
+          } else if (handleDirection.includes("n") || handleDirection.includes("s")) {
+            scaleY = scale;
+          }
+        }
+      }
+      else {
+        scaleX = scale;
+        scaleY = scale;
+      }
     }
 
     /**


### PR DESCRIPTION
This PR addresses #9342. It adds an additional check for to see if the user is holding shift and if it is a grouped object. I tried to add on to the code instead of removing things since I'm scared it might break more things. i know it could be a lot cleaner but just wanted to get feedback first. Please let me know what I could improve on!