### PR TITLE
fixes the issue with undoing the actionFinalize action issue #9495

### DIFF
--- a/packages/excalidraw/actions/actionFinalize.tsx
+++ b/packages/excalidraw/actions/actionFinalize.tsx
@@ -121,6 +121,7 @@ export const actionFinalize = register({
               : undefined,
           appState: {
             ...appState,
+            selectionElement: null,
             cursorButton: "up",
             editingLinearElement: null,
           },


### PR DESCRIPTION
the undo problem in issue #9495 fixed in this PR

Actual Issue.
Missing an attribute of appState in the ActionFinalize method

Video Of Working Condition
https://github.com/user-attachments/assets/29556747-83d1-4624-b0cf-d538ecdef710

