### PR TITLE
test: add MC/DC unit tests for prepareElementsForExport (packages/excalidraw)

### DIFF
--- a/packages/excalidraw/tests/prepareElementsForExport.test.ts
+++ b/packages/excalidraw/tests/prepareElementsForExport.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Tests for prepareElementsForExport (MC/DC cases CT1..CT6)
+ *
+ * This file mocks ../scene and @excalidraw/element using factory mocks so that
+ * exported functions are jest.fn() and can be controlled with .mockReturnValue.
+ *
+ * Map of CTs:
+ * CT1 - exportSelectionOnly = true, selection exists, selectedElements.length > 1
+ * CT2 - exportSelectionOnly = true, no selection (isSomeElementSelected = false)
+ * CT3 - exportSelectionOnly = false, selection exists
+ * CT4 - selectedElements.length === 1 && isFrameLikeElement === true (frame case)
+ * CT5 - selectedElements.length === 1 && isFrameLikeElement === false (single non-frame)
+ * CT6 - not exporting selection (covers branch exportedElements = elements)
+ */
+
+import { vi } from "vitest";
+import { prepareElementsForExport } from "../data/index"; // function under test
+
+// Provide factory mocks for modules to guarantee functions are vi.fn()
+vi.mock("../scene", () => ({
+  isSomeElementSelected: vi.fn(),
+  getSelectedElements: vi.fn(),
+}));
+
+vi.mock("@excalidraw/element", () => ({
+  // minimal set of helpers used by prepareElementsForExport
+  isFrameLikeElement: vi.fn(),
+  getElementsOverlappingFrame: vi.fn(),
+  getNonDeletedElements: vi.fn((els: any[]) => els.filter((e: any) => !e.isDeleted)),
+}));
+
+// For cloneJSON we can use real implementation or a simple deep clone
+vi.mock("@excalidraw/common", async () => {
+  const original = await vi.importActual<typeof import("@excalidraw/common")>("@excalidraw/common");
+  return {
+    ...original,
+    cloneJSON: (v: any) => JSON.parse(JSON.stringify(v)),
+  };
+});
+
+import * as scene from "../scene";
+import * as elementModule from "@excalidraw/element";
+
+// Helper minimal element factory
+const makeElement = (overrides: any = {}) => ({
+  id: overrides.id ?? Math.random().toString(36).slice(2),
+  type: overrides.type ?? "rectangle",
+  isDeleted: overrides.isDeleted ?? false,
+  frameId: overrides.frameId ?? null,
+  containerId: overrides.containerId ?? null,
+  boundElements: overrides.boundElements ?? undefined,
+  ...overrides,
+});
+
+beforeEach(() => {
+  // reset mocks before each test
+  vi.mocked(scene.isSomeElementSelected).mockReset();
+  vi.mocked(scene.getSelectedElements).mockReset();
+  vi.mocked(elementModule.isFrameLikeElement).mockReset();
+  vi.mocked(elementModule.getElementsOverlappingFrame).mockReset();
+  vi.mocked(elementModule.getNonDeletedElements).mockReset();
+  // default behavior for getNonDeletedElements
+  vi.mocked(elementModule.getNonDeletedElements).mockImplementation((els: readonly any[]) =>
+    els.filter((e: any) => !e.isDeleted) as any,
+  );
+});
+
+test("CT1 - export selection when flag true and selection exists (A1=1,A2=1; exportedElements.length>1)", () => {
+  const el1 = makeElement({ id: "e1" });
+  const el2 = makeElement({ id: "e2" });
+  const el3 = makeElement({ id: "e3" });
+  const elements = [el1, el2, el3];
+
+  vi.mocked(scene.isSomeElementSelected).mockReturnValue(true);
+  vi.mocked(scene.getSelectedElements).mockReturnValue([el1, el2]);
+  vi.mocked(elementModule.isFrameLikeElement).mockReturnValue(false);
+
+  const result = prepareElementsForExport(elements, { selectedElementIds: { e1: true, e2: true } }, true);
+
+  expect(result.exportingFrame).toBeNull();
+  expect(result.exportedElements).toHaveLength(2);
+  expect(result.exportedElements).toEqual(
+    expect.arrayContaining([expect.objectContaining({ id: "e1" }), expect.objectContaining({ id: "e2" })]),
+  );
+});
+
+test("CT2 - exportSelectionOnly true but no selection (A1=1,A2=0)", () => {
+  const el1 = makeElement({ id: "e1" });
+  const el2 = makeElement({ id: "e2" });
+  const elements = [el1, el2];
+
+  vi.mocked(scene.isSomeElementSelected).mockReturnValue(false);
+  vi.mocked(scene.getSelectedElements).mockReturnValue([]);
+
+  const result = prepareElementsForExport(elements, { selectedElementIds: {} }, true);
+
+  expect(result.exportingFrame).toBeNull();
+  expect(result.exportedElements).toHaveLength(elements.length);
+  expect(result.exportedElements).toEqual(elements);
+});
+
+test("CT3 - exportSelectionOnly false even when selection exists (A1=0,A2=1)", () => {
+  const el1 = makeElement({ id: "e1" });
+  const el2 = makeElement({ id: "e2" });
+  const elements = [el1, el2];
+
+  vi.mocked(scene.isSomeElementSelected).mockReturnValue(true);
+  vi.mocked(scene.getSelectedElements).mockReturnValue([el1]);
+
+  const result = prepareElementsForExport(elements, { selectedElementIds: { e1: true } }, false);
+
+  expect(result.exportingFrame).toBeNull();
+  expect(result.exportedElements).toHaveLength(elements.length);
+  expect(result.exportedElements).toEqual(elements);
+});
+
+test("CT4 - selection is single frame (B1=1,B2=1)", () => {
+  const frame = makeElement({ id: "frame1", type: "frame" });
+  const insideA = makeElement({ id: "i1", frameId: "frame1" });
+  const insideB = makeElement({ id: "i2", frameId: "frame1" });
+
+  const elements = [frame, insideA, insideB];
+
+  vi.mocked(scene.isSomeElementSelected).mockReturnValue(true);
+  vi.mocked(scene.getSelectedElements).mockReturnValue([frame]);
+  vi.mocked(elementModule.isFrameLikeElement).mockImplementation((el: any) => el.type === "frame");
+  vi.mocked(elementModule.getElementsOverlappingFrame).mockReturnValue([insideA, insideB]);
+
+  const result = prepareElementsForExport(elements, { selectedElementIds: { frame1: true } }, true);
+
+  expect(result.exportingFrame).toEqual(expect.objectContaining({ id: "frame1" }));
+  expect(result.exportedElements).toEqual(expect.arrayContaining([expect.objectContaining({ id: "i1" }), expect.objectContaining({ id: "i2" })]));
+});
+
+test("CT5 - selection single non-frame (B1=1,B2=0)", () => {
+  const single = makeElement({ id: "s1", type: "rectangle" });
+  const elements = [single];
+
+  vi.mocked(scene.isSomeElementSelected).mockReturnValue(true);
+  vi.mocked(scene.getSelectedElements).mockReturnValue([single]);
+  vi.mocked(elementModule.isFrameLikeElement).mockReturnValue(false);
+
+  const result = prepareElementsForExport(elements, { selectedElementIds: { s1: true } }, true);
+
+  expect(result.exportingFrame).toBeNull();
+  expect(result.exportedElements).toHaveLength(1);
+  expect(result.exportedElements[0]).toEqual(expect.objectContaining({ id: "s1" }));
+});
+
+test("CT6 - not exporting selection returns full list (CD3 false)", () => {
+  const a = makeElement({ id: "a" });
+  const b = makeElement({ id: "b" });
+  const elements = [a, b];
+
+  vi.mocked(scene.isSomeElementSelected).mockReturnValue(false);
+
+  const result = prepareElementsForExport(elements, { selectedElementIds: {} }, false);
+
+  expect(result.exportingFrame).toBeNull();
+  expect(result.exportedElements).toHaveLength(2);
+  expect(result.exportedElements).toEqual(elements);
+});


