### PR TITLE
fix: frame child detached from frame when aligned outside of frame bounds

### DIFF
--- a/packages/element/src/frame.ts
+++ b/packages/element/src/frame.ts
@@ -780,12 +780,14 @@ export const isElementInFrame = (
   };
 
   if (
+    // to account for unique case when element is aligned where it is selected, and still has a frameId
+    // check if element overlaps first with the frame
+    elementOverlapsWithFrame(_element, frame, allElementsMap) &&
     // if the element is not selected, or it is selected but not being dragged,
     // frame membership won't update, so return true
-    !appState.selectedElementIds[_element.id] ||
-    !appState.selectedElementsAreBeingDragged ||
-    // if both frame and element are selected, won't update membership, so return true
-    (appState.selectedElementIds[_element.id] &&
+    (!appState.selectedElementIds[_element.id] ||
+      !appState.selectedElementsAreBeingDragged ||
+      // if both frame and element are selected, won't update membership, so return true
       appState.selectedElementIds[frame.id])
   ) {
     return true;

--- a/packages/element/tests/align.test.tsx
+++ b/packages/element/tests/align.test.tsx
@@ -1009,4 +1009,48 @@ describe("aligning", () => {
     expect(API.getSelectedElements()[1].x).toEqual(150);
     expect(API.getSelectedElements()[2].x).toEqual(100);
   });
+
+  const createAndSelectChildOfFrameAndExternalRectangle = () => {
+    const frame = API.createElement({
+      id: "id0",
+      type: "frame",
+      x: 0,
+      y: 0,
+      width: 100,
+      height: 100,
+    });
+    const child = API.createElement({
+      id: "id1",
+      type: "rectangle",
+      x: 10,
+      y: 10,
+      width: 50,
+      height: 50,
+      frameId: frame.id,
+    });
+    const external = API.createElement({
+      id: "id2",
+      type: "rectangle",
+      x: 100,
+      y: 100,
+      width: 200,
+      height: 200,
+    });
+
+    API.setElements([frame, child, external]);
+    API.setSelectedElements([child, external]);
+  };
+
+  it("removes frame membership on alignment outside bounds of frame", () => {
+    createAndSelectChildOfFrameAndExternalRectangle();
+
+    expect(API.getSelectedElements()[0].x).toEqual(10);
+    expect(API.getSelectedElements()[1].x).toEqual(100);
+
+    API.executeAction(actionAlignRight);
+
+    expect(API.getSelectedElements()[0].x).toEqual(250);
+    expect(API.getSelectedElements()[1].x).toEqual(100);
+    expect(API.getSelectedElements()[1].frameId).toEqual(null);
+  });
 });


### PR DESCRIPTION
# Summary
Prevents the bug where if a child element of a frame is aligned to an external element outside of frame bounds, the child element will retain it's `frameId`.

## Fix:
- found point of interest in `isElementInFrame` in `frame.ts`, where a condition defaulted to `true` in the case stated above. 
- Since alignment repositions elements without triggering drag state changes, affected child elements remained selected and retained their `frameId` despite being moved out of bounds.
- Added an additional condition within isElementInFrame to handle this unique alignment case.
- Included a test to verify that aligned child elements moved outside their parent frame correctly have frameId set to null.

### Additional Notes:
- This scenario felt unique to the alignment behavior, so I placed the test there. Open to moving it to the frame tests if that feels more appropriate.

### Feedback Welcome
Open and willing to make any changes or modifications necessary.

## Related Issue:
Fixes #9793 

cc: @dwelle @Mrazator – Appreciate any input you guys may have on this, If any issues or modifications are required, just let me know.