### PR TITLE
feat: export duplicateElement duplicateElements

### DIFF
--- a/packages/excalidraw/index.tsx
+++ b/packages/excalidraw/index.tsx
@@ -305,3 +305,4 @@ export { getDataURL } from "./data/blob";
 export { isElementLink } from "@excalidraw/element";
 
 export { setCustomTextMetricsProvider } from "@excalidraw/element";
+export { duplicateElement, duplicateElements } from "@excalidraw/element";


### PR DESCRIPTION
## Background

I'm integrating Excalidraw into my website and working on building a custom library panel. I've already managed to fetch data from the library URL and display SVGs using `loadLibraryFromBlob` and `exportToSvg`. However, if I want to copy data to event transfer, I need to handle it using `duplicateElements` and `duplicateElement` which is not exported form the main package.

thank you

