### PR TITLE
feat: Fixed point binding for simple arrows

### DIFF
--- a/packages/excalidraw/data/__snapshots__/transform.test.ts.snap
+++ b/packages/excalidraw/data/__snapshots__/transform.test.ts.snap
@@ -88,8 +88,12 @@ exports[`Test Transform > Test arrow bindings > should bind arrows to existing s
   "endArrowhead": "arrow",
   "endBinding": {
     "elementId": "ellipse-1",
-    "focus": -0.007519379844961235,
-    "gap": 11.562288374879595,
+    "fixedPoint": [
+      0.04,
+      0.4633333333333333,
+    ],
+    "focus": 0,
+    "gap": 0,
   },
   "fillStyle": "solid",
   "frameId": null,
@@ -174,8 +178,12 @@ exports[`Test Transform > Test arrow bindings > should bind arrows to existing s
   "startArrowhead": null,
   "startBinding": {
     "elementId": "diamond-1",
+    "fixedPoint": [
+      0.9357142857142857,
+      0.5001,
+    ],
     "focus": 0,
-    "gap": 4.535423522449215,
+    "gap": 0,
   },
   "strokeColor": "#e67700",
   "strokeStyle": "solid",
@@ -1539,8 +1547,12 @@ exports[`Test Transform > should transform the elements correctly when linear el
   "endArrowhead": "arrow",
   "endBinding": {
     "elementId": "B",
+    "fixedPoint": [
+      0.46387050630528887,
+      0.48466257668711654,
+    ],
     "focus": 0,
-    "gap": 32,
+    "gap": 0,
   },
   "fillStyle": "solid",
   "frameId": null,

--- a/packages/excalidraw/data/restore.ts
+++ b/packages/excalidraw/data/restore.ts
@@ -29,8 +29,13 @@ import { bumpVersion } from "@excalidraw/element";
 import { getContainerElement } from "@excalidraw/element";
 import { detectLineHeight } from "@excalidraw/element";
 import {
+  isPointInElement,
+  calculateFixedPointForNonElbowArrowBinding,
+} from "@excalidraw/element";
+import {
   isArrowBoundToElement,
   isArrowElement,
+  isBindableElement,
   isElbowArrow,
   isFixedPointBinding,
   isLinearElement,
@@ -519,6 +524,87 @@ const repairFrameMembership = (
   }
 };
 
+/**
+ * Migrates old PointBinding to FixedPointBinding for non-elbow arrows
+ * when arrow endpoints are inside bindable shapes.
+ *
+ * NOTE mutates element.
+ */
+const migratePointBindingToFixedPoint = (
+  element: Mutable<ExcalidrawElement>,
+  elementsMap: Map<string, Mutable<ExcalidrawElement>>,
+) => {
+  if (!isArrowElement(element) || isElbowArrow(element)) {
+    return;
+  }
+
+  let shouldUpdateElement = false;
+  let newStartBinding: FixedPointBinding | PointBinding | null =
+    element.startBinding;
+  let newEndBinding: FixedPointBinding | PointBinding | null =
+    element.endBinding;
+
+  // Check start binding
+  if (element.startBinding && !isFixedPointBinding(element.startBinding)) {
+    const boundElement = elementsMap.get(element.startBinding.elementId);
+    if (boundElement && isBindableElement(boundElement)) {
+      const edgePoint = LinearElementEditor.getPointAtIndexGlobalCoordinates(
+        element,
+        0,
+        elementsMap,
+      );
+      if (isPointInElement(edgePoint, boundElement, elementsMap)) {
+        const { fixedPoint } = calculateFixedPointForNonElbowArrowBinding(
+          element,
+          boundElement,
+          "start",
+          elementsMap,
+        );
+        newStartBinding = {
+          elementId: element.startBinding.elementId,
+          focus: 0,
+          gap: 0,
+          fixedPoint,
+        };
+        shouldUpdateElement = true;
+      }
+    }
+  }
+
+  // Check end binding
+  if (element.endBinding && !isFixedPointBinding(element.endBinding)) {
+    const boundElement = elementsMap.get(element.endBinding.elementId);
+    if (boundElement && isBindableElement(boundElement)) {
+      const edgePoint = LinearElementEditor.getPointAtIndexGlobalCoordinates(
+        element,
+        -1,
+        elementsMap,
+      );
+      if (isPointInElement(edgePoint, boundElement, elementsMap)) {
+        const { fixedPoint } = calculateFixedPointForNonElbowArrowBinding(
+          element,
+          boundElement,
+          "end",
+          elementsMap,
+        );
+        newEndBinding = {
+          elementId: element.endBinding.elementId,
+          focus: 0,
+          gap: 0,
+          fixedPoint,
+        };
+        shouldUpdateElement = true;
+      }
+    }
+  }
+
+  if (shouldUpdateElement) {
+    (element as Mutable<ExcalidrawLinearElement>).startBinding =
+      newStartBinding;
+    (element as Mutable<ExcalidrawLinearElement>).endBinding = newEndBinding;
+  }
+};
+
 export const restoreElements = (
   elements: ImportedDataState["elements"],
   /** NOTE doesn't serve for reconciliation */
@@ -598,6 +684,9 @@ export const restoreElements = (
         (element as Mutable<ExcalidrawLinearElement>).endBinding = null;
       }
     }
+
+    // Migrate old PointBinding to FixedPointBinding for non-elbow arrows
+    migratePointBindingToFixedPoint(element, restoredElementsMap);
   }
 
   // NOTE (mtolmacs): Temporary fix for extremely large arrows

--- a/packages/excalidraw/tests/__snapshots__/history.test.tsx.snap
+++ b/packages/excalidraw/tests/__snapshots__/history.test.tsx.snap
@@ -195,7 +195,7 @@ exports[`history > multiplayer undo/redo > conflicts in arrows and their bindabl
   "fillStyle": "solid",
   "frameId": null,
   "groupIds": [],
-  "height": "99.19972",
+  "height": 150,
   "id": "id4",
   "index": "a2",
   "isDeleted": false,
@@ -209,8 +209,8 @@ exports[`history > multiplayer undo/redo > conflicts in arrows and their bindabl
       0,
     ],
     [
-      "98.40611",
-      "99.19972",
+      "124.00500",
+      150,
     ],
   ],
   "roughness": 1,
@@ -225,7 +225,7 @@ exports[`history > multiplayer undo/redo > conflicts in arrows and their bindabl
   "type": "arrow",
   "updated": 1,
   "version": 35,
-  "width": "98.40611",
+  "width": "124.00500",
   "x": 1,
   "y": 0,
 }
@@ -332,15 +332,15 @@ exports[`history > multiplayer undo/redo > conflicts in arrows and their bindabl
               "focus": 0,
               "gap": 1,
             },
-            "height": "68.58402",
+            "height": "104.34908",
             "points": [
               [
                 0,
                 0,
               ],
               [
-                98,
-                "68.58402",
+                "124.00500",
+                "104.34908",
               ],
             ],
             "startBinding": {
@@ -356,7 +356,7 @@ exports[`history > multiplayer undo/redo > conflicts in arrows and their bindabl
               "focus": "-0.02000",
               "gap": 1,
             },
-            "height": "0.00656",
+            "height": "0.00849",
             "points": [
               [
                 0,
@@ -364,7 +364,7 @@ exports[`history > multiplayer undo/redo > conflicts in arrows and their bindabl
               ],
               [
                 "98.00000",
-                "-0.00656",
+                "-0.00849",
               ],
             ],
             "startBinding": {
@@ -415,15 +415,15 @@ exports[`history > multiplayer undo/redo > conflicts in arrows and their bindabl
         },
         "id4": {
           "deleted": {
-            "height": "99.19972",
+            "height": 150,
             "points": [
               [
                 0,
                 0,
               ],
               [
-                "98.40611",
-                "99.19972",
+                "124.00500",
+                150,
               ],
             ],
             "startBinding": null,
@@ -431,15 +431,15 @@ exports[`history > multiplayer undo/redo > conflicts in arrows and their bindabl
             "y": 0,
           },
           "inserted": {
-            "height": "68.58402",
+            "height": "104.34908",
             "points": [
               [
                 0,
                 0,
               ],
               [
-                98,
-                "68.58402",
+                "124.00500",
+                "104.34908",
               ],
             ],
             "startBinding": {
@@ -448,7 +448,7 @@ exports[`history > multiplayer undo/redo > conflicts in arrows and their bindabl
               "gap": 1,
             },
             "version": 33,
-            "y": "35.82151",
+            "y": "45.65092",
           },
         },
       },
@@ -1228,7 +1228,7 @@ exports[`history > multiplayer undo/redo > conflicts in arrows and their bindabl
   "fillStyle": "solid",
   "frameId": null,
   "groupIds": [],
-  "height": "1.36342",
+  "height": "49.99000",
   "id": "id4",
   "index": "Zz",
   "isDeleted": false,
@@ -1242,8 +1242,8 @@ exports[`history > multiplayer undo/redo > conflicts in arrows and their bindabl
       0,
     ],
     [
-      98,
-      "1.36342",
+      "150.01000",
+      "49.99000",
     ],
   ],
   "roughness": 1,
@@ -1264,9 +1264,9 @@ exports[`history > multiplayer undo/redo > conflicts in arrows and their bindabl
   "type": "arrow",
   "updated": 1,
   "version": 11,
-  "width": 98,
-  "x": 1,
-  "y": 0,
+  "width": "150.01000",
+  "x": 0,
+  "y": "0.01000",
 }
 `;
 
@@ -1591,7 +1591,7 @@ exports[`history > multiplayer undo/redo > conflicts in arrows and their bindabl
   "fillStyle": "solid",
   "frameId": null,
   "groupIds": [],
-  "height": "1.36342",
+  "height": "49.99000",
   "id": "id5",
   "index": "a0",
   "isDeleted": false,
@@ -1605,8 +1605,8 @@ exports[`history > multiplayer undo/redo > conflicts in arrows and their bindabl
       0,
     ],
     [
-      98,
-      "1.36342",
+      "249.99000",
+      "-49.99000",
     ],
   ],
   "roughness": 1,
@@ -1627,9 +1627,9 @@ exports[`history > multiplayer undo/redo > conflicts in arrows and their bindabl
   "type": "arrow",
   "updated": 1,
   "version": 11,
-  "width": 98,
-  "x": 1,
-  "y": 0,
+  "width": "249.99000",
+  "x": "-49.99000",
+  "y": 50,
 }
 `;
 
@@ -1741,7 +1741,7 @@ exports[`history > multiplayer undo/redo > conflicts in arrows and their bindabl
             "fillStyle": "solid",
             "frameId": null,
             "groupIds": [],
-            "height": "1.36342",
+            "height": "49.99000",
             "index": "a0",
             "isDeleted": false,
             "lastCommittedPoint": null,
@@ -1754,8 +1754,8 @@ exports[`history > multiplayer undo/redo > conflicts in arrows and their bindabl
                 0,
               ],
               [
-                98,
-                "1.36342",
+                "249.99000",
+                "-49.99000",
               ],
             ],
             "roughness": 1,
@@ -1775,9 +1775,9 @@ exports[`history > multiplayer undo/redo > conflicts in arrows and their bindabl
             "strokeWidth": 2,
             "type": "arrow",
             "version": 11,
-            "width": 98,
-            "x": 1,
-            "y": 0,
+            "width": "249.99000",
+            "x": "-49.99000",
+            "y": 50,
           },
           "inserted": {
             "isDeleted": true,


### PR DESCRIPTION
This PR implements fixed-point binding for simple (non-elbow) arrows, enabling more intuitive arrow behavior when binding to filled shapes.

## Key Features:
  - Same-element binding: Simple arrows can now bind both endpoints to the same element
  - Fixed relative positioning: When arrow endpoints are drawn inside filled shapes, they maintain their relative position within the bound element as it moves
  - Automatic migration: Existing PointBinding objects are automatically migrated to FixedPointBinding when
  appropriate
  - Enhanced collision detection: Improved logic for detecting when arrow endpoints should use fixed-point binding vs traditional focus/gap binding

## Changes:
  - Enhanced binding logic in packages/element/src/binding.ts with new calculateFixedPointForNonElbowArrowBinding function
  - Added migration logic in packages/excalidraw/data/restore.ts to convert legacy
  bindings
  - Comprehensive test suite covering same-element binding, position maintenance, and edge cases
  - Updated snapshots to reflect the new binding behavior

  This improves the user experience by making arrows behave  more predictably when drawn inside shapes, maintaining
  their visual relationship even when the bound elements are moved or transformed.
