### PR TITLE
Show validation feedback for invalid hex colors

### DIFF
--- a/packages/excalidraw/components/ColorPicker/ColorInput.test.tsx
+++ b/packages/excalidraw/components/ColorPicker/ColorInput.test.tsx
@@ -1,0 +1,38 @@
+import { fireEvent, render } from "@testing-library/react";
+import { vi } from "vitest";
+
+import { EditorJotaiProvider } from "../../editor-jotai";
+
+import { ColorInput } from "./ColorInput";
+
+describe("<ColorInput />", () => {
+  it("shows validation feedback for invalid input and clears it once corrected", () => {
+    const onChange = vi.fn();
+    const { getByLabelText, getByText, queryByText } = render(
+      <EditorJotaiProvider>
+        <ColorInput
+          color="#1a1a1a"
+          label="Stroke color"
+          onChange={onChange}
+          colorPickerType="elementStroke"
+        />
+      </EditorJotaiProvider>,
+    );
+
+    const input = getByLabelText("Stroke color") as HTMLInputElement;
+
+    fireEvent.change(input, { target: { value: "gggggg" } });
+    expect(onChange).not.toHaveBeenCalled();
+    expect(queryByText("Enter a valid hex color")).not.toBeInTheDocument();
+
+    fireEvent.blur(input);
+    expect(getByText("Enter a valid hex color")).toBeInTheDocument();
+    expect(input).toHaveValue("gggggg");
+    expect(input).toHaveAttribute("aria-invalid", "true");
+
+    fireEvent.change(input, { target: { value: "ff0000" } });
+    expect(onChange).toHaveBeenCalledWith("#ff0000");
+    expect(queryByText("Enter a valid hex color")).not.toBeInTheDocument();
+    expect(input).toHaveAttribute("aria-invalid", "false");
+  });
+});

--- a/packages/excalidraw/components/ColorPicker/ColorInput.tsx
+++ b/packages/excalidraw/components/ColorPicker/ColorInput.tsx
@@ -1,5 +1,5 @@
 import clsx from "clsx";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useId, useRef, useState } from "react";
 
 import { KEYS, normalizeInputColor } from "@excalidraw/common";
 
