### PR TITLE
feat: added visual feedback for invalid  color(hex code)

### DIFF
--- a/packages/excalidraw/components/ColorPicker/ColorInput.test.tsx
+++ b/packages/excalidraw/components/ColorPicker/ColorInput.test.tsx
@@ -1,0 +1,278 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { ColorInput } from "./ColorInput";
+import { vi } from "vitest";
+import { EditorJotaiProvider } from "../../editor-jotai";
+import * as App from "../App";
+
+// Mock useEditorInterface
+vi.mock("../App", async () => {
+  const actual = await vi.importActual<typeof App>("../App");
+  return {
+    ...actual,
+    useEditorInterface: () => ({ formFactor: "desktop" }),
+  };
+});
+
+describe("ColorInput", () => {
+  const defaultProps = {
+    color: "#ff0000",
+    onChange: vi.fn(),
+    label: "Color",
+    colorPickerType: "elementBackground" as const,
+    placeholder: "Enter color",
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const renderWithProviders = (ui: React.ReactElement) => {
+    return render(<EditorJotaiProvider>{ui}</EditorJotaiProvider>);
+  };
+
+  it("should render with initial color value", () => {
+    renderWithProviders(<ColorInput {...defaultProps} />);
+    const input = screen.getByLabelText("Color") as HTMLInputElement;
+    expect(input.value).toBe("ff0000");
+  });
+
+  it("should call onChange with valid hex color", () => {
+    renderWithProviders(<ColorInput {...defaultProps} />);
+    const input = screen.getByLabelText("Color");
+
+    fireEvent.change(input, { target: { value: "00ff00" } });
+
+    expect(defaultProps.onChange).toHaveBeenCalledWith("#00ff00");
+  });
+
+  it("should add invalid class when entering invalid hex code", async () => {
+    const { container } = renderWithProviders(<ColorInput {...defaultProps} />);
+    const input = screen.getByLabelText("Color");
+    const inputLabel = container.querySelector(".color-picker__input-label");
+
+    fireEvent.change(input, { target: { value: "zzz" } });
+
+    await waitFor(() => {
+      expect(inputLabel).toHaveClass("color-picker__input-label--invalid");
+    });
+  });
+
+  it("should not add invalid class for valid hex code", async () => {
+    const { container } = renderWithProviders(<ColorInput {...defaultProps} />);
+    const input = screen.getByLabelText("Color");
+    const inputLabel = container.querySelector(".color-picker__input-label");
+
+    fireEvent.change(input, { target: { value: "123456" } });
+
+    await waitFor(() => {
+      expect(inputLabel).not.toHaveClass("color-picker__input-label--invalid");
+    });
+  });
+
+  it("should not add invalid class for empty input", async () => {
+    const { container } = renderWithProviders(<ColorInput {...defaultProps} />);
+    const input = screen.getByLabelText("Color");
+    const inputLabel = container.querySelector(".color-picker__input-label");
+
+    fireEvent.change(input, { target: { value: "" } });
+
+    await waitFor(() => {
+      expect(inputLabel).not.toHaveClass("color-picker__input-label--invalid");
+    });
+  });
+
+  it("should remove invalid class when valid color is entered after invalid", async () => {
+    const { container } = renderWithProviders(<ColorInput {...defaultProps} />);
+    const input = screen.getByLabelText("Color");
+    const inputLabel = container.querySelector(".color-picker__input-label");
+
+    // Enter invalid color
+    fireEvent.change(input, { target: { value: "zzz" } });
+
+    await waitFor(() => {
+      expect(inputLabel).toHaveClass("color-picker__input-label--invalid");
+    });
+
+    // Enter valid color
+    fireEvent.change(input, { target: { value: "ff0000" } });
+
+    await waitFor(() => {
+      expect(inputLabel).not.toHaveClass("color-picker__input-label--invalid");
+    });
+  });
+
+  it("should clear invalid state on blur", async () => {
+    const { container } = renderWithProviders(<ColorInput {...defaultProps} />);
+    const input = screen.getByLabelText("Color");
+    const inputLabel = container.querySelector(".color-picker__input-label");
+
+    // Enter invalid color
+    fireEvent.change(input, { target: { value: "xyz" } });
+
+    await waitFor(() => {
+      expect(inputLabel).toHaveClass("color-picker__input-label--invalid");
+    });
+
+    // Blur the input
+    fireEvent.blur(input);
+
+    await waitFor(() => {
+      expect(inputLabel).not.toHaveClass("color-picker__input-label--invalid");
+    });
+  });
+
+  it("should reset to original color value on blur", () => {
+    renderWithProviders(<ColorInput {...defaultProps} />);
+    const input = screen.getByLabelText("Color") as HTMLInputElement;
+
+    fireEvent.change(input, { target: { value: "invalid" } });
+    expect(input.value).toBe("invalid");
+
+    fireEvent.blur(input);
+    expect(input.value).toBe("ff0000");
+  });
+
+  it("should handle transparent color", () => {
+    renderWithProviders(<ColorInput {...defaultProps} color="transparent" />);
+    const input = screen.getByLabelText("Color") as HTMLInputElement;
+    expect(input.value).toBe("transparent");
+  });
+
+  it("should accept valid color with # prefix", () => {
+    renderWithProviders(<ColorInput {...defaultProps} />);
+    const input = screen.getByLabelText("Color");
+
+    fireEvent.change(input, { target: { value: "#00ff00" } });
+
+    expect(defaultProps.onChange).toHaveBeenCalledWith("#00ff00");
+  });
+
+  it("should handle 3-character hex codes", () => {
+    renderWithProviders(<ColorInput {...defaultProps} />);
+    const input = screen.getByLabelText("Color");
+
+    fireEvent.change(input, { target: { value: "f00" } });
+
+    expect(defaultProps.onChange).toHaveBeenCalledWith("#f00");
+  });
+
+  it("should not call onChange for invalid colors", () => {
+    const onChange = vi.fn();
+    renderWithProviders(<ColorInput {...defaultProps} onChange={onChange} />);
+    const input = screen.getByLabelText("Color");
+
+    onChange.mockClear();
+    fireEvent.change(input, { target: { value: "notacolor" } });
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("should update when color prop changes", async () => {
+    const { rerender } = renderWithProviders(<ColorInput {...defaultProps} />);
+    const input = screen.getByLabelText("Color") as HTMLInputElement;
+
+    expect(input.value).toBe("ff0000");
+
+    rerender(
+      <EditorJotaiProvider>
+        <ColorInput {...defaultProps} color="#00ff00" />
+      </EditorJotaiProvider>,
+    );
+
+    await waitFor(() => {
+      expect(input.value).toBe("00ff00");
+    });
+  });
+
+  it("should clear invalid state when color prop changes", async () => {
+    const { container, rerender } = renderWithProviders(
+      <ColorInput {...defaultProps} />,
+    );
+    const input = screen.getByLabelText("Color");
+    const inputLabel = container.querySelector(".color-picker__input-label");
+
+    // Enter invalid color
+    fireEvent.change(input, { target: { value: "invalid" } });
+
+    await waitFor(() => {
+      expect(inputLabel).toHaveClass("color-picker__input-label--invalid");
+    });
+
+    // Update color prop
+    rerender(
+      <EditorJotaiProvider>
+        <ColorInput {...defaultProps} color="#0000ff" />
+      </EditorJotaiProvider>,
+    );
+
+    await waitFor(() => {
+      expect(inputLabel).not.toHaveClass("color-picker__input-label--invalid");
+    });
+  });
+
+  it("should not show invalid feedback for 1 or 2 characters", async () => {
+    const { container } = renderWithProviders(<ColorInput {...defaultProps} />);
+    const input = screen.getByLabelText("Color");
+    const inputLabel = container.querySelector(".color-picker__input-label");
+
+    // Type 1 character
+    fireEvent.change(input, { target: { value: "z" } });
+
+    await waitFor(() => {
+      expect(inputLabel).not.toHaveClass("color-picker__input-label--invalid");
+    });
+
+    // Type 2 characters
+    fireEvent.change(input, { target: { value: "zz" } });
+
+    await waitFor(() => {
+      expect(inputLabel).not.toHaveClass("color-picker__input-label--invalid");
+    });
+  });
+
+  it("should show invalid feedback starting at 3 characters", async () => {
+    const { container } = renderWithProviders(<ColorInput {...defaultProps} />);
+    const input = screen.getByLabelText("Color");
+    const inputLabel = container.querySelector(".color-picker__input-label");
+
+    // Type 3 invalid characters
+    fireEvent.change(input, { target: { value: "zzz" } });
+
+    await waitFor(() => {
+      expect(inputLabel).toHaveClass("color-picker__input-label--invalid");
+    });
+  });
+
+  it("should handle # prefix correctly when checking length", async () => {
+    const { container } = renderWithProviders(<ColorInput {...defaultProps} />);
+    const input = screen.getByLabelText("Color");
+    const inputLabel = container.querySelector(".color-picker__input-label");
+
+    // Type # followed by 2 characters (should not show invalid)
+    fireEvent.change(input, { target: { value: "#zz" } });
+
+    await waitFor(() => {
+      expect(inputLabel).not.toHaveClass("color-picker__input-label--invalid");
+    });
+
+    // Type # followed by 3 invalid characters (should show invalid)
+    fireEvent.change(input, { target: { value: "#zzz" } });
+
+    await waitFor(() => {
+      expect(inputLabel).toHaveClass("color-picker__input-label--invalid");
+    });
+  });
+
+  it("should not show invalid for valid 3-character hex", async () => {
+    const { container } = renderWithProviders(<ColorInput {...defaultProps} />);
+    const input = screen.getByLabelText("Color");
+    const inputLabel = container.querySelector(".color-picker__input-label");
+
+    // Type valid 3-character hex
+    fireEvent.change(input, { target: { value: "abc" } });
+
+    await waitFor(() => {
+      expect(inputLabel).not.toHaveClass("color-picker__input-label--invalid");
+    });
+  });
+});

--- a/packages/excalidraw/components/ColorPicker/ColorInput.tsx
+++ b/packages/excalidraw/components/ColorPicker/ColorInput.tsx
@@ -32,12 +32,14 @@ export const ColorInput = ({
 }: ColorInputProps) => {
   const editorInterface = useEditorInterface();
   const [innerValue, setInnerValue] = useState(color);
+  const [isInvalid, setIsInvalid] = useState(false);
   const [activeSection, setActiveColorPickerSection] = useAtom(
     activeColorPickerSectionAtom,
   );
 
   useEffect(() => {
     setInnerValue(color);
+    setIsInvalid(false);
   }, [color]);
 
   const changeColor = useCallback(
@@ -47,6 +49,12 @@ export const ColorInput = ({
 
       if (color) {
         onChange(color);
+        setIsInvalid((prev) => (prev ? false : prev));
+      } else if (value.trim() !== "" && value.replace(/^#/, "").length >= 3) {
+        // Only show invalid feedback when user has typed at least 3 characters
+        setIsInvalid((prev) => (prev ? prev : true));
+      } else {
+        setIsInvalid((prev) => (prev ? false : prev));
       }
       setInnerValue(value);
     },
@@ -71,7 +79,11 @@ export const ColorInput = ({
   }, [setEyeDropperState]);
 
   return (
-    <div className="color-picker__input-label">
+    <div
+      className={clsx("color-picker__input-label", {
+        "color-picker__input-label--invalid": isInvalid,
+      })}
+    >
       <div className="color-picker__input-hash">#</div>
       <input
         ref={activeSection === "hex" ? inputRef : undefined}
@@ -85,6 +97,7 @@ export const ColorInput = ({
         value={(innerValue || "").replace(/^#/, "")}
         onBlur={() => {
           setInnerValue(color);
+          setIsInvalid(false);
         }}
         tabIndex={-1}
         onFocus={() => setActiveColorPickerSection("hex")}

--- a/packages/excalidraw/components/ColorPicker/ColorPicker.scss
+++ b/packages/excalidraw/components/ColorPicker/ColorPicker.scss
@@ -382,6 +382,14 @@
       box-shadow: 0 0 0 1px var(--color-primary-darkest);
       border-radius: var(--border-radius-lg);
     }
+
+    &--invalid {
+      border-color: red;
+
+      &:focus-within {
+        box-shadow: none;
+      }
+    }
   }
 
   .color-picker__input-hash {


### PR DESCRIPTION
Description: Add visual feedback with red border for invalid hex color codes in ColorPicker, displaying error only after 3+ characters to improve UX and help users catch input mistakes immediately.

Before:
<img width="189" height="81" alt="image" src="https://github.com/user-attachments/assets/1e65f7d0-59af-4f9c-9fc8-e8b54423c4c0" />

After(invalid hex): 
<img width="144" height="62" alt="image" src="https://github.com/user-attachments/assets/2ffccf86-4476-4085-b70c-9b1a5686cd81" />

Valid hex:
<img width="147" height="63" alt="image" src="https://github.com/user-attachments/assets/b02e3066-76ee-4dfa-9596-49891a78e186" />


Also found an issue related with this not resolved yet:
https://github.com/excalidraw/excalidraw/issues/9527
