### PR TITLE
feat: implement searchable shortcuts in HelpDialog

### DIFF
--- a/packages/excalidraw/components/HelpDialog.scss
+++ b/packages/excalidraw/components/HelpDialog.scss
@@ -6,6 +6,38 @@
       max-width: 960px;
     }
 
+    .HelpDialog__search-input {
+      width: 0;
+      opacity: 0;
+      margin-left: 0;
+      padding: 4px 0;
+      font-size: 1rem;
+      background: transparent;
+      color: var(--text-primary-color);
+      border: none;
+      border-bottom: 2px solid var(--color-primary);
+      outline: none;
+      box-shadow: none;
+      appearance: none;
+      font-family: inherit;
+      transition: width 0.3s ease, opacity 0.2s ease, margin 0.2s ease;
+
+      &::placeholder {
+        color: var(--text-secondary-color, #aaa);
+        opacity: 0.7;
+      }
+
+      &:focus {
+        border-bottom-color: var(--color-primary);
+      }
+
+      &--active {
+        width: 180px;
+        opacity: 1;
+        margin-left: 8px;
+      }
+    }
+
     h3 {
       margin: 1.5rem 0;
       font-weight: 700;
@@ -126,5 +158,6 @@
       font-family: inherit;
       line-height: 1;
     }
+
   }
 }

--- a/packages/excalidraw/components/HelpDialog.tsx
+++ b/packages/excalidraw/components/HelpDialog.tsx
@@ -1,5 +1,4 @@
-import React from "react";
-
+import React, { useState, useRef, useEffect } from "react";
 import { isDarwin, isFirefox, isWindows } from "@excalidraw/common";
 
 import { KEYS, getShortcutKey } from "@excalidraw/common";
@@ -54,6 +53,13 @@ const Header = () => (
       YouTube
     </a>
   </div>
+);
+
+const SearchIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg width="20" height="20" viewBox="0 0 20 20" fill="none" {...props}>
+    <circle cx="9" cy="9" r="7" stroke="currentColor" strokeWidth="2" />
+    <line x1="14.4142" y1="14" x2="18" y2="17.5858" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+  </svg>
 );
 
 const Section = (props: { title: string; children: React.ReactNode }) => (
@@ -129,385 +135,187 @@ export const HelpDialog = ({ onClose }: { onClose?: () => void }) => {
     }
   }, [onClose]);
 
