### PR TITLE
perf: Enable browser spellcheck for text fields by default

### DIFF
--- a/packages/excalidraw/wysiwyg/textWysiwyg.tsx
+++ b/packages/excalidraw/wysiwyg/textWysiwyg.tsx
@@ -284,6 +284,8 @@ export const textWysiwyg = ({
   // prevent line wrapping on Safari
   editable.wrap = "off";
   editable.classList.add("excalidraw-wysiwyg");
+  // add spellcheck
+  editable.spellcheck = true;
 
   let whiteSpace = "pre";
   let wordBreak = "normal";


### PR DESCRIPTION
### Connected Issue
#9747

### Summary
This change enables the native browser spellcheck and autocorrect for all text fields in Excalidraw by default.

### Motivation
Currently, text inputs in Excalidraw do not have browser spellcheck or autocorrect enabled, which can lead to typos during presentations or live collaboration. Enabling this improves user experience without affecting existing functionality.

### Implementation
- Set `spellcheck: true` on all text field WYSIWYG elements (`textWysiwyg.ts`).
- No other behavior was changed.

### Testing
- Verified that typing in a new text element highlights typos in Chrome, Firefox, and Safari.
- Autocorrect suggestions are shown where supported.

### Notes
- This does not add a setting to toggle spellcheck; it is always enabled by default.