### PR TITLE
fix: ghost point issue when moving a shape after dragging a point in the line editor

### DIFF
--- a/packages/element/src/linearElementEditor.ts
+++ b/packages/element/src/linearElementEditor.ts
@@ -508,6 +508,8 @@ export class LinearElementEditor {
     return {
       ...editingLinearElement,
       ...bindings,
+      segmentMidPointHoveredCoords: null,
+      hoverPointIndex: -1,
       // if clicking without previously dragging a point(s), and not holding
       // shift, deselect all points except the one clicked. If holding shift,
       // toggle the point.


### PR DESCRIPTION
This updates fixes the https://github.com/excalidraw/excalidraw/issues/9500 ghost point which appear while moving the shape after dragging a point in the line editor.
What's changed :

- In linearElementEditor.ts , handlePointerUp function's return value is updated , two more properties were added to updated
  linearElementEditor Element :
   { 
      segmentMidPointHoveredCoords: null, 
      hoverPointIndex: -1,
   }

       segmentMidPointHoveredCoords takes care of the all the points apart from edges , 
       while hoverPointIndex takes care of the edge points

@dwelle  @ryan-di  @ad1992 