+  const [search, setSearch] = useState("");
+  const [isSearchActive, setIsSearchActive] = useState(false);
+  const searchInputRef = useRef<HTMLInputElement>(null);
+  const searchLower = search.toLowerCase();
+
+  useEffect(() => {
+    if (isSearchActive) {
+      searchInputRef.current?.focus();
+    }
+  }, [isSearchActive]);
+
+  // --- Shortcut definitions as arrays ---
+  const toolShortcuts = [
+    { label: t("toolBar.hand"), shortcuts: [KEYS.H] },
+    { label: t("toolBar.selection"), shortcuts: [KEYS.V, KEYS["1"]] },
+    { label: t("toolBar.rectangle"), shortcuts: [KEYS.R, KEYS["2"]] },
+    { label: t("toolBar.diamond"), shortcuts: [KEYS.D, KEYS["3"]] },
+    { label: t("toolBar.ellipse"), shortcuts: [KEYS.O, KEYS["4"]] },
+    { label: t("toolBar.arrow"), shortcuts: [KEYS.A, KEYS["5"]] },
+    { label: t("toolBar.line"), shortcuts: [KEYS.L, KEYS["6"]] },
+    { label: t("toolBar.freedraw"), shortcuts: [KEYS.P, KEYS["7"]] },
+    { label: t("toolBar.text"), shortcuts: [KEYS.T, KEYS["8"]] },
+    { label: t("toolBar.image"), shortcuts: [KEYS["9"]] },
+    { label: t("toolBar.eraser"), shortcuts: [KEYS.E, KEYS["0"]] },
+    { label: t("toolBar.frame"), shortcuts: [KEYS.F] },
+    { label: t("toolBar.laser"), shortcuts: [KEYS.K] },
+    { label: t("labels.eyeDropper"), shortcuts: [KEYS.I, "Shift+S", "Shift+G"] },
+    { label: t("helpDialog.editLineArrowPoints"), shortcuts: [getShortcutKey("CtrlOrCmd+Enter")] },
+    { label: t("helpDialog.editText"), shortcuts: [getShortcutKey("Enter")] },
+    { label: t("helpDialog.textNewLine"), shortcuts: [getShortcutKey("Enter"), getShortcutKey("Shift+Enter")] },
+    { label: t("helpDialog.textFinish"), shortcuts: [getShortcutKey("Esc"), getShortcutKey("CtrlOrCmd+Enter")] },
+    { label: t("helpDialog.curvedArrow"), shortcuts: ["A", t("helpDialog.click"), t("helpDialog.click"), t("helpDialog.click")], isOr: false },
+    { label: t("helpDialog.curvedLine"), shortcuts: ["L", t("helpDialog.click"), t("helpDialog.click"), t("helpDialog.click")], isOr: false },
+    { label: t("helpDialog.cropStart"), shortcuts: [t("helpDialog.doubleClick"), getShortcutKey("Enter")], isOr: true },
+    { label: t("helpDialog.cropFinish"), shortcuts: [getShortcutKey("Enter"), getShortcutKey("Escape")], isOr: true },
+    { label: t("toolBar.lock"), shortcuts: [KEYS.Q] },
+    { label: t("helpDialog.preventBinding"), shortcuts: [getShortcutKey("CtrlOrCmd")] },
+    { label: t("toolBar.link"), shortcuts: [getShortcutKey("CtrlOrCmd+K")] },
+    { label: t("toolBar.convertElementType"), shortcuts: ["Tab", "Shift+Tab"], isOr: true },
+  ];
+
+  const viewShortcuts = [
+    { label: t("buttons.zoomIn"), shortcuts: [getShortcutKey("CtrlOrCmd++")] },
+    { label: t("buttons.zoomOut"), shortcuts: [getShortcutKey("CtrlOrCmd+-")] },
+    { label: t("buttons.resetZoom"), shortcuts: [getShortcutKey("CtrlOrCmd+0")] },
+    { label: t("helpDialog.zoomToFit"), shortcuts: ["Shift+1"] },
+    { label: t("helpDialog.zoomToSelection"), shortcuts: ["Shift+2"] },
+    { label: t("helpDialog.movePageUpDown"), shortcuts: ["PgUp/PgDn"] },
+    { label: t("helpDialog.movePageLeftRight"), shortcuts: ["Shift+PgUp/PgDn"] },
+    { label: t("buttons.zenMode"), shortcuts: [getShortcutKey("Alt+Z")] },
+    { label: t("buttons.objectsSnapMode"), shortcuts: [getShortcutKey("Alt+S")] },
+    { label: t("labels.toggleGrid"), shortcuts: [getShortcutKey("CtrlOrCmd+'")] },
+    { label: t("labels.viewMode"), shortcuts: [getShortcutKey("Alt+R")] },
+    { label: t("labels.toggleTheme"), shortcuts: [getShortcutKey("Alt+Shift+D")] },
+    { label: t("stats.fullTitle"), shortcuts: [getShortcutKey("Alt+/")] },
+    { label: t("search.title"), shortcuts: [getShortcutFromShortcutName("searchMenu")] },
+    { label: t("commandPalette.title"), shortcuts: isFirefox ? [getShortcutFromShortcutName("commandPalette")] : [getShortcutFromShortcutName("commandPalette"), getShortcutFromShortcutName("commandPalette", 1)] },
+  ];
+
+  const editorShortcuts = [
+    { label: t("helpDialog.createFlowchart"), shortcuts: [getShortcutKey(`CtrlOrCmd+Arrow Key`)], isOr: true },
+    { label: t("helpDialog.navigateFlowchart"), shortcuts: [getShortcutKey(`Alt+Arrow Key`)], isOr: true },
+    { label: t("labels.moveCanvas"), shortcuts: [getShortcutKey(`Space+${t("helpDialog.drag")}`), getShortcutKey(`Wheel+${t("helpDialog.drag")}`)], isOr: true },
+    { label: t("buttons.clearReset"), shortcuts: [getShortcutKey("CtrlOrCmd+Delete")] },
+    { label: t("labels.delete"), shortcuts: [getShortcutKey("Delete")] },
+    { label: t("labels.cut"), shortcuts: [getShortcutKey("CtrlOrCmd+X")] },
+    { label: t("labels.copy"), shortcuts: [getShortcutKey("CtrlOrCmd+C")] },
+    { label: t("labels.paste"), shortcuts: [getShortcutKey("CtrlOrCmd+V")] },
+    { label: t("labels.pasteAsPlaintext"), shortcuts: [getShortcutKey("CtrlOrCmd+Shift+V")] },
+    { label: t("labels.selectAll"), shortcuts: [getShortcutKey("CtrlOrCmd+A")] },
+    { label: t("labels.multiSelect"), shortcuts: [getShortcutKey(`Shift+${t("helpDialog.click")}`)] },
+    { label: t("helpDialog.deepSelect"), shortcuts: [getShortcutKey(`CtrlOrCmd+${t("helpDialog.click")}`)] },
+    { label: t("helpDialog.deepBoxSelect"), shortcuts: [getShortcutKey(`CtrlOrCmd+${t("helpDialog.drag")}`)] },
+    // Conditional shortcut for PNG copy
+    ...(probablySupportsClipboardBlob || isFirefox ? [{ label: t("labels.copyAsPng"), shortcuts: [getShortcutKey("Shift+Alt+C")] }] : []),
+    { label: t("labels.copyStyles"), shortcuts: [getShortcutKey("CtrlOrCmd+Alt+C")] },
+    { label: t("labels.pasteStyles"), shortcuts: [getShortcutKey("CtrlOrCmd+Alt+V")] },
+    { label: t("labels.sendToBack"), shortcuts: [isDarwin ? getShortcutKey("CtrlOrCmd+Alt+[") : getShortcutKey("CtrlOrCmd+Shift+[")] },
+    { label: t("labels.bringToFront"), shortcuts: [isDarwin ? getShortcutKey("CtrlOrCmd+Alt+]") : getShortcutKey("CtrlOrCmd+Shift+]")] },
+    { label: t("labels.sendBackward"), shortcuts: [getShortcutKey("CtrlOrCmd+[")] },
+    { label: t("labels.bringForward"), shortcuts: [getShortcutKey("CtrlOrCmd+]")] },
+    { label: t("labels.alignTop"), shortcuts: [getShortcutKey("CtrlOrCmd+Shift+Up")] },
+    { label: t("labels.alignBottom"), shortcuts: [getShortcutKey("CtrlOrCmd+Shift+Down")] },
+    { label: t("labels.alignLeft"), shortcuts: [getShortcutKey("CtrlOrCmd+Shift+Left")] },
+    { label: t("labels.alignRight"), shortcuts: [getShortcutKey("CtrlOrCmd+Shift+Right")] },
+    { label: t("labels.duplicateSelection"), shortcuts: [getShortcutKey("CtrlOrCmd+D"), getShortcutKey(`Alt+${t("helpDialog.drag")}`)] },
+    { label: t("helpDialog.toggleElementLock"), shortcuts: [getShortcutKey("CtrlOrCmd+Shift+L")] },
+    { label: t("buttons.undo"), shortcuts: [getShortcutKey("CtrlOrCmd+Z")] },
+    { label: t("buttons.redo"), shortcuts: isWindows ? [getShortcutKey("CtrlOrCmd+Y"), getShortcutKey("CtrlOrCmd+Shift+Z")] : [getShortcutKey("CtrlOrCmd+Shift+Z")] },
+    { label: t("labels.group"), shortcuts: [getShortcutKey("CtrlOrCmd+G")] },
+    { label: t("labels.ungroup"), shortcuts: [getShortcutKey("CtrlOrCmd+Shift+G")] },
+    { label: t("labels.flipHorizontal"), shortcuts: [getShortcutKey("Shift+H")] },
+    { label: t("labels.flipVertical"), shortcuts: [getShortcutKey("Shift+V")] },
+    { label: t("labels.showStroke"), shortcuts: [getShortcutKey("S")] },
+    { label: t("labels.showBackground"), shortcuts: [getShortcutKey("G")] },
+    { label: t("labels.showFonts"), shortcuts: [getShortcutKey("Shift+F")] },
+    { label: t("labels.decreaseFontSize"), shortcuts: [getShortcutKey("CtrlOrCmd+Shift+<")] },
+    { label: t("labels.increaseFontSize"), shortcuts: [getShortcutKey("CtrlOrCmd+Shift+>")] },
+  ];
+
+  const filterShortcuts = (shortcuts: { label: string; shortcuts: string[] }[]) => {
+    if (!searchLower) return shortcuts;
+    return shortcuts.filter(({ label, shortcuts }) => {
+      return (
+        label.toLowerCase().includes(searchLower) ||
+        shortcuts.some((s) => s.toLowerCase().includes(searchLower))
+      );
+    });
+  };
+
   return (
-    <>
-      <Dialog
-        onCloseRequest={handleClose}
-        title={t("helpDialog.title")}
-        className={"HelpDialog"}
-      >
-        <Header />
-        <Section title={t("helpDialog.shortcuts")}>
-          <ShortcutIsland
-            className="HelpDialog__island--tools"
-            caption={t("helpDialog.tools")}
+    <Dialog
+      onCloseRequest={handleClose}
+      title={
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            position: "relative",
+            width: "100%",
+          }}
+        >
+          <span>{t("helpDialog.title")}</span>
+          <div
+            style={{
+              marginLeft: "auto",
+              position: "relative",
+              display: "flex",
+              alignItems: "center",
+            }}
           >
