### PR TITLE
fix: added normalization to images added with the image tool to prevent MIME-mismatches

### DIFF
--- a/packages/excalidraw/clipboard.ts
+++ b/packages/excalidraw/clipboard.ts
@@ -470,13 +470,14 @@ export const parseDataTransferEvent = async (
       Array.from(items || []).map(
         async (item): Promise<ParsedDataTransferItem | null> => {
           if (item.kind === "file") {
-            const file = item.getAsFile();
+            let file = item.getAsFile();
             if (file) {
+              file = await normalizeFile(file);
               const fileHandle = await getFileHandle(item);
               return {
                 type: file.type,
                 kind: "file",
-                file: await normalizeFile(file),
+                file,
                 fileHandle,
               };
             }

--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -10453,7 +10453,6 @@ class App extends React.Component<AppProps, AppState> {
     const initialized = await Promise.all(
       placeholders.map(async (placeholder, i) => {
         try {
-          //imageFiles[i] = await normalizeFile(imageFiles[i]);
           return await this.initializeImage(placeholder, imageFiles[i]);
         } catch (error: any) {
           this.setState({

--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -10233,6 +10233,10 @@ class App extends React.Component<AppProps, AppState> {
         multiple: true,
       });
 
+      for (let i = 0; i < imageFiles.length; i++) {
+        imageFiles[i] = await normalizeFile(imageFiles[i]);
+      }
+
       this.insertImages(imageFiles, x, y);
     } catch (error: any) {
       if (error.name !== "AbortError") {
@@ -10449,6 +10453,7 @@ class App extends React.Component<AppProps, AppState> {
     const initialized = await Promise.all(
       placeholders.map(async (placeholder, i) => {
         try {
+          //imageFiles[i] = await normalizeFile(imageFiles[i]);
           return await this.initializeImage(placeholder, imageFiles[i]);
         } catch (error: any) {
           this.setState({


### PR DESCRIPTION
The changes were made to preserve the normalization of all copy-pasted files. Another solution to this is to put the normalization inside the insertImages() function. This would however result in normalizeFile() being called twice when copy-pasting images into the canvas and would require either removing the normalization of files all files when copy-pasting (which is a good idea to protect against malicious code) or broader changes in how normalized files are detected prevent duplicate calls.