### PR TITLE
fix: correct fill color for outline arrowheads in dark mode

### DIFF
--- a/packages/element/src/shape.ts
+++ b/packages/element/src/shape.ts
@@ -334,6 +334,10 @@ const getArrowheadShapes = (
     ? applyDarkModeFilter(element.strokeColor)
     : element.strokeColor;
 
+  const fillColor = isDarkMode
+    ? applyDarkModeFilter(canvasBackgroundColor)
+    : canvasBackgroundColor;
+
   switch (arrowhead) {
     case "dot":
     case "circle":
@@ -348,7 +352,7 @@ const getArrowheadShapes = (
           ...options,
           fill:
             arrowhead === "circle_outline"
-              ? canvasBackgroundColor
+              ? fillColor
               : strokeColor,
 
           fillStyle: "solid",
@@ -376,7 +380,7 @@ const getArrowheadShapes = (
             ...options,
             fill:
               arrowhead === "triangle_outline"
-                ? canvasBackgroundColor
+                ? fillColor
                 : strokeColor,
             fillStyle: "solid",
             roughness: Math.min(1, options.roughness || 0),
@@ -404,7 +408,7 @@ const getArrowheadShapes = (
             ...options,
             fill:
               arrowhead === "diamond_outline"
-                ? canvasBackgroundColor
+                ? fillColor
                 : strokeColor,
             fillStyle: "solid",
             roughness: Math.min(1, options.roughness || 0),


### PR DESCRIPTION
## Description
This PR fixes a rendering issue where outline arrowheads (`triangle_outline`, `circle_outline`, `diamond_outline`) would appear filled with white when used in dark mode.

### The Problem
The renderer uses `canvasBackgroundColor` to fill these shapes in order to mask the line endpoints underneath. However, the raw `canvasBackgroundColor` was being used without checking for dark mode, causing the fill to remain white even when the canvas was dark.

### The Fix
I updated `getArrowheadShapes` to explicitly check `isDarkMode`.
- If `true`, it now applies `applyDarkModeFilter(canvasBackgroundColor)` to generate the correct dark fill.
- If `false`, it uses the original `canvasBackgroundColor`.

## Fixed Issue
#10696

## Changes
- Updated `packages/excalidraw/src/element/shape.ts`
- Added `fillColor` logic to handle dark mode filtering.
- Applied `fillColor` to:
  - `circle_outline`
  - `triangle_outline`
  - `diamond_outline`

## Screenshots

| Before (Dark Mode) | After (Dark Mode) |
| :---: | :---: |
| <img src="https://github.com/user-attachments/assets/7da1c493-e48e-4307-9853-f6d177dc419b" width="400" alt="Before Fix" /> | <img src="https://github.com/user-attachments/assets/1375cf9d-50cc-480a-99a2-884c0769d2e4" width="400" alt="After Fix" /> |

## Test Plan
1. Switch to **Dark Mode**.
2. Select Arrow tool with **Triangle (outline)**, **Circle (outline)**, or **Diamond (outline)**.
3. Draw an arrow.
4. Verify that the arrowhead interior matches the dark background color (not white).