### PR TITLE
feat: add Cmd-K as alternative shortcut for command palette

### DIFF
--- a/packages/excalidraw/actions/shortcuts.ts
+++ b/packages/excalidraw/actions/shortcuts.ts
@@ -66,6 +66,7 @@ const shortcutMap: Record<ShortcutName, string[]> = {
   commandPalette: [
     getShortcutKey("CtrlOrCmd+/"),
     getShortcutKey("CtrlOrCmd+Shift+P"),
+    getShortcutKey("CtrlOrCmd+K"),
   ],
   cut: [getShortcutKey("CtrlOrCmd+X")],
   copy: [getShortcutKey("CtrlOrCmd+C")],

--- a/packages/excalidraw/components/CommandPalette/CommandPalette.tsx
+++ b/packages/excalidraw/components/CommandPalette/CommandPalette.tsx
@@ -142,7 +142,8 @@ const isCommandPaletteToggleShortcut = (event: KeyboardEvent) => {
     !event.altKey &&
     event[KEYS.CTRL_OR_CMD] &&
     ((event.shiftKey && event.key.toLowerCase() === KEYS.P) ||
-      event.key === KEYS.SLASH)
+      event.key === KEYS.SLASH ||
+      event.key.toLowerCase() === KEYS.K)
   );
 };
 


### PR DESCRIPTION
Fixes #10299

## Solution
- Added Cmd-K as an additional shortcut alongside existing Cmd-/ and Cmd-Shift-P
- All three shortcuts remain available for user preference

## Changes
- Updated `isCommandPaletteToggleShortcut` to recognize Cmd-K
- Updated `shortcutMap` to display all three shortcuts in the UI

## Testing
- Tested locally with `yarn start`
- Verified Cmd-K opens command palette
- Verified existing shortcuts (Cmd-/ and Cmd-Shift-P) still work