### PR TITLE
fix: Fix the root cause of `flushSync` flickering

### DIFF
--- a/packages/excalidraw/components/canvases/StaticCanvas.tsx
+++ b/packages/excalidraw/components/canvases/StaticCanvas.tsx
@@ -49,26 +49,6 @@ const StaticCanvas = (props: StaticCanvasProps) => {
       canvas.classList.add("excalidraw__canvas", "static");
     }
 
-    const widthString = `${props.appState.width}px`;
-    const heightString = `${props.appState.height}px`;
-    if (canvas.style.width !== widthString) {
-      canvas.style.width = widthString;
-    }
-    if (canvas.style.height !== heightString) {
-      canvas.style.height = heightString;
-    }
-
-    const scaledWidth = props.appState.width * props.scale;
-    const scaledHeight = props.appState.height * props.scale;
-    // setting width/height resets the canvas even if dimensions not changed,
-    // which would cause flicker when we skip frame (due to throttling)
-    if (canvas.width !== scaledWidth) {
-      canvas.width = scaledWidth;
-    }
-    if (canvas.height !== scaledHeight) {
-      canvas.height = scaledHeight;
-    }
-
     renderStaticScene(
       {
         canvas,
@@ -83,6 +63,13 @@ const StaticCanvas = (props: StaticCanvasProps) => {
       isRenderThrottlingEnabled(),
     );
   });
+
+  useEffect(() => {
+    props.canvas.style.width = `${props.appState.width}px`;
+    props.canvas.style.height = `${props.appState.height}px`;
+    props.canvas.width = props.appState.width * props.scale;
+    props.canvas.height = props.appState.height * props.scale;
+  }, [props.appState.height, props.appState.width, props.canvas, props.scale]);
 
   return <div className="excalidraw__canvas-wrapper" ref={wrapperRef} />;
 };

--- a/packages/excalidraw/components/canvases/StaticCanvas.tsx
+++ b/packages/excalidraw/components/canvases/StaticCanvas.tsx
@@ -35,6 +35,13 @@ const StaticCanvas = (props: StaticCanvasProps) => {
   const isComponentMounted = useRef(false);
 
   useEffect(() => {
+    props.canvas.style.width = `${props.appState.width}px`;
+    props.canvas.style.height = `${props.appState.height}px`;
+    props.canvas.width = props.appState.width * props.scale;
+    props.canvas.height = props.appState.height * props.scale;
+  }, [props.appState.height, props.appState.width, props.canvas, props.scale]);
+
+  useEffect(() => {
     const wrapper = wrapperRef.current;
     if (!wrapper) {
       return;
@@ -63,13 +70,6 @@ const StaticCanvas = (props: StaticCanvasProps) => {
       isRenderThrottlingEnabled(),
     );
   });
-
-  useEffect(() => {
-    props.canvas.style.width = `${props.appState.width}px`;
-    props.canvas.style.height = `${props.appState.height}px`;
-    props.canvas.width = props.appState.width * props.scale;
-    props.canvas.height = props.appState.height * props.scale;
-  }, [props.appState.height, props.appState.width, props.canvas, props.scale]);
 
   return <div className="excalidraw__canvas-wrapper" ref={wrapperRef} />;
 };


### PR DESCRIPTION
The problem was that browsers have some rounding logic when doing `canvas.style.[width|height] = ...` and `canvas.[width|height] = ...`. Hence, with some setups, conditions like [this](https://github.com/excalidraw/excalidraw/blob/d6a934ed196874e50dac498c63e9f2af7c90296d/packages/excalidraw/components/canvases/StaticCanvas.tsx#L54) always returned false. These conditions are there to prevent flickering.

The solution in this PR switches from comparing against the DOM values to comparing against previous values (via `useEffect`).

This PR should fix `flushSync` flickering issues like flickering during alt-duplication and flickering during line editor point addition.