### PR TITLE
fix: wheel scroll when embeddable has canvas element

### DIFF
--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -11161,11 +11161,11 @@ class App extends React.Component<AppProps, AppState> {
       // if not scrolling on canvas/wysiwyg, ignore
       if (
         !(
-          event.target instanceof HTMLCanvasElement ||
+          (event.target instanceof HTMLCanvasElement &&
+            event.target.classList.contains("excalidraw__canvas")) ||
           event.target instanceof HTMLTextAreaElement ||
           event.target instanceof HTMLIFrameElement
-        ) ||
-        this.state.activeEmbeddable?.state === "active"
+        )
       ) {
         // prevent zooming the browser (but allow scrolling DOM)
         if (event[KEYS.CTRL_OR_CMD]) {

--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -2739,12 +2739,6 @@ class App extends React.Component<AppProps, AppState> {
       addEventListener(window, EVENT.BLUR, this.onBlur, false),
       addEventListener(
         this.excalidrawContainerRef.current,
-        EVENT.WHEEL,
-        this.handleWheel,
-        { passive: false },
-      ),
-      addEventListener(
-        this.excalidrawContainerRef.current,
         EVENT.DRAG_OVER,
         this.disableEvent,
         false,
@@ -11170,7 +11164,8 @@ class App extends React.Component<AppProps, AppState> {
           event.target instanceof HTMLCanvasElement ||
           event.target instanceof HTMLTextAreaElement ||
           event.target instanceof HTMLIFrameElement
-        )
+        ) ||
+        this.state.activeEmbeddable?.state === "active"
       ) {
         // prevent zooming the browser (but allow scrolling DOM)
         if (event[KEYS.CTRL_OR_CMD]) {


### PR DESCRIPTION
See https://github.com/excalidraw/excalidraw/pull/8437#issuecomment-3207261276 for a description of the issue. This regression was introduced in #8437

1)
In Obsidian, the Excalidraw plugin uses props.renderEmbeddable to render custom embeddables. This includes rendering a PDF viewer that uses a canvas to display the PDF document.  The condition in `handleWheel` misinterprets the canvas for the Excalidraw canvas, and scrolling of the PDF was not possible.

2)
It seems to me that `this.handleWheel` is added twice to `excalidrawContainerRef`. Adding it once should be sufficient.

Here's the first time it is added:

https://github.com/excalidraw/excalidraw/blob/42fe6c2632dfbad9b40644c3768b746afa6929ad/packages/excalidraw/components/App.tsx#L2658C1-L2663C9
