### PR TITLE
fix(editor): spacing in the left menu

### DIFF
--- a/packages/excalidraw/components/Actions.tsx
+++ b/packages/excalidraw/components/Actions.tsx
@@ -226,7 +226,7 @@ export const SelectedShapeActions = ({
       {(appState.activeTool.type === "text" ||
         targetElements.some(isTextElement)) && (
         <>
-          {renderAction("changeFontFamily")}
+          <fieldset>{renderAction("changeFontFamily")}</fieldset>
           {renderAction("changeFontSize")}
           {(appState.activeTool.type === "text" ||
             suppportsHorizontalAlign(targetElements, elementsMap)) &&


### PR DESCRIPTION
Fixes spacing in the left menu (the label for `fontFamily` was not contained in a group with the buttons, resulting in a gap from it's `flex` parent).

new on the left, old on the right:
<img width="408" height="172" alt="image" src="https://github.com/user-attachments/assets/c4bf3d57-df80-48e0-b408-52a4fcddfc00" />

Open to any suggestions, the `div` around the _Stroke Color Elements_ should probably be changed to `fieldset` (I didn't want to convolute this PR with _unnecessary_ changes yet).
I would like to request a review. @mtolmacs @dwelle


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced the structural organization of font family options in text element controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->