### PR TITLE
Bug Fix: Mobile Footer Not Rendering (#10233)

### DIFF
--- a/packages/excalidraw/components/main-menu/MainMenu.tsx
+++ b/packages/excalidraw/components/main-menu/MainMenu.tsx
@@ -26,7 +26,7 @@ const MainMenu = Object.assign(
        */
       onSelect?: (event: Event) => void;
     }) => {
-      const { MainMenuTunnel } = useTunnels();
+      const { MainMenuTunnel, FooterCenterTunnel } = useTunnels();
       const device = useDevice();
       const appState = useUIAppState();
       const setAppState = useExcalidrawSetAppState();
@@ -66,6 +66,7 @@ const MainMenu = Object.assign(
                   />
                 </fieldset>
               )}
+              {device.editor.isMobile && <FooterCenterTunnel.Out />}
             </DropdownMenu.Content>
           </DropdownMenu>
         </MainMenuTunnel.In>


### PR DESCRIPTION
This pull request makes a small update to the `MainMenu` component to improve mobile device support. The main change is the addition of the `FooterCenterTunnel` outlet, which is conditionally rendered for mobile editors.

- MainMenu enhancements for mobile:
  * Added `FooterCenterTunnel` to the list of tunnels used in `MainMenu`, allowing content to be rendered in the footer center area on mobile devices. (`packages/excalidraw/components/main-menu/MainMenu.tsx`)
  * Conditionally rendered `<FooterCenterTunnel.Out />` in the menu dropdown content when the editor is on a mobile device. (`packages/excalidraw/components/main-menu/MainMenu.tsx`)