### PR TITLE
fix: convert mermaid <br> tags to newlines in text labels

### DIFF
--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -417,6 +417,7 @@ import { textWysiwyg } from "../wysiwyg/textWysiwyg";
 import { isOverScrollBars } from "../scene/scrollbars";
 
 import { isMaybeMermaidDefinition } from "../mermaid";
+import { sanitizeMermaidElements } from "./TTDDialog/common";
 
 import { LassoTrail } from "../lasso";
 
@@ -3502,9 +3503,12 @@ class App extends React.Component<AppProps, AppState> {
         const { elements: skeletonElements, files } =
           await api.parseMermaidToExcalidraw(data.text);
 
-        const elements = convertToExcalidrawElements(skeletonElements, {
-          regenerateIds: true,
-        });
+        const elements = convertToExcalidrawElements(
+          sanitizeMermaidElements(skeletonElements),
+          {
+            regenerateIds: true,
+          },
+        );
 
         this.addElementsFromPasteOrLibrary({
           elements,

--- a/packages/excalidraw/components/TTDDialog/common.ts
+++ b/packages/excalidraw/components/TTDDialog/common.ts
@@ -14,7 +14,51 @@ import {
 
 import type { MermaidToExcalidrawLibProps } from "./types";
 
+import type { MermaidToExcalidrawResult } from "@excalidraw/mermaid-to-excalidraw/dist/interfaces";
+
 import type { AppClassProperties, BinaryFiles } from "../../types";
+
+/**
+ * Replaces HTML <br> tags (including <br/> and <br />) with newline characters.
+ * Mermaid supports <br> tags for multiline text in node labels,
+ * but Excalidraw renders text as-is, so we need to convert them to newlines.
+ */
+const replaceBrTags = (text: string): string => {
+  return text.replace(/<br\s*\/?>/gi, "\n");
+};
+
+/**
+ * Post-processes skeleton elements from mermaid-to-excalidraw to convert
+ * HTML <br> tags in text labels to actual newline characters.
+ */
+export const sanitizeMermaidElements = (
+  elements: MermaidToExcalidrawResult["elements"],
+): MermaidToExcalidrawResult["elements"] => {
+  return elements.map((el) => {
+    const result = { ...el };
+
+    // Handle label text on container elements (rectangles, diamonds, etc.)
+    if (
+      "label" in result &&
+      result.label &&
+      typeof result.label === "object" &&
+      "text" in result.label &&
+      typeof result.label.text === "string"
+    ) {
+      result.label = {
+        ...result.label,
+        text: replaceBrTags(result.label.text),
+      };
+    }
+
+    // Handle direct text property on text elements
+    if ("text" in result && typeof result.text === "string") {
+      (result as any).text = replaceBrTags(result.text);
+    }
+
+    return result;
+  });
+};
 
 export const resetPreview = ({
   canvasRef,
@@ -87,9 +131,12 @@ export const convertMermaidToExcalidraw = async ({
     setError(null);
 
     data.current = {
-      elements: convertToExcalidrawElements(elements, {
-        regenerateIds: true,
-      }),
+      elements: convertToExcalidrawElements(
+        sanitizeMermaidElements(elements),
+        {
+          regenerateIds: true,
+        },
+      ),
       files,
     };
 

--- a/packages/excalidraw/tests/clipboard.test.tsx
+++ b/packages/excalidraw/tests/clipboard.test.tsx
@@ -487,6 +487,10 @@ describe("clipboard - pasting mermaid definition", () => {
         const lines = definition.split("\n");
         return new Promise((resolve, reject) => {
           if (lines.some((line) => line === "flowchart TD")) {
+            // Simulate mermaid parser returning <br> tags as literal text
+            const labelText = definition.includes("<br>")
+              ? "User Registration<br>Process"
+              : "A";
             resolve({
               elements: [
                 {
@@ -500,7 +504,7 @@ describe("clipboard - pasting mermaid definition", () => {
                   strokeWidth: 2,
                   label: {
                     groupIds: [],
-                    text: "A",
+                    text: labelText,
                     fontSize: 20,
                   },
                   link: null,
@@ -554,6 +558,24 @@ describe("clipboard - pasting mermaid definition", () => {
         expect.arrayContaining([
           expect.objectContaining({ type: "text", text: "flowchart TD xx" }),
           expect.objectContaining({ type: "text", text: "A" }),
+        ]),
+      );
+    });
+  });
+
+  it("should convert <br> tags to newlines in mermaid labels", async () => {
+    const text =
+      'flowchart TD\n    A["User Registration<br>Process"]';
+    pasteWithCtrlCmdV(text);
+    await waitFor(() => {
+      expect(h.elements.length).toEqual(2);
+      expect(h.elements).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ type: "rectangle" }),
+          expect.objectContaining({
+            type: "text",
+            text: expect.stringContaining("User Registration\nProcess"),
+          }),
         ]),
       );
     });


### PR DESCRIPTION
## What

Adds a sanitization step that converts HTML `<br>`, `<br/>`, and `<br />` tags to actual newline characters (`\n`) in mermaid skeleton element text before converting them to Excalidraw elements.

## Why

Mermaid supports `<br>` tags for multiline text in node labels (e.g. `A["User Registration<br>Process"]`). When `@excalidraw/mermaid-to-excalidraw` parses these diagrams, the `<br>` tags are preserved as literal text in the skeleton elements. This causes Excalidraw to render the raw `<br>` tag instead of a line break.

The [official Mermaid editor](https://www.mermaidchart.com/play) handles `<br>` correctly, and many AI tools generate mermaid definitions using `<br>` tags, so this is a common pain point.

## How

- Added `sanitizeMermaidElements()` utility in `TTDDialog/common.ts` that processes skeleton elements to replace `<br>` variants with `\n` in both:
  - `label.text` (container elements like rectangles, diamonds)
  - `text` (text elements)
- Applied the sanitization in both code paths:
  - **Paste handler** (`App.tsx`) — when pasting mermaid definitions via Ctrl+V
  - **TTD Dialog** (`common.ts`) — when using the Mermaid-to-Excalidraw dialog
- Added test coverage in `clipboard.test.tsx`

## Tests

- Extended the existing mermaid paste test mock to return `<br>` tags when present in the definition
- Added a new test: `"should convert <br> tags to newlines in mermaid labels"`

Fixes #9708