### PR TITLE
chore: fix typo in Trans.test.tsx

### DIFF
--- a/packages/excalidraw/components/Trans.test.tsx
+++ b/packages/excalidraw/components/Trans.test.tsx
@@ -8,7 +8,7 @@ import Trans from "./Trans";
 import type { TranslationKeys } from "../i18n";
 
 describe("Test <Trans/>", () => {
-  it("should translate the the strings correctly", () => {
+  it("should translate the strings correctly", () => {
     //@ts-ignore
     fallbackLangData.transTest = {
       key1: "Hello {{audience}}",


### PR DESCRIPTION
## Description
Fixed a small typo in the test description string in `Trans.test.tsx` ("the the" -> "the").

## Changes
- `packages/excalidraw/components/Trans.test.tsx`: Corrected duplicate word in `it` block description.

## Verification
- Verified that it is a string literal change in a test file.