### PR TITLE
Fix send to front/back shortcuts

### DIFF
--- a/packages/excalidraw/actions/actionZindex.tsx
+++ b/packages/excalidraw/actions/actionZindex.tsx
@@ -35,9 +35,14 @@ export const actionSendBackward = register({
   },
   keyPriority: 40,
   keyTest: (event) =>
-    event[KEYS.CTRL_OR_CMD] &&
-    !event.shiftKey &&
-    event.code === CODES.BRACKET_LEFT,
+    isDarwin
+      ? event[KEYS.CTRL_OR_CMD] &&
+        !event.altKey &&
+        !event.shiftKey &&
+        event.code === CODES.BRACKET_LEFT
+      : event[KEYS.CTRL_OR_CMD] &&
+        !event.shiftKey &&
+        event.code === CODES.BRACKET_LEFT,
   PanelComponent: ({ updateData, appState }) => (
     <button
       type="button"
@@ -65,9 +70,14 @@ export const actionBringForward = register({
   },
   keyPriority: 40,
   keyTest: (event) =>
-    event[KEYS.CTRL_OR_CMD] &&
-    !event.shiftKey &&
-    event.code === CODES.BRACKET_RIGHT,
+    isDarwin
+      ? event[KEYS.CTRL_OR_CMD] &&
+        !event.altKey &&
+        !event.shiftKey &&
+        event.code === CODES.BRACKET_RIGHT
+      : event[KEYS.CTRL_OR_CMD] &&
+        !event.shiftKey &&
+        event.code === CODES.BRACKET_RIGHT,
   PanelComponent: ({ updateData, appState }) => (
     <button
       type="button"
@@ -131,14 +141,15 @@ export const actionBringToFront = register({
       captureUpdate: CaptureUpdateAction.IMMEDIATELY,
     };
   },
-  keyTest: (event) =>
-    isDarwin
+  keyTest: (event) => {
+    return isDarwin
       ? event[KEYS.CTRL_OR_CMD] &&
-        event.altKey &&
-        event.code === CODES.BRACKET_RIGHT
+          event.altKey &&
+          event.code === CODES.BRACKET_RIGHT
       : event[KEYS.CTRL_OR_CMD] &&
-        event.shiftKey &&
-        event.code === CODES.BRACKET_RIGHT,
+          event.shiftKey &&
+          event.code === CODES.BRACKET_RIGHT;
+  },
   PanelComponent: ({ updateData, appState }) => (
     <button
       type="button"


### PR DESCRIPTION
This PR fixes an issue where on MacOS pressing `⌘+⌥+[` and `⌘+⌥+]` wouldn't work for bringing the elements front/back.

<img width="2218" height="160" alt="CleanShot 2025-12-02 at 14 45 04@2x" src="https://github.com/user-attachments/assets/02bf5ed7-fe77-439a-88c6-2654ef43aa9b" />

The only way to actually trigger those was to use `⌘+⌥+SHIFT+[` and `⌘+⌥+SHIFT+]` which was different then in the shortcuts panel.