### PR TITLE
fix: set root directory to project root for proper deployment

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -65,6 +65,6 @@
       "destination": "https://marketplace.visualstudio.com/items?itemName=pomdtr.excalidraw-editor"
     }
   ],
-  "outputDirectory": "excalidraw-app/build",
-  "installCommand": "yarn install"
+  "outputDirectory": "build",
+  "installCommand": "yarn install && yarn build:app"
 }


### PR DESCRIPTION
### Summary
Fixed deployment issue on Vercel by aligning the build output to the project root. Previously, `outputDirectory` pointed to `excalidraw-app/build`, which caused failed deployments unless the Vercel Root Directory was manually set.

### Changes Made
- Updated `vercel.json` to set `outputDirectory` to `"build"`.
- Adjusted `installCommand` to `yarn install && yarn build:app` for proper build step execution.

### Related Issues
- Fixes #9155
- Related: #7139, #8734

### Testing
- Deployed successfully to Vercel without modifying the Root Directory.
- Confirmed that the app builds and serves correctly.
