### PR TITLE
#9884 - feat:Option to make laser drawings persistent (like iPad laser)

### DIFF
--- a/packages/common/src/constants.ts
+++ b/packages/common/src/constants.ts
@@ -470,6 +470,7 @@ export const TOOL_TYPE = {
   hand: "hand",
   frame: "frame",
   magicframe: "magicframe",
+  persistentlaser: "persistentlaser",
   embeddable: "embeddable",
   laser: "laser",
 } as const;

--- a/packages/element/src/showSelectedShapeActions.ts
+++ b/packages/element/src/showSelectedShapeActions.ts
@@ -17,6 +17,7 @@ export const showSelectedShapeActions = (
             appState.activeTool.type !== "lasso" &&
             appState.activeTool.type !== "eraser" &&
             appState.activeTool.type !== "hand" &&
-            appState.activeTool.type !== "laser"))) ||
+            appState.activeTool.type !== "laser" &&
+            appState.activeTool.type !== "persistentlaser"))) ||
         getSelectedElements(elements, appState).length),
   );

--- a/packages/excalidraw/components/Actions.tsx
+++ b/packages/excalidraw/components/Actions.tsx
@@ -295,6 +295,7 @@ export const ShapesSwitcher = ({
 
   const frameToolSelected = activeTool.type === "frame";
   const laserToolSelected = activeTool.type === "laser";
+  const persistentLaserPointer = activeTool.type === "persistentlaser";
   const lassoToolSelected = activeTool.type === "lasso";
 
   const embeddableToolSelected = activeTool.type === "embeddable";
@@ -372,6 +373,7 @@ export const ShapesSwitcher = ({
               // in collab we're already highlighting the laser button
               // outside toolbar, so let's not highlight extra-tools button
               // on top of it
+              persistentLaserPointer ||
               (laserToolSelected && !app.props.isCollaborating),
           })}
           onToggle={() => setIsExtraToolsMenuOpen(!isExtraToolsMenuOpen)}
@@ -385,6 +387,8 @@ export const ShapesSwitcher = ({
             ? laserPointerToolIcon
             : lassoToolSelected
             ? LassoIcon
+            : persistentLaserPointer
+            ? laserPointerToolIcon
             : extraToolsIcon}
         </DropdownMenu.Trigger>
         <DropdownMenu.Content
@@ -417,6 +421,15 @@ export const ShapesSwitcher = ({
             shortcut={KEYS.K.toLocaleUpperCase()}
           >
             {t("toolBar.laser")}
+          </DropdownMenu.Item>
+          <DropdownMenu.Item
+            onSelect={() => app.setActiveTool({ type: "persistentlaser" })}
+            icon={laserPointerToolIcon}
+            data-testid="toolbar-persistentLaserPointer"
+            selected={persistentLaserPointer}
+            shortcut={KEYS.P.toLocaleUpperCase()}
+          >
+            {t("toolBar.persistentLaser")}
           </DropdownMenu.Item>
           <DropdownMenu.Item
             onSelect={() => app.setActiveTool({ type: "lasso" })}

--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -1538,7 +1538,7 @@ class App extends React.Component<AppProps, AppState> {
           this.state.newElement ||
           this.state.selectedElementsAreBeingDragged ||
           this.state.resizingElement ||
-          (this.state.activeTool.type === "laser" &&
+          ((this.state.activeTool.type === "laser" || this.state.activeTool.type === "persistentlaser") &&
             // technically we can just test on this once we make it more safe
             this.state.cursorButton === "down");
 
@@ -4592,7 +4592,7 @@ class App extends React.Component<AppProps, AppState> {
       }
 
       if (event.key === KEYS.K && !event.altKey && !event[KEYS.CTRL_OR_CMD]) {
-        if (this.state.activeTool.type === "laser") {
+        if (this.state.activeTool.type === "laser" || this.state.activeTool.type === "persistentlaser") {
           this.setActiveTool({ type: "selection" });
         } else {
           this.setActiveTool({ type: "laser" });
@@ -6632,7 +6632,7 @@ class App extends React.Component<AppProps, AppState> {
         pointerDownState,
         this.state.activeTool.type,
       );
-    } else if (this.state.activeTool.type === "laser") {
+    } else if (this.state.activeTool.type === "laser" || this.state.activeTool.type === "persistentlaser") {
       this.laserTrails.startPath(
         pointerDownState.lastCoords.x,
         pointerDownState.lastCoords.y,
@@ -6675,7 +6675,7 @@ class App extends React.Component<AppProps, AppState> {
       onPointerUp(_event || event.nativeEvent),
     );
 
-    if (!this.state.viewModeEnabled || this.state.activeTool.type === "laser") {
+    if (!this.state.viewModeEnabled || this.state.activeTool.type === "laser" || this.state.activeTool.type === "persistentlaser") {
       window.addEventListener(EVENT.POINTER_MOVE, onPointerMove);
       window.addEventListener(EVENT.POINTER_UP, onPointerUp);
       window.addEventListener(EVENT.KEYDOWN, onKeyDown);
@@ -8155,7 +8155,7 @@ class App extends React.Component<AppProps, AppState> {
         return;
       }
 
-      if (this.state.activeTool.type === "laser") {
+      if (this.state.activeTool.type === "laser" || this.state.activeTool.type === "persistentlaser") {
         this.laserTrails.addPointToPath(pointerCoords.x, pointerCoords.y);
       }
 
@@ -9782,7 +9782,7 @@ class App extends React.Component<AppProps, AppState> {
         );
       }
 
-      if (activeTool.type === "laser") {
+      if (activeTool.type === "laser" || activeTool.type === "persistentlaser") {
         this.laserTrails.endPath();
         return;
       }

--- a/packages/excalidraw/cursor.ts
+++ b/packages/excalidraw/cursor.ts
@@ -94,7 +94,7 @@ export const setCursorForShape = (
     // do nothing if image tool is selected which suggests there's
     // a image-preview set as the cursor
     // Ignore custom type as well and let host decide
-  } else if (appState.activeTool.type === "laser") {
+  } else if (appState.activeTool.type === "laser" || appState.activeTool.type === "persistentlaser") {
     const url =
       appState.theme === THEME.LIGHT
         ? laserPointerCursorDataURL_lightMode

--- a/packages/excalidraw/data/restore.ts
+++ b/packages/excalidraw/data/restore.ts
@@ -103,6 +103,7 @@ export const AllowedExcalidrawActiveTools: Record<
   embeddable: true,
   hand: true,
   laser: false,
+  persistentlaser: false,
   magicframe: false,
 };
 

--- a/packages/excalidraw/laser-trails.ts
+++ b/packages/excalidraw/laser-trails.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_LASER_COLOR, easeOut } from "@excalidraw/common";
+import { DEFAULT_LASER_COLOR, easeOut, TOOL_TYPE } from "@excalidraw/common";
 
 import type { LaserPointerOptions } from "@excalidraw/laser-pointer";
 
@@ -33,6 +33,11 @@ export class LaserTrails implements Trail {
       simplify: 0,
       streamline: 0.4,
       sizeMapping: (c) => {
+        // Check if current tool is persistent laser
+        if (this.app.state.activeTool.type === TOOL_TYPE.persistentlaser) {
+          return 1; // No decay - always full opacity
+        }
+        // Original decay logic for regular laser
         const DECAY_TIME = 1000;
         const DECAY_LENGTH = 50;
         const t = Math.max(

--- a/packages/excalidraw/locales/en.json
+++ b/packages/excalidraw/locales/en.json
@@ -302,6 +302,7 @@
     "magicframe": "Wireframe to code",
     "embeddable": "Web Embed",
     "laser": "Laser pointer",
+    "persistentLaser": "Persistent Laser",
     "hand": "Hand (panning tool)",
     "extraTools": "More tools",
     "mermaidToExcalidraw": "Mermaid to Excalidraw",

--- a/packages/excalidraw/types.ts
+++ b/packages/excalidraw/types.ts
@@ -154,6 +154,7 @@ export type ToolType =
   | "frame"
   | "magicframe"
   | "embeddable"
+  | "persistentlaser"
   | "laser";
 
 export type ElementOrToolType = ExcalidrawElementType | ToolType | "custom";


### PR DESCRIPTION
## Summary
Implements persistent laser drawings that remain visible until user selects another tool/option, similar to iPad laser functionality.

## Implementation Details
- Laser drawings now persist on screen instead of disappearing immediately
- Drawings are cleared when user switches to any other tool/option

## Demo

https://github.com/user-attachments/assets/13b47770-b84e-42cf-aded-b7b3bc5a54d2

Fixes #9884