### PR DESCRIPTION
Summary

Add 6 unit tests that apply Modified Condition/Decision Coverage (MC/DC) to the function prepareElementsForExport (packages/excalidraw/data/index.ts).
The tests validate internal decisions (D1, D2a, D2b) and verify correct export behavior across main scenarios:
export all (fallback)
export selection with single frame
export selection with multiple elements
What changed

Added test file:
packages/excalidraw/tests/prepareElementsForExport.test.ts
No production code changes.
Tests use Vitest and vi.mock/vi.mocked to isolate dependencies (getSelectedElements, getElementsOverlappingFrame, isFrameLikeElement, cloneJSON, etc.).
Test cases implemented (mapping)

CT1 — A=V, B=V, multi-selection (D1 → D2b true)
CT2 — A=V, B=F (exportSelectionOnly true, but no valid selection)
CT3 — A=F, B=V (exportSelectionOnly false, selection exists — selection ignored)
CT4 — D2a single-frame (A=V, B=V, exportedElements.length === 1 && isFrameLike true)
CT5 — D2a single non-frame (A=V, B=F, exportedElements.length === 1 && isFrameLike false)
CT6 — fallback / export all (A=F, B=F)
MC/DC rationale (short)

Decisions covered:
D1: exportSelectionOnly && isSomeElementSelected(...)
D2a: exportedElements.length === 1 && isFrameLikeElement(...)
D2b: exportedElements.length > 1 (single-condition decision)
For D1 and D2a, MC/DC pairs were constructed so each atomic condition is shown to independently influence the decision outcome. D2b is covered with both true and false cases.
How to run locally

