### PR TITLE
chore: move isBounds method to math package (#10362)

### DIFF
--- a/packages/common/src/visualdebug.ts
+++ b/packages/common/src/visualdebug.ts
@@ -6,7 +6,7 @@ import {
   type LocalPoint,
 } from "@excalidraw/math";
 
-import { isBounds } from "@excalidraw/element";
+import { isBounds } from "@excalidraw/math";
 
 import type { Curve } from "@excalidraw/math";
 import type { LineSegment } from "@excalidraw/utils";

--- a/packages/element/src/typeChecks.ts
+++ b/packages/element/src/typeChecks.ts
@@ -367,15 +367,6 @@ export const isFixedPointBinding = (
   );
 };
 
-// TODO: Move this to @excalidraw/math
-export const isBounds = (box: unknown): box is Bounds =>
-  Array.isArray(box) &&
-  box.length === 4 &&
-  typeof box[0] === "number" &&
-  typeof box[1] === "number" &&
-  typeof box[2] === "number" &&
-  typeof box[3] === "number";
-
 export const getLinearElementSubType = (
   element: ExcalidrawLinearElement,
 ): ExcalidrawLinearElementSubType => {

--- a/packages/math/src/utils.ts
+++ b/packages/math/src/utils.ts
@@ -1,3 +1,5 @@
+import { Bounds } from "@excalidraw/element";
+
 export const PRECISION = 10e-5;
 
 export const clamp = (value: number, min: number, max: number) => {
@@ -31,3 +33,11 @@ export const isFiniteNumber = (value: any): value is number => {
 
 export const isCloseTo = (a: number, b: number, precision = PRECISION) =>
   Math.abs(a - b) < precision;
+
+export const isBounds = (box: unknown): box is Bounds =>
+  Array.isArray(box) &&
+  box.length === 4 &&
+  typeof box[0] === "number" &&
+  typeof box[1] === "number" &&
+  typeof box[2] === "number" &&
+  typeof box[3] === "number";


### PR DESCRIPTION
#10362

move isBounds method to math package and update imports where used.