### PR TITLE
feat: notion embeddable (#7950 - #9409)

### DIFF
--- a/packages/element/src/embeddable.ts
+++ b/packages/element/src/embeddable.ts
@@ -56,6 +56,8 @@ const RE_REDDIT =
 const RE_REDDIT_EMBED =
   /^<blockquote[\s\S]*?\shref=["'](https?:\/\/(?:www\.)?reddit\.com\/[^"']*)/i;
 
+const RE_NOTION = /^https:\/\/([a-zA-Z0-9-]+)\.notion\.site\/.+/;
+
 const parseYouTubeLikeTimestamp = (url: string): number => {
   let timeParam: string | null | undefined;
 
@@ -83,6 +85,27 @@ const parseYouTubeLikeTimestamp = (url: string): number => {
 
   const [, hours = "0", minutes = "0", seconds = "0"] = timeMatch;
   return parseInt(hours) * 3600 + parseInt(minutes) * 60 + parseInt(seconds);
+};
+
+const toNotionEmbedURL = (url: string): string | null => {
+  try {
+    const parsed = new URL(url);
+
+    if (!parsed.hostname.endsWith(".notion.site")) {
+      return null;
+    }
+
+    const match = parsed.pathname.match(/([a-f0-9]{32})$/i);
+    if (!match) {
+      return null;
+    }
+
+    const pageId = match[1];
+
+    return `https://${parsed.hostname}/ebd/${pageId}`;
+  } catch {
+    return null;
+  }
 };
 
 const parseGoogleDriveVideoLink = (
@@ -141,6 +164,7 @@ const ALLOWED_DOMAINS = new Set([
   "gist.github.com",
   "twitter.com",
   "x.com",
+  "*.notion.site",
   "*.simplepdf.eu",
   "stackblitz.com",
   "val.town",
@@ -158,6 +182,7 @@ const ALLOW_SAME_ORIGIN = new Set([
   "figma.com",
   "twitter.com",
   "x.com",
+  "*.notion.site",
   "*.simplepdf.eu",
   "stackblitz.com",
   "reddit.com",
@@ -276,6 +301,28 @@ export const getEmbedLink = (
       type,
       sandbox: { allowSameOrigin },
     };
+  }
+
+  const notionLink = link.match(RE_NOTION);
+  if (notionLink) {
+    const embedURL = toNotionEmbedURL(link);
+    if (embedURL) {
+      type = "generic";
+      link = embedURL;
+      aspectRatio = { w: 550, h: 550 };
+      embeddedLinkCache.set(originalLink, {
+        link,
+        intrinsicSize: aspectRatio,
+        type,
+        sandbox: { allowSameOrigin },
+      });
+      return {
+        link,
+        intrinsicSize: aspectRatio,
+        type,
+        sandbox: { allowSameOrigin },
+      };
+    }
   }
 
   const figmaLink = link.match(RE_FIGMA);


### PR DESCRIPTION
# Related Issues
- #9409
- #7950
# Result
<img width="470" height="426" alt="image" src="https://github.com/user-attachments/assets/78609e2d-4f8c-485f-b452-53aad6056ab4" />

# Usage
First the notion page has to be published, click on share and publish.
<img width="610" height="206" alt="image" src="https://github.com/user-attachments/assets/d645c20d-73ec-4cae-9292-436fb3df0a76" />

The site has to be public and accessable through browser, and we will copy the given link.
<img width="603" height="645" alt="image" src="https://github.com/user-attachments/assets/3550cc84-823d-4a78-8362-0a02528714c6" />

(https://www.embednotionpages.com/blog/notion-feature-iframe-embed)
# Solution Implemented
Line 59-60 Add regex to recognize any notion page site.

+89/109 toNotionEmbedURL(url) : This will create the output URL, based on the iframe that notion created when you click on "embed this page", which takes this structure :` https://${parsed.hostname}/ebd/${pageId} `

+167/185 : ALLOW_SAME_ORIGIN/ALLOWED_DOMAINS `*.notion.site`

+305/326 : Create and return notion iframe