### PR TITLE
docs: add SECURITY.md for responsible vulnerability disclosure

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,20 @@
+# Security Policy
+
+## Supported Versions
+
+We currently support only the latest version of Excalidraw. Please update to the latest version before reporting a vulnerability.
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability, please report it responsibly.
+
+- Email us at: [security@excalidraw.com](mailto:security@excalidraw.com)
+- Or use GitHub's [private vulnerability reporting](https://github.com/excalidraw/excalidraw/security/advisories)
+
+Please include as much information as possible to help us reproduce and resolve the issue quickly.
+
+We typically respond within **5 business days** and will coordinate a fix as soon as possible. We support responsible disclosure and request that you do not share vulnerability details publicly until we have addressed the issue.
+
+## Scope
+
+This policy applies to the [excalidraw/excalidraw](https://github.com/excalidraw/excalidraw) repository. For issues in third-party dependencies, please report them to the respective maintainers.


### PR DESCRIPTION
This PR adds a `SECURITY.md` file to define a clear and responsible vulnerability disclosure process for Excalidraw.

- Helps users and contributors report vulnerabilities securely
- Improves the overall security posture of the project
- May improve the project's OpenSSF Scorecard rating

Let me know if you'd like any changes.

Closes #8862 