### PR TITLE
fix: curved arrow with bound text crops when exported as PNG

### DIFF
--- a/packages/element/src/renderElement.ts
+++ b/packages/element/src/renderElement.ts
@@ -932,8 +932,8 @@ export const renderElement = (
           tempCanvasContext.scale(appState.exportScale, appState.exportScale);
 
           // Shift the canvas to left most point of the arrow
-          shiftX = element.width / 2 - (element.x - x1);
-          shiftY = element.height / 2 - (element.y - y1);
+          shiftX = (x2 - x1) / 2 - (element.x - x1);
+          shiftY = (y2 - y1) / 2 - (element.y - y1);
 
           tempCanvasContext.rotate(element.angle);
           const tempRc = rough.canvas(tempCanvas);


### PR DESCRIPTION
## Summary

Fixes #8995

When a curved multi-point arrow has a bound text element, exporting as PNG
crops the arrow. SVG export works correctly.

## Root cause

In `renderElement.ts`, when an arrow has a bound text element it renders
into a temporary canvas. The shift values used to position the arrow inside
that canvas were calculated using `element.width / 2` and `element.height / 2`:
```ts
shiftX = element.width / 2 - (element.x - x1);
shiftY = element.height / 2 - (element.y - y1);
```

For curved arrows, `element.width/height` reflects the bounding box of the
raw control points, not the actual rendered curve, which can extend beyond
those points. This caused the arrow to be rendered offset inside the temp
canvas, producing the crop.

## Fix

Use the same formula already used for the non-bound-text path, which derives
the shift from `getElementAbsoluteCoords` (`x1, y1, x2, y2`) that correctly
accounts for the actual curve extent:
```ts
shiftX = (x2 - x1) / 2 - (element.x - x1);
shiftY = (y2 - y1) / 2 - (element.y - y1);
```

## Before / After

**Before**

<img width="500" src="https://github.com/user-attachments/assets/98706ca7-2be9-41d7-b971-458cadcb43d9" />

**After**

<img width="500" src="https://github.com/user-attachments/assets/afe2fb33-6efe-4566-bc3d-9f4ae504efd0" />