### PR TITLE
Fix: use selection color for grouping border (#7177)

### DIFF
--- a/packages/excalidraw/renderer/interactiveScene.ts
+++ b/packages/excalidraw/renderer/interactiveScene.ts
@@ -1383,7 +1383,7 @@ const _renderInteractiveScene = ({
           y2,
           selectionColors: groupElements.some((el) => el.locked)
             ? ["#ced4da"]
-            : ["#000"],
+            : [selectionColor],
           dashed: true,
           cx: x1 + (x2 - x1) / 2,
           cy: y1 + (y2 - y1) / 2,


### PR DESCRIPTION
This PR updates the grouping selection border color to use the theme's dynamic selectionColor (Excalidraw Purple) instead of a hardcoded black color.

Motivation: Previously, when a user was in Light Theme but set their Canvas Background to Black, the dashed grouping indicator became invisible because it was black-on-black. By using the brand selection color, we ensure visibility across all custom background choices.

Testing:
 Verified visually in Light Theme with Black background.
 Verified consistency with single-element selection color.
 Ran all existing tests (yarn test) - All 1,190 tests passed.