### PR TITLE
feat: eraser delete top most element (#9648)

### DIFF
--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -9457,13 +9457,14 @@ class App extends React.Component<AppProps, AppState> {
             },
             this.state,
           );
-          const hitElements = this.getElementsAtPosition(
+          const hitElement = this.getElementAtPosition(
             scenePointer.x,
             scenePointer.y,
           );
-          hitElements.forEach((hitElement) =>
-            this.elementsPendingErasure.add(hitElement.id),
-          );
+
+          if (hitElement) {
+            this.elementsPendingErasure.add(hitElement.id);
+          }
         }
         this.eraseElements();
         return;

--- a/packages/excalidraw/eraser/index.ts
+++ b/packages/excalidraw/eraser/index.ts
@@ -89,6 +89,12 @@ export class EraserTrail extends AnimatedTrail {
 
     const candidateElementsMap = arrayToMap(candidateElements);
 
+    const topMostElement = candidateElements[candidateElements.length - 1];
+
+    const isSegmentInsideTopElementOnly = shouldTestInside(topMostElement) &&
+      isPointInElement(pathSegment[0], topMostElement, candidateElementsMap) &&
+      isPointInElement(pathSegment[1], topMostElement, candidateElementsMap);
+
     for (const element of candidateElements) {
       // restore only if already added to the to-be-erased set
       if (restoreToErase && this.elementsToErase.has(element.id)) {
@@ -127,6 +133,10 @@ export class EraserTrail extends AnimatedTrail {
           this.elementsToErase.delete(element.id);
         }
       } else if (!restoreToErase && !this.elementsToErase.has(element.id)) {
+        if (isSegmentInsideTopElementOnly && element !== topMostElement) {
+          continue;
+        }
+
         const intersects = eraserTest(
           pathSegment,
           element,


### PR DESCRIPTION
Right now I am only deleting the top most element like in the linked issue (#9648). 
Not sure about the behavior when you are holding down to erase as it still only deletes the top most element as requested but if it's not the top most element it will also delete any element that happens to be beneath it.