### PR TITLE
fix: incorrect position after zoomToFit on mobile viewport

### DIFF
--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -4404,9 +4404,12 @@ class App extends React.Component<AppProps, AppState> {
   );
 
   public getEditorUIOffsets = (): Offsets => {
+    const isMobile = this.editorInterface.formFactor === "phone";
+    const toolBarSelector = isMobile ? ".App-toolbar-content" : ".App-toolbar";
+
     const toolbarBottom =
       this.excalidrawContainerRef?.current
-        ?.querySelector(".App-toolbar")
+        ?.querySelector(toolBarSelector)
         ?.getBoundingClientRect()?.bottom ?? 0;
     const sidebarRect = this.excalidrawContainerRef?.current
       ?.querySelector(".sidebar")


### PR DESCRIPTION
Before:

https://github.com/user-attachments/assets/226e8e92-a199-4bdb-aeea-8257071d8874

After:


https://github.com/user-attachments/assets/d6301357-0938-40f5-a8aa-c09e23f298f2

