### PR TITLE
feat(ui): show error feedback for invalid hex color input (#9527)

### DIFF
--- a/packages/excalidraw/components/ColorPicker/ColorInput.tsx
+++ b/packages/excalidraw/components/ColorPicker/ColorInput.tsx
@@ -32,12 +32,14 @@ export const ColorInput = ({
 }: ColorInputProps) => {
   const editorInterface = useEditorInterface();
   const [innerValue, setInnerValue] = useState(color);
+  const [error, setError] = useState<string | null>(null);
   const [activeSection, setActiveColorPickerSection] = useAtom(
     activeColorPickerSectionAtom,
   );
 
   useEffect(() => {
     setInnerValue(color);
+    setError(null);
   }, [color]);
 
   const changeColor = useCallback(
@@ -47,6 +49,12 @@ export const ColorInput = ({
 
       if (color) {
         onChange(color);
+        setError(null);
+      } else if (value.trim()) {
+        // Only show error for non-empty invalid input
+        setError(t("colorPicker.invalidHex"));
+      } else {
+        setError(null);
       }
       setInnerValue(value);
     },
@@ -79,12 +87,15 @@ export const ColorInput = ({
         spellCheck={false}
         className="color-picker-input"
         aria-label={label}
+        aria-invalid={!!error}
+        aria-describedby={error ? "color-input-error" : undefined}
         onChange={(event) => {
           changeColor(event.target.value);
         }}
         value={(innerValue || "").replace(/^#/, "")}
         onBlur={() => {
           setInnerValue(color);
+          setError(null);
         }}
         tabIndex={-1}
         onFocus={() => setActiveColorPickerSection("hex")}
@@ -98,6 +109,23 @@ export const ColorInput = ({
         }}
         placeholder={placeholder}
       />
+      {error && (
+        <div
+          id="color-input-error"
+          role="alert"
+          style={{
+            color: "var(--color-danger)",
+            fontSize: "0.75rem",
+            marginTop: "0.25rem",
+            position: "absolute",
+            top: "100%",
+            left: 0,
+            whiteSpace: "nowrap",
+          }}
+        >
+          {error}
+        </div>
+      )}
       {/* TODO reenable on mobile with a better UX */}
       {editorInterface.formFactor !== "phone" && (
         <>

--- a/packages/excalidraw/locales/en.json
+++ b/packages/excalidraw/locales/en.json
@@ -574,7 +574,8 @@
     "colors": "Colors",
     "shades": "Shades",
     "hexCode": "Hex code",
-    "noShades": "No shades available for this color"
+    "noShades": "No shades available for this color",
+    "invalidHex": "Invalid hex color (use 3/4/6/8 digits: 0-9, a-f)"
   },
   "overwriteConfirm": {
     "action": {


### PR DESCRIPTION
<img width="2938" height="1792" alt="image" src="https://github.com/user-attachments/assets/0166627c-7eac-49c8-a0b2-94799060bb60" />
<img width="2938" height="1792" alt="after" src="https://github.com/user-attachments/assets/4889be96-3234-4189-8fba-09b8dce17e8c" />
