### PR TITLE
fix: correct tablet breakpoint for compact styles panel (#10360)

### DIFF
--- a/packages/common/src/editorInterface.ts
+++ b/packages/common/src/editorInterface.ts
@@ -73,10 +73,22 @@ export const isTabletBreakpoint = (
   editorWidth: number,
   editorHeight: number,
 ) => {
-  const minSide = Math.min(editorWidth, editorHeight);
-  const maxSide = Math.max(editorWidth, editorHeight);
+  const width = editorWidth;
+  const height = editorHeight;
+  const maxSide = Math.max(width, height);
 
-  return minSide >= MQ_MIN_TABLET && maxSide <= MQ_MAX_TABLET;
+  // Tablet / compact layout:
+  // - wide enough to not be phone
+  // - not wider than tablet max
+  // - HEIGHT is the limiting factor: compact only when height < 600px
+  // - and we don't classify phones as tablets
+  return (
+    !isMobileBreakpoint(width, height) &&
+    width >= MQ_MIN_TABLET &&
+    width <= MQ_MAX_TABLET &&
+    height < MQ_MIN_TABLET &&
+    maxSide <= MQ_MAX_TABLET
+  );
 };
 
 const isMobileOrTablet = (): boolean => {


### PR DESCRIPTION
## **Summary**

On certain viewports (e.g., **1400×661**), the editor was incorrectly classified as `tablet`, causing the Styles Panel to switch into **compact mode** and hide the full color palette — even though the viewport height was sufficient for the full layout.

This happened because `isTabletBreakpoint()` relied on the **minimum side** of the viewport, so wide/tall desktop-sized screens (height > 600px) were still treated as tablets.

---

## **Changes**

* Updated `isTabletBreakpoint` so that:

  * Tablet mode only applies when width is in **600–1400px**, **and**
  * **Height is below 600px** (i.e., compact mode for short tablet screens only).
* Ensures large-height desktop screens no longer incorrectly trigger compact mode.

---

## **Before (Incorrect Compact Mode)**

<p>
  <img src="https://github.com/user-attachments/assets/b0023202-a846-4068-ba0a-afdf3c4719e8" width="85%" />
</p>

<p>
  <img src="https://github.com/user-attachments/assets/0a6e9e16-21f0-4972-9655-ca1a473673e5" width="85%" />
</p>

---

## **After (Correct Desktop Detection)**

<p>
  <img src="https://github.com/user-attachments/assets/efdb7ccd-cf34-4c65-b2c8-4bfdd35f15e2" width="85%" />
</p>

---

## **Testing**

* **1401×661** → `desktop`, full Styles Panel visible.
* **1400×661** → now also `desktop`, full panel visible (previously compact).
* **~1000×550** → correctly `tablet`, compact mode enabled.

---

**Fixes #10360**