### PR TITLE
feat: inherit link from container for bound text elements in SVG export

### DIFF
--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -5692,6 +5692,36 @@ class App extends React.Component<AppProps, AppState> {
 
     for (let index = elements.length - 1; index >= 0; index--) {
       const element = elements[index];
+      // If pointer is over a bound text element that doesn't have a link
+      // itself but its container does, we want to treat the container link
+      // as clickable. We only do this in view mode (same semantics as base
+      // link hit detection uses when over bounding box) so editing UX stays
+      // unchanged.
+      if (
+        element.type === "text" &&
+        !element.link &&
+        (element as any).containerId &&
+        this.state.viewModeEnabled
+      ) {
+        const container = this.scene.getNonDeletedElement(
+          (element as any).containerId,
+        );
+        if (container && container.link) {
+          // Re-run hit test using container so that clicking directly on
+          // the text triggers the container's link.
+          if (
+            isPointHittingLink(
+              container,
+              this.scene.getNonDeletedElementsMap(),
+              this.state,
+              pointFrom(scenePointer.x, scenePointer.y),
+              this.device.editor.isMobile,
+            )
+          ) {
+            return container as ExcalidrawElement;
+          }
+        }
+      }
       if (
         hitElementMightBeLocked &&
         element.id === hitElementMightBeLocked.id

--- a/packages/excalidraw/renderer/staticSvgScene.ts
+++ b/packages/excalidraw/renderer/staticSvgScene.ts
@@ -710,8 +710,18 @@ export const renderSceneToSvg = (
 
           const boundTextElement = getBoundTextElement(element, elementsMap);
           if (boundTextElement) {
+            // If the container has a link but the bound text doesn't, inherit
+            // the link so clicking the text in exported SVG is also clickable.
+            // We avoid mutating original element by shallow cloning.
+            const container = elementsMap.get(
+              (boundTextElement as any).containerId,
+            );
+            const textForRender =
+              !boundTextElement.link && container?.link
+                ? { ...boundTextElement, link: container.link }
+                : boundTextElement;
             renderElementToSvg(
-              boundTextElement,
+              textForRender,
               elementsMap,
               rsvg,
               svgRoot,

--- a/packages/excalidraw/tests/export.test.tsx
+++ b/packages/excalidraw/tests/export.test.tsx
@@ -218,4 +218,44 @@ describe("export", () => {
     // src/tests/fixtures/svg-image-exporting-reference.svg
     expect(svgText).toMatchSnapshot(`svg export output`);
   });
+
+  it("export svg: bound text inside linked shape inherits link", async () => {
+    const container = API.createElement({
+      type: "rectangle",
+      x: 10,
+      y: 10,
+      width: 100,
+      height: 60,
+      id: "rect1",
+    });
+    // @ts-expect-error setting link for test
+    container.link = "https://example.com";
+    const textEl = API.createElement({
+      type: "text",
+      text: "Click me",
+      x: 10,
+      y: 10,
+      containerId: container.id,
+      width: 80,
+      height: 20,
+      id: "text1",
+    });
+    // minimal binding setup
+    // @ts-expect-error test mutation
+    container.boundElements = [{ type: "text", id: textEl.id }];
+
+    const svg = await exportToSvg(
+      [container, textEl],
+      { ...getDefaultAppState(), exportBackground: false },
+      {},
+    );
+    const svgText = svg.outerHTML;
+    // container anchor
+    expect(svgText).toMatch(/<a[^>]+href="https:\/\/example.com"/);
+    // bound text anchor (inherited)
+    // Should render exactly twice (shape + text)
+    const anchorMatches =
+      svgText.match(/<a[^>]+href="https:\/\/example.com"/g) || [];
+    expect(anchorMatches.length).toBe(2);
+  });
 });


### PR DESCRIPTION
This pull request enhances link handling for bound text elements in Excalidraw, ensuring that when a text element is bound to a container shape with a link, the text inherits the link in both view mode and SVG exports. This improves the user experience by making links more consistently clickable and ensures exported SVGs accurately reflect link associations.

**Link inheritance for bound text elements:**

* In `App.tsx`, updated pointer hit detection so that in view mode, clicking on a bound text element without its own link but whose container has a link will treat the container's link as clickable. This change only affects view mode, preserving editing behavior.
* In `staticSvgScene.ts`, modified SVG export logic so bound text elements inside a linked container inherit the container's link, making both the shape and its text clickable in the exported SVG. The implementation avoids mutating the original element by shallow cloning.

**Testing improvements:**

* Added a test in `export.test.tsx` to verify that bound text inside a linked shape correctly inherits the link in SVG exports, ensuring both the shape and text render with the link.

### related issue

closes - #10065 