### PR TITLE
fix: allow selecting locked elements

### DIFF
--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -7213,6 +7213,10 @@ class App extends React.Component<AppProps, AppState> {
           this.getElementAtPosition(
             pointerDownState.origin.x,
             pointerDownState.origin.y,
+            {
+              preferSelected: true,
+              includeLockedElements: true,
+            },
           );
 
         this.hitLinkElement = this.getElementLinkAtPosition(

--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -5169,7 +5169,7 @@ class App extends React.Component<AppProps, AppState> {
     x: number,
     y: number,
     includeBoundTextElement: boolean = false,
-    includeLockedElements: boolean = false,
+    includeLockedElements: boolean = true,
   ): NonDeleted<ExcalidrawElement>[] {
     const iframeLikes: Ordered<ExcalidrawIframeElement>[] = [];
 


### PR DESCRIPTION
Locked elements previously could not be focused previously, making it diffucult to unlock elements without using right click or undo. This patch addresses the issue while mainting functionality (elements cannot be moved once locked). The selected element is still prioritized (locked or not), followed by the z-index. Closes: #9533

https://github.com/user-attachments/assets/8ea84a1c-c9dc-4582-9b72-92822d820797

