### PR TITLE
fix: alt + ctrl lasso selected elements not always kept

### DIFF
--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -9528,7 +9528,10 @@ class App extends React.Component<AppProps, AppState> {
         // if we're editing a line, pointerup shouldn't switch selection if
         // box selected
         (!this.state.editingLinearElement ||
-          !pointerDownState.boxSelection.hasOccurred)
+          !pointerDownState.boxSelection.hasOccurred) &&
+        // hitElemnt can be set when alt + ctrl to toggle lasso and we will
+        // just respect the selected elements from lasso instead
+        this.state.activeTool.type !== "lasso"
       ) {
         // when inside line editor, shift selects points instead
         if (childEvent.shiftKey && !this.state.editingLinearElement) {

--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -9529,7 +9529,7 @@ class App extends React.Component<AppProps, AppState> {
         // box selected
         (!this.state.editingLinearElement ||
           !pointerDownState.boxSelection.hasOccurred) &&
-        // hitElemnt can be set when alt + ctrl to toggle lasso and we will
+        // hitElement can be set when alt + ctrl to toggle lasso and we will
         // just respect the selected elements from lasso instead
         this.state.activeTool.type !== "lasso"
       ) {


### PR DESCRIPTION
close #9521 