### PR TITLE
fix: default cursor

### DIFF
--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -667,9 +667,7 @@ class App extends React.Component<AppProps, AppState> {
   constructor(props: AppProps) {
     super(props);
     const defaultAppState = getDefaultAppState();
-    this.defaultSelectionTool = this.isMobileOrTablet()
-      ? ("lasso" as const)
-      : ("selection" as const);
+    this.defaultSelectionTool = "selection" as const;
     const {
       excalidrawAPI,
       viewModeEnabled = false,


### PR DESCRIPTION
Fix to issue #9937. 

This will select the "selection" cursor as the default for both mobile and desktop. 