### PR TITLE
feat: add persistent laser pointer mode

### DIFF
--- a/packages/excalidraw/appState.ts
+++ b/packages/excalidraw/appState.ts
@@ -128,6 +128,7 @@ export const getDefaultAppState = (): Omit<
     lockedMultiSelections: {},
     activeLockedId: null,
     bindMode: "orbit",
+    laserToolPersistence: false,
   };
 };
 
@@ -254,6 +255,7 @@ const APP_STATE_STORAGE_CONF = (<
   lockedMultiSelections: { browser: true, export: true, server: true },
   activeLockedId: { browser: false, export: false, server: false },
   bindMode: { browser: true, export: false, server: false },
+  laserToolPersistence: { browser: true, export: false, server: false },
 });
 
 const _clearAppStateForStorage = <

--- a/packages/excalidraw/components/Actions.tsx
+++ b/packages/excalidraw/components/Actions.tsx
@@ -82,6 +82,7 @@ import {
   DotsHorizontalIcon,
   SelectionIcon,
   pencilIcon,
+  TrashIcon,
 } from "./icons";
 
 import { Island } from "./Island";
@@ -1241,6 +1242,29 @@ export const ShapesSwitcher = ({
           >
             {t("toolBar.laser")}
           </DropdownMenu.Item>
+          <DropdownMenu.ItemCheckbox
+            checked={app.state.laserToolPersistence}
+            onSelect={() => {
+              const next = !app.state.laserToolPersistence;
+              app.setAppState({ laserToolPersistence: next });
+              // When disabling persistence, clear any lingering trails
+              if (!next) {
+                app.laserTrails.clearTrails();
+              }
+            }}
+            data-testid="toolbar-laser-persistence"
+          >
+            {t("toolBar.laserPersist")}
+          </DropdownMenu.ItemCheckbox>
+          {app.state.laserToolPersistence && (
+            <DropdownMenu.Item
+              onSelect={() => app.laserTrails.clearTrails()}
+              icon={TrashIcon}
+              data-testid="toolbar-laser-clear"
+            >
+              {t("toolBar.laserClear")}
+            </DropdownMenu.Item>
+          )}
           {isFullStylesPanel && (
             <DropdownMenu.Item
               onSelect={() => app.setActiveTool({ type: "lasso" })}

--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -4988,6 +4988,18 @@ class App extends React.Component<AppProps, AppState> {
         return;
       }
 
+      // Clear persistent laser trails with Delete/Backspace when laser tool is
+      // active in persistent mode (issue #9884)
+      if (
+        this.state.activeTool.type === "laser" &&
+        this.state.laserToolPersistence &&
+        (event.key === KEYS.DELETE || event.key === KEYS.BACKSPACE)
+      ) {
+        this.laserTrails.clearTrails();
+        event.preventDefault();
+        return;
+      }
+
       // Handle Alt key for bind mode
       if (event.key === KEYS.ALT) {
         if (getFeatureFlag("COMPLEX_BINDINGS")) {

--- a/packages/excalidraw/laser-trails.ts
+++ b/packages/excalidraw/laser-trails.ts
@@ -33,6 +33,10 @@ export class LaserTrails implements Trail {
       simplify: 0,
       streamline: 0.4,
       sizeMapping: (c) => {
+        // In persistent mode, trails stay at full size without decaying.
+        if (this.app.state.laserToolPersistence) {
+          return 1;
+        }
         const DECAY_TIME = 1000;
         const DECAY_LENGTH = 50;
         const t = Math.max(
@@ -59,6 +63,14 @@ export class LaserTrails implements Trail {
 
   endPath(): void {
     this.localTrail.endPath();
+  }
+
+  /**
+   * Clears all local laser trails from the screen.
+   * Used in persistent mode to explicitly remove accumulated trails.
+   */
+  clearTrails(): void {
+    this.localTrail.clearTrails();
   }
 
   start(container: SVGSVGElement) {

--- a/packages/excalidraw/locales/en.json
+++ b/packages/excalidraw/locales/en.json
@@ -325,6 +325,8 @@
     "magicframe": "Wireframe to code",
     "embeddable": "Web Embed",
     "laser": "Laser pointer",
+    "laserPersist": "Persistent laser",
+    "laserClear": "Clear laser trails",
     "hand": "Hand (panning tool)",
     "extraTools": "More tools",
     "mermaidToExcalidraw": "Mermaid to Excalidraw",

--- a/packages/excalidraw/types.ts
+++ b/packages/excalidraw/types.ts
@@ -469,6 +469,12 @@ export interface AppState {
   // and also remove groupId from this map
   lockedMultiSelections: { [groupId: string]: true };
   bindMode: BindMode;
+  /**
+   * When true, laser trails persist on screen until explicitly cleared
+   * instead of fading out automatically. Useful for presentations and teaching.
+   * Related to issue #9884.
+   */
+  laserToolPersistence: boolean;
 }
 
 export type SearchMatch = {
@@ -828,6 +834,7 @@ export type AppClassProperties = {
   bindModeHandler: App["bindModeHandler"];
 
   setAppState: App["setAppState"];
+  laserTrails: App["laserTrails"];
 };
 
 export type PointerDownState = Readonly<{


### PR DESCRIPTION
## Summary

Adds a "Persistent laser" toggle in the laser pointer dropdown so users can keep laser trails visible on screen instead of having them fade away. Useful for presentations and teaching.

### Changes
- **AppState**: add `laserToolPersistence: boolean` field (persisted to browser storage, default `false`)
- **LaserTrails**: when persistence is on, `sizeMapping` returns `1` (no time/length decay) so trails never fade; expose `clearTrails()` method
- **Actions.tsx**: add `DropdownMenu.ItemCheckbox` for the persistence toggle and a "Clear laser trails" item (visible only when persistence is on)
- **App.tsx**: Delete/Backspace clears persistent trails when laser tool is active
- **locales/en.json**: add `laserPersist` and `laserClear` i18n keys

When persistence is disabled, all existing fade behavior is unchanged.

## Test plan

- [ ] Toggle "Persistent laser" on → draw with laser → trails remain visible
- [ ] Click "Clear laser trails" → all visible trails are removed
- [ ] Press Delete/Backspace while laser tool is active → trails clear
- [ ] Toggle persistence off → laser trails fade normally as before
- [ ] Reload page → persistence setting is remembered

Fixes #9884

🤖 Generated with [Claude Code](https://claude.com/claude-code)