### PR TITLE
fix: show error state for invalid hex color input

### DIFF
--- a/packages/excalidraw/components/ColorPicker/ColorInput.tsx
+++ b/packages/excalidraw/components/ColorPicker/ColorInput.tsx
@@ -29,6 +29,7 @@ export const ColorInput = ({
 }) => {
   const editorInterface = useEditorInterface();
   const [innerValue, setInnerValue] = useState(color);
+  const [isInvalid, setIsInvalid] = useState(false);
   const [activeSection, setActiveColorPickerSection] = useAtom(
     activeColorPickerSectionAtom,
   );
@@ -44,6 +45,9 @@ export const ColorInput = ({
 
       if (color) {
         onChange(color);
+        setIsInvalid(false);
+      } else {
+        setIsInvalid(value.trim().length > 0);
       }
       setInnerValue(value);
     },
@@ -74,14 +78,16 @@ export const ColorInput = ({
         ref={activeSection === "hex" ? inputRef : undefined}
         style={{ border: 0, padding: 0 }}
         spellCheck={false}
-        className="color-picker-input"
+        className={clsx("color-picker-input", { "color-picker-input--error": isInvalid })}
         aria-label={label}
+        aria-invalid={isInvalid}
         onChange={(event) => {
           changeColor(event.target.value);
         }}
         value={(innerValue || "").replace(/^#/, "")}
         onBlur={() => {
           setInnerValue(color);
+          setIsInvalid(false);
         }}
         tabIndex={-1}
         onFocus={() => setActiveColorPickerSection("hex")}

--- a/packages/excalidraw/components/ColorPicker/ColorPicker.scss
+++ b/packages/excalidraw/components/ColorPicker/ColorPicker.scss
@@ -421,6 +421,11 @@
     &:focus-visible {
       box-shadow: none;
     }
+
+    &--error {
+      color: var(--color-danger);
+      border-color: var(--color-danger);
+    }
   }
 
   .color-picker-label-swatch-container {

--- a/packages/excalidraw/locales/en.json
+++ b/packages/excalidraw/locales/en.json
@@ -582,6 +582,7 @@
     "colors": "Colors",
     "shades": "Shades",
     "hexCode": "Hex code",
+    "invalidHexCode": "Invalid hex color",
     "noShades": "No shades available for this color"
   },
   "overwriteConfirm": {


### PR DESCRIPTION
## Summary

- Typing an invalid hex color code previously gave no feedback — the input just silently ignored it and reverted on blur
- Added `isInvalid` state to `ColorInput` that is set when input is non-empty but not a valid color
- Error state applies a red text + border style via `.color-picker-input--error` CSS modifier
- Error clears when the user types a valid color or blurs the field
- Added `"invalidHexCode"` i18n string for future use

## Test plan

- Open the color picker on any element
- Type an invalid string in the hex input (e.g. `zzzzzz` or `12345g`)
- Input should turn red to indicate the value is invalid
- Fix the value — red should clear immediately
- Blur the field — it should revert to last valid color with no error state

Closes #9527