### PR TITLE
feat: Add "showLibraryButton" for "UIOption" to control the visibility of Library button

### DIFF
--- a/packages/excalidraw/components/LayerUI.tsx
+++ b/packages/excalidraw/components/LayerUI.tsx
@@ -392,6 +392,7 @@ const LayerUI = ({
   };
 
   const isSidebarDocked = useAtomValue(isSidebarDockedAtom);
+  const showLibraryButton = UIOptions.showLibraryButton ?? true;
 
   const layerUIJSX = (
     <>
@@ -403,23 +404,25 @@ const LayerUI = ({
           tunneled away. We only render tunneled components that actually
         have defaults when host do not render anything. */}
       <DefaultMainMenu UIOptions={UIOptions} />
-      <DefaultSidebar.Trigger
-        __fallback
-        icon={LibraryIcon}
-        title={capitalizeString(t("toolBar.library"))}
-        onToggle={(open) => {
-          if (open) {
-            trackEvent(
-              "sidebar",
-              `${DEFAULT_SIDEBAR.name} (open)`,
-              `button (${device.editor.isMobile ? "mobile" : "desktop"})`,
-            );
-          }
-        }}
-        tab={DEFAULT_SIDEBAR.defaultTab}
-      >
-        {t("toolBar.library")}
-      </DefaultSidebar.Trigger>
+      {showLibraryButton && (
+        <DefaultSidebar.Trigger
+          __fallback
+          icon={LibraryIcon}
+          title={capitalizeString(t("toolBar.library"))}
+          onToggle={(open) => {
+            if (open) {
+              trackEvent(
+                "sidebar",
+                `${DEFAULT_SIDEBAR.name} (open)`,
+                `button (${device.editor.isMobile ? "mobile" : "desktop"})`,
+              );
+            }
+          }}
+          tab={DEFAULT_SIDEBAR.defaultTab}
+        >
+          {t("toolBar.library")}
+        </DefaultSidebar.Trigger>
+      )}
       <DefaultOverwriteConfirmDialog />
       {appState.openDialog?.name === "ttd" && <TTDDialog __fallback />}
       {/* ------------------------------------------------------------------ */}

--- a/packages/excalidraw/types.ts
+++ b/packages/excalidraw/types.ts
@@ -666,6 +666,7 @@ export type UIOptions = Partial<{
   };
   /** @deprecated does nothing. Will be removed in 0.15 */
   welcomeScreen?: boolean;
+  showLibraryButton: boolean;
 }>;
 
 export type AppProps = Merge<


### PR DESCRIPTION
# Background

This PR aims to create an option to control the visibility of "Library Button" on the top-right corner of the UI. In some cases we don't want the user to use the `Library` feature for excalidraw

# Test

| default | showLibraryButton=False |
| -- | -- |
| <img width="1010" alt="Screenshot 2025-06-18 at 2 34 42 PM" src="https://github.com/user-attachments/assets/512bbdd0-d079-4a9d-a056-4285464c144c" /> | <img width="958" alt="Screenshot 2025-06-18 at 2 35 17 PM" src="https://github.com/user-attachments/assets/f1c3df81-5369-4bbe-a25a-1002d0be6845" /> |