### PR TITLE
feat(editor): cancel in-progress pointer creation on Escape

### DIFF
--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -9019,10 +9019,86 @@ class App extends React.Component<AppProps, AppState> {
     }
   }
 
+  private removePointerInteractionEventListeners = (
+    pointerDownState: PointerDownState,
+  ) => {
+    this.missingPointerEventCleanupEmitter.clear();
+
+    window.removeEventListener(
+      EVENT.POINTER_MOVE,
+      pointerDownState.eventListeners.onMove!,
+    );
+    window.removeEventListener(
+      EVENT.POINTER_UP,
+      pointerDownState.eventListeners.onUp!,
+    );
+    window.removeEventListener(
+      EVENT.KEYDOWN,
+      pointerDownState.eventListeners.onKeyDown!,
+    );
+    window.removeEventListener(
+      EVENT.KEYUP,
+      pointerDownState.eventListeners.onKeyUp!,
+    );
+  };
+
+  private cancelInProgressPointerCreation = (
+    pointerDownState: PointerDownState,
+  ): boolean => {
+    const { newElement, multiElement } = this.state;
+
+    if (!newElement || multiElement) {
+      return false;
+    }
+
+    if (pointerDownState.eventListeners.onMove) {
+      pointerDownState.eventListeners.onMove.flush();
+    }
+
+    this.removePointerInteractionEventListeners(pointerDownState);
+    this.lassoTrail.endPath();
+    this.previousPointerMoveCoords = null;
+    SnapCache.setReferenceSnapPoints(null);
+    SnapCache.setVisibleGaps(null);
+
+    const nextSelectedElementIds = { ...this.state.selectedElementIds };
+    delete nextSelectedElementIds[newElement.id];
+
+    this.updateScene({
+      elements: this.scene
+        .getElementsIncludingDeleted()
+        .filter((element) => element.id !== newElement.id),
+      appState: {
+        cursorButton: "up",
+        newElement: null,
+        multiElement: null,
+        selectionElement: null,
+        selectedLinearElement: null,
+        startBoundElement: null,
+        suggestedBinding: null,
+        selectedElementIds: makeNextSelectedElementIds(
+          nextSelectedElementIds,
+          this.state,
+        ),
+      },
+      captureUpdate: CaptureUpdateAction.NEVER,
+    });
+
+    return true;
+  };
+
   private onKeyDownFromPointerDownHandler(
     pointerDownState: PointerDownState,
   ): (event: KeyboardEvent) => void {
     return withBatchedUpdates((event: KeyboardEvent) => {
+      if (
+        event.key === KEYS.ESCAPE &&
+        this.cancelInProgressPointerCreation(pointerDownState)
+      ) {
+        event.preventDefault();
+        return;
+      }
+
       if (this.maybeHandleResize(pointerDownState, event)) {
         return;
       }
@@ -10161,24 +10237,7 @@ class App extends React.Component<AppProps, AppState> {
         }
       }
 
-      this.missingPointerEventCleanupEmitter.clear();
-
-      window.removeEventListener(
-        EVENT.POINTER_MOVE,
-        pointerDownState.eventListeners.onMove!,
-      );
-      window.removeEventListener(
-        EVENT.POINTER_UP,
-        pointerDownState.eventListeners.onUp!,
-      );
-      window.removeEventListener(
-        EVENT.KEYDOWN,
-        pointerDownState.eventListeners.onKeyDown!,
-      );
-      window.removeEventListener(
-        EVENT.KEYUP,
-        pointerDownState.eventListeners.onKeyUp!,
-      );
+      this.removePointerInteractionEventListeners(pointerDownState);
 
       this.props?.onPointerUp?.(activeTool, pointerDownState);
       this.onPointerUpEmitter.trigger(

--- a/packages/excalidraw/tests/dragCreate.test.tsx
+++ b/packages/excalidraw/tests/dragCreate.test.tsx
@@ -357,4 +357,59 @@ describe("Test dragCreate", () => {
       ]);
     });
   });
