### PR TITLE
fix: allow embedding from app.botmockups.com

### DIFF
--- a/packages/element/src/embeddable.ts
+++ b/packages/element/src/embeddable.ts
@@ -101,6 +101,7 @@ const ALLOWED_DOMAINS = new Set([
   "giphy.com",
   "reddit.com",
   "forms.microsoft.com",
+  "app.botmockups.com",
 ]);
 
 const ALLOW_SAME_ORIGIN = new Set([

--- a/packages/element/tests/embeddableValidator.test.ts
+++ b/packages/element/tests/embeddableValidator.test.ts
@@ -1,0 +1,14 @@
+
+import { embeddableURLValidator } from "../src/embeddable";
+
+describe("embeddableURLValidator", () => {
+    it("should validate app.botmockups.com", () => {
+        const url = "https://app.botmockups.com/chat/123";
+        expect(embeddableURLValidator(url, undefined)).toBe(true);
+    });
+
+    it("should not validate unknown domains", () => {
+        const url = "https://unknown-domain.com/something";
+        expect(embeddableURLValidator(url, undefined)).toBe(false);
+    });
+});


### PR DESCRIPTION
This PR whitelists `app.botmockups.com` as an allowed domain for web embeds in Excalidraw. This enables users to embed interactive chatbot demos from BotMockups directly into the Excalidraw canvas.

BotMockups is commonly used for creating lightweight chatbot and conversational UI demos, which are frequently presented in design reviews and client walkthroughs. Supporting embeds from this domain improves Excalidraw’s usefulness for these workflows.

---

## Changes

* Added `app.botmockups.com` to `ALLOWED_DOMAINS` in
  `packages/element/src/embeddable.ts`
* Added unit tests in
  `packages/element/tests/embeddableValidator.test.ts`
  to verify the updated whitelist behavior

---

## Steps to Verify

1. Open Excalidraw.
2. Create a **Web Embed** element.
3. Paste a BotMockups URL, for example:
   `https://app.botmockups.com/chat/123`
4. Verify the URL is accepted and does **not** trigger the
   “URL needs to be whitelisted” error.

---

## Security Considerations

* Only a single, explicit domain is added to the allowlist.
* No changes were made to embed permissions or execution behavior.

---

## Checklist

* [x] My code follows the code style of this project
* [x] I have added tests to cover my changes
* [x] All new and existing tests passed


