### PR TITLE
fix: improve ctrl+alt lasso selecting

### DIFF
--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -7276,8 +7276,13 @@ class App extends React.Component<AppProps, AppState> {
           });
           // If we click on something
         } else if (hitElement != null) {
+          // == deep selection ==
           // on CMD/CTRL, drill down to hit element regardless of groups etc.
           if (event[KEYS.CTRL_OR_CMD]) {
+            if (event.altKey) {
+              // ctrl + alt means we're lasso selecting
+              return false;
+            }
             if (!this.state.selectedElementIds[hitElement.id]) {
               pointerDownState.hit.wasAddedToSelection = true;
             }
@@ -8636,17 +8641,19 @@ class App extends React.Component<AppProps, AppState> {
         pointerDownState.lastCoords.x = pointerCoords.x;
         pointerDownState.lastCoords.y = pointerCoords.y;
         if (event.altKey) {
-          this.setActiveTool(
-            { type: "lasso", fromSelection: true },
-            event.shiftKey,
-          );
-          this.lassoTrail.startPath(
-            pointerDownState.origin.x,
-            pointerDownState.origin.y,
-            event.shiftKey,
-          );
-          this.setAppState({
-            selectionElement: null,
+          flushSync(() => {
+            this.setActiveTool(
+              { type: "lasso", fromSelection: true },
+              event.shiftKey,
+            );
+            this.lassoTrail.startPath(
+              pointerDownState.origin.x,
+              pointerDownState.origin.y,
+              event.shiftKey,
+            );
+            this.setAppState({
+              selectionElement: null,
+            });
           });
         } else {
           this.maybeDragNewGenericElement(pointerDownState, event);

--- a/packages/excalidraw/snapping.ts
+++ b/packages/excalidraw/snapping.ts
@@ -173,6 +173,8 @@ export const isSnappingEnabled = ({
       (app.state.objectsSnapModeEnabled && !event[KEYS.CTRL_OR_CMD]) ||
       (!app.state.objectsSnapModeEnabled &&
         event[KEYS.CTRL_OR_CMD] &&
+        // ctrl + alt means we're lasso selecting
+        !event.altKey &&
         !isGridModeEnabled(app))
     );
   }


### PR DESCRIPTION
when ctrl-alt lasso selecting:
- don't attempt to snap to objects (show snap lines)
- don't immediately select the element under cursor