### PR TITLE
build: Docker compose version removed

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 services:
   excalidraw:
     build:


### PR DESCRIPTION
The `version` field in **docker-compose.yml** file is not longer needed since it's deprecated, so it can be removed.