### PR TITLE
Opens New Canvas

### DIFF
--- a/excalidraw-app/App.tsx
+++ b/excalidraw-app/App.tsx
@@ -288,6 +288,11 @@ const initializeScene = async (opts: {
     }
   }
 
+  if (window.location.hash === "#new") {
+  localStorage.removeItem("excalidraw"); // start fresh
+}
+
+
   if (roomLinkData && opts.collabAPI) {
     const { excalidrawAPI } = opts;
 

--- a/excalidraw-app/components/AppMainMenu.tsx
+++ b/excalidraw-app/components/AppMainMenu.tsx
@@ -2,6 +2,7 @@ import {
   loginIcon,
   ExcalLogo,
   eyeIcon,
+  PlusIcon,
 } from "@excalidraw/excalidraw/components/icons";
 import { MainMenu } from "@excalidraw/excalidraw/index";
 import React from "react";
@@ -25,21 +26,38 @@ export const AppMainMenu: React.FC<{
 }> = React.memo((props) => {
   return (
     <MainMenu>
+      {/* NEW CANVAS BUTTON */}
+      <MainMenu.Item
+        icon={PlusIcon}
+        onSelect={() => {
+          // Open a fresh new canvas by adding a hash to signal new canvas
+          const url = new URL(window.location.href);
+          url.hash = "#new"; // your app can detect this
+          url.search = "";
+          window.open(url.toString(), "_blank");
+        }}
+      >
+        New Canvas
+      </MainMenu.Item>
+
       <MainMenu.DefaultItems.LoadScene />
       <MainMenu.DefaultItems.SaveToActiveFile />
       <MainMenu.DefaultItems.Export />
       <MainMenu.DefaultItems.SaveAsImage />
+
       {props.isCollabEnabled && (
         <MainMenu.DefaultItems.LiveCollaborationTrigger
           isCollaborating={props.isCollaborating}
           onSelect={() => props.onCollabDialogOpen()}
         />
       )}
+
       <MainMenu.DefaultItems.CommandPalette className="highlighted" />
       <MainMenu.DefaultItems.SearchMenu />
       <MainMenu.DefaultItems.Help />
       <MainMenu.DefaultItems.ClearCanvas />
       <MainMenu.Separator />
+
       <MainMenu.ItemLink
         icon={ExcalLogo}
         href={`${
@@ -49,7 +67,9 @@ export const AppMainMenu: React.FC<{
       >
         Excalidraw+
       </MainMenu.ItemLink>
+
       <MainMenu.DefaultItems.Socials />
+
       <MainMenu.ItemLink
         icon={loginIcon}
         href={`${import.meta.env.VITE_APP_PLUS_APP}${
@@ -59,6 +79,7 @@ export const AppMainMenu: React.FC<{
       >
         {isExcalidrawPlusSignedUser ? "Sign in" : "Sign up"}
       </MainMenu.ItemLink>
+
       {isDevEnv() && (
         <MainMenu.Item
           icon={eyeIcon}
@@ -76,15 +97,19 @@ export const AppMainMenu: React.FC<{
           Visual Debug
         </MainMenu.Item>
       )}
+
       <MainMenu.Separator />
+
       <MainMenu.DefaultItems.ToggleTheme
         allowSystemTheme
         theme={props.theme}
         onSelect={props.setTheme}
       />
+
       <MainMenu.ItemCustom>
         <LanguageList style={{ width: "100%" }} />
       </MainMenu.ItemCustom>
+
       <MainMenu.DefaultItems.ChangeCanvasBackground />
     </MainMenu>
   );


### PR DESCRIPTION
<img width="1366" height="680" alt="image" src="https://github.com/user-attachments/assets/6dd93da6-ee67-47ac-be20-b345ddc2a2db" />
This PR introduces a “New Canvas” button in the Excalidraw main menu that allows users to open a fresh, blank canvas in a new browser tab.
Previously, opening a new tab replicated the current canvas state due to persistent localStorage.
This change improves usability by letting users quickly start a new drawing without manually clearing the existing one.