### PR TITLE
fix: recalculate roundness for all shape types during conversion

### DIFF
--- a/packages/excalidraw/components/ConvertElementTypePopup.tsx
+++ b/packages/excalidraw/components/ConvertElementTypePopup.tsx
@@ -832,7 +832,7 @@ const convertElementType = <
         ...element,
         type: targetType,
         roundness:
-          targetType === "diamond" && element.roundness
+          CONVERTIBLE_GENERIC_TYPES.has(targetType) && element.roundness
             ? {
                 type: isUsingAdaptiveRadius(targetType)
                   ? ROUNDNESS.ADAPTIVE_RADIUS


### PR DESCRIPTION
## Summary
- Fixed shape switch (Rectangle -> Diamond -> Ellipse cycle) leaving overly round corners
- Changed roundness recalculation to apply to all convertible generic types, not just diamond

## Root cause
In `convertElementType` within `ConvertElementTypePopup.tsx`, the roundness type recalculation was gated behind `targetType === "diamond"`. When cycling Rectangle -> Diamond -> Ellipse, the roundness was set to `PROPORTIONAL_RADIUS` for diamond but never reverted back to `ADAPTIVE_RADIUS` when converting to rectangle or ellipse, because the condition failed for those types and the stale roundness was carried over.

## Fix
Changed the condition from `targetType === "diamond"` to `CONVERTIBLE_GENERIC_TYPES.has(targetType)` so that `isUsingAdaptiveRadius()` is consulted for every generic shape conversion, ensuring the correct roundness type is always applied.

## Test plan
- [ ] Create a rectangle with rounded corners
- [ ] Use shape switch to convert: Rectangle -> Diamond -> Ellipse -> Rectangle
- [ ] Verify corners remain correctly rounded at each step (not overly round)
- [ ] Verify diamond still gets PROPORTIONAL_RADIUS and rectangle/ellipse get ADAPTIVE_RADIUS
- [ ] Verify shapes without roundness (sharp corners) are unaffected by the change

Fixes #9662

🤖 Generated with [Claude Code](https://claude.com/claude-code)