### PR TITLE
fix: default condition export for index.css

### DIFF
--- a/packages/excalidraw/package.json
+++ b/packages/excalidraw/package.json
@@ -23,7 +23,8 @@
     },
     "./index.css": {
       "development": "./dist/dev/index.css",
-      "production": "./dist/prod/index.css"
+      "production": "./dist/prod/index.css",
+      "default": "./dist/prod/index.css"
     },
     ".": {
       "types": "./dist/types/excalidraw/index.d.ts",


### PR DESCRIPTION
Fixes issue [#10782](https://github.com/excalidraw/excalidraw/issues/10782)

Path resolution fails for `index.css` under the default condition if neither the `production` nor `development` conditions are set. This adds the `default` condition to the exports entry for `index.css. I have tested it by building Excalidraw and observing that the correct CSS is applied.