### PR TITLE
fix: Add default CSS Export to fix deno imports

### DIFF
--- a/packages/excalidraw/package.json
+++ b/packages/excalidraw/package.json
@@ -23,7 +23,8 @@
     },
     "./index.css": {
       "development": "./dist/dev/index.css",
-      "production": "./dist/prod/index.css"
+      "production": "./dist/prod/index.css",
+      "default": "./dist/prod/index.css"
     },
     ".": {
       "types": "./dist/types/excalidraw/index.d.ts",


### PR DESCRIPTION
## Problem
When using Deno/Vite with Excalidraw, when importing the CSS file an error is thrown by Deno (though it works fine as Vite bundles it anyways). 

```ts
import "@excalidraw/excalidraw/index.css";
```

```shell
error: Error: [ERR_INVALID_PACKAGE_TARGET] Invalid "exports" target {"development":"./dist/dev/index.css","production":"./dist/prod/index.css"} defined for './index.css' in the package .../node_modules/@excalidraw/excalidraw/package.json imported from 'apps/web/src/excalidraw/Excalidraw.tsx'; target must start with "./"
```

The error is a bit misleading, as the export is defined but does not have any condition Deno recognizes, nor are in the [package.json spec](https://nodejs.org/api/packages.html#conditional-exports)  (development and production). 

## Changes
This PR adds a 'default' condition to the css exports target, which Deno recognizes and fixes the error during typechecking. 