### PR TITLE
feat: removed hints that are not specific to mobile view

### DIFF
--- a/packages/excalidraw/components/HintViewer.scss
+++ b/packages/excalidraw/components/HintViewer.scss
@@ -21,9 +21,12 @@ $wide-viewport-width: 1000px;
     font-size: 0.75rem;
 
     @include isMobile {
-      position: static;
-      padding-right: 2rem;
+      display: none;
     }
+    @include isTabletOrMobile {
+    display: none;
+    }
+
 
     > span {
       padding: 0.25rem;

--- a/packages/excalidraw/css/variables.module.scss
+++ b/packages/excalidraw/css/variables.module.scss
@@ -5,6 +5,11 @@
     @content;
   }
 }
+@mixin isTabletOrMobile() {
+  @media (min-width: 10px) and (max-width: 1400px) {
+    @content;
+  }
+}
 
 @mixin toolbarButtonColorStates {
   &.fillable {


### PR DESCRIPTION
# What is this change?
## removed suggestions that are not related to mobile view like the below
<img width="485" height="94" alt="image" src="https://github.com/user-attachments/assets/e39b3165-18ca-4721-9cbb-1aa282a8ff76" />
# How was this implemented?
1.checked whether a device is mobile or tablet by i.e (min-width: 10px) and (max-width: 1400px)
2.if it is mobile or tablet the disabled the view of hints at that position