### PR TITLE
feat: add “Precision draw (ignore grid)” shortcut to Help dialog

### DIFF
--- a/packages/excalidraw/components/HelpDialog.tsx
+++ b/packages/excalidraw/components/HelpDialog.tsx
@@ -245,6 +245,10 @@ export const HelpDialog = ({ onClose }: { onClose?: () => void }) => {
               shortcuts={[getShortcutKey("CtrlOrCmd")]}
             />
             <Shortcut
+              label={t("helpDialog.preventGridSnapping")}
+              shortcuts={[getShortcutKey("CtrlOrCmd")]}
+            />
+            <Shortcut
               label={t("toolBar.link")}
               shortcuts={[getShortcutKey("CtrlOrCmd+K")]}
             />

--- a/packages/excalidraw/locales/en.json
+++ b/packages/excalidraw/locales/en.json
@@ -425,6 +425,7 @@
     "howto": "Follow our guides",
     "or": "or",
     "preventBinding": "Prevent arrow binding",
+    "preventGridSnapping": "Precision draw (ignore grid)",
     "tools": "Tools",
     "shortcuts": "Keyboard shortcuts",
     "textFinish": "Finish editing (text editor)",


### PR DESCRIPTION
Refs #1902 

This PR adds a new keyboard shortcut entry to the Help → Keyboard Shortcuts dialog to make the existing Ctrl precision-draw behavior discoverable.

Holding Ctrl already bypasses grid snapping (via gridSize = null), allowing users to draw freely in grid mode, including creating dot-sized circles. This change documents that behavior without modifying any drawing logic.


