### PR TITLE
fix: make opacity slider compatible with RTL layout

### DIFF
--- a/packages/excalidraw/components/Range.scss
+++ b/packages/excalidraw/components/Range.scss
@@ -49,8 +49,15 @@
   .zero-label {
     position: absolute;
     bottom: 0;
-    left: 4px;
     font-size: 12px;
     color: var(--text-primary-color);
+
+    :root[dir="ltr"] & {
+      left: 4px;
+    }
+
+    :root[dir="rtl"] & {
+      right: 4px;
+    }
   }
 }

--- a/packages/excalidraw/components/Range.tsx
+++ b/packages/excalidraw/components/Range.tsx
@@ -38,8 +38,16 @@ export const Range = ({ updateData, app, testId }: RangeProps) => {
       const thumbWidth = 15; // 15 is the width of the thumb
       const position =
         (value / 100) * (inputWidth - thumbWidth) + thumbWidth / 2;
-      valueElement.style.left = `${position}px`;
-      rangeElement.style.background = `linear-gradient(to right, var(--color-slider-track) 0%, var(--color-slider-track) ${value}%, var(--button-bg) ${value}%, var(--button-bg) 100%)`;
+      const isRTL = document.documentElement.dir === "rtl";
+      if (isRTL) {
+        valueElement.style.right = `${position}px`;
+        valueElement.style.left = "auto";
+      } else {
+        valueElement.style.left = `${position}px`;
+        valueElement.style.right = "auto";
+      }
+      const gradientDir = isRTL ? "to left" : "to right";
+      rangeElement.style.background = `linear-gradient(${gradientDir}, var(--color-slider-track) 0%, var(--color-slider-track) ${value}%, var(--button-bg) ${value}%, var(--button-bg) 100%)`;
     }
   }, [value]);
 


### PR DESCRIPTION
## Summary

Fixes #9710 - The element transparency/opacity slider bar was not compatible with RTL (right-to-left) languages like Arabic, Persian, and Hebrew.

## Changes

**`Range.tsx`**:
- Detect RTL mode via `document.documentElement.dir`
- Position the value bubble using `right` instead of `left` in RTL mode
- Flip the background gradient direction (`to left` in RTL, `to right` in LTR)

**`Range.scss`**:
- Replace hard-coded `left: 4px` on `.zero-label` with RTL-aware `:root[dir="ltr"]`/`:root[dir="rtl"]` rules, following the same pattern used in `IconPicker.scss`, `ToolIcon.scss`, `Actions.scss`, etc.

## Test plan

- [ ] Switch language to Arabic (or any RTL language) and verify the opacity slider renders correctly with the track fill, value bubble, and "0" label all mirrored
- [ ] Verify LTR languages still work as before

> This PR was created with AI assistance. Happy to make any adjustments!