### PR TITLE
Fix: Make undo button revert open file operation

### DIFF
--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -11644,8 +11644,7 @@ class App extends React.Component<AppProps, AppState> {
         // restore the fractional indices by mutating elements
         syncInvalidIndices(elements.concat(ret.data.elements));
 
-        // don't capture and only update the store snapshot for old elements,
-        // otherwise we would end up with duplicated fractional indices on undo
+        // Clear the current scene and record it as a single history entry
         this.store.scheduleMicroAction({
           action: CaptureUpdateAction.NEVER,
           elements,
@@ -11653,15 +11652,48 @@ class App extends React.Component<AppProps, AppState> {
         });
 
         this.setState({ isLoading: true });
-        this.syncActionResult({
-          ...ret.data,
-          appState: {
-            ...(ret.data.appState || this.state),
-            isLoading: false,
-          },
-          replaceFiles: true,
-          captureUpdate: CaptureUpdateAction.IMMEDIATELY,
+        
+        // Instead of syncActionResult, we need to:
+        // 1. Clear the current scene
+        // 2. Insert the new elements
+        // 3. Record it as a single undoable action
+        
+        // First, mark all current elements as deleted
+        const deletedElements = elements.map(el => 
+          newElementWith(el, { isDeleted: true })
+        );
+        
+        // Then combine with new elements
+        const allElements = [
+          ...deletedElements,
+          ...ret.data.elements,
+        ];
+        
+        // Update the scene
+        this.scene.replaceAllElements(allElements);
+        
+        // Update app state
+        const newAppState = {
+          ...(ret.data.appState || this.state),
+          isLoading: false,
+        };
+        
+        // Update files
+        if (ret.data.files) {
+          this.addMissingFiles(ret.data.files, true);
+          this.addNewImagesToImageCache();
+        }
+        
+        // Record this as a single undoable action
+        this.store.scheduleMicroAction({
+          action: CaptureUpdateAction.IMMEDIATELY,
+          elements: allElements,
+          appState: getObservedAppState(newAppState),
         });
+        
+        // Update the UI
+        this.setState(newAppState);
+        
       } else if (ret.type === MIME_TYPES.excalidrawlib) {
         await this.library
           .updateLibrary({


### PR DESCRIPTION
I try to modify the loadFileToCanvas function to change how scene files are loaded and recorded in the undo history. Instead of using syncActionResult, the revised implementation explicitly clears the current scene by marking existing elements as deleted and then inserts the newly loaded elements. These operations are combined and recorded as a single undoable action using scheduleMicroAction with CaptureUpdateAction.IMMEDIATELY, ensuring that loading a file appears as one step in the undo history.

I also add the missing getObservedAppState, which is required to properly capture the app state when recording the history entry. The implementation uses scene.replaceAllElements to update the canvas and includes logic to update files and image caches when the loaded scene contains image assets. This change improves history management and ensures the canvas state, files, and UI update consistently when a scene is loaded, allowing users to undo file loading and restore their previous work.

Related to the issue [#10829](https://github.com/excalidraw/excalidraw/issues/10829)