### PR TITLE
fix: while saving to disk, default file name is some older date 

### DIFF
--- a/packages/excalidraw/actions/actionExport.tsx
+++ b/packages/excalidraw/actions/actionExport.tsx
@@ -159,23 +159,20 @@ export const actionSaveToActiveFile = register({
   },
   perform: async (elements, appState, value, app) => {
     const fileHandleExists = !!appState.fileHandle;
-    const newName = `${t("labels.untitled")}-${getDateTime()}`;
-    const newAppState = { ...appState, name: newName };
     try {
       const { fileHandle } = isImageFileHandle(appState.fileHandle)
         ? await resaveAsImageWithScene(
             elements,
-            newAppState,
+            appState,
             app.files,
-            newName,
+            app.getName(),
           )
-        : await saveAsJSON(elements, newAppState, app.files, newName);
+        : await saveAsJSON(elements, appState, app.files, app.getName());
 
       return {
         captureUpdate: CaptureUpdateAction.EVENTUALLY,
         appState: {
-          ...newAppState,
-          name: newName,
+          ...appState,
           fileHandle,
           toast: fileHandleExists
             ? {


### PR DESCRIPTION
# Description
Fixes #10345 

<img width="1365" height="767" alt="image" src="https://github.com/user-attachments/assets/0414adba-9728-4dd5-875d-eee40afc6952" />


When a user creates a new drawing and tries to save it to disk for the first time, the default file name appears as an older date (Here `Untitled-2025-10-20-1203.excalidraw`)

**Expected Behaviour**: The default file name should be the current date-time while saving. (E.g. `Untitled-2025-11-22-1005.excalidraw` in this case.)

# The bug
<img width="709" height="625" alt="image-1" src="https://github.com/user-attachments/assets/999d084c-708e-48a1-b37c-46ac208559d5" />

The date which appears there is not just any random date, but the timestamp when `excalidraw.com` was first loaded on that browser profile.

Even clearing the entire LocalStorage from the browser, does not help, because as far as I could understand, excalidraw uses Service Workers behind the scenes to store the cache for PWA and offline supports. After reload, everything reappears.

# The Root Cause
<img width="1102" height="499" alt="image-2" src="https://github.com/user-attachments/assets/2d28b43b-664d-49f0-807c-d2fc26c194e7" />

the variable `name` inside `state` object gets overwritten here. `this.state.name` till here contained the correct current timestamp, however `actionResult.appState` retrieves the name from localStorage and overrides it with wrong value.

# The Fix
I edited the actionSaveToActiveFile and actionSaveFileToDisk methods to take in the current timestamped file name before saving it to JSON.

# Another related major issue
This can be raised as another issue.
**Expected Behaviour**: When opening an existing `.excalidraw` file (e.g. `lorem.excalidraw`), the Save to current file option should be visible and Ctrl+S should over-write the changes to the lorem.excalidraw file.

**Current Behaviour**: There is no Save to current file option and pressing Ctrl+S acts just like another new file.

# Problem
In the `loadFromJSON` method defined inside `json.ts`, it is expected that the library browser-fs-access should return a valid fileHandle object. However it returns undefined everytime on the browsers I tested (Chrome, Edge, Firefox).

<img width="791" height="275" alt="image-3" src="https://github.com/user-attachments/assets/7616a488-9cac-45fb-b92b-55c8193e36c4" />

One possible cause for this issue which I think might be due to the misspelled `'browser-fs-acces'` written in `global.d.ts`
After correcting the typo, the code crashes and I still could not exactly figure out what the issue is. 
I was able to trace the call chain, but got stuck and lost after a while.

# Testing
Tested on Windows with Chrome, Firefox, Edge browsers.