### PR TITLE
docs: added shape cycling shortcut in helper dialog

### DIFF
--- a/packages/excalidraw/components/HelpDialog.tsx
+++ b/packages/excalidraw/components/HelpDialog.tsx
@@ -248,7 +248,7 @@ export const HelpDialog = ({ onClose }: { onClose?: () => void }) => {
               shortcuts={[getShortcutKey("CtrlOrCmd+K")]}
             />
             <Shortcut
-              label={t("toolBar.shapeSwitch")}
+              label={t("toolBar.convertElementType")}
               shortcuts={["Tab", "Shift+Tab"]}
               isOr={true}
             />

--- a/packages/excalidraw/components/HelpDialog.tsx
+++ b/packages/excalidraw/components/HelpDialog.tsx
@@ -144,6 +144,11 @@ export const HelpDialog = ({ onClose }: { onClose?: () => void }) => {
           >
             <Shortcut label={t("toolBar.hand")} shortcuts={[KEYS.H]} />
             <Shortcut
+              label={t("toolBar.shapeSwitch")}
+              shortcuts={["Tab", "Shift+Tab"]}
+              isOr={true}
+            />
+            <Shortcut
               label={t("toolBar.selection")}
               shortcuts={[KEYS.V, KEYS["1"]]}
             />

--- a/packages/excalidraw/components/HelpDialog.tsx
+++ b/packages/excalidraw/components/HelpDialog.tsx
@@ -144,11 +144,6 @@ export const HelpDialog = ({ onClose }: { onClose?: () => void }) => {
           >
             <Shortcut label={t("toolBar.hand")} shortcuts={[KEYS.H]} />
             <Shortcut
-              label={t("toolBar.shapeSwitch")}
-              shortcuts={["Tab", "Shift+Tab"]}
-              isOr={true}
-            />
-            <Shortcut
               label={t("toolBar.selection")}
               shortcuts={[KEYS.V, KEYS["1"]]}
             />
@@ -251,6 +246,11 @@ export const HelpDialog = ({ onClose }: { onClose?: () => void }) => {
             <Shortcut
               label={t("toolBar.link")}
               shortcuts={[getShortcutKey("CtrlOrCmd+K")]}
+            />
+            <Shortcut
+              label={t("toolBar.shapeSwitch")}
+              shortcuts={["Tab", "Shift+Tab"]}
+              isOr={true}
             />
           </ShortcutIsland>
           <ShortcutIsland

--- a/packages/excalidraw/locales/en.json
+++ b/packages/excalidraw/locales/en.json
@@ -298,7 +298,8 @@
     "laser": "Laser pointer",
     "hand": "Hand (panning tool)",
     "extraTools": "More tools",
-    "mermaidToExcalidraw": "Mermaid to Excalidraw"
+    "mermaidToExcalidraw": "Mermaid to Excalidraw",
+    "shapeSwitch": "Cycle through shapes"
   },
   "element": {
     "rectangle": "Rectangle",

--- a/packages/excalidraw/locales/en.json
+++ b/packages/excalidraw/locales/en.json
@@ -299,7 +299,7 @@
     "hand": "Hand (panning tool)",
     "extraTools": "More tools",
     "mermaidToExcalidraw": "Mermaid to Excalidraw",
-    "shapeSwitch": "Cycle through shapes"
+    "convertElementType": "Toggle shape type"
   },
   "element": {
     "rectangle": "Rectangle",


### PR DESCRIPTION
Related Issue Id: #9463 
- Document Tab and Shift+Tab usage for shape cycling

![image](https://github.com/user-attachments/assets/18b1c09a-c72d-4752-a161-8a226b4d0dbc)
