### PR TITLE
fix: Make canvas search results stable by sorting by ID (#9503)

### DIFF
--- a/packages/excalidraw/components/SearchMenu.tsx
+++ b/packages/excalidraw/components/SearchMenu.tsx
@@ -800,8 +800,8 @@ const handleSearch = debounce(
       isFrameLikeElement(el),
     ) as ExcalidrawFrameLikeElement[];
 
-    texts.sort((a, b) => a.y - b.y);
-    frames.sort((a, b) => a.y - b.y);
+    texts.sort((a, b) => a.id.localeCompare(b.id));
+    frames.sort((a, b) => a.id.localeCompare(b.id));
 
     const textMatches: SearchMatchItem[] = [];
 


### PR DESCRIPTION
Fixes #9503

Prevents canvas search results from reordering when matched elements are dragged.

The results were previously sorted by element Y position, which changes during dragging, causing the list to reorder. This change sorts by the stable element ID instead.

**To test:**
1. Add multiple text elements containing the same word (e.g., "test 1", "test 2").
2. Search for that word ("test").
3. Drag one of the matching elements on the canvas.
4. Verify the order of results in the search list remains unchanged.

Before:
![before](https://github.com/user-attachments/assets/7c763fa9-f888-4792-880b-7bd4ba56cce4)

After:
![after](https://github.com/user-attachments/assets/c160ffad-2347-4391-b450-523affc578bf)