### PR TITLE
fix: Remove local elements when there is room data during `startCollaboration`

### DIFF
--- a/excalidraw-app/collab/Collab.tsx
+++ b/excalidraw-app/collab/Collab.tsx
@@ -530,7 +530,10 @@ class Collab extends PureComponent<CollabProps, CollabState> {
       return null;
     }
 
-    if (!existingRoomLinkData) {
+    if (existingRoomLinkData) {
+      // Local elements not needed in this case
+      this.excalidrawAPI.resetScene();
+    } else {
       const elements = this.excalidrawAPI.getSceneElements().map((element) => {
         if (isImageElement(element) && element.status === "saved") {
           return newElementWith(element, { status: "pending" });


### PR DESCRIPTION
fixes #9706

The problem was that, on URL hash change, our local elements were still in the scene, so the collaboration elements reconciliation would leak them into the room.