### PR TITLE
refactor: align point types across codebase (#9297)

### DIFF
--- a/packages/common/src/points.ts
+++ b/packages/common/src/points.ts
@@ -1,14 +1,10 @@
-import {
-  pointFromPair,
-  type GlobalPoint,
-  type LocalPoint,
-} from "@excalidraw/math";
+import { pointFromPair, type GenericPoint } from "@excalidraw/math";
+
+import type { GlobalPoint } from "@excalidraw/math";
 
 import type { NullableGridSize } from "@excalidraw/excalidraw/types";
 
-export const getSizeFromPoints = (
-  points: readonly (GlobalPoint | LocalPoint)[],
-) => {
+export const getSizeFromPoints = (points: readonly GenericPoint[]) => {
   const xs = points.map((point) => point[0]);
   const ys = points.map((point) => point[1]);
   return {
@@ -18,7 +14,7 @@ export const getSizeFromPoints = (
 };
 
 /** @arg dimension, 0 for rescaling only x, 1 for y */
-export const rescalePoints = <Point extends GlobalPoint | LocalPoint>(
+export const rescalePoints = <Point extends GenericPoint>(
   dimension: 0 | 1,
   newSize: number,
   points: readonly Point[],
@@ -32,14 +28,14 @@ export const rescalePoints = <Point extends GlobalPoint | LocalPoint>(
 
   let nextMinCoordinate = Infinity;
 
-  const scaledPoints = points.map((point): Point => {
+  const scaledPoints = points.map((point) => {
     const newCoordinate = point[dimension] * scale;
-    const newPoint = [...point];
+    const newPoint: Point = [...point];
     newPoint[dimension] = newCoordinate;
     if (newCoordinate < nextMinCoordinate) {
       nextMinCoordinate = newCoordinate;
     }
-    return newPoint as Point;
+    return newPoint;
   });
 
   if (!normalize) {
@@ -65,16 +61,16 @@ export const rescalePoints = <Point extends GlobalPoint | LocalPoint>(
 };
 
 // TODO: Rounding this point causes some shake when free drawing
-export const getGridPoint = (
+export const getGridPoint = <Point extends GlobalPoint>(
   x: number,
   y: number,
   gridSize: NullableGridSize,
-): [number, number] => {
+): Point => {
   if (gridSize) {
-    return [
+    return pointFromPair<Point>([
       Math.round(x / gridSize) * gridSize,
       Math.round(y / gridSize) * gridSize,
-    ];
+    ]);
   }
-  return [x, y];
+  return pointFromPair<Point>([x, y]);
 };

--- a/packages/element/src/dragElements.ts
+++ b/packages/element/src/dragElements.ts
@@ -1,10 +1,12 @@
 import {
   type Bounds,
-  TEXT_AUTOWRAP_THRESHOLD,
-  getGridPoint,
-  getFontString,
   DRAGGING_THRESHOLD,
+  TEXT_AUTOWRAP_THRESHOLD,
+  getFontString,
+  getGridPoint,
 } from "@excalidraw/common";
+
+import { vector } from "@excalidraw/math";
 
 import type {
   AppState,
@@ -225,7 +227,7 @@ export const getDragOffsetXY = (
   y: number,
 ): [number, number] => {
   const [x1, y1] = getCommonBounds(selectedElements);
-  return [x - x1, y - y1];
+  return vector(x, y, x1, y1);
 };
 
 export const dragNewElement = ({

--- a/packages/element/src/elbowArrow.ts
+++ b/packages/element/src/elbowArrow.ts
@@ -9,30 +9,33 @@ import {
   vectorCross,
   vectorFromPoint,
   vectorScale,
+  type GenericPoint,
   type GlobalPoint,
   type LocalPoint,
 } from "@excalidraw/math";
 
 import {
   type Bounds,
+  arrayToMap,
   BinaryHeap,
+  getSizeFromPoints,
   invariant,
   isAnyTrue,
-  getSizeFromPoints,
   isDevEnv,
-  arrayToMap,
 } from "@excalidraw/common";
 
 import type { AppState } from "@excalidraw/excalidraw/types";
 
 import {
-  bindPointToSnapToElementOutline,
-  getHeadingForElbowArrowSnap,
-  getGlobalFixedPointForBindableElement,
-  getBindingGap,
-  maxBindingDistance_simple,
   BASE_BINDING_GAP_ELBOW,
+  bindPointToSnapToElementOutline,
+  getBindingGap,
+  getGlobalFixedPointForBindableElement,
+  getHeadingForElbowArrowSnap,
+  maxBindingDistance_simple,
 } from "./binding";
+import { aabbForElement, pointInsideBounds } from "./bounds";
+import { getHoveredElementForBinding } from "./collision";
 import { distanceToElement } from "./distance";
 import {
   compareHeading,
@@ -41,10 +44,10 @@ import {
   HEADING_LEFT,
   HEADING_RIGHT,
   HEADING_UP,
+  headingForPoint,
   headingForPointIsHorizontal,
   headingIsHorizontal,
   vectorToHeading,
-  headingForPoint,
 } from "./heading";
 import { type ElementUpdate } from "./mutateElement";
 import { isBindableElement } from "./typeChecks";
@@ -52,8 +55,6 @@ import {
   type ExcalidrawElbowArrowElement,
   type NonDeletedSceneElementsMap,
 } from "./types";
-import { aabbForElement, pointInsideBounds } from "./bounds";
-import { getHoveredElementForBinding } from "./collision";
 
 import type { Heading } from "./heading";
 import type {
@@ -1649,7 +1650,7 @@ const pathTo = (start: Node, node: Node) => {
   return path;
 };
 
-const m_dist = (a: GlobalPoint | LocalPoint, b: GlobalPoint | LocalPoint) =>
+const m_dist = (a: GenericPoint, b: GenericPoint) =>
   Math.abs(a[0] - b[0]) + Math.abs(a[1] - b[1]);
 
 /**
@@ -2283,7 +2284,7 @@ const getHoveredElement = (
 const gridAddressesEqual = (a: GridAddress, b: GridAddress): boolean =>
   a[0] === b[0] && a[1] === b[1];
 
-export const validateElbowPoints = <P extends GlobalPoint | LocalPoint>(
+export const validateElbowPoints = <P extends GenericPoint>(
   points: readonly P[],
   tolerance: number = DEDUP_TRESHOLD,
 ) =>

--- a/packages/element/src/heading.ts
+++ b/packages/element/src/heading.ts
@@ -18,7 +18,7 @@ import {
 } from "@excalidraw/math";
 
 import type {
-  LocalPoint,
+  GenericPoint,
   GlobalPoint,
   Triangle,
   Vector,
@@ -48,12 +48,10 @@ export const vectorToHeading = (vec: Vector): Heading => {
   return HEADING_UP;
 };
 
-export const headingForPoint = <P extends GlobalPoint | LocalPoint>(
-  p: P,
-  o: P,
-) => vectorToHeading(vectorFromPoint<P>(p, o));
+export const headingForPoint = <P extends GenericPoint>(p: P, o: P) =>
+  vectorToHeading(vectorFromPoint<P>(p, o));
 
-export const headingForPointIsHorizontal = <P extends GlobalPoint | LocalPoint>(
+export const headingForPointIsHorizontal = <P extends GenericPoint>(
   p: P,
   o: P,
 ) => headingIsHorizontal(headingForPoint<P>(p, o));

--- a/packages/element/src/linearElementEditor.ts
+++ b/packages/element/src/linearElementEditor.ts
@@ -1,27 +1,27 @@
 import {
-  pointCenter,
-  pointFrom,
-  pointRotateRads,
-  pointsEqual,
-  type GlobalPoint,
-  type LocalPoint,
-  pointDistance,
-  vectorFromPoint,
   curveLength,
   curvePointAtLength,
   lineSegment,
+  pointCenter,
+  pointDistance,
+  pointFrom,
+  pointRotateRads,
+  pointsEqual,
+  vectorFromPoint,
+  type GlobalPoint,
+  type LocalPoint,
 } from "@excalidraw/math";
 
 import { getCurvePathOps } from "@excalidraw/utils/shape";
 
 import {
   DRAGGING_THRESHOLD,
-  KEYS,
-  shouldRotateWithDiscreteAngle,
+  getFeatureFlag,
   getGridPoint,
   invariant,
   isShallowEqual,
-  getFeatureFlag,
+  KEYS,
+  shouldRotateWithDiscreteAngle,
 } from "@excalidraw/common";
 
 import {
@@ -32,17 +32,17 @@ import {
   type Store,
 } from "@excalidraw/element";
 
-import type { Radians } from "@excalidraw/math";
+import type { Bounds } from "@excalidraw/common";
+import type { GenericPoint, Radians } from "@excalidraw/math";
 
 import type {
-  AppState,
-  PointerCoords,
-  InteractiveCanvasAppState,
   AppClassProperties,
+  AppState,
+  InteractiveCanvasAppState,
   NullableGridSize,
+  PointerCoords,
   Zoom,
 } from "@excalidraw/excalidraw/types";
-import type { Bounds } from "@excalidraw/common";
 
 import {
   calculateFixedPointForNonElbowArrowBinding,
@@ -70,19 +70,19 @@ import { isLineElement } from "./typeChecks";
 import type { Scene } from "./Scene";
 
 import type {
-  NonDeleted,
-  ExcalidrawLinearElement,
-  ExcalidrawElement,
-  ExcalidrawTextElementWithContainer,
   ElementsMap,
-  NonDeletedSceneElementsMap,
+  ExcalidrawBindableElement,
+  ExcalidrawElbowArrowElement,
+  ExcalidrawElement,
+  ExcalidrawLinearElement,
+  ExcalidrawTextElementWithContainer,
   FixedPointBinding,
   FixedSegment,
-  ExcalidrawElbowArrowElement,
-  PointsPositionUpdates,
+  NonDeleted,
   NonDeletedExcalidrawElement,
+  NonDeletedSceneElementsMap,
   Ordered,
-  ExcalidrawBindableElement,
+  PointsPositionUpdates,
 } from "./types";
 
 /**
@@ -856,7 +856,7 @@ export class LinearElementEditor {
     return null;
   };
 
-  static isSegmentTooShort<P extends GlobalPoint | LocalPoint>(
+  static isSegmentTooShort<P extends GenericPoint>(
     element: NonDeleted<ExcalidrawLinearElement>,
     startPoint: P,
     endPoint: P,
@@ -1116,7 +1116,7 @@ export class LinearElementEditor {
     return ret;
   }
 
-  static arePointsEqual<Point extends LocalPoint | GlobalPoint>(
+  static arePointsEqual<Point extends GenericPoint>(
     point1: Point | null,
     point2: Point | null,
   ) {

--- a/packages/element/src/resizeElements.ts
+++ b/packages/element/src/resizeElements.ts
@@ -2,6 +2,7 @@ import {
   pointCenter,
   normalizeRadians,
   pointFrom,
+  pointFromPair,
   pointRotateRads,
   type Radians,
   type LocalPoint,
@@ -493,7 +494,7 @@ export const getResizeOffsetXY = (
   elementsMap: ElementsMap,
   x: number,
   y: number,
-): [number, number] => {
+): GlobalPoint => {
   const [x1, y1, x2, y2] =
     selectedElements.length === 1
       ? getElementAbsoluteCoords(selectedElements[0], elementsMap)
@@ -542,7 +543,7 @@ export const getResizeOffsetXY = (
     case "se":
       return pointRotateRads(pointFrom(x - x2, y - y2), pointFrom(0, 0), angle);
     default:
-      return [0, 0];
+      return pointFromPair<GlobalPoint>([0, 0]);
   }
 };
 

--- a/packages/element/src/resizeTest.ts
+++ b/packages/element/src/resizeTest.ts
@@ -2,6 +2,8 @@ import {
   pointFrom,
   pointOnLineSegment,
   pointRotateRads,
+  type GenericPoint,
+  type LineSegment,
   type Radians,
 } from "@excalidraw/math";
 
@@ -10,30 +12,28 @@ import {
   type EditorInterface,
 } from "@excalidraw/common";
 
-import type { GlobalPoint, LineSegment, LocalPoint } from "@excalidraw/math";
-
 import type { AppState, Zoom } from "@excalidraw/excalidraw/types";
 import type { Bounds } from "@excalidraw/common";
 
 import { getElementAbsoluteCoords } from "./bounds";
 import {
-  getTransformHandlesFromCoords,
-  getTransformHandles,
-  getOmitSidesForEditorInterface,
   canResizeFromSides,
+  getOmitSidesForEditorInterface,
+  getTransformHandles,
+  getTransformHandlesFromCoords,
 } from "./transformHandles";
 import { isImageElement, isLinearElement } from "./typeChecks";
 
 import type {
-  TransformHandleType,
-  TransformHandle,
   MaybeTransformHandleType,
+  TransformHandle,
+  TransformHandleType,
 } from "./transformHandles";
 import type {
-  ExcalidrawElement,
-  PointerType,
-  NonDeletedExcalidrawElement,
   ElementsMap,
+  ExcalidrawElement,
+  NonDeletedExcalidrawElement,
+  PointerType,
 } from "./types";
 
 const isInsideTransformHandle = (
@@ -46,7 +46,7 @@ const isInsideTransformHandle = (
   y >= transformHandle[1] &&
   y <= transformHandle[1] + transformHandle[3];
 
-export const resizeTest = <Point extends GlobalPoint | LocalPoint>(
+export const resizeTest = <Point extends GenericPoint>(
   element: NonDeletedExcalidrawElement,
   elementsMap: ElementsMap,
   appState: AppState,
@@ -155,9 +155,7 @@ export const getElementWithTransformHandleType = (
   }, null as { element: NonDeletedExcalidrawElement; transformHandleType: MaybeTransformHandleType } | null);
 };
 
-export const getTransformHandleTypeFromCoords = <
-  Point extends GlobalPoint | LocalPoint,
->(
+export const getTransformHandleTypeFromCoords = <Point extends GenericPoint>(
   [x1, y1, x2, y2]: Bounds,
   scenePointerX: number,
   scenePointerY: number,
@@ -274,7 +272,7 @@ export const getCursorForResizingElement = (resizingElement: {
   return cursor ? `${cursor}-resize` : "";
 };
 
-const getSelectionBorders = <Point extends LocalPoint | GlobalPoint>(
+const getSelectionBorders = <Point extends GenericPoint>(
   [x1, y1]: Point,
   [x2, y2]: Point,
   center: Point,

--- a/packages/element/src/shape.ts
+++ b/packages/element/src/shape.ts
@@ -10,36 +10,37 @@ import {
 } from "@excalidraw/utils/shape";
 
 import {
-  pointFrom,
-  pointDistance,
-  type LocalPoint,
-  pointRotateRads,
-} from "@excalidraw/math";
-import {
-  ROUGHNESS,
-  isTransparent,
   assertNever,
   COLOR_PALETTE,
+  isTransparent,
   LINE_POLYGON_POINT_MERGE_DISTANCE,
+  ROUGHNESS,
 } from "@excalidraw/common";
+import {
+  type LocalPoint,
+  pointDistance,
+  pointFrom,
+  pointRotateRads,
+} from "@excalidraw/math";
 
 import { RoughGenerator } from "roughjs/bin/generator";
 
-import type { GlobalPoint } from "@excalidraw/math";
+import type { GenericPoint, GlobalPoint } from "@excalidraw/math";
 
 import type { Mutable } from "@excalidraw/common/utility-types";
 
 import type {
-  AppState,
-  EmbedsValidationStatus,
-} from "@excalidraw/excalidraw/types";
-import type {
   ElementShape,
   ElementShapes,
 } from "@excalidraw/excalidraw/scene/types";
+import type {
+  AppState,
+  EmbedsValidationStatus,
+} from "@excalidraw/excalidraw/types";
 
 import { elementWithCanvasCache } from "./renderElement";
 
+import { headingForPointIsHorizontal } from "./heading";
 import {
   canBecomePolygon,
   isElbowArrow,
@@ -49,10 +50,7 @@ import {
   isLinearElement,
 } from "./typeChecks";
 import { getCornerRadius, isPathALoop } from "./utils";
-import { headingForPointIsHorizontal } from "./heading";
 
-import { canChangeRoundness } from "./comparisons";
-import { generateFreeDrawShape } from "./renderElement";
 import {
   getArrowheadPoints,
   getCenterForBounds,
@@ -60,16 +58,18 @@ import {
   getElementAbsoluteCoords,
 } from "./bounds";
 import { shouldTestInside } from "./collision";
+import { canChangeRoundness } from "./comparisons";
+import { generateFreeDrawShape } from "./renderElement";
 
 import type {
-  ExcalidrawElement,
-  NonDeletedExcalidrawElement,
-  ExcalidrawSelectionElement,
-  ExcalidrawLinearElement,
   Arrowhead,
-  ExcalidrawFreeDrawElement,
   ElementsMap,
+  ExcalidrawElement,
+  ExcalidrawFreeDrawElement,
+  ExcalidrawLinearElement,
   ExcalidrawLineElement,
+  ExcalidrawSelectionElement,
+  NonDeletedExcalidrawElement,
 } from "./types";
 
 import type { Drawable, Options } from "roughjs/bin/core";
@@ -538,7 +538,7 @@ export const generateLinearCollisionShape = (
       );
 
       return generator
-        .curve(simplifiedPoints as [number, number][], options)
+        .curve(simplifiedPoints, options)
         .sets[0].ops.slice(0, element.points.length)
         .map((op, i) => {
           if (i === 0) {
@@ -811,7 +811,7 @@ const generateElementShape = (
           element.points as Mutable<LocalPoint[]>,
           0.75,
         );
-        shape = generator.curve(simplifiedPoints as [number, number][], {
+        shape = generator.curve(simplifiedPoints, {
           ...generateRoughOptions(element),
           stroke: "none",
         });
@@ -843,7 +843,7 @@ const generateElbowArrowShape = (
   points: readonly LocalPoint[],
   radius: number,
 ) => {
-  const subpoints = [] as [number, number][];
+  const subpoints: [number, number][] = [];
   for (let i = 1; i < points.length - 1; i += 1) {
     const prev = points[i - 1];
     const next = points[i + 1];
@@ -871,7 +871,7 @@ const generateElbowArrowShape = (
       subpoints.push([points[i][0], points[i][1] + corner]);
     }
 
-    subpoints.push(points[i] as [number, number]);
+    subpoints.push(points[i]);
 
     if (nextIsHorizontal) {
       if (next[0] < point[0]) {
@@ -908,7 +908,7 @@ const generateElbowArrowShape = (
  * get the pure geometric shape of an excalidraw elementw
  * which is then used for hit detection
  */
-export const getElementShape = <Point extends GlobalPoint | LocalPoint>(
+export const getElementShape = <Point extends GenericPoint>(
   element: ExcalidrawElement,
   elementsMap: ElementsMap,
 ): GeometricShape<Point> => {

--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -16,6 +16,7 @@ import {
   vectorSubtract,
   vectorDot,
   vectorNormalize,
+  pointFromPair,
 } from "@excalidraw/math";
 
 import {
@@ -250,7 +251,12 @@ import {
   maxBindingDistance_simple,
 } from "@excalidraw/element";
 
-import type { GlobalPoint, LocalPoint, Radians } from "@excalidraw/math";
+import type {
+  GlobalPoint,
+  LocalPoint,
+  Radians,
+  ViewportPoint,
+} from "@excalidraw/math";
 
 import type {
   ExcalidrawElement,
@@ -5395,10 +5401,10 @@ class App extends React.Component<AppProps, AppState> {
           },
           this.state,
         );
-        return [
+        return pointFromPair<ViewportPoint>([
           viewportX - this.state.offsetLeft,
           viewportY - this.state.offsetTop,
-        ];
+        ]);
       },
       onChange: withBatchedUpdates((nextOriginalText) => {
         updateElement(nextOriginalText, false);

--- a/packages/excalidraw/renderer/interactiveScene.ts
+++ b/packages/excalidraw/renderer/interactiveScene.ts
@@ -2,8 +2,8 @@ import {
   clamp,
   pointFrom,
   pointsEqual,
+  type GenericPoint,
   type GlobalPoint,
-  type LocalPoint,
   type Radians,
 } from "@excalidraw/math";
 import oc from "open-color";
@@ -141,7 +141,7 @@ const renderLinearElementPointHighlight = (
   context.restore();
 };
 
-const highlightPoint = <Point extends LocalPoint | GlobalPoint>(
+const highlightPoint = <Point extends GenericPoint>(
   point: Point,
   context: CanvasRenderingContext2D,
   appState: InteractiveCanvasAppState,
@@ -157,7 +157,7 @@ const highlightPoint = <Point extends LocalPoint | GlobalPoint>(
   );
 };
 
-const renderSingleLinearPoint = <Point extends GlobalPoint | LocalPoint>(
+const renderSingleLinearPoint = <Point extends GenericPoint>(
   context: CanvasRenderingContext2D,
   appState: InteractiveCanvasAppState,
   point: Point,
@@ -809,7 +809,7 @@ const renderLinearPointHandles = (
   context.save();
   context.translate(appState.scrollX, appState.scrollY);
   context.lineWidth = 1 / appState.zoom.value;
-  const points: GlobalPoint[] = LinearElementEditor.getPointsGlobalCoordinates(
+  const points = LinearElementEditor.getPointsGlobalCoordinates(
     element,
     elementsMap,
   );

--- a/packages/excalidraw/renderer/renderSnaps.ts
+++ b/packages/excalidraw/renderer/renderSnaps.ts
@@ -1,4 +1,4 @@
-import { pointFrom, type GlobalPoint, type LocalPoint } from "@excalidraw/math";
+import { pointFrom, type GenericPoint } from "@excalidraw/math";
 
 import { THEME } from "@excalidraw/common";
 
@@ -88,7 +88,7 @@ const drawPointerSnapLine = (
   }
 };
 
-const drawCross = <Point extends LocalPoint | GlobalPoint>(
+const drawCross = <Point extends GenericPoint>(
   [x, y]: Point,
   appState: InteractiveCanvasAppState,
   context: CanvasRenderingContext2D,
@@ -109,7 +109,7 @@ const drawCross = <Point extends LocalPoint | GlobalPoint>(
   context.restore();
 };
 
-const drawLine = <Point extends LocalPoint | GlobalPoint>(
+const drawLine = <Point extends GenericPoint>(
   from: Point,
   to: Point,
   context: CanvasRenderingContext2D,
@@ -120,7 +120,7 @@ const drawLine = <Point extends LocalPoint | GlobalPoint>(
   context.stroke();
 };
 
-const drawGapLine = <Point extends LocalPoint | GlobalPoint>(
+const drawGapLine = <Point extends GenericPoint>(
   from: Point,
   to: Point,
   direction: "horizontal" | "vertical",

--- a/packages/excalidraw/wysiwyg/textWysiwyg.tsx
+++ b/packages/excalidraw/wysiwyg/textWysiwyg.tsx
@@ -44,6 +44,8 @@ import type {
   ExcalidrawTextElement,
 } from "@excalidraw/element/types";
 
+import type { ViewportPoint } from "@excalidraw/math";
+
 import { actionSaveToActiveFile } from "../actions";
 
 import { parseDataTransferEvent } from "../clipboard";
@@ -103,7 +105,7 @@ export const textWysiwyg = ({
    */
   onChange?: (nextOriginalText: string) => void;
   onSubmit: (data: { viaKeyboard: boolean; nextOriginalText: string }) => void;
-  getViewportCoords: (x: number, y: number) => [number, number];
+  getViewportCoords: (x: number, y: number) => ViewportPoint;
   element: ExcalidrawTextElement;
   canvas: HTMLCanvasElement;
   excalidrawContainer: HTMLDivElement | null;

--- a/packages/math/src/angle.ts
+++ b/packages/math/src/angle.ts
@@ -1,12 +1,6 @@
 import { PRECISION } from "./utils";
 
-import type {
-  Degrees,
-  GlobalPoint,
-  LocalPoint,
-  PolarCoords,
-  Radians,
-} from "./types";
+import type { Degrees, GenericPoint, PolarCoords, Radians } from "./types";
 
 export const normalizeRadians = (angle: Radians): Radians =>
   angle < 0
@@ -18,7 +12,7 @@ export const normalizeRadians = (angle: Radians): Radians =>
  * (x, y) for the center point 0,0 where the first number returned is the radius,
  * the second is the angle in radians.
  */
-export const cartesian2Polar = <P extends GlobalPoint | LocalPoint>([
+export const cartesian2Polar = <P extends GenericPoint>([
   x,
   y,
 ]: P): PolarCoords => [

--- a/packages/math/src/curve.ts
+++ b/packages/math/src/curve.ts
@@ -1,8 +1,14 @@
-import { isPoint, pointDistance, pointFrom, pointFromVector } from "./point";
+import {
+  isPoint,
+  pointDistance,
+  pointFrom,
+  pointFromPair,
+  pointFromVector,
+} from "./point";
 import { vector, vectorNormal, vectorNormalize, vectorScale } from "./vector";
 import { LegendreGaussN24CValues, LegendreGaussN24TValues } from "./constants";
 
-import type { Curve, GlobalPoint, LineSegment, LocalPoint } from "./types";
+import type { Curve, GlobalPoint, LineSegment, GenericPoint } from "./types";
 
 /**
  *
@@ -12,7 +18,7 @@ import type { Curve, GlobalPoint, LineSegment, LocalPoint } from "./types";
  * @param d
  * @returns
  */
-export function curve<Point extends GlobalPoint | LocalPoint>(
+export function curve<Point extends GenericPoint>(
   a: Point,
   b: Point,
   c: Point,
@@ -21,7 +27,7 @@ export function curve<Point extends GlobalPoint | LocalPoint>(
   return [a, b, c, d] as Curve<Point>;
 }
 
-function solveWithAnalyticalJacobian<Point extends GlobalPoint | LocalPoint>(
+function solveWithAnalyticalJacobian<Point extends GenericPoint>(
   curve: Curve<Point>,
   lineSegment: LineSegment<Point>,
   t0: number,
@@ -112,7 +118,7 @@ function solveWithAnalyticalJacobian<Point extends GlobalPoint | LocalPoint>(
   return [t0, s0];
 }
 
-export const bezierEquation = <Point extends GlobalPoint | LocalPoint>(
+export const bezierEquation = <Point extends GenericPoint>(
   c: Curve<Point>,
   t: number,
 ) =>
@@ -127,13 +133,13 @@ export const bezierEquation = <Point extends GlobalPoint | LocalPoint>(
       t ** 3 * c[3][1],
   );
 
-const initial_guesses: [number, number][] = [
-  [0.5, 0],
-  [0.2, 0],
-  [0.8, 0],
+const initial_guesses = [
+  pointFromPair<GenericPoint>([0.5, 0]),
+  pointFromPair<GenericPoint>([0.2, 0]),
+  pointFromPair<GenericPoint>([0.8, 0]),
 ];
 
-const calculate = <Point extends GlobalPoint | LocalPoint>(
+const calculate = <Point extends GenericPoint>(
   [t0, s0]: [number, number],
   l: LineSegment<Point>,
   c: Curve<Point>,
@@ -156,9 +162,10 @@ const calculate = <Point extends GlobalPoint | LocalPoint>(
 /**
  * Computes the intersection between a cubic spline and a line segment.
  */
-export function curveIntersectLineSegment<
-  Point extends GlobalPoint | LocalPoint,
->(c: Curve<Point>, l: LineSegment<Point>): Point[] {
+export function curveIntersectLineSegment<Point extends GenericPoint>(
+  c: Curve<Point>,
+  l: LineSegment<Point>,
+): Point[] {
   let solution = calculate(initial_guesses[0], l, c);
   if (solution) {
     return [solution];
@@ -190,7 +197,7 @@ export function curveIntersectLineSegment<
  * @param maxLevel
  * @returns
  */
-export function curveClosestPoint<Point extends GlobalPoint | LocalPoint>(
+export function curveClosestPoint<Point extends GenericPoint>(
   c: Curve<Point>,
   p: Point,
   tolerance: number = 1e-3,
@@ -247,7 +254,7 @@ export function curveClosestPoint<Point extends GlobalPoint | LocalPoint>(
  * @param c The curve to test
  * @param p The point to measure from
  */
-export function curvePointDistance<Point extends GlobalPoint | LocalPoint>(
+export function curvePointDistance<Point extends GenericPoint>(
   c: Curve<Point>,
   p: Point,
 ) {
@@ -263,9 +270,7 @@ export function curvePointDistance<Point extends GlobalPoint | LocalPoint>(
 /**
  * Determines if the parameter is a Curve
  */
-export function isCurve<P extends GlobalPoint | LocalPoint>(
-  v: unknown,
-): v is Curve<P> {
+export function isCurve<P extends GenericPoint>(v: unknown): v is Curve<P> {
   return (
     Array.isArray(v) &&
     v.length === 4 &&
@@ -276,7 +281,7 @@ export function isCurve<P extends GlobalPoint | LocalPoint>(
   );
 }
 
-export function curveTangent<Point extends GlobalPoint | LocalPoint>(
+export function curveTangent<Point extends GenericPoint>(
   [p0, p1, p2, p3]: Curve<Point>,
   t: number,
 ) {
@@ -321,9 +326,10 @@ export function curveCatmullRomQuadraticApproxPoints(
   return pointSets;
 }
 
-export function curveCatmullRomCubicApproxPoints<
-  Point extends GlobalPoint | LocalPoint,
->(points: Point[], tension = 0.5) {
+export function curveCatmullRomCubicApproxPoints<Point extends GenericPoint>(
+  points: Point[],
+  tension = 0.5,
+) {
   if (points.length < 2) {
     return;
   }
@@ -410,9 +416,7 @@ export function offsetPointsForQuadraticBezier(
  * @param c The curve to calculate the length of
  * @returns The approximated length of the curve
  */
-export function curveLength<P extends GlobalPoint | LocalPoint>(
-  c: Curve<P>,
-): number {
+export function curveLength<P extends GenericPoint>(c: Curve<P>): number {
   const z2 = 0.5;
   let sum = 0;
 
@@ -437,7 +441,7 @@ export function curveLength<P extends GlobalPoint | LocalPoint>(
  * @param t The parameter value (0 to 1) to calculate length up to
  * @returns The length of the curve from beginning to parameter t
  */
-export function curveLengthAtParameter<P extends GlobalPoint | LocalPoint>(
+export function curveLengthAtParameter<P extends GenericPoint>(
   c: Curve<P>,
   t: number,
 ): number {
@@ -476,7 +480,7 @@ export function curveLengthAtParameter<P extends GlobalPoint | LocalPoint>(
  * @param percent A value between 0 and 1 representing the percentage of the curve's length
  * @returns The point at the specified percentage of curve length
  */
-export function curvePointAtLength<P extends GlobalPoint | LocalPoint>(
+export function curvePointAtLength<P extends GenericPoint>(
   c: Curve<P>,
   percent: number,
 ): P {

--- a/packages/math/src/ellipse.ts
+++ b/packages/math/src/ellipse.ts
@@ -13,13 +13,7 @@ import {
   vectorScale,
 } from "./vector";
 
-import type {
-  Ellipse,
-  GlobalPoint,
-  Line,
-  LineSegment,
-  LocalPoint,
-} from "./types";
+import type { Ellipse, GenericPoint, Line, LineSegment } from "./types";
 
 /**
  * Construct an Ellipse object from the parameters
@@ -30,7 +24,7 @@ import type {
  * @param halfHeight Half of the height of a non-slanted version of the ellipse
  * @returns The constructed Ellipse object
  */
-export function ellipse<Point extends GlobalPoint | LocalPoint>(
+export function ellipse<Point extends GenericPoint>(
   center: Point,
   halfWidth: number,
   halfHeight: number,
@@ -49,7 +43,7 @@ export function ellipse<Point extends GlobalPoint | LocalPoint>(
  * @param ellipse The ellipse to compare against
  * @returns TRUE if the point is inside or on the outline of the ellipse
  */
-export const ellipseIncludesPoint = <Point extends GlobalPoint | LocalPoint>(
+export const ellipseIncludesPoint = <Point extends GenericPoint>(
   p: Point,
   ellipse: Ellipse<Point>,
 ) => {
@@ -69,7 +63,7 @@ export const ellipseIncludesPoint = <Point extends GlobalPoint | LocalPoint>(
  * @param threshold The distance to consider a point close enough to be "on" the outline
  * @returns TRUE if the point is on the ellise outline
  */
-export const ellipseTouchesPoint = <Point extends GlobalPoint | LocalPoint>(
+export const ellipseTouchesPoint = <Point extends GenericPoint>(
   point: Point,
   ellipse: Ellipse<Point>,
   threshold = PRECISION,
@@ -85,9 +79,7 @@ export const ellipseTouchesPoint = <Point extends GlobalPoint | LocalPoint>(
  * @param ellipse The ellipse to calculate the distance to
  * @returns The eucledian distance
  */
-export const ellipseDistanceFromPoint = <
-  Point extends GlobalPoint | LocalPoint,
->(
+export const ellipseDistanceFromPoint = <Point extends GenericPoint>(
   p: Point,
   ellipse: Ellipse<Point>,
 ): number => {
@@ -140,9 +132,10 @@ export const ellipseDistanceFromPoint = <
  * Calculate a maximum of two intercept points for a line going throug an
  * ellipse.
  */
-export function ellipseSegmentInterceptPoints<
-  Point extends GlobalPoint | LocalPoint,
->(e: Readonly<Ellipse<Point>>, s: Readonly<LineSegment<Point>>): Point[] {
+export function ellipseSegmentInterceptPoints<Point extends GenericPoint>(
+  e: Readonly<Ellipse<Point>>,
+  s: Readonly<LineSegment<Point>>,
+): Point[] {
   const rx = e.halfWidth;
   const ry = e.halfHeight;
 
@@ -194,9 +187,7 @@ export function ellipseSegmentInterceptPoints<
   return intersections;
 }
 
-export function ellipseLineIntersectionPoints<
-  Point extends GlobalPoint | LocalPoint,
->(
+export function ellipseLineIntersectionPoints<Point extends GenericPoint>(
   { center, halfWidth, halfHeight }: Ellipse<Point>,
   [g, h]: Line<Point>,
 ): Point[] {

--- a/packages/math/src/line.ts
+++ b/packages/math/src/line.ts
@@ -1,6 +1,6 @@
 import { pointFrom } from "./point";
 
-import type { GlobalPoint, Line, LocalPoint } from "./types";
+import type { GenericPoint, Line } from "./types";
 
 /**
  * Create a line from two points.
@@ -8,7 +8,7 @@ import type { GlobalPoint, Line, LocalPoint } from "./types";
  * @param points The two points lying on the line
  * @returns The line on which the points lie
  */
-export function line<P extends GlobalPoint | LocalPoint>(a: P, b: P): Line<P> {
+export function line<P extends GenericPoint>(a: P, b: P): Line<P> {
   return [a, b] as Line<P>;
 }
 
@@ -20,7 +20,7 @@ export function line<P extends GlobalPoint | LocalPoint>(a: P, b: P): Line<P> {
  * @param b
  * @returns
  */
-export function linesIntersectAt<Point extends GlobalPoint | LocalPoint>(
+export function linesIntersectAt<Point extends GenericPoint>(
   a: Line<Point>,
   b: Line<Point>,
 ): Point | null {

--- a/packages/math/src/point.ts
+++ b/packages/math/src/point.ts
@@ -2,13 +2,7 @@ import { degreesToRadians } from "./angle";
 import { PRECISION } from "./utils";
 import { vectorFromPoint, vectorScale } from "./vector";
 
-import type {
-  LocalPoint,
-  GlobalPoint,
-  Radians,
-  Degrees,
-  Vector,
-} from "./types";
+import type { Degrees, GenericPoint, Radians, Vector } from "./types";
 
 /**
  * Create a properly typed Point instance from the X and Y coordinates.
@@ -17,7 +11,7 @@ import type {
  * @param y The Y coordinate
  * @returns The branded and created point
  */
-export function pointFrom<Point extends GlobalPoint | LocalPoint>(
+export function pointFrom<Point extends GenericPoint>(
   x: number,
   y: number,
 ): Point {
@@ -30,7 +24,7 @@ export function pointFrom<Point extends GlobalPoint | LocalPoint>(
  * @param numberArray The number array to check and to convert to Point
  * @returns The point instance
  */
-export function pointFromArray<Point extends GlobalPoint | LocalPoint>(
+export function pointFromArray<Point extends GenericPoint>(
   numberArray: number[],
 ): Point | undefined {
   return numberArray.length === 2
@@ -44,7 +38,7 @@ export function pointFromArray<Point extends GlobalPoint | LocalPoint>(
  * @param pair A number pair to convert to Point
  * @returns The point instance
  */
-export function pointFromPair<Point extends GlobalPoint | LocalPoint>(
+export function pointFromPair<Point extends GenericPoint>(
   pair: [number, number],
 ): Point {
   return pair as Point;
@@ -56,7 +50,7 @@ export function pointFromPair<Point extends GlobalPoint | LocalPoint>(
  * @param v The vector to convert
  * @returns The point the vector points at with origin 0,0
  */
-export function pointFromVector<P extends GlobalPoint | LocalPoint>(
+export function pointFromVector<P extends GenericPoint>(
   v: Vector,
   offset: P = pointFrom(0, 0),
 ): P {
@@ -69,7 +63,7 @@ export function pointFromVector<P extends GlobalPoint | LocalPoint>(
  * @param p The value to attempt verification on
  * @returns TRUE if the provided value has the shape of a local or global point
  */
-export function isPoint(p: unknown): p is LocalPoint | GlobalPoint {
+export function isPoint(p: unknown): p is GenericPoint {
   return (
     Array.isArray(p) &&
     p.length === 2 &&
@@ -88,7 +82,7 @@ export function isPoint(p: unknown): p is LocalPoint | GlobalPoint {
  * @param b Point The second point to compare
  * @returns TRUE if the points are sufficiently close to each other
  */
-export function pointsEqual<Point extends GlobalPoint | LocalPoint>(
+export function pointsEqual<Point extends GenericPoint>(
   a: Point,
   b: Point,
   tolerance: number = PRECISION,
@@ -105,7 +99,7 @@ export function pointsEqual<Point extends GlobalPoint | LocalPoint>(
  * @param angle The radians to rotate the point by
  * @returns The rotated point
  */
-export function pointRotateRads<Point extends GlobalPoint | LocalPoint>(
+export function pointRotateRads<Point extends GenericPoint>(
   [x, y]: Point,
   [cx, cy]: Point,
   angle: Radians,
@@ -124,7 +118,7 @@ export function pointRotateRads<Point extends GlobalPoint | LocalPoint>(
  * @param angle The degree to rotate the point by
  * @returns The rotated point
  */
-export function pointRotateDegs<Point extends GlobalPoint | LocalPoint>(
+export function pointRotateDegs<Point extends GenericPoint>(
   point: Point,
   center: Point,
   angle: Degrees,
@@ -146,8 +140,8 @@ export function pointRotateDegs<Point extends GlobalPoint | LocalPoint>(
  */
 // TODO 99% of use is translating between global and local coords, which need to be formalized
 export function pointTranslate<
-  From extends GlobalPoint | LocalPoint,
-  To extends GlobalPoint | LocalPoint,
+  From extends GenericPoint,
+  To extends GenericPoint,
 >(p: From, v: Vector = [0, 0] as Vector): To {
   return pointFrom(p[0] + v[0], p[1] + v[1]);
 }
@@ -159,7 +153,7 @@ export function pointTranslate<
  * @param b The other point to create the middle point for
  * @returns The middle point
  */
-export function pointCenter<P extends LocalPoint | GlobalPoint>(a: P, b: P): P {
+export function pointCenter<P extends GenericPoint>(a: P, b: P): P {
   return pointFrom((a[0] + b[0]) / 2, (a[1] + b[1]) / 2);
 }
 
@@ -170,10 +164,7 @@ export function pointCenter<P extends LocalPoint | GlobalPoint>(a: P, b: P): P {
  * @param b Second point
  * @returns The euclidean distance between the two points.
  */
-export function pointDistance<P extends LocalPoint | GlobalPoint>(
-  a: P,
-  b: P,
-): number {
+export function pointDistance<P extends GenericPoint>(a: P, b: P): number {
   return Math.hypot(b[0] - a[0], b[1] - a[1]);
 }
 
@@ -186,10 +177,7 @@ export function pointDistance<P extends LocalPoint | GlobalPoint>(
  * @param b Second point
  * @returns The euclidean distance between the two points.
  */
-export function pointDistanceSq<P extends LocalPoint | GlobalPoint>(
-  a: P,
-  b: P,
-): number {
+export function pointDistanceSq<P extends GenericPoint>(a: P, b: P): number {
   const xDiff = b[0] - a[0];
   const yDiff = b[1] - a[1];
 
@@ -204,7 +192,7 @@ export function pointDistanceSq<P extends LocalPoint | GlobalPoint>(
  * @param multiplier The scaling factor
  * @returns
  */
-export const pointScaleFromOrigin = <P extends GlobalPoint | LocalPoint>(
+export const pointScaleFromOrigin = <P extends GenericPoint>(
   p: P,
   mid: P,
   multiplier: number,
@@ -219,7 +207,7 @@ export const pointScaleFromOrigin = <P extends GlobalPoint | LocalPoint>(
  * @param r The other point to compare against
  * @returns TRUE if q is indeed between p and r
  */
-export const isPointWithinBounds = <P extends GlobalPoint | LocalPoint>(
+export const isPointWithinBounds = <P extends GenericPoint>(
   p: P,
   q: P,
   r: P,

--- a/packages/math/src/polygon.ts
+++ b/packages/math/src/polygon.ts
@@ -2,21 +2,17 @@ import { pointsEqual } from "./point";
 import { lineSegment, pointOnLineSegment } from "./segment";
 import { PRECISION } from "./utils";
 
-import type { GlobalPoint, LocalPoint, Polygon } from "./types";
+import type { GenericPoint, Polygon } from "./types";
 
-export function polygon<Point extends GlobalPoint | LocalPoint>(
-  ...points: Point[]
-) {
+export function polygon<Point extends GenericPoint>(...points: Point[]) {
   return polygonClose(points) as Polygon<Point>;
 }
 
-export function polygonFromPoints<Point extends GlobalPoint | LocalPoint>(
-  points: Point[],
-) {
+export function polygonFromPoints<Point extends GenericPoint>(points: Point[]) {
   return polygonClose(points) as Polygon<Point>;
 }
 
-export const polygonIncludesPoint = <Point extends LocalPoint | GlobalPoint>(
+export const polygonIncludesPoint = <Point extends GenericPoint>(
   point: Point,
   polygon: Polygon<Point>,
 ) => {
@@ -41,7 +37,7 @@ export const polygonIncludesPoint = <Point extends LocalPoint | GlobalPoint>(
   return inside;
 };
 
-export const polygonIncludesPointNonZero = <Point extends [number, number]>(
+export const polygonIncludesPointNonZero = <Point extends GenericPoint>(
   point: Point,
   polygon: Point[],
 ): boolean => {
@@ -69,7 +65,7 @@ export const polygonIncludesPointNonZero = <Point extends [number, number]>(
   return windingNumber !== 0;
 };
 
-export const pointOnPolygon = <Point extends LocalPoint | GlobalPoint>(
+export const pointOnPolygon = <Point extends GenericPoint>(
   p: Point,
   poly: Polygon<Point>,
   threshold = PRECISION,
@@ -86,16 +82,12 @@ export const pointOnPolygon = <Point extends LocalPoint | GlobalPoint>(
   return on;
 };
 
-function polygonClose<Point extends LocalPoint | GlobalPoint>(
-  polygon: Point[],
-) {
+function polygonClose<Point extends GenericPoint>(polygon: Point[]) {
   return polygonIsClosed(polygon)
     ? polygon
     : ([...polygon, polygon[0]] as Polygon<Point>);
 }
 
-function polygonIsClosed<Point extends LocalPoint | GlobalPoint>(
-  polygon: Point[],
-) {
+function polygonIsClosed<Point extends GenericPoint>(polygon: Point[]) {
   return pointsEqual(polygon[0], polygon[polygon.length - 1]);
 }

--- a/packages/math/src/rectangle.ts
+++ b/packages/math/src/rectangle.ts
@@ -1,24 +1,28 @@
 import { pointFrom } from "./point";
 import { lineSegment, lineSegmentIntersectionPoints } from "./segment";
 
-import type { GlobalPoint, LineSegment, LocalPoint, Rectangle } from "./types";
+import type { GenericPoint, LineSegment, Rectangle } from "./types";
 
-export function rectangle<P extends GlobalPoint | LocalPoint>(
+export function rectangle<P extends GenericPoint>(
   topLeft: P,
   bottomRight: P,
 ): Rectangle<P> {
   return [topLeft, bottomRight] as Rectangle<P>;
 }
 
-export function rectangleFromNumberSequence<
-  Point extends LocalPoint | GlobalPoint,
->(minX: number, minY: number, maxX: number, maxY: number) {
+export function rectangleFromNumberSequence<Point extends GenericPoint>(
+  minX: number,
+  minY: number,
+  maxX: number,
+  maxY: number,
+) {
   return rectangle(pointFrom<Point>(minX, minY), pointFrom<Point>(maxX, maxY));
 }
 
-export function rectangleIntersectLineSegment<
-  Point extends LocalPoint | GlobalPoint,
->(r: Rectangle<Point>, l: LineSegment<Point>): Point[] {
+export function rectangleIntersectLineSegment<Point extends GenericPoint>(
+  r: Rectangle<Point>,
+  l: LineSegment<Point>,
+): Point[] {
   return [
     lineSegment(r[0], pointFrom(r[1][0], r[0][1])),
     lineSegment(pointFrom(r[1][0], r[0][1]), r[1]),
@@ -29,9 +33,10 @@ export function rectangleIntersectLineSegment<
     .filter((i): i is Point => !!i);
 }
 
-export function rectangleIntersectRectangle<
-  Point extends LocalPoint | GlobalPoint,
->(rectangle1: Rectangle<Point>, rectangle2: Rectangle<Point>): boolean {
+export function rectangleIntersectRectangle<Point extends GenericPoint>(
+  rectangle1: Rectangle<Point>,
+  rectangle2: Rectangle<Point>,
+): boolean {
   const [[minX1, minY1], [maxX1, maxY1]] = rectangle1;
   const [[minX2, minY2], [maxX2, maxY2]] = rectangle2;
 

--- a/packages/math/src/segment.ts
+++ b/packages/math/src/segment.ts
@@ -14,7 +14,7 @@ import {
   vectorSubtract,
 } from "./vector";
 
-import type { GlobalPoint, LineSegment, LocalPoint, Radians } from "./types";
+import type { LineSegment, GenericPoint, Radians } from "./types";
 
 /**
  * Create a line segment from two points.
@@ -22,7 +22,7 @@ import type { GlobalPoint, LineSegment, LocalPoint, Radians } from "./types";
  * @param points The two points delimiting the line segment on each end
  * @returns The line segment delineated by the points
  */
-export function lineSegment<P extends GlobalPoint | LocalPoint>(
+export function lineSegment<P extends GenericPoint>(
   a: P,
   b: P,
 ): LineSegment<P> {
@@ -34,7 +34,7 @@ export function lineSegment<P extends GlobalPoint | LocalPoint>(
  * @param segment
  * @returns
  */
-export const isLineSegment = <Point extends GlobalPoint | LocalPoint>(
+export const isLineSegment = <Point extends GenericPoint>(
   segment: unknown,
 ): segment is LineSegment<Point> =>
   Array.isArray(segment) &&
@@ -51,7 +51,7 @@ export const isLineSegment = <Point extends GlobalPoint | LocalPoint>(
  * @param origin
  * @returns
  */
-export const lineSegmentRotate = <Point extends LocalPoint | GlobalPoint>(
+export const lineSegmentRotate = <Point extends GenericPoint>(
   l: LineSegment<Point>,
   angle: Radians,
   origin?: Point,
@@ -66,7 +66,7 @@ export const lineSegmentRotate = <Point extends LocalPoint | GlobalPoint>(
  * Calculates the point two line segments with a definite start and end point
  * intersect at.
  */
-export const segmentsIntersectAt = <Point extends GlobalPoint | LocalPoint>(
+export const segmentsIntersectAt = <Point extends GenericPoint>(
   a: Readonly<LineSegment<Point>>,
   b: Readonly<LineSegment<Point>>,
 ): Point | null => {
@@ -99,7 +99,7 @@ export const segmentsIntersectAt = <Point extends GlobalPoint | LocalPoint>(
   return null;
 };
 
-export const pointOnLineSegment = <Point extends LocalPoint | GlobalPoint>(
+export const pointOnLineSegment = <Point extends GenericPoint>(
   point: Point,
   line: LineSegment<Point>,
   threshold = PRECISION,
@@ -113,7 +113,7 @@ export const pointOnLineSegment = <Point extends LocalPoint | GlobalPoint>(
   return distance < threshold;
 };
 
-export const distanceToLineSegment = <Point extends LocalPoint | GlobalPoint>(
+export const distanceToLineSegment = <Point extends GenericPoint>(
   point: Point,
   line: LineSegment<Point>,
 ) => {
@@ -158,9 +158,7 @@ export const distanceToLineSegment = <Point extends LocalPoint | GlobalPoint>(
  * @param s
  * @returns
  */
-export function lineSegmentIntersectionPoints<
-  Point extends GlobalPoint | LocalPoint,
->(
+export function lineSegmentIntersectionPoints<Point extends GenericPoint>(
   l: LineSegment<Point>,
   s: LineSegment<Point>,
   threshold?: number,
@@ -178,7 +176,7 @@ export function lineSegmentIntersectionPoints<
   return candidate;
 }
 
-export function lineSegmentsDistance<Point extends GlobalPoint | LocalPoint>(
+export function lineSegmentsDistance<Point extends GenericPoint>(
   s1: LineSegment<Point>,
   s2: LineSegment<Point>,
 ): number {

--- a/packages/math/src/triangle.ts
+++ b/packages/math/src/triangle.ts
@@ -1,4 +1,4 @@
-import type { GlobalPoint, LocalPoint, Triangle } from "./types";
+import type { GenericPoint, Triangle } from "./types";
 
 // Types
 
@@ -11,7 +11,7 @@ import type { GlobalPoint, LocalPoint, Triangle } from "./types";
  * @param p The point to test whether is in the triangle
  * @returns TRUE if the point is inside of the triangle
  */
-export function triangleIncludesPoint<P extends GlobalPoint | LocalPoint>(
+export function triangleIncludesPoint<P extends GenericPoint>(
   [a, b, c]: Triangle<P>,
   p: P,
 ): boolean {

--- a/packages/math/src/types.ts
+++ b/packages/math/src/types.ts
@@ -43,12 +43,18 @@ export type LocalPoint = [x: number, y: number] & {
   _brand: "excalimath__localpoint";
 };
 
+export type ViewportPoint = [x: number, y: number] & {
+  _brand: "excalimath__viewportpoint";
+};
+
+export type GenericPoint = GlobalPoint | LocalPoint | ViewportPoint;
+
 // Line
 
 /**
  * A line is an infinitely long object with no width, depth, or curvature.
  */
-export type Line<P extends GlobalPoint | LocalPoint> = [p: P, q: P] & {
+export type Line<P extends GenericPoint> = [p: P, q: P] & {
   _brand: "excalimath_line";
 };
 
@@ -57,7 +63,7 @@ export type Line<P extends GlobalPoint | LocalPoint> = [p: P, q: P] & {
  * line that is bounded by two distinct end points, and
  * contains every point on the line that is between its endpoints.
  */
-export type LineSegment<P extends GlobalPoint | LocalPoint> = [a: P, b: P] & {
+export type LineSegment<P extends GenericPoint> = [a: P, b: P] & {
   _brand: "excalimath_linesegment";
 };
 
@@ -77,18 +83,14 @@ export type Vector = [u: number, v: number] & {
 /**
  * A triangle represented by 3 points
  */
-export type Triangle<P extends GlobalPoint | LocalPoint> = [
-  a: P,
-  b: P,
-  c: P,
-] & {
+export type Triangle<P extends GenericPoint> = [a: P, b: P, c: P] & {
   _brand: "excalimath__triangle";
 };
 
 /**
  * A rectangular shape represented by 4 points at its corners
  */
-export type Rectangle<P extends GlobalPoint | LocalPoint> = [a: P, b: P] & {
+export type Rectangle<P extends GenericPoint> = [a: P, b: P] & {
   _brand: "excalimath__rectangle";
 };
 
@@ -100,7 +102,7 @@ export type Rectangle<P extends GlobalPoint | LocalPoint> = [a: P, b: P] & {
  * A polygon is a closed shape by connecting the given points
  * rectangles and diamonds are modelled by polygons
  */
-export type Polygon<Point extends GlobalPoint | LocalPoint> = Point[] & {
+export type Polygon<Point extends GenericPoint> = Point[] & {
   _brand: "excalimath_polygon";
 };
 
@@ -111,12 +113,7 @@ export type Polygon<Point extends GlobalPoint | LocalPoint> = Point[] & {
 /**
  * Cubic bezier curve with four control points
  */
-export type Curve<Point extends GlobalPoint | LocalPoint> = [
-  Point,
-  Point,
-  Point,
-  Point,
-] & {
+export type Curve<Point extends GenericPoint> = [Point, Point, Point, Point] & {
   _brand: "excalimath_curve";
 };
 
@@ -131,7 +128,7 @@ export type PolarCoords = [
   but for the sake of simplicity, we've used halfWidth and halfHeight instead
   in replace of semi major and semi minor axes
  */
-export type Ellipse<Point extends GlobalPoint | LocalPoint> = {
+export type Ellipse<Point extends GenericPoint> = {
   center: Point;
   halfWidth: number;
   halfHeight: number;

--- a/packages/math/src/vector.ts
+++ b/packages/math/src/vector.ts
@@ -1,4 +1,4 @@
-import type { GlobalPoint, LocalPoint, Vector } from "./types";
+import type { GenericPoint, Vector } from "./types";
 
 /**
  * Create a vector from the x and y coordiante elements.
@@ -25,7 +25,7 @@ export function vector(
  * @param defaultValue The default value to return if the vector is 'undefined'
  * @returns The created vector from the point and the origin or default
  */
-export function vectorFromPoint<Point extends GlobalPoint | LocalPoint>(
+export function vectorFromPoint<Point extends GenericPoint>(
   p: Point,
   origin: Point = [0, 0] as Point,
   threshold?: number,

--- a/packages/utils/src/bbox.ts
+++ b/packages/utils/src/bbox.ts
@@ -1,17 +1,14 @@
 import {
   vectorCross,
   vectorFromPoint,
-  type GlobalPoint,
-  type LocalPoint,
+  type GenericPoint,
 } from "@excalidraw/math";
 
 import type { Bounds } from "@excalidraw/common";
 
-export type LineSegment<P extends LocalPoint | GlobalPoint> = [P, P];
+export type LineSegment<P extends GenericPoint> = [P, P];
 
-export function getBBox<P extends LocalPoint | GlobalPoint>(
-  line: LineSegment<P>,
-): Bounds {
+export function getBBox<P extends GenericPoint>(line: LineSegment<P>): Bounds {
   return [
     Math.min(line[0][0], line[1][0]),
     Math.min(line[0][1], line[1][1]),
@@ -26,10 +23,7 @@ export function doBBoxesIntersect(a: Bounds, b: Bounds) {
 
 const EPSILON = 0.000001;
 
-export function isPointOnLine<P extends GlobalPoint | LocalPoint>(
-  l: LineSegment<P>,
-  p: P,
-) {
+export function isPointOnLine<P extends GenericPoint>(l: LineSegment<P>, p: P) {
   const p1 = vectorFromPoint(l[1], l[0]);
   const p2 = vectorFromPoint(p, l[0]);
 
@@ -38,7 +32,7 @@ export function isPointOnLine<P extends GlobalPoint | LocalPoint>(
   return Math.abs(r) < EPSILON;
 }
 
-export function isPointRightOfLine<P extends GlobalPoint | LocalPoint>(
+export function isPointRightOfLine<P extends GenericPoint>(
   l: LineSegment<P>,
   p: P,
 ) {
@@ -48,9 +42,10 @@ export function isPointRightOfLine<P extends GlobalPoint | LocalPoint>(
   return vectorCross(p1, p2) < 0;
 }
 
-export function isLineSegmentTouchingOrCrossingLine<
-  P extends GlobalPoint | LocalPoint,
->(a: LineSegment<P>, b: LineSegment<P>) {
+export function isLineSegmentTouchingOrCrossingLine<P extends GenericPoint>(
+  a: LineSegment<P>,
+  b: LineSegment<P>,
+) {
   return (
     isPointOnLine(a, b[0]) ||
     isPointOnLine(a, b[1]) ||
@@ -61,7 +56,7 @@ export function isLineSegmentTouchingOrCrossingLine<
 }
 
 // https://martin-thoma.com/how-to-check-if-two-line-segments-intersect/
-export function doLineSegmentsIntersect<P extends GlobalPoint | LocalPoint>(
+export function doLineSegmentsIntersect<P extends GenericPoint>(
   a: LineSegment<P>,
   b: LineSegment<P>,
 ) {

--- a/packages/utils/src/shape.ts
+++ b/packages/utils/src/shape.ts
@@ -17,8 +17,8 @@ import { invariant } from "@excalidraw/common";
 import {
   curve,
   lineSegment,
-  pointFrom,
   pointDistance,
+  pointFrom,
   pointFromArray,
   pointFromVector,
   pointRotateRads,
@@ -30,8 +30,6 @@ import {
   vectorAdd,
   vectorFromPoint,
   vectorScale,
-  type GlobalPoint,
-  type LocalPoint,
 } from "@excalidraw/math";
 
 import { getElementAbsoluteCoords } from "@excalidraw/element";
@@ -52,31 +50,36 @@ import type {
   ExcalidrawSelectionElement,
   ExcalidrawTextElement,
 } from "@excalidraw/element/types";
-import type { Curve, LineSegment, Polygon, Radians } from "@excalidraw/math";
+import type {
+  Curve,
+  LineSegment,
+  GenericPoint,
+  Polygon,
+  Radians,
+} from "@excalidraw/math";
 
 import type { Drawable, Op } from "roughjs/bin/core";
 
 // a polyline (made up term here) is a line consisting of other line segments
 // this corresponds to a straight line element in the editor but it could also
 // be used to model other elements
-export type Polyline<Point extends GlobalPoint | LocalPoint> =
-  LineSegment<Point>[];
+export type Polyline<Point extends GenericPoint> = LineSegment<Point>[];
 
 // a polycurve is a curve consisting of ther curves, this corresponds to a complex
 // curve on the canvas
-export type Polycurve<Point extends GlobalPoint | LocalPoint> = Curve<Point>[];
+export type Polycurve<Point extends GenericPoint> = Curve<Point>[];
 
 // an ellipse is specified by its center, angle, and its major and minor axes
 // but for the sake of simplicity, we've used halfWidth and halfHeight instead
 // in replace of semi major and semi minor axes
-export type Ellipse<Point extends GlobalPoint | LocalPoint> = {
+export type Ellipse<Point extends GenericPoint> = {
   center: Point;
   angle: Radians;
   halfWidth: number;
   halfHeight: number;
 };
 
-export type GeometricShape<Point extends GlobalPoint | LocalPoint> =
+export type GeometricShape<Point extends GenericPoint> =
   | {
       type: "line";
       data: LineSegment<Point>;
@@ -113,7 +116,7 @@ type RectangularElement =
   | ExcalidrawSelectionElement;
 
 // polygon
-export const getPolygonShape = <Point extends GlobalPoint | LocalPoint>(
+export const getPolygonShape = <Point extends GenericPoint>(
   element: RectangularElement,
 ): GeometricShape<Point> => {
   const { angle, width, height, x, y } = element;
@@ -148,7 +151,7 @@ export const getPolygonShape = <Point extends GlobalPoint | LocalPoint>(
 };
 
 // return the selection box for an element, possibly rotated as well
-export const getSelectionBoxShape = <Point extends GlobalPoint | LocalPoint>(
+export const getSelectionBoxShape = <Point extends GenericPoint>(
   element: ExcalidrawElement,
   elementsMap: ElementsMap,
   padding = 10,
@@ -178,7 +181,7 @@ export const getSelectionBoxShape = <Point extends GlobalPoint | LocalPoint>(
 };
 
 // ellipse
-export const getEllipseShape = <Point extends GlobalPoint | LocalPoint>(
+export const getEllipseShape = <Point extends GenericPoint>(
   element: ExcalidrawEllipseElement,
 ): GeometricShape<Point> => {
   const { width, height, angle, x, y } = element;
@@ -209,7 +212,7 @@ export const getCurvePathOps = (shape: Drawable): Op[] => {
 };
 
 // linear
-export const getCurveShape = <Point extends GlobalPoint | LocalPoint>(
+export const getCurveShape = <Point extends GenericPoint>(
   roughShape: Drawable,
   startingPoint: Point = pointFrom(0, 0),
   angleInRadian: Radians,
@@ -247,7 +250,7 @@ export const getCurveShape = <Point extends GlobalPoint | LocalPoint>(
   };
 };
 
-const polylineFromPoints = <Point extends GlobalPoint | LocalPoint>(
+const polylineFromPoints = <Point extends GenericPoint>(
   points: Point[],
 ): Polyline<Point> => {
   let previousPoint: Point = points[0];
@@ -262,7 +265,7 @@ const polylineFromPoints = <Point extends GlobalPoint | LocalPoint>(
   return polyline;
 };
 
-export const getFreedrawShape = <Point extends GlobalPoint | LocalPoint>(
+export const getFreedrawShape = <Point extends GenericPoint>(
   element: ExcalidrawFreeDrawElement,
   center: Point,
   isClosed: boolean = false,
@@ -293,7 +296,7 @@ export const getFreedrawShape = <Point extends GlobalPoint | LocalPoint>(
   ) as GeometricShape<Point>;
 };
 
-export const getClosedCurveShape = <Point extends GlobalPoint | LocalPoint>(
+export const getClosedCurveShape = <Point extends GenericPoint>(
   element: ExcalidrawLinearElement,
   roughShape: Drawable,
   startingPoint: Point = pointFrom<Point>(0, 0),
@@ -359,9 +362,7 @@ export const getClosedCurveShape = <Point extends GlobalPoint | LocalPoint>(
  * @returns An array of intersections
  */
 // TODO: Replace with final rounded rectangle code
-export const segmentIntersectRectangleElement = <
-  Point extends LocalPoint | GlobalPoint,
->(
+export const segmentIntersectRectangleElement = <Point extends GenericPoint>(
   element: ExcalidrawBindableElement,
   segment: LineSegment<Point>,
   gap: number = 0,
@@ -399,7 +400,7 @@ export const segmentIntersectRectangleElement = <
     .filter((i): i is Point => !!i);
 };
 
-const distanceToEllipse = <Point extends LocalPoint | GlobalPoint>(
+const distanceToEllipse = <Point extends GenericPoint>(
   p: Point,
   ellipse: Ellipse<Point>,
 ) => {
@@ -456,7 +457,7 @@ const distanceToEllipse = <Point extends LocalPoint | GlobalPoint>(
   );
 };
 
-export const pointOnEllipse = <Point extends LocalPoint | GlobalPoint>(
+export const pointOnEllipse = <Point extends GenericPoint>(
   point: Point,
   ellipse: Ellipse<Point>,
   threshold = PRECISION,
@@ -464,7 +465,7 @@ export const pointOnEllipse = <Point extends LocalPoint | GlobalPoint>(
   return distanceToEllipse(point, ellipse) <= threshold;
 };
 
-export const pointInEllipse = <Point extends LocalPoint | GlobalPoint>(
+export const pointInEllipse = <Point extends GenericPoint>(
   p: Point,
   ellipse: Ellipse<Point>,
 ) => {
@@ -486,7 +487,7 @@ export const pointInEllipse = <Point extends LocalPoint | GlobalPoint>(
   );
 };
 
-export const ellipseAxes = <Point extends LocalPoint | GlobalPoint>(
+export const ellipseAxes = <Point extends GenericPoint>(
   ellipse: Ellipse<Point>,
 ) => {
   const widthGreaterThanHeight = ellipse.halfWidth > ellipse.halfHeight;
@@ -504,7 +505,7 @@ export const ellipseAxes = <Point extends LocalPoint | GlobalPoint>(
   };
 };
 
-export const ellipseFocusToCenter = <Point extends LocalPoint | GlobalPoint>(
+export const ellipseFocusToCenter = <Point extends GenericPoint>(
   ellipse: Ellipse<Point>,
 ) => {
   const { majorAxis, minorAxis } = ellipseAxes(ellipse);
@@ -512,7 +513,7 @@ export const ellipseFocusToCenter = <Point extends LocalPoint | GlobalPoint>(
   return Math.sqrt(majorAxis ** 2 - minorAxis ** 2);
 };
 
-export const ellipseExtremes = <Point extends LocalPoint | GlobalPoint>(
+export const ellipseExtremes = <Point extends GenericPoint>(
   ellipse: Ellipse<Point>,
 ) => {
   const { center, angle } = ellipse;


### PR DESCRIPTION
  - add new type ViewportPoint
  - add type union GenericPoint which consists all possible points
  - typ [number, number] types with Point types where applicable
  - enhance few usage of existing logic around points

I've run `yarn test:all` locally. Everything passed, expect of few tests which timeouted :)

This MR closes #9297 