### PR TITLE
Fix: display error message for invalid hex color codes (#9527)

### DIFF
--- a/packages/excalidraw/components/ColorPicker/ColorInput.tsx
+++ b/packages/excalidraw/components/ColorPicker/ColorInput.tsx
@@ -32,6 +32,7 @@ export const ColorInput = ({
   const [activeSection, setActiveColorPickerSection] = useAtom(
     activeColorPickerSectionAtom,
   );
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     setInnerValue(color);
@@ -44,6 +45,11 @@ export const ColorInput = ({
 
       if (color) {
         onChange(color);
+        setError(null);
+      } else if (value && value !== "#") {
+        setError(t("colorPicker.invalidColor"));
+      } else {
+        setError(null);
       }
       setInnerValue(value);
     },
@@ -68,67 +74,71 @@ export const ColorInput = ({
   }, [setEyeDropperState]);
 
   return (
-    <div className="color-picker__input-label">
-      <div className="color-picker__input-hash">#</div>
-      <input
-        ref={activeSection === "hex" ? inputRef : undefined}
-        style={{ border: 0, padding: 0 }}
-        spellCheck={false}
-        className="color-picker-input"
-        aria-label={label}
-        onChange={(event) => {
-          changeColor(event.target.value);
-        }}
-        value={(innerValue || "").replace(/^#/, "")}
-        onBlur={() => {
-          setInnerValue(color);
-        }}
-        tabIndex={-1}
-        onFocus={() => setActiveColorPickerSection("hex")}
-        onKeyDown={(event) => {
-          if (event.key === KEYS.TAB) {
-            return;
-          } else if (event.key === KEYS.ESCAPE) {
-            eyeDropperTriggerRef.current?.focus();
-          }
-          event.stopPropagation();
-        }}
-        placeholder={placeholder}
-      />
-      {/* TODO reenable on mobile with a better UX */}
-      {editorInterface.formFactor !== "phone" && (
-        <>
-          <div
-            style={{
-              width: "1px",
-              height: "1.25rem",
-              backgroundColor: "var(--default-border-color)",
-            }}
-          />
-          <div
-            ref={eyeDropperTriggerRef}
-            className={clsx("excalidraw-eye-dropper-trigger", {
-              selected: eyeDropperState,
-            })}
-            onClick={() =>
-              setEyeDropperState((s) =>
-                s
-                  ? null
-                  : {
+    <>
+      <div className="color-picker__input-label">
+        <div className="color-picker__input-hash">#</div>
+        <input
+          ref={activeSection === "hex" ? inputRef : undefined}
+          style={{ border: 0, padding: 0 }}
+          spellCheck={false}
+          className="color-picker-input"
+          aria-label={label}
+          onChange={(event) => {
+            changeColor(event.target.value);
+          }}
+          value={(innerValue || "").replace(/^#/, "")}
+          onBlur={() => {
+            setInnerValue(color);
+            setError(null);
+          }}
+          tabIndex={-1}
+          onFocus={() => setActiveColorPickerSection("hex")}
+          onKeyDown={(event) => {
+            if (event.key === KEYS.TAB) {
+              return;
+            } else if (event.key === KEYS.ESCAPE) {
+              eyeDropperTriggerRef.current?.focus();
+            }
+            event.stopPropagation();
+          }}
+          placeholder={placeholder}
+        />
+        {/* TODO reenable on mobile with a better UX */}
+        {editorInterface.formFactor !== "phone" && (
+          <>
+            <div
+              style={{
+                width: "1px",
+                height: "1.25rem",
+                backgroundColor: "var(--default-border-color)",
+              }}
+            />
+            <div
+              ref={eyeDropperTriggerRef}
+              className={clsx("excalidraw-eye-dropper-trigger", {
+                selected: eyeDropperState,
+              })}
+              onClick={() =>
+                setEyeDropperState((s) =>
+                  s
+                    ? null
+                    : {
                       keepOpenOnAlt: false,
                       onSelect: (color) => onChange(color),
                       colorPickerType,
                     },
-              )
-            }
-            title={`${t(
-              "labels.eyeDropper",
-            )} — ${KEYS.I.toLocaleUpperCase()} or ${getShortcutKey("Alt")} `}
-          >
-            {eyeDropperIcon}
-          </div>
-        </>
-      )}
-    </div>
+                )
+              }
+              title={`${t(
+                "labels.eyeDropper",
+              )} — ${KEYS.I.toLocaleUpperCase()} or ${getShortcutKey("Alt")} `}
+            >
+              {eyeDropperIcon}
+            </div>
+          </>
+        )}
+      </div>
+      {error && <div className="color-picker__input-error">{error}</div>}
+    </>
   );
 };

--- a/packages/excalidraw/components/ColorPicker/ColorPicker.scss
+++ b/packages/excalidraw/components/ColorPicker/ColorPicker.scss
@@ -385,6 +385,12 @@
     }
   }
 
+  .color-picker__input-error {
+    color: var(--color-danger-dark);
+    font-size: 0.75rem;
+    margin: -4px 8px 8px 12px;
+  }
+
   .color-picker__input-hash {
     padding: 0 0.25rem;
   }

--- a/packages/excalidraw/locales/en.json
+++ b/packages/excalidraw/locales/en.json
@@ -574,7 +574,8 @@
     "colors": "Colors",
     "shades": "Shades",
     "hexCode": "Hex code",
-    "noShades": "No shades available for this color"
+    "noShades": "No shades available for this color",
+    "invalidColor": "Invalid color code"
   },
   "overwriteConfirm": {
     "action": {


### PR DESCRIPTION
Summary: This PR adds real-time validation and localized error feedback for the hex color input in the ColorPicker component.

Changes:

Added a new translation key colorPicker.invalidColor in en.json.
Introduced an error state in ColorInput.tsx to track and display validation status.
Implemented real-time validation using normalizeInputColor.
Added styling for the error message in ColorPicker.scss to ensure it is visually clear and follows the app's design system.
Reset error state on input blur to maintain a clean UI.

Testing:

 Verified that invalid inputs (e.g., zzz, 12345) trigger the "Invalid color code" message.
 Verified that valid inputs (e.g., 123, ff0000) clear the error message.
 Ran the full test suite (yarn test) - All 1,190 tests passed.