### PR TITLE
fix: to support wrapping with autoResize and given dimensions

### DIFF
--- a/packages/element/src/textElement.ts
+++ b/packages/element/src/textElement.ts
@@ -8,6 +8,8 @@ import {
   getFontString,
   isProdEnv,
   invariant,
+  DEFAULT_FONT_FAMILY,
+  getLineHeight,
 } from "@excalidraw/common";
 
 import { pointFrom, pointRotateRads, type Radians } from "@excalidraw/math";
@@ -30,6 +32,8 @@ import {
   isTextElement,
 } from "./typeChecks";
 
+import type { NewTextElementOptions } from "./newElement";
+
 import type { Scene } from "./Scene";
 
 import type { MaybeTransformHandleType } from "./transformHandles";
@@ -40,6 +44,7 @@ import type {
   ExcalidrawTextContainer,
   ExcalidrawTextElement,
   ExcalidrawTextElementWithContainer,
+  FontFamilyValues,
   NonDeletedExcalidrawElement,
 } from "./types";
 
@@ -527,4 +532,25 @@ export const getTextFromElements = (
     }, [])
     .join(separator);
   return text;
+};
+
+/** When text is already measured and wrapped, we want to respect those dimensions */
+export const getInitialTextMetrics = (
+  text: NewTextElementOptions,
+  fontFamily: FontFamilyValues = DEFAULT_FONT_FAMILY,
+  fontSize: number = DEFAULT_FONT_SIZE,
+) => {
+  const shouldUseProvidedDimensions =
+    text.autoResize === false && text.width && text.height;
+
+  return shouldUseProvidedDimensions
+    ? {
+        width: text.width,
+        height: text.height,
+      }
+    : measureText(
+        text.text,
+        getFontString({ fontFamily, fontSize }),
+        text.lineHeight ?? getLineHeight(fontFamily),
+      );
 };

--- a/packages/element/src/transform.ts
+++ b/packages/element/src/transform.ts
@@ -10,10 +10,8 @@ import {
   arrayToMap,
   assertNever,
   cloneJSON,
-  getFontString,
   isDevEnv,
   toBrandedType,
-  getLineHeight,
 } from "@excalidraw/common";
 
 import type { MarkOptional } from "@excalidraw/common/utility-types";
@@ -29,12 +27,11 @@ import {
   newTextElement,
   type ElementConstructorOpts,
 } from "./newElement";
-import { measureText, normalizeText } from "./textMeasurements";
 import { isArrowElement } from "./typeChecks";
 
 import { syncInvalidIndices } from "./fractionalIndex";
 
-import { redrawTextBoundingBox } from "./textElement";
+import { getInitialTextMetrics, redrawTextBoundingBox } from "./textElement";
 
 import { LinearElementEditor } from "./linearElementEditor";
 
@@ -579,20 +576,7 @@ export const convertToExcalidrawElements = (
       case "text": {
         const fontFamily = element?.fontFamily || DEFAULT_FONT_FAMILY;
         const fontSize = element?.fontSize || DEFAULT_FONT_SIZE;
-        const lineHeight = element?.lineHeight || getLineHeight(fontFamily);
-        const text = element.text ?? "";
-        const shouldUseProvidedDimensions =
-          element.autoResize === false && element.width && element.height;
-        const metrics = shouldUseProvidedDimensions
-          ? {
-              width: element.width,
-              height: element.height,
-            }
-          : measureText(
-              normalizeText(text),
-              getFontString({ fontFamily, fontSize }),
-              lineHeight,
-            );
+        const metrics = getInitialTextMetrics(element, fontFamily, fontSize);
 
         excalidrawElement = newTextElement({
           width: metrics.width,


### PR DESCRIPTION
On the server, we can wrap and measure the wrapped text. This would put "\n"s in the original text. The changes in the PR is to ensure that text can unwrap on the client.