### PR TITLE
fix: calling toLowerCase on potentially undefined `navigator.*` values

### DIFF
--- a/packages/common/src/constants.ts
+++ b/packages/common/src/constants.ts
@@ -28,11 +28,9 @@ export const isBrave = () =>
 export const isMobile =
   isIOS ||
   /android|webos|ipod|blackberry|iemobile|opera mini/i.test(
-    navigator.userAgent.toLowerCase(),
+    navigator.userAgent,
   ) ||
-  /android|ios|ipod|blackberry|windows phone/i.test(
-    navigator.platform.toLowerCase(),
-  );
+  /android|ios|ipod|blackberry|windows phone/i.test(navigator.platform);
 
 export const supportsResizeObserver =
   typeof window !== "undefined" && "ResizeObserver" in window;


### PR DESCRIPTION
We were breaking runtimes that don't define `navigator.platform` when loading `constants.ts`.