### PR TITLE
fix: add Segoe UI Symbol fallback for Excalifont (fixes #10056)

### DIFF
--- a/packages/common/src/constants.ts
+++ b/packages/common/src/constants.ts
@@ -135,6 +135,7 @@ export const CLASSES = {
 
 export const CJK_HAND_DRAWN_FALLBACK_FONT = "Xiaolai";
 export const WINDOWS_EMOJI_FALLBACK_FONT = "Segoe UI Emoji";
+export const WINDOWS_SYMBOL_FALLBACK_FONT = "Segoe UI Symbol";
 
 /**
  * // TODO: shouldn't be really `const`, likely neither have integers as values, due to value for the custom fonts, which should likely be some hash.
@@ -171,6 +172,7 @@ export const FONT_FAMILY_FALLBACKS = {
   [CJK_HAND_DRAWN_FALLBACK_FONT]: 100,
   ...FONT_FAMILY_GENERIC_FALLBACKS,
   [WINDOWS_EMOJI_FALLBACK_FONT]: 1000,
+  [WINDOWS_SYMBOL_FALLBACK_FONT]: 1001,
 };
 
 export function getGenericFontFamilyFallback(
@@ -196,6 +198,7 @@ export const getFontFamilyFallbacks = (
       return [
         CJK_HAND_DRAWN_FALLBACK_FONT,
         genericFallbackFont,
+        WINDOWS_SYMBOL_FALLBACK_FONT,
         WINDOWS_EMOJI_FALLBACK_FONT,
       ];
     default:

--- a/packages/common/src/font-metadata.ts
+++ b/packages/common/src/font-metadata.ts
@@ -131,6 +131,17 @@ export const FONT_METADATA: Record<number, FontMetadata> = {
     local: true,
     fallback: true,
   },
+  [FONT_FAMILY_FALLBACKS["Segoe UI Symbol"]]: {
+    metrics: {
+      // conservative metrics similar to Segoe UI Emoji / Excalifont
+      unitsPerEm: 1000,
+      ascender: 886,
+      descender: -374,
+      lineHeight: 1.25,
+    },
+    local: true,
+    fallback: true,
+  },
 };
 
 /** Unicode ranges defined by google fonts */


### PR DESCRIPTION
## Summary

Add a system symbol fallback font to improve rendering of arrows, mathematical symbols, and other symbol glyphs when the selected font does not provide them.

This change adds `Segoe UI Symbol` as a fallback for Excalifont so symbol/math glyphs resolve to a symbol-capable system font before falling back to the emoji font.

## What I changed

- `packages/common/src/constants.ts`
  - Added `WINDOWS_SYMBOL_FALLBACK_FONT = "Segoe UI Symbol"`.
  - Added it to `FONT_FAMILY_FALLBACKS`.
  - Updated `getFontFamilyFallbacks` so Excalifont fallbacks are defined in the order:
    1. `Xiaolai` (CJK hand-drawn fallback)
    2. Generic fallback (sans-serif / monospace as appropriate)
    3. `Segoe UI Symbol`
    4. `Segoe UI Emoji`

- `packages/common/src/font-metadata.ts`
  - Added conservative `FontMetadata` entry for `Segoe UI Symbol` and marked it as `local: true` and `fallback: true`.

## Rationale

- Many arrow, math, and other symbol glyphs are missing from Excalifont (and other UI fonts). When the chosen font lacks a glyph, browsers can fall back to an emoji font which produces inconsistent appearance or to fonts that don't render the glyph correctly.
- Adding a symbol-capable system font (where available) improves glyph coverage and reduces the chance of emoji or missing glyphs being used for mathematical / symbol characters.
- This is a minimal, low-risk change that does not bundle any new fonts or increase project size.

## How I tested

- Typecheck: `yarn tsc --noEmit` — passed.
- Verified that the rendering paths use `getFontFamilyString` / `getFontString`, so the new fallback will appear in:
  - canvas font strings (used with `measureText`)
  - SVG export (`font-family` attributes)

## Notes for reviewers

- `Segoe UI Symbol` is a system font name commonly available on Windows. On platforms that don't provide this font, browsers will skip it and proceed with the remaining fallbacks in the list — no runtime errors are introduced.
- This PR intentionally does not bundle any cross-platform symbol font. Bundling a font (e.g., Noto Symbols) would increase repo/build size and requires license and size review; I recommend that as a follow-up only if cross-platform parity is required.

## Follow-ups (suggested)

- Add a unit/integration test asserting exported SVG `font-family` includes the symbol fallback for texts that contain arrows / math symbols.
- Optionally bundle an open, permissively-licensed symbol font (Noto Sans Symbols or similar) and integrate it with the existing subset+inline font pipeline for full cross-platform coverage.
- Add a short note in docs about font fallbacks and how to add custom fonts.

## Checklist

- [x] Code changes
- [x] Typecheck passes
- [ ] Add tests (recommended follow-up)
- [ ] Documentation update (recommended follow-up)

## Resolves

Closes #10056