### PR TITLE
docs: add webmcp-bridge to integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Check out our [documentation](https://docs.excalidraw.com/docs/@excalidraw/excal
 
 ## Who's integrating Excalidraw
 
-[Google Cloud](https://googlecloudcheatsheet.withgoogle.com/architecture) • [Meta](https://meta.com/) • [CodeSandbox](https://codesandbox.io/) • [Obsidian Excalidraw](https://github.com/zsviczian/obsidian-excalidraw-plugin) • [Replit](https://replit.com/) • [Slite](https://slite.com/) • [Notion](https://notion.so/) • [HackerRank](https://www.hackerrank.com/) • and many others
+[Google Cloud](https://googlecloudcheatsheet.withgoogle.com/architecture) • [Meta](https://meta.com/) • [CodeSandbox](https://codesandbox.io/) • [Obsidian Excalidraw](https://github.com/zsviczian/obsidian-excalidraw-plugin) • [Replit](https://replit.com/) • [Slite](https://slite.com/) • [Notion](https://notion.so/) • [HackerRank](https://www.hackerrank.com/) • [webmcp-bridge](https://github.com/holon-run/webmcp-bridge) • and many others
 
 ## Sponsors & support
 


### PR DESCRIPTION
## Summary
- add `webmcp-bridge` to the README integrations showcase

## Why
`webmcp-bridge` provides a local MCP-to-browser WebMCP bridge and includes a live Excalidraw board example. Adding it here makes the integration discoverable alongside other ecosystem projects already listed in the README.
