### PR TITLE
fix: Don't show ConvertElementTypePopup if it's position is (0, 0)

### DIFF
--- a/packages/excalidraw/components/ConvertElementTypePopup.tsx
+++ b/packages/excalidraw/components/ConvertElementTypePopup.tsx
@@ -313,6 +313,7 @@ const Panel = ({
       ref={panelRef}
       tabIndex={-1}
       style={{
+        visibility: `${positionRef.current === "" ? "hidden" : "visible"}`,
         position: "absolute",
         top: `${
           panelPosition.y +


### PR DESCRIPTION
One line fix for this issue: #9815
