### PR TITLE
very small PR (20 lines?): better filenames that include the text selected

### DIFF
--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -2242,7 +2242,7 @@ class App extends React.Component<AppProps, AppState> {
       this.files,
       {
         exportBackground: this.state.exportBackground,
-        name: this.getName(),
+        name: this.getName(elements),
         viewBackgroundColor: this.state.viewBackgroundColor,
         exportingFrame: opts.exportingFrame,
       },
@@ -5291,10 +5291,25 @@ class App extends React.Component<AppProps, AppState> {
     return gesture.pointers.size >= 2;
   };
 
-  public getName = () => {
-    return (
-      this.state.name ||
-      this.props.name ||
+  public getName = (elements?: readonly ExcalidrawElement[]) => {
+
+    // <PR by obaidregens | the selected text (max 30 chars) will be included before appName for the suggested filename>
+
+    // ?. makes 'text' undefined if elements is undefined so the default return value will be skipped to
+    const text = elements?.filter((el) => !el.isDeleted && isTextElement(el))
+    .map((el) => (el as ExcalidrawTextElement).text)
+    .join("")
+    .trim();                                                                              
+
+    if (text){
+      return `[${text.slice(0, 30)}] ${t("labels.untitled")}-${getDateTime()}`;
+    }
+
+    // </PR by obaidregens | the selected text (max 30 chars) will be included before appName for the suggested filename>
+                                                                                                                                                                                                                
+    return (                                                                                                                                                                                                    
+      this.state.name ||                                                                                                                                                                                        
+      this.props.name ||                                                                                                                                                                                        
       `${t("labels.untitled")}-${getDateTime()}`
     );
   };


### PR DESCRIPTION
kind of addresses #10384 because the older-date app.name (which is saved from when localStorage was last cleared)'s biggest inconvenience is that you can't easily differentiate different elements exported from the same canvas,

see 4s video of what has changed visually (If no text is selected the name is the exact same as before)

https://github.com/user-attachments/assets/155c9ac7-62be-487f-a2e2-e761110a5d15

