### PR TITLE
Feat: Export selection on right click and not just on hamburger menu or shortcut

### DIFF
--- a/packages/excalidraw/actions/actionExport.tsx
+++ b/packages/excalidraw/actions/actionExport.tsx
@@ -294,6 +294,20 @@ export const actionLoadScene = register({
   keyTest: (event) => event[KEYS.CTRL_OR_CMD] && event.key === KEYS.O,
 });
 
+export const actionExportImage = register({
+  name: "imageExport",
+  label: "buttons.exportImage",
+  trackEvent: { category: "export", action: "dialog" },
+  perform: (_elements, appState) => {
+    return {
+      appState: { ...appState, openDialog: { name: "imageExport" } },
+      captureUpdate: CaptureUpdateAction.EVENTUALLY,
+    };
+  },
+  keyTest: (event) =>
+    event[KEYS.CTRL_OR_CMD] && event.shiftKey && event.key === KEYS.E,
+});
+
 export const actionExportWithDarkMode = register<
   AppState["exportWithDarkMode"]
 >({

--- a/packages/excalidraw/actions/index.ts
+++ b/packages/excalidraw/actions/index.ts
@@ -41,6 +41,7 @@ export {
   actionSaveToActiveFile,
   actionSaveFileToDisk,
   actionLoadScene,
+  actionExportImage,
 } from "./actionExport";
 
 export { actionCopyStyles, actionPasteStyles } from "./actionStyles";

--- a/packages/excalidraw/actions/types.ts
+++ b/packages/excalidraw/actions/types.ts
@@ -142,7 +142,8 @@ export type ActionName =
   | "wrapSelectionInFrame"
   | "toggleLassoTool"
   | "toggleShapeSwitch"
-  | "togglePolygon";
+  | "togglePolygon"
+  | "imageExport";
 
 export type PanelComponentProps = {
   elements: readonly ExcalidrawElement[];

--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -295,6 +295,7 @@ import {
   actionCopy,
   actionCopyAsPng,
   actionCopyAsSvg,
+  actionExportImage,
   copyText,
   actionCopyStyles,
   actionCut,
@@ -12004,6 +12005,7 @@ class App extends React.Component<AppProps, AppState> {
       return [
         actionPaste,
         CONTEXT_MENU_SEPARATOR,
+        actionExportImage,
         actionCopyAsPng,
         actionCopyAsSvg,
         copyText,
@@ -12051,6 +12053,7 @@ class App extends React.Component<AppProps, AppState> {
       CONTEXT_MENU_SEPARATOR,
       actionToggleCropEditor,
       CONTEXT_MENU_SEPARATOR,
+      actionExportImage,
       ...options,
       CONTEXT_MENU_SEPARATOR,
       actionCopyStyles,


### PR DESCRIPTION
# Why I added this small fix
As a excalidraw users, many a times I wanted to export selected canvas, but I need to navigate to hamburger menu and click export. Naturally users don't use the Ctrl+shift+E shortcut. Users tend to right click to export. So I have added the export option in right click. A very small fix, but would be useful for me as well as others