### PR TITLE
fix: Use analytical Jacobian for curve intersection testing

### DIFF
--- a/packages/excalidraw/tests/__snapshots__/history.test.tsx.snap
+++ b/packages/excalidraw/tests/__snapshots__/history.test.tsx.snap
@@ -363,7 +363,7 @@ exports[`history > multiplayer undo/redo > conflicts in arrows and their bindabl
                 0,
               ],
               [
-                "98.00000",
+                98,
                 "-0.00656",
               ],
             ],

--- a/packages/math/tests/curve.test.ts
+++ b/packages/math/tests/curve.test.ts
@@ -46,9 +46,11 @@ describe("Math curve", () => {
         pointFrom(10, 50),
         pointFrom(50, 50),
       );
-      const l = lineSegment(pointFrom(0, 112.5), pointFrom(90, 0));
+      const l = lineSegment(pointFrom(10, -60), pointFrom(10, 60));
 
-      expect(curveIntersectLineSegment(c, l)).toCloselyEqualPoints([[50, 50]]);
+      expect(curveIntersectLineSegment(c, l)).toCloselyEqualPoints([
+        [9.99, 5.05],
+      ]);
     });
 
     it("can be detected where the determinant is overly precise", () => {


### PR DESCRIPTION
No change in behavior, just a faster numerical method for rounded corners