### PR TITLE
fix: shortcut to save file while editing frame name

### DIFF
--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -311,6 +311,7 @@ import {
   actionToggleLinearEditor,
   actionToggleObjectsSnapMode,
   actionToggleCropEditor,
+  actionSaveToActiveFile,
 } from "../actions";
 import { actionWrapTextInContainer } from "../actions/actionBoundText";
 import { actionToggleHandTool, zoomToFit } from "../actions/actionCanvas";
@@ -1764,7 +1765,14 @@ class App extends React.Component<AppProps, AppState> {
               // for some inexplicable reason, `onBlur` triggered on ESC
               // does not reset `state.editingFrame` despite being called,
               // and we need to reset it here as well
-              if (event.key === KEYS.ESCAPE || event.key === KEYS.ENTER) {
+              if (actionSaveToActiveFile.keyTest(event)) {
+                event.preventDefault();
+                this.resetEditingFrame(f);
+                this.actionManager.executeAction(actionSaveToActiveFile);
+              } else if (
+                event.key === KEYS.ESCAPE ||
+                event.key === KEYS.ENTER
+              ) {
                 this.resetEditingFrame(f);
               }
             }}


### PR DESCRIPTION
fix for CTRL + S opens browser 'save as html webpage' if a text field is selected instead of saving as .excalidraw #9281