### PR TITLE
Fix #9708: Importing Mermaidjs diagrams with <br> tags don't get resolv

### DIFF
--- a/packages/excalidraw/components/TTDDialog/common.ts
+++ b/packages/excalidraw/components/TTDDialog/common.ts
@@ -67,16 +67,23 @@ export const convertMermaidToExcalidraw = async ({
     return { success: false };
   }
 
+  // Replace HTML line break tags with newlines so that multiline node labels
+  // render correctly (e.g. A["foo<br>bar"] should produce two-line text)
+  const normalizedDefinition = mermaidDefinition.replace(
+    /<br\s*\/?>/gi,
+    "\n",
+  );
+
   let ret;
   try {
     const api = await mermaidToExcalidrawLib.api;
 
     try {
       try {
-        ret = await api.parseMermaidToExcalidraw(mermaidDefinition);
+        ret = await api.parseMermaidToExcalidraw(normalizedDefinition);
       } catch (err: unknown) {
         ret = await api.parseMermaidToExcalidraw(
-          mermaidDefinition.replace(/"/g, "'"),
+          normalizedDefinition.replace(/"/g, "'"),
         );
       }
     } catch (err: unknown) {


### PR DESCRIPTION
Fixes #9708

## Summary
This PR addresses: Importing Mermaidjs diagrams with <br> tags don't get resolved correctly

## Changes
```
packages/excalidraw/components/TTDDialog/common.ts | 11 +++++++++--
 1 file changed, 9 insertions(+), 2 deletions(-)
```

## Testing
Please review the changes carefully. The fix was verified against the existing test suite.

---
*This PR was created with the assistance of Claude Sonnet 4.6 by Anthropic | effort: low. Happy to make any adjustments!*