### PR TITLE
docs: fix typo in excalidraw installation guide

### DIFF
--- a/dev-docs/docs/@excalidraw/excalidraw/installation.mdx
+++ b/dev-docs/docs/@excalidraw/excalidraw/installation.mdx
@@ -37,7 +37,7 @@ or, if you serve your assets from the root of your CDN, you would do:
 </head>
 ```
 
-or, if you prefer the path to be dynamicly set based on the `location.origin`, you could do the following:
+or, if you prefer the path to be dynamically set based on the `location.origin`, you could do the following:
 
 ```jsx
 // Next.js


### PR DESCRIPTION
Fixed a typo in the Excalidraw installation documentation.