### PR TITLE
fix: rounded left and top clipped image export to SVG

### DIFF
--- a/packages/excalidraw/renderer/staticSvgScene.ts
+++ b/packages/excalidraw/renderer/staticSvgScene.ts
@@ -541,7 +541,7 @@ const renderElementToSvg = (
             "clipPath",
           );
           clipPath.id = `image-clipPath-${element.id}`;
-
+          clipPath.setAttribute("clipPathUnits", "userSpaceOnUse");
           const clipRect = svgRoot.ownerDocument!.createElementNS(
             SVG_NS,
             "rect",
@@ -550,6 +550,10 @@ const renderElementToSvg = (
             Math.min(element.width, element.height),
             element,
           );
+          const clipOffsetX = element.crop ? normalizedCropX : 0;
+          const clipOffsetY = element.crop ? normalizedCropY : 0;
+          clipRect.setAttribute("x", `${clipOffsetX}`);
+          clipRect.setAttribute("y", `${clipOffsetY}`);
           clipRect.setAttribute("width", `${element.width}`);
           clipRect.setAttribute("height", `${element.height}`);
           clipRect.setAttribute("rx", `${radius}`);


### PR DESCRIPTION
fixes: #10386

Sample: https://excalidraw-pi69bw6x7-excalidraw.vercel.app/#json=1-__LRvH8gQ0YR6AWAknh,LEaR3InSkwcHghzpEYEmSQ

The SVG result:

![demo svg](https://github.com/user-attachments/assets/6b0e9c99-847f-44d3-a659-632ac1d3dff8)
