### PR TITLE
fix(#9527): Implement hex color validation error messages

### DIFF
--- a/packages/excalidraw/components/ColorPicker/ColorInput.tsx
+++ b/packages/excalidraw/components/ColorPicker/ColorInput.tsx
@@ -29,21 +29,30 @@ export const ColorInput = ({
 }) => {
   const editorInterface = useEditorInterface();
   const [innerValue, setInnerValue] = useState(color);
+  const [error, setError] = useState<string | null>(null);
   const [activeSection, setActiveColorPickerSection] = useAtom(
     activeColorPickerSectionAtom,
   );
 
   useEffect(() => {
     setInnerValue(color);
+    setError(null);
   }, [color]);
 
   const changeColor = useCallback(
     (inputValue: string) => {
       const value = inputValue.toLowerCase();
-      const color = normalizeInputColor(value);
+      const parsedColor = normalizeInputColor(value);
 
-      if (color) {
-        onChange(color);
+      if (parsedColor) {
+        onChange(parsedColor);
+        setError(null);
+      } else {
+        if (value.trim() !== "") {
+          setError(t("colorPicker.invalidHex"));
+        } else {
+          setError(null);
+        }
       }
       setInnerValue(value);
     },
@@ -68,67 +77,75 @@ export const ColorInput = ({
   }, [setEyeDropperState]);
 
   return (
-    <div className="color-picker__input-label">
-      <div className="color-picker__input-hash">#</div>
-      <input
-        ref={activeSection === "hex" ? inputRef : undefined}
-        style={{ border: 0, padding: 0 }}
-        spellCheck={false}
-        className="color-picker-input"
-        aria-label={label}
-        onChange={(event) => {
-          changeColor(event.target.value);
-        }}
-        value={(innerValue || "").replace(/^#/, "")}
-        onBlur={() => {
-          setInnerValue(color);
-        }}
-        tabIndex={-1}
-        onFocus={() => setActiveColorPickerSection("hex")}
-        onKeyDown={(event) => {
-          if (event.key === KEYS.TAB) {
-            return;
-          } else if (event.key === KEYS.ESCAPE) {
-            eyeDropperTriggerRef.current?.focus();
-          }
-          event.stopPropagation();
-        }}
-        placeholder={placeholder}
-      />
-      {/* TODO reenable on mobile with a better UX */}
-      {editorInterface.formFactor !== "phone" && (
-        <>
-          <div
-            style={{
-              width: "1px",
-              height: "1.25rem",
-              backgroundColor: "var(--default-border-color)",
-            }}
-          />
-          <div
-            ref={eyeDropperTriggerRef}
-            className={clsx("excalidraw-eye-dropper-trigger", {
-              selected: eyeDropperState,
-            })}
-            onClick={() =>
-              setEyeDropperState((s) =>
-                s
-                  ? null
-                  : {
+    <div className="color-picker-input-wrapper">
+      <div
+        className={clsx("color-picker__input-label", {
+          "color-picker__input-label--error": error,
+        })}
+      >
+        <div className="color-picker__input-hash">#</div>
+        <input
+          ref={activeSection === "hex" ? inputRef : undefined}
+          style={{ border: 0, padding: 0 }}
+          spellCheck={false}
+          className="color-picker-input"
+          aria-label={label}
+          onChange={(event) => {
+            changeColor(event.target.value);
+          }}
+          value={(innerValue || "").replace(/^#/, "")}
+          onBlur={() => {
+            setInnerValue(color);
+            setError(null);
+          }}
+          tabIndex={-1}
+          onFocus={() => setActiveColorPickerSection("hex")}
+          onKeyDown={(event) => {
+            if (event.key === KEYS.TAB) {
+              return;
+            } else if (event.key === KEYS.ESCAPE) {
+              eyeDropperTriggerRef.current?.focus();
+            }
+            event.stopPropagation();
+          }}
+          placeholder={placeholder}
+        />
+        {/* TODO reenable on mobile with a better UX */}
+        {editorInterface.formFactor !== "phone" && (
+          <>
+            <div
+              style={{
+                width: "1px",
+                height: "1.25rem",
+                backgroundColor: "var(--default-border-color)",
+              }}
+            />
+            <div
+              ref={eyeDropperTriggerRef}
+              className={clsx("excalidraw-eye-dropper-trigger", {
+                selected: eyeDropperState,
+              })}
+              onClick={() =>
+                setEyeDropperState((s) =>
+                  s
+                    ? null
+                    : {
                       keepOpenOnAlt: false,
                       onSelect: (color) => onChange(color),
                       colorPickerType,
                     },
-              )
-            }
-            title={`${t(
-              "labels.eyeDropper",
-            )} — ${KEYS.I.toLocaleUpperCase()} or ${getShortcutKey("Alt")} `}
-          >
-            {eyeDropperIcon}
-          </div>
-        </>
-      )}
+                )
+              }
+              title={`${t(
+                "labels.eyeDropper",
+              )} — ${KEYS.I.toLocaleUpperCase()} or ${getShortcutKey("Alt")} `}
+            >
+              {eyeDropperIcon}
+            </div>
+          </>
+        )}
+      </div>
+      {error && <div className="color-picker-error">{error}</div>}
     </div>
   );
 };

--- a/packages/excalidraw/components/ColorPicker/ColorPicker.scss
+++ b/packages/excalidraw/components/ColorPicker/ColorPicker.scss
@@ -86,6 +86,7 @@
       display: flex;
       align-items: center;
       justify-content: center;
+
       svg {
         color: var(--color-gray-60);
         width: 1.25rem;
@@ -97,6 +98,7 @@
       display: flex;
       align-items: center;
       justify-content: center;
+
       svg {
         width: 100%;
         height: 100%;
@@ -151,9 +153,11 @@
 
     &--no-focus-visible {
       border: 0;
+
       &::after {
         display: none;
       }
+
       &:focus-visible {
         outline: none !important;
       }
@@ -207,7 +211,7 @@
     column-gap: 0.5rem;
   }
 
-  .color-picker-control-container + .popover {
+  .color-picker-control-container+.popover {
     position: static;
   }
 
@@ -330,8 +334,7 @@
 
   .color-picker-transparent,
   .color-picker-label-swatch {
-    background: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAMUlEQVQ4T2NkYGAQYcAP3uCTZhw1gGGYhAGBZIA/nYDCgBDAm9BGDWAAJyRCgLaBCAAgXwixzAS0pgAAAABJRU5ErkJggg==")
-      left center;
+    background: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAMUlEQVQ4T2NkYGAQYcAP3uCTZhw1gGGYhAGBZIA/nYDCgBDAm9BGDWAAJyRCgLaBCAAgXwixzAS0pgAAAABJRU5ErkJggg==") left center;
   }
 
   .color-picker-hash {
@@ -368,6 +371,21 @@
     }
   }
 
+  .color-picker-input-wrapper {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .color-picker-error {
+    color: var(--color-danger);
+    font-size: 0.75rem;
+    padding: 0 0.5rem;
+    margin-top: -0.25rem;
+    margin-bottom: 0.25rem;
+    margin-left: 0.5rem;
+    font-weight: 500;
+  }
+
   .color-picker__input-label {
     display: grid;
     grid-template-columns: auto 1fr auto auto;
@@ -382,6 +400,14 @@
     &:focus-within {
       box-shadow: 0 0 0 1px var(--color-primary-darkest);
       border-radius: var(--border-radius-lg);
+    }
+
+    &--error {
+      border-color: var(--color-danger);
+
+      &:focus-within {
+        box-shadow: 0 0 0 1px var(--color-danger);
+      }
     }
   }
 
@@ -489,6 +515,7 @@
     .color-picker-type-elementBackground .color-picker-keybinding {
       color: #000;
     }
+
     .color-picker-swatch[aria-label="transparent"] .color-picker-keybinding {
       color: #000;
     }

--- a/packages/excalidraw/locales/en.json
+++ b/packages/excalidraw/locales/en.json
@@ -584,6 +584,7 @@
     "colors": "Colors",
     "shades": "Shades",
     "hexCode": "Hex code",
+    "invalidHex": "Invalid hex code",
     "noShades": "No shades available for this color"
   },
   "overwriteConfirm": {


### PR DESCRIPTION
### Fixes

Fixes #9527

### Description

This PR implements user-friendly hex color validation error messages within the color picker popup. 

Previously, an invalid hex code had no explicit visual feedback until the user clicked away. This update adds a translated error state that reflects validation to the user in real-time as they type by outlining the input container in red and rendering an "Invalid hex code" error text below it.

### Changes Made

- Added `"invalidHex"` translation string to [en.json](cci:7://file:///Users/pro/excalidraw/packages/excalidraw/locales/en.json:0:0-0:0).
- Added validation logic in [ColorInput.tsx](cci:7://file:///Users/pro/excalidraw/packages/excalidraw/components/ColorPicker/ColorInput.tsx:0:0-0:0) to display the error text explicitly when [normalizeInputColor](cci:1://file:///Users/pro/excalidraw/packages/common/src/colors.ts:333:0-354:2) fails.
- Automatically clears the error on blur or when navigating away, restoring the input value to the active color.
- Applied CSS modifiers (`.color-picker-error`, `.color-picker__input-label--error`) leveraging existing `var(--color-danger)` tokens to visually represent the validation failure.
<img width="1788" height="1025" alt="Screenshot 2026-03-06 at 11 29 10 PM" src="https://github.com/user-attachments/assets/be3c1fef-4bc7-48f4-9ee5-1727d30015f7" />
