### PR TITLE
fix: close floating sidebar on main menu open

### DIFF
--- a/packages/excalidraw/components/dropdownMenu/DropdownMenu.tsx
+++ b/packages/excalidraw/components/dropdownMenu/DropdownMenu.tsx
@@ -35,10 +35,16 @@ const DropdownMenu = ({
       : MenuContentComp;
 
   return (
-    <>
+    <div
+      className="dropdown-menu-container"
+      style={{
+        // remove this div from box layout
+        display: "contents",
+      }}
+    >
       {MenuTriggerComp}
       {open && MenuContentCompWithPlacement}
-    </>
+    </div>
   );
 };
 

--- a/packages/excalidraw/components/dropdownMenu/DropdownMenuContent.tsx
+++ b/packages/excalidraw/components/dropdownMenu/DropdownMenuContent.tsx
@@ -34,8 +34,15 @@ const MenuContent = ({
 
   const callbacksRef = useStable({ onClickOutside });
 
-  useOutsideClick(menuRef, () => {
-    callbacksRef.onClickOutside?.();
+  useOutsideClick(menuRef, (event) => {
+    // prevents closing if clicking on the trigger button
+    if (
+      !menuRef.current
+        ?.closest(".dropdown-menu-container")
+        ?.contains(event.target)
+    ) {
+      callbacksRef.onClickOutside?.();
+    }
   });
 
   useEffect(() => {

--- a/packages/excalidraw/components/dropdownMenu/DropdownMenuTrigger.tsx
+++ b/packages/excalidraw/components/dropdownMenu/DropdownMenuTrigger.tsx
@@ -24,7 +24,6 @@ const MenuTrigger = ({
   ).trim();
   return (
     <button
-      data-prevent-outside-click
       className={classNames}
       onClick={onToggle}
       type="button"

--- a/packages/excalidraw/css/styles.scss
+++ b/packages/excalidraw/css/styles.scss
@@ -13,10 +13,10 @@
   --zIndex-hyperlinkContainer: 7;
 
   --zIndex-ui-bottom: 60;
-  --zIndex-ui-library: 80;
   --zIndex-ui-context-menu: 90;
   --zIndex-ui-styles-popup: 100;
   --zIndex-ui-top: 100;
+  --zIndex-ui-library: 120;
 
   --zIndex-modal: 1000;
   --zIndex-popup: 1001;

--- a/packages/excalidraw/hooks/useOutsideClick.ts
+++ b/packages/excalidraw/hooks/useOutsideClick.ts
@@ -5,7 +5,7 @@ import { EVENT } from "@excalidraw/common";
 export function useOutsideClick<T extends HTMLElement>(
   ref: React.RefObject<T | null>,
   /** if performance is of concern, memoize the callback */
-  callback: (event: Event) => void,
+  callback: (event: Event & { target: T }) => void,
   /**
    * Optional callback which is called on every click.
    *


### PR DESCRIPTION
- move sidebar above top layer UI (especially top-right) so that buttons aren't above the sidebar when open
- close sidebar (when not docked) when opening main menu. This is necessary otherwise the previous change would make the main menu below the sidebar on mobile.