@@ -29,12 +29,15 @@ export const ColorInput = ({
 }) => {
   const editorInterface = useEditorInterface();
   const [innerValue, setInnerValue] = useState(color);
+  const [showValidationError, setShowValidationError] = useState(false);
   const [activeSection, setActiveColorPickerSection] = useAtom(
     activeColorPickerSectionAtom,
   );
+  const validationMessageId = useId();
 
   useEffect(() => {
     setInnerValue(color);
+    setShowValidationError(false);
   }, [color]);
 
   const changeColor = useCallback(
@@ -44,6 +47,9 @@ export const ColorInput = ({
 
       if (color) {
         onChange(color);
+        setShowValidationError(false);
+      } else if (!value.trim()) {
+        setShowValidationError(false);
       }
       setInnerValue(value);
     },
@@ -68,67 +74,100 @@ export const ColorInput = ({
   }, [setEyeDropperState]);
 
   return (
-    <div className="color-picker__input-label">
-      <div className="color-picker__input-hash">#</div>
-      <input
-        ref={activeSection === "hex" ? inputRef : undefined}
-        style={{ border: 0, padding: 0 }}
-        spellCheck={false}
-        className="color-picker-input"
-        aria-label={label}
-        onChange={(event) => {
-          changeColor(event.target.value);
-        }}
-        value={(innerValue || "").replace(/^#/, "")}
-        onBlur={() => {
-          setInnerValue(color);
-        }}
-        tabIndex={-1}
-        onFocus={() => setActiveColorPickerSection("hex")}
-        onKeyDown={(event) => {
-          if (event.key === KEYS.TAB) {
-            return;
-          } else if (event.key === KEYS.ESCAPE) {
-            eyeDropperTriggerRef.current?.focus();
+    <div>
+      <div
+        className={clsx("color-picker__input-label", {
+          "color-picker__input-label--invalid": showValidationError,
+        })}
+      >
+        <div className="color-picker__input-hash">#</div>
+        <input
+          ref={activeSection === "hex" ? inputRef : undefined}
+          style={{ border: 0, padding: 0 }}
+          spellCheck={false}
+          className="color-picker-input"
+          aria-label={label}
+          aria-invalid={showValidationError}
+          aria-describedby={
+            showValidationError ? validationMessageId : undefined
           }
-          event.stopPropagation();
-        }}
-        placeholder={placeholder}
-      />
-      {/* TODO reenable on mobile with a better UX */}
-      {editorInterface.formFactor !== "phone" && (
-        <>
-          <div
-            style={{
-              width: "1px",
-              height: "1.25rem",
-              backgroundColor: "var(--default-border-color)",
-            }}
-          />
-          <div
-            ref={eyeDropperTriggerRef}
-            className={clsx("excalidraw-eye-dropper-trigger", {
-              selected: eyeDropperState,
-            })}
-            onClick={() =>
-              setEyeDropperState((s) =>
-                s
-                  ? null
-                  : {
-                      keepOpenOnAlt: false,
-                      onSelect: (color) => onChange(color),
-                      colorPickerType,
-                    },
-              )
+          onChange={(event) => {
+            changeColor(event.target.value);
+          }}
+          value={(innerValue || "").replace(/^#/, "")}
+          onBlur={() => {
+            const normalizedColor = normalizeInputColor(innerValue);
+
+            if (!innerValue.trim()) {
+              setShowValidationError(false);
+              setInnerValue(color);
+              return;
             }
-            title={`${t(
-              "labels.eyeDropper",
-            )} — ${KEYS.I.toLocaleUpperCase()} or ${getShortcutKey("Alt")} `}
-          >
-            {eyeDropperIcon}
-          </div>
-        </>
-      )}
+
+            if (!normalizedColor) {
+              setShowValidationError(true);
+              return;
+            }
+
+            setShowValidationError(false);
+            setInnerValue(normalizedColor);
+          }}
+          tabIndex={-1}
+          onFocus={() => setActiveColorPickerSection("hex")}
+          onKeyDown={(event) => {
+            if (event.key === KEYS.TAB) {
+              return;
+            } else if (event.key === KEYS.ESCAPE) {
+              eyeDropperTriggerRef.current?.focus();
+            }
+            event.stopPropagation();
+          }}
+          placeholder={placeholder}
+        />
+        {/* TODO reenable on mobile with a better UX */}
+        {editorInterface.formFactor !== "phone" && (
+          <>
+            <div
+              style={{
+                width: "1px",
+                height: "1.25rem",
+                backgroundColor: "var(--default-border-color)",
+              }}
+            />
+            <div
+              ref={eyeDropperTriggerRef}
+              className={clsx("excalidraw-eye-dropper-trigger", {
+                selected: eyeDropperState,
+              })}
+              onClick={() =>
+                setEyeDropperState((s) =>
+                  s
+                    ? null
+                    : {
+                        keepOpenOnAlt: false,
+                        onSelect: (color) => onChange(color),
+                        colorPickerType,
+                      },
+                )
+              }
+              title={`${t(
+                "labels.eyeDropper",
+              )} — ${KEYS.I.toLocaleUpperCase()} or ${getShortcutKey("Alt")} `}
+            >
+              {eyeDropperIcon}
+            </div>
+          </>
+        )}
+      </div>
+      {showValidationError ? (
+        <div
+          id={validationMessageId}
+          className="color-picker__input-error"
+          role="alert"
+        >
+          {t("colorPicker.invalidHexCode")}
+        </div>
+      ) : null}
     </div>
   );
 };

--- a/packages/excalidraw/components/ColorPicker/ColorPicker.scss
+++ b/packages/excalidraw/components/ColorPicker/ColorPicker.scss
@@ -385,6 +385,19 @@
     }
   }
 
+  .color-picker__input-label--invalid {
+    border-color: var(--color-danger);
+
+    &:focus-within {
+      box-shadow: 0 0 0 1px var(--color-danger);
+    }
+
+    .color-picker__input-hash,
+    .color-picker-input {
+      color: var(--color-danger);
+    }
+  }
+
   .color-picker__input-hash {
     padding: 0 0.25rem;
   }
@@ -421,6 +434,13 @@
     &:focus-visible {
       box-shadow: none;
     }
+  }
+
+  .color-picker__input-error {
+    margin: 0 8px 8px;
+    color: var(--color-danger);
+    font-size: 0.75rem;
+    line-height: 1.4;
   }
 
   .color-picker-label-swatch-container {

--- a/packages/excalidraw/locales/en.json
+++ b/packages/excalidraw/locales/en.json
@@ -595,6 +595,7 @@
     "colors": "Colors",
     "shades": "Shades",
     "hexCode": "Hex code",
+    "invalidHexCode": "Enter a valid hex color",
     "noShades": "No shades available for this color"
   },
   "overwriteConfirm": {


### PR DESCRIPTION
## Summary
- keep invalid hex input visible instead of immediately resetting it
- mark the input invalid and show inline feedback on blur
- add focused test coverage for the invalid-to-valid correction flow

## Testing
- corepack yarn vitest --run packages/excalidraw/components/ColorPicker/ColorInput.test.tsx
- corepack yarn test:typecheck

Closes #9527