### PR TITLE
fix: use adaptive scale-aware delta in gradient function for numerical stability

### DIFF
--- a/packages/math/src/curve.ts
+++ b/packages/math/src/curve.ts
@@ -25,11 +25,14 @@ function gradient(
   f: (t: number, s: number) => number,
   t0: number,
   s0: number,
-  delta: number = 1e-6,
+  delta: number = 1e-7,
 ): number[] {
+  const dt = delta * Math.max(Math.abs(t0), 1);
+  const ds = delta * Math.max(Math.abs(s0), 1);
+
   return [
-    (f(t0 + delta, s0) - f(t0 - delta, s0)) / (2 * delta),
-    (f(t0, s0 + delta) - f(t0, s0 - delta)) / (2 * delta),
+    (f(t0 + dt, s0) - f(t0 - dt, s0)) / (2 * dt),
+    (f(t0, s0 + ds) - f(t0, s0 - ds)) / (2 * ds),
   ];
 }
 


### PR DESCRIPTION
This PR fixes a numerical stability issue in the gradient() function in curve.ts.
Previously, a fixed delta (1e-6) was used, which could cause inaccurate or unstable gradients for large or very small input values.

Fix:
Replaced fixed delta with scale-aware deltaT(dt) and deltaS(ds) based on delta(default : 1e-7)
Ensures that central difference approximation adapts to input scale

Why this matters:
Prevents false intersections or tangent miscalculations in Bezier curve operations
More stable Newton solver behavior

Fixes #9690
