### PR TITLE
Fix: Add error handling for zero-sized ellipses to prevent division by zero

### DIFF
--- a/packages/math/tests/ellipse.test.ts
+++ b/packages/math/tests/ellipse.test.ts
@@ -4,6 +4,7 @@ import {
   ellipseIncludesPoint,
   ellipseTouchesPoint,
   ellipseLineIntersectionPoints,
+  ellipseDistanceFromPoint,
 } from "../src/ellipse";
 import { line } from "../src/line";
 import { pointFrom } from "../src/point";
@@ -57,6 +58,22 @@ describe("point and ellipse", () => {
 
     expect(ellipseIncludesPoint(pointFrom(-1, 1), target)).toBe(false);
     expect(ellipseIncludesPoint(pointFrom(-1.4, 0.8), target)).toBe(false);
+  });
+
+  it("handles zero-sized axes without throwing", () => {
+    const degenerate = ellipse(pointFrom(0, 0), 0, 0);
+
+    expect(() => ellipseIncludesPoint(pointFrom(0, 0), degenerate)).not.toThrow();
+    expect(ellipseIncludesPoint(pointFrom(0, 0), degenerate)).toBe(true);
+    expect(ellipseIncludesPoint(pointFrom(1, 0), degenerate)).toBe(false);
+
+    expect(() =>
+      ellipseTouchesPoint(pointFrom(0, 0), degenerate),
+    ).not.toThrow();
+    expect(ellipseTouchesPoint(pointFrom(0, 0), degenerate)).toBe(true);
+    expect(
+      Number.isFinite(ellipseDistanceFromPoint(pointFrom(2, 0), degenerate)),
+    ).toBe(true);
   });
 });
 

--- a/packages/utils/tests/ellipse.test.ts
+++ b/packages/utils/tests/ellipse.test.ts
@@ -1,0 +1,26 @@
+import { pointFrom, type Radians } from "@excalidraw/math";
+
+import { pointInEllipse, pointOnEllipse } from "../src/shape";
+
+describe("ellipse helpers handle zero-sized axes", () => {
+  const degenerateEllipse = {
+    center: pointFrom(0, 0),
+    angle: 0 as Radians,
+    halfWidth: 0,
+    halfHeight: 0,
+  };
+
+  it("pointInEllipse treats zero-sized ellipse as a point", () => {
+    expect(pointInEllipse(pointFrom(0, 0), degenerateEllipse)).toBe(true);
+    expect(pointInEllipse(pointFrom(1, 0), degenerateEllipse)).toBe(false);
+  });
+
+  it("pointOnEllipse does not error for zero-sized ellipse", () => {
+    expect(() =>
+      pointOnEllipse(pointFrom(0, 0), degenerateEllipse),
+    ).not.toThrow();
+    expect(pointOnEllipse(pointFrom(0, 0), degenerateEllipse)).toBe(true);
+    expect(pointOnEllipse(pointFrom(2, 0), degenerateEllipse)).toBe(false);
+  });
+});
+


### PR DESCRIPTION
# Fix: Add error handling for zero-sized ellipses to prevent division by zero

## Problem

Ellipse geometry functions were performing division operations on `halfWidth` and `halfHeight` without proper guards. When either axis is zero (degenerate ellipses created during editing), this causes:

- **Division by zero** → `Infinity`/`NaN` values
- **Cascading layout glitches** in the editor
- **Potential crashes** when manipulating shapes that collapse to zero size

## Solution

Added comprehensive error handling for zero-sized ellipses across the codebase:

1. **Added `MIN_ELLIPSE_AXIS_LENGTH` constant** (1e-6) to clamp minimum axis values
2. **Updated all ellipse functions** to handle degenerate cases:
   - `ellipseIncludesPoint`: Treats zero-sized ellipse as a point; returns `true` only if point is at center
   - `ellipseDistanceFromPoint`: Returns distance from point to center for zero-sized ellipses
   - `pointInEllipse` (utils): Same degenerate handling
   - `distanceToEllipse` (utils): Same degenerate handling

## Changes

### `packages/math/src/ellipse.ts`
- Added `MIN_ELLIPSE_AXIS_LENGTH` constant and `clampAxisLength` helper function
- Updated `ellipseIncludesPoint()` to handle zero-sized ellipses
- Updated `ellipseDistanceFromPoint()` to handle zero-sized ellipses
- Applied clamping to all division operations

### `packages/utils/src/shape.ts`
- Added `clampEllipseAxis` helper function
- Updated `distanceToEllipse()` to handle zero-sized ellipses
- Updated `pointInEllipse()` to handle zero-sized ellipses
- Applied clamping to all division operations

### Tests
- Added test cases for zero-sized ellipses in `packages/math/tests/ellipse.test.ts`
- Added test cases for zero-sized ellipses in `packages/utils/tests/ellipse.test.ts`
- All tests passing ✅

## Testing

yarn test:app --run packages/math/tests/ellipse.test.ts packages/utils/tests/ellipse.test.ts**Results:** All 9 tests passing ✓

## Impact

- ✅ Prevents division-by-zero errors in ellipse calculations
- ✅ Handles degenerate ellipses gracefully (treats as point at center)
- ✅ Maintains backward compatibility (no breaking changes)
- ✅ Improves stability during editing workflows when shapes collapse to zero size

## Related Issues

Fixes missing error handling for division by zero in ellipse geometry calculations.