+
+  describe("cancel in-progress creation with Escape", () => {
+    it("rectangle", async () => {
+      const { getByToolName, container } = await render(
+        <Excalidraw handleKeyboardGlobally={true} />,
+      );
+      fireEvent.click(getByToolName("rectangle"));
+
+      const canvas = container.querySelector("canvas.interactive")!;
+
+      fireEvent.pointerDown(canvas, { clientX: 30, clientY: 20 });
+      fireEvent.pointerMove(canvas, { clientX: 80, clientY: 70 });
+      fireEvent.keyDown(document, { key: KEYS.ESCAPE });
+      fireEvent.pointerUp(canvas, { clientX: 80, clientY: 70 });
+
+      expect(h.state.newElement).toBeNull();
+      expect(h.elements.length).toBe(0);
+    });
+
+    it("arrow", async () => {
+      const { getByToolName, container } = await render(
+        <Excalidraw handleKeyboardGlobally={true} />,
+      );
+      fireEvent.click(getByToolName("arrow"));
+
+      const canvas = container.querySelector("canvas.interactive")!;
+
+      fireEvent.pointerDown(canvas, { clientX: 30, clientY: 20 });
+      fireEvent.pointerMove(canvas, { clientX: 80, clientY: 70 });
+      fireEvent.keyDown(document, { key: KEYS.ESCAPE });
+      fireEvent.pointerUp(canvas, { clientX: 80, clientY: 70 });
+
+      expect(h.state.newElement).toBeNull();
+      expect(h.state.multiElement).toBeNull();
+      expect(h.elements.length).toBe(0);
+    });
+
+    it("freedraw", async () => {
+      const { getByToolName, container } = await render(
+        <Excalidraw handleKeyboardGlobally={true} />,
+      );
+      fireEvent.click(getByToolName("freedraw"));
+
+      const canvas = container.querySelector("canvas.interactive")!;
+
+      fireEvent.pointerDown(canvas, { clientX: 30, clientY: 20 });
+      fireEvent.pointerMove(canvas, { clientX: 40, clientY: 30 });
+      fireEvent.pointerMove(canvas, { clientX: 55, clientY: 45 });
+      fireEvent.keyDown(document, { key: KEYS.ESCAPE });
+      fireEvent.pointerUp(canvas, { clientX: 55, clientY: 45 });
+
+      expect(h.state.newElement).toBeNull();
+      expect(h.elements.length).toBe(0);
+    });
+  });
 });

--- a/packages/excalidraw/tests/multiPointCreate.test.tsx
+++ b/packages/excalidraw/tests/multiPointCreate.test.tsx
@@ -138,6 +138,35 @@ describe("multi point mode in linear elements", () => {
     h.elements.forEach((element) => expect(element).toMatchSnapshot());
   });
 
+  it("arrow can still be finished with Escape in multi-point mode", async () => {
+    const { getByToolName, container } = await render(<Excalidraw />);
+    const tool = getByToolName("arrow");
+    fireEvent.click(tool);
+
+    const canvas = container.querySelector("canvas.interactive")!;
+    fireEvent.pointerDown(canvas, { clientX: 30, clientY: 30 });
+    fireEvent.pointerUp(canvas, { clientX: 30, clientY: 30 });
+    fireEvent.pointerMove(canvas, { clientX: 50, clientY: 60 });
+
+    fireEvent.pointerDown(canvas, { clientX: 50, clientY: 60 });
+    fireEvent.pointerUp(canvas);
+    fireEvent.pointerMove(canvas, { clientX: 100, clientY: 140 });
+
+    fireEvent.keyDown(document, {
+      key: KEYS.ESCAPE,
+    });
+
+    expect(h.elements.length).toEqual(1);
+
+    const element = h.elements[0] as ExcalidrawLinearElement;
+    expect(element.type).toEqual("arrow");
+    expect(element.points).toEqual([
+      [0, 0],
+      [20, 30],
+      [70, 110],
+    ]);
+  });
+
   it("line", async () => {
     const { getByToolName, container } = await render(<Excalidraw />);
     // select tool


### PR DESCRIPTION
fixes #10814

### Summary

  This PR adds Esc support to cancel in-progress pointer-based element creation, so users can abort accidental draws immediately instead of finishing and deleting afterward.

  ### Why

  Esc-to-cancel is a standard interaction in modern whiteboard/design tools.
  Without it, accidental pointer-down actions force extra cleanup steps and slow down sketching flow.

  ### What changed

  - Added explicit cancellation flow for in-progress pointer creation in packages/excalidraw/components/App.tsx.
  - On Esc during pointer creation:
      - flushes pending pointer move handling
      - removes pointer/key listeners
      - clears transient draw/snap/lasso state
      - removes the temporary element from the scene
      - resets app state (newElement, selection-related transient state, etc.)
  - Kept existing multi-point linear behavior intact: Esc still finalizes multi-point arrow creation.

  ### Tests

  Added coverage for:

  - Esc cancels in-progress rectangle drag-create
  - Esc cancels in-progress arrow drag-create
  - Esc cancels in-progress freedraw
  - Regression: multi-point arrow can still be finished with Esc

  Updated files:

  - packages/excalidraw/components/App.tsx
  - packages/excalidraw/tests/dragCreate.test.tsx
  - packages/excalidraw/tests/multiPointCreate.test.tsx

  Validation run:

  - yarn test:app packages/excalidraw/tests/dragCreate.test.tsx packages/excalidraw/tests/multiPointCreate.test.tsx --watch=false
  - Result: 2/2 files passed, 19/19 tests passed.

### Screen Recording

https://github.com/user-attachments/assets/0e20812a-8602-47fa-9cad-a1cdb73c7771
