### PR TITLE
fix(app): support opening embedded scene image files in PWA

### DIFF
--- a/excalidraw-app/vite.config.mts
+++ b/excalidraw-app/vite.config.mts
@@ -239,6 +239,8 @@ export default defineConfig(({ mode }) => {
               action: "/",
               accept: {
                 "application/vnd.excalidraw+json": [".excalidraw"],
+                "image/png": [".excalidraw.png"],
+                "image/svg+xml": [".excalidraw.svg"],
               },
             },
           ],


### PR DESCRIPTION
Closes #10689

## Summary
- register .excalidraw.png as a PWA file handler
- register .excalidraw.svg as a PWA file handler
- keep the existing .excalidraw handler unchanged

## Testing
- Confirmed the manifest source includes the new file handler extensions
- Confirmed the generated build manifest includes the new file handler extensions
- Manually verified the installed PWA can open embedded-scene PNG and SVG exports