### PR TITLE
feat: laser tool can now click on links and cursor changes icon when hovered over link

### DIFF
--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -6581,6 +6581,34 @@ class App extends React.Component<AppProps, AppState> {
     }
 
     const hasDeselectedButton = Boolean(event.buttons);
+
+    // Laser tool: only handle link icon hovering
+    if (this.state.activeTool.type === "laser" && !hasDeselectedButton) {
+      const hitElementMightBeLocked = this.getElementAtPosition(
+        scenePointerX,
+        scenePointerY,
+        { preferSelected: true, includeLockedElements: true },
+      );
+      this.hitLinkElement = this.getElementLinkAtPosition(
+        scenePointer,
+        hitElementMightBeLocked,
+      );
+      if (
+        this.hitLinkElement &&
+        !this.state.selectedElementIds[this.hitLinkElement.id]
+      ) {
+        setCursor(this.interactiveCanvas, CURSOR_TYPE.POINTER);
+        showHyperlinkTooltip(
+          this.hitLinkElement,
+          this.state,
+          this.scene.getNonDeletedElementsMap(),
+        );
+      } else {
+        hideHyperlinkToolip();
+      }
+      return;
+    }
+
     if (
       hasDeselectedButton ||
       (this.state.activeTool.type !== "selection" &&


### PR DESCRIPTION
# Summary:
- User can now use the laser pointer tool and be able to click on links
- When using the laser pointer tool, cursor changes from laser icon to pointer icon when hovered over link
- Passes all existing test cases

https://github.com/user-attachments/assets/d6ae2a03-472a-4dff-bf31-ff6f45cc0c28

## Alternate approaches:
1. We examined a few different approaches for hitTesting where bounding box was considered, however when we have multiple element layered on top of each other, the very top most layer's link gets recognized, and anything inside is ignored. This could create problems as drawings increase in complexity. 
2. We also considered separate hitTesting specific to laser tool. However, we wanted to produce a minimal code option. First, gain feedback and discuss the options further. 

### Welcome to Feedback
Open to any suggestions, and if there's any better approaches, we are willing to change and/or collaborate!
@Mrazator @mtolmacs 

Fixes #9649 