### PR TITLE
fix: ESC key now cancels font size input in Properties panel

### DIFF
--- a/packages/excalidraw/components/Stats/DragInput.tsx
+++ b/packages/excalidraw/components/Stats/DragInput.tsx
@@ -344,12 +344,15 @@ const StatsDragInput = <
         onKeyDown={(event) => {
           if (editable) {
             const eventTarget = event.target;
-            if (
-              eventTarget instanceof HTMLInputElement &&
-              event.key === KEYS.ENTER
-            ) {
-              handleInputValue(eventTarget.value, elements, appState);
-              app.focusContainer();
+            if (eventTarget instanceof HTMLInputElement) {
+              if (event.key === KEYS.ENTER) {
+                handleInputValue(eventTarget.value, elements, appState);
+                app.focusContainer();
+              } else if (event.key === KEYS.ESCAPE) {
+                setInputValue(value.toString());
+                stateRef.current.updatePending = false;
+                app.focusContainer();
+              }
             }
           }
         }}


### PR DESCRIPTION
## Fix ESC key behavior for font size input in Properties panel

### Problem
ESC key was applying font size changes instead of canceling them in the Properties panel, inconsistent with other invalid input handling.

### Solution
- Added ESC key handler in StatsDragInput to revert input value and prevent updates
- ESC now cancels pending changes and restores original value
- Maintains consistency with existing behavior for invalid inputs

### Changes
- Modified `onKeyDown` handler in `DragInput.tsx` to handle ESC key
- ESC resets input value and clears pending update flag

Fixes #10064 

### Testing
- Enter font size input field
- Type new value
- Press ESC → value reverts to original
- Press Enter → value applies normally