### PR TITLE
feat: beforeElementCreated hook

### DIFF
--- a/packages/element/src/types.ts
+++ b/packages/element/src/types.ts
@@ -32,6 +32,10 @@ type VerticalAlignKeys = keyof typeof VERTICAL_ALIGN;
 export type VerticalAlign = typeof VERTICAL_ALIGN[VerticalAlignKeys];
 export type FractionalIndex = string & { _brand: "franctionalIndex" };
 
+export type beforeElementCreated = (
+  element: ExcalidrawElement,
+) => ExcalidrawElement;
+
 export type BoundElement = Readonly<{
   id: ExcalidrawLinearElement["id"];
   type: "arrow" | "text";

--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -694,6 +694,9 @@ class App extends React.Component<AppProps, AppState> {
       this,
     );
     this.scene = new Scene();
+    if (props.beforeElementCreated) {
+      this.scene.beforeElementCreated(props.beforeElementCreated);
+    }
 
     this.canvas = document.createElement("canvas");
     this.rc = rough.canvas(this.canvas);

--- a/packages/excalidraw/index.tsx
+++ b/packages/excalidraw/index.tsx
@@ -23,6 +23,7 @@ polyfill();
 const ExcalidrawBase = (props: ExcalidrawProps) => {
   const {
     onChange,
+    beforeElementCreated,
     onIncrement,
     initialData,
     excalidrawAPI,
@@ -115,6 +116,7 @@ const ExcalidrawBase = (props: ExcalidrawProps) => {
       <InitializeApp langCode={langCode} theme={theme}>
         <App
           onChange={onChange}
+          beforeElementCreated={beforeElementCreated}
           onIncrement={onIncrement}
           initialData={initialData}
           excalidrawAPI={excalidrawAPI}

--- a/packages/excalidraw/types.ts
+++ b/packages/excalidraw/types.ts
@@ -533,6 +533,7 @@ export interface ExcalidrawProps {
     appState: AppState,
     files: BinaryFiles,
   ) => void;
+  beforeElementCreated?: (element: ExcalidrawElement) => ExcalidrawElement;
   onIncrement?: (event: DurableIncrement | EphemeralIncrement) => void;
   initialData?:
     | (() => MaybePromise<ExcalidrawInitialDataState | null>)


### PR DESCRIPTION
In order to add customData to newly created Elements it would be useful to have a beforeElementCreated hook exposed from the npm package.
resolves #9858 