### PR TITLE
fix(editor): "hand" tool active after exiting view mode if laser point was used

### DIFF
--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -4866,7 +4866,7 @@ class App extends React.Component<AppProps, AppState> {
         this.state.viewModeEnabled &&
         event.key === KEYS.ESCAPE
       ) {
-        this.setActiveTool({ type: "hand" });
+        this.setActiveTool({ type: "selection" });
         return;
       }
 


### PR DESCRIPTION
@dwelle, 
fixes: #10840, introduced in #10802