### PR TITLE
feat: add dot and izometric dot grids

### DIFF
--- a/excalidraw-app/components/AppMainMenu.tsx
+++ b/excalidraw-app/components/AppMainMenu.tsx
@@ -85,6 +85,7 @@ export const AppMainMenu: React.FC<{
       <MainMenu.ItemCustom>
         <LanguageList style={{ width: "100%" }} />
       </MainMenu.ItemCustom>
+      <MainMenu.DefaultItems.ChangeGridType />
       <MainMenu.DefaultItems.ChangeCanvasBackground />
     </MainMenu>
   );

--- a/packages/excalidraw/actions/actionChangeGridType.tsx
+++ b/packages/excalidraw/actions/actionChangeGridType.tsx
@@ -1,0 +1,17 @@
+import { CaptureUpdateAction } from "@excalidraw/element";
+import { register } from "./register";
+import type { AppState } from "../types";
+import { GridType } from "../types";
+
+export const actionChangeGridType = register({
+	name: "changeGridType",
+	label: "labels.changeGridType",
+	trackEvent: { category: "canvas" },
+    viewMode: true,
+	perform(elements, appState: Readonly<AppState>, value: { gridType: GridType }) {
+		return {
+			appState: { ...appState, gridType: value.gridType },
+			captureUpdate: CaptureUpdateAction.EVENTUALLY,
+		};
+	}
+}); 

--- a/packages/excalidraw/actions/index.ts
+++ b/packages/excalidraw/actions/index.ts
@@ -80,6 +80,7 @@ export {
 } from "./actionClipboard";
 
 export { actionToggleGridMode } from "./actionToggleGridMode";
+export { actionChangeGridType } from "./actionChangeGridType";
 export { actionToggleZenMode } from "./actionToggleZenMode";
 export { actionToggleObjectsSnapMode } from "./actionToggleObjectsSnapMode";
 

--- a/packages/excalidraw/actions/types.ts
+++ b/packages/excalidraw/actions/types.ts
@@ -143,7 +143,8 @@ export type ActionName =
   | "wrapSelectionInFrame"
   | "toggleLassoTool"
   | "toggleShapeSwitch"
