### PR TITLE
fix: improve ShareDialog platform detection (#9583) and fix RTL opacity slider (#9710)

### DIFF
--- a/excalidraw-app/share/ShareDialog.tsx
+++ b/excalidraw-app/share/ShareDialog.tsx
@@ -15,7 +15,7 @@ import {
 import { useUIAppState } from "@excalidraw/excalidraw/context/ui-appState";
 import { useCopyStatus } from "@excalidraw/excalidraw/hooks/useCopiedIndicator";
 import { useI18n } from "@excalidraw/excalidraw/i18n";
-import { KEYS, getFrame } from "@excalidraw/common";
+import { KEYS, getFrame, isDarwin, isWindows } from "@excalidraw/common";
 import { useEffect, useRef, useState } from "react";
 
 import { atom, useAtom, useAtomValue } from "../app-jotai";
@@ -34,13 +34,9 @@ export const shareDialogStateAtom = atom<
 >({ isOpen: false });
 
 const getShareIcon = () => {
-  const navigator = window.navigator as any;
-  const isAppleBrowser = /Apple/.test(navigator.vendor);
-  const isWindowsBrowser = navigator.appVersion.indexOf("Win") !== -1;
-
-  if (isAppleBrowser) {
+  if (isDarwin) {
     return shareIOS;
-  } else if (isWindowsBrowser) {
+  } else if (isWindows) {
     return shareWindows;
   }
 

--- a/packages/excalidraw/components/Range.scss
+++ b/packages/excalidraw/components/Range.scss
@@ -49,7 +49,7 @@
   .zero-label {
     position: absolute;
     bottom: 0;
-    left: 4px;
+    inset-inline-start: 4px;
     font-size: 12px;
     color: var(--text-primary-color);
   }

--- a/packages/excalidraw/components/Range.tsx
+++ b/packages/excalidraw/components/Range.tsx
@@ -36,10 +36,14 @@ export const Range = ({ updateData, app, testId }: RangeProps) => {
       const valueElement = valueRef.current;
       const inputWidth = rangeElement.offsetWidth;
       const thumbWidth = 15; // 15 is the width of the thumb
+      const isRTL =
+        getComputedStyle(rangeElement).direction === "rtl";
       const position =
         (value / 100) * (inputWidth - thumbWidth) + thumbWidth / 2;
-      valueElement.style.left = `${position}px`;
-      rangeElement.style.background = `linear-gradient(to right, var(--color-slider-track) 0%, var(--color-slider-track) ${value}%, var(--button-bg) ${value}%, var(--button-bg) 100%)`;
+      valueElement.style.insetInlineStart = `${position}px`;
+      valueElement.style.insetInlineEnd = "auto";
+      const gradientDir = isRTL ? "to left" : "to right";
+      rangeElement.style.background = `linear-gradient(${gradientDir}, var(--color-slider-track) 0%, var(--color-slider-track) ${value}%, var(--button-bg) ${value}%, var(--button-bg) 100%)`;
     }
   }, [value]);
 


### PR DESCRIPTION
## Summary

This PR addresses two open bugs:

### 1. ShareDialog: Replace fragile UA string parsing (#9583)
The `getShareIcon()` function used deprecated `navigator.vendor` and `navigator.appVersion`. Replaced with existing `isDarwin`/`isWindows` from `@excalidraw/common`.

### 2. Opacity slider RTL incompatibility (#9710)
The Range component used `left` positioning and hardcoded `to right` gradient — both break in RTL. Fixed with `inset-inline-start` and direction-aware gradient.

Fixes #9583, Fixes #9710