### PR TITLE
fix: align MQ breakpoints and always use editor dimensions

### DIFF
--- a/packages/common/src/constants.ts
+++ b/packages/common/src/constants.ts
@@ -347,15 +347,12 @@ export const DEFAULT_UI_OPTIONS: AppProps["UIOptions"] = {
 
 // breakpoints
 // -----------------------------------------------------------------------------
-// md screen
-export const MQ_MAX_WIDTH_LANDSCAPE = 1000;
-export const MQ_MAX_HEIGHT_LANDSCAPE = 500;
 
 // mobile: up to 699px
-export const MQ_MAX_WIDTH_MOBILE = 699;
+export const MQ_MAX_WIDTH_MOBILE = 599;
 
 // tablets
-export const MQ_MIN_TABLET = 600; // lower bound (excludes phones)
+export const MQ_MIN_TABLET = MQ_MAX_WIDTH_MOBILE + 1; // lower bound (excludes phones)
 export const MQ_MAX_TABLET = 1400; // upper bound (excludes laptops/desktops)
 
 // desktop/laptop

--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -101,8 +101,6 @@ import {
   DOUBLE_TAP_POSITION_THRESHOLD,
   isMobileOrTablet,
   MQ_MAX_WIDTH_MOBILE,
-  MQ_MAX_HEIGHT_LANDSCAPE,
-  MQ_MAX_WIDTH_LANDSCAPE,
   MQ_MIN_TABLET,
   MQ_MAX_TABLET,
 } from "@excalidraw/common";
@@ -2423,10 +2421,8 @@ class App extends React.Component<AppProps, AppState> {
   };
 
   private isMobileBreakpoint = (width: number, height: number) => {
-    return (
-      width <= MQ_MAX_WIDTH_MOBILE ||
-      (height < MQ_MAX_HEIGHT_LANDSCAPE && width < MQ_MAX_WIDTH_LANDSCAPE)
-    );
+    const minSide = Math.min(width, height);
+    return minSide <= MQ_MAX_WIDTH_MOBILE;
   };
 
   private isTabletBreakpoint = (editorWidth: number, editorHeight: number) => {
@@ -2442,14 +2438,14 @@ class App extends React.Component<AppProps, AppState> {
       return;
     }
 
-    const { clientWidth: viewportWidth, clientHeight: viewportHeight } =
-      document.body;
+    const { width: editorWidth, height: editorHeight } =
+      container.getBoundingClientRect();
 
     const prevViewportState = this.device.viewport;
 
     const nextViewportState = updateObject(prevViewportState, {
-      isLandscape: viewportWidth > viewportHeight,
-      isMobile: this.isMobileBreakpoint(viewportWidth, viewportHeight),
+      isLandscape: editorWidth > editorHeight,
+      isMobile: this.isMobileBreakpoint(editorWidth, editorHeight),
     });
 
     if (prevViewportState !== nextViewportState) {


### PR DESCRIPTION
- previously, the tablet MQ was not consistent with mobile MQ.
- we also weren't using editor dimensions on init (but used editor dimensions on later resize events)