### PR TITLE
fix: Switch between lasso and selection tools

### DIFF
--- a/packages/excalidraw/components/Actions.tsx
+++ b/packages/excalidraw/components/Actions.tsx
@@ -1152,6 +1152,7 @@ export const ShapesSwitcher = ({
                   app.togglePenMode(true);
                 }
 
+                // special handling for selection - can press again to switch between lasso and selection
                 if (value === "selection") {
                   if (app.state.activeTool.type === "selection") {
                     app.setActiveTool({ type: "lasso" });
@@ -1160,15 +1161,12 @@ export const ShapesSwitcher = ({
                   }
                 }
               }}
-              onChange={({ pointerType }) => {
+              onChange={() => {
                 if (app.state.activeTool.type !== value) {
                   trackEvent("toolbar", value, "ui");
                 }
-                if (value === "image") {
-                  app.setActiveTool({
-                    type: value,
-                  });
-                } else {
+                // For selection, need to avoid onPointerDown and onChange interfering with each other
+                if (value !== "selection") {
                   app.setActiveTool({ type: value });
                 }
               }}


### PR DESCRIPTION
**Bug / Current Behavior**

You can _sort of_ quick switch between the two selection modes using the Toolbar currently - you need to press and hold on the "selection"/pointer toolbar option, then move your cursor elsewhere and let go. If you just click selection again, you get this weird flicker (it very quickly changes to `lasso` and back again).

**Explanation** (at least this is what I believe)
Doing this fires the `onPointerDown` but not the `onChange`. If you click it normally, my understanding is:
1. The `onPointerDown` fires immediately, switching to lasso (note: this is already weird if you click through the toolbar, it's the only tool that switches immediately)
2. The `onChange` event fires later in the event cycle. Native `onchange` events on radios only trigger when a radio input becomes `checked`. But due to the `onPointerDown` changing the value of `props.checked` to false, by the time the radio gets around to figuring out if it should fire `onChange`, it thinks its just been clicked and is currently unchecked. It therefore fires the `onChange` handler and immediately sets the tool back to `"selection"`.

**Attempted fix**
I updated the `onChange` to not fire for the `"selection"` tool. How it is selected is covered by the `onPointerDown` handler already , and these paths for this case just mess with each other. This coincided with removing this existing odd `if/else` which always does the same thing in either branch anyway.
