### PR TITLE
fix: improve line creation ux on touch screens

### DIFF
--- a/packages/excalidraw/actions/actionFinalize.tsx
+++ b/packages/excalidraw/actions/actionFinalize.tsx
@@ -157,7 +157,9 @@ export const actionFinalize = register({
       if (
         appState.multiElement &&
         element.type !== "freedraw" &&
-        appState.lastPointerDownWith !== "touch"
+        appState.lastPointerDownWith !== "touch" &&
+        // don't remove the last point on touch devices
+        !app.device.isTouchScreen
       ) {
         const { points, lastCommittedPoint } = element;
         if (

--- a/packages/excalidraw/components/Actions.tsx
+++ b/packages/excalidraw/components/Actions.tsx
@@ -46,6 +46,8 @@ import {
   hasStrokeWidth,
 } from "../scene";
 
+import { actionFinalize } from "../actions";
+
 import { SHAPES } from "./shapes";
 
 import "./Actions.scss";
@@ -507,13 +509,16 @@ export const ExitZenModeAction = ({
 );
 
 export const FinalizeAction = ({
-  renderAction,
+  actionManager,
   className,
 }: {
-  renderAction: ActionManager["renderAction"];
+  actionManager: ActionManager;
   className?: string;
 }) => (
-  <div className={`finalize-button ${className}`}>
-    {renderAction("finalize", { size: "small" })}
+  <div
+    className={`finalize-button ${className ?? ""}`}
+    onClick={() => actionManager.executeAction(actionFinalize)}
+  >
+    Finish
   </div>
 );

--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -9103,19 +9103,23 @@ class App extends React.Component<AppProps, AppState> {
         );
 
         if (!pointerDownState.drag.hasOccurred && newElement && !multiElement) {
-          this.scene.mutateElement(
-            newElement,
-            {
-              points: [
-                ...newElement.points,
-                pointFrom<LocalPoint>(
-                  pointerCoords.x - newElement.x,
-                  pointerCoords.y - newElement.y,
-                ),
-              ],
-            },
-            { informMutation: false, isDragging: false },
-          );
+          const dx = pointerCoords.x - newElement.x;
+          const dy = pointerCoords.y - newElement.y;
+          const MIN_DISTANCE_TO_ADD_POINT_ON_TOUCH = 10;
+          const shouldAddPoint = this.device.isTouchScreen
+            ? Math.abs(dx) >= MIN_DISTANCE_TO_ADD_POINT_ON_TOUCH ||
+              Math.abs(dy) >= MIN_DISTANCE_TO_ADD_POINT_ON_TOUCH
+            : true;
+
+          if (shouldAddPoint) {
+            this.scene.mutateElement(
+              newElement,
+              {
+                points: [...newElement.points, pointFrom<LocalPoint>(dx, dy)],
+              },
+              { informMutation: false, isDragging: false },
+            );
+          }
 
           this.setState({
             multiElement: newElement,

--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -416,6 +416,7 @@ import {
 } from "./hyperlink/helpers";
 import { MagicIcon, copyIcon, fullscreenIcon } from "./icons";
 import { Toast } from "./Toast";
+import { FinalizeAction } from "./Actions";
 
 import { findShapeByKey } from "./shapes";
 
@@ -1502,6 +1503,46 @@ class App extends React.Component<AppProps, AppState> {
       event.type === "pointerenter" ? "none" : "auto";
   }
 
+  // Render floating finalize button near the last point during multi-point creation on touch devices
+  private renderFloatingFinalize = () => {
+    if (!this.device.isTouchScreen) {
+      return null;
+    }
+
+    const { multiElement } = this.state;
+    if (!multiElement) {
+      return null;
+    }
+
+    const elementsMap = arrayToMap(this.scene.getNonDeletedElements());
+    const globalPt = LinearElementEditor.getPointAtIndexGlobalCoordinates(
+      multiElement as any,
+      -1,
+      elementsMap,
+    );
+
+    const { x: viewportX, y: viewportY } = sceneCoordsToViewportCoords(
+      { sceneX: globalPt[0], sceneY: globalPt[1] },
+      this.state,
+    );
+
+    const OFFSET = 12;
+
+    return (
+      <div
+        className={CLASSES.CONVERT_ELEMENT_TYPE_POPUP}
+        style={{
+          position: "absolute",
+          left: viewportX + OFFSET,
+          top: viewportY - OFFSET,
+          zIndex: 1000,
+        }}
+      >
+        <FinalizeAction actionManager={this.actionManager} />
+      </div>
+    );
+  };
+
   public render() {
     const selectedElements = this.scene.getSelectedElements(this.state);
     const { renderTopRightUI, renderCustomStats } = this.props;
@@ -1818,6 +1859,7 @@ class App extends React.Component<AppProps, AppState> {
                           />
                         )}
                         {this.renderFrameNames()}
+                        {this.renderFloatingFinalize()}
                         {this.state.activeLockedId && (
                           <UnlockPopup
                             app={this}

--- a/packages/excalidraw/components/footer/Footer.tsx
+++ b/packages/excalidraw/components/footer/Footer.tsx
@@ -62,7 +62,7 @@ const Footer = ({
             )}
             {showFinalize && (
               <FinalizeAction
-                renderAction={actionManager.renderAction}
+                actionManager={actionManager}
                 className={clsx("zen-mode-transition", {
                   "layer-ui__wrapper__footer-left--transition-left":
                     appState.zenModeEnabled,

--- a/packages/excalidraw/components/footer/Footer.tsx
+++ b/packages/excalidraw/components/footer/Footer.tsx
@@ -2,13 +2,7 @@ import clsx from "clsx";
 
 import { actionShortcuts } from "../../actions";
 import { useTunnels } from "../../context/tunnels";
-import {
-  ExitZenModeAction,
-  FinalizeAction,
-  UndoRedoActions,
-  ZoomActions,
-} from "../Actions";
-import { useDevice } from "../App";
+import { ExitZenModeAction, UndoRedoActions, ZoomActions } from "../Actions";
 import { HelpButton } from "../HelpButton";
 import { Section } from "../Section";
 import Stack from "../Stack";
@@ -28,10 +22,6 @@ const Footer = ({
   renderWelcomeScreen: boolean;
 }) => {
   const { FooterCenterTunnel, WelcomeScreenHelpHintTunnel } = useTunnels();
-
-  const device = useDevice();
-  const showFinalize =
-    !appState.viewModeEnabled && appState.multiElement && device.isTouchScreen;
 
   return (
     <footer
@@ -56,15 +46,6 @@ const Footer = ({
                 renderAction={actionManager.renderAction}
                 className={clsx("zen-mode-transition", {
                   "layer-ui__wrapper__footer-left--transition-bottom":
-                    appState.zenModeEnabled,
-                })}
-              />
-            )}
-            {showFinalize && (
-              <FinalizeAction
-                actionManager={actionManager}
-                className={clsx("zen-mode-transition", {
-                  "layer-ui__wrapper__footer-left--transition-left":
                     appState.zenModeEnabled,
                 })}
               />

--- a/packages/excalidraw/css/styles.scss
+++ b/packages/excalidraw/css/styles.scss
@@ -481,7 +481,6 @@ body.excalidraw-cursor-resize * {
     gap: 0.4em;
     margin-top: auto;
     margin-bottom: auto;
-    margin-inline-start: 0.6em;
   }
 
   .undo-redo-buttons,

--- a/packages/excalidraw/css/styles.scss
+++ b/packages/excalidraw/css/styles.scss
@@ -481,6 +481,7 @@ body.excalidraw-cursor-resize * {
     gap: 0.4em;
     margin-top: auto;
     margin-bottom: auto;
+    margin-inline-start: 0.6em;
   }
 
   .undo-redo-buttons,


### PR DESCRIPTION
Instead of the complex/awkward flow of creating a multi-point arrow/line on a touch screen, we now replace it with a "press" to add a default line/arrow feature.