### PR TITLE
feat(toolbar): add rainbow animation to main top toolbar

### DIFF
--- a/packages/excalidraw/components/Toolbar.scss
+++ b/packages/excalidraw/components/Toolbar.scss
@@ -1,7 +1,18 @@
 @use "../css/variables.module" as *;
 
+@keyframes rainbow-bg {
+  0%   { background-color: hsl(0, 80%, 88%); }
+  16%  { background-color: hsl(60, 80%, 88%); }
+  33%  { background-color: hsl(120, 80%, 88%); }
+  50%  { background-color: hsl(180, 80%, 88%); }
+  66%  { background-color: hsl(240, 80%, 88%); }
+  83%  { background-color: hsl(300, 80%, 88%); }
+  100% { background-color: hsl(360, 80%, 88%); }
+}
+
 .excalidraw {
   .App-toolbar {
+    animation: rainbow-bg 5s linear infinite;
     &.zen-mode {
       .ToolIcon__keybinding,
       .HintViewer {


### PR DESCRIPTION
## Summary
- Adds a `@keyframes rainbow-bg` CSS animation to `Toolbar.scss`
- The `.App-toolbar` background smoothly cycles through pastel rainbow colors (red → yellow → green → cyan → blue → magenta) over 5 seconds, looping infinitely
- Uses 88% lightness HSL values to keep the toolbar pale so dark tool icons remain legible

## Test plan
- [ ] Open the app in the browser
- [ ] Verify the top toolbar smoothly animates through rainbow pastel colors every 5 seconds
- [ ] Verify tool icons remain clearly visible against the animated background

🤖 Generated with [Claude Code](https://claude.com/claude-code)