### PR TITLE
fix: resolve MetaProperty lint error by extracting import.meta.env to constants

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,10 +1,22 @@
 {
-  "extends": ["@excalidraw/eslint-config", "react-app"],
+  "extends": [
+    "@excalidraw/eslint-config",
+    "react-app"
+  ],
   "rules": {
     "import/order": [
       "warn",
       {
-        "groups": ["builtin", "external", "internal", "parent", "sibling", "index", "object", "type"],
+        "groups": [
+          "builtin",
+          "external",
+          "internal",
+          "parent",
+          "sibling",
+          "index",
+          "object",
+          "type"
+        ],
         "pathGroups": [
           {
             "pattern": "@excalidraw/**",

--- a/excalidraw-app/App.tsx
+++ b/excalidraw-app/App.tsx
@@ -147,6 +147,9 @@ polyfill();
 
 window.EXCALIDRAW_THROTTLE_RENDER = true;
 
+const VITE_APP_PLUS_LP = import.meta.env.VITE_APP_PLUS_LP;
+const VITE_APP_PLUS_APP = import.meta.env.VITE_APP_PLUS_APP;
+
 declare global {
   interface BeforeInstallPromptEventChoiceResult {
     outcome: "accepted" | "dismissed";
@@ -768,9 +771,7 @@ const ExcalidrawWrapper = () => {
     keywords: ["plus", "cloud", "server"],
     perform: () => {
       window.open(
-        `${
-          import.meta.env.VITE_APP_PLUS_LP
-        }/plus?utm_source=excalidraw&utm_medium=app&utm_content=command_palette`,
+        `${VITE_APP_PLUS_LP}/plus?utm_source=excalidraw&utm_medium=app&utm_content=command_palette`,
         "_blank",
       );
     },
@@ -791,9 +792,7 @@ const ExcalidrawWrapper = () => {
     ],
     perform: () => {
       window.open(
-        `${
-          import.meta.env.VITE_APP_PLUS_APP
-        }?utm_source=excalidraw&utm_medium=app&utm_content=command_palette`,
+        `${VITE_APP_PLUS_APP}?utm_source=excalidraw&utm_medium=app&utm_content=command_palette`,
         "_blank",
       );
     },

--- a/excalidraw-app/components/AppWelcomeScreen.tsx
+++ b/excalidraw-app/components/AppWelcomeScreen.tsx
@@ -6,6 +6,9 @@ import React from "react";
 
 import { isExcalidrawPlusSignedUser } from "../app_constants";
 
+const VITE_APP_PLUS_APP = import.meta.env.VITE_APP_PLUS_APP;
+const VITE_APP_PLUS_LP = import.meta.env.VITE_APP_PLUS_LP;
+
 export const AppWelcomeScreen: React.FC<{
   onCollabDialogOpen: () => any;
   isCollabEnabled: boolean;
@@ -21,9 +24,7 @@ export const AppWelcomeScreen: React.FC<{
           return (
             <a
               style={{ pointerEvents: POINTER_EVENTS.inheritFromUI }}
-              href={`${
-                import.meta.env.VITE_APP_PLUS_APP
-              }?utm_source=excalidraw&utm_medium=app&utm_content=welcomeScreenSignedInUser`}
+              href={`${VITE_APP_PLUS_APP}?utm_source=excalidraw&utm_medium=app&utm_content=welcomeScreenSignedInUser`}
               key={idx}
             >
               Excalidraw+
@@ -58,9 +59,7 @@ export const AppWelcomeScreen: React.FC<{
           )}
           {!isExcalidrawPlusSignedUser && (
             <WelcomeScreen.Center.MenuItemLink
-              href={`${
-                import.meta.env.VITE_APP_PLUS_LP
-              }/plus?utm_source=excalidraw&utm_medium=app&utm_content=welcomeScreenGuest`}
+              href={`${VITE_APP_PLUS_LP}/plus?utm_source=excalidraw&utm_medium=app&utm_content=welcomeScreenGuest`}
               shortcut={null}
               icon={loginIcon}
             >

--- a/excalidraw-app/components/ExcalidrawPlusPromoBanner.tsx
+++ b/excalidraw-app/components/ExcalidrawPlusPromoBanner.tsx
@@ -1,3 +1,6 @@
+const VITE_APP_PLUS_APP = import.meta.env.VITE_APP_PLUS_APP;
+const VITE_APP_PLUS_LP = import.meta.env.VITE_APP_PLUS_LP;
+
 export const ExcalidrawPlusPromoBanner = ({
   isSignedIn,
 }: {
@@ -7,10 +10,8 @@ export const ExcalidrawPlusPromoBanner = ({
     <a
       href={
         isSignedIn
-          ? import.meta.env.VITE_APP_PLUS_APP
-          : `${
-              import.meta.env.VITE_APP_PLUS_LP
-            }/plus?utm_source=excalidraw&utm_medium=app&utm_content=guestBanner#excalidraw-redirect`
+          ? VITE_APP_PLUS_APP
+          : `${VITE_APP_PLUS_LP}/plus?utm_source=excalidraw&utm_medium=app&utm_content=guestBanner#excalidraw-redirect`
       }
       target="_blank"
       rel="noopener"

--- a/packages/excalidraw/components/LibraryMenuBrowseButton.tsx
+++ b/packages/excalidraw/components/LibraryMenuBrowseButton.tsx
@@ -4,6 +4,8 @@ import { t } from "../i18n";
 
 import type { ExcalidrawProps, UIAppState } from "../types";
 
+const VITE_APP_LIBRARY_URL = import.meta.env.VITE_APP_LIBRARY_URL;
+
 const LibraryMenuBrowseButton = ({
   theme,
   id,
@@ -18,7 +20,7 @@ const LibraryMenuBrowseButton = ({
   return (
     <a
       className="library-menu-browse-button"
-      href={`${import.meta.env.VITE_APP_LIBRARY_URL}?target=${
+      href={`${VITE_APP_LIBRARY_URL}?target=${
         window.name || "_blank"
       }&referrer=${referrer}&useHash=true&token=${id}&theme=${theme}&version=${
         VERSIONS.excalidrawLibrary

--- a/packages/excalidraw/components/PublishLibrary.tsx
+++ b/packages/excalidraw/components/PublishLibrary.tsx
@@ -36,6 +36,8 @@ interface PublishLibraryDataParams {
   website: string;
 }
 
+const LIBRARY_BACKEND = import.meta.env.VITE_APP_LIBRARY_BACKEND;
+
 const generatePreviewImage = async (libraryItems: LibraryItems) => {
   const MAX_ITEMS_PER_ROW = 6;
   const BOX_SIZE = 128;
@@ -299,7 +301,7 @@ const PublishLibrary = ({
     formData.append("twitterHandle", libraryData.twitterHandle);
     formData.append("website", libraryData.website);
 
-    fetch(`${import.meta.env.VITE_APP_LIBRARY_BACKEND}/submit`, {
+    fetch(`${LIBRARY_BACKEND}/submit`, {
       method: "post",
       body: formData,
     })


### PR DESCRIPTION
Fixes #10405. This PR resolves the 'MetaProperty could not be resolved' lint error by extracting `import.meta.env` usages to constants in the affected files.