### PR TITLE
[ Critical BugFix ]Images inserted via paste/tool display correctly initially but show grey placeholders after reopening when remote file fetch (Firebase Storage) is blocked   (fixes #9161)

### DIFF
--- a/excalidraw-app/App.tsx
+++ b/excalidraw-app/App.tsx
@@ -61,6 +61,7 @@ import type { RemoteExcalidrawElement } from "@excalidraw/excalidraw/data/reconc
 import type { RestoredDataState } from "@excalidraw/excalidraw/data/restore";
 import type {
   FileId,
+  ExcalidrawElement,
   NonDeletedExcalidrawElement,
   OrderedExcalidrawElement,
 } from "@excalidraw/element/types";
@@ -416,14 +417,60 @@ const ExcalidrawWrapper = () => {
               elements: data.scene.elements,
               forceFetchFiles: true,
             })
-            .then(({ loadedFiles, erroredFiles }) => {
-              excalidrawAPI.addFiles(loadedFiles);
+            .then(
+              async ({
+                loadedFiles,
+                erroredFiles,
+              }: {
+                loadedFiles: import("@excalidraw/excalidraw/types").BinaryFileData[];
+                erroredFiles: Map<FileId, true>;
+              }) => {
+              // Persist successfully fetched files to local cache for offline/future use
+              if (loadedFiles.length) {
+                excalidrawAPI.addFiles(loadedFiles);
+                try {
+                  const filesMap: BinaryFiles = {};
+                  for (const f of loadedFiles) filesMap[f.id] = f;
+                  const elementsToSave = excalidrawAPI
+                    .getSceneElementsIncludingDeleted()
+                    .filter((el: ExcalidrawElement) =>
+                      isInitializedImageElement(el) && filesMap[el.fileId],
+                    );
+                  await LocalData.fileStorage.saveFiles({
+                    elements: elementsToSave,
+                    files: filesMap,
+                  });
+                } catch (err) {
+                  // non-fatal: caching to IDB failed
+                  console.warn("Failed to save fetched files to IDB", err);
+                }
+              }
+
+              // If some files errored (e.g., Firebase blocked by VPN), try local IDB fallback
+              if (erroredFiles.size) {
+                try {
+                  const fallback = await LocalData.fileStorage.getFiles([
+                    ...erroredFiles.keys(),
+                  ]);
+                  if (fallback.loadedFiles.length) {
+                    excalidrawAPI.addFiles(fallback.loadedFiles);
+                    // Remove recovered files from the errored set
+                    for (const f of fallback.loadedFiles) {
+                      erroredFiles.delete(f.id);
+                    }
+                  }
+                } catch (err) {
+                  console.warn("Failed to load files from IDB fallback", err);
+                }
+              }
+
               updateStaleImageStatuses({
                 excalidrawAPI,
                 erroredFiles,
                 elements: excalidrawAPI.getSceneElementsIncludingDeleted(),
               });
-            });
+              },
+            );
         }
       } else {
         const fileIds =
@@ -439,14 +486,58 @@ const ExcalidrawWrapper = () => {
             `${FIREBASE_STORAGE_PREFIXES.shareLinkFiles}/${data.id}`,
             data.key,
             fileIds,
-          ).then(({ loadedFiles, erroredFiles }) => {
-            excalidrawAPI.addFiles(loadedFiles);
+          ).then(
+            async ({
+              loadedFiles,
+              erroredFiles,
+            }: {
+              loadedFiles: import("@excalidraw/excalidraw/types").BinaryFileData[];
+              erroredFiles: Map<FileId, true>;
+            }) => {
+            // Add and persist successfully fetched files
+            if (loadedFiles.length) {
+              excalidrawAPI.addFiles(loadedFiles);
+              try {
+                const filesMap: BinaryFiles = {};
+                for (const f of loadedFiles) filesMap[f.id] = f;
+                const elementsToSave = excalidrawAPI
+                  .getSceneElementsIncludingDeleted()
+                  .filter((el: ExcalidrawElement) =>
+                    isInitializedImageElement(el) && filesMap[el.fileId],
+                  );
+                await LocalData.fileStorage.saveFiles({
+                  elements: elementsToSave,
+                  files: filesMap,
+                });
+              } catch (err) {
+                console.warn("Failed to save fetched files to IDB", err);
+              }
+            }
+
+            // VPN/blocked network fallback: try to read missing files from local IDB
+            if (erroredFiles.size) {
+              try {
+                const fallback = await LocalData.fileStorage.getFiles([
+                  ...erroredFiles.keys(),
+                ]);
+                if (fallback.loadedFiles.length) {
+                  excalidrawAPI.addFiles(fallback.loadedFiles);
+                  for (const f of fallback.loadedFiles) {
+                    erroredFiles.delete(f.id);
+                  }
+                }
+              } catch (err) {
+                console.warn("Failed to load files from IDB fallback", err);
+              }
+            }
+
             updateStaleImageStatuses({
               excalidrawAPI,
               erroredFiles,
               elements: excalidrawAPI.getSceneElementsIncludingDeleted(),
             });
-          });
+          },
+          );
         } else if (isInitialLoad) {
           if (fileIds.length) {
             LocalData.fileStorage


### PR DESCRIPTION
Description

Problem: Images inserted via paste/tool display correctly initially but show grey placeholders after reopening when remote file fetch (Firebase Storage) is blocked (e.g., VPN). See #9161.
Root cause: Images are stored separately; on reload the app fetches files from Firebase. If the request fails, image elements remain in “error” and render placeholders.
Solution: Persist any successfully fetched image files to local IndexedDB and use a local fallback when remote fetch fails.
On collab fetch (collabAPI.fetchImageFilesFromFirebase):
Add fetched files to editor and persist them to IndexedDB.
For errored fileIds, try loading them from IndexedDB; add recovered files and suppress “error” status for those.
On share-link fetch (loadFilesFromFirebase):
Same persist-on-success and fallback-on-error flow.
Scope: [App.tsx](vscode-file://vscode-app/private/var/folders/gs/jnsjv8h14gd8mkxd180ykkf00000gn/T/AppTranslocation/F003915A-CC31-4A16-A851-4A6D5222B00B/d/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) only. No public API changes. No changes to scene JSON format.

How it works

First successful fetch seeds IDB. Subsequent loads work even when Firebase is blocked because files are recovered from IDB.
If a file was never fetched successfully at least once, there’s nothing to recover locally; those will still appear as placeholders when remote is unreachable.
Testing

Insert an image, create share/collab link.
Load once without VPN (seeds cache), then block [https://firebasestorage.googleapis.com](vscode-file://vscode-app/private/var/folders/gs/jnsjv8h14gd8mkxd180ykkf00000gn/T/AppTranslocation/F003915A-CC31-4A16-A851-4A6D5222B00B/d/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) (e.g., enable VPN).
Reopen the same scene: images load from IDB, no grey placeholders.
Verified both:
Collaboration flow (collab fetch → cache; fallback from IDB).
Share-link flow (share fetch → cache; fallback from IDB).