### PR TITLE
feat: Allow to switch into different arrow types when using "Tab" switcher when bound to element/s or text

### DIFF
--- a/packages/element/src/newElement.ts
+++ b/packages/element/src/newElement.ts
@@ -48,6 +48,8 @@ import type {
   ExcalidrawArrowElement,
   ExcalidrawElbowArrowElement,
   ExcalidrawLineElement,
+  FixedPointBinding,
+  PointBinding,
 } from "./types";
 
 export type ElementConstructorOpts = MarkOptional<
@@ -493,6 +495,8 @@ export const newArrowElement = <T extends boolean>(
     points?: ExcalidrawArrowElement["points"];
     elbowed?: T;
     fixedSegments?: ExcalidrawElbowArrowElement["fixedSegments"] | null;
+    startBinding?: PointBinding | FixedPointBinding | null;
+    endBinding?: PointBinding | FixedPointBinding | null;
   } & ElementConstructorOpts,
 ): T extends true
   ? NonDeleted<ExcalidrawElbowArrowElement>
@@ -502,8 +506,8 @@ export const newArrowElement = <T extends boolean>(
       ..._newElementBase<ExcalidrawElbowArrowElement>(opts.type, opts),
       points: opts.points || [],
       lastCommittedPoint: null,
-      startBinding: null,
-      endBinding: null,
+      startBinding: opts.startBinding || null,
+      endBinding: opts.endBinding || null,
       startArrowhead: opts.startArrowhead || null,
       endArrowhead: opts.endArrowhead || null,
       elbowed: true,
@@ -517,8 +521,8 @@ export const newArrowElement = <T extends boolean>(
     ..._newElementBase<ExcalidrawArrowElement>(opts.type, opts),
     points: opts.points || [],
     lastCommittedPoint: null,
-    startBinding: null,
-    endBinding: null,
+    startBinding: opts.startBinding || null,
+    endBinding: opts.endBinding || null,
     startArrowhead: opts.startArrowhead || null,
     endArrowhead: opts.endArrowhead || null,
     elbowed: false,

--- a/packages/excalidraw/components/ConvertElementTypePopup.tsx
+++ b/packages/excalidraw/components/ConvertElementTypePopup.tsx
@@ -294,12 +294,18 @@ const Panel = ({
 
   const SHAPES: [string, ReactNode][] =
     conversionType === "linear"
-      ? [
-          ["line", LineIcon],
-          ["sharpArrow", sharpArrowIcon],
-          ["curvedArrow", roundArrowIcon],
-          ["elbowArrow", elbowArrowIcon],
-        ]
+      ? hasBoundArrows(elements)
+        ? [
+            ["sharpArrow", sharpArrowIcon],
+            ["curvedArrow", roundArrowIcon],
+            ["elbowArrow", elbowArrowIcon],
+          ]
+        : [
+            ["line", LineIcon],
+            ["sharpArrow", sharpArrowIcon],
+            ["curvedArrow", roundArrowIcon],
+            ["elbowArrow", elbowArrowIcon],
+          ]
       : conversionType === "generic"
       ? [
           ["rectangle", RectangleIcon],
@@ -522,6 +528,10 @@ export const convertElementTypes = (
         LINEAR_TYPES[
           (index + LINEAR_TYPES.length + advancement) % LINEAR_TYPES.length
         ];
+
+      if (hasBoundArrows(selectedElements) && nextType === "line") {
+        nextType = LINEAR_TYPES[LINEAR_TYPES.indexOf("line") + 1];
+      }
     }
 
     if (isConvertibleLinearType(nextType)) {
@@ -657,8 +667,7 @@ export const getConversionTypeFromElements = (
 const isEligibleLinearElement = (element: ExcalidrawElement) => {
   return (
     isLinearElement(element) &&
-    (!isArrowElement(element) ||
-      (!isArrowBoundToElement(element) && !hasBoundTextElement(element)))
+    (!isArrowElement(element) || !hasBoundTextElement(element))
   );
 };
 
@@ -868,6 +877,8 @@ const convertElementType = <
             roundness: null,
             startArrowhead: app.state.currentItemStartArrowhead,
             endArrowhead: app.state.currentItemEndArrowhead,
+            startBinding: isArrowElement(element) ? element.startBinding : null,
+            endBinding: isArrowElement(element) ? element.endBinding : null,
           }),
         );
       }
@@ -882,6 +893,8 @@ const convertElementType = <
             },
             startArrowhead: app.state.currentItemStartArrowhead,
             endArrowhead: app.state.currentItemEndArrowhead,
+            startBinding: isArrowElement(element) ? element.startBinding : null,
+            endBinding: isArrowElement(element) ? element.endBinding : null,
           }),
         );
       }
@@ -891,8 +904,10 @@ const convertElementType = <
             ...element,
             type: "arrow",
             elbowed: true,
-            fixedSegments: null,
+            fixedSegments: [],
             roundness: null,
+            startBinding: isArrowElement(element) ? element.startBinding : null,
+            endBinding: isArrowElement(element) ? element.endBinding : null,
           }),
         );
       }
@@ -934,6 +949,15 @@ const getConvertibleType = (
     return getLinearElementSubType(element);
   }
   return element.type;
+};
+
+const hasBoundArrows = (elements: ExcalidrawElement[]) => {
+  for (const element of elements) {
+    if (isArrowElement(element) && isArrowBoundToElement(element)) {
+      return true;
+    }
+  }
+  return false;
 };
 
 export default ConvertElementTypePopup;


### PR DESCRIPTION
### Description

This PR is for allowing Tab functionality to work with arrows if they are bound to elements already by ignoring check for if the arrow is bound. and modifying the panel to hide line functionality for bounded arrows.

 ### What's Added

- A `hasBoundArrows()` function that checks the entire selection for bounded arrows.
- Added parameters in "packages/element/src/newElement.ts" file to create new arrow element with startBinding and endBinding as bounded arrows did not remain bounded on "Tab" switch by default. So startBinding and endBinding has to be passed from old arrow to new.

### Changes 

- Removed check for `!isArrowBoundToElement(element)` from the `isEligibleLinearElement` function to allow tab changing.
- Additional Panel List rendering check, to not render line option if arrow is bounded.
- Skipping of "line" type in nextType if arrow is bounded.

### Files Changed

- `packages/element/src/newElement.ts`
- `packages/excalidraw/components/ConvertElementTypePopup.tsx`

### Notes
If multiple arrows are selected and one of them is bounded to a element then line option will disappear for all of them in the panel.