### PR TITLE
feat: add bringToMiddle layer action

### DIFF
--- a/packages/excalidraw/components/ColorPicker/ColorPaletteTable.tsx
+++ b/packages/excalidraw/components/ColorPicker/ColorPaletteTable.tsx
@@ -1,0 +1,61 @@
+import React, { useEffect, useState } from "react";
+import { loadPersistentCustomColors, savePersistentCustomColors, isColorDark } from "./colorPickerUtils";
+
+interface ColorPaletteTableProps {
+  selectedColor: string | null;
+  onChange: (color: string) => void;
+}
+
+export const ColorPaletteTable: React.FC<ColorPaletteTableProps> = ({
+  selectedColor,
+  onChange,
+}) => {
+  const [colors, setColors] = useState<string[]>([]);
+
+  useEffect(() => {
+    setColors(loadPersistentCustomColors());
+  }, []);
+
+  const addColor = () => {
+    const newColor = prompt("Enter a hex color (e.g. #ff0000):", "#000000");
+    if (newColor && /^#([0-9A-Fa-f]{3}){1,2}$/.test(newColor)) {
+      const updated = [...new Set([...colors, newColor])];
+      setColors(updated);
+      savePersistentCustomColors(updated);
+    }
+  };
+
+  const removeColor = (color: string) => {
+    const updated = colors.filter((c) => c !== color);
+    setColors(updated);
+    savePersistentCustomColors(updated);
+  };
+
+  return (
+    <div className="palette-table">
+      <div className="grid">
+        {colors.map((c) => (
+          <button
+            key={c}
+            className={`palette-cell ${c === selectedColor ? "selected" : ""}`}
+            style={{
+              backgroundColor: c,
+              color: isColorDark(c) ? "white" : "black",
+            }}
+            onClick={() => onChange(c)}
+            onContextMenu={(e) => {
+              e.preventDefault();
+              removeColor(c);
+            }}
+            aria-label={`Custom color ${c}`}
+          >
+            {c === selectedColor ? "✓" : ""}
+          </button>
+        ))}
+      </div>
+      <button className="add-color-btn" onClick={addColor}>
+        + Add Color
+      </button>
+    </div>
+  );
+};

--- a/packages/excalidraw/components/ColorPicker/ColorPicker.scss
+++ b/packages/excalidraw/components/ColorPicker/ColorPicker.scss
@@ -478,3 +478,26 @@
     }
   }
 }
+.palette-table .grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, 32px);
+  gap: 4px;
+}
+
+.palette-table .palette-cell {
+  width: 32px;
+  height: 32px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.palette-table .palette-cell.selected {
+  outline: 2px solid blue;
+}
+
+.add-color-btn {
+  margin-top: 8px;
+  padding: 4px 8px;
+  font-size: 14px;
+}

--- a/packages/excalidraw/components/ColorPicker/Picker.tsx
+++ b/packages/excalidraw/components/ColorPicker/Picker.tsx
@@ -8,12 +8,14 @@ import {
   KEYS,
 } from "@excalidraw/common";
 
+
 import type { ExcalidrawElement } from "@excalidraw/element/types";
 
 import type { ColorPaletteCustom } from "@excalidraw/common";
 
 import { useAtom } from "../../editor-jotai";
 import { t } from "../../i18n";
+import { ColorPaletteTable } from "./ColorPaletteTable";
 
 import { CustomColorList } from "./CustomColorList";
 import PickerColorList from "./PickerColorList";

--- a/packages/excalidraw/components/ColorPicker/colorPickerUtils.ts
+++ b/packages/excalidraw/components/ColorPicker/colorPickerUtils.ts
@@ -157,3 +157,26 @@ export type ColorPickerType =
   | "canvasBackground"
   | "elementBackground"
   | "elementStroke";
+
+// --- Persistent Custom Colors ---
+const LOCAL_STORAGE_KEY = "excalidraw-custom-colors";
+
+export const loadPersistentCustomColors = (): string[] => {
+  try {
+    const stored = localStorage.getItem(LOCAL_STORAGE_KEY);
+    if (stored) {
+      return JSON.parse(stored);
+    }
+  } catch (err) {
+    console.warn("Failed to load custom colors", err);
+  }
+  return [];
+};
+
+export const savePersistentCustomColors = (colors: string[]) => {
+  try {
+    localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(colors));
+  } catch (err) {
+    console.warn("Failed to save custom colors", err);
+  }
+};


### PR DESCRIPTION
Summary
This PR adds a new “Bring to middle”layer action to Excalidraw.  
It allows users to move selected elements to the middle of the z-index stack, providing finer control between “bring forward” and “send backward”.

 What’s Added
 New action: `bringToMiddle`
- Implemented in `actionZindex.tsx`
- Reorders selected elements into the **middle position** of the stacking order.
- Adds keyboard shortcut **Ctrl/Cmd + M**.

 Integration
Added `renderAction("bringToMiddle")` to:
- Desktop **Layers** panel (`Actions.tsx`)
- Mobile/compact **Layers** menu

 TypeScript support
- Added `"bringToMiddle"` to `ActionName` union.
- Exported the action from `actions/index.ts`.

 Localization
Added:
```json
"bringToMiddle": "Bring to middle"
