### PR TITLE
fix: convert ArrowheadNoneIcon to component matching arrowhead icon pattern

### DIFF
--- a/packages/excalidraw/actions/actionProperties.tsx
+++ b/packages/excalidraw/actions/actionProperties.tsx
@@ -1555,7 +1555,7 @@ const getArrowheadOptions = (flip: boolean) => {
       value: null,
       text: t("labels.arrowhead_none"),
       keyBinding: "q",
-      icon: ArrowheadNoneIcon,
+      icon: <ArrowheadNoneIcon flip={flip} />,
     },
     {
       value: "arrow",

--- a/packages/excalidraw/components/icons.tsx
+++ b/packages/excalidraw/components/icons.tsx
@@ -1287,13 +1287,21 @@ export const EdgeRoundIcon = createIcon(
   tablerIconProps,
 );
 
-export const ArrowheadNoneIcon = createIcon(
-  <g stroke="currentColor" opacity={0.3} strokeWidth={2}>
-    <path d="M12 12l9 0" />
-    <path d="M3 9l6 6" />
-    <path d="M3 15l6 -6" />
-  </g>,
-  tablerIconProps,
+export const ArrowheadNoneIcon = React.memo(
+  ({ flip = false }: { flip?: boolean }) =>
+    createIcon(
+      <g
+        transform={flip ? "translate(24, 0) scale(-1, 1)" : ""}
+        stroke="currentColor"
+        opacity={0.3}
+        strokeWidth={2}
+      >
+        <path d="M12 12l-9 0" />
+        <path d="M21 9l-6 6" />
+        <path d="M21 15l-6 -6" />
+      </g>,
+      tablerIconProps,
+    ),
 );
 
 export const ArrowheadArrowIcon = React.memo(


### PR DESCRIPTION
# Summary
The "none" arrowhead icon was pointing in the opposite direction of all other end arrowhead icons.

<img width="2048" height="1035" alt="image" src="https://github.com/user-attachments/assets/520a3717-ecd1-4adc-9104-3b6cda93594e" />

## Fix
- convert `ArrowheadNoneIcon` from a static icon to a React.memo component to reflect the same pattern as all other arrowhead icons
- mirrored SVG path, to point in the direction of all other arrowhead's by default.

<img width="2048" height="1035" alt="image" src="https://github.com/user-attachments/assets/3041bc73-1c45-496f-96b3-8bd3af31b590" />

## Feedback Welcome
Open to any suggestions, and if there's a better approach, I'm more than willing to change and/or collaborate! @mtolmacs @dwelle

Follow-up to #10778
