### PR TITLE
feat: add duplicate-in-place action

### DIFF
--- a/packages/excalidraw/actions/actionDuplicateInPlace.tsx
+++ b/packages/excalidraw/actions/actionDuplicateInPlace.tsx
@@ -1,0 +1,11 @@
+import { register } from "./register";
+import { actionDuplicateSelection } from "./actionDuplicateSelection";
+
+export const actionDuplicateInPlace = register({
+  name: "duplicateInPlace",
+  label: "labels.duplicateInPlace",
+  trackEvent: { category: "element" },
+  perform: (elements, appState, data, app) => {
+    return actionDuplicateSelection.perform(elements, appState, data, app);
+  },
+});

--- a/packages/excalidraw/actions/index.ts
+++ b/packages/excalidraw/actions/index.ts
@@ -7,6 +7,7 @@ export {
 } from "./actionZindex";
 export { actionSelectAll } from "./actionSelectAll";
 export { actionDuplicateSelection } from "./actionDuplicateSelection";
+export { actionDuplicateInPlace } from "./actionDuplicateInPlace";
 export {
   actionChangeStrokeColor,
   actionChangeBackgroundColor,

--- a/packages/excalidraw/actions/types.ts
+++ b/packages/excalidraw/actions/types.ts
@@ -83,6 +83,7 @@ export type ActionName =
   | "saveFileToDisk"
   | "loadScene"
   | "duplicateSelection"
+  | "duplicateInPlace"
   | "deleteSelectedElements"
   | "changeViewBackgroundColor"
   | "clearCanvas"

--- a/packages/excalidraw/components/Actions.tsx
+++ b/packages/excalidraw/components/Actions.tsx
@@ -302,6 +302,8 @@ export const SelectedShapeActions = ({
             {editorInterface.formFactor !== "phone" &&
               renderAction("duplicateSelection")}
             {editorInterface.formFactor !== "phone" &&
+              renderAction("duplicateInPlace")}
+            {editorInterface.formFactor !== "phone" &&
               renderAction("deleteSelectedElements")}
             {renderAction("group")}
             {renderAction("ungroup")}

--- a/packages/excalidraw/locales/en.json
+++ b/packages/excalidraw/locales/en.json
@@ -88,6 +88,7 @@
     "language": "Language",
     "liveCollaboration": "Live collaboration...",
     "duplicateSelection": "Duplicate",
+    "duplicateInPlace": "Duplicate in place",
     "untitled": "Untitled",
     "name": "Name",
     "yourName": "Your name",


### PR DESCRIPTION
 Summary

This PR adds a “Duplicate in place” action next to the existing “Duplicate” action in the Selected shape actions panel.

- New `duplicateInPlace` action which creates a copy of the current selection at the same position.
- Exposes the action via `ActionManager` and the toolbar actions.
- Adds a new localization string: `labels.duplicateInPlace`.

### Testing

- Select one or more elements on the canvas.
- Click **Duplicate in place**:
  - A copy is created at the same position.
  - Original selection is preserved.
