### PR TITLE
fix: disable background color for open-path lines

### DIFF
--- a/packages/excalidraw/actions/actionProperties.tsx
+++ b/packages/excalidraw/actions/actionProperties.tsx
@@ -372,33 +372,31 @@ export const actionChangeBackgroundColor = register({
       };
     }
 
-    let nextElements;
-
     const selectedElements = app.scene.getSelectedElements(appState);
-    const shouldEnablePolygon =
-      !isTransparent(value.currentItemBackgroundColor) &&
-      selectedElements.every(
-        (el) => isLineElement(el) && canBecomePolygon(el.points),
-      );
-
-    if (shouldEnablePolygon) {
-      const selectedElementsMap = arrayToMap(selectedElements);
-      nextElements = elements.map((el) => {
-        if (selectedElementsMap.has(el.id) && isLineElement(el)) {
-          return newElementWith(el, {
-            backgroundColor: value.currentItemBackgroundColor,
-            ...toggleLinePolygonState(el, true),
-          });
+    const selectedElementsMap = arrayToMap(selectedElements);
+    const nextElements = elements.map((el) => {
+      if (selectedElementsMap.has(el.id)) {
+        if (
+          !isTransparent(value.currentItemBackgroundColor) &&
+          isLineElement(el)
+        ) {
+          if (canBecomePolygon(el.points)) {
+            return newElementWith(el, {
+              backgroundColor: value.currentItemBackgroundColor,
+              ...toggleLinePolygonState(el, true),
+            });
+          }
+          return {
+            ...el,
+            backgroundColor: "transparent",
+          };
         }
-        return el;
-      });
-    } else {
-      nextElements = changeProperty(elements, appState, (el) =>
-        newElementWith(el, {
+        return newElementWith(el, {
           backgroundColor: value.currentItemBackgroundColor,
-        }),
-      );
-    }
+        });
+      }
+      return el;
+    });
 
     return {
       elements: nextElements,


### PR DESCRIPTION
### Summary
This PR fixes issue #10161 where the background color option was enabled but non-functional for simple, open-path lines. Selecting a color would indicate a change in the UI but visually do nothing to the line.

### Changes
- Lines with only a start and end point (open-path) now automatically get `backgroundColor: transparent` and disabled after that.
- Background color functionality is preserved for:
  1. Lines that are already polygons
  2. Lines that can become polygons
  3. Other shapes
- The behavior matches the expected UX: open-path lines cannot have a background color.

### How to Test
1. Select the Line tool and draw a simple line (open-path).
2. Select the line and open the background color panel.
3. Selecting any color will not fill the line and automatically changes to transparent, indicating the option is effectively disabled.
4. Draw a polygon or a line that can form a polygon: background color is fully functional.

### Video :- 

https://github.com/user-attachments/assets/48806b7d-1aad-4118-9bc5-505f3f26e200


Before:
- Background color selectable for open line, but no visual effect.

After:
- Background color automatically changes to transparent for open-path lines and then becomes disabled
- Works correctly for polygons and other shapes.

### Notes
- This fix does not affect other shapes.
- Future improvement: Consider greying out the background color picker or removing it for open-path lines instead of just setting transparent color.

---

**Closes:** #10161

---

### Hacktoberfest 2025
This contribution is part of Hacktoberfest 2025 🎃
