### PR TITLE
Adjust welcome screen layout for large screens

### DIFF
--- a/packages/excalidraw/components/welcome-screen/WelcomeScreen.scss
+++ b/packages/excalidraw/components/welcome-screen/WelcomeScreen.scss
@@ -136,6 +136,10 @@
     top: 1rem;
     right: 1rem;
     bottom: 1rem;
+
+    @media (max-width: 1535px) and (min-width: 1024px) {
+      top: 9rem;
+    }
   }
 
   .welcome-screen-center__logo {


### PR DESCRIPTION
This PR fixes #10246 - a layout bug on the welcome screen where the "Pick a tool & Start drawing!" hint overlaps with the Excalidraw logo. The issue occurs on screen widths common to 13" and 15" laptops (roughly between 1024px and 1535px), but not on very large monitors.

### Before

The hint arrow and text are rendered on top of the logo, making both difficult to read.

<img width="1366" height="637" alt="The toolbar hint is overlapping the Excalidraw logo on the welcome screen." src="https://github.com/user-attachments/assets/68e0545d-0e43-4163-9950-2472c07174bc" />

### After

With the fix, the hint and logo are positioned correctly without any overlap.

<img width="1366" height="637" alt="screenshot" src="https://github.com/user-attachments/assets/a39004bf-031a-4986-b81e-0c66c45dc921" />

### How it's fixed

I've added a simple CSS media query to `WelcomeScreen.scss`. It adjusts the `top` position of the `.welcome-screen-center` container on viewports between `1024px` and `1535px`. This pushes the logo and menu down just enough to create space and resolve the overlap.

### How to test

1.  Go to the welcome screen.
2.  Resize your browser's viewport to a width between 1024px and 1535px.
3.  Confirm the toolbar hint no longer covers the logo.