### PR TITLE
fix: typo overriden → overridden in comments

### DIFF
--- a/packages/element/src/binding.ts
+++ b/packages/element/src/binding.ts
@@ -563,7 +563,7 @@ const bindingStrategyForSimpleArrowEndpointDragging_complex = (
   }
 
   // Must return as only one endpoint is dragged, therefore
-  // the end binding strategy might accidentally gets overriden
+  // the end binding strategy might accidentally gets overridden
   return { current, other: isMultiPoint ? { mode: undefined } : other };
 };
 

--- a/packages/excalidraw/fonts/Fonts.ts
+++ b/packages/excalidraw/fonts/Fonts.ts
@@ -193,7 +193,7 @@ export class Fonts {
         charsPerFamily[family] = new Set(characters);
 
         // the order between the families and fallbacks is important, as fallbacks need to be defined first and in the reversed order
-        // so that they get overriden with the later defined font faces, i.e. in case they share some codepoints
+        // so that they get overridden with the later defined font faces, i.e. in case they share some codepoints
         families.unshift(FONT_FAMILY_FALLBACKS[CJK_HAND_DRAWN_FALLBACK_FONT]);
       }
     }


### PR DESCRIPTION
Fixes a minor typo in two code comments where `overriden` was used instead of `overridden`.