### PR TITLE
feat: add shortcut to clear canvas menu item

### DIFF
--- a/packages/excalidraw/components/main-menu/DefaultItems.tsx
+++ b/packages/excalidraw/components/main-menu/DefaultItems.tsx
@@ -203,6 +203,7 @@ export const ClearCanvas = () => {
     <DropdownMenuItem
       icon={TrashIcon}
       onSelect={() => setActiveConfirmDialog("clearCanvas")}
+      shortcut={getShortcutFromShortcutName("clearCanvas")}
       data-testid="clear-canvas-button"
       aria-label={t("buttons.clearReset")}
     >


### PR DESCRIPTION
This PR adds a keyboard shortcut hint to the Clear Canvas item in the main dropdown menu. This improves discoverability for users who want to quickly reset their workspace using keyboard shortcuts.

Before :-
<img width="231" height="37" alt="Screenshot from 2025-12-22 21-43-27" src="https://github.com/user-attachments/assets/2acceb0f-294d-4e30-ad68-966bd0233c26" />

After :-

<img width="231" height="37" alt="Screenshot from 2025-12-22 21-44-58" src="https://github.com/user-attachments/assets/623a7259-ace0-4ac8-9429-03cefe0d04c2" />

issue :- #10558
