### PR TITLE
Replace unsafe innerHTML with proper DOM API in replaceChildren polyfill

### DIFF
--- a/packages/excalidraw/polyfill.ts
+++ b/packages/excalidraw/polyfill.ts
@@ -25,7 +25,9 @@ const polyfill = () => {
 
   if (!Element.prototype.replaceChildren) {
     Element.prototype.replaceChildren = function (...nodes) {
-      this.innerHTML = "";
+      while (this.firstChild) {
+        this.removeChild(this.firstChild);
+      }
       this.append(...nodes);
     };
   }


### PR DESCRIPTION
Here’s a polished, professional version of your text:

---

### Summary

Improves the `replaceChildren` polyfill implementation by replacing `innerHTML = ""` with proper DOM manipulation methods.

### Changes

* Replaced `this.innerHTML = ""` with:

  ```js
  while (this.firstChild) {
    this.removeChild(this.firstChild);
  }
  ```

  in the `replaceChildren` polyfill.

### Why This Change Is Needed

* **More accurate polyfill behavior** – The native `replaceChildren()` method removes existing child nodes using standard DOM operations rather than relying on HTML parsing via `innerHTML`.
* **Improved performance** – Avoids unnecessary HTML parsing and reduces the likelihood of triggering expensive layout recalculations.
* **Safer implementation** – Prevents potential side effects associated with `innerHTML` manipulation, such as removed event listeners or memory leaks in older browsers.
* **Aligns with DOM best practices** – Uses explicit DOM APIs that more closely match the native specification.

### Testing

* Existing tests should continue to pass.
* The polyfill is only applied in environments lacking native `replaceChildren()` support (primarily older browsers).

---
