### PR TITLE
fix: add RTL support for opacity slider

### DIFF
--- a/packages/excalidraw/components/Range.scss
+++ b/packages/excalidraw/components/Range.scss
@@ -52,5 +52,10 @@
     left: 4px;
     font-size: 12px;
     color: var(--text-primary-color);
+
+    :root[dir="rtl"] & {
+      left: auto;
+      right: 4px;
+    }
   }
 }

--- a/packages/excalidraw/components/Range.tsx
+++ b/packages/excalidraw/components/Range.tsx
@@ -36,10 +36,21 @@ export const Range = ({ updateData, app, testId }: RangeProps) => {
       const valueElement = valueRef.current;
       const inputWidth = rangeElement.offsetWidth;
       const thumbWidth = 15; // 15 is the width of the thumb
+      const isRTL = document.documentElement.getAttribute("dir") === "rtl";
       const position =
         (value / 100) * (inputWidth - thumbWidth) + thumbWidth / 2;
-      valueElement.style.left = `${position}px`;
-      rangeElement.style.background = `linear-gradient(to right, var(--color-slider-track) 0%, var(--color-slider-track) ${value}%, var(--button-bg) ${value}%, var(--button-bg) 100%)`;
+
+      // Reset both left and right before setting the correct one for the direction
+      valueElement.style.left = "";
+      valueElement.style.right = "";
+
+      if (isRTL) {
+        valueElement.style.right = `${position}px`;
+        rangeElement.style.background = `linear-gradient(to left, var(--color-slider-track) 0%, var(--color-slider-track) ${value}%, var(--button-bg) ${value}%, var(--button-bg) 100%)`;
+      } else {
+        valueElement.style.left = `${position}px`;
+        rangeElement.style.background = `linear-gradient(to right, var(--color-slider-track) 0%, var(--color-slider-track) ${value}%, var(--button-bg) ${value}%, var(--button-bg) 100%)`;
+      }
     }
   }, [value]);
 


### PR DESCRIPTION
## Summary
Fixes #9710

The opacity/transparency slider and its value bubble were not displaying correctly in RTL (right-to-left) languages.

## Changes
- **Range.tsx**: Detect RTL direction and position the value bubble using `right` instead of `left`, and reverse the gradient direction
- **Range.scss**: Add RTL override for the zero-label position

## Implementation Notes
This follows the existing RTL handling patterns used elsewhere in the codebase:
- RTL detection: `document.documentElement.getAttribute("dir") === "rtl"` (same as Actions.tsx)
- SCSS RTL selector: `:root[dir="rtl"] &` (same as Sidebar.scss)

## Testing
Tested by setting `dir="rtl"` on the document root element. The slider now correctly:
- Positions the value bubble from the right side
- Reverses the gradient direction
- Positions the zero label on the right