### PR TITLE
feat: expose `applyTo` options, don't commit empty text element

### DIFF
--- a/packages/element/src/delta.ts
+++ b/packages/element/src/delta.ts
@@ -1733,6 +1733,11 @@ export class ElementsDelta implements DeltaContainer<SceneElementsMap> {
         continue;
       }
 
+      if (!boundText.text) {
+        // skip redraw if the text is empty, as it would redraw the container incorreclty, according to the with empty text dimensions
+        continue;
+      }
+
       redrawTextBoundingBox(boundText, container, scene);
     }
   }

--- a/packages/element/src/delta.ts
+++ b/packages/element/src/delta.ts
@@ -1733,11 +1733,6 @@ export class ElementsDelta implements DeltaContainer<SceneElementsMap> {
         continue;
       }
 
-      if (!boundText.text) {
-        // skip redraw if the text is empty, as it would redraw the container incorreclty, according to the with empty text dimensions
-        continue;
-      }
-
       redrawTextBoundingBox(boundText, container, scene);
     }
   }

--- a/packages/element/src/store.ts
+++ b/packages/element/src/store.ts
@@ -27,6 +27,8 @@ import {
   isImageElement,
 } from "./index";
 
+import type { ApplyToOptions } from "./delta";
+
 import type {
   ExcalidrawElement,
   OrderedExcalidrawElement,
@@ -570,9 +572,15 @@ export class StoreDelta {
     delta: StoreDelta,
     elements: SceneElementsMap,
     appState: AppState,
+    options: ApplyToOptions = {
+      excludedProperties: new Set(),
+    },
   ): [SceneElementsMap, AppState, boolean] {
-    const [nextElements, elementsContainVisibleChange] =
-      delta.elements.applyTo(elements);
+    const [nextElements, elementsContainVisibleChange] = delta.elements.applyTo(
+      elements,
+      StoreSnapshot.empty().elements,
+      options,
+    );
 
     const [nextAppState, appStateContainsVisibleChange] =
       delta.appState.applyTo(appState, nextElements);

--- a/packages/excalidraw/wysiwyg/textWysiwyg.test.tsx
+++ b/packages/excalidraw/wysiwyg/textWysiwyg.test.tsx
@@ -704,7 +704,7 @@ describe("textWysiwyg", () => {
         rectangle.x + rectangle.width / 2,
         rectangle.y + rectangle.height / 2,
       );
-      expect(h.elements.length).toBe(3);
+      expect(h.elements.length).toBe(2);
 
       text = h.elements[1] as ExcalidrawTextElementWithContainer;
       expect(text.type).toBe("text");
@@ -1198,7 +1198,7 @@ describe("textWysiwyg", () => {
       updateTextEditor(editor, "   ");
       Keyboard.exitTextEditor(editor);
       expect(rectangle.boundElements).toStrictEqual([]);
-      expect(h.elements[1].isDeleted).toBe(true);
+      expect(h.elements[1]).toBeUndefined();
     });
 
     it("should restore original container height and clear cache once text is unbind", async () => {


### PR DESCRIPTION
- expose `applyTo` options
- don't commit empty text element (i.e. when losing focus), as it causes redraw issues