### PR TITLE
fix: canvas size limit export

### DIFF
--- a/packages/common/src/constants.ts
+++ b/packages/common/src/constants.ts
@@ -338,6 +338,8 @@ export const DEFAULT_EXPORT_PADDING = 10; // px
 
 export const DEFAULT_MAX_IMAGE_WIDTH_OR_HEIGHT = 1440;
 
+export const MAX_ALLOWED_CANVAS_WIDTH_OR_HEIGHT = 8192;
+
 export const MAX_ALLOWED_FILE_BYTES = 4 * 1024 * 1024;
 
 export const SVG_NS = "http://www.w3.org/2000/svg";

--- a/packages/excalidraw/scene/export.ts
+++ b/packages/excalidraw/scene/export.ts
@@ -13,6 +13,7 @@ import {
   getFontString,
   toBrandedType,
   applyDarkModeFilter,
+  MAX_ALLOWED_CANVAS_WIDTH_OR_HEIGHT,
 } from "@excalidraw/common";
 
 import { getCommonBounds, getElementAbsoluteCoords } from "@excalidraw/element";
@@ -61,6 +62,7 @@ import { renderSceneToSvg } from "../renderer/staticSvgScene";
 import type { RenderableElementsMap } from "./types";
 
 import type { AppState, BinaryFiles } from "../types";
+import { aspectFitScale } from "@excalidraw/math";
 
 const truncateText = (element: ExcalidrawTextElement, maxWidth: number) => {
   if (element.width <= maxWidth) {
@@ -191,7 +193,13 @@ export const exportToCanvas = async (
     const canvas = document.createElement("canvas");
     canvas.width = width * appState.exportScale;
     canvas.height = height * appState.exportScale;
-    return { canvas, scale: appState.exportScale };
+    let scale = appState.exportScale;
+    if(canvas.width > MAX_ALLOWED_CANVAS_WIDTH_OR_HEIGHT || canvas.height > MAX_ALLOWED_CANVAS_WIDTH_OR_HEIGHT) {
+      scale = aspectFitScale(width, height, MAX_ALLOWED_CANVAS_WIDTH_OR_HEIGHT);
+      canvas.width = width * scale;
+      canvas.height = height * scale;
+    }
+    return { canvas, scale: scale };
   },
   loadFonts: () => Promise<void> = async () => {
     await Fonts.loadElementsFonts(elements);

--- a/packages/math/src/utils.ts
+++ b/packages/math/src/utils.ts
@@ -31,3 +31,11 @@ export const isFiniteNumber = (value: any): value is number => {
 
 export const isCloseTo = (a: number, b: number, precision = PRECISION) =>
   Math.abs(a - b) < precision;
+
+
+export const aspectFitScale = (width: number, height: number, maxSide: number) => {
+  let scaleX = maxSide / width;
+  let scaleY = maxSide / height;
+  let scale = Math.min(scaleX, scaleY);
+  return scale;
+};


### PR DESCRIPTION
[question](https://github.com/excalidraw/excalidraw/issues/10713) Due to canvas limitations, very large images cannot be exported. I have added a restriction: if the image exceeds the limit, its longest side will be scaled down to fit within the restricted area.