### PR TITLE
fix: ungrouped bound text when duplicating element from a group outside to frame

### DIFF
--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -9262,6 +9262,29 @@ class App extends React.Component<AppProps, AppState> {
                   },
                   false,
                 );
+
+                const boundTextElementToContainer = getBoundTextElement(
+                  element,
+                  this.scene.getNonDeletedElementsMap(),
+                );
+
+                if (
+                  boundTextElementToContainer &&
+                  this.state.editingGroupId &&
+                  boundTextElementToContainer.groupIds.includes(
+                    this.state.editingGroupId,
+                  )
+                ) {
+                  mutateElement(
+                    boundTextElementToContainer,
+                    {
+                      groupIds: boundTextElementToContainer.groupIds.filter(
+                        (id) => id !== this.state.editingGroupId,
+                      ),
+                    },
+                    false,
+                  );
+                }
               }
 
               nextElements.forEach((element) => {


### PR DESCRIPTION

Related Issue Id: #9411 

![ezgif-82ece023283c51](https://github.com/user-attachments/assets/f3eb1f73-6fae-4c3d-9841-d55ccc7082ac)
