### PR TITLE
feat: more idiomatic element filters [POC]

### DIFF
--- a/packages/common/src/utility-types.ts
+++ b/packages/common/src/utility-types.ts
@@ -89,7 +89,7 @@ export type OutputAccumulator<
   : Accumulator extends MapAccumulator
   ? Map<
       OutputType extends { id: string } ? OutputType["id"] : string,
-      OutputType
+      [Attr] extends [never] ? OutputType : Attr
     >
   : Array<OutputType>;
 // -----------------------------------------------------------------------------

--- a/packages/common/src/utility-types.ts
+++ b/packages/common/src/utility-types.ts
@@ -68,3 +68,28 @@ export type MaybePromise<T> = T | Promise<T>;
 
 // get union of all keys from the union of types
 export type AllPossibleKeys<T> = T extends any ? keyof T : never;
+
+// utlity types for filter helper and related data structures
+// -----------------------------------------------------------------------------
+export type ReadonlyArrayOrMap<
+  T,
+  K = T extends { id: string } ? T["id"] : string,
+> = readonly T[] | ReadonlyMap<K, T>;
+
+export type GenericAccumulator<T = unknown> = Set<T> | Map<T, T> | Array<T>;
+export type ArrayAccumulator<T = unknown> = Array<T>;
+export type MapAccumulator<T = unknown, K = unknown> = Map<T, K>;
+export type SetAccumulator<T = unknown> = Set<T>;
+export type OutputAccumulator<
+  Accumulator,
+  OutputType,
+  Attr extends keyof OutputType = never,
+> = Accumulator extends SetAccumulator
+  ? Set<[Attr] extends [never] ? OutputType : Attr>
+  : Accumulator extends MapAccumulator
+  ? Map<
+      OutputType extends { id: string } ? OutputType["id"] : string,
+      OutputType
+    >
+  : Array<OutputType>;
+// -----------------------------------------------------------------------------

--- a/packages/element/src/dragElements.ts
+++ b/packages/element/src/dragElements.ts
@@ -26,6 +26,10 @@ import {
   isTextElement,
 } from "./typeChecks";
 
+import { filterElements } from "./utils";
+
+import { getFrameChildren } from "./frame";
+
 import type Scene from "./Scene";
 
 import type { Bounds } from "./bounds";
@@ -65,23 +69,13 @@ export const dragSelectedElements = (
     return true;
   });
 
-  // we do not want a frame and its elements to be selected at the same time
-  // but when it happens (due to some bug), we want to avoid updating element
-  // in the frame twice, hence the use of set
-  const elementsToUpdate = new Set<NonDeletedExcalidrawElement>(
-    selectedElements,
+  // update frames and their children (use a set to make sure we avoid
+  // duplicates in case the user already selected the frame's children)
+  const elementsToUpdate = getFrameChildren(
+    scene.getNonDeletedElements(),
+    filterElements(selectedElements, isFrameLikeElement, new Set(), "id"),
+    new Set(selectedElements),
   );
-  const frames = selectedElements
-    .filter((e) => isFrameLikeElement(e))
-    .map((f) => f.id);
-
-  if (frames.length > 0) {
-    for (const element of scene.getNonDeletedElements()) {
-      if (element.frameId !== null && frames.includes(element.frameId)) {
-        elementsToUpdate.add(element);
-      }
-    }
-  }
 
   const origElements: ExcalidrawElement[] = [];
 


### PR DESCRIPTION
[Proof of concept]

Just an idea for a more FP idiomatic element filtering helpers, instead of creating variables looping everywhere which makes it harder to read and maintain.

If we don't think it worth the cost, let's scrap it.

PR includes the `filterElements()` helper + rewrite of `getFrameChildren()` to use it + one use case in `dragSelectedElements()`.

---

The low-level helper would be `filterElements(elementsOrMap, predicateFunction, accumulator?, attr?)`.

You could use `filterElements()` directly to e.g. get frame elements by calling `filter(selectedElements, isFrameElement)`. By default it'd return `ExcalidrawFrameElement[]`.

If you wanted a Map instead, you'd do `filter(selectedElements, isFrameElement, new Map())` to get `Map<ExcalidrawFrameElement["id"], ExcalidrawFrameElement>`.

If you wanted a Set of frame ids, you could do: `filterElements(sceneElements, isFrameElement, new Set(), "id")`.

---

Then, we can build other higher-level filter methods on top, such as `getFrameChildren()` which underneath still uses `filterElements()` but uses its own `predicate` function. Thus callers don't touch `filterElements` at all when using `getFrameChildren()`.

## Downsides

The `filterElements` itself is low level and its complexity and type-unsafety ([case in point](https://github.com/excalidraw/excalidraw/pull/9487/commits/a050e87c0467b3e82d2eb0abed5ad53ff4bb63e2)) can be unit-tested & unit-tested.

But any higher-level functions such as the `getFrameChildren()` example also grows in complexity due to all the generic typing, so depending on how many other filter functions we'd wanna migrate to this new API, the codebase could get harder to maintain (and less safe due to the return type assertion — unless it can be worked around).

---

IMO, I think the `filterElements()` by itself is useful enough so we can keep at least that one.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a utility function for flexible, type-safe filtering and accumulation of elements from collections.
- **Refactor**
  - Improved the collection and handling of frame and child elements during drag operations for better performance and maintainability.
  - Enhanced the method for retrieving frame children to support multiple input types and accumulators, offering greater flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->