### PR TITLE
fix(editor): On focus drag only update other binding if it's orbit

### DIFF
--- a/packages/element/src/arrows/focus.ts
+++ b/packages/element/src/arrows/focus.ts
@@ -137,7 +137,7 @@ const focusPointUpdate = (
   }
 
   // Also update the adjacent end if it has a binding
-  if (adjacentBinding) {
+  if (adjacentBinding && adjacentBinding.mode === "orbit") {
     const adjacentBindableElement = elementsMap.get(
       adjacentBinding.elementId,
     ) as ExcalidrawBindableElement;


### PR DESCRIPTION
Before and after:
[Screencast from 2026-02-02 11-30-06.webm](https://github.com/user-attachments/assets/d4243838-8216-4260-ba0e-6a09931c5e13)
