### PR TITLE
fix: unify line height across default fonts

### DIFF
--- a/packages/common/src/font-metadata.ts
+++ b/packages/common/src/font-metadata.ts
@@ -46,7 +46,7 @@ export const FONT_METADATA: Record<number, FontMetadata> = {
       unitsPerEm: 1000,
       ascender: 1011,
       descender: -353,
-      lineHeight: 1.35,
+      lineHeight: 1.25,
     },
   },
   [FONT_FAMILY["Lilita One"]]: {
@@ -116,7 +116,7 @@ export const FONT_METADATA: Record<number, FontMetadata> = {
       unitsPerEm: 1000,
       ascender: 880,
       descender: -144,
-      lineHeight: 1.15,
+      lineHeight: 1.25,
     },
     fallback: true,
   },

--- a/packages/excalidraw/wysiwyg/textWysiwyg.test.tsx
+++ b/packages/excalidraw/wysiwyg/textWysiwyg.test.tsx
@@ -1324,7 +1324,7 @@ describe("textWysiwyg", () => {
       ).toEqual(FONT_FAMILY.Nunito);
       expect(
         (h.elements[1] as ExcalidrawTextElementWithContainer).lineHeight,
-      ).toEqual(1.35);
+      ).toEqual(1.25);
     });
 
     describe("should align correctly", () => {


### PR DESCRIPTION
- unifies line-height across default fonts into 1.25


Closes #9511
