### PR TITLE
feat: notify user when no shape tool is active

### DIFF
--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -621,6 +621,19 @@ const gesture: Gesture = {
 };
 
 class App extends React.Component<AppProps, AppState> {
+  private static readonly NON_DRAWING_TOOLS: readonly ToolType[] = [
+    "selection",
+    "hand",
+    "lasso",
+    "text",
+    "image",
+    "eraser",
+    "frame",
+    "magicframe",
+    "embeddable",
+    "laser"
+  ];
+
   canvas: AppClassProperties["canvas"];
   interactiveCanvas: AppClassProperties["interactiveCanvas"] = null;
   rc: RoughCanvas;
@@ -6433,6 +6446,18 @@ class App extends React.Component<AppProps, AppState> {
   private handleCanvasPointerDown = (
     event: React.PointerEvent<HTMLElement>,
   ) => {
+    const isNonDrawingTool = 
+      this.state.activeTool.type === "custom" || 
+      App.NON_DRAWING_TOOLS.includes(this.state.activeTool.type as ToolType);
+    
+    if (isNonDrawingTool) {
+      this.setToast({
+        message: "Please select a shape tool to draw.",
+        closable: true,
+        duration: 2000,
+      });
+      return;
+    }
     const target = event.target as HTMLElement;
     // capture subsequent pointer events to the canvas
     // this makes other elements non-interactive until pointer up
@@ -9816,7 +9841,7 @@ class App extends React.Component<AppProps, AppState> {
         !(hitElement && isElbowArrow(hitElement)) &&
         // not dragged
         !pointerDownState.drag.hasOccurred &&
-        // not resized
+        // not resizing
         !this.state.isResizing &&
         // only hitting the bounding box of the previous hit element
         ((hitElement &&


### PR DESCRIPTION
Adds a toast notification that prompts the user to select a shape tool before drawing. If a non-drawing tool is selected and the user tries to draw, a toast appears with the message: "Please select a shape tool to draw." 

## Summary of Changes

- **Feature:** Added a toast notification to guide users when attempting to draw without a shape tool selected.
- **Behavior:**  
  - If a user tries to draw while a non-drawing tool (such as selection, hand, lasso, text, image, eraser, custom, frame, magicframe, or laser) is active, a toast appears with the message:  
    **"Please select a shape tool to draw."**
  - The drawing action is prevented until a shape tool is selected.
- **Implementation:**  
  - Inserted a check at the top of the `handleCanvasPointerDown` method in `App.tsx`.
  - If a non-drawing tool is selected, the toast is shown using `this.setToast` and the method returns early.

---

fixes #9541


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a notification prompting users to select a shape tool when attempting to draw with a non-drawing or custom tool. The message appears as a closable toast for 2 seconds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->