### PR TITLE
fix: preserve stylesPanelMode during canvas reset to prevent mobile color picker UI corruption

### DIFF
--- a/packages/excalidraw/actions/actionCanvas.tsx
+++ b/packages/excalidraw/actions/actionCanvas.tsx
@@ -120,6 +120,7 @@ export const actionClearCanvas = register({
         gridModeEnabled: appState.gridModeEnabled,
         stats: appState.stats,
         pasteDialog: appState.pasteDialog,
+        stylesPanelMode: appState.stylesPanelMode,
         activeTool:
           appState.activeTool.type === "image"
             ? {

--- a/packages/excalidraw/components/Actions.tsx
+++ b/packages/excalidraw/components/Actions.tsx
@@ -1,5 +1,5 @@
 import clsx from "clsx";
-import { useRef, useState } from "react";
+import { useRef, useState, useEffect } from "react";
 import * as Popover from "@radix-ui/react-popover";
 
 import {
@@ -900,9 +900,35 @@ export const MobileShapeActions = ({
   const targetElements = getTargetElements(elementsMap, appState);
   const { container } = useExcalidrawContainer();
   const mobileActionsRef = useRef<HTMLDivElement>(null);
+  const [actionsWidth, setActionsWidth] = useState(0);
 
-  const ACTIONS_WIDTH =
-    mobileActionsRef.current?.getBoundingClientRect()?.width ?? 0;
+  // Use useEffect to properly measure width after render
+  useEffect(() => {
+    const measureWidth = () => {
+      if (mobileActionsRef.current) {
+        const width = mobileActionsRef.current.getBoundingClientRect().width;
+        if (width > 0) {
+          setActionsWidth(width);
+        }
+      }
+    };
+
+    measureWidth();
+
+    // Re-measure on resize if ResizeObserver is available
+    if (typeof ResizeObserver !== "undefined") {
+      const resizeObserver = new ResizeObserver(measureWidth);
+      if (mobileActionsRef.current) {
+        resizeObserver.observe(mobileActionsRef.current);
+      }
+
+      return () => {
+        resizeObserver.disconnect();
+      };
+    }
+  }, []);
+
+  const ACTIONS_WIDTH = actionsWidth;
 
   // 7 actions + 2 for undo/redo
   const MIN_ACTIONS = 9;


### PR DESCRIPTION
## Description

Fixes #10252 - Color picker falls apart after resetting the canvas on the new mobile UI

This PR addresses a critical mobile UI bug where the color picker would display incorrectly after canvas reset, showing only basic color swatches instead of the full expanded interface.

## Root Cause

The issue was caused by two problems:

1. **State Reset**: During canvas reset (`actionClearCanvas`), the `stylesPanelMode` was being reset to `"full"` instead of preserving the current mode (`"mobile"` for mobile devices)
2. **Width Measurement**: The `MobileShapeActions` component was using synchronous width measurement that could fail during re-renders after canvas reset

## Solution

### 1. Preserve stylesPanelMode during canvas reset
- Modified `actionClearCanvas` to preserve the current `stylesPanelMode` value
- This ensures mobile devices maintain `stylesPanelMode: "mobile"` which is required for proper color picker display

### 2. Improve width measurement reliability  
- Added proper `useEffect` with `ResizeObserver` for accurate width measurement
- Added fallback for test environments where `ResizeObserver` is not available
- This prevents layout calculation errors that could break the mobile UI

## Before/After Screenshots

### Before (Broken) 
The color picker shows only basic horizontal color swatches with "Stroke" text - broken layout after canvas reset.
<img width="1213" height="1011" alt="Screenshot from 2025-10-26 14-19-48" src="https://github.com/user-attachments/assets/84d224cd-51f0-401e-a593-734064edc74c" />


### After (Fixed) 
The color picker displays the full expanded interface with proper sections: Background, Colors, Shades, Hex code - working correctly after canvas reset.
=>

https://github.com/user-attachments/assets/295507c6-b6bf-4c0d-ae5b-8c81c50a5891



## Testing

-  All existing tests pass (1034 passed, 47 skipped)
-  Mobile color picker works correctly after canvas reset
- Desktop functionality remains unaffected
-  No regressions in other mobile UI components

## Technical Details

The fix ensures that:
1. Mobile devices always maintain proper `stylesPanelMode` state
2. Color picker components receive correct `compactMode` props
3. Width measurements are accurate and reliable
4. Test environments handle missing browser APIs gracefully

Closes #10252
