### PR TITLE
feat: add toast notification when no shape tool is active

### DIFF
--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -7275,6 +7275,19 @@ class App extends React.Component<AppProps, AppState> {
         });
         pointerDownState.hit.wasAddedToSelection = true;
       }
+    } else if (this.state.activeTool.type === "selection") {
+      // Show toast notification when user clicks on empty canvas with selection tool
+      // to guide them to select a shape tool for drawing
+      if (
+        !pointerDownState.hit.element &&
+        !pointerDownState.hit.hasHitCommonBoundingBoxOfSelectedElements &&
+        !pointerDownState.resize.handleType
+      ) {
+        this.setToast({
+          message: t("toast.noToolSelected"),
+          duration: 3000,
+        });
+      }
     } else if (this.state.activeTool.type === "text") {
       this.handleTextOnPointerDown(event, pointerDownState);
     } else if (

--- a/packages/excalidraw/locales/en.json
+++ b/packages/excalidraw/locales/en.json
@@ -536,7 +536,8 @@
     "pasteAsSingleElement": "Use {{shortcut}} to paste as a single element,\nor paste into an existing text editor",
     "unableToEmbed": "Embedding this url is currently not allowed. Raise an issue on GitHub to request the url whitelisted",
     "unrecognizedLinkFormat": "The link you embedded does not match the expected format. Please try to paste the 'embed' string provided by the source site",
-    "elementLinkCopied": "Link copied to clipboard"
+    "elementLinkCopied": "Link copied to clipboard",
+    "noToolSelected": "Please select a shape tool from the toolbar to start drawing"
   },
   "colors": {
     "transparent": "Transparent",


### PR DESCRIPTION
## Description
This PR implements a toast notification to improve UX when users try to draw without selecting a shape tool.

## Changes
- Added toast notification that appears when the selection tool is active and the user clicks on an empty area of the canvas
- Added `noToolSelected` localization string to `en.json` with a helpful message
- Toast displays for 3 seconds to guide users to select a shape tool before drawing

## Fixes
Closes #9541

## Testing
- TypeScript compilation passes
- Tested locally: toast appears when clicking empty canvas with selection tool active
- Toast does not appear when clicking on elements or when other tools are active

## Implementation Details
The notification logic was added to the `handleCanvasPointerDown` method in `App.tsx`. It checks if:
1. The selection tool is currently active
2. No element was clicked
3. No common bounding box of selected elements was hit
4. No resize handle is being interacted with

When all these conditions are met, a toast notification is shown to guide the user.
