### PR TITLE
fix: allow Ctrl+F search while help dialog is open

### DIFF
--- a/packages/excalidraw/actions/actionToggleSearchMenu.ts
+++ b/packages/excalidraw/actions/actionToggleSearchMenu.ts
@@ -25,7 +25,7 @@ export const actionToggleSearchMenu = register({
     predicate: (appState) => appState.gridModeEnabled,
   },
   perform(elements, appState, _, app) {
-    if (appState.openDialog) {
+    if (appState.openDialog && appState.openDialog.name !== "help") {
       return false;
     }
 


### PR DESCRIPTION
## Summary

- The search menu action (`actionToggleSearchMenu`) blocked on any open dialog, including the help dialog
- Changed the guard from `if (appState.openDialog)` to `if (appState.openDialog && appState.openDialog.name !== "help")` so Ctrl+F works while the help menu is open

## Test plan

- Open excalidraw
- Press `?` to open the help menu
- Press `Ctrl+F` — search sidebar should open and help dialog should close

Closes #9276