### PR TITLE
fix: Increase the maximumFileSizeToCacheInBytes limit to 5MB in the v…

### DIFF
--- a/excalidraw-app/vite.config.mts
+++ b/excalidraw-app/vite.config.mts
@@ -140,7 +140,7 @@ export default defineConfig(({ mode }) => {
         },
 
         workbox: {
-          maximumFileSizeToCacheInBytes: 5 * 1024 *1024 // 5MB
+          maximumFileSizeToCacheInBytes: 5 * 1024 *1024, // 5MB
           // don't precache fonts, locales and separate chunks
           globIgnores: [
             "fonts.css",


### PR DESCRIPTION
Reference Issue: [9354](https://github.com/excalidraw/excalidraw/issues/9354)


Based on the error message, the build is failing because the main JavaScript bundle (assets/index-DlRwqTH8.js) is 2.3 MB, which exceeds the default 2 MB limit for precaching in the workbox configuration.

This PR fixes it by:

Increasing the maximumFileSizeToCacheInBytes limit to 5MB in the vite-plugin-pwa configuration