### PR TITLE
fix: update arrowhead property defaultValue handling

### DIFF
--- a/packages/excalidraw/actions/actionProperties.tsx
+++ b/packages/excalidraw/actions/actionProperties.tsx
@@ -1683,7 +1683,8 @@ export const actionChangeArrowhead = register<{
                   ? element.startArrowhead
                   : appState.currentItemStartArrowhead,
               true,
-              appState.currentItemStartArrowhead,
+              (hasSelection) =>
+                hasSelection ? null : appState.currentItemStartArrowhead,
             )}
             onChange={(value) => updateData({ position: "start", type: value })}
             numberOfOptionsToAlwaysShow={4}
@@ -1700,7 +1701,8 @@ export const actionChangeArrowhead = register<{
                   ? element.endArrowhead
                   : appState.currentItemEndArrowhead,
               true,
-              appState.currentItemEndArrowhead,
+              (hasSelection) =>
+                hasSelection ? null : appState.currentItemEndArrowhead,
             )}
             onChange={(value) => updateData({ position: "end", type: value })}
             numberOfOptionsToAlwaysShow={4}


### PR DESCRIPTION
# Summary
When an arrow with `null` start or end arrowhead is selected after another arrow defines an arrowhead, the properties panel incorrectly shows the most recently changed arrowhead instead of `null`.

## Fix
changed `defaultValue` from `currentItem*` to a callback(reflecting behavior similar to other properties), to prevent fallback of appState when a selected element has a null value.

https://github.com/user-attachments/assets/6354bdff-fc89-4aeb-a271-2294df93fdf5

## Additional Notes
While testing this change, I did notice that the icon for a 'null' end arrowhead isn't flipped in the direction of the other end arrowheads. I wasn't sure if this is an issue but if the team were open to it, I could look to make this change as well.

<img width="218" height="141" alt="image" src="https://github.com/user-attachments/assets/5fb7d300-e59b-49c3-b687-88b709781e3e" />

## Feedback Welcome
Open to any suggestions, and if there's a better approach, I'm more than willing to change and/or collaborate! @mtolmacs @dwelle

Fixes #10768 