### PR TITLE
fix: text to diagram translation update issue on language update

### DIFF
--- a/packages/excalidraw/components/Actions.tsx
+++ b/packages/excalidraw/components/Actions.tsx
@@ -12,18 +12,15 @@ import {
 import {
   shouldAllowVerticalAlign,
   suppportsHorizontalAlign,
-} from "@excalidraw/element";
-
-import {
   hasBoundTextElement,
   isElbowArrow,
   isImageElement,
   isLinearElement,
   isTextElement,
   isArrowElement,
+  hasStrokeColor,
+  toolIsArrow,
 } from "@excalidraw/element";
-
-import { hasStrokeColor, toolIsArrow } from "@excalidraw/element";
 
 import type {
   ExcalidrawElement,
@@ -902,16 +899,14 @@ export const ShapesSwitcher = ({
             {t("toolBar.mermaidToExcalidraw")}
           </DropdownMenu.Item>
           {app.props.aiEnabled !== false && app.plugins.diagramToCode && (
-            <>
-              <DropdownMenu.Item
-                onSelect={() => app.onMagicframeToolSelect()}
-                icon={MagicIcon}
-                data-testid="toolbar-magicframe"
-              >
-                {t("toolBar.magicframe")}
-                <DropdownMenu.Item.Badge>AI</DropdownMenu.Item.Badge>
-              </DropdownMenu.Item>
-            </>
+            <DropdownMenu.Item
+              onSelect={() => app.onMagicframeToolSelect()}
+              icon={MagicIcon}
+              data-testid="toolbar-magicframe"
+            >
+              {t("toolBar.magicframe")}
+              <DropdownMenu.Item.Badge>AI</DropdownMenu.Item.Badge>
+            </DropdownMenu.Item>
           )}
         </DropdownMenu.Content>
       </DropdownMenu>

--- a/packages/excalidraw/components/TTDDialog/TTDDialogTrigger.tsx
+++ b/packages/excalidraw/components/TTDDialog/TTDDialogTrigger.tsx
@@ -1,12 +1,11 @@
 import { trackEvent } from "../../analytics";
 import { useTunnels } from "../../context/tunnels";
-import { t } from "../../i18n";
+import { useI18n } from "../../i18n";
 import { useExcalidrawSetAppState } from "../App";
 import DropdownMenu from "../dropdownMenu/DropdownMenu";
 import { brainIcon } from "../icons";
 
-import type { ReactNode } from "react";
-import type { JSX } from "react";
+import type { JSX, ReactNode } from "react";
 
 export const TTDDialogTrigger = ({
   children,
@@ -15,6 +14,7 @@ export const TTDDialogTrigger = ({
   children?: ReactNode;
   icon?: JSX.Element;
 }) => {
+  const { t } = useI18n();
   const { TTDDialogTriggerTunnel } = useTunnels();
   const setAppState = useExcalidrawSetAppState();
 


### PR DESCRIPTION
## Summary

This PR addresses an issue where the 'Text to Diagram' label in the action panel does not update immediately when the application language is changed. Previously, the label would remain in its previous language or untranslated until the app was reloaded. This update ensures that the label reacts to language changes and updates in real time.

## Related Issue
#10015