### PR TITLE
fix: increase PWA precache file size limit to 3 MiB

### DIFF
--- a/excalidraw-app/vite.config.mts
+++ b/excalidraw-app/vite.config.mts
@@ -140,6 +140,10 @@ export default defineConfig(({ mode }) => {
         },
 
         workbox: {
+
+          // 3 MiB
+          maximumFileSizeToCacheInBytes: 3000000,
+
           // don't precache fonts, locales and separate chunks
           globIgnores: [
             "fonts.css",


### PR DESCRIPTION
See https://github.com/excalidraw/excalidraw/issues/9354 for a description of the issue.