### PR TITLE
style: badge spacing in dropdown menu items

### DIFF
--- a/packages/excalidraw/components/dropdownMenu/DropdownMenu.scss
+++ b/packages/excalidraw/components/dropdownMenu/DropdownMenu.scss
@@ -138,6 +138,12 @@
         overflow: hidden;
         white-space: nowrap;
         gap: 0.75rem;
+
+        span {
+          display: flex;
+          align-items: center;
+          gap: 0.2rem;
+        }
       }
 
       &__shortcut {


### PR DESCRIPTION
## Description
Fixes badge spacing issue in dropdown menu items where the badge appears too close to the text.

## Changes
- Added proper spacing between text and AI badge
- Follows existing spacing patterns in the codebase

## Screenshots
Before: 
<img width="886" height="384" alt="image" src="https://github.com/user-attachments/assets/22905c26-6206-4575-86a7-67a62c59341c" />

After:
<img width="878" height="369" alt="image" src="https://github.com/user-attachments/assets/b2d77c38-3e82-4162-9e13-c93801b852ce" />


## Testing
- [V] Tested in light theme
- [V] Tested in dark theme
- [V] Checked all affected dropdown items