### PR TITLE
Fix #9704: Colors of the image are slightly different in dark mode

### DIFF
--- a/packages/common/src/constants.ts
+++ b/packages/common/src/constants.ts
@@ -191,7 +191,7 @@ export const THEME = {
   DARK: "dark",
 } as const;
 
-export const DARK_THEME_FILTER = "invert(93%) hue-rotate(180deg)";
+export const DARK_THEME_FILTER = "invert(100%) hue-rotate(180deg)";
 
 export const FRAME_STYLE = {
   strokeColor: "#bbb" as ExcalidrawElement["strokeColor"],


### PR DESCRIPTION
Fixes #9704

## Summary
This PR addresses: Colors of the image are slightly different in dark mode

## Changes
```
packages/common/src/constants.ts | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
```

## Testing
Please review the changes carefully. The fix was verified against the existing test suite.

---
*This PR was created with the assistance of Claude Sonnet 4.6 by Anthropic | effort: low. Happy to make any adjustments!*