### PR TITLE
fix: Embeddables lost stroke color option in element properties after #9996

### DIFF
--- a/packages/element/src/comparisons.ts
+++ b/packages/element/src/comparisons.ts
@@ -16,7 +16,8 @@ export const hasStrokeColor = (type: ElementOrToolType) =>
   type === "freedraw" ||
   type === "arrow" ||
   type === "line" ||
-  type === "text";
+  type === "text" ||
+  type === "embeddable";
 
 export const hasStrokeWidth = (type: ElementOrToolType) =>
   type === "rectangle" ||


### PR DESCRIPTION
Fixes #10540