### PR TITLE
perf(heap): Minor Binary Heap Optimization

### DIFF
--- a/packages/common/src/binary-heap.ts
+++ b/packages/common/src/binary-heap.ts
@@ -5,17 +5,21 @@ export class BinaryHeap<T> {
 
   sinkDown(idx: number) {
     const node = this.content[idx];
+    const nodeScore = this.scoreFunction(node);
+
     while (idx > 0) {
       const parentN = ((idx + 1) >> 1) - 1;
       const parent = this.content[parentN];
-      if (this.scoreFunction(node) < this.scoreFunction(parent)) {
-        this.content[parentN] = node;
+
+      if (nodeScore < this.scoreFunction(parent)) {
         this.content[idx] = parent;
-        idx = parentN; // TODO: Optimize
+        idx = parentN;
       } else {
         break;
       }
     }
+
+    this.content[idx] = node;
   }
 
   bubbleUp(idx: number) {


### PR DESCRIPTION
This minor optimization improves performance gains in large or frequently updated heaps by:

1. Avoiding Repeated Function Calls to `scoreFunction(node)`

    - **Before**: `O(logn)` calls for each `sinkDown()` call
    - **After**: Only 1 call, Cached outside the loop

2. Reducing node swaps and memory writes

    - **Before**: `O(log n)` swaps involving node on each iteration
    - **After**: node is written only once, after finding the correct position
    - Parents are shifted down instead of performing full swaps each time