### PR TITLE
Add Cmd+K / Ctrl+K as an alternative shortcut for the command palette

### DIFF
--- a/packages/excalidraw/components/CommandPalette/CommandPalette.tsx
+++ b/packages/excalidraw/components/CommandPalette/CommandPalette.tsx
@@ -142,7 +142,8 @@ const isCommandPaletteToggleShortcut = (event: KeyboardEvent) => {
     !event.altKey &&
     event[KEYS.CTRL_OR_CMD] &&
     ((event.shiftKey && event.key.toLowerCase() === KEYS.P) ||
-      event.key === KEYS.SLASH)
+      event.key === KEYS.SLASH||
+      event.key.toLowerCase()==="k")
   );
 };
 


### PR DESCRIPTION
This pull request adds a new keyboard shortcut — Cmd + K on macOS and Ctrl + K on Windows/Linux — as an alternative way to open the Command Palette.

On several European keyboards, such as German or Danish layouts, the / key requires Shift, which makes Cmd + / unusable. On macOS, Cmd + / also opens the system Help menu instead of the Excalidraw command palette. This change solves both issues and makes the feature easier to access across all keyboard layouts.

The update modifies the function isCommandPaletteToggleShortcut in CommandPalette.tsx to include Cmd + K / Ctrl + K while keeping all existing shortcuts (Cmd + /, Ctrl + /, and Cmd + Shift + P).

Testing was done to ensure all old shortcuts still work correctly and that Cmd + K / Ctrl + K opens the command palette without conflicts.

This small improvement enhances accessibility and provides a smoother user experience for people using different keyboard layouts.