### PR TITLE
feat: allow forms.microsoft.com domain for embeddables

### DIFF
--- a/packages/element/src/embeddable.ts
+++ b/packages/element/src/embeddable.ts
@@ -33,6 +33,8 @@ const RE_GH_GIST = /^https:\/\/gist\.github\.com\/([\w_-]+)\/([\w_-]+)/;
 const RE_GH_GIST_EMBED =
   /^<script[\s\S]*?\ssrc=["'](https:\/\/gist\.github\.com\/.*?)\.js["']/i;
 
+const RE_MSFORMS = /^(?:https?:\/\/)?forms\.microsoft\.com\//;
+
 // not anchored to start to allow <blockquote> twitter embeds
 const RE_TWITTER =
   /(?:https?:\/\/)?(?:(?:w){3}\.)?(?:twitter|x)\.com\/[^/]+\/status\/(\d+)/;
@@ -208,7 +210,7 @@ export const getEmbedLink = (
     };
   }
 
-  if (link.includes("forms.microsoft.com") && !link.includes("embed=true")) {
+  if (RE_MSFORMS.test(link) && !link.includes("embed=true")) {
     link += link.includes("?") ? "&embed=true" : "?embed=true";
   }
 

--- a/packages/element/src/embeddable.ts
+++ b/packages/element/src/embeddable.ts
@@ -83,7 +83,6 @@ const ALLOW_SAME_ORIGIN = new Set([
   "*.simplepdf.eu",
   "stackblitz.com",
   "reddit.com",
-  "forms.microsoft.com",
 ]);
 
 export const createSrcDoc = (body: string) => {

--- a/packages/element/src/embeddable.ts
+++ b/packages/element/src/embeddable.ts
@@ -69,6 +69,7 @@ const ALLOWED_DOMAINS = new Set([
   "val.town",
   "giphy.com",
   "reddit.com",
+  "forms.microsoft.com",
 ]);
 
 const ALLOW_SAME_ORIGIN = new Set([
@@ -82,6 +83,7 @@ const ALLOW_SAME_ORIGIN = new Set([
   "*.simplepdf.eu",
   "stackblitz.com",
   "reddit.com",
+  "forms.microsoft.com",
 ]);
 
 export const createSrcDoc = (body: string) => {

--- a/packages/element/src/embeddable.ts
+++ b/packages/element/src/embeddable.ts
@@ -208,6 +208,10 @@ export const getEmbedLink = (
     };
   }
 
+  if (link.includes("forms.microsoft.com") && !link.includes("embed=true")) {
+    link += link.includes("?") ? "&embed=true" : "?embed=true";
+  }
+
   if (RE_TWITTER.test(link)) {
     const postId = link.match(RE_TWITTER)![1];
     // the embed srcdoc still supports twitter.com domain only.

--- a/packages/element/src/embeddable.ts
+++ b/packages/element/src/embeddable.ts
@@ -83,6 +83,7 @@ const ALLOW_SAME_ORIGIN = new Set([
   "*.simplepdf.eu",
   "stackblitz.com",
   "reddit.com",
+  "forms.microsoft.com",
 ]);
 
 export const createSrcDoc = (body: string) => {


### PR DESCRIPTION
I'd love to use Excalidraw+ presentations in newsletters, and would love to include surveys in my newsletters.

I have tested the form with and without adding forms.microsoft.com to `ALLOW_SAME_ORIGIN`. The form does not load without whitelisting Microsoft Forms to `ALLOW_SAME_ORIGIN`.

Need to use the embeddable link for Microsoft Forms.

Test link: https://excalidraw-okf0e5ldz-excalidraw.vercel.app/#json=5AXOAgFQjS6FxIY3n8BkX,AYzsvRPpEtBZaRmElPgwrQ

![image](https://github.com/user-attachments/assets/6be8c283-612a-47ef-83a9-017e2824dccc)