-            <Shortcut label={t("toolBar.hand")} shortcuts={[KEYS.H]} />
-            <Shortcut
-              label={t("toolBar.selection")}
-              shortcuts={[KEYS.V, KEYS["1"]]}
-            />
-            <Shortcut
-              label={t("toolBar.rectangle")}
-              shortcuts={[KEYS.R, KEYS["2"]]}
-            />
-            <Shortcut
-              label={t("toolBar.diamond")}
-              shortcuts={[KEYS.D, KEYS["3"]]}
-            />
-            <Shortcut
-              label={t("toolBar.ellipse")}
-              shortcuts={[KEYS.O, KEYS["4"]]}
-            />
-            <Shortcut
-              label={t("toolBar.arrow")}
-              shortcuts={[KEYS.A, KEYS["5"]]}
-            />
-            <Shortcut
-              label={t("toolBar.line")}
-              shortcuts={[KEYS.L, KEYS["6"]]}
-            />
-            <Shortcut
-              label={t("toolBar.freedraw")}
-              shortcuts={[KEYS.P, KEYS["7"]]}
-            />
-            <Shortcut
-              label={t("toolBar.text")}
-              shortcuts={[KEYS.T, KEYS["8"]]}
-            />
-            <Shortcut label={t("toolBar.image")} shortcuts={[KEYS["9"]]} />
-            <Shortcut
-              label={t("toolBar.eraser")}
-              shortcuts={[KEYS.E, KEYS["0"]]}
-            />
-            <Shortcut label={t("toolBar.frame")} shortcuts={[KEYS.F]} />
-            <Shortcut label={t("toolBar.laser")} shortcuts={[KEYS.K]} />
-            <Shortcut
-              label={t("labels.eyeDropper")}
-              shortcuts={[KEYS.I, "Shift+S", "Shift+G"]}
-            />
-            <Shortcut
-              label={t("helpDialog.editLineArrowPoints")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+Enter")]}
-            />
-            <Shortcut
-              label={t("helpDialog.editText")}
-              shortcuts={[getShortcutKey("Enter")]}
-            />
-            <Shortcut
-              label={t("helpDialog.textNewLine")}
-              shortcuts={[
-                getShortcutKey("Enter"),
-                getShortcutKey("Shift+Enter"),
-              ]}
-            />
-            <Shortcut
-              label={t("helpDialog.textFinish")}
-              shortcuts={[
-                getShortcutKey("Esc"),
-                getShortcutKey("CtrlOrCmd+Enter"),
-              ]}
-            />
-            <Shortcut
-              label={t("helpDialog.curvedArrow")}
-              shortcuts={[
-                "A",
-                t("helpDialog.click"),
-                t("helpDialog.click"),
-                t("helpDialog.click"),
-              ]}
-              isOr={false}
-            />
-            <Shortcut
-              label={t("helpDialog.curvedLine")}
-              shortcuts={[
-                "L",
-                t("helpDialog.click"),
-                t("helpDialog.click"),
-                t("helpDialog.click"),
-              ]}
-              isOr={false}
-            />
-            <Shortcut
-              label={t("helpDialog.cropStart")}
-              shortcuts={[t("helpDialog.doubleClick"), getShortcutKey("Enter")]}
-              isOr={true}
-            />
-            <Shortcut
-              label={t("helpDialog.cropFinish")}
-              shortcuts={[getShortcutKey("Enter"), getShortcutKey("Escape")]}
-              isOr={true}
-            />
-            <Shortcut label={t("toolBar.lock")} shortcuts={[KEYS.Q]} />
-            <Shortcut
-              label={t("helpDialog.preventBinding")}
-              shortcuts={[getShortcutKey("CtrlOrCmd")]}
-            />
-            <Shortcut
-              label={t("toolBar.link")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+K")]}
-            />
-            <Shortcut
-              label={t("toolBar.convertElementType")}
-              shortcuts={["Tab", "Shift+Tab"]}
-              isOr={true}
-            />
-          </ShortcutIsland>
-          <ShortcutIsland
-            className="HelpDialog__island--view"
-            caption={t("helpDialog.view")}
-          >
-            <Shortcut
-              label={t("buttons.zoomIn")}
-              shortcuts={[getShortcutKey("CtrlOrCmd++")]}
-            />
-            <Shortcut
-              label={t("buttons.zoomOut")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+-")]}
-            />
-            <Shortcut
-              label={t("buttons.resetZoom")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+0")]}
-            />
-            <Shortcut
-              label={t("helpDialog.zoomToFit")}
-              shortcuts={["Shift+1"]}
-            />
-            <Shortcut
-              label={t("helpDialog.zoomToSelection")}
-              shortcuts={["Shift+2"]}
-            />
-            <Shortcut
-              label={t("helpDialog.movePageUpDown")}
-              shortcuts={["PgUp/PgDn"]}
-            />
-            <Shortcut
-              label={t("helpDialog.movePageLeftRight")}
-              shortcuts={["Shift+PgUp/PgDn"]}
-            />
-            <Shortcut
-              label={t("buttons.zenMode")}
-              shortcuts={[getShortcutKey("Alt+Z")]}
-            />
-            <Shortcut
-              label={t("buttons.objectsSnapMode")}
-              shortcuts={[getShortcutKey("Alt+S")]}
-            />
-            <Shortcut
-              label={t("labels.toggleGrid")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+'")]}
-            />
-            <Shortcut
-              label={t("labels.viewMode")}
-              shortcuts={[getShortcutKey("Alt+R")]}
-            />
-            <Shortcut
-              label={t("labels.toggleTheme")}
-              shortcuts={[getShortcutKey("Alt+Shift+D")]}
-            />
-            <Shortcut
-              label={t("stats.fullTitle")}
-              shortcuts={[getShortcutKey("Alt+/")]}
-            />
-            <Shortcut
-              label={t("search.title")}
-              shortcuts={[getShortcutFromShortcutName("searchMenu")]}
-            />
-            <Shortcut
-              label={t("commandPalette.title")}
-              shortcuts={
-                isFirefox
-                  ? [getShortcutFromShortcutName("commandPalette")]
-                  : [
-                      getShortcutFromShortcutName("commandPalette"),
-                      getShortcutFromShortcutName("commandPalette", 1),
-                    ]
-              }
-            />
-          </ShortcutIsland>
-          <ShortcutIsland
-            className="HelpDialog__island--editor"
-            caption={t("helpDialog.editor")}
-          >
-            <Shortcut
-              label={t("helpDialog.createFlowchart")}
-              shortcuts={[getShortcutKey(`CtrlOrCmd+Arrow Key`)]}
-              isOr={true}
-            />
-            <Shortcut
-              label={t("helpDialog.navigateFlowchart")}
-              shortcuts={[getShortcutKey(`Alt+Arrow Key`)]}
-              isOr={true}
-            />
-            <Shortcut
-              label={t("labels.moveCanvas")}
-              shortcuts={[
-                getShortcutKey(`Space+${t("helpDialog.drag")}`),
-                getShortcutKey(`Wheel+${t("helpDialog.drag")}`),
-              ]}
-              isOr={true}
-            />
-            <Shortcut
-              label={t("buttons.clearReset")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+Delete")]}
-            />
-            <Shortcut
-              label={t("labels.delete")}
-              shortcuts={[getShortcutKey("Delete")]}
-            />
-            <Shortcut
-              label={t("labels.cut")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+X")]}
-            />
-            <Shortcut
-              label={t("labels.copy")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+C")]}
-            />
-            <Shortcut
-              label={t("labels.paste")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+V")]}
-            />
-            <Shortcut
-              label={t("labels.pasteAsPlaintext")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+Shift+V")]}
-            />
-            <Shortcut
-              label={t("labels.selectAll")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+A")]}
-            />
-            <Shortcut
-              label={t("labels.multiSelect")}
-              shortcuts={[getShortcutKey(`Shift+${t("helpDialog.click")}`)]}
-            />
-            <Shortcut
-              label={t("helpDialog.deepSelect")}
-              shortcuts={[getShortcutKey(`CtrlOrCmd+${t("helpDialog.click")}`)]}
-            />
-            <Shortcut
-              label={t("helpDialog.deepBoxSelect")}
-              shortcuts={[getShortcutKey(`CtrlOrCmd+${t("helpDialog.drag")}`)]}
-            />
-            {/* firefox supports clipboard API under a flag, so we'll
-                show users what they can do in the error message */}
-            {(probablySupportsClipboardBlob || isFirefox) && (
-              <Shortcut
-                label={t("labels.copyAsPng")}
-                shortcuts={[getShortcutKey("Shift+Alt+C")]}
-              />
+            {!isSearchActive && (
+              <button
+                onClick={() => setIsSearchActive(true)}
+                style={{
+                  background: "transparent",
+                  border: "none",
+                  cursor: "pointer",
+                  padding: "4px",
+                }}
+              >
+                <SearchIcon />
+              </button>
             )}
-            <Shortcut
-              label={t("labels.copyStyles")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+Alt+C")]}
+
+            <input
+              ref={searchInputRef}
+              type="text"
+              className={`HelpDialog__search-input ${isSearchActive ? "HelpDialog__search-input--active" : ""}`}
+              placeholder={t("quickSearch.placeholder") || "Quick search"}
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              onBlur={() => {
+                if (!search) setIsSearchActive(false);
+              }}
             />
-            <Shortcut
-              label={t("labels.pasteStyles")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+Alt+V")]}
-            />
-            <Shortcut
-              label={t("labels.sendToBack")}
-              shortcuts={[
-                isDarwin
-                  ? getShortcutKey("CtrlOrCmd+Alt+[")
-                  : getShortcutKey("CtrlOrCmd+Shift+["),
-              ]}
-            />
-            <Shortcut
-              label={t("labels.bringToFront")}
-              shortcuts={[
-                isDarwin
-                  ? getShortcutKey("CtrlOrCmd+Alt+]")
-                  : getShortcutKey("CtrlOrCmd+Shift+]"),
-              ]}
-            />
-            <Shortcut
-              label={t("labels.sendBackward")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+[")]}
-            />
-            <Shortcut
-              label={t("labels.bringForward")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+]")]}
-            />
-            <Shortcut
-              label={t("labels.alignTop")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+Shift+Up")]}
-            />
-            <Shortcut
-              label={t("labels.alignBottom")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+Shift+Down")]}
-            />
-            <Shortcut
-              label={t("labels.alignLeft")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+Shift+Left")]}
-            />
-            <Shortcut
-              label={t("labels.alignRight")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+Shift+Right")]}
-            />
-            <Shortcut
-              label={t("labels.duplicateSelection")}
-              shortcuts={[
-                getShortcutKey("CtrlOrCmd+D"),
-                getShortcutKey(`Alt+${t("helpDialog.drag")}`),
-              ]}
-            />
-            <Shortcut
-              label={t("helpDialog.toggleElementLock")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+Shift+L")]}
-            />
-            <Shortcut
-              label={t("buttons.undo")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+Z")]}
-            />
-            <Shortcut
-              label={t("buttons.redo")}
-              shortcuts={
-                isWindows
-                  ? [
-                      getShortcutKey("CtrlOrCmd+Y"),
-                      getShortcutKey("CtrlOrCmd+Shift+Z"),
-                    ]
-                  : [getShortcutKey("CtrlOrCmd+Shift+Z")]
-              }
-            />
-            <Shortcut
-              label={t("labels.group")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+G")]}
-            />
-            <Shortcut
-              label={t("labels.ungroup")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+Shift+G")]}
-            />
-            <Shortcut
-              label={t("labels.flipHorizontal")}
-              shortcuts={[getShortcutKey("Shift+H")]}
-            />
-            <Shortcut
-              label={t("labels.flipVertical")}
-              shortcuts={[getShortcutKey("Shift+V")]}
-            />
-            <Shortcut
-              label={t("labels.showStroke")}
-              shortcuts={[getShortcutKey("S")]}
-            />
-            <Shortcut
-              label={t("labels.showBackground")}
-              shortcuts={[getShortcutKey("G")]}
-            />
-            <Shortcut
-              label={t("labels.showFonts")}
-              shortcuts={[getShortcutKey("Shift+F")]}
-            />
-            <Shortcut
-              label={t("labels.decreaseFontSize")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+Shift+<")]}
-            />
-            <Shortcut
-              label={t("labels.increaseFontSize")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+Shift+>")]}
-            />
-          </ShortcutIsland>
-        </Section>
-      </Dialog>
-    </>
+
+          </div>
+        </div>
+      }
+      className={"HelpDialog"}
+    >
+      <Header />
+      <Section title={t("helpDialog.shortcuts")}>
+        <ShortcutIsland className="HelpDialog__island--tools" caption={t("helpDialog.tools")}>
+          {filterShortcuts(toolShortcuts).map((sc, i) => (
+            <Shortcut key={sc.label + i} {...sc} />
+          ))}
+        </ShortcutIsland>
+        <ShortcutIsland className="HelpDialog__island--view" caption={t("helpDialog.view")}>
+          {filterShortcuts(viewShortcuts).map((sc, i) => (
+            <Shortcut key={sc.label + i} {...sc} />
+          ))}
+        </ShortcutIsland>
+        <ShortcutIsland className="HelpDialog__island--editor" caption={t("helpDialog.editor")}>
+          {filterShortcuts(editorShortcuts).map((sc, i) => (
+            <Shortcut key={sc.label + i} {...sc} />
+          ))}
+        </ShortcutIsland>
+      </Section>
+    </Dialog>
   );
 };


### PR DESCRIPTION
This diff introduces a new search experience inside the HelpDialog that allows users to filter keyboard shortcuts in real time.

i have removed hardcoded components with a cleaner, array-driven approach using toolShortcuts, viewShortcuts, and editorShortcuts, this to improve maintainability, enables filtering/searching easily, and reduces repetition across the Help Dialog.

Fixes:[#9703 ]

search not active:
![image](https://github.com/user-attachments/assets/3b055632-a407-4cc5-919c-0db321e9a61e)

search active:
![image](https://github.com/user-attachments/assets/8cf57b8b-da86-485d-b38d-ac1aa685b7f7)

on search:
![image](https://github.com/user-attachments/assets/24f78e13-ca3f-4fa4-a6ec-6dd44e60df7e)
