### PR TITLE
chore: Add DeepWiki badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@
   <a href="https://discord.gg/UexuTaE">
     <img alt="Chat on Discord" src="https://img.shields.io/discord/723672430744174682?color=738ad6&label=Chat%20on%20Discord&logo=discord&logoColor=ffffff&widge=false"/>
   </a>
+  <a href="https://deepwiki.com/excalidraw/excalidraw">
+    <img alt="Ask DeepWiki" src="https://deepwiki.com/badge.svg" />
+  </a>
   <a href="https://twitter.com/excalidraw">
     <img alt="Follow Excalidraw on Twitter" src="https://img.shields.io/twitter/follow/excalidraw.svg?label=follow+@excalidraw&style=social&logo=twitter"/>
   </a>


### PR DESCRIPTION
Last index was on `17 April 2025`, which makes it a bit out of date now.

Adding the badge should re-index it weekly, according to this popup:

<img width="372" alt="Screenshot 2025-05-22 at 12 31 07" src="https://github.com/user-attachments/assets/5d5343d3-6899-465c-9e94-0fc08f7b5390" />
