### PR TITLE
fix: elbow arrow ALT+drag duplication binding issue (#8435)

### DIFF
--- a/packages/element/src/binding.ts
+++ b/packages/element/src/binding.ts
@@ -1838,8 +1838,17 @@ export const fixDuplicatedBindingsAfterDuplication = (
   duplicatedElements: ExcalidrawElement[],
   origIdToDuplicateId: Map<ExcalidrawElement["id"], ExcalidrawElement["id"]>,
   duplicateElementsMap: NonDeletedSceneElementsMap,
+  isAltDrag?: boolean,
 ) => {
+  // For "everything" type duplication (programmatic, not user interaction),
+  // isAltDrag is undefined and we preserve all bindings like before.
+  // For "in-place" duplication:
+  // - isAltDrag = true: ALT+drag - keep bindings only when both elements are duplicated
+  // - isAltDrag = false: Ctrl+D - remove arrow bindings, but keep container bindings
+  const shouldPreserveAllBindings = isAltDrag === undefined;
+
   for (const duplicateElement of duplicatedElements) {
+    // For boundElements (arrows/text bound to this element)
     if ("boundElements" in duplicateElement && duplicateElement.boundElements) {
       Object.assign(duplicateElement, {
         boundElements: duplicateElement.boundElements.reduce(
@@ -1848,8 +1857,18 @@ export const fixDuplicatedBindingsAfterDuplication = (
             binding,
           ) => {
             const newBindingId = origIdToDuplicateId.get(binding.id);
-            if (newBindingId) {
-              acc.push({ ...binding, id: newBindingId });
+            // Keep binding if:
+            // - It's programmatic duplication AND bound element exists in map
+            // - It's an ALT+drag AND both elements were duplicated
+            // - It's Ctrl+D AND it's a text element (container binding)
+            const shouldKeepBinding = shouldPreserveAllBindings
+              ? newBindingId
+              : isAltDrag
+              ? newBindingId
+              : binding.type === "text" && newBindingId;
+
+            if (shouldKeepBinding) {
+              acc.push({ ...binding, id: newBindingId! });
             }
             return acc;
           },
@@ -1858,19 +1877,37 @@ export const fixDuplicatedBindingsAfterDuplication = (
       });
     }
 
+    // For containerId (text bound to container)
     if ("containerId" in duplicateElement && duplicateElement.containerId) {
+      const newContainerId = origIdToDuplicateId.get(
+        duplicateElement.containerId,
+      );
       Object.assign(duplicateElement, {
-        containerId:
-          origIdToDuplicateId.get(duplicateElement.containerId) ?? null,
+        // Always preserve containerId if container was duplicated
+        containerId: newContainerId ?? null,
       });
     }
+
+    // For arrow bindings - track if we had bindings to shapes that were duplicated
+    let shouldRecalculateElbow = false;
 
     if ("endBinding" in duplicateElement && duplicateElement.endBinding) {
       const newEndBindingId = origIdToDuplicateId.get(
         duplicateElement.endBinding.elementId,
       );
+      // For Ctrl+D, if binding target wasn't duplicated, we'll need to recalculate
+      if (isAltDrag === false && !newEndBindingId) {
+        shouldRecalculateElbow = true;
+      }
       Object.assign(duplicateElement, {
-        endBinding: newEndBindingId
+        endBinding: shouldPreserveAllBindings
+          ? newEndBindingId
+            ? {
+                ...duplicateElement.endBinding,
+                elementId: newEndBindingId,
+              }
+            : null
+          : isAltDrag && newEndBindingId
           ? {
               ...duplicateElement.endBinding,
               elementId: newEndBindingId,
@@ -1879,20 +1916,46 @@ export const fixDuplicatedBindingsAfterDuplication = (
       });
     }
     if ("startBinding" in duplicateElement && duplicateElement.startBinding) {
-      const newEndBindingId = origIdToDuplicateId.get(
+      const newStartBindingId = origIdToDuplicateId.get(
         duplicateElement.startBinding.elementId,
       );
+      // For Ctrl+D, if binding target wasn't duplicated, we'll need to recalculate
+      if (isAltDrag === false && !newStartBindingId) {
+        shouldRecalculateElbow = true;
+      }
       Object.assign(duplicateElement, {
-        startBinding: newEndBindingId
+        startBinding: shouldPreserveAllBindings
+          ? newStartBindingId
+            ? {
+                ...duplicateElement.startBinding,
+                elementId: newStartBindingId,
+              }
+            : null
+          : isAltDrag && newStartBindingId
           ? {
               ...duplicateElement.startBinding,
-              elementId: newEndBindingId,
+              elementId: newStartBindingId,
             }
           : null,
       });
     }
 
-    if (isElbowArrow(duplicateElement)) {
+    // Update elbow arrow points
+    // - For programmatic duplication: always update
+    // - For ALT+drag: always update
+    // - For Ctrl+D: only update if binding target wasn't duplicated
+    if (isElbowArrow(duplicateElement) && isAltDrag !== false) {
+      Object.assign(
+        duplicateElement,
+        updateElbowArrowPoints(duplicateElement, duplicateElementsMap, {
+          points: [
+            duplicateElement.points[0],
+            duplicateElement.points[duplicateElement.points.length - 1],
+          ],
+        }),
+      );
+    } else if (isElbowArrow(duplicateElement) && shouldRecalculateElbow) {
+      // Ctrl+D case where binding targets weren't duplicated
       Object.assign(
         duplicateElement,
         updateElbowArrowPoints(duplicateElement, duplicateElementsMap, {

--- a/packages/element/src/duplicate.ts
+++ b/packages/element/src/duplicate.ts
@@ -119,8 +119,13 @@ export const duplicateElements = (
          *
          * Use this when duplicating Scene elements, during user interaction
          * such as alt-drag or on duplicate action.
+         *
+         * isAltDrag:
+         * - true: ALT+drag - keep bindings only when both elements are duplicated
+         * - false: Ctrl+D - remove all bindings
          */
         type: "in-place";
+        isAltDrag: boolean;
         idsOfElementsToDuplicate: Map<
           ExcalidrawElement["id"],
           ExcalidrawElement
@@ -369,6 +374,7 @@ export const duplicateElements = (
     duplicatedElements,
     origIdToDuplicateId,
     duplicateElementsMap as NonDeletedSceneElementsMap,
+    opts.type === "in-place" ? opts.isAltDrag : undefined,
   );
 
   bindElementsToFramesAfterDuplication(

--- a/packages/excalidraw/actions/actionDuplicateSelection.tsx
+++ b/packages/excalidraw/actions/actionDuplicateSelection.tsx
@@ -71,6 +71,7 @@ export const actionDuplicateSelection = register({
       ),
       appState,
       randomizeSeed: true,
+      isAltDrag: false,
       overrides: ({ origElement, origIdToDuplicateId }) => {
         const duplicateFrameId =
           origElement.frameId && origIdToDuplicateId.get(origElement.frameId);

--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -9371,6 +9371,7 @@ class App extends React.Component<AppProps, AppState> {
               elements,
               appState: this.state,
               randomizeSeed: true,
+              isAltDrag: true,
               idsOfElementsToDuplicate,
               overrides: ({ duplicateElement, origElement }) => {
                 return {


### PR DESCRIPTION
- Add isAltDrag parameter to distinguish ALT+drag from Ctrl+D duplication
- For ALT+drag: keep bindings only when both elements are duplicated
- For Ctrl+D: remove arrow bindings, preserve container bindings
- For Ctrl+D: keep original elbow shape if targets duplicated, reshape if not

Fixes #8435