### PR TITLE
Fix: Invisible Background-Color Swatch in Compact Toolbar (#10392)

### DIFF
--- a/packages/excalidraw/components/ColorPicker/ColorPicker.scss
+++ b/packages/excalidraw/components/ColorPicker/ColorPicker.scss
@@ -167,6 +167,7 @@
     &.compact-sizing {
       width: var(--mobile-action-button-size);
       height: var(--mobile-action-button-size);
+      border: 1px solid var(--color-gray-30);
     }
 
     &.mobile-border {


### PR DESCRIPTION
This PR fixes an issue where the background-color swatch becomes nearly invisible in the compact toolbar layout when the selected color matches the toolbar background (e.g., Shade Level 2).

What was wrong

In compact mode, the swatch had no outline, so certain colors blended into the toolbar UI and looked like the control was missing.

Fix

Added a subtle 1px border to the color swatch in compact sizing to ensure it always remains visible.



I have tested this fix across all color shades in both light and dark themes, and the swatch remains consistently visible in every case. Everything works as expected.

Result

The background-color picker is now consistently visible across screen sizes and themes.
<img width="496" height="615" alt="Screenshot 2025-11-23 at 8 30 23 PM" src="https://github.com/user-attachments/assets/899d0d12-3263-4e5a-8661-5d18a9e26976" />
