### PR TITLE
feat: Use selection-color for line-handles, box select and snap anchors

### DIFF
--- a/packages/common/src/colors.ts
+++ b/packages/common/src/colors.ts
@@ -187,32 +187,48 @@ export const rgbToString = (color: ColorRGBTuple, alpha = 1) =>
     : `rgba(${color[0]}, ${color[1]}, ${color[2]}, ${alpha})`;
 
 /**
- * Will convert a css color string to a color-tuple. 
+ * Will convert a css color string to a color-tuple.
  * Colors must be in a valid format.
- * 
+ *
  * Supported formats are:
  * - #000, #000f, #000000, #000000ff
  * - rgb(255, 255, 255)
  * - rgba(255, 255, 255, 80%)
- * 
+ *
  * Unhandled formats (hsv, lch, ...) will return [0, 0, 0] (black).
- * 
+ *
  * @param color a css color-string
  * @returns a color-tuple
  */
 const colorToRgb = (color: string) => {
   if (color[0] === "#") {
-    let c = parseInt(color.slice(1), 16);
+    const c = parseInt(color.slice(1), 16);
     if (!isNaN(c)) {
       switch (color.length) {
         case 4:
-          return [(c & 0xf00) >> 4, c & 0xf0, (c & 0xf) << 4] as ColorRGBTuple;
+          return [
+            (c & 0xf00) >> 4,
+            c & 0xf0, 
+            (c & 0xf) << 4
+          ] as ColorRGBTuple;
         case 5:
-          return [(c & 0xf000) >> 8, (c & 0xf00) >> 4, c & 0xf0] as ColorRGBTuple;
+          return [
+            (c & 0xf000) >> 8,
+            (c & 0xf00) >> 4,
+            c & 0xf0
+          ] as ColorRGBTuple;
         case 7:
-          return [c >> 16, (c & 0xff00) >> 8, c & 0xff] as ColorRGBTuple;
+          return [
+            c >> 16,
+            (c & 0xff00) >> 8,
+            c & 0xff
+          ] as ColorRGBTuple;
         case 9:
-          return [c >> 24, (c & 0xff0000) >> 16, (c & 0xff00) >> 8] as ColorRGBTuple;
+          return [
+            c >> 24, 
+            (c & 0xff0000) >> 16,
+            (c & 0xff00) >> 8
+          ] as ColorRGBTuple;
       }
     }
   } else if (color.startsWith("rgba(")) {
@@ -233,10 +249,11 @@ const colorToRgb = (color: string) => {
  * Tries to convert a css-color of unknown format to a RGB-tuple.
  * Will fail with `lch`, `oklch`, `lab` or `oklab`, returning [0,0,0] (black),
  * but handles any notation of `rgb`, `rgba`, `hsl` and `hwb` as well as _named colors_.
- * 
+ *
  * @returns a RGB-tuple or black if the conversion was unsuccessfull.
  */
-export const colorToRgbWithCanvas = (context: CanvasRenderingContext2D, color: string) => {
+export const colorToRgbWithCanvas = 
+  (context: CanvasRenderingContext2D, color: string) => {
   context.save();
 
   context.fillStyle = color;
@@ -247,6 +264,6 @@ export const colorToRgbWithCanvas = (context: CanvasRenderingContext2D, color: s
 
   // this wont throw, as the canvas will only return normalized colors or #000000 as fallback.
   return colorToRgb(recomputedFillStyle);
-}
+};
 
 // -----------------------------------------------------------------------------

--- a/packages/element/src/renderElement.ts
+++ b/packages/element/src/renderElement.ts
@@ -29,7 +29,7 @@ import type {
 
 import type {
   StaticCanvasRenderConfig,
-  RenderableElementsMap
+  RenderableElementsMap,
 } from "@excalidraw/excalidraw/scene/types";
 
 import { getElementAbsoluteCoords } from "./bounds";

--- a/packages/excalidraw/renderer/interactiveScene.ts
+++ b/packages/excalidraw/renderer/interactiveScene.ts
@@ -15,11 +15,11 @@ import {
   THEME,
   throttleRAF,
 } from "@excalidraw/common";
-import { 
+import {
   colorToRgbWithCanvas,
   lightenRgb,
   rgbToString,
-  type ColorRGBTuple
+  type ColorRGBTuple,
 } from "@excalidraw/common/colors";
 
 import { FIXED_BINDING_DISTANCE, maxBindingGap } from "@excalidraw/element";
@@ -102,7 +102,7 @@ import type {
 const renderElbowArrowMidPointHighlight = (
   context: CanvasRenderingContext2D,
   appState: InteractiveCanvasAppState,
-  selectionColor: ColorRGBTuple
+  selectionColor: ColorRGBTuple,
 ) => {
   invariant(appState.selectedLinearElement, "selectedLinearElement is null");
 
@@ -113,17 +113,21 @@ const renderElbowArrowMidPointHighlight = (
   context.save();
   context.translate(appState.scrollX, appState.scrollY);
 
-  highlightPoint(segmentMidPointHoveredCoords, context, appState, selectionColor);
+  highlightPoint(
+    segmentMidPointHoveredCoords,
+    context,
+    appState,
+    selectionColor,
+  );
 
   context.restore();
 };
-
 
 const renderLinearElementPointHighlight = (
   context: CanvasRenderingContext2D,
   appState: InteractiveCanvasAppState,
   elementsMap: ElementsMap,
-  selectionColor: ColorRGBTuple
+  selectionColor: ColorRGBTuple,
 ) => {
   const { elementId, hoverPointIndex } = appState.selectedLinearElement!;
   if (
@@ -154,7 +158,7 @@ const highlightPoint = <Point extends LocalPoint | GlobalPoint>(
   point: Point,
   context: CanvasRenderingContext2D,
   appState: InteractiveCanvasAppState,
-  selectionColor: ColorRGBTuple
+  selectionColor: ColorRGBTuple,
 ) => {
   context.fillStyle = rgbToString(selectionColor, 0.4);
 
@@ -778,7 +782,10 @@ const _renderInteractiveScene = ({
   });
 
   
-  const selectionColor = colorToRgbWithCanvas(context, renderConfig.selectionColor);
+  const selectionColor = colorToRgbWithCanvas(
+    context, 
+    renderConfig.selectionColor,
+  );
 
   if (editingLinearElement) {
     renderLinearPointHandles(
@@ -874,7 +881,7 @@ const _renderInteractiveScene = ({
       appState,
       selectedElements[0] as NonDeleted<ExcalidrawLinearElement>,
       elementsMap,
-      selectionColor
+      selectionColor,
     );
   }
 
@@ -894,7 +901,12 @@ const _renderInteractiveScene = ({
           editor.hoverPointIndex === firstSelectedLinear.points.length - 1
         : editor.hoverPointIndex >= 0
     ) {
-      renderLinearElementPointHighlight(context, appState, elementsMap, selectionColor);
+      renderLinearElementPointHighlight(
+        context,
+        appState,
+        elementsMap,
+        selectionColor
+      );
     }
   }
 
@@ -1155,7 +1167,7 @@ const _renderInteractiveScene = ({
     }
   });
 
-  renderSnaps(context, appState, renderConfig.selectionColor);
+  renderSnaps(context, appState);
 
   context.restore();
 

--- a/packages/excalidraw/renderer/renderSnaps.ts
+++ b/packages/excalidraw/renderer/renderSnaps.ts
@@ -1,27 +1,30 @@
 import { pointFrom, type GlobalPoint, type LocalPoint } from "@excalidraw/math";
 
+import { THEME } from "@excalidraw/common";
+
 import type { PointSnapLine, PointerSnapLine } from "../snapping";
 import type { InteractiveCanvasAppState } from "../types";
-import type { InteractiveCanvasRenderConfig } from "../scene/types";
 
+const SNAP_COLOR_LIGHT = "#ff6b6b";
+const SNAP_COLOR_DARK = "#ff0000";
 const SNAP_WIDTH = 1;
 const SNAP_CROSS_SIZE = 2;
 
 export const renderSnaps = (
   context: CanvasRenderingContext2D,
   appState: InteractiveCanvasAppState,
-  selectionColor: InteractiveCanvasRenderConfig["selectionColor"],
 ) => {
   if (!appState.snapLines.length) {
     return;
   }
 
-  // Previously, in dark mode, we needed to adjust the color to account 
-  // for color inversion.
+  // in dark mode, we need to adjust the color to account for color inversion.
   // Don't change if zen mode, because we draw only crosses, we want the
   // colors to be more visible
-  // Something similar might be considered with the selection color.
-  const snapColor = selectionColor;
+  const snapColor =
+    appState.theme === THEME.LIGHT || appState.zenModeEnabled
+      ? SNAP_COLOR_LIGHT
+      : SNAP_COLOR_DARK;
   // in zen mode make the cross more visible since we don't draw the lines
   const snapWidth =
     (appState.zenModeEnabled ? SNAP_WIDTH * 1.5 : SNAP_WIDTH) /


### PR DESCRIPTION
Heya,

i was bothered by the fact that selections don't fully follow my prefered colors, so I did something about it.

I applied the `selectionColor` to `Line-Handles` (in that edit points-mode) and the background of the `box-selection`, as well as the anchor-lines/crosses of the `snap-mode`.

To do that, I had to change the way we handle the `selectionColor`, so the color could be modified in `alpha` and `brightness`
The color is parsed once into a rgb-tuple, which is then just converted to a string, as necessary. The color-parsing allows all common css `<color>` strings. However, for some reason `lch`, `oklch`, `lab` and `oklab` aren't translated by the _HTML-canvas conversion method_ I implemented... It would need a much more sophisticated conversion routine to add alpha to those colors, which I deemed unnecessary, considering their infrequent use.

I used jsperf.app to compare some color-conversion approaches that I had in mind and used them accordingly.

### Testing

to see this in action, change the `--color-selection` variable on the div.excalidraw, for example with the Chrome Dev-Tools.

![image](https://github.com/excalidraw/excalidraw/assets/65970327/dc296ec4-4690-4809-aa53-edf48b8c85a5)

![image](https://github.com/excalidraw/excalidraw/assets/65970327/a2b5ee3e-bff0-4a94-b0a3-67ba86b55929)

(this was recreated from #8188, because my previous PR got convuluted after rebasing)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added new color manipulation utilities, including functions to lighten colors, convert between color formats, and consistently handle CSS color strings.
- **Refactor**
  - Updated rendering logic to use dynamic, configurable selection colors for highlights, handles, and snap lines instead of hardcoded values.
  - Streamlined color handling across interactive scene elements for improved color consistency and flexibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->