### PR TITLE
Fix : Fixed the Loosing text focus while switching tabs 

### DIFF
--- a/packages/excalidraw/wysiwyg/textWysiwyg.tsx
+++ b/packages/excalidraw/wysiwyg/textWysiwyg.tsx
@@ -577,6 +577,11 @@ export const textWysiwyg = ({
     });
   };
 
+  const handleBlur = ()=>{
+    if(!document.hasFocus()) return ;
+    handleSubmit();
+  }
+
   const cleanup = () => {
     // remove events to ensure they don't late-fire
     editable.onblur = null;
@@ -626,7 +631,7 @@ export const textWysiwyg = ({
       }
 
       // Otherwise, re-enable submit on blur and refocus the editor.
-      editable.onblur = handleSubmit;
+      editable.onblur = handleBlur;
       editable.focus();
     });
   };
@@ -636,7 +641,7 @@ export const textWysiwyg = ({
     window.addEventListener("pointerup", bindBlurEvent);
     // handle edge-case where pointerup doesn't fire e.g. due to user
     // alt-tabbing away
-    window.addEventListener("blur", handleSubmit);
+    window.addEventListener("blur", handleBlur);
   };
 
   // prevent blur when changing properties from the menu


### PR DESCRIPTION
### The Bug
Whenever someone switches tabs the text editor incorrectly loses focus and submits, closing the editor.

### Why
The editor treated all blur events the same, causing unintended submission when the
document temporarily lost focus. This made it impossible to resume typing after returning.

### What I fixed 
- Wrapped blur handling with a focus check using `document.hasFocus()`
- Prevented forced refocus when the page is not visible

### Testing
- Added/updated unit tests for blur behavior
- Verified manually:
  - Alt-Tab / tab switch keeps editor open
  - Clicking outside submits as expected

### Demo  Video 

https://github.com/user-attachments/assets/faad40ab-8c5f-43ae-b733-84a517b3c35e



