### PR TITLE
fix(packages/excalidraw): store PNG scene metadata in iTXt chunks

### DIFF
--- a/packages/excalidraw/data/image.ts
+++ b/packages/excalidraw/data/image.ts
@@ -1,3 +1,4 @@
+import { inflate } from "pako";
 import tEXt from "png-chunk-text";
 import encodePng from "png-chunks-encode";
 import decodePng from "png-chunks-extract";
@@ -7,18 +8,109 @@ import { EXPORT_DATA_TYPES, MIME_TYPES } from "@excalidraw/common";
 import { blobToArrayBuffer } from "./blob";
 import { encode, decode } from "./encode";
 
+type PNGMetadataChunk = {
+  keyword: string;
+  text: string;
+};
+
+const textEncoder = new TextEncoder();
+const textDecoder = new TextDecoder();
+
+const readNullTerminatedText = (data: Uint8Array, offset: number) => {
+  const index = data.indexOf(0, offset);
+  if (index < 0) {
+    throw new Error("INVALID");
+  }
+  return {
+    value: textDecoder.decode(data.slice(offset, index)),
+    nextOffset: index + 1,
+  };
+};
+
+const decodeITXtChunk = (data: Uint8Array): PNGMetadataChunk => {
+  let offset = 0;
+
+  const keywordSection = readNullTerminatedText(data, offset);
+  offset = keywordSection.nextOffset;
+
+  const compressionFlag = data[offset++];
+  const compressionMethod = data[offset++];
+
+  if (compressionFlag !== 0 && compressionFlag !== 1) {
+    throw new Error("INVALID");
+  }
+  if (compressionFlag === 1 && compressionMethod !== 0) {
+    throw new Error("INVALID");
+  }
+
+  const languageSection = readNullTerminatedText(data, offset);
+  offset = languageSection.nextOffset;
+
+  const translatedKeywordSection = readNullTerminatedText(data, offset);
+  offset = translatedKeywordSection.nextOffset;
+
+  const textSection = data.slice(offset);
+  const inflatedTextSection =
+    compressionFlag === 1 ? inflate(textSection) : textSection;
+  const textBytes =
+    inflatedTextSection instanceof Uint8Array
+      ? inflatedTextSection
+      : new Uint8Array(inflatedTextSection);
+
+  return {
+    keyword: keywordSection.value,
+    text: textDecoder.decode(textBytes),
+  };
+};
+
+const encodeITXtChunk = ({ keyword, text }: PNGMetadataChunk): ITXtChunk => {
+  const keywordBytes = textEncoder.encode(keyword);
+  const textBytes = textEncoder.encode(text);
+  const data = new Uint8Array(
+    keywordBytes.length + 1 + 1 + 1 + 1 + 1 + textBytes.length,
+  );
+
+  let offset = 0;
+  data.set(keywordBytes, offset);
+  offset += keywordBytes.length;
+  data[offset++] = 0;
+  // Store metadata uncompressed. The scene payload is already compressed by
+  // encode(), and uncompressed iTXt keeps browser-side decoding simple.
+  data[offset++] = 0;
+  data[offset++] = 0;
+  data[offset++] = 0;
+  data[offset++] = 0;
+  data.set(textBytes, offset);
+
+  return {
+    name: "iTXt",
+    data,
+  };
+};
+
 // -----------------------------------------------------------------------------
 // PNG
 // -----------------------------------------------------------------------------
 
 export const getTEXtChunk = async (
   blob: Blob,
-): Promise<{ keyword: string; text: string } | null> => {
+): Promise<PNGMetadataChunk | null> => {
   const chunks = decodePng(new Uint8Array(await blobToArrayBuffer(blob)));
-  const metadataChunk = chunks.find((chunk) => chunk.name === "tEXt");
-  if (metadataChunk) {
-    return tEXt.decode(metadataChunk.data);
+
+  const iTXtMetadataChunk = chunks.find((chunk) => chunk.name === "iTXt");
+  if (iTXtMetadataChunk) {
+    try {
+      return decodeITXtChunk(iTXtMetadataChunk.data);
+    } catch {
+      // Fall back to legacy tEXt metadata.
+    }
   }
+
+  const tEXtMetadataChunk = chunks.find((chunk) => chunk.name === "tEXt");
+  if (tEXtMetadataChunk) {
+    return tEXt.decode(tEXtMetadataChunk.data);
+  }
+
   return null;
 };
 
@@ -31,15 +123,15 @@ export const encodePngMetadata = async ({
 }) => {
   const chunks = decodePng(new Uint8Array(await blobToArrayBuffer(blob)));
 
-  const metadataChunk = tEXt.encode(
-    MIME_TYPES.excalidraw,
-    JSON.stringify(
+  const metadataChunk = encodeITXtChunk({
+    keyword: MIME_TYPES.excalidraw,
+    text: JSON.stringify(
       encode({
         text: metadata,
         compress: true,
       }),
     ),
-  );
+  });
   // insert metadata before last chunk (iEND)
   chunks.splice(-1, 0, metadataChunk);
 

--- a/packages/excalidraw/data/image.ts
+++ b/packages/excalidraw/data/image.ts
@@ -97,18 +97,30 @@ export const getTEXtChunk = async (
 ): Promise<PNGMetadataChunk | null> => {
   const chunks = decodePng(new Uint8Array(await blobToArrayBuffer(blob)));
 
-  const iTXtMetadataChunk = chunks.find((chunk) => chunk.name === "iTXt");
-  if (iTXtMetadataChunk) {
-    try {
-      return decodeITXtChunk(iTXtMetadataChunk.data);
-    } catch {
-      // Fall back to legacy tEXt metadata.
+  for (const chunk of chunks) {
+    if (chunk.name === "iTXt") {
+      try {
+        const metadata = decodeITXtChunk(chunk.data);
+        if (metadata.keyword === MIME_TYPES.excalidraw) {
+          return metadata;
+        }
+      } catch {
+        // Continue to the next chunk
+      }
     }
   }
 
-  const tEXtMetadataChunk = chunks.find((chunk) => chunk.name === "tEXt");
-  if (tEXtMetadataChunk) {
-    return tEXt.decode(tEXtMetadataChunk.data);
+  for (const chunk of chunks) {
+    if (chunk.name === "tEXt") {
+      try {
+        const metadata = tEXt.decode(chunk.data);
+        if (metadata.keyword === MIME_TYPES.excalidraw) {
+          return metadata;
+        }
+      } catch {
+        // Continue to the next chunk
+      }
+    }
   }
 
   return null;

--- a/packages/excalidraw/data/image.ts
+++ b/packages/excalidraw/data/image.ts
@@ -39,7 +39,7 @@ const decodeITXtChunk = (data: Uint8Array): PNGMetadataChunk => {
   if (compressionFlag !== 0 && compressionFlag !== 1) {
     throw new Error("INVALID");
   }
-  if (compressionFlag === 1 && compressionMethod !== 0) {
+  if (compressionMethod !== 0) {
     throw new Error("INVALID");
   }
 

--- a/packages/excalidraw/data/image.ts
+++ b/packages/excalidraw/data/image.ts
@@ -1,4 +1,4 @@
-import { inflate } from "pako";
+import { Inflate } from "pako";
 import tEXt from "png-chunk-text";
 import encodePng from "png-chunks-encode";
 import decodePng from "png-chunks-extract";
@@ -15,6 +15,7 @@ type PNGMetadataChunk = {
 
 const textEncoder = new TextEncoder();
 const textDecoder = new TextDecoder();
+const MAX_ITXT_DECOMPRESSED_SIZE = 10 * 1024 * 1024;
 
 const readNullTerminatedText = (data: Uint8Array, offset: number) => {
   const index = data.indexOf(0, offset);
@@ -25,6 +26,46 @@ const readNullTerminatedText = (data: Uint8Array, offset: number) => {
     value: textDecoder.decode(data.slice(offset, index)),
     nextOffset: index + 1,
   };
+};
+
+const mergeUint8Arrays = (chunks: Uint8Array[], totalLength: number) => {
+  const result = new Uint8Array(totalLength);
+  let offset = 0;
+
+  for (const chunk of chunks) {
+    result.set(chunk, offset);
+    offset += chunk.length;
+  }
+
+  return result;
+};
+
+const inflateWithLimit = (data: Uint8Array) => {
+  const inflator = new Inflate();
+  const chunks: Uint8Array[] = [];
+  let totalLength = 0;
+
+  inflator.onData = (chunk) => {
+    const bytes = chunk instanceof Uint8Array ? chunk : new Uint8Array(chunk);
+
+    totalLength += bytes.length;
+    if (totalLength > MAX_ITXT_DECOMPRESSED_SIZE) {
+      throw new Error("INVALID");
+    }
+    chunks.push(bytes);
+  };
+
+  try {
+    inflator.push(data, true);
+  } catch {
+    throw new Error("INVALID");
+  }
+
+  if (inflator.err) {
+    throw new Error("INVALID");
+  }
+
+  return mergeUint8Arrays(chunks, totalLength);
 };
 
 const decodeITXtChunk = (data: Uint8Array): PNGMetadataChunk => {
@@ -51,7 +92,7 @@ const decodeITXtChunk = (data: Uint8Array): PNGMetadataChunk => {
 
   const textSection = data.slice(offset);
   const inflatedTextSection =
-    compressionFlag === 1 ? inflate(textSection) : textSection;
+    compressionFlag === 1 ? inflateWithLimit(textSection) : textSection;
   const textBytes =
     inflatedTextSection instanceof Uint8Array
       ? inflatedTextSection

--- a/packages/excalidraw/global.d.ts
+++ b/packages/excalidraw/global.d.ts
@@ -33,6 +33,8 @@ interface Clipboard extends EventTarget {
 // PNG encoding/decoding
 // -----------------------------------------------------------------------------
 type TEXtChunk = { name: "tEXt"; data: Uint8Array };
+type ITXtChunk = { name: "iTXt"; data: Uint8Array };
+type PNGChunk = { name: string; data: Uint8Array };
 
 declare module "png-chunk-text" {
   function encode(
@@ -42,11 +44,11 @@ declare module "png-chunk-text" {
   function decode(data: Uint8Array): { keyword: string; text: string };
 }
 declare module "png-chunks-encode" {
-  function encode(chunks: TEXtChunk[]): Uint8Array<ArrayBuffer>;
+  function encode(chunks: PNGChunk[]): Uint8Array<ArrayBuffer>;
   export = encode;
 }
 declare module "png-chunks-extract" {
-  function extract(buffer: Uint8Array): TEXtChunk[];
+  function extract(buffer: Uint8Array): PNGChunk[];
   export = extract;
 }
 // -----------------------------------------------------------------------------

--- a/packages/excalidraw/tests/image.test.tsx
+++ b/packages/excalidraw/tests/image.test.tsx
@@ -1,9 +1,11 @@
-import { randomId, reseed } from "@excalidraw/common";
+import { EXPORT_DATA_TYPES, randomId, reseed } from "@excalidraw/common";
+import decodePng from "png-chunks-extract";
 
 import type { FileId } from "@excalidraw/element/types";
 
 import * as blobModule from "../data/blob";
 import * as filesystemModule from "../data/filesystem";
+import { decodePngMetadata, encodePngMetadata } from "../data/image";
 import { Excalidraw } from "../index";
 import { createPasteEvent } from "../clipboard";
 
@@ -111,5 +113,50 @@ describe("image insertion", () => {
     UI.clickTool("image");
 
     await assert();
+  });
+});
+
+describe("png metadata", () => {
+  it("stores scene metadata in iTXt chunks", async () => {
+    const pngBlob = await API.loadFile("./fixtures/smiley.png");
+    const metadata = JSON.stringify({
+      type: EXPORT_DATA_TYPES.excalidraw,
+      elements: [{ type: "text", text: "😀" }],
+    });
+
+    const embedded = await encodePngMetadata({
+      blob: pngBlob,
+      metadata,
+    });
+
+    const chunks = decodePng(
+      new Uint8Array(await blobModule.blobToArrayBuffer(embedded)),
+    );
+
+    expect(chunks.some((chunk) => chunk.name === "iTXt")).toBe(true);
+  });
+
+  it("roundtrips iTXt metadata content", async () => {
+    const pngBlob = await API.loadFile("./fixtures/smiley.png");
+    const metadata = JSON.stringify({
+      type: EXPORT_DATA_TYPES.excalidraw,
+      elements: [{ type: "text", text: "😀" }],
+    });
+
+    const embedded = await encodePngMetadata({
+      blob: pngBlob,
+      metadata,
+    });
+
+    await expect(decodePngMetadata(embedded)).resolves.toBe(metadata);
+  });
+
+  it("keeps legacy tEXt decoding support", async () => {
+    const legacyBlob = await API.loadFile("./fixtures/smiley_embedded_v2.png");
+    const metadata = await decodePngMetadata(legacyBlob);
+
+    expect(JSON.parse(metadata).elements).toEqual([
+      expect.objectContaining({ type: "text", text: "😀" }),
+    ]);
   });
 });

--- a/packages/excalidraw/tests/image.test.tsx
+++ b/packages/excalidraw/tests/image.test.tsx
@@ -1,4 +1,6 @@
 import { EXPORT_DATA_TYPES, randomId, reseed } from "@excalidraw/common";
+import tEXt from "png-chunk-text";
+import encodePng from "png-chunks-encode";
 import decodePng from "png-chunks-extract";
 
 import type { FileId } from "@excalidraw/element/types";
@@ -20,6 +22,49 @@ import {
 import { INITIALIZED_IMAGE_PROPS } from "./helpers/constants";
 
 const { h } = window;
+
+const createITXtChunk = (keyword: string, text: string) => {
+  const keywordBytes = new TextEncoder().encode(keyword);
+  const textBytes = new TextEncoder().encode(text);
+  const data = new Uint8Array(
+    keywordBytes.length + 1 + 1 + 1 + 1 + 1 + textBytes.length,
+  );
+
+  let offset = 0;
+  data.set(keywordBytes, offset);
+  offset += keywordBytes.length;
+  data[offset++] = 0;
+  data[offset++] = 0;
+  data[offset++] = 0;
+  data[offset++] = 0;
+  data[offset++] = 0;
+  data.set(textBytes, offset);
+
+  return { name: "iTXt" as const, data };
+};
+
+const insertChunkBeforeFirst = async ({
+  blob,
+  chunk,
+  targetChunkName,
+}: {
+  blob: Blob;
+  chunk: { name: string; data: Uint8Array };
+  targetChunkName: string;
+}) => {
+  const chunks = decodePng(
+    new Uint8Array(await blobModule.blobToArrayBuffer(blob)),
+  );
+  const targetIndex = chunks.findIndex(
+    (existingChunk) => existingChunk.name === targetChunkName,
+  );
+
+  expect(targetIndex).toBeGreaterThan(-1);
+
+  chunks.splice(targetIndex, 0, chunk);
+
+  return new Blob([encodePng(chunks)], { type: "image/png" });
+};
 
 export const setupImageTest = async (
   sizes: { width: number; height: number }[],
@@ -154,6 +199,43 @@ describe("png metadata", () => {
   it("keeps legacy tEXt decoding support", async () => {
     const legacyBlob = await API.loadFile("./fixtures/smiley_embedded_v2.png");
     const metadata = await decodePngMetadata(legacyBlob);
+
+    expect(JSON.parse(metadata).elements).toEqual([
+      expect.objectContaining({ type: "text", text: "😀" }),
+    ]);
+  });
+
+  it("ignores unrelated iTXt chunks before the excalidraw metadata", async () => {
+    const pngBlob = await API.loadFile("./fixtures/smiley.png");
+    const metadata = JSON.stringify({
+      type: EXPORT_DATA_TYPES.excalidraw,
+      elements: [{ type: "text", text: "😀" }],
+    });
+
+    const embedded = await encodePngMetadata({
+      blob: pngBlob,
+      metadata,
+    });
+
+    const withUnrelatedITXt = await insertChunkBeforeFirst({
+      blob: embedded,
+      chunk: createITXtChunk("Comment", "preview metadata"),
+      targetChunkName: "iTXt",
+    });
+
+    await expect(decodePngMetadata(withUnrelatedITXt)).resolves.toBe(metadata);
+  });
+
+  it("ignores unrelated tEXt chunks before the excalidraw metadata", async () => {
+    const legacyBlob = await API.loadFile("./fixtures/smiley_embedded_v2.png");
+
+    const withUnrelatedTEXt = await insertChunkBeforeFirst({
+      blob: legacyBlob,
+      chunk: tEXt.encode("Comment", "preview metadata"),
+      targetChunkName: "tEXt",
+    });
+
+    const metadata = await decodePngMetadata(withUnrelatedTEXt);
 
     expect(JSON.parse(metadata).elements).toEqual([
       expect.objectContaining({ type: "text", text: "😀" }),

--- a/packages/excalidraw/tests/image.test.tsx
+++ b/packages/excalidraw/tests/image.test.tsx
@@ -1,4 +1,9 @@
-import { EXPORT_DATA_TYPES, randomId, reseed } from "@excalidraw/common";
+import {
+  EXPORT_DATA_TYPES,
+  MIME_TYPES,
+  randomId,
+  reseed,
+} from "@excalidraw/common";
 import tEXt from "png-chunk-text";
 import encodePng from "png-chunks-encode";
 import decodePng from "png-chunks-extract";
@@ -23,9 +28,18 @@ import { INITIALIZED_IMAGE_PROPS } from "./helpers/constants";
 
 const { h } = window;
 
-const createITXtChunk = (keyword: string, text: string) => {
+const createITXtChunk = (
+  keyword: string,
+  text: string,
+  options?: {
+    compressionFlag?: 0 | 1;
+    compressionMethod?: number;
+  },
+) => {
   const keywordBytes = new TextEncoder().encode(keyword);
   const textBytes = new TextEncoder().encode(text);
+  const compressionFlag = options?.compressionFlag ?? 0;
+  const compressionMethod = options?.compressionMethod ?? 0;
   const data = new Uint8Array(
     keywordBytes.length + 1 + 1 + 1 + 1 + 1 + textBytes.length,
   );
@@ -34,8 +48,8 @@ const createITXtChunk = (keyword: string, text: string) => {
   data.set(keywordBytes, offset);
   offset += keywordBytes.length;
   data[offset++] = 0;
-  data[offset++] = 0;
-  data[offset++] = 0;
+  data[offset++] = compressionFlag;
+  data[offset++] = compressionMethod;
   data[offset++] = 0;
   data[offset++] = 0;
   data.set(textBytes, offset);
@@ -224,6 +238,30 @@ describe("png metadata", () => {
     });
 
     await expect(decodePngMetadata(withUnrelatedITXt)).resolves.toBe(metadata);
+  });
+
+  it("ignores invalid iTXt chunks with a non-zero compression method", async () => {
+    const pngBlob = await API.loadFile("./fixtures/smiley.png");
+    const metadata = JSON.stringify({
+      type: EXPORT_DATA_TYPES.excalidraw,
+      elements: [{ type: "text", text: "😀" }],
+    });
+
+    const embedded = await encodePngMetadata({
+      blob: pngBlob,
+      metadata,
+    });
+
+    const withInvalidITXt = await insertChunkBeforeFirst({
+      blob: embedded,
+      chunk: createITXtChunk(MIME_TYPES.excalidraw, "invalid metadata", {
+        compressionFlag: 0,
+        compressionMethod: 1,
+      }),
+      targetChunkName: "iTXt",
+    });
+
+    await expect(decodePngMetadata(withInvalidITXt)).resolves.toBe(metadata);
   });
 
   it("ignores unrelated tEXt chunks before the excalidraw metadata", async () => {

--- a/packages/excalidraw/tests/image.test.tsx
+++ b/packages/excalidraw/tests/image.test.tsx
@@ -4,6 +4,7 @@ import {
   randomId,
   reseed,
 } from "@excalidraw/common";
+import { deflate } from "pako";
 import tEXt from "png-chunk-text";
 import encodePng from "png-chunks-encode";
 import decodePng from "png-chunks-extract";
@@ -34,14 +35,19 @@ const createITXtChunk = (
   options?: {
     compressionFlag?: 0 | 1;
     compressionMethod?: number;
+    compressedText?: boolean;
   },
 ) => {
   const keywordBytes = new TextEncoder().encode(keyword);
   const textBytes = new TextEncoder().encode(text);
   const compressionFlag = options?.compressionFlag ?? 0;
   const compressionMethod = options?.compressionMethod ?? 0;
+  const payloadBytes =
+    options?.compressedText && compressionFlag === 1
+      ? deflate(textBytes)
+      : textBytes;
   const data = new Uint8Array(
-    keywordBytes.length + 1 + 1 + 1 + 1 + 1 + textBytes.length,
+    keywordBytes.length + 1 + 1 + 1 + 1 + 1 + payloadBytes.length,
   );
 
   let offset = 0;
@@ -52,7 +58,7 @@ const createITXtChunk = (
   data[offset++] = compressionMethod;
   data[offset++] = 0;
   data[offset++] = 0;
-  data.set(textBytes, offset);
+  data.set(payloadBytes, offset);
 
   return { name: "iTXt" as const, data };
 };
@@ -262,6 +268,32 @@ describe("png metadata", () => {
     });
 
     await expect(decodePngMetadata(withInvalidITXt)).resolves.toBe(metadata);
+  });
+
+  it("ignores compressed iTXt chunks that decompress beyond the safety limit", async () => {
+    const pngBlob = await API.loadFile("./fixtures/smiley.png");
+    const metadata = JSON.stringify({
+      type: EXPORT_DATA_TYPES.excalidraw,
+      elements: [{ type: "text", text: "😀" }],
+    });
+
+    const embedded = await encodePngMetadata({
+      blob: pngBlob,
+      metadata,
+    });
+
+    const oversizedPayload = "x".repeat(10 * 1024 * 1024 + 1);
+    const withOversizedITXt = await insertChunkBeforeFirst({
+      blob: embedded,
+      chunk: createITXtChunk(MIME_TYPES.excalidraw, oversizedPayload, {
+        compressionFlag: 1,
+        compressionMethod: 0,
+        compressedText: true,
+      }),
+      targetChunkName: "iTXt",
+    });
+
+    await expect(decodePngMetadata(withOversizedITXt)).resolves.toBe(metadata);
   });
 
   it("ignores unrelated tEXt chunks before the excalidraw metadata", async () => {


### PR DESCRIPTION
Closes #9269

## Summary
- store embedded PNG scene metadata in `iTXt` chunks instead of `tEXt`
- keep backward-compatible decoding for legacy `tEXt` metadata
- ignore unrelated `iTXt`/`tEXt` chunks and only read the Excalidraw metadata chunk
- implement the `iTXt` encode/decode locally in `packages/excalidraw/data/image.ts` without adding a new dependency

## Why
`tEXt` is latin1-only, but the scene metadata is UTF-8 JSON. `iTXt` supports UTF-8 and is a better fit for new exports, while older `tEXt`-based PNGs still need to load correctly.

## Tests
- `yarn test:other`
- `yarn test:code`
- `yarn test:typecheck`
- `yarn test:app --watch=false`
