### PR TITLE
feat: adjust stroke width for better visibility

### DIFF
--- a/packages/excalidraw/components/icons.tsx
+++ b/packages/excalidraw/components/icons.tsx
@@ -365,6 +365,14 @@ export const ArrowIcon = createIcon(
   tablerIconProps,
 );
 
+export const ArrowDownIcon = createIcon(
+  <g strokeWidth="1.5" fill="none" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M6 9l6 6 6-6" />
+  </g>,
+  tablerIconProps,
+);
+
+
 // custom?
 export const LineIcon = createIcon(
   <path d="M4.167 10h11.666" strokeWidth="1.5" />,


### PR DESCRIPTION
Now only supports for 3 different stroke widths: thin, medium, and thick. This change enhances the user experience by providing clearer distinctions between stroke widths in the drawing application.

| Mobile view | Desktop view |
|---------|---------|
| <img src="https://github.com/user-attachments/assets/8ace6665-328f-4542-919a-96b864d2377b" width="200" height="500" alt="ch-1" /> | <img src="https://github.com/user-attachments/assets/26cede01-fabf-4625-8050-cc88501f023c" width="500" height="500" alt="exaclidraw-2" /> |

Fixes #10309