### PR TITLE
fix: Context menu paste adding image twice #10542

### DIFF
--- a/packages/excalidraw/clipboard.ts
+++ b/packages/excalidraw/clipboard.ts
@@ -113,7 +113,6 @@ export const createPasteEvent = ({
       if (typeof value !== "string") {
         files = files || [];
         files.push(value);
-        event.clipboardData?.items.add(value);
         continue;
       }
       try {


### PR DESCRIPTION
Fixes #10542 

The line I removed was added in [this](https://github.com/excalidraw/excalidraw/pull/9947) pull request.

I tested this in firefox too and both paste options still work (I'm on MacOS, I couldn't test it on windows)