### PR TITLE
feat: Allow to disable library publishing

### DIFF
--- a/packages/excalidraw/components/LibraryMenuHeaderContent.tsx
+++ b/packages/excalidraw/components/LibraryMenuHeaderContent.tsx
@@ -11,7 +11,7 @@ import { useAtom } from "../editor-jotai";
 import { useLibraryCache } from "../hooks/useLibraryItemSvg";
 import { t } from "../i18n";
 
-import { useApp, useExcalidrawSetAppState } from "./App";
+import { useApp, useAppProps, useExcalidrawSetAppState } from "./App";
 import ConfirmDialog from "./ConfirmDialog";
 import { Dialog } from "./Dialog";
 import { isLibraryMenuOpenAtom } from "./LibraryMenu";
@@ -44,6 +44,7 @@ export const LibraryDropdownMenuButton: React.FC<{
   onSelectItems: (items: LibraryItem["id"][]) => void;
   appState: UIAppState;
   className?: string;
+  canPublishLibrary?: boolean;
 }> = ({
   setAppState,
   selectedItems,
@@ -53,6 +54,7 @@ export const LibraryDropdownMenuButton: React.FC<{
   onSelectItems,
   appState,
   className,
+  canPublishLibrary = true,
 }) => {
   const [libraryItemsData] = useAtom(libraryItemsAtom);
   const [isLibraryMenuOpen, setIsLibraryMenuOpen] = useAtom(
@@ -229,7 +231,7 @@ export const LibraryDropdownMenuButton: React.FC<{
               {resetLabel}
             </DropdownMenu.Item>
           )}
-          {itemsSelected && (
+          {itemsSelected && canPublishLibrary && (
             <DropdownMenu.Item
               icon={publishIcon}
               onSelect={() => setShowPublishLibraryDialog(true)}
@@ -293,6 +295,7 @@ export const LibraryDropdownMenu = ({
   className?: string;
 }) => {
   const { library } = useApp();
+  const appProps = useAppProps();
   const { clearLibraryCache, deleteItemsFromLibraryCache } = useLibraryCache();
   const appState = useUIAppState();
   const setAppState = useExcalidrawSetAppState();
@@ -329,6 +332,7 @@ export const LibraryDropdownMenu = ({
       }
       resetLibrary={resetLibrary}
       className={className}
+      canPublishLibrary={appProps.UIOptions.publishLibrary}
     />
   );
 };

--- a/packages/excalidraw/types.ts
+++ b/packages/excalidraw/types.ts
@@ -684,6 +684,7 @@ export type UIOptions = Partial<{
    */
   formFactor?: EditorInterface["formFactor"];
   desktopUIMode?: EditorInterface["desktopUIMode"];
+  publishLibrary: boolean;
   /** @deprecated does nothing. Will be removed in 0.15 */
   welcomeScreen?: boolean;
 }>;


### PR DESCRIPTION
These commits introduce a new publishLibrary boolean flag in UIOptions that allows embedders to disable the library publishing feature. When disabled, the "Publish Library" option is hidden from the library dropdown menu.

This provides control over library publishing in embedded contexts where sharing libraries to public repositories may not be desired. 