### PR TITLE
fix(toast): prevent toast from re-rendering and resetting timeout  Fixes #9714

### DIFF
--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -593,6 +593,11 @@ class App extends React.Component<AppProps, AppState> {
    * insert to DOM before user initially scrolls to them) */
   private initializedEmbeds = new Set<ExcalidrawIframeLikeElement["id"]>();
 
+  private handleToastClose = () => {
+  this.setToast(null);
+  };
+
+
   private elementsPendingErasure: ElementsPendingErasure = new Set();
 
   public flowChartCreator: FlowChartCreator = new FlowChartCreator();
@@ -1707,14 +1712,16 @@ class App extends React.Component<AppProps, AppState> {
                               />
                             </ElementCanvasButtons>
                           )}
+                        
                         {this.state.toast !== null && (
-                          <Toast
-                            message={this.state.toast.message}
-                            onClose={() => this.setToast(null)}
-                            duration={this.state.toast.duration}
-                            closable={this.state.toast.closable}
-                          />
+                        <Toast
+                         message={this.state.toast.message}
+                         onClose={this.handleToastClose} // ✅ Stable reference
+                         duration={this.state.toast.duration}
+                         closable={this.state.toast.closable}
+                         />
                         )}
+
                         {this.state.contextMenu && (
                           <ContextMenu
                             items={this.state.contextMenu.items}

--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -594,9 +594,8 @@ class App extends React.Component<AppProps, AppState> {
   private initializedEmbeds = new Set<ExcalidrawIframeLikeElement["id"]>();
 
   private handleToastClose = () => {
-  this.setToast(null);
+    this.setToast(null);
   };
-
 
   private elementsPendingErasure: ElementsPendingErasure = new Set();
 
@@ -1712,14 +1711,14 @@ class App extends React.Component<AppProps, AppState> {
                               />
                             </ElementCanvasButtons>
                           )}
-                        
+
                         {this.state.toast !== null && (
-                        <Toast
-                         message={this.state.toast.message}
-                         onClose={this.handleToastClose} // ✅ Stable reference
-                         duration={this.state.toast.duration}
-                         closable={this.state.toast.closable}
-                         />
+                          <Toast
+                            message={this.state.toast.message}
+                            onClose={this.handleToastClose}
+                            duration={this.state.toast.duration}
+                            closable={this.state.toast.closable}
+                          />
                         )}
 
                         {this.state.contextMenu && (


### PR DESCRIPTION
This PR fixes a bug where the Toast component would re-render and reschedule its dismissal timer on every render due to an unstable inline `onClose` handler.

✅ Changes:
- Moved `onClose={() => this.setToast(null)}` to a class method `handleToastClose` to ensure a stable reference.
- Prevents unnecessary re-renders and ensures the toast closes after the intended duration.

Fixes #9714
