### PR TITLE
Add issue templates for bug report and feature request

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,25 @@
+---
+name: Bug Report
+about: Create a report to help us improve
+title: "[BUG]"
+labels: bug
+assignees: ''
+
+---
+
+A clear and concise description of what the bug is.
+
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '...'
+3. Scroll down to '...'
+4. See error
+
+A clear and concise description of what you expected to happen.
+
+If applicable, add screenshots to help explain your problem.
+
+ - OS: [e.g. Windows, macOS]
+ - Browser [e.g. chrome, safari]
+
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,13 @@
+---
+name: Feature Request
+about: Suggest an idea for this project
+title: "[FEATURE]"
+labels: enhancement
+assignees: ''
+
+---
+A clear and concise description of what you want to happen.
+
+A clear and concise description of any alternative solutions or features you've considered.
+
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
This pull request adds issue templates for bug reports and feature requests under the .github/ISSUE_TEMPLATE directory.

- Closes #10044
- Provides a standardized structure for contributors to report bugs or request features.
