### PR TITLE
feat: add hex color input validation with error feedback

### DIFF
--- a/packages/excalidraw/components/ColorPicker/ColorInput.tsx
+++ b/packages/excalidraw/components/ColorPicker/ColorInput.tsx
@@ -11,6 +11,7 @@ import { eyeDropperIcon } from "../icons";
 
 import { getColor } from "./ColorPicker";
 import { activeColorPickerSectionAtom } from "./colorPickerUtils";
+import { validateHexColor } from "./hexValidation";
 
 import type { ColorPickerType } from "./colorPickerUtils";
 
@@ -31,23 +32,32 @@ export const ColorInput = ({
 }: ColorInputProps) => {
   const device = useDevice();
   const [innerValue, setInnerValue] = useState(color);
+  const [validationError, setValidationError] = useState<string | null>(null);
   const [activeSection, setActiveColorPickerSection] = useAtom(
     activeColorPickerSectionAtom,
   );
 
   useEffect(() => {
     setInnerValue(color);
+    setValidationError(null);
   }, [color]);
 
   const changeColor = useCallback(
     (inputValue: string) => {
       const value = inputValue.toLowerCase();
-      const color = getColor(value);
-
-      if (color) {
-        onChange(color);
-      }
       setInnerValue(value);
+
+      const validation = validateHexColor(value);
+
+      if (validation.isValid) {
+        setValidationError(null);
+        const color = getColor(value);
+        if (color) {
+          onChange(color);
+        }
+      } else {
+        setValidationError(validation.errorKey || "colorPicker.invalidHexCode");
+      }
     },
     [onChange],
   );
@@ -70,66 +80,91 @@ export const ColorInput = ({
   }, [setEyeDropperState]);
 
   return (
-    <div className="color-picker__input-label">
-      <div className="color-picker__input-hash">#</div>
-      <input
-        ref={activeSection === "hex" ? inputRef : undefined}
-        style={{ border: 0, padding: 0 }}
-        spellCheck={false}
-        className="color-picker-input"
-        aria-label={label}
-        onChange={(event) => {
-          changeColor(event.target.value);
-        }}
-        value={(innerValue || "").replace(/^#/, "")}
-        onBlur={() => {
-          setInnerValue(color);
-        }}
-        tabIndex={-1}
-        onFocus={() => setActiveColorPickerSection("hex")}
-        onKeyDown={(event) => {
-          if (event.key === KEYS.TAB) {
-            return;
-          } else if (event.key === KEYS.ESCAPE) {
-            eyeDropperTriggerRef.current?.focus();
-          }
-          event.stopPropagation();
-        }}
-        placeholder={placeholder}
-      />
-      {/* TODO reenable on mobile with a better UX */}
-      {!device.editor.isMobile && (
-        <>
-          <div
-            style={{
-              width: "1px",
-              height: "1.25rem",
-              backgroundColor: "var(--default-border-color)",
-            }}
-          />
-          <div
-            ref={eyeDropperTriggerRef}
-            className={clsx("excalidraw-eye-dropper-trigger", {
-              selected: eyeDropperState,
-            })}
-            onClick={() =>
-              setEyeDropperState((s) =>
-                s
-                  ? null
-                  : {
-                      keepOpenOnAlt: false,
-                      onSelect: (color) => onChange(color),
-                      colorPickerType,
-                    },
-              )
+    <div>
+      <div
+        className={clsx("color-picker__input-label", {
+          "color-picker__input-label--error": validationError,
+        })}
+      >
+        <div className="color-picker__input-hash">#</div>
+        <input
+          ref={activeSection === "hex" ? inputRef : undefined}
+          style={{ border: 0, padding: 0 }}
+          spellCheck={false}
+          className={clsx("color-picker-input", {
+            "color-picker-input--error": validationError,
+          })}
+          aria-label={label}
+          aria-invalid={!!validationError}
+          aria-describedby={validationError ? "hex-error" : undefined}
+          onChange={(event) => {
+            changeColor(event.target.value);
+          }}
+          value={(innerValue || "").replace(/^#/, "")}
+          onBlur={() => {
+            setInnerValue(color);
+            setValidationError(null);
+          }}
+          tabIndex={-1}
+          onFocus={() => setActiveColorPickerSection("hex")}
+          onKeyDown={(event) => {
+            if (event.key === KEYS.TAB) {
+              return;
+            } else if (event.key === KEYS.ESCAPE) {
+              eyeDropperTriggerRef.current?.focus();
             }
-            title={`${t(
-              "labels.eyeDropper",
-            )} — ${KEYS.I.toLocaleUpperCase()} or ${getShortcutKey("Alt")} `}
-          >
-            {eyeDropperIcon}
-          </div>
-        </>
+            event.stopPropagation();
+          }}
+          placeholder={placeholder}
+        />
+        {/* TODO reenable on mobile with a better UX */}
+        {!device.editor.isMobile && (
+          <>
+            <div
+              style={{
+                width: "1px",
+                height: "1.25rem",
+                backgroundColor: "var(--default-border-color)",
+              }}
+            />
+            <div
+              ref={eyeDropperTriggerRef}
+              className={clsx("excalidraw-eye-dropper-trigger", {
+                selected: eyeDropperState,
+              })}
+              onClick={() =>
+                setEyeDropperState((s) =>
+                  s
+                    ? null
+                    : {
+                        keepOpenOnAlt: false,
+                        onSelect: (color) => onChange(color),
+                        colorPickerType,
+                      },
+                )
+              }
+              title={`${t(
+                "labels.eyeDropper",
+              )} — ${KEYS.I.toLocaleUpperCase()} or ${getShortcutKey("Alt")} `}
+            >
+              {eyeDropperIcon}
+            </div>
+          </>
+        )}
+      </div>
+      {validationError && (
+        <div
+          id="hex-error"
+          className="color-picker__input-error"
+          role="alert"
+          aria-live="polite"
+        >
+          {validationError === "colorPicker.hexCodeLength"
+            ? t("colorPicker.hexCodeLength")
+            : validationError === "colorPicker.hexCodeCharacters"
+            ? t("colorPicker.hexCodeCharacters")
+            : t("colorPicker.invalidHexCode")}
+        </div>
       )}
     </div>
   );

--- a/packages/excalidraw/components/ColorPicker/ColorPicker.scss
+++ b/packages/excalidraw/components/ColorPicker/ColorPicker.scss
@@ -351,10 +351,28 @@
       box-shadow: 0 0 0 1px var(--color-primary-darkest);
       border-radius: var(--border-radius-lg);
     }
+
+    &--error {
+      border-color: var(--color-danger);
+
+      &:focus-within {
+        box-shadow: 0 0 0 1px var(--color-danger);
+      }
+    }
   }
 
   .color-picker__input-hash {
     padding: 0 0.25rem;
+  }
+
+  .color-picker__input-error {
+    font-size: 0.75rem;
+    color: var(--color-danger-icon-color);
+    margin: 0 8px 8px 8px;
+    padding: 4px 8px;
+    background-color: var(--color-danger-icon-background);
+    border-radius: 4px;
+    border: 1px solid var(--color-danger);
   }
 
   .color-picker-input {
@@ -388,6 +406,10 @@
 
     &:focus-visible {
       box-shadow: none;
+    }
+
+    &--error {
+      color: var(--color-danger);
     }
   }
 

--- a/packages/excalidraw/components/ColorPicker/ColorPicker.tsx
+++ b/packages/excalidraw/components/ColorPicker/ColorPicker.tsx
@@ -25,6 +25,7 @@ import { Picker } from "./Picker";
 import PickerHeading from "./PickerHeading";
 import { TopPicks } from "./TopPicks";
 import { activeColorPickerSectionAtom, isColorDark } from "./colorPickerUtils";
+import { validateHexColor, isValidColorBrowser } from "./hexValidation";
 
 import "./ColorPicker.scss";
 
@@ -32,23 +33,24 @@ import type { ColorPickerType } from "./colorPickerUtils";
 
 import type { AppState } from "../../types";
 
-const isValidColor = (color: string) => {
-  const style = new Option().style;
-  style.color = color;
-  return !!style.color;
-};
-
 export const getColor = (color: string): string | null => {
   if (isTransparent(color)) {
     return color;
   }
 
-  // testing for `#` first fixes a bug on Electron (more specfically, an
+  // First try our hex validation for better error handling
+  const hexValidation = validateHexColor(color);
+  if (hexValidation.isValid && hexValidation.normalizedValue) {
+    return hexValidation.normalizedValue;
+  }
+
+  // Fallback to browser validation for edge cases (named colors, etc.)
+  // testing for `#` first fixes a bug on Electron (more specifically, an
   // Obsidian popout window), where a hex color without `#` is (incorrectly)
   // considered valid
-  return isValidColor(`#${color}`)
+  return isValidColorBrowser(`#${color}`)
     ? `#${color}`
-    : isValidColor(color)
+    : isValidColorBrowser(color)
     ? color
     : null;
 };

--- a/packages/excalidraw/components/ColorPicker/hexValidation.test.ts
+++ b/packages/excalidraw/components/ColorPicker/hexValidation.test.ts
@@ -1,0 +1,110 @@
+import { validateHexColor } from "./hexValidation";
+
+describe("validateHexColor", () => {
+  it("should accept valid hex colors", () => {
+    // 3-character hex
+    expect(validateHexColor("abc")).toEqual({
+      isValid: true,
+      normalizedValue: "#abc",
+    });
+
+    // 4-character hex (with alpha)
+    expect(validateHexColor("abcd")).toEqual({
+      isValid: true,
+      normalizedValue: "#abcd",
+    });
+
+    // 6-character hex
+    expect(validateHexColor("abcdef")).toEqual({
+      isValid: true,
+      normalizedValue: "#abcdef",
+    });
+
+    // 8-character hex (with alpha)
+    expect(validateHexColor("abcdef12")).toEqual({
+      isValid: true,
+      normalizedValue: "#abcdef12",
+    });
+
+    // With # prefix
+    expect(validateHexColor("#abc")).toEqual({
+      isValid: true,
+      normalizedValue: "#abc",
+    });
+
+    // Uppercase letters
+    expect(validateHexColor("ABCDEF")).toEqual({
+      isValid: true,
+      normalizedValue: "#abcdef",
+    });
+  });
+
+  it("should reject invalid lengths", () => {
+    // Too short
+    expect(validateHexColor("a")).toEqual({
+      isValid: false,
+      errorKey: "colorPicker.hexCodeLength",
+    });
+
+    expect(validateHexColor("ab")).toEqual({
+      isValid: false,
+      errorKey: "colorPicker.hexCodeLength",
+    });
+
+    // Invalid lengths
+    expect(validateHexColor("abcde")).toEqual({
+      isValid: false,
+      errorKey: "colorPicker.hexCodeLength",
+    });
+
+    expect(validateHexColor("abcdefg")).toEqual({
+      isValid: false,
+      errorKey: "colorPicker.hexCodeLength",
+    });
+
+    // Too long
+    expect(validateHexColor("123456789")).toEqual({
+      isValid: false,
+      errorKey: "colorPicker.hexCodeLength",
+    });
+  });
+
+  it("should reject invalid characters", () => {
+    expect(validateHexColor("zzzzzz")).toEqual({
+      isValid: false,
+      errorKey: "colorPicker.hexCodeCharacters",
+    });
+
+    expect(validateHexColor("blue")).toEqual({
+      isValid: false,
+      errorKey: "colorPicker.hexCodeCharacters",
+    });
+
+    expect(validateHexColor("12345g")).toEqual({
+      isValid: false,
+      errorKey: "colorPicker.hexCodeCharacters",
+    });
+
+    expect(validateHexColor("abc!")).toEqual({
+      isValid: false,
+      errorKey: "colorPicker.hexCodeCharacters",
+    });
+  });
+
+  it("should handle empty input", () => {
+    expect(validateHexColor("")).toEqual({
+      isValid: true,
+    });
+
+    expect(validateHexColor("   ")).toEqual({
+      isValid: true,
+    });
+  });
+
+  it("should handle whitespace", () => {
+    expect(validateHexColor("  abc  ")).toEqual({
+      isValid: true,
+      normalizedValue: "#abc",
+    });
+  });
+});

--- a/packages/excalidraw/components/ColorPicker/hexValidation.ts
+++ b/packages/excalidraw/components/ColorPicker/hexValidation.ts
@@ -1,0 +1,53 @@
+export interface HexValidationResult {
+  isValid: boolean;
+  errorKey?: string;
+  normalizedValue?: string;
+}
+
+/**
+ * Validates a hex color input and returns detailed validation result
+ * @param input - The hex color input (with or without #)
+ * @returns Validation result with error details
+ */
+export const validateHexColor = (input: string): HexValidationResult => {
+  if (!input || input.trim() === "") {
+    return { isValid: true }; // Empty input is valid (will be handled as no color)
+  }
+
+  // Remove # if present and convert to lowercase
+  const cleanInput = input.replace(/^#/, "").toLowerCase().trim();
+
+  // Check for valid length (3, 4, 6, or 8 characters)
+  const validLengths = [3, 4, 6, 8];
+  if (!validLengths.includes(cleanInput.length)) {
+    return {
+      isValid: false,
+      errorKey: "colorPicker.hexCodeLength",
+    };
+  }
+
+  // Check for valid hex characters (0-9, a-f)
+  const hexPattern = /^[0-9a-f]+$/;
+  if (!hexPattern.test(cleanInput)) {
+    return {
+      isValid: false,
+      errorKey: "colorPicker.hexCodeCharacters",
+    };
+  }
+
+  // If we get here, it's a valid hex color
+  return {
+    isValid: true,
+    normalizedValue: `#${cleanInput}`,
+  };
+};
+
+/**
+ * Checks if a hex color is valid using browser's native validation
+ * This is used as a fallback for edge cases
+ */
+export const isValidColorBrowser = (color: string): boolean => {
+  const style = new Option().style;
+  style.color = color;
+  return !!style.color;
+};

--- a/packages/excalidraw/locales/en.json
+++ b/packages/excalidraw/locales/en.json
@@ -561,7 +561,10 @@
     "colors": "Colors",
     "shades": "Shades",
     "hexCode": "Hex code",
-    "noShades": "No shades available for this color"
+    "noShades": "No shades available for this color",
+    "invalidHexCode": "Invalid hex code",
+    "hexCodeLength": "Hex code must be 3, 4, 6, or 8 characters",
+    "hexCodeCharacters": "Hex code can only contain 0-9 and A-F"
   },
   "overwriteConfirm": {
     "action": {


### PR DESCRIPTION
#### Description

Add hex color input validation with error feedback

- Validate hex color length (3,4,6,8 chars) and characters (0-9,A-F)
- Show user-friendly error messages with theme support
- Add comprehensive test coverage
- Improve UX by replacing silent failures with clear feedback

#### Issue Link
https://github.com/excalidraw/excalidraw/issues/9527

#### Screenshot (Light mode)

<img width="1440" alt="Screenshot 2025-05-25 at 11 26 24 PM" src="https://github.com/user-attachments/assets/17b446ca-badc-4ccd-b29c-e6da46751f3d" />

<img width="1440" alt="Screenshot 2025-05-25 at 11 26 06 PM" src="https://github.com/user-attachments/assets/b1bbc54a-01a5-4bba-9d58-3804b55b62ad" />

#### Screenshot (Dark mode)

<img width="1440" alt="Screenshot 2025-05-25 at 11 26 48 PM" src="https://github.com/user-attachments/assets/417b84e5-f15f-4db4-a1f7-2720bb1bf1f6" />

<img width="1440" alt="Screenshot 2025-05-25 at 11 26 55 PM" src="https://github.com/user-attachments/assets/bfb4cae3-2620-485f-ac38-c2e4ec574897" />


