### PR TITLE
Fix: Scaling multi-selected items sometimes scales dimensionally, sometimes aspect-ratio

### DIFF
--- a/packages/element/src/resizeElements.ts
+++ b/packages/element/src/resizeElements.ts
@@ -1249,7 +1249,7 @@ export const resizeMultipleElements = (
       targetElements.some(
         (item) =>
           item.latest.angle !== 0 ||
-          isTextElement(item.latest) ||
+          (isTextElement(item.latest) && !isBoundToContainer(item.latest)) ||
           isInGroup(item.latest),
       );
 


### PR DESCRIPTION
An issue was raised in the #10128  that 
When multi-selecting elements where one has a label, aspect ratio was incorrectly locked for all elements. This was caused by bound text elements triggering the aspect ratio check in resizeMultipleElements().
Changes:
Modified keepAspectRatio logic to exclude bound text elements from forcing aspect ratio
Bound text elements are already handled separately in the resize logic
Before: Multi-selecting a labeled rectangle + unlabeled rectangles → can't resize width independently
After: Multi-selecting labeled + unlabeled elements → can resize width independently
Files changed:
packages/element/src/resizeElements.ts (1 line)
Testing:
[x] Existing resize tests pass
[x] Manual testing with labeled/unlabeled elements
[x] No regression in other scaling behaviors