### PR TITLE
fix: prevent arrow bind to invisble parts of elements in a frame

### DIFF
--- a/packages/element/src/binding.ts
+++ b/packages/element/src/binding.ts
@@ -1599,6 +1599,23 @@ export const bindingBorderTest = (
   fullShape?: boolean,
 ): boolean => {
   const p = pointFrom<GlobalPoint>(x, y);
+  // If the element is inside a frame, ignore binding requests coming from
+  // outside of the frame's visible area. This ensures that hidden parts of
+  // elements (clipped by the frame) are not bindable.
+  if (element.frameId) {
+    const frame = elementsMap.get(element.frameId);
+    if (frame && isFrameLikeElement(frame)) {
+      const frameBounds = getElementBounds(frame, elementsMap);
+      if (
+        p[0] < frameBounds[0] ||
+        p[0] > frameBounds[2] ||
+        p[1] < frameBounds[1] ||
+        p[1] > frameBounds[3]
+      ) {
+        return false;
+      }
+    }
+  }
   const threshold = maxBindingGap(element, element.width, element.height, zoom);
   const shouldTestInside =
     // disable fullshape snapping for frame elements so we


### PR DESCRIPTION

## Description
This PR fixes a bug where arrows could still bind to parts of an element that were hidden behind a frame.

Added this case to the binding border checker. If the element is inside a frame, ignore binding requests coming from outside of the frame's visible area. This ensures that hidden parts of elements (clipped by the frame) are not bindable.

## Related Tickets & Documents
Fixes #6777 

## Mobile & Desktop Screenshots/Recordings

[Excalidraw Frame Binding.webm](https://github.com/user-attachments/assets/69cc6bc8-2744-41f7-97d7-77efd7873ba4)