### PR TITLE
fix(editor): detect actual content type for .excalidraw files

### DIFF
--- a/packages/excalidraw/data/blob.test.ts
+++ b/packages/excalidraw/data/blob.test.ts
@@ -1,0 +1,65 @@
+import { MIME_TYPES } from "@excalidraw/common";
+
+import { normalizeFile } from "./blob";
+
+// PNG magic bytes: 137 80 78 71 13 10 26 10
+const PNG_MAGIC = new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10]);
+
+describe("normalizeFile", () => {
+  it("should detect SVG content in .excalidraw file", async () => {
+    const svgContent = `<?xml version="1.0" encoding="UTF-8"?><svg xmlns="http://www.w3.org/2000/svg"></svg>`;
+    const file = new File([svgContent], "drawing.excalidraw", {
+      type: "",
+    });
+    const result = await normalizeFile(file);
+    expect(result.type).toBe(MIME_TYPES.svg);
+  });
+
+  it("should detect SVG content starting with <svg in .excalidraw file", async () => {
+    const svgContent = `<svg xmlns="http://www.w3.org/2000/svg"><rect/></svg>`;
+    const file = new File([svgContent], "drawing.excalidraw", {
+      type: "",
+    });
+    const result = await normalizeFile(file);
+    expect(result.type).toBe(MIME_TYPES.svg);
+  });
+
+  it("should detect SVG content with leading whitespace in .excalidraw file", async () => {
+    const svgContent = `  \n  <?xml version="1.0"?><svg></svg>`;
+    const file = new File([svgContent], "drawing.excalidraw", {
+      type: "",
+    });
+    const result = await normalizeFile(file);
+    expect(result.type).toBe(MIME_TYPES.svg);
+  });
+
+  it("should detect PNG content in .excalidraw file", async () => {
+    const file = new File([PNG_MAGIC], "drawing.excalidraw", {
+      type: "",
+    });
+    const result = await normalizeFile(file);
+    expect(result.type).toBe(MIME_TYPES.png);
+  });
+
+  it("should keep excalidraw MIME for valid JSON content in .excalidraw file", async () => {
+    const jsonContent = JSON.stringify({
+      type: "excalidraw",
+      version: 2,
+      elements: [],
+    });
+    const file = new File([jsonContent], "drawing.excalidraw", {
+      type: "",
+    });
+    const result = await normalizeFile(file);
+    expect(result.type).toBe(MIME_TYPES.excalidraw);
+  });
+
+  it("should not sniff content for .excalidrawlib files", async () => {
+    const svgContent = `<svg xmlns="http://www.w3.org/2000/svg"></svg>`;
+    const file = new File([svgContent], "lib.excalidrawlib", {
+      type: "",
+    });
+    const result = await normalizeFile(file);
+    expect(result.type).toBe(MIME_TYPES.excalidrawlib);
+  });
+});

--- a/packages/excalidraw/data/blob.ts
+++ b/packages/excalidraw/data/blob.ts
@@ -458,6 +458,14 @@ export const createFile = (
   });
 };
 
+const isSVGContent = async (file: Blob | File): Promise<boolean> => {
+  const leadingText = new TextDecoder().decode(
+    await blobToArrayBuffer(file.slice(0, 200)),
+  );
+  const trimmed = leadingText.trimStart();
+  return trimmed.startsWith("<?xml") || trimmed.startsWith("<svg");
+};
+
 const normalizedFileSymbol = Symbol("fileNormalized");
 
 /** attempts to detect correct mimeType if none is set, or if an image
@@ -472,7 +480,16 @@ export const normalizeFile = async (file: File) => {
   if (file?.name?.endsWith(".excalidrawlib")) {
     file = createFile(file, MIME_TYPES.excalidrawlib, file.name);
   } else if (file?.name?.endsWith(".excalidraw")) {
-    file = createFile(file, MIME_TYPES.excalidraw, file.name);
+    // Content sniff: file might be SVG or image saved with wrong extension
+    const actualImageMime = await getActualMimeTypeFromImage(file);
+    const imageMimeValues: readonly string[] = Object.values(IMAGE_MIME_TYPES);
+    if (actualImageMime && imageMimeValues.includes(actualImageMime)) {
+      file = createFile(file, actualImageMime, file.name);
+    } else if (await isSVGContent(file)) {
+      file = createFile(file, MIME_TYPES.svg, file.name);
+    } else {
+      file = createFile(file, MIME_TYPES.excalidraw, file.name);
+    }
   } else if (!file.type || file.type?.startsWith("image/")) {
     // when the file is an image, make sure the extension corresponds to the
     // actual mimeType (this is an edge case, but happens - especially


### PR DESCRIPTION
When a file with `.excalidraw` extension contains SVG or image content (e.g., from an SVG export saved with the wrong extension), `normalizeFile` now sniffs the content bytes to detect the actual MIME type instead of blindly setting it to `application/vnd.excalidraw+json`.

This routes the file to the correct decoder (SVG/PNG) and produces meaningful error messages instead of the generic "Error: invalid file".

fix https://github.com/excalidraw/excalidraw/issues/10871