### PR TITLE
feat: allow configurable max image size

### DIFF
--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -10846,10 +10846,16 @@ class App extends React.Component<AppProps, AppState> {
         );
       }
 
-      if (imageFile.size > MAX_ALLOWED_FILE_BYTES) {
+      const maxImageSizeBytes =
+        typeof this.props.maxImageSizeBytes === "number" &&
+        this.props.maxImageSizeBytes > 0
+          ? this.props.maxImageSizeBytes
+          : MAX_ALLOWED_FILE_BYTES;
+
+      if (imageFile.size > maxImageSizeBytes) {
         throw new Error(
           t("errors.fileTooBig", {
-            maxSize: `${Math.trunc(MAX_ALLOWED_FILE_BYTES / 1024 / 1024)}MB`,
+            maxSize: `${Math.trunc(maxImageSizeBytes / 1024 / 1024)}MB`,
           }),
         );
       }

--- a/packages/excalidraw/types.ts
+++ b/packages/excalidraw/types.ts
@@ -603,6 +603,10 @@ export interface ExcalidrawProps {
   onLibraryChange?: (libraryItems: LibraryItems) => void | Promise<any>;
   autoFocus?: boolean;
   generateIdForFile?: (file: File) => string | Promise<string>;
+  /**
+   * Max allowed image file size in bytes. Defaults to MAX_ALLOWED_FILE_BYTES.
+   */
+  maxImageSizeBytes?: number;
   generateLinkForSelection?: (id: string, type: "element" | "group") => string;
   onLinkOpen?: (
     element: NonDeletedExcalidrawElement,


### PR DESCRIPTION
## Summary
- add optional maxImageSizeBytes prop to Excalidraw
- enforce configurable limit when inserting images (defaults to MAX_ALLOWED_FILE_BYTES)

## Testing
- not run