### PR TITLE
fix: display error message for invalid hex color codes

### DIFF
--- a/packages/excalidraw/components/ColorPicker/ColorInput.tsx
+++ b/packages/excalidraw/components/ColorPicker/ColorInput.tsx
@@ -29,12 +29,14 @@ export const ColorInput = ({
 }) => {
   const editorInterface = useEditorInterface();
   const [innerValue, setInnerValue] = useState(color);
+  const [isInvalid, setIsInvalid] = useState(false);
   const [activeSection, setActiveColorPickerSection] = useAtom(
     activeColorPickerSectionAtom,
   );
 
   useEffect(() => {
     setInnerValue(color);
+    setIsInvalid(false);
   }, [color]);
 
   const changeColor = useCallback(
@@ -44,6 +46,9 @@ export const ColorInput = ({
 
       if (color) {
         onChange(color);
+        setIsInvalid(false);
+      } else {
+        setIsInvalid(value.length > 0);
       }
       setInnerValue(value);
     },
@@ -74,14 +79,18 @@ export const ColorInput = ({
         ref={activeSection === "hex" ? inputRef : undefined}
         style={{ border: 0, padding: 0 }}
         spellCheck={false}
-        className="color-picker-input"
+        className={clsx("color-picker-input", {
+          "color-picker-input--invalid": isInvalid,
+        })}
         aria-label={label}
+        aria-invalid={isInvalid}
         onChange={(event) => {
           changeColor(event.target.value);
         }}
         value={(innerValue || "").replace(/^#/, "")}
         onBlur={() => {
           setInnerValue(color);
+          setIsInvalid(false);
         }}
         tabIndex={-1}
         onFocus={() => setActiveColorPickerSection("hex")}
@@ -95,6 +104,11 @@ export const ColorInput = ({
         }}
         placeholder={placeholder}
       />
+      {isInvalid && (
+        <div className="color-picker-input__error" role="alert">
+          {t("colorPicker.invalidColor")}
+        </div>
+      )}
       {/* TODO reenable on mobile with a better UX */}
       {editorInterface.formFactor !== "phone" && (
         <>

--- a/packages/excalidraw/components/ColorPicker/ColorPicker.scss
+++ b/packages/excalidraw/components/ColorPicker/ColorPicker.scss
@@ -378,6 +378,7 @@
     padding: 0 12px;
     margin: 8px;
     box-sizing: border-box;
+    position: relative;
 
     &:focus-within {
       box-shadow: 0 0 0 1px var(--color-primary-darkest);
@@ -421,6 +422,22 @@
     &:focus-visible {
       box-shadow: none;
     }
+
+    &--invalid {
+      border-color: var(--color-danger);
+      color: var(--color-danger);
+    }
+  }
+
+  .color-picker-input__error {
+    position: absolute;
+    top: 100%;
+    left: 0;
+    right: 0;
+    font-size: 0.75rem;
+    color: var(--color-danger);
+    padding: 0.25rem 0.5rem;
+    white-space: nowrap;
   }
 
   .color-picker-label-swatch-container {

--- a/packages/excalidraw/locales/en.json
+++ b/packages/excalidraw/locales/en.json
@@ -578,7 +578,8 @@
     "colors": "Colors",
     "shades": "Shades",
     "hexCode": "Hex code",
-    "noShades": "No shades available for this color"
+    "noShades": "No shades available for this color",
+    "invalidColor": "Invalid color code"
   },
   "overwriteConfirm": {
     "action": {


### PR DESCRIPTION
## Summary

Fixes #9527

When users enter invalid hex color values (e.g., `123456789`, `zzzzzz`, `blue`, `1`) in the color picker input, the app now displays a clear error message instead of silently ignoring the input.

## Changes

- **ColorInput.tsx**: Added `isInvalid` state that tracks whether the current input is a valid color. When invalid, the input gets a red border and an error message appears below it. The error clears when a valid color is entered, the input is emptied, or the field loses focus.
- **ColorPicker.scss**: Added styles for the invalid input state (`.color-picker-input--invalid`) and the error message (`.color-picker-input__error`).
- **en.json**: Added `colorPicker.invalidColor` translation key.

## How it works

The existing `normalizeInputColor` function already returns `null` for invalid colors. This PR adds visual feedback when that happens:
- Red border on the input field
- "Invalid color code" message below the input
- `aria-invalid` attribute for accessibility
- `role="alert"` on the error message for screen readers