### PR TITLE
fix: allow Ctrl+F browser search in help menu

### DIFF
--- a/packages/excalidraw/actions/actionToggleSearchMenu.ts
+++ b/packages/excalidraw/actions/actionToggleSearchMenu.ts
@@ -56,5 +56,8 @@ export const actionToggleSearchMenu = register({
   predicate: (element, appState, props) => {
     return props.gridModeEnabled === undefined;
   },
-  keyTest: (event) => event[KEYS.CTRL_OR_CMD] && event.key === KEYS.F,
+  keyTest: (event, appState) =>
+    !appState.openDialog &&
+    event[KEYS.CTRL_OR_CMD] &&
+    event.key === KEYS.F,
 });


### PR DESCRIPTION
## Summary

When the help menu (or any dialog) is open, pressing Ctrl+F now triggers the browser's native find-in-page instead of being intercepted by Excalidraw's search menu action.

## The Problem

The `searchMenu` action's `keyTest` matched Ctrl+F unconditionally. Even though `perform()` correctly bailed out when a dialog was open (`if (appState.openDialog) return false`), the action manager had already called `event.preventDefault()` and `event.stopPropagation()` before invoking `perform()`, blocking the browser's native Ctrl+F.

## The Fix

Added an `!appState.openDialog` check to the `keyTest` predicate so the action doesn't match when any dialog is open. This lets the browser handle Ctrl+F natively, enabling find-in-page within the help menu content.

## Testing

1. Open the help menu (click `?` or press `Shift+?`)
2. Press Ctrl+F (or Cmd+F on macOS)
3. Browser's native find-in-page dialog appears and searches within the help menu

Fixes #9276