### PR TITLE
feat: Allow PWA to open .excalidraw.png / .excalidraw.svg files

### DIFF
--- a/excalidraw-app/vite.config.mts
+++ b/excalidraw-app/vite.config.mts
@@ -239,6 +239,10 @@ export default defineConfig(({ mode }) => {
               action: "/",
               accept: {
                 "application/vnd.excalidraw+json": [".excalidraw"],
+                "application/vnd.excalidraw+png": [".excalidraw.png"],
+                "application/vnd.excalidraw+svg": [".excalidraw.svg"],
+                "image/png": [".png"],
+                "image/svg+xml": [".svg"],
               },
             },
           ],
@@ -252,8 +256,12 @@ export default defineConfig(({ mode }) => {
                   name: "file",
                   accept: [
                     "application/vnd.excalidraw+json",
+                    "application/vnd.excalidraw+png",
+                    "application/vnd.excalidraw+svg",
                     "application/json",
                     ".excalidraw",
+                    ".excalidraw.png",
+                    ".excalidraw.svg",
                   ],
                 },
               ],


### PR DESCRIPTION
The Excalidraw app is already able to open .excalidraw.png / .excalidraw.svg files that contain Scene information. ("Export image..." ➜ "Embed scene".)

However, desktop apps such as macOS Finder refuse to allow Excalidraw's PWA to open the file as a supported application. That's because the PWA manifest currently doesn't specify that these file types are supported by Excalidraw.

This PR adds the necessary mime-types & file-extensions to enable this. Resolves #10689.


(Additional context: The spec for the manifest 'file_handlers' option is somewhat under-specified, and whether a multipart file-ending like `.excalidraw.png` is distinct from `.png` is left unspecified. Therefore, this PR includes `.png`/`.svg` in addition to the more specific `.excalidraw.png`/`.excalidraw.svg` file extensions.)