### PR TITLE
feat: Add the zoom mode with Z + Drag

### DIFF
--- a/packages/common/src/constants.ts
+++ b/packages/common/src/constants.ts
@@ -48,6 +48,7 @@ export const CURSOR_TYPE = {
   GRAB: "grab",
   POINTER: "pointer",
   MOVE: "move",
+  ZOOM_IN: "zoom-in",
   AUTO: "",
 };
 export const POINTER_BUTTON = {

--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -603,6 +603,8 @@ let didTapTwice: boolean = false;
 let tappedTwiceTimer = 0;
 let isHoldingSpace: boolean = false;
 let isPanning: boolean = false;
+let isHoldingZ: boolean = false;
+let isZooming: boolean = false;
 let isDraggingScrollBar: boolean = false;
 let currentScrollBars: ScrollBars = { horizontal: null, vertical: null };
 let touchTimeout = 0;
@@ -4600,6 +4602,14 @@ class App extends React.Component<AppProps, AppState> {
         event.preventDefault();
       }
 
+      if (event.key === KEYS.Z && gesture.pointers.size === 0) {
+        isHoldingZ = true;
+        if (!isHoldingSpace) {
+          setCursor(this.interactiveCanvas, CURSOR_TYPE.ZOOM_IN);
+        }
+        event.preventDefault();
+      }
+
       if (
         (event.key === KEYS.G || event.key === KEYS.S) &&
         !event.altKey &&
@@ -4691,7 +4701,9 @@ class App extends React.Component<AppProps, AppState> {
 
   private onKeyUp = withBatchedUpdates((event: KeyboardEvent) => {
     if (event.key === KEYS.SPACE) {
-      if (
+      if (isHoldingZ === true) {
+        setCursor(this.interactiveCanvas, CURSOR_TYPE.ZOOM_IN);
+      } else if (
         this.state.viewModeEnabled ||
         this.state.openDialog?.name === "elementLinkSelector"
       ) {
@@ -4711,6 +4723,22 @@ class App extends React.Component<AppProps, AppState> {
         });
       }
       isHoldingSpace = false;
+    }
+    if (event.key === KEYS.Z) {
+      if (this.state.viewModeEnabled) {
+        setCursor(this.interactiveCanvas, CURSOR_TYPE.GRAB);
+      } else if (this.state.activeTool.type === "selection") {
+        resetCursor(this.interactiveCanvas);
+      } else {
+        setCursorForShape(this.interactiveCanvas, this.state);
+        this.setState({
+          selectedElementIds: makeNextSelectedElementIds({}, this.state),
+          selectedGroupIds: {},
+          editingGroupId: null,
+          activeEmbeddable: null,
+        });
+      }
+      isHoldingZ = false;
     }
     if (!event[KEYS.CTRL_OR_CMD] && !this.state.isBindingEnabled) {
       this.setState({ isBindingEnabled: true });
@@ -4818,7 +4846,7 @@ class App extends React.Component<AppProps, AppState> {
     const nextActiveTool = updateActiveTool(this.state, tool);
     if (nextActiveTool.type === "hand") {
       setCursor(this.interactiveCanvas, CURSOR_TYPE.GRAB);
-    } else if (!isHoldingSpace) {
+    } else if (!isHoldingSpace && !isHoldingZ) {
       setCursorForShape(this.interactiveCanvas, {
         ...this.state,
         activeTool: nextActiveTool,
@@ -5850,6 +5878,8 @@ class App extends React.Component<AppProps, AppState> {
     if (
       isHoldingSpace ||
       isPanning ||
+      isHoldingZ ||
+      isZooming ||
       isDraggingScrollBar ||
       isHandToolActive(this.state)
     ) {
@@ -6509,7 +6539,7 @@ class App extends React.Component<AppProps, AppState> {
       this.device = updateObject(this.device, { isTouchScreen: true });
     }
 
-    if (isPanning) {
+    if (isPanning || isZooming) {
       return;
     }
 
@@ -6519,6 +6549,10 @@ class App extends React.Component<AppProps, AppState> {
     // else it will send pointer state & laser pointer events in collab when
     // panning
     if (this.handleCanvasPanUsingWheelOrSpaceDrag(event)) {
+      return;
+    }
+
+    if (this.handleCanvasZoomUsingZDrag(event)) {
       return;
     }
 
@@ -6956,6 +6990,74 @@ class App extends React.Component<AppProps, AppState> {
       passive: true,
     });
     window.addEventListener(EVENT.POINTER_UP, teardown);
+    return true;
+  };
+
+  // Returns whether the event is a zooming
+  public handleCanvasZoomUsingZDrag = (
+    event: React.PointerEvent<HTMLElement> | MouseEvent,
+  ): boolean => {
+    if (
+      event.button === POINTER_BUTTON.WHEEL || !isHoldingZ
+    ) {
+      return false;
+    }
+    isZooming = true;
+    event.preventDefault();
+
+    let { clientX: lastX, clientY: lastY } = event;
+    const onPointerMove = withBatchedUpdatesThrottled((event: PointerEvent) => {
+      const deltaX = lastX - event.clientX;
+      const deltaY = lastY - event.clientY;
+
+      lastX = event.clientX;
+      lastY = event.clientY;
+
+      const newZoom =
+        this.state.zoom.value +
+        (deltaY / 500) * this.state.zoom.value -
+        (deltaX / 500) * this.state.zoom.value;
+
+      this.translateCanvas((state) => ({
+        ...getStateForZoom(
+          {
+            viewportX: this.lastViewportPosition.x,
+            viewportY: this.lastViewportPosition.y,
+            nextZoom: getNormalizedZoom(newZoom),
+          },
+          state,
+        ),
+        shouldCacheIgnoreZoom: true,
+      }));
+      this.resetShouldCacheIgnoreZoomDebounced();
+    });
+    const teardown = withBatchedUpdates(
+      (lastPointerUp = () => {
+        lastPointerUp = null;
+        isZooming = false;
+        if (!isHoldingZ) {
+          if (this.state.viewModeEnabled) {
+            setCursor(this.interactiveCanvas, CURSOR_TYPE.GRAB);
+          } else {
+            setCursorForShape(this.interactiveCanvas, this.state);
+          }
+        }
+        this.setState({
+          cursorButton: "up",
+        });
+        this.savePointer(event.clientX, event.clientY, "up");
+        window.removeEventListener(EVENT.POINTER_MOVE, onPointerMove);
+        window.removeEventListener(EVENT.POINTER_UP, teardown);
+        window.removeEventListener(EVENT.BLUR, teardown);
+        onPointerMove.flush();
+      }),
+    );
+    window.addEventListener(EVENT.BLUR, teardown);
+    window.addEventListener(EVENT.POINTER_MOVE, onPointerMove, {
+      passive: true,
+    });
+    window.addEventListener(EVENT.POINTER_UP, teardown);
+
     return true;
   };
 
@@ -11080,7 +11182,7 @@ class App extends React.Component<AppProps, AppState> {
 
       event.preventDefault();
 
-      if (isPanning) {
+      if (isPanning || isZooming) {
         return;
       }
 


### PR DESCRIPTION
What's Changed:  
- Drag-to-Zoom with Z key:
    - Hold Z + drag right/up to zoom in.
    - Hold Z + drag left/down to zoom out.
    - Works like the Space+drag panning for consistency.
- Custom zoom cursors: Added zoom-in (+) and zoom-out (-) cursor icons.
- Tablet/stylus support: Enables zoom without a mouse wheel.

Revives #7802: Completes the abandoned PR to improve accessibility and UX.

Resolve de issues #4626 and #7801. That users on tablets/stylus devices struggled with traditional zoom methods (e.g., mouse wheel or keyboard shortcuts). This provides an intuitive, pen-friendly alternative.

Key Benefits:
- **Familiar workflow**: Mirrors panning (Space+drag) for easier learning.
- **Tablet-friendly**: Perfect for stylus users (no mouse wheel needed).
- **Pro software feel**: Matches tools like Adobe (modifier key + drag).

Obs: Existing zoom methods (mouse wheel, shortcuts) remain unchanged.