### PR TITLE
Fix: Remove Dark Mode Inversion Filter to Preserve Accurate Canvas & Image Colors

### DIFF
--- a/packages/excalidraw/css/theme.scss
+++ b/packages/excalidraw/css/theme.scss
@@ -177,7 +177,7 @@
   }
 
   &.theme--dark {
-    --theme-filter: invert(93%) hue-rotate(180deg);
+    --theme-filter: none;
     --button-destructive-bg-color: #5a0000;
     --button-destructive-color: #{$oc-red-3};
 


### PR DESCRIPTION
This PR resolves an issue where imported images and canvas elements appeared washed out, inverted, or color-shifted when switching to Dark Mode in Excalidraw.

The root cause was the use of a global CSS inversion filter (invert() + hue-rotate()) applied indirectly through the --theme-filter variable during dark mode.
This filter also affected the <canvas> and imported images, resulting in inaccurate colors.

This PR removes the inversion behavior entirely, ensuring that both light and dark themes render colors faithfully.

What Was Changed
1. Disabled the global theme inversion filter

Replaced:
`
--theme-filter: invert(93%) hue-rotate(180deg);
`

with:
`
--theme-filter: none;
`

for both light and dark themes.


2. Ensured neutral filter behavior across .excalidraw

3. Ensured Dark Mode uses correct non-inverted colors

Updated the .theme--dark block to explicitly set:
`
--theme-filter: none;
`

Visual Impact

Before:-
- Imported images appear lighter, inverted, or off-color
- Canvas export does not match user-visible colors
- Color bars (e.g., RGB stripes) shift significantly in dark mode

After:-
- Imported images retain original colors
- Canvas and exports match exactly
- UI still respects dark mode styling via CSS variables

No filter is applied to the canvas or any drawing elements

Fixes:- #10373