### PR TITLE
fix: move elementCenterPoint from common/src/utils.ts to element/src/bounds.ts

### DIFF
--- a/packages/common/src/utils.ts
+++ b/packages/common/src/utils.ts
@@ -1,12 +1,9 @@
-import { average, pointFrom, type GlobalPoint } from "@excalidraw/math";
-import { getCenterForBounds, getElementBounds } from "@excalidraw/element";
+import { average } from "@excalidraw/math";
 
 import type {
   ExcalidrawBindableElement,
   FontFamilyValues,
   FontString,
-  ExcalidrawElement,
-  ElementsMap,
 } from "@excalidraw/element/types";
 
 import type {
@@ -1238,17 +1235,6 @@ export const escapeDoubleQuotes = (str: string) => {
 
 export const castArray = <T>(value: T | T[]): T[] =>
   Array.isArray(value) ? value : [value];
-
-export const elementCenterPoint = (
-  element: ExcalidrawElement,
-  elementsMap: ElementsMap,
-  xOffset: number = 0,
-  yOffset: number = 0,
-) => {
-  const [x, y] = getCenterForBounds(getElementBounds(element, elementsMap));
-
-  return pointFrom<GlobalPoint>(x + xOffset, y + yOffset);
-};
 
 /** hack for Array.isArray type guard not working with readonly value[] */
 export const isReadonlyArray = (value?: any): value is readonly any[] => {

--- a/packages/element/src/binding.ts
+++ b/packages/element/src/binding.ts
@@ -6,7 +6,6 @@ import {
   invariant,
   isDevEnv,
   isTestEnv,
-  elementCenterPoint,
 } from "@excalidraw/common";
 
 import {
@@ -61,7 +60,7 @@ import {
   isTextElement,
 } from "./typeChecks";
 
-import { aabbForElement } from "./bounds";
+import { aabbForElement, elementCenterPoint } from "./bounds";
 import { updateElbowArrowPoints } from "./elbowArrow";
 
 import type { Scene } from "./Scene";

--- a/packages/element/src/bounds.ts
+++ b/packages/element/src/bounds.ts
@@ -2,7 +2,6 @@ import rough from "roughjs/bin/rough";
 
 import {
   arrayToMap,
-  elementCenterPoint,
   invariant,
   rescalePoints,
   sizeOf,
@@ -1244,3 +1243,14 @@ export const pointInsideBounds = <P extends GlobalPoint | LocalPoint>(
   bounds: Bounds,
 ): boolean =>
   p[0] > bounds[0] && p[0] < bounds[2] && p[1] > bounds[1] && p[1] < bounds[3];
+
+export const elementCenterPoint = (
+  element: ExcalidrawElement,
+  elementsMap: ElementsMap,
+  xOffset: number = 0,
+  yOffset: number = 0,
+) => {
+  const [x, y] = getCenterForBounds(getElementBounds(element, elementsMap));
+
+  return pointFrom<GlobalPoint>(x + xOffset, y + yOffset);
+};

--- a/packages/element/src/collision.ts
+++ b/packages/element/src/collision.ts
@@ -1,4 +1,4 @@
-import { isTransparent, elementCenterPoint } from "@excalidraw/common";
+import { isTransparent } from "@excalidraw/common";
 import {
   curveIntersectLineSegment,
   isPointWithinBounds,
@@ -26,6 +26,7 @@ import { isPathALoop } from "./utils";
 import {
   type Bounds,
   doBoundsIntersect,
+  elementCenterPoint,
   getCenterForBounds,
   getElementBounds,
 } from "./bounds";

--- a/packages/element/src/cropElement.ts
+++ b/packages/element/src/cropElement.ts
@@ -14,9 +14,8 @@ import {
 } from "@excalidraw/math";
 import { type Point } from "points-on-curve";
 
-import { elementCenterPoint } from "@excalidraw/common";
-
 import {
+  elementCenterPoint,
   getElementAbsoluteCoords,
   getResizedElementAbsoluteCoords,
 } from "./bounds";

--- a/packages/element/src/distance.ts
+++ b/packages/element/src/distance.ts
@@ -6,8 +6,6 @@ import {
 
 import { ellipse, ellipseDistanceFromPoint } from "@excalidraw/math/ellipse";
 
-import { elementCenterPoint } from "@excalidraw/common";
-
 import type { GlobalPoint, Radians } from "@excalidraw/math";
 
 import {
@@ -15,6 +13,8 @@ import {
   deconstructLinearOrFreeDrawElement,
   deconstructRectanguloidElement,
 } from "./utils";
+
+import { elementCenterPoint } from "./bounds";
 
 import type {
   ElementsMap,

--- a/packages/excalidraw/renderer/helpers.ts
+++ b/packages/excalidraw/renderer/helpers.ts
@@ -1,8 +1,8 @@
-import { elementCenterPoint, THEME, THEME_FILTER } from "@excalidraw/common";
+import { THEME, THEME_FILTER } from "@excalidraw/common";
 
 import { FIXED_BINDING_DISTANCE } from "@excalidraw/element";
 import { getDiamondPoints } from "@excalidraw/element";
-import { getCornerRadius } from "@excalidraw/element";
+import { elementCenterPoint, getCornerRadius } from "@excalidraw/element";
 
 import {
   curve,

--- a/packages/excalidraw/tests/helpers/ui.ts
+++ b/packages/excalidraw/tests/helpers/ui.ts
@@ -1,6 +1,10 @@
 import { pointFrom, pointRotateRads } from "@excalidraw/math";
 
-import { getCommonBounds, getElementPointsCoords } from "@excalidraw/element";
+import {
+  elementCenterPoint,
+  getCommonBounds,
+  getElementPointsCoords,
+} from "@excalidraw/element";
 import { cropElement } from "@excalidraw/element";
 import {
   getTransformHandles,
@@ -16,7 +20,7 @@ import {
   isTextElement,
   isFrameLikeElement,
 } from "@excalidraw/element";
-import { KEYS, arrayToMap, elementCenterPoint } from "@excalidraw/common";
+import { KEYS, arrayToMap } from "@excalidraw/common";
 
 import type { GlobalPoint, LocalPoint, Radians } from "@excalidraw/math";
 


### PR DESCRIPTION
#9488 imported getCenterForBounds, getElementBounds from "@excalidraw/element" to @excalidraw/common/src/utils.ts creating a circular reference and breaking the self-contained integrity of the elements and common packages.

elementCenterPoint thematically fits better in element/src/bounds.ts

This PR moves the function there.

for more see utils.ts review comment in #9488