### PR TITLE
fix: replace `-moz-crisp-edges` with `crisp-edges` for better Firefox…

### DIFF
--- a/packages/excalidraw/css/styles.scss
+++ b/packages/excalidraw/css/styles.scss
@@ -82,9 +82,10 @@ body.excalidraw-cursor-resize * {
     // following props improve blurriness at certain devicePixelRatios.
     // AFAIK it doesn't affect export (in fact, export seems sharp either way).
 
-    image-rendering: pixelated; // chromium
-    // NOTE: must be declared *after* the above
-    image-rendering: -moz-crisp-edges; // FF
+    // image-rendering: pixelated; // chromium
+    // // NOTE: must be declared *after* the above
+    // image-rendering: -moz-crisp-edges; // FF
+    image-rendering: crisp-edges; // This will provide the same effect
 
     z-index: var(--zIndex-canvas);
 


### PR DESCRIPTION
… canvas rendering

Updated the canvas style to use `crisp-edges` instead of `-moz-crisp-edges` to avoid visual issues in Firefox. 
The previous combination of `pixelated` and `-moz-crisp-edges` caused conflicts, leading to blurry or distorted rendering. 

This change ensures smoother and more consistent visuals across browsers by using `crisp-edges`
fix : [https://github.com/excalidraw/excalidraw/issues/9470](https://github.com/excalidraw/excalidraw/issues/9470)