### PR TITLE
fix(editor): do not conditionally disable midpoint snapping menu preference

### DIFF
--- a/packages/excalidraw/components/main-menu/DefaultItems.tsx
+++ b/packages/excalidraw/components/main-menu/DefaultItems.tsx
@@ -469,7 +469,6 @@ const PreferencesToggleMidpointSnappingItem = () => {
   return (
     <DropdownMenuItemCheckbox
       checked={appState.isMidpointSnappingEnabled}
-      disabled={appState.bindingPreference === "disabled"}
       onSelect={(event) => {
         actionManager.executeAction(actionToggleMidpointSnapping);
         event.preventDefault();


### PR DESCRIPTION
Even though it made some semantic sense (midpoint snapping only works when arrow binding is enabled in the first place), the snapping can be enabled with ctrl while binding is disabled, so the setting still makes sense in isolation.