### PR TITLE
fix: update scene example in docs

### DIFF
--- a/dev-docs/src/theme/ReactLiveScope/index.js
+++ b/dev-docs/src/theme/ReactLiveScope/index.js
@@ -33,6 +33,7 @@ const ExcalidrawScope = {
   initialData,
   useI18n: ExcalidrawComp.useI18n,
   convertToExcalidrawElements: ExcalidrawComp.convertToExcalidrawElements,
+  CaptureUpdateAction: ExcalidrawComp.CaptureUpdateAction,
 };
 
 export default ExcalidrawScope;


### PR DESCRIPTION
The `updateScene` button is broken in the docs since the `CaptureUpdateAction` import was missing. This PR fixes it.