### PR TITLE
fix: fix hyperlink popup disappering when hovering on the bottom right edge

### DIFF
--- a/packages/excalidraw/components/hyperlink/Hyperlink.tsx
+++ b/packages/excalidraw/components/hyperlink/Hyperlink.tsx
@@ -483,11 +483,14 @@ const shouldHideLinkPopup = (
     elementsMap,
   );
 
+  const clientXWithOffset = clientX - appState.offsetLeft;
+  const clientYWithOffset = clientY - appState.offsetTop;
   if (
-    clientX >= popoverX - threshold &&
-    clientX <= popoverX + POPUP_WIDTH + POPUP_PADDING * 2 + threshold &&
-    clientY >= popoverY - threshold &&
-    clientY <= popoverY + threshold + POPUP_PADDING * 2 + POPUP_HEIGHT
+    clientXWithOffset >= popoverX - threshold &&
+    clientXWithOffset <=
+      popoverX + POPUP_WIDTH + POPUP_PADDING * 2 + threshold &&
+    clientYWithOffset >= popoverY - threshold &&
+    clientYWithOffset <= popoverY + threshold + POPUP_PADDING * 2 + POPUP_HEIGHT
   ) {
     return false;
   }


### PR DESCRIPTION
This Pull Request fixes the issue where if you hover over the hyperlink's bottom right edge in case the canvas isn't drawn on (0,0) of the viewport 

## Example

<table>
  <thead>
    <tr>
      <th>Before</th>
      <th>After</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td>
        <video
          src="https://github.com/user-attachments/assets/63286486-b0ce-4e58-abd6-e8765d52e0ac"
        />
      </td>
      <td>
        <video
          src="https://github.com/user-attachments/assets/4380ae27-8f98-4771-a804-7c6856d9a985"
        />
      </td>
    </tr>
  </tbody>
</table>

## Solution

The issue was the fact that while calculating if the cursor is over the popup, we didn't take the offset position when determining the cursor's position