### PR TITLE
fix: canvas panning stops when hovering over frame title (#10340)

### DIFF
--- a/packages/common/src/constants.ts
+++ b/packages/common/src/constants.ts
@@ -105,6 +105,7 @@ export const CLASSES = {
   SEARCH_MENU_INPUT_WRAPPER: "layer-ui__search-inputWrapper",
   CONVERT_ELEMENT_TYPE_POPUP: "ConvertElementTypePopup",
   SHAPE_ACTIONS_THEME_SCOPE: "shape-actions-theme-scope",
+  FRAME_NAME: "frame-name",
 };
 
 export const CJK_HAND_DRAWN_FALLBACK_FONT = "Xiaolai";

--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -1476,6 +1476,7 @@ class App extends React.Component<AppProps, AppState> {
       return (
         <div
           id={this.getFrameNameDOMId(f)}
+          className={CLASSES.FRAME_NAME}
           key={f.id}
           style={{
             position: "absolute",
@@ -11252,18 +11253,13 @@ class App extends React.Component<AppProps, AppState> {
     (
       event: WheelEvent | React.WheelEvent<HTMLDivElement | HTMLCanvasElement>,
     ) => {
-            // Check if event target is a frame title div (allows wheel events from frame titles
-      // to be passed through for canvas panning, e.g., two-finger trackpad gestures on macOS)
-      const target = event.target as HTMLElement;
-      const isFrameTitle =
-        target.id?.includes("-frame-name-") ||
-        target.closest?.('[id*="-frame-name-"]') !== null;
-        // if not scrolling on canvas/wysiwyg/frame-title, ignore
       if (
         !(
           event.target instanceof HTMLCanvasElement ||
           event.target instanceof HTMLTextAreaElement ||
-          event.target instanceof HTMLIFrameElement || isFrameTitle
+          event.target instanceof HTMLIFrameElement ||
+          (event.target instanceof HTMLElement &&
+            event.target.classList.contains(CLASSES.FRAME_NAME))
         )
       ) {
         // prevent zooming the browser (but allow scrolling DOM)


### PR DESCRIPTION
## Description

Fixes #10340

This PR fixes an issue where canvas panning with two-finger trackpad gestures on macOS would stop when the cursor hovered over a frame title.

## The Bug

On macOS, when using two-finger trackpad gestures to pan the canvas, the canvas movement would stop as soon as the cursor touched a frame's title. Users had to manually move the cursor away from the frame title to continue panning.

**Root Cause:**
The `handleWheel()` function was rejecting wheel events from frame title div elements. Frame titles are rendered as DOM elements (divs with IDs like `${appId}-frame-name-${frameId}`), and when two-finger trackpad gestures generated wheel events over these elements, they were filtered out before reaching the canvas panning logic.

## The Fix

Modified `handleWheel()` to detect frame title divs by checking if the event target's ID contains `-frame-name-` or if the target is inside such an element. When a frame title is detected, the wheel events are now allowed to pass through to the canvas panning logic, just like events from canvas, textarea, or iframe elements.

**Changes:**
- Added frame title detection logic in `handleWheel()` method
- Extended the allowed event targets to include frame title divs
- Minimal change: Only 10 lines added/modified in a single method

## Testing

Tested on macOS with two-finger trackpad gestures:
- Canvas panning continues smoothly when cursor moves over frame titles
- Normal canvas interaction (clicking, dragging) still works correctly
- Frame title editing (double-click) still works as expected
- No regressions in other panning methods (space+drag, hand tool)

