### PR TITLE
fix: prevent duplicate ToolPopover buttons when switching bw lasso and selection tools

### DIFF
--- a/packages/excalidraw/components/shapes.tsx
+++ b/packages/excalidraw/components/shapes.tsx
@@ -119,6 +119,7 @@ export const SHAPES = [
 export const getToolbarTools = (app: AppClassProperties) => {
   return app.state.preferredSelectionTool.type === "lasso"
     ? ([
+        SHAPES[0],
         {
           value: "lasso",
           icon: SelectionIcon,
@@ -127,7 +128,7 @@ export const getToolbarTools = (app: AppClassProperties) => {
           fillable: true,
           toolbar: true,
         },
-        ...SHAPES.slice(1),
+        ...SHAPES.slice(2),
       ] as const)
     : SHAPES;
 };


### PR DESCRIPTION
Fixes #10882 

### **Problem:**
In compact (tablet) mode, repeatedly switching between the selection and lasso tools caused extra buttons to accumulate in the toolbar.

When the lasso tool was set as the preferred selection tool, `getToolbarTools` returned an array containing both "lasso" (prepended at position 0) and "selection" (retained via SHAPES.slice(1)).

### **Fix:**
Changed `getToolbarTools` to replace "selection" with "lasso" at the same position in the toolbar (position 1), while keeping "hand" at position 0. This ensures only one entry ever triggers the `ToolPopover` branch.

### **Result:**
Switching between lasso and selection now correctly updates the single ToolPopover button's icon without creating additional buttons.