### PR TITLE
fix: display red border on invalid hex color input

### DIFF
--- a/packages/excalidraw/components/ColorPicker/ColorInput.tsx
+++ b/packages/excalidraw/components/ColorPicker/ColorInput.tsx
@@ -29,21 +29,27 @@ export const ColorInput = ({
 }) => {
   const editorInterface = useEditorInterface();
   const [innerValue, setInnerValue] = useState(color);
+  const [isInvalid, setIsInvalid] = useState(false);
   const [activeSection, setActiveColorPickerSection] = useAtom(
     activeColorPickerSectionAtom,
   );
 
   useEffect(() => {
     setInnerValue(color);
+    setIsInvalid(false);
   }, [color]);
 
   const changeColor = useCallback(
     (inputValue: string) => {
       const value = inputValue.toLowerCase();
-      const color = normalizeInputColor(value);
+      const normalizedColor = normalizeInputColor(value);
 
-      if (color) {
-        onChange(color);
+      if (normalizedColor) {
+        onChange(normalizedColor);
+        setIsInvalid(false);
+      } else {
+        // Only show invalid state when there is actual input
+        setIsInvalid(value.trim().length > 0);
       }
       setInnerValue(value);
     },
@@ -68,7 +74,12 @@ export const ColorInput = ({
   }, [setEyeDropperState]);
 
   return (
-    <div className="color-picker__input-label">
+    <div
+      className={clsx("color-picker__input-label", {
+        "color-picker__input-label--invalid": isInvalid,
+      })}
+      title={isInvalid ? t("colorPicker.invalidColor") : undefined}
+    >
       <div className="color-picker__input-hash">#</div>
       <input
         ref={activeSection === "hex" ? inputRef : undefined}
@@ -76,12 +87,14 @@ export const ColorInput = ({
         spellCheck={false}
         className="color-picker-input"
         aria-label={label}
+        aria-invalid={isInvalid}
         onChange={(event) => {
           changeColor(event.target.value);
         }}
         value={(innerValue || "").replace(/^#/, "")}
         onBlur={() => {
           setInnerValue(color);
+          setIsInvalid(false);
         }}
         tabIndex={-1}
         onFocus={() => setActiveColorPickerSection("hex")}

--- a/packages/excalidraw/components/ColorPicker/ColorPicker.scss
+++ b/packages/excalidraw/components/ColorPicker/ColorPicker.scss
@@ -383,6 +383,14 @@
       box-shadow: 0 0 0 1px var(--color-primary-darkest);
       border-radius: var(--border-radius-lg);
     }
+
+    &--invalid {
+      border-color: var(--color-danger);
+
+      &:focus-within {
+        box-shadow: 0 0 0 1px var(--color-danger);
+      }
+    }
   }
 
   .color-picker__input-hash {

--- a/packages/excalidraw/locales/en.json
+++ b/packages/excalidraw/locales/en.json
@@ -595,7 +595,8 @@
     "colors": "Colors",
     "shades": "Shades",
     "hexCode": "Hex code",
-    "noShades": "No shades available for this color"
+    "noShades": "No shades available for this color",
+    "invalidColor": "Invalid color"
   },
   "overwriteConfirm": {
     "action": {


### PR DESCRIPTION
## Summary

When a user types an invalid color code in the color picker hex input, the input container now shows a red border and a tooltip with "Invalid color". The invalid color is not applied to the element. The error state clears on blur or when a valid color is entered.

### Changes
- Added `isInvalid` state to `ColorInput` component
- Applied `color-picker__input-label--invalid` CSS modifier class with `--color-danger` border
- Added `aria-invalid` attribute for accessibility
- Added `colorPicker.invalidColor` i18n key to `en.json`

## Test plan

- [ ] Type an invalid hex code (e.g., "zzz") → red border appears, color is NOT applied
- [ ] Type a valid hex code → red border disappears, color is applied
- [ ] Click away (blur) from invalid input → red border clears
- [ ] Screen reader announces invalid state via `aria-invalid`

Fixes #9527

🤖 Generated with [Claude Code](https://claude.com/claude-code)