### PR TITLE
Feat: enable enter edit group mode

### DIFF
--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -215,7 +215,6 @@ import {
   isElementInGroup,
   isSelectedViaGroup,
   selectGroupsForSelectedElements,
-  elementsAreInSameGroup,
   syncInvalidIndices,
   syncMovedIndices,
   excludeElementsInFramesFromSelection,
@@ -4555,7 +4554,9 @@ class App extends React.Component<AppProps, AppState> {
           }
         } else if (
           selectedGroupIds.length === 1 &&
-          elementsAreInSameGroup(selectedElements)
+          selectedElements.every((element) =>
+            isElementInGroup(element, selectedGroupIds[0]),
+          )
         ) {
           const nextEditingGroupId = selectedGroupIds[0];
           const selectedElements = getElementsInGroup(
@@ -4565,15 +4566,17 @@ class App extends React.Component<AppProps, AppState> {
 
           const nextGroupIds: Record<string, true> = {};
           const nextSelectedElementIds: Record<string, true> = {};
+          // iterate through elements in the group
           selectedElements.forEach((element) => {
             const editingGroupIndex =
               element.groupIds.indexOf(nextEditingGroupId);
             const groupIds = element.groupIds.slice(0, editingGroupIndex);
-
+            // we can confidently select element if it's in a nested group
             if (groupIds.length > 0) {
               const lastGroupId = groupIds[groupIds.length - 1];
               nextGroupIds[lastGroupId] = true;
               nextSelectedElementIds[element.id] = true;
+              // otherwise, we need to filter out bound text elements
             } else if (!isBoundToContainer(element)) {
               nextSelectedElementIds[element.id] = true;
             }


### PR DESCRIPTION
## Summary
This PR extends off the work of @aqandrew PR #8528 and could Close #8511, to account for nested, sub-nested, and sibling nested groups when enter is pressed while a single group is selected. 

Within the process I applied a few different approaches, with the use of group-related functions `selectGroupsForSelectedElements` and `selectGroupsFromGivenElements`, however, the case seemed unique in that we also need to account for bound-text elements, and filtering them out when they aren't a member of a top-most nested group. 

Alternatively, I considered iterating through the selected elements once to account for this, while also collecting the groupIds to be selected. In all it seems to require an update to `selectedElementIds`, `selectedGroupIds` and the `editingGroupId` of AppState.


https://github.com/user-attachments/assets/e03cbffa-f93e-4b5b-b02d-0011ef150931


### Feedback Welcome
If there is any feedback, or modifications necessary, please let me know as I'd be happy to collaborate and fix if required.

@dwelle , Apologies for the delay on this, as I attempted to make contact with the original author, but was unable to get ahold of.