### PR TITLE
fix: Shape switch ends up with different roundness type

### DIFF
--- a/packages/excalidraw/components/ConvertElementTypePopup.tsx
+++ b/packages/excalidraw/components/ConvertElementTypePopup.tsx
@@ -834,7 +834,7 @@ const convertElementType = <
         ...element,
         type: targetType,
         roundness:
-          targetType === "diamond" && element.roundness
+          CONVERTIBLE_GENERIC_TYPES.has(targetType) && element.roundness
             ? {
                 type: isUsingAdaptiveRadius(targetType)
                   ? ROUNDNESS.ADAPTIVE_RADIUS


### PR DESCRIPTION
Ensure that Proportional roundness is not carried over to shapes using adaptive radius

Fixes #9662 Shape switch ends up with too round corners 