### PR TITLE
feat(font): add fine-grained font size control (#10096)

### DIFF
--- a/packages/excalidraw/actions/actionProperties.tsx
+++ b/packages/excalidraw/actions/actionProperties.tsx
@@ -730,8 +730,8 @@ export const actionChangeOpacity = register<ExcalidrawElement["opacity"]>({
   ),
 });
 
-export const actionChangeFontSize = register<ExcalidrawTextElement["fontSize"]>(
-  {
+export const actionChangeFontSize =
+  register<ExcalidrawTextElement["fontSize"]>({
     name: "changeFontSize",
     label: "labels.fontSize",
     trackEvent: false,
@@ -741,7 +741,10 @@ export const actionChangeFontSize = register<ExcalidrawTextElement["fontSize"]>(
         appState,
         app,
         () => {
-          invariant(value, "actionChangeFontSize: Expected a font size value");
+          invariant(
+            value,
+            "actionChangeFontSize: Expected a font size value",
+          );
           return value;
         },
         value,
@@ -749,6 +752,46 @@ export const actionChangeFontSize = register<ExcalidrawTextElement["fontSize"]>(
     },
     PanelComponent: ({ elements, appState, updateData, app, data }) => {
       const { isCompact } = getStylesPanelInfo(app);
+
+      const currentFontSize = getFormValue(
+        elements,
+        app,
+        (element) => {
+          if (isTextElement(element)) {
+            return element.fontSize;
+          }
+          const boundTextElement = getBoundTextElement(
+            element,
+            app.scene.getNonDeletedElementsMap(),
+          );
+          if (boundTextElement) {
+            return boundTextElement.fontSize;
+          }
+          return null;
+        },
+        (element) =>
+          isTextElement(element) ||
+          getBoundTextElement(
+            element,
+            app.scene.getNonDeletedElementsMap(),
+          ) !== null,
+        (hasSelection) =>
+          hasSelection
+            ? null
+            : appState.currentItemFontSize || DEFAULT_FONT_SIZE,
+      );
+
+      const applyFontSize = (size: number) => {
+        if (!Number.isFinite(size) || size <= 0) {
+          return;
+        }
+        withCaretPositionPreservation(
+          () => updateData(size as ExcalidrawTextElement["fontSize"]),
+          isCompact,
+          !!appState.editingTextElement,
+          data?.onPreventClose,
+        );
+      };
 
       return (
         <fieldset>
@@ -782,48 +825,36 @@ export const actionChangeFontSize = register<ExcalidrawTextElement["fontSize"]>(
                   testId: "fontSize-veryLarge",
                 },
               ]}
-              value={getFormValue(
-                elements,
-                app,
-                (element) => {
-                  if (isTextElement(element)) {
-                    return element.fontSize;
-                  }
-                  const boundTextElement = getBoundTextElement(
-                    element,
-                    app.scene.getNonDeletedElementsMap(),
-                  );
-                  if (boundTextElement) {
-                    return boundTextElement.fontSize;
-                  }
-                  return null;
-                },
-                (element) =>
-                  isTextElement(element) ||
-                  getBoundTextElement(
-                    element,
-                    app.scene.getNonDeletedElementsMap(),
-                  ) !== null,
-                (hasSelection) =>
-                  hasSelection
-                    ? null
-                    : appState.currentItemFontSize || DEFAULT_FONT_SIZE,
-              )}
+              value={currentFontSize}
               onChange={(value) => {
-                withCaretPositionPreservation(
-                  () => updateData(value),
-                  isCompact,
-                  !!appState.editingTextElement,
-                  data?.onPreventClose,
-                );
+                applyFontSize(value);
+              }}
+            />
+          </div>
+
+          {/* exact numeric control */}
+          <div className="font-size-input">
+            <div className="font-size-input__label">
+              {t("labels.fontSize")}
+            </div>
+            <input
+              className="font-size-input__control"
+              type="number"
+              min={1}
+              max={500}
+              step={1}
+              value={currentFontSize ?? DEFAULT_FONT_SIZE}
+              onChange={(event) => {
+                const next = Number(event.target.value);
+                applyFontSize(next);
               }}
             />
           </div>
         </fieldset>
       );
     },
-  },
-);
+  });
+
 
 export const actionDecreaseFontSize = register({
   name: "decreaseFontSize",


### PR DESCRIPTION
This PR adds fine-grained font size control to the text styles panel.

Before this change, users could only choose one of four presets being small, medium, large, or extra large. This change keeps those presets but adds a numeric input below them so users can specify an exact font size like 17, 41, etc.

Fixes #10096 