### PR TITLE
Fix #9662: Shape switch ends up with too round corners

### DIFF
--- a/packages/excalidraw/components/ConvertElementTypePopup.tsx
+++ b/packages/excalidraw/components/ConvertElementTypePopup.tsx
@@ -834,7 +834,7 @@ const convertElementType = <
         ...element,
         type: targetType,
         roundness:
-          targetType === "diamond" && element.roundness
+          CONVERTIBLE_GENERIC_TYPES.has(targetType) && element.roundness
             ? {
                 type: isUsingAdaptiveRadius(targetType)
                   ? ROUNDNESS.ADAPTIVE_RADIUS


### PR DESCRIPTION
Fixes #9662

## Summary
This PR addresses: Shape switch ends up with too round corners

## Changes
```
packages/excalidraw/components/ConvertElementTypePopup.tsx | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
```

## Testing
Please review the changes carefully. The fix was verified against the existing test suite.

---
*This PR was created with the assistance of Claude Sonnet 4.6 by Anthropic | effort: low. Happy to make any adjustments!*