### PR TITLE
feat: [POC] Save reminder

### DIFF
--- a/excalidraw-app/App.tsx
+++ b/excalidraw-app/App.tsx
@@ -416,6 +416,10 @@ const ExcalidrawWrapper = () => {
   }, [excalidrawAPI]);
 
   useEffect(() => {
+    setReminderState(importReminderStateFromLocalStorage());
+  }, []);
+
+  useEffect(() => {
     if (!excalidrawAPI || (!isCollabDisabled && !collabAPI)) {
       return;
     }
@@ -681,7 +685,7 @@ const ExcalidrawWrapper = () => {
               },
             },
           });
-          setReminderState({
+          updateReminderState({
             nextIndex: currentReminderIndex + 1,
             sceneId: appState.id,
           });

--- a/excalidraw-app/app_constants.ts
+++ b/excalidraw-app/app_constants.ts
@@ -38,6 +38,7 @@ export const ROOM_ID_BYTES = 10;
 export const STORAGE_KEYS = {
   LOCAL_STORAGE_ELEMENTS: "excalidraw",
   LOCAL_STORAGE_APP_STATE: "excalidraw-state",
+  LOCAL_STORAGE_REMINDER_STATE: "excalidraw-reminder",
   LOCAL_STORAGE_COLLAB: "excalidraw-collab",
   LOCAL_STORAGE_THEME: "excalidraw-theme",
   LOCAL_STORAGE_DEBUG: "excalidraw-debug",
@@ -57,3 +58,33 @@ export const COOKIES = {
 export const isExcalidrawPlusSignedUser = document.cookie.includes(
   COOKIES.AUTH_STATE_COOKIE,
 );
+
+// Time is in ms
+// export const REMINDER_THRESHOLDS = [
+//   {
+//     time: 172800000, // 2 days
+//     elementsCount: 100,
+//   },
+//   {
+//     time: 345600000, // 4 days
+//     elementsCount: 200,
+//   },
+//   {
+//     time: 518400000, // 6 days
+//     elementsCount: 300,
+//   },
+// ];
+export const REMINDER_THRESHOLDS = [
+  {
+    time: 15000, // 2 days
+    elementsCount: 10,
+  },
+  {
+    time: 30000, // 4 days
+    elementsCount: 20,
+  },
+  {
+    time: 45000, // 6 days
+    elementsCount: 30,
+  },
+];

--- a/excalidraw-app/data/localStorage.ts
+++ b/excalidraw-app/data/localStorage.ts
@@ -9,11 +9,27 @@ import type { AppState } from "@excalidraw/excalidraw/types";
 
 import { STORAGE_KEYS } from "../app_constants";
 
+import type { ReminderState } from "excalidraw-app/App";
+
 export const saveUsernameToLocalStorage = (username: string) => {
   try {
     localStorage.setItem(
       STORAGE_KEYS.LOCAL_STORAGE_COLLAB,
       JSON.stringify({ username }),
+    );
+  } catch (error: any) {
+    // Unable to access window.localStorage
+    console.error(error);
+  }
+};
+
+export const saveReminderStateToLocalStorage = (
+  reminderState: ReminderState,
+) => {
+  try {
+    localStorage.setItem(
+      STORAGE_KEYS.LOCAL_STORAGE_REMINDER_STATE,
+      JSON.stringify(reminderState),
     );
   } catch (error: any) {
     // Unable to access window.localStorage
@@ -29,6 +45,21 @@ export const importUsernameFromLocalStorage = (): string | null => {
     }
   } catch (error: any) {
     // Unable to access localStorage
+    console.error(error);
+  }
+
+  return null;
+};
+
+export const importReminderStateFromLocalStorage = (): ReminderState | null => {
+  try {
+    const data = localStorage.getItem(
+      STORAGE_KEYS.LOCAL_STORAGE_REMINDER_STATE,
+    );
+    if (data) {
+      return JSON.parse(data);
+    }
+  } catch (error: any) {
     console.error(error);
   }
 

--- a/packages/excalidraw/actions/actionExport.tsx
+++ b/packages/excalidraw/actions/actionExport.tsx
@@ -25,7 +25,7 @@ import { resaveAsImageWithScene } from "../data/resave";
 
 import { t } from "../i18n";
 import { getSelectedElements, isSomeElementSelected } from "../scene";
-import { getExportSize } from "../scene/export";
+import { generateLastSave, getExportSize } from "../scene/export";
 
 import "../components/ToolIcon.scss";
 
@@ -174,6 +174,7 @@ export const actionSaveToActiveFile = register({
         appState: {
           ...appState,
           fileHandle,
+          lastSave: generateLastSave(elements),
           toast: fileHandleExists
             ? {
                 message: fileHandle?.name
@@ -220,6 +221,7 @@ export const actionSaveFileToDisk = register({
         captureUpdate: CaptureUpdateAction.EVENTUALLY,
         appState: {
           ...appState,
+          lastSave: generateLastSave(elements),
           openDialog: null,
           fileHandle,
           toast: { message: t("toast.fileSaved") },

--- a/packages/excalidraw/actions/actionExport.tsx
+++ b/packages/excalidraw/actions/actionExport.tsx
@@ -270,7 +270,10 @@ export const actionLoadScene = register({
       } = await loadFromJSON(appState, elements);
       return {
         elements: loadedElements,
-        appState: loadedAppState,
+        appState: {
+          ...loadedAppState,
+          lastSave: generateLastSave(loadedElements),
+        },
         files,
         captureUpdate: CaptureUpdateAction.IMMEDIATELY,
       };

--- a/packages/excalidraw/appState.ts
+++ b/packages/excalidraw/appState.ts
@@ -124,6 +124,7 @@ export const getDefaultAppState = (): Omit<
     searchMatches: null,
     lockedMultiSelections: {},
     activeLockedId: null,
+    lastSave: null,
   };
 };
 
@@ -249,6 +250,7 @@ const APP_STATE_STORAGE_CONF = (<
   searchMatches: { browser: false, export: false, server: false },
   lockedMultiSelections: { browser: true, export: true, server: true },
   activeLockedId: { browser: false, export: false, server: false },
+  lastSave: { browser: true, export: false, server: false },
 });
 
 const _clearAppStateForStorage = <

--- a/packages/excalidraw/appState.ts
+++ b/packages/excalidraw/appState.ts
@@ -13,6 +13,8 @@ import {
   isTestEnv,
 } from "@excalidraw/common";
 
+import { nanoid } from "nanoid";
+
 import type { AppState, NormalizedZoomValue } from "./types";
 
 const defaultExportScale = EXPORT_SCALES.includes(devicePixelRatio)
@@ -24,6 +26,7 @@ export const getDefaultAppState = (): Omit<
   "offsetTop" | "offsetLeft" | "width" | "height"
 > => {
   return {
+    id: nanoid(),
     showWelcomeScreen: false,
     theme: THEME.LIGHT,
     collaborators: new Map(),
@@ -144,6 +147,7 @@ const APP_STATE_STORAGE_CONF = (<
   T extends Record<keyof AppState, Values>,
 >(config: { [K in keyof T]: K extends keyof AppState ? T[K] : never }) =>
   config)({
+  id: { browser: true, export: true, server: true },
   showWelcomeScreen: { browser: true, export: false, server: false },
   theme: { browser: true, export: false, server: false },
   collaborators: { browser: false, export: false, server: false },

--- a/packages/excalidraw/appState.ts
+++ b/packages/excalidraw/appState.ts
@@ -15,6 +15,8 @@ import {
 
 import { nanoid } from "nanoid";
 
+import { generateLastSave } from "@excalidraw/excalidraw/scene/export";
+
 import type { AppState, NormalizedZoomValue } from "./types";
 
 const defaultExportScale = EXPORT_SCALES.includes(devicePixelRatio)
@@ -127,7 +129,7 @@ export const getDefaultAppState = (): Omit<
     searchMatches: null,
     lockedMultiSelections: {},
     activeLockedId: null,
-    lastSave: null,
+    lastSave: generateLastSave([]),
   };
 };
 

--- a/packages/excalidraw/locales/en.json
+++ b/packages/excalidraw/locales/en.json
@@ -521,6 +521,7 @@
     "copyToClipboardAsPng": "Copied {{exportSelection}} to clipboard as PNG\n({{exportColorScheme}})",
     "copyToClipboardAsSvg": "Copied {{exportSelection}} to clipboard as SVG\n({{exportColorScheme}})",
     "fileSaved": "File saved.",
+    "rememberToSave": "This drawing is only saved in your browser. Save to file to keep it safe",
     "fileSavedToFilename": "Saved to {filename}",
     "canvas": "canvas",
     "selection": "selection",

--- a/packages/excalidraw/scene/export.ts
+++ b/packages/excalidraw/scene/export.ts
@@ -15,7 +15,11 @@ import {
   toBrandedType,
 } from "@excalidraw/common";
 
-import { getCommonBounds, getElementAbsoluteCoords } from "@excalidraw/element";
+import {
+  getCommonBounds,
+  getElementAbsoluteCoords,
+  hashElementsVersion,
+} from "@excalidraw/element";
 
 import {
   getInitializedImageElements,
@@ -47,6 +51,7 @@ import type {
   ExcalidrawTextElement,
   NonDeletedExcalidrawElement,
   NonDeletedSceneElementsMap,
+  OrderedExcalidrawElement,
 } from "@excalidraw/element/types";
 
 import { getDefaultAppState } from "../appState";
@@ -575,3 +580,10 @@ export const getExportSize = (
 
   return [width, height];
 };
+
+export const generateLastSave = (
+  elements: readonly OrderedExcalidrawElement[],
+): AppState["lastSave"] => ({
+  hash: hashElementsVersion(elements),
+  timestamp: Date.now(),
+});

--- a/packages/excalidraw/scene/export.ts
+++ b/packages/excalidraw/scene/export.ts
@@ -18,6 +18,7 @@ import {
 import {
   getCommonBounds,
   getElementAbsoluteCoords,
+  getNonDeletedElements,
   hashElementsVersion,
 } from "@excalidraw/element";
 
@@ -583,7 +584,11 @@ export const getExportSize = (
 
 export const generateLastSave = (
   elements: readonly OrderedExcalidrawElement[],
-): AppState["lastSave"] => ({
-  hash: hashElementsVersion(elements),
-  timestamp: Date.now(),
-});
+): AppState["lastSave"] => {
+  const nonDeletedElements = getNonDeletedElements(elements);
+  return {
+    hash: hashElementsVersion(nonDeletedElements),
+    timestamp: Date.now(),
+    elementsCount: nonDeletedElements.length,
+  };
+};

--- a/packages/excalidraw/types.ts
+++ b/packages/excalidraw/types.ts
@@ -271,6 +271,8 @@ export interface AppState {
     element: NonDeletedExcalidrawElement;
     state: "hover" | "active";
   } | null;
+  /* A unique identifier that is only changed on scene change */
+  id: string;
   /**
    * for a newly created element
    * - set on pointer down, updated during pointer move, used on pointer up

--- a/packages/excalidraw/types.ts
+++ b/packages/excalidraw/types.ts
@@ -452,7 +452,7 @@ export interface AppState {
     timestamp: number;
     hash: number;
     elementsCount: number;
-  } | null;
+  };
 }
 
 export type SearchMatch = {

--- a/packages/excalidraw/types.ts
+++ b/packages/excalidraw/types.ts
@@ -451,6 +451,7 @@ export interface AppState {
   lastSave: {
     timestamp: number;
     hash: number;
+    elementsCount: number;
   } | null;
 }
 

--- a/packages/excalidraw/types.ts
+++ b/packages/excalidraw/types.ts
@@ -444,6 +444,12 @@ export interface AppState {
   // as elements are unlocked, we remove the groupId from the elements
   // and also remove groupId from this map
   lockedMultiSelections: { [groupId: string]: true };
+
+  /* Timestamp and hashed elements version of last time we stored on disk */
+  lastSave: {
+    timestamp: number;
+    hash: number;
+  } | null;
 }
 
 export type SearchMatch = {


### PR DESCRIPTION
This is the idea behind the MVP I made to send a toast reminder when the drawing hasn't been saved in a while. It still doesn't have tests nor is rigorously tested. I cut some corners, but I kept notes whenever I did something dirty, so refactoring it shall be straightforward.

## Requirements

- Default toast with default duration
- Only notify during `onChange` to ensure user is not idle
- A "reminder threshold" consists of element count and time
  - Threshold 1: 100 elements, 2 days
  - Threshold 2: 200 elements, 4 days
  - Threshold 3: 300 elements, 6 days
- User shall be reminded after not saving for nth threshold
- If user saves, thresholds shall be reset but be based on delta with last save (for both time and count)
- On refresh, nothing shall be different
- Reminders shall fire in one tab only and their state shall be shared across all tabs
- Reminders state shall be reset if the user clears the scene

## Implementation

- Have a randomly-generated scene id in appState that is only changed when the canvas is cleared (defined in `getDefaultAppState()`) — this is used to ensure separate reminders state when the user wants a new scene
- **Hack for now:** Have a `lastSave` in appState — used to calculate the deltas. `lastSave` has:
  - The last saved elements versions hash
  - The last saved elements count
  - The last saved timestamp
- Reminder is basically `f(appState.lastSave, currentTime, currentVersion, currentElementsCount)`
- lastSave is the time the scene was created, saved or loaded from file (think of it as last clean state)
- Reminder state is updated synchronously from localStorage and retrieved on init and on visibility change

## Problems with such approach

- After saving, deleting all elements then adding new elements of similar count will not trigger a reminder even if such change was large. (Changes are based on delta after saving).

## Stuff that can be improved (other than refactoring)

- `ctrl + a -> delete` does not reset the scene id
- `Math.abs()` in delta from last save and current state
- Either check against elements count or elements version hash — checking against both seems redundant
- Fix no way to detect if actually saved with browsers that don't support file system access api
- Fix no special handling for re-saving as image
- Didn't handle collab (just no reminders there)
- Didn't check for other cases like viewMode and viewing links
- Fix elements loop in hot onChange path. Possible options:
  - Debounce/throttle reminder logic checking
  - Check if Excalidraw has an efficient way to check if stfuf changed, and smartly call the reminders based on current state and last saved state

## What needs to be refactored

- `onSave` and `onLoad` callbacks instead of `appState.lastSave`
- Currently have the reminder logic in the App.tsx wrapper for experimenting — should probably be its own API like CollabAPI
- importReminderStateFromLocalStorage(), saveReminderStateToLocalStorage()