-  | "togglePolygon";
+  | "togglePolygon"
+  | "changeGridType";
 
 export type PanelComponentProps = {
   elements: readonly ExcalidrawElement[];

--- a/packages/excalidraw/appState.ts
+++ b/packages/excalidraw/appState.ts
@@ -13,7 +13,7 @@ import {
   isTestEnv,
 } from "@excalidraw/common";
 
-import type { AppState, NormalizedZoomValue } from "./types";
+import { GridType, AppState, NormalizedZoomValue } from "./types";
 
 const defaultExportScale = EXPORT_SCALES.includes(devicePixelRatio)
   ? devicePixelRatio
@@ -65,6 +65,7 @@ export const getDefaultAppState = (): Omit<
     fileHandle: null,
     gridSize: DEFAULT_GRID_SIZE,
     gridStep: DEFAULT_GRID_STEP,
+    gridType: GridType.DEFAULT,
     gridModeEnabled: false,
     isBindingEnabled: true,
     defaultSidebarDockedPreference: false,
@@ -185,6 +186,7 @@ const APP_STATE_STORAGE_CONF = (<
   fileHandle: { browser: false, export: false, server: false },
   gridSize: { browser: true, export: true, server: true },
   gridStep: { browser: true, export: true, server: true },
+  gridType: { browser: true, export: false, server: false },
   gridModeEnabled: { browser: true, export: true, server: true },
   height: { browser: false, export: false, server: false },
   isBindingEnabled: { browser: false, export: false, server: false },

--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -298,6 +298,7 @@ import {
   actionToggleLinearEditor,
   actionToggleObjectsSnapMode,
   actionToggleCropEditor,
+  actionChangeGridType,
 } from "../actions";
 import { actionWrapTextInContainer } from "../actions/actionBoundText";
 import { actionToggleHandTool, zoomToFit } from "../actions/actionCanvas";

--- a/packages/excalidraw/components/CommandPalette/CommandPalette.tsx
+++ b/packages/excalidraw/components/CommandPalette/CommandPalette.tsx
@@ -51,6 +51,7 @@ import {
   mermaidLogoIcon,
   brainIconThin,
   LibraryIcon,
+  gridIcon,
 } from "../icons";
 
 import { SHAPES } from "../shapes";
@@ -473,6 +474,18 @@ function CommandPaletteInner({
             setAppState((prevState) => ({
               openMenu: prevState.openMenu === "canvas" ? null : "canvas",
               openPopup: "canvasBackground",
+            }));
+          },
+        },
+        {
+          label: "Change grid type",
+          keywords: ["grid", "dot", "izometric"],
+          icon: gridIcon,
+          category: DEFAULT_CATEGORIES.editor,
+          viewMode: false,
+          perform: () => {
+            setAppState((prevState) => ({
+              openMenu: prevState.openMenu === "canvas" ? null : "canvas",
             }));
           },
         },

--- a/packages/excalidraw/components/LayerUI.tsx
+++ b/packages/excalidraw/components/LayerUI.tsx
@@ -120,6 +120,7 @@ const DefaultMainMenu: React.FC<{
       <MainMenu.Separator />
       <MainMenu.DefaultItems.ToggleTheme />
       <MainMenu.DefaultItems.ChangeCanvasBackground />
+      <MainMenu.DefaultItems.ChangeGridType />
     </MainMenu>
   );
 };

--- a/packages/excalidraw/components/canvases/StaticCanvas.tsx
+++ b/packages/excalidraw/components/canvases/StaticCanvas.tsx
@@ -93,6 +93,7 @@ const getRelevantAppStateProps = (appState: AppState): StaticCanvasAppState => {
     selectedElementsAreBeingDragged: appState.selectedElementsAreBeingDragged,
     gridSize: appState.gridSize,
     gridStep: appState.gridStep,
+    gridType: appState.gridType,
     frameRendering: appState.frameRendering,
     selectedElementIds: appState.selectedElementIds,
     frameToHighlight: appState.frameToHighlight,

--- a/packages/excalidraw/components/main-menu/DefaultItems.tsx
+++ b/packages/excalidraw/components/main-menu/DefaultItems.tsx
@@ -11,6 +11,7 @@ import {
   actionShortcuts,
   actionToggleSearchMenu,
   actionToggleTheme,
+  actionChangeGridType,
 } from "../../actions";
 import { getShortcutFromShortcutName } from "../../actions/shortcuts";
 import { trackEvent } from "../../analytics";
@@ -44,8 +45,11 @@ import {
   TrashIcon,
   usersIcon,
 } from "../icons";
+import { GridType } from "../../types";
 
 import "./DefaultItems.scss";
+import DropdownMenu from "../dropdownMenu/DropdownMenu";
+import { RadioGroup } from "../RadioGroup";
 
 export const LoadScene = () => {
   const { t } = useI18n();
@@ -320,6 +324,47 @@ export const ChangeCanvasBackground = () => {
   );
 };
 ChangeCanvasBackground.displayName = "ChangeCanvasBackground";
+
+export const ChangeGridType = () => {
+  const { t } = useI18n();
+  const appState = useUIAppState();
+  const actionManager = useExcalidrawActionManager();
+
+  if (appState.viewModeEnabled) {
+    return null;
+  }
+
+  return (
+    <div style={{ marginTop: "0.5rem" }}>
+      <div
+        data-testid="grid-type-label"
+        style={{ fontSize: ".75rem", marginBottom: ".5rem" }}
+      >
+        Grid Type
+      </div>
+      <div>
+        <select
+          style={{ width: "100%" }}
+          className="dropdown-select dropdown-select__language"
+          name="gridType"
+          value={appState.gridType}
+          onChange={(e) => {
+            actionManager.executeAction(
+              actionChangeGridType,
+              "ui",
+              { gridType: Number.parseInt(e.target.value) as GridType }
+            );
+          }}
+        >
+          <option value={GridType.DEFAULT}>Default</option>
+          <option value={GridType.DOT}>Dot</option>
+          <option value={GridType.IZOMETRIC_DOT}>Isometric Dot</option>
+        </select>
+      </div>
+    </div>
+  );
+};
+ChangeGridType.displayName = "ChangeGridType";
 
 export const Export = () => {
   const { t } = useI18n();

--- a/packages/excalidraw/types.ts
+++ b/packages/excalidraw/types.ts
@@ -201,6 +201,7 @@ export type StaticCanvasAppState = Readonly<
     selectedElementsAreBeingDragged: AppState["selectedElementsAreBeingDragged"];
     gridSize: AppState["gridSize"];
     gridStep: AppState["gridStep"];
+    gridType: AppState["gridType"];
     frameRendering: AppState["frameRendering"];
     currentHoveredFontFamily: AppState["currentHoveredFontFamily"];
     hoveredElementIds: AppState["hoveredElementIds"];
@@ -255,6 +256,12 @@ export type ObservedElementsAppState = {
   croppingElementId: AppState["croppingElementId"];
   lockedMultiSelections: AppState["lockedMultiSelections"];
   activeLockedId: AppState["activeLockedId"];
+};
+
+export enum GridType {
+  DEFAULT,
+  DOT,
+  IZOMETRIC_DOT
 };
 
 export interface AppState {
@@ -382,6 +389,7 @@ export interface AppState {
   /** grid cell px size */
   gridSize: number;
   gridStep: number;
+  gridType: GridType;
   gridModeEnabled: boolean;
   viewModeEnabled: boolean;
 
@@ -571,6 +579,7 @@ export interface ExcalidrawProps {
   langCode?: Language["code"];
   viewModeEnabled?: boolean;
   zenModeEnabled?: boolean;
+  gridType?: GridType;
   gridModeEnabled?: boolean;
   objectsSnapModeEnabled?: boolean;
   libraryReturnUrl?: string;


### PR DESCRIPTION
I noticed [that many users](https://github.com/excalidraw/excalidraw/issues/6773) would love the ability to have more grid options available. As such, I modified the source code in order to add two new grid types: *the dot grid* and the *izometric dot grid*. The user can change the type of grid from the main menu, where I added a new *Grid Type* setting. This commit also adds a command pallet entry for "Change grid type", but as of now, it only opens the main menu, the user being responsible for identifying the setting.

# Screenshots
<img width="1042" height="747" alt="Screenshot 2025-08-20 at 23 16 17" src="https://github.com/user-attachments/assets/a253443a-4171-4164-a103-fae045dc591d" />

<img width="342" height="581" alt="Screenshot 2025-08-20 at 23 17 20" src="https://github.com/user-attachments/assets/aadd10eb-03ad-45fc-802a-b7c76b837968" />

<img width="1045" height="688" alt="Screenshot 2025-08-20 at 23 18 36" src="https://github.com/user-attachments/assets/f0c93b88-e0f9-43e3-aa77-f132b576c379" />

