### PR TITLE
fix: add file data when loading scenes in example app (#9578)

### DIFF
--- a/examples/with-script-in-browser/components/ExampleApp.tsx
+++ b/examples/with-script-in-browser/components/ExampleApp.tsx
@@ -287,7 +287,15 @@ export default function ExampleApp({
     const file = await fileOpen({ description: "Excalidraw or library file" });
     const contents = await loadSceneOrLibraryFromBlob(file, null, null);
     if (contents.type === MIME_TYPES.excalidraw) {
-      excalidrawAPI?.updateScene(contents.data as any);
+      const sceneData = contents.data as any;
+      
+      // Add files first if they exist
+      if (sceneData.files) {
+        excalidrawAPI?.addFiles(sceneData.files);
+      }
+      
+      // Then update the scene
+      excalidrawAPI?.updateScene(sceneData);
     } else if (contents.type === MIME_TYPES.excalidrawlib) {
       excalidrawAPI?.updateLibrary({
         libraryItems: (contents.data as ImportedLibraryData).libraryItems!,


### PR DESCRIPTION
## Problem Statement

When loading `.excalidraw` files through the "Load Scene or Library" button in the example app, images
within the scene fail to render properly. Only the pre-loaded rocket image displays correctly, while
all other images appear broken.

## Root Cause

The `loadSceneOrLibrary` function in `ExampleApp.tsx` was calling `updateScene()` with the scene data
but not adding the associated file data to the app state.

```typescript
// Before - files were not being added
excalidrawAPI?.updateScene(contents.data as any);
```

The `updateScene` API method doesn't automatically handle file data, unlike the internal `syncActionResult`
method used in the main Excalidraw app which has a `replaceFiles: true` option.

## Solution

Add the file data to the app state before updating the scene:
 
```typescript
// After - properly handle file data
const sceneData = contents.data as any;

 // Add files first if they exist
if (sceneData.files) {
  excalidrawAPI?.addFiles(sceneData.files);
}

// Then update the scene
excalidrawAPI?.updateScene(sceneData);
```

##Why Only the Rocket Image Worked

The rocket image was pre-loaded in a `useEffect` hook with fileId: "rocket" and added via
`excalidrawAPI.addFiles()`, which is why it was the only image that rendered correctly. All other images
loaded from .excalidraw files were missing because their file data wasn't being added.

## Testing

Tested with:
- ✅ Loading .excalidraw files containing multiple images
- ✅ Loading .excalidrawlib library files (no changes needed)
- ✅ Verified rocket image continues to work
- ✅ Confirmed all images now render properly

## Impact

This fix ensures that the example app properly handles all image data when loading scenes, providing a
consistent experience for developers using the Excalidraw library.

Fixes #9578
