### PR TITLE
Use FilledButton in Text-To-Diagramm Dialog

### DIFF
--- a/packages/excalidraw/components/TTDDialog/TTDDialog.scss
+++ b/packages/excalidraw/components/TTDDialog/TTDDialog.scss
@@ -470,71 +470,9 @@ $fullScreenModalBreakpoint: 600px;
     }
   }
 
-  .ttd-dialog-panel-button {
-    &.excalidraw-button {
-      font-family: inherit;
-      font-weight: 600;
-      height: 2.5rem;
-
-      font-size: 12px;
-      color: #fff;
-      background-color: var(--color-primary);
-      width: 100%;
-
-      &:hover {
-        background-color: var(--color-primary-darker);
-      }
-      &:active {
-        background-color: var(--color-primary-darkest);
-      }
-
-      &:disabled {
-        opacity: 0.5;
-        cursor: not-allowed;
-
-        &:hover {
-          background-color: var(--color-primary);
-        }
-      }
-
-      @media screen and (min-width: $verticalBreakpoint) {
-        width: auto;
-        min-width: 7.5rem;
-      }
-
-      @at-root .excalidraw.theme--dark#{&} {
-        color: var(--color-gray-100);
-      }
-    }
-
-    & {
-      position: relative;
-    }
-
-    div {
-      display: contents;
-
-      &.invisible {
-        visibility: hidden;
-      }
-
-      &.Spinner {
-        display: flex !important;
-        position: absolute;
-        inset: 0;
-
-        --spinner-color: white;
-
-        @at-root .excalidraw.theme--dark#{&} {
-          --spinner-color: var(--color-gray-100);
-        }
-      }
-
-      span {
-        padding-left: 0.5rem;
-        display: flex;
-      }
-    }
+  // move the icon to the right
+  .ttd-dialog-panel-button .ExcButton__icon {
+    order: 2;
   }
 
   .ttd-dialog-submit-shortcut {

--- a/packages/excalidraw/components/TTDDialog/TTDDialogPanel.tsx
+++ b/packages/excalidraw/components/TTDDialog/TTDDialogPanel.tsx
@@ -2,8 +2,7 @@ import clsx from "clsx";
 
 import { Fragment } from "react";
 
-import { Button } from "../Button";
-import Spinner from "../Spinner";
+import { FilledButton } from "../FilledButton";
 
 import type { ReactNode } from "react";
 
@@ -67,17 +66,14 @@ export const TTDDialogPanel = ({
 
     if (panelAction?.variant === "button") {
       return (
-        <Button
+        <FilledButton
           className={clsx("ttd-dialog-panel-button", panelAction.className)}
-          onSelect={panelAction.action ? panelAction.action : () => {}}
+          onClick={panelAction.action ? panelAction.action : () => {}}
           disabled={panelAction?.disabled || onTextSubmitInProgess}
-        >
-          <div className={clsx({ invisible: onTextSubmitInProgess })}>
-            {panelAction?.label}
-            {panelAction?.icon && <span>{panelAction.icon}</span>}
-          </div>
-          {onTextSubmitInProgess && <Spinner />}
-        </Button>
+          label={panelAction?.label}
+          icon={panelAction.icon}
+          status={onTextSubmitInProgess ? "loading" : null}
+        />
       );
     }
 


### PR DESCRIPTION
Instead of reinventing the button, we should reuse what's already there. I added a CSS-rule to move the icon to the right, as it was previously, because I didn't feel like adding positioning to the button itself, altho that wouldn't be too hard.

This was bothering me, because ontop of extra styles, there was a color hack for dark mode inside, which drove me nuts 😁.

@dwelle this is ready to merge.