### PR TITLE
fix(editor): crop editor cursor drift

### DIFF
--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -254,6 +254,7 @@ import {
   handleFocusPointPointerDown,
   handleFocusPointPointerUp,
   maybeHandleArrowPointlikeDrag,
+  getUncroppedWidthAndHeight,
 } from "@excalidraw/element";
 
 import type { GlobalPoint, LocalPoint, Radians } from "@excalidraw/math";
@@ -9340,10 +9341,20 @@ class App extends React.Component<AppProps, AppState> {
                 this.imageCache.get(croppingElement.fileId)?.image;
 
               if (image && !(image instanceof Promise)) {
+                const uncroppedSize =
+                  getUncroppedWidthAndHeight(croppingElement);
                 const instantDragOffset = vector(
                   pointerCoords.x - lastPointerCoords.x,
                   pointerCoords.y - lastPointerCoords.y,
                 );
+
+                // to reduce cursor:image drift, we need to take into account
+                // the canvas image element scaling so we can accurately
+                // track the pixels on movement
+                instantDragOffset[0] *=
+                  image.naturalWidth / uncroppedSize.width;
+                instantDragOffset[1] *=
+                  image.naturalHeight / uncroppedSize.height;
 
                 const [x1, y1, x2, y2, cx, cy] = getElementAbsoluteCoords(
                   croppingElement,


### PR DESCRIPTION
non-1 scaling resulted in the cursor movement either drifting ahead or behind the image being dragged.

test: https://excalidraw-git-dwelle-fix-cropping-scaling-excalidraw.vercel.app/#json=wdWZoL6zYDqmOk5dKW4a0,m8SS7CMsX8a-HGBiYfrgSg

before:


https://github.com/user-attachments/assets/22d7cc34-b5a3-4323-b331-abecddc2dd89



after:


https://github.com/user-attachments/assets/ba1d7c70-e15e-426d-a44a-fc69d6b867b3

