### PR TITLE
Fix hex popover overlapping preferences menu items

### DIFF
--- a/packages/excalidraw/components/dropdownMenu/DropdownMenuSubContent.tsx
+++ b/packages/excalidraw/components/dropdownMenu/DropdownMenuSubContent.tsx
@@ -58,7 +58,7 @@ const DropdownMenuSubContent = ({
         <Island
           className="dropdown-menu-container"
           padding={2}
-          style={{ zIndex: 1 }}
+          style={{ zIndex: "var(--zIndex-ui-main-menu)" }}
         >
           {children}
         </Island>


### PR DESCRIPTION
Fixes #10863

## Problem
The hex color picker popover was overlapping the preferences submenu, making it difficult to interact with menu items like Zen mode, View mode, etc.

## Solution
Updated the z-index of the dropdown submenu from `1` to use `var(--zIndex-ui-main-menu)` (110), which places it above the color picker popover (z-index: 100).

## Changes
- Modified `DropdownMenuSubContent.tsx` to use the proper z-index variable for submenu layering

## Testing
- Open the sidebar and expand Preferences
- Click the custom color (hex) button under Canvas background
- Verify the hex popover no longer obscures the preferences menu items
