### PR TITLE
Update buildDocs.js Reduce the complexity of this program

### DIFF
--- a/scripts/buildDocs.js
+++ b/scripts/buildDocs.js
@@ -1,21 +1,21 @@
 const { exec } = require("child_process");
 
-// get files changed between prev and head commit
-exec(`git diff --name-only HEAD^ HEAD`, async (error, stdout, stderr) => {
+// Get files changed between prev and head commit
+exec(`git diff --name-only HEAD^ HEAD`, (error, stdout, stderr) => {
   if (error || stderr) {
-    console.error(error);
+    console.error(error || stderr);
     process.exit(1);
   }
-  const changedFiles = stdout.trim().split("\n");
 
-  const docFiles = changedFiles.filter((file) => {
-    return file.indexOf("docs") >= 0;
-  });
+  const hasDocChange = stdout
+    .split("\n")
+    .some((file) => file.includes("docs"));
 
-  if (!docFiles.length) {
+  if (!hasDocChange) {
     console.info("Skipping building docs as no valid diff found");
     process.exit(0);
   }
+
   // Exit code 1 to build the docs in ignoredBuildStep
   process.exit(1);
 });


### PR DESCRIPTION
Why this is better

Space complexity:
Old code creates changedFiles (all files) + docFiles (filtered subset). New code only creates a single array from split and scans it once.

Time complexity:
Old: O(n) for filter + O(m) for .length check (m ≤ n). New: O(n) worst case, but short-circuits early if a "docs" file is found.

So in practice it runs faster in most real cases (especially when docs files are present early in the list).