### PR TITLE
feat: auto-pan canvas while dragging selections near viewport edges

### DIFF
--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -567,6 +567,8 @@ let isDraggingScrollBar: boolean = false;
 let currentScrollBars: ScrollBars = { horizontal: null, vertical: null };
 let touchTimeout = 0;
 let invalidateContextMenu = false;
+const EDGE_PAN_THRESHOLD = 24;
+const EDGE_PAN_MAX_STEP = 4;
 
 /**
  * Map of youtube embed video states
@@ -651,6 +653,13 @@ class App extends React.Component<AppProps, AppState> {
   /** previous frame pointer coords */
   previousPointerMoveCoords: { x: number; y: number } | null = null;
   lastViewportPosition = { x: 0, y: 0 };
+  private selectionEdgePanRafId: number | null = null;
+  private selectionEdgePanLastEvent: PointerEvent | null = null;
+  private isSelectionEdgePanSyntheticMove = false;
+  private isSelectionEdgePanPrimed = false;
+  private skipNextSelectionEdgePanTick = false;
+  private selectionEdgePanLastClientCoords: { x: number; y: number } | null =
+    null;
 
   animationFrameHandler = new AnimationFrameHandler();
 
@@ -7529,6 +7538,11 @@ class App extends React.Component<AppProps, AppState> {
   private handleCanvasPointerUp = (
     event: React.PointerEvent<HTMLCanvasElement>,
   ) => {
+    this.selectionEdgePanLastEvent = null;
+    this.isSelectionEdgePanPrimed = false;
+    this.skipNextSelectionEdgePanTick = false;
+    this.selectionEdgePanLastClientCoords = null;
+    this.stopSelectionEdgePanLoop();
     if (getFeatureFlag("COMPLEX_BINDINGS")) {
       this.resetDelayedBindMode();
     }
@@ -9047,10 +9061,27 @@ class App extends React.Component<AppProps, AppState> {
     pointerDownState: PointerDownState,
   ) {
     return withBatchedUpdatesThrottled((event: PointerEvent) => {
+      const pointerMoveClientDelta = { x: 0, y: 0 };
+      if (!this.isSelectionEdgePanSyntheticMove) {
+        // Prioritize real pointer movement over synthetic edge-pan ticks
+        // without restarting the loop every pointermove (smoother feel).
+        this.skipNextSelectionEdgePanTick = true;
+        if (this.selectionEdgePanLastClientCoords) {
+          pointerMoveClientDelta.x =
+            event.clientX - this.selectionEdgePanLastClientCoords.x;
+          pointerMoveClientDelta.y =
+            event.clientY - this.selectionEdgePanLastClientCoords.y;
+        }
+        this.selectionEdgePanLastClientCoords = {
+          x: event.clientX,
+          y: event.clientY,
+        };
+        this.selectionEdgePanLastEvent = event;
+      }
       if (this.state.openDialog?.name === "elementLinkSelector") {
         return;
       }
-      const pointerCoords = viewportCoordsToSceneCoords(event, this.state);
+      let pointerCoords = viewportCoordsToSceneCoords(event, this.state);
 
       if (this.state.activeLockedId) {
         this.setState({
@@ -9383,6 +9414,62 @@ class App extends React.Component<AppProps, AppState> {
           !this.state.editingTextElement &&
           this.state.activeEmbeddable?.state !== "active"
         ) {
+          const edgePanDelta = this.getSelectionEdgePanDelta(event);
+          // Pan only when user pushes towards an edge, or while holding still
+          // at edge (delta ~= 0), to avoid accidental pan near top/left.
+          if (
+            (edgePanDelta.x < 0 && pointerMoveClientDelta.x > 0) ||
+            (edgePanDelta.x > 0 && pointerMoveClientDelta.x < 0)
+          ) {
+            edgePanDelta.x = 0;
+          }
+          if (
+            (edgePanDelta.y < 0 && pointerMoveClientDelta.y > 0) ||
+            (edgePanDelta.y > 0 && pointerMoveClientDelta.y < 0)
+          ) {
+            edgePanDelta.y = 0;
+          }
+          const isEdgePanZone = edgePanDelta.x !== 0 || edgePanDelta.y !== 0;
+          if (edgePanDelta.x || edgePanDelta.y) {
+            this.startSelectionEdgePanLoop(pointerDownState);
+            // Avoid accidental pan on first edge contact during a normal drag.
+            // Continuous pan is handled by the edge-pan RAF loop.
+            if (
+              !this.isSelectionEdgePanSyntheticMove &&
+              !this.isSelectionEdgePanPrimed
+            ) {
+              this.isSelectionEdgePanPrimed = true;
+              edgePanDelta.x = 0;
+              edgePanDelta.y = 0;
+            }
+          } else {
+            this.isSelectionEdgePanPrimed = false;
+            this.stopSelectionEdgePanLoop();
+          }
+          if (edgePanDelta.x || edgePanDelta.y) {
+            const zoomValue = this.state.zoom.value;
+            this.translateCanvas((prevState) => ({
+              scrollX:
+                prevState.scrollX - edgePanDelta.x / prevState.zoom.value,
+              scrollY:
+                prevState.scrollY - edgePanDelta.y / prevState.zoom.value,
+            }));
+            // Keep edge-pan speed deterministic: when edge-pan is active for
+            // an axis, use fixed per-frame movement instead of raw pointer
+            // deltas (which vary with mouse speed).
+            pointerCoords = {
+              x:
+                edgePanDelta.x !== 0
+                  ? lastPointerCoords.x + edgePanDelta.x / zoomValue
+                  : pointerCoords.x,
+              y:
+                edgePanDelta.y !== 0
+                  ? lastPointerCoords.y + edgePanDelta.y / zoomValue
+                  : pointerCoords.y,
+            };
+            this.previousPointerMoveCoords = pointerCoords;
+          }
+
           const dragOffset = {
             x: pointerCoords.x - pointerDownState.drag.origin.x,
             y: pointerCoords.y - pointerDownState.drag.origin.y,
@@ -9511,16 +9598,22 @@ class App extends React.Component<AppProps, AppState> {
           // Snap cache *must* be synchronously popuplated before initial drag,
           // otherwise the first drag even will not snap, causing a jump before
           // it snaps to its position if previously snapped already.
-          this.maybeCacheVisibleGaps(event, selectedElements);
-          this.maybeCacheReferenceSnapPoints(event, selectedElements);
+          let snapOffset = { x: 0, y: 0 };
+          let snapLines = [] as AppState["snapLines"];
+          if (!isEdgePanZone) {
+            this.maybeCacheVisibleGaps(event, selectedElements);
+            this.maybeCacheReferenceSnapPoints(event, selectedElements);
 
-          const { snapOffset, snapLines } = snapDraggedElements(
-            originalElements,
-            dragOffset,
-            this,
-            event,
-            this.scene.getNonDeletedElementsMap(),
-          );
+            const snapResult = snapDraggedElements(
+              originalElements,
+              dragOffset,
+              this,
+              event,
+              this.scene.getNonDeletedElementsMap(),
+            );
+            snapOffset = snapResult.snapOffset;
+            snapLines = snapResult.snapLines;
+          }
 
           this.setState({ snapLines });
 
@@ -9533,7 +9626,11 @@ class App extends React.Component<AppProps, AppState> {
               dragOffset,
               this.scene,
               snapOffset,
-              event[KEYS.CTRL_OR_CMD] ? null : this.getEffectiveGridSize(),
+              event[KEYS.CTRL_OR_CMD] ||
+                this.isSelectionEdgePanSyntheticMove ||
+                isEdgePanZone
+                ? null
+                : this.getEffectiveGridSize(),
             );
           }
 
@@ -9948,6 +10045,94 @@ class App extends React.Component<AppProps, AppState> {
     return false;
   }
 
+  private getSelectionEdgePanDelta(event: PointerEvent) {
+    if (
+      event.pointerType === "touch" ||
+      this.state.width <= 0 ||
+      this.state.height <= 0
+    ) {
+      return { x: 0, y: 0 };
+    }
+
+    const canvasRect = this.interactiveCanvas?.getBoundingClientRect();
+    const hasValidCanvasRect =
+      !!canvasRect && canvasRect.width > 0 && canvasRect.height > 0;
+    const rect = hasValidCanvasRect
+      ? {
+          left: canvasRect.left,
+          right: canvasRect.right,
+          top: canvasRect.top,
+          bottom: canvasRect.bottom,
+        }
+      : {
+          left: this.state.offsetLeft,
+          right: this.state.offsetLeft + this.state.width,
+          top: this.state.offsetTop,
+          bottom: this.state.offsetTop + this.state.height,
+        };
+    const getAxisDelta = (pointerPos: number, min: number, max: number) => {
+      if (pointerPos < min + EDGE_PAN_THRESHOLD) {
+        return -EDGE_PAN_MAX_STEP;
+      }
+      if (pointerPos > max - EDGE_PAN_THRESHOLD) {
+        return EDGE_PAN_MAX_STEP;
+      }
+      return 0;
+    };
+
+    return {
+      x: getAxisDelta(event.clientX, rect.left, rect.right),
+      y: getAxisDelta(event.clientY, rect.top, rect.bottom),
+    };
+  }
+
+  private startSelectionEdgePanLoop(pointerDownState: PointerDownState) {
+    if (this.selectionEdgePanRafId !== null) {
+      return;
+    }
+
+    const tick = () => {
+      if (this.state.cursorButton !== "down") {
+        this.stopSelectionEdgePanLoop();
+        return;
+      }
+      if (
+        this.selectionEdgePanLastEvent &&
+        typeof this.selectionEdgePanLastEvent.buttons === "number" &&
+        this.selectionEdgePanLastEvent.buttons === 0
+      ) {
+        this.stopSelectionEdgePanLoop();
+        return;
+      }
+      if (this.skipNextSelectionEdgePanTick) {
+        this.skipNextSelectionEdgePanTick = false;
+        this.selectionEdgePanRafId = window.requestAnimationFrame(tick);
+        return;
+      }
+      const onMove = pointerDownState.eventListeners.onMove;
+      if (!onMove || !this.selectionEdgePanLastEvent) {
+        this.stopSelectionEdgePanLoop();
+        return;
+      }
+      this.isSelectionEdgePanSyntheticMove = true;
+      try {
+        onMove(this.selectionEdgePanLastEvent);
+      } finally {
+        this.isSelectionEdgePanSyntheticMove = false;
+      }
+      this.selectionEdgePanRafId = window.requestAnimationFrame(tick);
+    };
+
+    this.selectionEdgePanRafId = window.requestAnimationFrame(tick);
+  }
+
+  private stopSelectionEdgePanLoop() {
+    if (this.selectionEdgePanRafId !== null) {
+      window.cancelAnimationFrame(this.selectionEdgePanRafId);
+      this.selectionEdgePanRafId = null;
+    }
+  }
+
   private onPointerUpFromPointerDownHandler(
     pointerDownState: PointerDownState,
   ): (event: PointerEvent) => void {
@@ -9955,6 +10140,11 @@ class App extends React.Component<AppProps, AppState> {
       const elementsMap = this.scene.getNonDeletedElementsMap();
 
       this.removePointer(childEvent);
+      this.selectionEdgePanLastEvent = null;
+      this.isSelectionEdgePanPrimed = false;
+      this.skipNextSelectionEdgePanTick = false;
+      this.selectionEdgePanLastClientCoords = null;
+      this.stopSelectionEdgePanLoop();
       pointerDownState.drag.blockDragging = false;
       if (pointerDownState.eventListeners.onMove) {
         pointerDownState.eventListeners.onMove.flush();
@@ -10179,6 +10369,10 @@ class App extends React.Component<AppProps, AppState> {
         EVENT.KEYUP,
         pointerDownState.eventListeners.onKeyUp!,
       );
+      pointerDownState.eventListeners.onMove = null;
+      pointerDownState.eventListeners.onUp = null;
+      pointerDownState.eventListeners.onKeyDown = null;
+      pointerDownState.eventListeners.onKeyUp = null;
 
       this.props?.onPointerUp?.(activeTool, pointerDownState);
       this.onPointerUpEmitter.trigger(


### PR DESCRIPTION
For feature: #10799

## Summary

- Add viewport edge auto-pan while dragging selected elements, so users can move selections beyond the currently visible canvas without zooming out or cut/paste workflows.
- Implement continuous, direction-aware edge-pan behavior with safeguards for pointer-up cleanup and immediate user steering control back toward canvas center.
- Improve drag consistency by using deterministic edge-pan speed and avoiding snap/grid interference while actively edge-panning.
- Add regression coverage for edge-pan drag behavior in `packages/excalidraw/tests/move.test.tsx`.

## Motivation

Dragging selected content to off-screen locations currently requires workaround flows (zoom out heavily, then drag; or copy/paste after manual pan).  
This change makes long-distance repositioning feel direct and efficient.

## Implementation Details

- Added edge-pan detection in `App` pointer-move selection-drag flow.
- Added RAF-driven edge-pan loop for “hold at edge” continuous panning.
- Added cleanup/reset on pointer-up to prevent stale drag continuation.
- Added direction filtering so edge-pan follows intended drag direction.
- During active edge-pan zone, temporarily bypasses snapping/grid correction to reduce jitter and conflicting movement corrections.
- Kept normal drag behavior unchanged outside edge-pan zone.

## Test Plan

### Automated

- `yarn test --watch=false packages/excalidraw/tests/move.test.tsx`
- `yarn test --watch=false packages/excalidraw/tests/regressionTests.test.tsx`
- Additional interaction/history sweeps were run during development:
  - `packages/excalidraw/tests/history.test.tsx`
  - `packages/excalidraw/tests/selection.test.tsx`
  - `packages/excalidraw/tests/scroll.test.tsx`
  - `packages/excalidraw/tests/dragCreate.test.tsx`
  - `packages/excalidraw/tests/lasso.test.tsx`

### Manual

- Drag a selected element toward each viewport edge and hold mouse:
  - canvas continues panning while drag is active.
- While still holding mouse, move pointer back toward center:
  - drag follows back immediately (no edge-lock).
- Release mouse during edge-pan:
  - auto-pan stops immediately.
- Verify behavior in grid mode:
  - reduced jitter during active edge-pan.
- Verify behavior remains normal when not near edges.

### Demo

https://github.com/user-attachments/assets/b3b5289d-6b43-41f9-bd90-ec468829df2d

Would love to get feedback on this and open to suggestions/changes!
@mtolmacs @dwelle 