### PR TITLE
fix: "Copy to clipboard as SVG" in Safari

### DIFF
--- a/packages/excalidraw/clipboard.ts
+++ b/packages/excalidraw/clipboard.ts
@@ -556,7 +556,10 @@ export const parseClipboard = async (
   return { text: parsedEventData.value };
 };
 
-export const copyBlobToClipboardAsPng = async (blob: Blob | Promise<Blob>) => {
+export const copyBlobToClipboard = async (
+  blob: Blob | Promise<Blob>,
+  type: typeof MIME_TYPES[keyof typeof MIME_TYPES],
+) => {
   try {
     // in Safari so far we need to construct the ClipboardItem synchronously
     // (i.e. in the same tick) otherwise browser will complain for lack of
@@ -568,7 +571,7 @@ export const copyBlobToClipboardAsPng = async (blob: Blob | Promise<Blob>) => {
     // So we need to await this and fallback to awaiting the blob if applicable.
     await navigator.clipboard.write([
       new window.ClipboardItem({
-        [MIME_TYPES.png]: blob,
+        [type]: blob,
       }),
     ]);
   } catch (error: any) {
@@ -577,7 +580,7 @@ export const copyBlobToClipboardAsPng = async (blob: Blob | Promise<Blob>) => {
     if (isPromiseLike(blob)) {
       await navigator.clipboard.write([
         new window.ClipboardItem({
-          [MIME_TYPES.png]: await blob,
+          [type]: await blob,
         }),
       ]);
     } else {

--- a/packages/excalidraw/data/index.ts
+++ b/packages/excalidraw/data/index.ts
@@ -20,10 +20,7 @@ import type {
   NonDeletedExcalidrawElement,
 } from "@excalidraw/element/types";
 
-import {
-  copyBlobToClipboardAsPng,
-  copyTextToSystemClipboard,
-} from "../clipboard";
+import { copyBlobToClipboard } from "../clipboard";
 
 import { t } from "../i18n";
 import { getSelectedElements, isSomeElementSelected } from "../scene";
@@ -150,9 +147,11 @@ export const exportCanvas = async (
         },
       );
     } else if (type === "clipboard-svg") {
-      const svg = await svgPromise.then((svg) => svg.outerHTML);
+      const blob = svgPromise.then(
+        (svg) => new Blob([svg.outerHTML], { type: MIME_TYPES.text }),
+      );
       try {
-        await copyTextToSystemClipboard(svg);
+        await copyBlobToClipboard(blob, MIME_TYPES.text);
       } catch (e) {
         throw new Error(t("errors.copyToSystemClipboardFailed"));
       }
@@ -191,7 +190,7 @@ export const exportCanvas = async (
   } else if (type === "clipboard") {
     try {
       const blob = canvasToBlob(tempCanvas);
-      await copyBlobToClipboardAsPng(blob);
+      await copyBlobToClipboard(blob, MIME_TYPES.png);
     } catch (error: any) {
       console.warn(error);
       if (error.name === "CANVAS_POSSIBLY_TOO_BIG") {

--- a/packages/utils/src/export.ts
+++ b/packages/utils/src/export.ts
@@ -1,8 +1,7 @@
 import { MIME_TYPES } from "@excalidraw/common";
 import { getDefaultAppState } from "@excalidraw/excalidraw/appState";
 import {
-  copyBlobToClipboardAsPng,
-  copyTextToSystemClipboard,
+  copyBlobToClipboard,
   copyToClipboard,
 } from "@excalidraw/excalidraw/clipboard";
 import { encodePngMetadata } from "@excalidraw/excalidraw/data/image";
@@ -204,10 +203,12 @@ export const exportToClipboard = async (
   },
 ) => {
   if (opts.type === "svg") {
-    const svg = await exportToSvg(opts);
-    await copyTextToSystemClipboard(svg.outerHTML);
+    const blob = exportToSvg(opts).then(
+      (svg) => new Blob([svg.outerHTML], { type: MIME_TYPES.svg }),
+    );
+    await copyBlobToClipboard(blob, MIME_TYPES.text);
   } else if (opts.type === "png") {
-    await copyBlobToClipboardAsPng(exportToBlob(opts));
+    await copyBlobToClipboard(exportToBlob(opts), MIME_TYPES.png);
   } else if (opts.type === "json") {
     await copyToClipboard(opts.elements, opts.files);
   } else {


### PR DESCRIPTION
Fixes #8676
This Pull Request fixes an issue with copying SVG to clipboard on Safari.

## Solution
The issue with the current solution was the fact that Safari requires user activation for writing to the clipboard. Because we are using an async export to the SVG, the user interaction is broken as the copy isn't in the synchronous context. This was already mentioned in the comment above `copyBlobToClipboardAsPng` .
```
// in Safari so far we need to construct the ClipboardItem synchronously
// (i.e. in the same tick) otherwise browser will complain for lack of
// user intent. Using a Promise ClipboardItem constructor solves this.
// https://bugs.webkit.org/show_bug.cgi?id=222262
```