### PR TITLE
fix: laser pointer trail disappearing on pointerup (#9413)

### DIFF
--- a/packages/excalidraw/animated-trail.ts
+++ b/packages/excalidraw/animated-trail.ts
@@ -129,7 +129,8 @@ export class AnimatedTrail implements Trail {
   }
 
   private update() {
-    this.pastTrails = [];
+
+    
     this.start();
     if (this.trailAnimation) {
       this.trailAnimation.setAttribute("begin", "indefinite");

--- a/packages/excalidraw/animated-trail.ts
+++ b/packages/excalidraw/animated-trail.ts
@@ -129,8 +129,6 @@ export class AnimatedTrail implements Trail {
   }
 
   private update() {
-
-    
     this.start();
     if (this.trailAnimation) {
       this.trailAnimation.setAttribute("begin", "indefinite");


### PR DESCRIPTION
### 🐛 Bug Fix
Fixes issue #9413 where the laser pointer trail disappears immediately on pointerup.

### ✅ Changes
- Delay trail removal to allow smoother pointer fade-out.

![Screen Recording 2025-04-22 at 11 54 06 AM](https://github.com/user-attachments/assets/66abbcec-834b-4a7a-b540-58e703a1a214)

