### PR TITLE
fix: add missing mermaid diagram types to paste detection

### DIFF
--- a/packages/excalidraw/mermaid.test.ts
+++ b/packages/excalidraw/mermaid.test.ts
@@ -12,4 +12,19 @@ describe("isMaybeMermaidDefinition", () => {
     expect(isMaybeMermaidDefinition("this flowchart")).toBe(false);
     expect(isMaybeMermaidDefinition("this\nflowchart")).toBe(false);
   });
+
+  it("should detect C4 diagram variants", () => {
+    expect(isMaybeMermaidDefinition("C4Context")).toBe(true);
+    expect(isMaybeMermaidDefinition("C4Container")).toBe(true);
+    expect(isMaybeMermaidDefinition("C4Component")).toBe(true);
+    expect(isMaybeMermaidDefinition("C4Dynamic")).toBe(true);
+    expect(isMaybeMermaidDefinition("C4Deployment")).toBe(true);
+  });
+
+  it("should detect newer mermaid v11+ diagram types", () => {
+    expect(isMaybeMermaidDefinition("architecture-beta")).toBe(true);
+    expect(isMaybeMermaidDefinition("kanban")).toBe(true);
+    expect(isMaybeMermaidDefinition("packet-beta")).toBe(true);
+    expect(isMaybeMermaidDefinition("classDiagram-v2")).toBe(true);
+  });
 });

--- a/packages/excalidraw/mermaid.ts
+++ b/packages/excalidraw/mermaid.ts
@@ -5,6 +5,7 @@ export const isMaybeMermaidDefinition = (text: string) => {
     "graph",
     "sequenceDiagram",
     "classDiagram",
+    "classDiagram-v2",
     "stateDiagram",
     "stateDiagram-v2",
     "erDiagram",
@@ -15,12 +16,19 @@ export const isMaybeMermaidDefinition = (text: string) => {
     "requirementDiagram",
     "gitGraph",
     "C4Context",
+    "C4Container",
+    "C4Component",
+    "C4Dynamic",
+    "C4Deployment",
     "mindmap",
     "timeline",
     "zenuml",
     "sankey",
     "xychart",
     "block",
+    "packet",
+    "architecture",
+    "kanban",
   ];
 
   const re = new RegExp(


### PR DESCRIPTION
## What

Adds missing mermaid diagram types to `isMaybeMermaidDefinition()` so that pasting these diagram definitions triggers mermaid-to-excalidraw conversion instead of plain text paste.

## Why

The bundled mermaid library (v11.12+) and `@excalidraw/mermaid-to-excalidraw` (v2.0.0) support several diagram types that are not listed in the paste detection heuristic. When users paste these diagram types, they are inserted as plain text instead of being converted to Excalidraw elements.

I verified the full list of supported types by checking mermaid's detector regexes in `node_modules/mermaid/dist/mermaid.core.mjs`.

## Added types

| Type | Notes |
|------|-------|
| `C4Container` | C4 model variant (only `C4Context` was listed) |
| `C4Component` | C4 model variant |
| `C4Dynamic` | C4 model variant |
| `C4Deployment` | C4 model variant |
| `classDiagram-v2` | Class diagram variant |
| `architecture` | New in mermaid v11.1+ |
| `kanban` | New in mermaid v11.2+ |
| `packet` | New in mermaid v11+ |

## Safety

If `@excalidraw/mermaid-to-excalidraw` cannot convert a particular diagram type, the existing `try/catch` in `App.tsx` gracefully falls back to pasting as plain text. So this change is safe even for edge cases.

## Tests

Added test cases for the new diagram types in `mermaid.test.ts`.