### PR TITLE
feat: Added Sharp Elbow Arrow as requested in issue #10593

### DIFF
--- a/packages/common/src/constants.ts
+++ b/packages/common/src/constants.ts
@@ -480,10 +480,13 @@ export const STATS_PANELS = { generalStats: 1, elementProperties: 2 } as const;
 
 export const MIN_WIDTH_OR_HEIGHT = 1;
 
-export const ARROW_TYPE: { [T in AppState["currentItemArrowType"]]: T } = {
+export const ARROW_TYPE: {
+  [T in AppState["currentItemArrowType"]]: T;
+} = {
   sharp: "sharp",
   round: "round",
   elbow: "elbow",
+  sharpElbow: "sharpElbow",
 };
 
 export const DEFAULT_REDUCED_GLOBAL_ALPHA = 0.3;

--- a/packages/element/src/shape.ts
+++ b/packages/element/src/shape.ts
@@ -480,7 +480,7 @@ export const generateLinearCollisionShape = (
         : [pointFrom<LocalPoint>(0, 0)];
 
       if (isElbowArrow(element)) {
-        return generator.path(generateElbowArrowShape(points, 16), options)
+        return generator.path(generateElbowArrowShape(element), options)
           .sets[0].ops;
       } else if (!element.roundness) {
         return points.map((point, idx) => {
@@ -774,7 +774,7 @@ const _generateElementShape = (
         } else {
           shape = [
             generator.path(
-              generateElbowArrowShape(points, 16),
+              generateElbowArrowShape(element),
               generateRoughOptions(element, true, isDarkMode),
             ),
           ];
@@ -876,10 +876,9 @@ const _generateElementShape = (
   }
 };
 
-const generateElbowArrowShape = (
-  points: readonly LocalPoint[],
-  radius: number,
-) => {
+const generateElbowArrowShape = (element: ExcalidrawLinearElement) => {
+  const radius = element.roundness ? 16 : 0;
+  const points = element.points;
   const subpoints = [] as [number, number][];
   for (let i = 1; i < points.length - 1; i += 1) {
     const prev = points[i - 1];

--- a/packages/excalidraw/actions/actionProperties.tsx
+++ b/packages/excalidraw/actions/actionProperties.tsx
@@ -1753,18 +1753,29 @@ export const actionChangeArrowType = register<keyof typeof ARROW_TYPE>({
         elementsMap,
       );
       let newElement = newElementWith(el, {
-        x: value === ARROW_TYPE.elbow ? startPoint[0] : el.x,
-        y: value === ARROW_TYPE.elbow ? startPoint[1] : el.y,
+        x:
+          value === ARROW_TYPE.elbow || value === ARROW_TYPE.sharpElbow
+            ? startPoint[0]
+            : el.x,
+        y:
+          value === ARROW_TYPE.elbow || value === ARROW_TYPE.sharpElbow
+            ? startPoint[1]
+            : el.y,
         roundness:
-          value === ARROW_TYPE.round
+          value === ARROW_TYPE.round || value === ARROW_TYPE.elbow
             ? {
                 type: ROUNDNESS.PROPORTIONAL_RADIUS,
               }
             : null,
-        elbowed: value === ARROW_TYPE.elbow,
-        angle: value === ARROW_TYPE.elbow ? (0 as Radians) : el.angle,
+        elbowed: value === ARROW_TYPE.elbow || value === ARROW_TYPE.sharpElbow,
+        angle:
+          value === ARROW_TYPE.elbow || value === ARROW_TYPE.sharpElbow
+            ? (0 as Radians)
+            : el.angle,
         points:
-          value === ARROW_TYPE.elbow || el.elbowed
+          value === ARROW_TYPE.elbow ||
+          value === ARROW_TYPE.sharpElbow ||
+          el.elbowed
             ? [
                 LinearElementEditor.pointFromAbsoluteCoords(
                   {
@@ -1946,15 +1957,24 @@ export const actionChangeArrowType = register<keyof typeof ARROW_TYPE>({
                 icon: elbowArrowIcon,
                 testId: "elbow-arrow",
               },
+              {
+                value: ARROW_TYPE.sharpElbow,
+                text: t("labels.arrowtype_sharpElbow"),
+                icon: elbowArrowIcon,
+                testId: "sharp-elbow-arrow",
+              },
             ]}
             value={getFormValue(
               elements,
               app,
               (element) => {
                 if (isArrowElement(element)) {
-                  return element.elbowed
-                    ? ARROW_TYPE.elbow
-                    : element.roundness
+                  if (element.elbowed) {
+                    return element.roundness
+                      ? ARROW_TYPE.elbow
+                      : ARROW_TYPE.sharpElbow;
+                  }
+                  return element.roundness
                     ? ARROW_TYPE.round
                     : ARROW_TYPE.sharp;
                 }

--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -8662,18 +8662,20 @@ class App extends React.Component<AppProps, AppState> {
               roughness: this.state.currentItemRoughness,
               opacity: this.state.currentItemOpacity,
               roundness:
-                this.state.currentItemArrowType === ARROW_TYPE.round
+                this.state.currentItemArrowType === ARROW_TYPE.round ||
+                this.state.currentItemArrowType === ARROW_TYPE.elbow
                   ? { type: ROUNDNESS.PROPORTIONAL_RADIUS }
-                  : // note, roundness doesn't have any effect for elbow arrows,
-                    // but it's best to set it to null as well
-                    null,
+                  : null,
               startArrowhead,
               endArrowhead,
               locked: false,
               frameId: topLayerFrame ? topLayerFrame.id : null,
-              elbowed: this.state.currentItemArrowType === ARROW_TYPE.elbow,
+              elbowed:
+                this.state.currentItemArrowType === ARROW_TYPE.elbow ||
+                this.state.currentItemArrowType === ARROW_TYPE.sharpElbow,
               fixedSegments:
-                this.state.currentItemArrowType === ARROW_TYPE.elbow
+                this.state.currentItemArrowType === ARROW_TYPE.elbow ||
+                this.state.currentItemArrowType === ARROW_TYPE.sharpElbow
                   ? []
                   : null,
             })

--- a/packages/excalidraw/locales/en.json
+++ b/packages/excalidraw/locales/en.json
@@ -54,6 +54,7 @@
     "arrowtype_sharp": "Sharp arrow",
     "arrowtype_round": "Curved arrow",
     "arrowtype_elbowed": "Elbow arrow",
+    "arrowtype_sharpElbow": "Sharp elbow arrow",
     "fontSize": "Font size",
     "fontFamily": "Font family",
     "addWatermark": "Add \"Made with Excalidraw\"",

--- a/packages/excalidraw/types.ts
+++ b/packages/excalidraw/types.ts
@@ -353,7 +353,7 @@ export interface AppState {
   currentItemEndArrowhead: Arrowhead | null;
   currentHoveredFontFamily: FontFamilyValues | null;
   currentItemRoundness: StrokeRoundness;
-  currentItemArrowType: "sharp" | "round" | "elbow";
+  currentItemArrowType: "sharp" | "round" | "elbow" | "sharpElbow";
   viewBackgroundColor: string;
   scrollX: number;
   scrollY: number;


### PR DESCRIPTION
# Sharp Elbow arrow

Many professional diagram uses sharp elbow arrows instead of rounded ones. This has been requested as a feature in Issue #10593. I have implemented the changes


The user can toggle between the already exisiting rounded elbow arrow and also the newer sharp ones
<img width="800" height="500" alt="image" src="https://github.com/user-attachments/assets/818a601d-16d8-4162-b0f6-472f6090ee5e" />

<img width="800" height="500" alt="image" src="https://github.com/user-attachments/assets/157e55a2-cc89-48f4-84f8-0370fa726080" />

