### PR TITLE
fix: restore initialData.appState when clearing canvas

### DIFF
--- a/packages/excalidraw/actions/actionCanvas.tsx
+++ b/packages/excalidraw/actions/actionCanvas.tsx
@@ -109,6 +109,7 @@ export const actionClearCanvas = register({
       ),
       appState: {
         ...getDefaultAppState(),
+        ...app.initialAppState,
         files: {},
         theme: appState.theme,
         penMode: appState.penMode,

--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -599,6 +599,7 @@ class App extends React.Component<AppProps, AppState> {
   public files: BinaryFiles = {};
   public imageCache: AppClassProperties["imageCache"] = new Map();
   private iFrameRefs = new Map<ExcalidrawElement["id"], HTMLIFrameElement>();
+  public initialAppState: Partial<AppState> | null = null;
   /**
    * Indicates whether the embeddable's url has been validated for rendering.
    * If value not set, indicates that the validation is pending.
@@ -2403,6 +2404,8 @@ class App extends React.Component<AppProps, AppState> {
       };
     }
 
+    this.initialAppState = scene.appState;
+
     this.resetStore();
     this.resetHistory();
     this.syncActionResult({
@@ -2545,6 +2548,12 @@ class App extends React.Component<AppProps, AppState> {
         fonts: {
           configurable: true,
           value: this.fonts,
+        },
+        initialAppState: {
+          configurable: true,
+          get: () => {
+            return this.initialAppState;
+          },
         },
       });
     }
@@ -11446,6 +11455,7 @@ declare global {
       app: InstanceType<typeof App>;
       history: History;
       store: Store;
+      initialAppState: Partial<AppState> | null;
     };
   }
 }

--- a/packages/excalidraw/types.ts
+++ b/packages/excalidraw/types.ts
@@ -740,6 +740,7 @@ export type AppClassProperties = {
   updateEditorAtom: App["updateEditorAtom"];
 
   defaultSelectionTool: "selection" | "lasso";
+  initialAppState: App["initialAppState"];
 };
 
 export type PointerDownState = Readonly<{


### PR DESCRIPTION
## Summary

- Fixes `actionClearCanvas` to respect user-provided `initialData.appState` values when clearing the canvas
- Previously, clearing canvas always reset to hardcoded defaults (e.g., white background), ignoring custom initial values
- Now stores the initial appState after scene initialization and restores it when clearing canvas

Closes #10027

## Changes
- Added `initialAppState` property to `App` class to store the processed initial state
- Modified `actionClearCanvas` to merge `initialAppState` with `getDefaultAppState()`
- Updated `AppClassProperties` type to include the new property
- Added `initialAppState` to debug window object for development/testing

## Testing
When users provide custom `initialData` like:
```tsx
<Excalidraw initialData={{ appState: { viewBackgroundColor: green } }} />
```

## Testing
When users provide custom `initialData` like:
```tsx
<Excalidraw initialData={{ appState: { viewBackgroundColor: green } }} />
```

Clicking "Clear canvas" (Cmd+Backspace) now correctly restores to the red background instead of resetting to white.