### PR TITLE
fix: do not translate bound elements twice

### DIFF
--- a/packages/excalidraw/components/Stats/utils.ts
+++ b/packages/excalidraw/components/Stats/utils.ts
@@ -215,23 +215,6 @@ export const moveElement = (
       updateBindings(latestChildElement, scene, {
         simultaneouslyUpdated: originalChildren,
       });
-
-      const boundTextElement = getBoundTextElement(
-        latestChildElement,
-        originalElementsMap,
-      );
-      if (boundTextElement) {
-        const latestBoundTextElement = elementsMap.get(boundTextElement.id);
-        latestBoundTextElement &&
-          scene.mutateElement(
-            latestBoundTextElement,
-            {
-              x: boundTextElement.x + changeInX,
-              y: boundTextElement.y + changeInY,
-            },
-            { informMutation: shouldInformMutation, isDragging: false },
-          );
-      }
     });
   }
 };


### PR DESCRIPTION
from https://github.com/excalidraw/excalidraw/pull/9433