From repository root:
yarn test:app packages/excalidraw/tests/prepareElementsForExport.test.ts
or: npx vitest run packages/excalidraw/tests/prepareElementsForExport.test.ts --coverage
Expected: all tests pass (6 passed). Coverage HTML will be generated under coverage/lcov-report.
Notes about coverage & scope

Scope: tests focus exclusively on the method prepareElementsForExport. That method lives inside a larger module (packages/excalidraw/data/index.ts). As a result, the overall file coverage may remain low if other functions in the same file are not tested.
This is intentional: the assignment objective was to apply MC/DC to a chosen method. The coverage evidence included with this PR demonstrates the method’s lines are covered; the file-level percentage is shown for transparency.
If maintainers request higher file-level coverage, I can add follow-up tests to cover other functions in index.ts.
Files changed / where to review

packages/excalidraw/tests/prepareElementsForExport.test.ts
Comments inside the test file indicate: which condition(s) are exercised per test, the MC/DC pairs demonstrated, and main assertions.
Mocks: getSelectedElements, getElementsOverlappingFrame, isFrameLikeElement, cloneJSON.
Screenshots / artifacts (please attach to PR)

tests-result.png — terminal showing "6 passed"
coverage-after-function.png — HTML coverage view zoomed to prepareElementsForExport (lines showing green coverage)
coverage-after-index.png — file summary for packages/excalidraw/data/index.ts (transparency about file-level percent)
Suggested reviewer notes

Focus review on:
correctness of test scenarios vs decisions (D1, D2a, D2b)
appropriateness of mocks and assertions (exports & exportingFrame)
naming / readability of tests (I can rename IDs to match repo conventions if requested)
Checklist

 Add 6 Vitest unit tests covering MC/DC for prepareElementsForExport
 Use vi.mock/vi.mocked to isolate dependencies
 Local coverage was generated and the method’s lines are covered (see attached HTML screenshot)
 (Optional) Add broader tests to increase file-level coverage if requested
 
 Thank you for reviewing — happy to iterate on test names, mocks, or assertions per maintainers’ feedback.