### PR TITLE
Feat: add visibility flag to support layers

### DIFF
--- a/packages/element/src/renderElement.ts
+++ b/packages/element/src/renderElement.ts
@@ -735,6 +735,10 @@ export const renderElement = (
   renderConfig: StaticCanvasRenderConfig,
   appState: StaticCanvasAppState,
 ) => {
+  if (element.visibility === "hidden") {
+    return;
+  }
+
   const reduceAlphaForSelection =
     appState.openDialog?.name === "elementLinkSelector" &&
     !appState.selectedElementIds[element.id] &&

--- a/packages/element/src/selection.ts
+++ b/packages/element/src/selection.ts
@@ -64,35 +64,37 @@ export const getElementsWithinSelection = (
   const [selectionX1, selectionY1, selectionX2, selectionY2] =
     getElementAbsoluteCoords(selection, elementsMap);
 
-  let elementsInSelection = elements.filter((element) => {
-    let [elementX1, elementY1, elementX2, elementY2] = getElementBounds(
-      element,
-      elementsMap,
-    );
-
-    const containingFrame = getContainingFrame(element, elementsMap);
-    if (containingFrame) {
-      const [fx1, fy1, fx2, fy2] = getElementBounds(
-        containingFrame,
+  let elementsInSelection = elements
+    .filter((e) => !e.visibility || e.visibility === "active")
+    .filter((element) => {
+      let [elementX1, elementY1, elementX2, elementY2] = getElementBounds(
+        element,
         elementsMap,
       );
 
-      elementX1 = Math.max(fx1, elementX1);
-      elementY1 = Math.max(fy1, elementY1);
-      elementX2 = Math.min(fx2, elementX2);
-      elementY2 = Math.min(fy2, elementY2);
-    }
+      const containingFrame = getContainingFrame(element, elementsMap);
+      if (containingFrame) {
+        const [fx1, fy1, fx2, fy2] = getElementBounds(
+          containingFrame,
+          elementsMap,
+        );
 
-    return (
-      element.locked === false &&
-      element.type !== "selection" &&
-      !isBoundToContainer(element) &&
-      selectionX1 <= elementX1 &&
-      selectionY1 <= elementY1 &&
-      selectionX2 >= elementX2 &&
-      selectionY2 >= elementY2
-    );
-  });
+        elementX1 = Math.max(fx1, elementX1);
+        elementY1 = Math.max(fy1, elementY1);
+        elementX2 = Math.min(fx2, elementX2);
+        elementY2 = Math.min(fy2, elementY2);
+      }
+
+      return (
+        element.locked === false &&
+        element.type !== "selection" &&
+        !isBoundToContainer(element) &&
+        selectionX1 <= elementX1 &&
+        selectionY1 <= elementY1 &&
+        selectionX2 >= elementX2 &&
+        selectionY2 >= elementY2
+      );
+    });
 
   elementsInSelection = excludeElementsInFrames
     ? excludeElementsInFramesFromSelection(elementsInSelection)

--- a/packages/element/src/types.ts
+++ b/packages/element/src/types.ts
@@ -78,6 +78,7 @@ type _ExcalidrawElementBase = Readonly<{
   updated: number;
   link: string | null;
   locked: boolean;
+  visibility?: "active" | "static" | "hidden";
   customData?: Record<string, any>;
 }>;
 

--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -5216,6 +5216,7 @@ class App extends React.Component<AppProps, AppState> {
                   !(isTextElement(element) && element.containerId)),
             )
     )
+      .filter((el) => !el.visibility || el.visibility === "active")
       .filter((el) => this.hitElement(x, y, el))
       .filter((element) => {
         // hitting a frame's element from outside the frame is not considered a hit

--- a/packages/excalidraw/data/restore.ts
+++ b/packages/excalidraw/data/restore.ts
@@ -156,8 +156,9 @@ const repairBinding = <T extends ExcalidrawLinearElement>(
 };
 
 const restoreElementWithProperties = <
-  T extends Required<Omit<ExcalidrawElement, "customData">> & {
+  T extends Required<Omit<ExcalidrawElement, "customData" | "visibility">> & {
     customData?: ExcalidrawElement["customData"];
+    visibility?: ExcalidrawElement["visibility"];
     /** @deprecated */
     boundElementIds?: readonly ExcalidrawElement["id"][];
     /** @deprecated */
@@ -172,7 +173,9 @@ const restoreElementWithProperties = <
     // @ts-ignore TS complains here but type checks the call sites fine.
     keyof K
   > &
-    Partial<Pick<ExcalidrawElement, "type" | "x" | "y" | "customData">>,
+    Partial<
+      Pick<ExcalidrawElement, "type" | "x" | "y" | "visibility" | "customData">
+    >,
 ): T => {
   const base: Pick<T, keyof ExcalidrawElement> = {
     type: extra.type || element.type,
@@ -217,6 +220,7 @@ const restoreElementWithProperties = <
     updated: element.updated ?? getUpdatedTimestamp(),
     link: element.link ? normalizeLink(element.link) : null,
     locked: element.locked ?? false,
+    visibility: element.visibility,
   };
 
   if ("customData" in element || "customData" in extra) {


### PR DESCRIPTION
This simple flag can be used by consuming apps to toggle the visibility state of an element. The visibility states are:
* `active` or `undefined`: current behavior - user can select, interact, etc.
* `static`: the element is rendered as usual, but cannot be interacted with in any way (selection, clicks, etc.)
* `hidden`: the element is managed but not rendered, and cannot be interacted with.

This allows `onChange` to transform the element's visibility flag as needed. Combined with `customData`, elements can be _moved_ to layers, where the correct visibility flag is set. For example:

```tsx
<Excalidraw
  onChange={(elements, files, appState) => {
    // set all elements outside the current layer to static
    elements
      .filter(e => e.customData?.layerId !== currentLayer.id)
      .forEach(e => { e.visibility = 'static' })
  }}
/>
```

Let me know what you think! Maybne there is an even better way to do this...

Edit: The visibility flag for `hidden` might actually not be needed, as consuming apps can just splice the hidden elements from the array and re-insert them when toggled. The `hidden` state is just a convenience because it simplifies state management for consuming apps. But there must be a flag to render elements and preventing the user to interact with them.