### PR TITLE
chore: Turn DragInput component into number input for improved UX

### DIFF
--- a/packages/excalidraw/components/Stats/DragInput.tsx
+++ b/packages/excalidraw/components/Stats/DragInput.tsx
@@ -315,6 +315,7 @@ const StatsDragInput = <
       </div>
       <input
         className="drag-input"
+        type="number"
         autoComplete="off"
         spellCheck="false"
         onKeyDown={(event) => {
@@ -331,9 +332,9 @@ const StatsDragInput = <
         }}
         ref={inputRef}
         value={inputValue}
-        onChange={(event) => {
+        onInput={(event) => {
           stateRef.current.updatePending = true;
-          setInputValue(event.target.value);
+          handleInputValue((event.target as HTMLInputElement).value, elements, appState);
         }}
         onFocus={(event) => {
           event.target.select();


### PR DESCRIPTION
This simply turns the underlying `input` HTML element in the `DragInput` component into a number input by adding the `type="number"` attribute and changing the `onChange` event to a slightly different `onInput` event to properly process the event.

The motivation for this is a slighly improved UX by allowing the user to either use their arrow keys or the native number input arrow buttons to modify the value, other than just the existing drag functionality. Depending on your OS, scrolling over the focused input element even works too.

![GIF](https://github.com/user-attachments/assets/f37e8b4e-ec95-4cd2-9ff5-883bf24c4f2a)

I personally am used to graphic programs offering this kind of functionality, so I thought it'd be helpful for many others too to be able to use this component in a similar fashion.

One might top that with modifier keys such as shift or CTRL / Alt / Option / whatever the OS offers to use steps like 10 or decimals, but I tried to keep it simple for now.