### PR TITLE
fix: hide the alignment buttons if there is only one group selected (…

### DIFF
--- a/packages/excalidraw/actions/actionAlign.tsx
+++ b/packages/excalidraw/actions/actionAlign.tsx
@@ -8,6 +8,8 @@ import { KEYS, arrayToMap, getShortcutKey } from "@excalidraw/common";
 
 import { alignElements } from "@excalidraw/element/align";
 
+import { getMaximumGroups } from "@excalidraw/element/groups";
+
 import type { ExcalidrawElement } from "@excalidraw/element/types";
 
 import type { Alignment } from "@excalidraw/element/align";
@@ -36,8 +38,12 @@ export const alignActionsPredicate = (
   app: AppClassProperties,
 ) => {
   const selectedElements = app.scene.getSelectedElements(appState);
+  const groups = getMaximumGroups(
+    selectedElements,
+    app.scene.getNonDeletedElementsMap(),
+  );
   return (
-    selectedElements.length > 1 &&
+    groups.length > 1 &&
     // TODO enable aligning frames when implemented properly
     !selectedElements.some((el) => isFrameLikeElement(el))
   );


### PR DESCRIPTION
…they do nothing if only one group is selected)

This simply makes the buttons not show up on the left element toolbar if only one group is selected - the buttons do nothing anyway

previously this did not take into account the group, so if a group had more than 1 element in it, selecting it would show the align buttons (which had no effect when pressed because it's a group)