### PR TITLE
fix(events): CMD+C/V shortcuts on iPadOS

### DIFF
--- a/packages/excalidraw/actions/actionClipboard.tsx
+++ b/packages/excalidraw/actions/actionClipboard.tsx
@@ -1,7 +1,7 @@
 import { isTextElement } from "@excalidraw/element";
 import { getTextFromElements } from "@excalidraw/element";
 
-import { CODES, KEYS, isFirefox } from "@excalidraw/common";
+import { CODES, isFirefox, isIOS, KEYS } from "@excalidraw/common";
 
 import { CaptureUpdateAction } from "@excalidraw/element";
 
@@ -25,7 +25,12 @@ export const actionCopy = register({
   label: "labels.copy",
   icon: DuplicateIcon,
   trackEvent: { category: "element" },
-  perform: async (elements, appState, event: ClipboardEvent | null, app) => {
+  perform: async (
+    elements,
+    appState,
+    event: ClipboardEvent | KeyboardEvent | null,
+    app,
+  ) => {
     const elementsToCopy = app.scene.getSelectedElements({
       selectedElementIds: appState.selectedElementIds,
       includeBoundTextElement: true,
@@ -33,7 +38,11 @@ export const actionCopy = register({
     });
 
     try {
-      await copyToClipboard(elementsToCopy, app.files, event);
+      await copyToClipboard(
+        elementsToCopy,
+        app.files,
+        event instanceof ClipboardEvent ? event : null,
+      );
     } catch (error: any) {
       return {
         captureUpdate: CaptureUpdateAction.EVENTUALLY,
@@ -49,7 +58,9 @@ export const actionCopy = register({
     };
   },
   // don't supply a shortcut since we handle this conditionally via onCopy event
-  keyTest: undefined,
+  keyTest: (event) =>
+    (isIOS && event[KEYS.CTRL_OR_CMD] && event.key === KEYS.C) ||
+    (event[KEYS.CTRL_OR_CMD] && event.key === KEYS.C),
 });
 
 export const actionPaste = register({
@@ -106,7 +117,9 @@ export const actionPaste = register({
     };
   },
   // don't supply a shortcut since we handle this conditionally via onCopy event
-  keyTest: undefined,
+  keyTest: (event) =>
+    (isIOS && event[KEYS.CTRL_OR_CMD] && event.key === KEYS.V) ||
+    (event[KEYS.CTRL_OR_CMD] && event.key === KEYS.V),
 });
 
 export const actionCut = register({


### PR DESCRIPTION
This change fixes an issue where CMD+C and CMD+V keyboard shortcuts were not working on iPadOS.

The root cause was that Excalidraw relied on `copy` and `paste` DOM events, which are not reliably fired on iPadOS when using keyboard shortcuts.

The fix is to add `keyTest` handlers for the `copy` and `paste` actions, which listen for `keydown` events. This mirrors the implementation of the `cut` action, which was already working correctly on iPadOS.