### PR TITLE
feat: display error feedback for invalid hex color input

### DIFF
--- a/packages/excalidraw/components/ColorPicker/ColorInput.tsx
+++ b/packages/excalidraw/components/ColorPicker/ColorInput.tsx
@@ -29,21 +29,26 @@ export const ColorInput = ({
 }) => {
   const editorInterface = useEditorInterface();
   const [innerValue, setInnerValue] = useState(color);
+  const [isInvalid, setIsInvalid] = useState(false);
   const [activeSection, setActiveColorPickerSection] = useAtom(
     activeColorPickerSectionAtom,
   );
 
   useEffect(() => {
     setInnerValue(color);
+    setIsInvalid(false);
   }, [color]);
 
   const changeColor = useCallback(
     (inputValue: string) => {
       const value = inputValue.toLowerCase();
-      const color = normalizeInputColor(value);
+      const normalized = normalizeInputColor(value);
 
-      if (color) {
-        onChange(color);
+      if (normalized) {
+        onChange(normalized);
+        setIsInvalid(false);
+      } else {
+        setIsInvalid(value.trim().length > 0);
       }
       setInnerValue(value);
     },
@@ -68,67 +73,79 @@ export const ColorInput = ({
   }, [setEyeDropperState]);
 
   return (
-    <div className="color-picker__input-label">
-      <div className="color-picker__input-hash">#</div>
-      <input
-        ref={activeSection === "hex" ? inputRef : undefined}
-        style={{ border: 0, padding: 0 }}
-        spellCheck={false}
-        className="color-picker-input"
-        aria-label={label}
-        onChange={(event) => {
-          changeColor(event.target.value);
-        }}
-        value={(innerValue || "").replace(/^#/, "")}
-        onBlur={() => {
-          setInnerValue(color);
-        }}
-        tabIndex={-1}
-        onFocus={() => setActiveColorPickerSection("hex")}
-        onKeyDown={(event) => {
-          if (event.key === KEYS.TAB) {
-            return;
-          } else if (event.key === KEYS.ESCAPE) {
-            eyeDropperTriggerRef.current?.focus();
-          }
-          event.stopPropagation();
-        }}
-        placeholder={placeholder}
-      />
-      {/* TODO reenable on mobile with a better UX */}
-      {editorInterface.formFactor !== "phone" && (
-        <>
-          <div
-            style={{
-              width: "1px",
-              height: "1.25rem",
-              backgroundColor: "var(--default-border-color)",
-            }}
-          />
-          <div
-            ref={eyeDropperTriggerRef}
-            className={clsx("excalidraw-eye-dropper-trigger", {
-              selected: eyeDropperState,
-            })}
-            onClick={() =>
-              setEyeDropperState((s) =>
-                s
-                  ? null
-                  : {
-                      keepOpenOnAlt: false,
-                      onSelect: (color) => onChange(color),
-                      colorPickerType,
-                    },
-              )
+    <>
+      <div
+        className={clsx("color-picker__input-label", {
+          "color-picker__input-label--invalid": isInvalid,
+        })}
+      >
+        <div className="color-picker__input-hash">#</div>
+        <input
+          ref={activeSection === "hex" ? inputRef : undefined}
+          style={{ border: 0, padding: 0 }}
+          spellCheck={false}
+          className="color-picker-input"
+          aria-label={label}
+          onChange={(event) => {
+            changeColor(event.target.value);
+          }}
+          value={(innerValue || "").replace(/^#/, "")}
+          onBlur={() => {
+            setInnerValue(color);
+            setIsInvalid(false);
+          }}
+          tabIndex={-1}
+          onFocus={() => setActiveColorPickerSection("hex")}
+          onKeyDown={(event) => {
+            if (event.key === KEYS.TAB) {
+              return;
+            } else if (event.key === KEYS.ESCAPE) {
+              eyeDropperTriggerRef.current?.focus();
             }
-            title={`${t(
-              "labels.eyeDropper",
-            )} — ${KEYS.I.toLocaleUpperCase()} or ${getShortcutKey("Alt")} `}
-          >
-            {eyeDropperIcon}
-          </div>
-        </>
+            event.stopPropagation();
+          }}
+          placeholder={placeholder}
+        />
+        {/* TODO reenable on mobile with a better UX */}
+        {editorInterface.formFactor !== "phone" && (
+          <>
+            <div
+              style={{
+                width: "1px",
+                height: "1.25rem",
+                backgroundColor: "var(--default-border-color)",
+              }}
+            />
+            <div
+              ref={eyeDropperTriggerRef}
+              className={clsx("excalidraw-eye-dropper-trigger", {
+                selected: eyeDropperState,
+              })}
+              onClick={() =>
+                setEyeDropperState((s) =>
+                  s
+                    ? null
+                    : {
+                        keepOpenOnAlt: false,
+                        onSelect: (color) => onChange(color),
+                        colorPickerType,
+                      },
+                )
+              }
+              title={`${t(
+                "labels.eyeDropper",
+              )} — ${KEYS.I.toLocaleUpperCase()} or ${getShortcutKey("Alt")} `}
+            >
+              {eyeDropperIcon}
+            </div>
+          </>
+        )}
+      </div>
+      {isInvalid && (
+        <div className="color-picker__input-error">
+          {t("colorPicker.invalidColor")}
+        </div>
       )}
-    </div>
+    </>
   );
 };

--- a/packages/excalidraw/components/ColorPicker/ColorPicker.scss
+++ b/packages/excalidraw/components/ColorPicker/ColorPicker.scss
@@ -385,6 +385,20 @@
     }
   }
 
+  .color-picker__input-label--invalid {
+    border-color: var(--color-danger);
+
+    &:focus-within {
+      box-shadow: 0 0 0 1px var(--color-danger);
+    }
+  }
+
+  .color-picker__input-error {
+    color: var(--color-danger);
+    font-size: 0.75rem;
+    padding: 0 0.75rem 0.25rem;
+  }
+
   .color-picker__input-hash {
     padding: 0 0.25rem;
   }

--- a/packages/excalidraw/locales/en.json
+++ b/packages/excalidraw/locales/en.json
@@ -578,7 +578,8 @@
     "colors": "Colors",
     "shades": "Shades",
     "hexCode": "Hex code",
-    "noShades": "No shades available for this color"
+    "noShades": "No shades available for this color",
+    "invalidColor": "Invalid color"
   },
   "overwriteConfirm": {
     "action": {


### PR DESCRIPTION
## Description

Closes #9527

Currently, Excalidraw silently ignores invalid hexadecimal color values entered in the color picker input — no visual or textual feedback is shown. This PR adds clear error feedback when an invalid color is entered.

## Changes

**`packages/excalidraw/components/ColorPicker/ColorInput.tsx`**
- Added `isInvalid` state to track whether the current input is a valid color
- Input border turns red (`--color-danger`) when an invalid value is entered
- An "Invalid color" error message renders below the input
- Error state clears on: valid input, blur (reverts to last valid color), or external color change

**`packages/excalidraw/components/ColorPicker/ColorPicker.scss`**
- Added `.color-picker__input-label--invalid` style (red border + red focus ring)
- Added `.color-picker__input-error` style for the error message text

**`packages/excalidraw/locales/en.json`**
- Added `colorPicker.invalidColor` i18n key

## How to test

1. Open Excalidraw and select any element
2. Open the color picker and click the hex code input
3. Enter invalid values like `zzzzzz`, `12345`, `1`
4. **Expected**: Red border appears on the input + "Invalid color" message shown below
5. Enter a valid value like `ff0000` → error clears, color applies
6. Enter invalid value, then click away → error clears, previous color restored

## Checklist

- [x] TypeScript type check passes (`yarn test:typecheck`)
- [x] Lint passes (`eslint --max-warnings=0`)
- [x] All tests pass (96 test files, 1205 tests)
- [x] Uses existing design tokens (`--color-danger`)
- [x] Uses i18n for user-facing strings