### PR TITLE
fix: implement live text preview functionality for off-screen text editing

### DIFF
--- a/packages/excalidraw/appState.ts
+++ b/packages/excalidraw/appState.ts
@@ -47,6 +47,7 @@ export const getDefaultAppState = (): Omit<
     activeEmbeddable: null,
     newElement: null,
     editingTextElement: null,
+    textPreview: null,
     editingGroupId: null,
     activeTool: {
       type: "selection",
@@ -178,6 +179,7 @@ const APP_STATE_STORAGE_CONF = (<
   activeEmbeddable: { browser: false, export: false, server: false },
   newElement: { browser: false, export: false, server: false },
   editingTextElement: { browser: false, export: false, server: false },
+  textPreview: { browser: false, export: false, server: false },
   editingGroupId: { browser: true, export: false, server: false },
   activeTool: { browser: true, export: false, server: false },
   preferredSelectionTool: { browser: true, export: false, server: false },

--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -430,6 +430,7 @@ import { ContextMenu, CONTEXT_MENU_SEPARATOR } from "./ContextMenu";
 import { activeEyeDropperAtom } from "./EyeDropper";
 import FollowMode from "./FollowMode/FollowMode";
 import LayerUI from "./LayerUI";
+import { TextPreview } from "./TextPreview";
 import { ElementCanvasButton } from "./MagicButton";
 import { SVGLayer } from "./SVGLayer";
 import { searchItemInFocusAtom } from "./SearchMenu";
@@ -1972,6 +1973,8 @@ class App extends React.Component<AppProps, AppState> {
                         >
                           {this.props.children}
                         </LayerUI>
+
+                        <TextPreview textPreview={this.state.textPreview} theme={this.state.theme} />
 
                         <div className="excalidraw-textEditorContainer" />
                         <div className="excalidraw-contextMenuContainer" />

--- a/packages/excalidraw/components/TextPreview.scss
+++ b/packages/excalidraw/components/TextPreview.scss
@@ -1,0 +1,26 @@
+.excalidraw-text-preview-container {
+  position: fixed;
+  bottom: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: var(--zIndex-wysiwyg);
+  pointer-events: none;
+  max-width: 400px;
+  width: calc(100% - 40px);
+  max-height: 200px;
+  contain: layout style paint;
+}
+
+.excalidraw-text-preview {
+  background: var(--island-bg-color);
+  border: 2px dashed var(--button-hover-bg);
+  border-radius: 8px;
+  padding: 12px 16px;
+  box-shadow: var(--shadow-island);
+  max-height: 180px;
+  overflow-y: auto;
+  font-size: 14px;
+  line-height: 1.4;
+  word-wrap: break-word;
+  contain: layout style paint;
+}

--- a/packages/excalidraw/components/TextPreview.tsx
+++ b/packages/excalidraw/components/TextPreview.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+import { AppState } from "../types";
+import "./TextPreview.scss";
+
+export const TextPreview = ({
+  textPreview,
+  theme,
+}: {
+  textPreview: AppState["textPreview"];
+  theme: AppState["theme"];
+}) => {
+  if (!textPreview) {
+    return null;
+  }
+
+  // In dark mode, use white text for better readability
+  const textColor = theme === "dark" ? "white" : textPreview.color;
+
+  return (
+    <div className="excalidraw-text-preview-container">
+      <div
+        className="excalidraw-text-preview"
+        style={{
+          font: textPreview.font,
+          textAlign: textPreview.textAlign as any,
+          color: textColor,
+          opacity: (textPreview.opacity / 100) * 0.8,
+          whiteSpace: "pre-wrap",
+          wordBreak: "break-word",
+          overflowWrap: "break-word",
+        }}
+      >
+        {textPreview.text}
+      </div>
+    </div>
+  );
+};

--- a/packages/excalidraw/types.ts
+++ b/packages/excalidraw/types.ts
@@ -313,6 +313,16 @@ export interface AppState {
    * set when a new text is created or when an existing text is being edited
    */
   editingTextElement: NonDeletedExcalidrawElement | null;
+  textPreview: {
+    text: string;
+    font: string;
+    textAlign: TextAlign;
+    verticalAlign: string;
+    color: string;
+    opacity: number;
+    width: number;
+    height: number;
+  } | null;
   activeTool: {
     /**
      * indicates a previous tool we should revert back to if we deselect the

--- a/packages/excalidraw/wysiwyg/textWysiwyg.tsx
+++ b/packages/excalidraw/wysiwyg/textWysiwyg.tsx
@@ -60,6 +60,59 @@ import {
 import type App from "../components/App";
 import type { AppState } from "../types";
 
+let mirror: HTMLDivElement | null = null;
+
+// ============================================================================
+// TEXT PREVIEW STATE MANAGEMENT
+// Tracks whether text is currently off-screen to decouple visibility from
+// content updates and position recalculations
+// ============================================================================
+let isTextCurrentlyOffScreen = false;
+let lastPreviewText = "";
+let textPreviewCheckScheduled = false;
+let previewVisibilityTimeout: ReturnType<typeof setTimeout> | null = null;
+const PREVIEW_VISIBILITY_DELAY = 200; // ms before showing preview
+
+const getCaretOffset = (textarea: HTMLTextAreaElement) => {
+  const { selectionStart, value } = textarea;
+  const textBeforeCaret = value.substring(0, selectionStart);
+
+  if (!mirror) {
+    mirror = document.createElement("div");
+    mirror.style.position = "absolute";
+    mirror.style.visibility = "hidden";
+    mirror.style.top = "0";
+    mirror.style.left = "0";
+    document.body.appendChild(mirror);
+  }
+
+  const style = window.getComputedStyle(textarea);
+  [
+    "fontFamily",
+    "fontSize",
+    "fontStyle",
+    "fontWeight",
+    "lineHeight",
+    "padding",
+    "border",
+    "boxSizing",
+    "whiteSpace",
+    "wordBreak",
+    "width",
+  ].forEach((prop) => {
+    (mirror!.style as any)[prop] = (style as any)[prop];
+  });
+
+  mirror.textContent = textBeforeCaret;
+  const caretMarker = document.createElement("span");
+  caretMarker.textContent = "\u200B";
+  mirror.appendChild(caretMarker);
+
+  const { offsetLeft, offsetTop } = caretMarker;
+
+  return { left: offsetLeft, top: offsetTop };
+};
+
 const getTransform = (
   width: number,
   height: number,
@@ -276,6 +329,129 @@ export const textWysiwyg = ({
     }
   };
 
+  /**
+   * Checks if text is off-screen and updates preview visibility.
+   * ONLY called on viewport changes (scroll, zoom, resize), NOT on input.
+   * Uses debouncing to batch multiple viewport changes.
+   * Also uses a delay before showing preview to avoid jarring transitions.
+   */
+  const checkAndUpdatePreviewVisibility = () => {
+    const appState = app.state;
+    const updatedTextElement = app.scene.getElement<ExcalidrawTextElement>(id);
+    if (!updatedTextElement || !editable) {
+      return;
+    }
+
+    const rect = editable.getBoundingClientRect();
+    const containerRect = excalidrawContainer?.getBoundingClientRect();
+
+    if (!containerRect) {
+      return;
+    }
+
+    const viewportWidth = containerRect.width;
+    const viewportHeight = containerRect.height;
+
+    const relativeTop = rect.top - containerRect.top;
+    const relativeLeft = rect.left - containerRect.left;
+    const relativeBottom = rect.bottom - containerRect.top;
+    const relativeRight = rect.right - containerRect.left;
+
+    const wasOffScreen = isTextCurrentlyOffScreen;
+    isTextCurrentlyOffScreen =
+      relativeBottom < 0 ||
+      relativeTop > viewportHeight ||
+      relativeRight < 0 ||
+      relativeLeft > viewportWidth;
+
+    // Check caret if textarea is on-screen
+    if (!isTextCurrentlyOffScreen) {
+      const caretOffset = getCaretOffset(editable);
+      const caretTop = relativeTop + caretOffset.top * appState.zoom.value;
+      const caretLeft = relativeLeft + caretOffset.left * appState.zoom.value;
+
+      isTextCurrentlyOffScreen =
+        caretTop < 0 ||
+        caretTop > viewportHeight ||
+        caretLeft < 0 ||
+        caretLeft > viewportWidth;
+    }
+
+    // Handle visibility state changes
+    if (wasOffScreen !== isTextCurrentlyOffScreen) {
+      // Clear any pending timeout
+      if (previewVisibilityTimeout) {
+        clearTimeout(previewVisibilityTimeout);
+        previewVisibilityTimeout = null;
+      }
+
+      if (isTextCurrentlyOffScreen) {
+        // Text went off-screen, show preview and move textarea completely off-screen
+        const { textAlign, verticalAlign } = updatedTextElement;
+        const font = getFontString(updatedTextElement);
+
+        // Position textarea completely off-screen so it doesn't render visually
+        editable.style.position = "fixed";
+        editable.style.left = "-9999px";
+        editable.style.top = "-9999px";
+        editable.style.width = "1px";
+        editable.style.height = "1px";
+        editable.style.pointerEvents = "none";
+        editable.style.opacity = "1";
+
+        app.setAppState({
+          textPreview: {
+            text: editable.value,
+            font,
+            textAlign,
+            verticalAlign,
+            color: updatedTextElement.strokeColor,
+            opacity: updatedTextElement.opacity,
+            width: updatedTextElement.width,
+            height: updatedTextElement.height,
+          },
+        });
+      } else {
+        // Text came back on-screen, restore textarea position and hide preview
+        editable.style.position = "absolute";
+        editable.style.left = "";
+        editable.style.top = "";
+        editable.style.width = "";
+        editable.style.height = "";
+        editable.style.pointerEvents = "auto";
+        app.setAppState({ textPreview: null });
+      }
+    }
+  };
+
+  /**
+   * Updates preview content ONLY (text) when user types.
+   * Does NOT re-check position to avoid layout thrashing.
+   * Position is only rechecked on viewport changes.
+   */
+  const updatePreviewContent = () => {
+    if (!isTextCurrentlyOffScreen) {
+      return; // Text is on-screen, no preview needed
+    }
+
+    const currentText = editable.value;
+    if (lastPreviewText === currentText) {
+      return; // No text change
+    }
+
+    lastPreviewText = currentText;
+    const appState = app.state;
+
+    if (appState.textPreview) {
+      app.setAppState({
+        textPreview: {
+          ...appState.textPreview,
+          text: currentText,
+        },
+      });
+    }
+  };
+
   const editable = document.createElement("textarea");
 
   editable.dir = "auto";
@@ -362,6 +538,8 @@ export const textWysiwyg = ({
         editable.selectionEnd = selectionStart;
       }
       onChange(editable.value);
+      // Update preview content ONLY, don't check position
+      updatePreviewContent();
     };
   }
 
@@ -370,14 +548,38 @@ export const textWysiwyg = ({
       event.preventDefault();
       app.actionManager.executeAction(actionZoomIn);
       updateWysiwygStyle();
+      // Check preview visibility after zoom
+      if (!textPreviewCheckScheduled) {
+        textPreviewCheckScheduled = true;
+        requestAnimationFrame(() => {
+          checkAndUpdatePreviewVisibility();
+          textPreviewCheckScheduled = false;
+        });
+      }
     } else if (!event.shiftKey && actionZoomOut.keyTest(event)) {
       event.preventDefault();
       app.actionManager.executeAction(actionZoomOut);
       updateWysiwygStyle();
+      // Check preview visibility after zoom
+      if (!textPreviewCheckScheduled) {
+        textPreviewCheckScheduled = true;
+        requestAnimationFrame(() => {
+          checkAndUpdatePreviewVisibility();
+          textPreviewCheckScheduled = false;
+        });
+      }
     } else if (!event.shiftKey && actionResetZoom.keyTest(event)) {
       event.preventDefault();
       app.actionManager.executeAction(actionResetZoom);
       updateWysiwygStyle();
+      // Check preview visibility after zoom
+      if (!textPreviewCheckScheduled) {
+        textPreviewCheckScheduled = true;
+        requestAnimationFrame(() => {
+          checkAndUpdatePreviewVisibility();
+          textPreviewCheckScheduled = false;
+        });
+      }
     } else if (actionDecreaseFontSize.keyTest(event)) {
       app.actionManager.executeAction(actionDecreaseFontSize);
     } else if (actionIncreaseFontSize.keyTest(event)) {
@@ -413,7 +615,22 @@ export const textWysiwyg = ({
       }
       // We must send an input event to resize the element
       editable.dispatchEvent(new Event("input"));
+    } else if (
+      event.key === KEYS.ARROW_LEFT ||
+      event.key === KEYS.ARROW_RIGHT ||
+      event.key === KEYS.ARROW_UP ||
+      event.key === KEYS.ARROW_DOWN ||
+      event.key === "Home" ||
+      event.key === "End"
+    ) {
+      // Caret movement doesn't change text, just update content display
+      updatePreviewContent();
     }
+  };
+
+  editable.onclick = () => {
+    // Click movement doesn't change text, just update content display
+    updatePreviewContent();
   };
 
   const TAB_SIZE = 4;
@@ -583,6 +800,12 @@ export const textWysiwyg = ({
     editable.oninput = null;
     editable.onkeydown = null;
 
+    // Clear any pending preview timeout
+    if (previewVisibilityTimeout) {
+      clearTimeout(previewVisibilityTimeout);
+      previewVisibilityTimeout = null;
+    }
+
     if (observer) {
       observer.disconnect();
     }
@@ -597,6 +820,7 @@ export const textWysiwyg = ({
     unbindOnScroll();
 
     editable.remove();
+    app.setAppState({ textPreview: null });
   };
 
   const bindBlurEvent = (event?: MouseEvent) => {
@@ -705,9 +929,20 @@ export const textWysiwyg = ({
 
   const unbindOnScroll = app.onScrollChangeEmitter.on(() => {
     updateWysiwygStyle();
+    // Check preview visibility on scroll (debounced via RAF)
+    if (!textPreviewCheckScheduled) {
+      textPreviewCheckScheduled = true;
+      requestAnimationFrame(() => {
+        checkAndUpdatePreviewVisibility();
+        textPreviewCheckScheduled = false;
+      });
+    }
   });
 
   // ---------------------------------------------------------------------------
+  // INITIALIZE TEXT PREVIEW: Check initial off-screen state
+  // ---------------------------------------------------------------------------
+  checkAndUpdatePreviewVisibility();
 
   let isDestroyed = false;
 
@@ -724,10 +959,28 @@ export const textWysiwyg = ({
   if (canvas && "ResizeObserver" in window) {
     observer = new window.ResizeObserver(() => {
       updateWysiwygStyle();
+      // Check preview visibility on resize
+      if (!textPreviewCheckScheduled) {
+        textPreviewCheckScheduled = true;
+        requestAnimationFrame(() => {
+          checkAndUpdatePreviewVisibility();
+          textPreviewCheckScheduled = false;
+        });
+      }
     });
     observer.observe(canvas);
   } else {
-    window.addEventListener("resize", updateWysiwygStyle);
+    window.addEventListener("resize", () => {
+      updateWysiwygStyle();
+      // Check preview visibility on resize
+      if (!textPreviewCheckScheduled) {
+        textPreviewCheckScheduled = true;
+        requestAnimationFrame(() => {
+          checkAndUpdatePreviewVisibility();
+          textPreviewCheckScheduled = false;
+        });
+      }
+    });
   }
 
   editable.onpointerdown = (event) => event.stopPropagation();


### PR DESCRIPTION
## 🎯 Problem

- #10585 

When editing text that goes off-screen, users can't see what they're typing because the canvas doesn't auto-pan.

## ✨ Solution

Added a live text preview box that appears at the bottom of the viewport when the text moves off-screen, showing exactly what the user is typing in real-time.

## 📹 Demo

**Before:**

https://github.com/user-attachments/assets/b7f8e36f-3b52-4268-8045-3c347121a2db

**After:**

https://github.com/user-attachments/assets/f864a3b7-0e7e-465e-b863-fed6a18c31ea




