### PR TITLE
fix: handle in-app paste while editing text editor / text elements

### DIFF
--- a/packages/excalidraw/clipboard.ts
+++ b/packages/excalidraw/clipboard.ts
@@ -204,10 +204,18 @@ export const copyToClipboard = async (
   /** supply if available to make the operation more certain to succeed */
   clipboardEvent?: ClipboardEvent | null,
 ) => {
-  await copyTextToSystemClipboard(
-    serializeAsClipboardJSON({ elements, files }),
-    clipboardEvent,
-  );
+  const json = serializeAsClipboardJSON({ elements, files });
+  if (clipboardEvent) {
+    try {
+      clipboardEvent.clipboardData?.setData(MIME_TYPES.excalidraw, json);
+      clipboardEvent.clipboardData?.setData(MIME_TYPES.text, json);
+      clipboardEvent.preventDefault();
+      return;
+    } catch (error) {
+      console.error(error);
+    }
+  }
+  await copyTextToSystemClipboard(json, clipboardEvent);
 };
 
 const parsePotentialSpreadsheet = (


### PR DESCRIPTION
## Note for future readers 👇

This PR contains the initial fix and investigation for the paste behavior issue
(raw Excalidraw JSON being inserted while editing text).

The **final implementation** was refined and merged in: 
➡️ https://github.com/excalidraw/excalidraw/pull/10710

That PR builds on this work and handles additional edge cases
(e.g. pasting element text when available).

Closing this PR in favor of the merged implementation to avoid confusion.

## Description

This PR fixes a bug where copying Excalidraw elements (like shapes or text) and pasting them while editing a text element would insert the raw Excalidraw JSON payload into the text field instead of ignoring it or pasting plain text.

The issue occurred because Excalidraw puts a JSON representation of the copied elements into the system clipboard's `text/plain` slot. The browser's default behavior for `contenteditable` is to paste this text, resulting in raw JSON appearing in the editor.

## Changes

- Modified `packages/excalidraw/wysiwyg/textWysiwyg.tsx` to intercept the `paste` event.
- Added a check to parse the clipboard's `text/plain` content.
- If the content is valid Excalidraw data (either a file export or a clipboard payload), the default paste event is prevented.
- This ensures that pasting shapes while editing text doesn't corrupt the text content, while still allowing normal plain text pasting from other sources.

## Test Plan

1. Create some shapes on the canvas (e.g., a rectangle and some text).
2. Select them and Copy (Cmd/Ctrl + C).
3. Create a new Text element or edit an existing one.
4. Paste (Cmd/Ctrl + V) while the text editor is active.
   - **Expectation:** Nothing happens (or valuable plain text if applicable), and specifically **no** raw JSON string is inserted into the text box.
5. Copy some regular text from a text editor or browser URL bar.
6. Paste into the Excalidraw text editor.
   - **Expectation:** The text is pasted normally.

## Screencasts

### Before

https://github.com/user-attachments/assets/4c9f7b94-0057-4e97-919f-3502b7a31b1d

### After

https://github.com/user-attachments/assets/c58adf8f-fbcb-4e28-ab72-8537ea56c427
