### PR TITLE
feat: Simplify the freedraw element at creation or restoration

### DIFF
--- a/packages/element/src/renderElement.ts
+++ b/packages/element/src/renderElement.ts
@@ -1052,15 +1052,14 @@ export function getFreeDrawSvgPath(element: ExcalidrawFreeDrawElement) {
 
 export function getFreedrawOutlineAsSegments(
   element: ExcalidrawFreeDrawElement,
-  points: [number, number][],
-  elementsMap: ElementsMap,
+  points: readonly [number, number][],
 ) {
   const bounds = getElementBounds(
     {
       ...element,
       angle: 0 as Radians,
     },
-    elementsMap,
+    new Map(),
   );
   const center = pointFrom<GlobalPoint>(
     (bounds[0] + bounds[2]) / 2,

--- a/packages/element/src/utils.ts
+++ b/packages/element/src/utils.ts
@@ -10,6 +10,7 @@ import {
   curveCatmullRomCubicApproxPoints,
   curveOffsetPoints,
   lineSegment,
+  perpendicularDistance,
   pointDistance,
   pointFrom,
   pointFromArray,
@@ -481,3 +482,24 @@ export const getCornerRadius = (x: number, element: ExcalidrawElement) => {
 
   return 0;
 };
+
+export function shouldSkipFreedrawPoint(
+  points: readonly LocalPoint[],
+  dx: number,
+  dy: number,
+  epsilon: number = 0.5,
+) {
+  const lastPoint = points.length > 0 && points[points.length - 1];
+  const nextToLastPoint = points.length > 1 && points[points.length - 2];
+  return (
+    (lastPoint && lastPoint[0] === dx && lastPoint[1] === dy) ||
+    // NOTE: Apply a simplification algorithm to reduce number of points
+    (nextToLastPoint && lastPoint
+      ? perpendicularDistance(
+          pointFrom<LocalPoint>(dx, dy),
+          lineSegment(nextToLastPoint, lastPoint),
+        ) < epsilon
+      : !points[0] ||
+        pointDistance(points[0], pointFrom<LocalPoint>(dx, dy)) < epsilon)
+  );
+}

--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -239,6 +239,7 @@ import {
   StoreDelta,
   type ApplyToOptions,
   positionElementsOnGrid,
+  shouldSkipFreedrawPoint,
 } from "@excalidraw/element";
 
 import type { LocalPoint, Radians } from "@excalidraw/math";
@@ -8922,10 +8923,7 @@ class App extends React.Component<AppProps, AppState> {
           const points = newElement.points;
           const dx = pointerCoords.x - newElement.x;
           const dy = pointerCoords.y - newElement.y;
-
-          const lastPoint = points.length > 0 && points[points.length - 1];
-          const discardPoint =
-            lastPoint && lastPoint[0] === dx && lastPoint[1] === dy;
+          const discardPoint = shouldSkipFreedrawPoint(points, dx, dy, 0.5);
 
           if (!discardPoint) {
             const pressures = newElement.simulatePressure

--- a/packages/excalidraw/data/restore.ts
+++ b/packages/excalidraw/data/restore.ts
@@ -1,4 +1,8 @@
-import { isFiniteNumber, pointFrom } from "@excalidraw/math";
+import {
+  curveSimplifyWithRDP,
+  isFiniteNumber,
+  pointFrom,
+} from "@excalidraw/math";
 
 import {
   DEFAULT_FONT_FAMILY,
@@ -18,7 +22,11 @@ import {
   normalizeLink,
   getLineHeight,
 } from "@excalidraw/common";
-import { getNonDeletedElements, isValidPolygon } from "@excalidraw/element";
+import {
+  getNonDeletedElements,
+  isFreeDrawElement,
+  isValidPolygon,
+} from "@excalidraw/element";
 import { normalizeFixedPoint } from "@excalidraw/element";
 import {
   updateElbowArrowPoints,
@@ -622,6 +630,12 @@ export const restoreElements = (
       ) {
         (element as Mutable<ExcalidrawLinearElement>).endBinding = null;
       }
+    }
+
+    if (isFreeDrawElement(element)) {
+      Object.assign(element, {
+        points: curveSimplifyWithRDP(element.points, 0.5),
+      });
     }
   }
 

--- a/packages/excalidraw/eraser/index.ts
+++ b/packages/excalidraw/eraser/index.ts
@@ -238,11 +238,7 @@ const eraserTest = (
   // which offers a good visual precision at various zoom levels
   if (isFreeDrawElement(element)) {
     const outlinePoints = getFreedrawOutlinePoints(element);
-    const strokeSegments = getFreedrawOutlineAsSegments(
-      element,
-      outlinePoints,
-      elementsMap,
-    );
+    const strokeSegments = getFreedrawOutlineAsSegments(element, outlinePoints);
     const tolerance = Math.max(2.25, 5 / zoom); // NOTE: Visually fine-tuned approximation
 
     for (const seg of strokeSegments) {


### PR DESCRIPTION
Simplify the curve points right at the creation point, so we don't store excessive and noisy detail in the element when exported.