### PR TITLE
enhancement: support multi-image upload and drag-and-drop

### DIFF
--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -10038,24 +10038,35 @@ class App extends React.Component<AppProps, AppState> {
       const clientX = this.state.width / 2 + this.state.offsetLeft;
       const clientY = this.state.height / 2 + this.state.offsetTop;
 
-      const { x, y } = viewportCoordsToSceneCoords(
+            const { x: baseX, y: baseY } = viewportCoordsToSceneCoords(
         { clientX, clientY },
         this.state,
       );
 
-      const imageFile = await fileOpen({
+      // Allow multiple images
+      const imageFiles = await fileOpen({
         description: "Image",
         extensions: Object.keys(
           IMAGE_MIME_TYPES,
         ) as (keyof typeof IMAGE_MIME_TYPES)[],
+        multiple: true,
       });
 
-      await this.createImageElement({
-        sceneX: x,
-        sceneY: y,
-        addToFrameUnderCursor: false,
-        imageFile,
-      });
+      // treat as array
+      const filesArray = Array.isArray(imageFiles) ? imageFiles : [imageFiles];
+      const gridSize = 40;
+      let imageIndex = 0;
+      for (const imageFile of filesArray) {
+        const sceneX = baseX + (imageIndex % 4) * gridSize;
+        const sceneY = baseY + Math.floor(imageIndex / 4) * gridSize;
+        await this.createImageElement({
+          sceneX,
+          sceneY,
+          addToFrameUnderCursor: false,
+          imageFile,
+        });
+        imageIndex++;
+      }
 
       // avoid being batched (just in case)
       this.setState({}, () => {


### PR DESCRIPTION
This PR adds support for uploading and dragging multiple images at once into Excalidraw.

Changes :

- Users can select and upload multiple images from the file manager.
- Users can drag and drop several images at once onto the canvas.
- Images are arranged in a grid layout to prevent overlap.
- Fixes long-standing issue: #6608 

Preview:
https://drive.google.com/file/d/1O03NQh5dI5drnvAxI6-Pcg1SJBXftQCT/view?usp=sharing