### PR TITLE
docs: added the correct CSS import for nextjs dynamic first import integration example

### DIFF
--- a/dev-docs/docs/@excalidraw/excalidraw/integration.mdx
+++ b/dev-docs/docs/@excalidraw/excalidraw/integration.mdx
@@ -38,6 +38,8 @@ If you want to only import `Excalidraw` component you can do :point_down:
 
 ```jsx showLineNumbers
 import dynamic from "next/dynamic";
+import "@excalidraw/excalidraw/index.css";
+
 const Excalidraw = dynamic(
   async () => (await import("@excalidraw/excalidraw")).Excalidraw,
   {


### PR DESCRIPTION
This is with reference to [this](https://github.com/excalidraw/excalidraw/issues/9562)