### PR TITLE
fix: convert <br> tags to newlines in Mermaid imports

### DIFF
--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -419,7 +419,10 @@ import { withBatchedUpdates, withBatchedUpdatesThrottled } from "../reactUtils";
 import { textWysiwyg } from "../wysiwyg/textWysiwyg";
 import { isOverScrollBars } from "../scene/scrollbars";
 
-import { isMaybeMermaidDefinition } from "../mermaid";
+import {
+  isMaybeMermaidDefinition,
+  sanitizeMermaidElementText,
+} from "../mermaid";
 
 import { LassoTrail } from "../lasso";
 
@@ -3703,8 +3706,10 @@ class App extends React.Component<AppProps, AppState> {
     if (!isPlainPaste && isMaybeMermaidDefinition(data.text)) {
       const api = await import("@excalidraw/mermaid-to-excalidraw");
       try {
-        const { elements: skeletonElements, files = {} } =
+        const { elements: rawSkeletonElements, files = {} } =
           await api.parseMermaidToExcalidraw(data.text);
+        const skeletonElements =
+          sanitizeMermaidElementText(rawSkeletonElements);
 
         const elements = convertToExcalidrawElements(skeletonElements, {
           regenerateIds: true,

--- a/packages/excalidraw/components/TTDDialog/common.ts
+++ b/packages/excalidraw/components/TTDDialog/common.ts
@@ -14,6 +14,7 @@ import type {
 } from "@excalidraw/element/types";
 
 import { EditorLocalStorage } from "../../data/EditorLocalStorage";
+import { sanitizeMermaidElementText } from "../../mermaid";
 
 import type { MermaidToExcalidrawLibProps } from "./types";
 
@@ -94,7 +95,8 @@ export const convertMermaidToExcalidraw = async ({
       }
     }
 
-    const { elements, files = {} } = ret;
+    const { elements: rawElements, files = {} } = ret;
+    const elements = sanitizeMermaidElementText(rawElements);
     setError(null);
 
     data.current = {

--- a/packages/excalidraw/mermaid.test.ts
+++ b/packages/excalidraw/mermaid.test.ts
@@ -1,4 +1,7 @@
-import { isMaybeMermaidDefinition } from "./mermaid";
+import {
+  isMaybeMermaidDefinition,
+  sanitizeMermaidElementText,
+} from "./mermaid";
 
 describe("isMaybeMermaidDefinition", () => {
   it("should return true for a valid mermaid definition", () => {
@@ -11,5 +14,62 @@ describe("isMaybeMermaidDefinition", () => {
     expect(isMaybeMermaidDefinition("graphs")).toBe(false);
     expect(isMaybeMermaidDefinition("this flowchart")).toBe(false);
     expect(isMaybeMermaidDefinition("this\nflowchart")).toBe(false);
+  });
+});
+
+describe("sanitizeMermaidElementText", () => {
+  it("should replace <br> in element text with newline", () => {
+    const elements = [{ text: "User Registration<br>Process" }];
+    const result = sanitizeMermaidElementText(elements);
+    expect(result[0].text).toBe("User Registration\nProcess");
+  });
+
+  it("should replace <br/> and <br /> variants", () => {
+    const elements = [
+      { text: "Line1<br/>Line2" },
+      { text: "Line1<br />Line2" },
+    ];
+    const result = sanitizeMermaidElementText(elements);
+    expect(result[0].text).toBe("Line1\nLine2");
+    expect(result[1].text).toBe("Line1\nLine2");
+  });
+
+  it("should replace <br> in label.text", () => {
+    const elements = [
+      {
+        label: { text: "Validate Input<br>Data", fontSize: 20 },
+      },
+    ];
+    const result = sanitizeMermaidElementText(elements);
+    expect(result[0].label!.text).toBe("Validate Input\nData");
+    // Preserve other label properties
+    expect((result[0].label as any).fontSize).toBe(20);
+  });
+
+  it("should handle case-insensitive tags", () => {
+    const elements = [{ text: "Hello<BR>World<Br/>End" }];
+    const result = sanitizeMermaidElementText(elements);
+    expect(result[0].text).toBe("Hello\nWorld\nEnd");
+  });
+
+  it("should not modify elements without <br> tags", () => {
+    const elements = [{ text: "No breaks here" }];
+    const result = sanitizeMermaidElementText(elements);
+    expect(result[0]).toBe(elements[0]); // same reference, not cloned
+  });
+
+  it("should handle multiple <br> tags in a single string", () => {
+    const elements = [{ text: "A<br>B<br>C<br>D" }];
+    const result = sanitizeMermaidElementText(elements);
+    expect(result[0].text).toBe("A\nB\nC\nD");
+  });
+
+  it("should handle elements with both text and label", () => {
+    const elements = [
+      { text: "Main<br>Text", label: { text: "Label<br>Text" } },
+    ];
+    const result = sanitizeMermaidElementText(elements);
+    expect(result[0].text).toBe("Main\nText");
+    expect(result[0].label!.text).toBe("Label\nText");
   });
 });

--- a/packages/excalidraw/mermaid.ts
+++ b/packages/excalidraw/mermaid.ts
@@ -1,3 +1,43 @@
+/**
+ * Replaces HTML line-break tags (`<br>`, `<br/>`, `<br />`) with newlines.
+ * Mermaid supports `<br>` inside node labels for multi-line text, but the
+ * mermaid-to-excalidraw converter may preserve them as literal strings in the
+ * output element text.  This helper normalises them so Excalidraw renders
+ * proper line breaks instead of showing the raw tag.
+ */
+const stripHtmlBreaks = (text: string) =>
+  text.replace(/<br\s*\/?>/gi, "\n");
+
+/**
+ * Post-processes skeleton elements returned by `parseMermaidToExcalidraw` so
+ * that HTML `<br>` tags embedded in text properties are converted to newlines.
+ */
+export const sanitizeMermaidElementText = <
+  T extends { text?: string; label?: { text: string } },
+>(
+  elements: T[],
+): T[] =>
+  elements.map((el) => {
+    let changed = false;
+    const patch: Record<string, unknown> = {};
+
+    if (typeof el.text === "string" && /<br\s*\/?>/i.test(el.text)) {
+      patch.text = stripHtmlBreaks(el.text);
+      changed = true;
+    }
+
+    if (
+      el.label &&
+      typeof el.label.text === "string" &&
+      /<br\s*\/?>/i.test(el.label.text)
+    ) {
+      patch.label = { ...el.label, text: stripHtmlBreaks(el.label.text) };
+      changed = true;
+    }
+
+    return changed ? { ...el, ...patch } : el;
+  });
+
 /** heuristically checks whether the text may be a mermaid diagram definition */
 export const isMaybeMermaidDefinition = (text: string) => {
   const chartTypes = [


### PR DESCRIPTION
## Summary

Fixes #10952 (related: #9708)

When importing Mermaid diagrams with `<br>` tags in node labels, the tags were showing up as literal text instead of being rendered as line breaks. This happened because `@excalidraw/mermaid-to-excalidraw` preserves the raw `<br>` in its output element text, and excalidraw wasn't sanitizing it before creating the final elements.

**Changes:**
- Added `sanitizeMermaidElementText()` in `mermaid.ts` that post-processes skeleton elements, replacing `<br>`, `<br/>`, `<br />` (case-insensitive) with `\n` in both `element.text` and `element.label.text`
- Applied the sanitizer in both the clipboard paste handler (`App.tsx`) and the Text-to-Diagram dialog (`TTDDialog/common.ts`)
- Added 7 test cases covering all variants (`<br>`, `<br/>`, `<br />`), case insensitivity, label text, multiple tags, and the no-op path

## Test plan

- [x] All existing `mermaid.test.ts` tests still pass
- [x] New `sanitizeMermaidElementText` tests pass (7 cases)
- [ ] Manual: paste a Mermaid diagram with `<br>` tags — text should render with proper line breaks
- [ ] Manual: use the Text-to-Diagram dialog with `<br>` tags — same result