### PR TITLE
fix: notify user when shape tool is deactivated with ESC

### DIFF
--- a/packages/excalidraw/locales/en.json
+++ b/packages/excalidraw/locales/en.json
@@ -536,7 +536,8 @@
     "pasteAsSingleElement": "Use {{shortcut}} to paste as a single element,\nor paste into an existing text editor",
     "unableToEmbed": "Embedding this url is currently not allowed. Raise an issue on GitHub to request the url whitelisted",
     "unrecognizedLinkFormat": "The link you embedded does not match the expected format. Please try to paste the 'embed' string provided by the source site",
-    "elementLinkCopied": "Link copied to clipboard"
+    "elementLinkCopied": "Link copied to clipboard",
+    "toolDeactivated": "Tool deactivated. Select a shape to draw."
   },
   "colors": {
     "transparent": "Transparent",


### PR DESCRIPTION
## Summary

Fixes #9541
This PR adds a toast notification when users deactivate a shape tool by pressing ESC, providing clear feedback that they need to select a shape to draw.

## Problem
When a user selected a shape tool (rectangle, ellipse, etc.) and then pressed ESC to deactivate it, the tool would silently switch to selection mode. Users would then try to draw but nothing would happen, with no indication of why.

## Solution
- Added logic in `actionFinalize` to detect when a shape tool is being deactivated without creating an element
- When this happens, a toast notification is displayed: "Tool deactivated. Select a shape to draw."
- The toast only shows for actual drawing tools (rectangle, diamond, ellipse, arrow, line, freedraw, text, frame, magicframe, embeddable), not for utility tools like selection, lasso, eraser, hand, etc.
- The toast doesn't show when:
  - An element was successfully created
  - Tool lock is enabled
  - User was in the middle of creating a multi-point element

## Changes
- `packages/excalidraw/actions/actionFinalize.tsx` - Added toast notification logic
- `packages/excalidraw/locales/en.json` - Added translation key

## Testing
- [x] TypeScript compilation passes
- [x] Toast appears when pressing ESC after selecting a shape tool without drawing
- [x] Toast does NOT appear when completing a drawing normally