### PR TITLE
fix: prevent translation of excalidraw container

### DIFF
--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -1575,7 +1575,8 @@ class App extends React.Component<AppProps, AppState> {
 
     return (
       <div
-        className={clsx("excalidraw excalidraw-container", {
+        translate="no"
+        className={clsx("excalidraw excalidraw-container notranslate", {
           "excalidraw--view-mode":
             this.state.viewModeEnabled ||
             this.state.openDialog?.name === "elementLinkSelector",


### PR DESCRIPTION
This PR should prevent browsers from translating the excalidraw container which messes up with React vdom, breaking the editor.

https://docs.cloud.google.com/translate/troubleshooting
https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/translate

Using both classname and `translate` tag to be sure.