### PR TITLE
fix: Test hook usage in production code

### DIFF
--- a/packages/excalidraw/renderer/helpers.ts
+++ b/packages/excalidraw/renderer/helpers.ts
@@ -16,6 +16,7 @@ import {
 } from "@excalidraw/math";
 
 import type {
+  ElementsMap,
   ExcalidrawDiamondElement,
   ExcalidrawRectanguloidElement,
 } from "@excalidraw/element/types";
@@ -128,14 +129,12 @@ function drawCatmullRomCubicApprox(
 export const drawHighlightForRectWithRotation = (
   context: CanvasRenderingContext2D,
   element: ExcalidrawRectanguloidElement,
+  elementsMap: ElementsMap,
   padding: number,
 ) => {
   const [x, y] = pointRotateRads(
     pointFrom<GlobalPoint>(element.x, element.y),
-    elementCenterPoint(
-      element,
-      window.h.app.scene.getElementsMapIncludingDeleted(),
-    ),
+    elementCenterPoint(element, elementsMap),
     element.angle,
   );
 
@@ -289,13 +288,11 @@ export const drawHighlightForDiamondWithRotation = (
   context: CanvasRenderingContext2D,
   padding: number,
   element: ExcalidrawDiamondElement,
+  elementsMap: ElementsMap,
 ) => {
   const [x, y] = pointRotateRads(
     pointFrom<GlobalPoint>(element.x, element.y),
-    elementCenterPoint(
-      element,
-      window.h.app.scene.getElementsMapIncludingDeleted(),
-    ),
+    elementCenterPoint(element, elementsMap),
     element.angle,
   );
   context.save();

--- a/packages/excalidraw/renderer/interactiveScene.ts
+++ b/packages/excalidraw/renderer/interactiveScene.ts
@@ -205,10 +205,15 @@ const renderBindingHighlightForBindableElement = (
     case "embeddable":
     case "frame":
     case "magicframe":
-      drawHighlightForRectWithRotation(context, element, padding);
+      drawHighlightForRectWithRotation(context, element, elementsMap, padding);
       break;
     case "diamond":
-      drawHighlightForDiamondWithRotation(context, padding, element);
+      drawHighlightForDiamondWithRotation(
+        context,
+        padding,
+        element,
+        elementsMap,
+      );
       break;
     case "ellipse": {
       const [x1, y1, x2, y2] = getElementAbsoluteCoords(element, elementsMap);

--- a/packages/excalidraw/tests/__snapshots__/history.test.tsx.snap
+++ b/packages/excalidraw/tests/__snapshots__/history.test.tsx.snap
@@ -363,7 +363,7 @@ exports[`history > multiplayer undo/redo > conflicts in arrows and their bindabl
                 0,
               ],
               [
-                "98.00000",
+                98,
                 "-0.00656",
               ],
             ],

--- a/packages/excalidraw/tests/__snapshots__/history.test.tsx.snap
+++ b/packages/excalidraw/tests/__snapshots__/history.test.tsx.snap
@@ -363,7 +363,7 @@ exports[`history > multiplayer undo/redo > conflicts in arrows and their bindabl
                 0,
               ],
               [
-                98,
+                "98.00000",
                 "-0.00656",
               ],
             ],


### PR DESCRIPTION
window.h used in renderer `helper.ts`