### PR TITLE
fix: text elements incorrectly linked to original container when wrapped

### DIFF
--- a/packages/excalidraw/actions/actionBoundText.tsx
+++ b/packages/excalidraw/actions/actionBoundText.tsx
@@ -232,6 +232,24 @@ export const actionWrapTextInContainer = register({
     const selectedElements = app.scene.getSelectedElements(appState);
     let updatedElements: readonly ExcalidrawElement[] = elements.slice();
     const containerIds: Mutable<AppState["selectedElementIds"]> = {};
+    const wrappedTextIds = new Set<string>();
+
+    for (const textElement of selectedElements) {
+      if (isTextElement(textElement)) {
+        wrappedTextIds.add(textElement.id);
+      }
+    }
+    //remove text link with prev shape
+    for (const element of selectedElements) {
+      if (!isTextElement(element) && element.boundElements?.length) {
+        const newBoundElementsArray = element.boundElements.filter(
+          (b) => !(b.type === "text" && wrappedTextIds.has(b.id)),
+        );
+        app.scene.mutateElement(element, {
+          boundElements: newBoundElementsArray,
+        });
+      }
+    }
 
     for (const textElement of selectedElements) {
       if (isTextElement(textElement)) {


### PR DESCRIPTION
### Problem
When using the "Wrap text in a container" action on shapes that already contain text, the text element could retain a reference to the original container. This caused unexpected behavior:
- Moving the original shape also moved the new text container incorrectly.
- Resizing or editing the original shape caused text to jump or swap between containers.

### Solution
This PR ensures that text elements are fully detached from their previous containers before wrapping them in a new container:
- Keeps track of text element IDs being wrapped.
- Removes them from any boundElements of other shapes in the selection.
- Creates a new container and associates only the text element with it.
- Arrow bindings are preserved correctly.

### Video :- 

https://github.com/user-attachments/assets/130ac328-4def-4262-a412-a54bfe1fc13a



---
Fixes: #10181 
---

### Hacktoberfest 2025
This contribution is part of Hacktoberfest 2025 🎃
