### PR TITLE
fix: display error message for invalid hex color codes (#9527)

### DIFF
--- a/packages/excalidraw/components/ColorPicker/ColorInput.tsx
+++ b/packages/excalidraw/components/ColorPicker/ColorInput.tsx
@@ -54,26 +54,35 @@ export const ColorInput = ({
 }) => {
   const editorInterface = useEditorInterface();
   const [innerValue, setInnerValue] = useState(color);
+  const [isInvalid, setIsInvalid] = useState(false);
   const [activeSection, setActiveColorPickerSection] = useAtom(
     activeColorPickerSectionAtom,
   );
 
   useEffect(() => {
     setInnerValue(color);
+    setIsInvalid(false);
   }, [color]);
 
   const changeColor = useCallback(
     (inputValue: string) => {
       const value = inputValue.toLowerCase();
-      const color = normalizeInputColor(value);
+      const normalizedColor = normalizeInputColor(value);
 
-      if (color) {
-        onChange(color);
+      if (normalizedColor) {
+        onChange(normalizedColor);
+        setIsInvalid(false);
+      } else if (value.trim() !== "") {
+        // Only show error if there's actual input that's invalid
+        setIsInvalid(true);
+      } else {
+        setIsInvalid(false);
       }
       setInnerValue(value);
     },
     [onChange],
   );
+
 
   const inputRef = useRef<HTMLInputElement>(null);
   const eyeDropperTriggerRef = useRef<HTMLDivElement>(null);
@@ -93,7 +102,7 @@ export const ColorInput = ({
   }, [setEyeDropperState]);
 
   return (
-    <div className="color-picker__input-label">
+    <div className={clsx("color-picker__input-label", { "color-picker__input-label--error": isInvalid })}>
       <div className="color-picker__input-hash">#</div>
       <input
         ref={activeSection === "hex" ? inputRef : undefined}
@@ -101,12 +110,15 @@ export const ColorInput = ({
         spellCheck={false}
         className="color-picker-input"
         aria-label={label}
+        aria-invalid={isInvalid}
+        title={isInvalid ? t("colorPicker.invalidColor") : undefined}
         onChange={(event) => {
           changeColor(event.target.value);
         }}
         value={(innerValue || "").replace(/^#/, "")}
         onBlur={() => {
           setInnerValue(color);
+          setIsInvalid(false);
         }}
         tabIndex={-1}
         onFocus={() => setActiveColorPickerSection("hex")}
@@ -140,10 +152,10 @@ export const ColorInput = ({
                 s
                   ? null
                   : {
-                      keepOpenOnAlt: false,
-                      onSelect: (color) => onChange(color),
-                      colorPickerType,
-                    },
+                    keepOpenOnAlt: false,
+                    onSelect: (color) => onChange(color),
+                    colorPickerType,
+                  },
               )
             }
             title={`${t(

--- a/packages/excalidraw/components/ColorPicker/ColorPicker.scss
+++ b/packages/excalidraw/components/ColorPicker/ColorPicker.scss
@@ -382,6 +382,15 @@
       box-shadow: 0 0 0 1px var(--color-primary-darkest);
       border-radius: var(--border-radius-lg);
     }
+
+    &--error {
+      border-color: #e03131;
+      background-color: rgba(224, 49, 49, 0.05);
+
+      &:focus-within {
+        box-shadow: 0 0 0 1px #e03131;
+      }
+    }
   }
 
   .color-picker__input-hash {

--- a/packages/excalidraw/locales/en.json
+++ b/packages/excalidraw/locales/en.json
@@ -574,7 +574,8 @@
     "colors": "Colors",
     "shades": "Shades",
     "hexCode": "Hex code",
-    "noShades": "No shades available for this color"
+    "noShades": "No shades available for this color",
+    "invalidColor": "Invalid color"
   },
   "overwriteConfirm": {
     "action": {


### PR DESCRIPTION
## Summary

Fixes #9527
This PR adds visual feedback when users enter invalid hexadecimal color codes in the color picker input field.

## Problem
Previously, when users typed invalid hex colors (e.g., "zzzzzz", "blue", incorrect lengths), the input was silently ignored without any feedback, leading to a confusing user experience.

## Solution
- Added `isInvalid` state to track when the color input contains an invalid value
- When `normalizeInputColor()` returns `null` (invalid color), the input shows:
  - Red border and subtle red background
  - Tooltip on hover displaying "Invalid color"
  - `aria-invalid` attribute for accessibility
- Error state clears when:
  - User enters a valid color
  - User clears the input
  - Input loses focus (reverts to last valid color)
  - 
## Changes
- `packages/excalidraw/components/ColorPicker/ColorInput.tsx` - Added error state logic
- `packages/excalidraw/components/ColorPicker/ColorPicker.scss` - Added error styling
- `packages/excalidraw/locales/en.json` - Added translation key

## Testing
- [x] TypeScript compilation passes
- [x] All 17 colorInput tests pass
- [x] Manually tested with various invalid inputs

## Screenshots
The invalid color input now shows a red border and tooltip:
- Valid input: Normal appearance
- Invalid input: Red border, subtle red background, "Invalid color" tooltip on hover