### PR TITLE
zoom problem is in help modal.

### DIFF
--- a/packages/excalidraw/components/Dialog.tsx
+++ b/packages/excalidraw/components/Dialog.tsx
@@ -50,7 +50,7 @@ function getDialogSize(size: DialogSize): number {
 export const Dialog = (props: DialogProps) => {
   const [islandNode, setIslandNode] = useCallbackRefState<HTMLDivElement>();
   const [lastActiveElement] = useState(document.activeElement);
-  const { id } = useExcalidrawContainer();
+  const { id, container } = useExcalidrawContainer();
   const isFullscreen = useDevice().viewport.isMobile;
 
   useEffect(() => {
@@ -99,7 +99,15 @@ export const Dialog = (props: DialogProps) => {
   const onClose = () => {
     setAppState({ openMenu: null });
     setIsLibraryMenuOpen(false);
-    (lastActiveElement as HTMLElement).focus();
+    
+    // Always focus the main Excalidraw container to ensure keyboard events work
+    if (container) {
+      container.focus();
+    } else {
+      // Fallback to previous behavior if container not found
+      (lastActiveElement as HTMLElement)?.focus();
+    }
+    
     props.onCloseRequest();
   };
 


### PR DESCRIPTION
#9978

### **Fix Applied: Restore Focus on Dialog Close**

This pull request addresses a bug where the application's focus was not correctly restored to the main canvas after closing a dialog.

#### **Changes**

I've modified the `./packages/excalidraw/components/Dialog.tsx` file to properly manage focus when a dialog closes.

**Before:**

```typescript
const onClose = () => {
  setAppState({ openMenu: null });
  setIsLibraryMenuOpen(false);
  (lastActiveElement as HTMLElement).focus(); // - Problematic behavior
  props.onCloseRequest();
};
```

**After:**

```typescript
const onClose = () => {
  setAppState({ openMenu: null });
  setIsLibraryMenuOpen(false);

  // Always focus the main Excalidraw container to ensure the canvas is active
  if (container) {
    container.focus();
  } else {
    // Fallback to previous behavior if container is not found
    (lastActiveElement as HTMLElement)?.focus();
  }
  props.onCloseRequest();
};
```

#### **What This Fixes**

1.  **Root Cause:** The dialog was trying to restore focus to the previously focused element, but this was often not the main canvas.
2.  **Solution:** This change ensures that after closing any dialog, the focus is always directed to the main Excalidraw container.
3.  **Result:** Zoom shortcuts (Ctrl+/Ctrl-) will now work immediately after closing the help modal and other dialogs.

