### PR TITLE
fix: resolve <br> tags to newlines when importing Mermaid diagrams

### DIFF
--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -421,7 +421,10 @@ import { isPointHittingTextAutoResizeHandle } from "../textAutoResizeHandle";
 import { textWysiwyg } from "../wysiwyg/textWysiwyg";
 import { isOverScrollBars } from "../scene/scrollbars";
 
-import { isMaybeMermaidDefinition } from "../mermaid";
+import {
+  isMaybeMermaidDefinition,
+  sanitizeMermaidElementText,
+} from "../mermaid";
 
 import { LassoTrail } from "../lasso";
 
@@ -3751,8 +3754,10 @@ class App extends React.Component<AppProps, AppState> {
     if (!isPlainPaste && isMaybeMermaidDefinition(data.text)) {
       const api = await import("@excalidraw/mermaid-to-excalidraw");
       try {
-        const { elements: skeletonElements, files = {} } =
+        const { elements: rawSkeletonElements, files = {} } =
           await api.parseMermaidToExcalidraw(data.text);
+        const skeletonElements =
+          sanitizeMermaidElementText(rawSkeletonElements);
 
         const elements = convertToExcalidrawElements(skeletonElements, {
           regenerateIds: true,

--- a/packages/excalidraw/components/TTDDialog/common.ts
+++ b/packages/excalidraw/components/TTDDialog/common.ts
@@ -14,6 +14,7 @@ import type {
 } from "@excalidraw/element/types";
 
 import { EditorLocalStorage } from "../../data/EditorLocalStorage";
+import { sanitizeMermaidElementText } from "../../mermaid";
 
 import type { MermaidToExcalidrawLibProps } from "./types";
 
@@ -94,7 +95,8 @@ export const convertMermaidToExcalidraw = async ({
       }
     }
 
-    const { elements, files = {} } = ret;
+    const { elements: rawElements, files = {} } = ret;
+    const elements = sanitizeMermaidElementText(rawElements);
     setError(null);
 
     data.current = {

--- a/packages/excalidraw/mermaid.test.ts
+++ b/packages/excalidraw/mermaid.test.ts
@@ -1,4 +1,7 @@
-import { isMaybeMermaidDefinition } from "./mermaid";
+import {
+  isMaybeMermaidDefinition,
+  sanitizeMermaidElementText,
+} from "./mermaid";
 
 describe("isMaybeMermaidDefinition", () => {
   it("should return true for a valid mermaid definition", () => {
@@ -11,5 +14,99 @@ describe("isMaybeMermaidDefinition", () => {
     expect(isMaybeMermaidDefinition("graphs")).toBe(false);
     expect(isMaybeMermaidDefinition("this flowchart")).toBe(false);
     expect(isMaybeMermaidDefinition("this\nflowchart")).toBe(false);
+  });
+});
+
+describe("sanitizeMermaidElementText", () => {
+  it("should replace <br> tags with newlines in label.text", () => {
+    const elements = [
+      {
+        type: "rectangle",
+        x: 0,
+        y: 0,
+        label: { text: "User Registration<br>Process" },
+      },
+    ];
+    const result = sanitizeMermaidElementText(elements);
+    expect(result[0].label.text).toBe("User Registration\nProcess");
+  });
+
+  it("should replace <br/> and <br /> variants in label.text", () => {
+    const elements = [
+      {
+        type: "rectangle",
+        x: 0,
+        y: 0,
+        label: { text: "Line 1<br/>Line 2<br />Line 3" },
+      },
+    ];
+    const result = sanitizeMermaidElementText(elements);
+    expect(result[0].label.text).toBe("Line 1\nLine 2\nLine 3");
+  });
+
+  it("should replace <br> tags in direct text property", () => {
+    const elements = [
+      {
+        type: "text",
+        x: 0,
+        y: 0,
+        text: "Hello<br>World",
+      },
+    ];
+    const result = sanitizeMermaidElementText(elements);
+    expect(result[0].text).toBe("Hello\nWorld");
+  });
+
+  it("should handle case-insensitive <BR> tags", () => {
+    const elements = [
+      {
+        type: "rectangle",
+        x: 0,
+        y: 0,
+        label: { text: "Line 1<BR>Line 2<Br>Line 3" },
+      },
+    ];
+    const result = sanitizeMermaidElementText(elements);
+    expect(result[0].label.text).toBe("Line 1\nLine 2\nLine 3");
+  });
+
+  it("should not modify elements without text or label", () => {
+    const elements = [
+      {
+        type: "rectangle",
+        x: 0,
+        y: 0,
+        width: 100,
+        height: 50,
+      },
+    ];
+    const result = sanitizeMermaidElementText(elements);
+    expect(result[0]).toEqual(elements[0]);
+  });
+
+  it("should not modify text that contains no <br> tags", () => {
+    const elements = [
+      {
+        type: "rectangle",
+        x: 0,
+        y: 0,
+        label: { text: "No breaks here" },
+      },
+    ];
+    const result = sanitizeMermaidElementText(elements);
+    expect(result[0].label.text).toBe("No breaks here");
+  });
+
+  it("should not mutate the original elements array", () => {
+    const elements = [
+      {
+        type: "rectangle",
+        x: 0,
+        y: 0,
+        label: { text: "Hello<br>World" },
+      },
+    ];
+    sanitizeMermaidElementText(elements);
+    expect(elements[0].label.text).toBe("Hello<br>World");
   });
 });

--- a/packages/excalidraw/mermaid.ts
+++ b/packages/excalidraw/mermaid.ts
@@ -1,3 +1,44 @@
+/**
+ * Replaces HTML <br> tags (and variants like <br/>, <br />) with newlines.
+ * Mermaid uses <br> tags for line breaks in node labels, but Excalidraw
+ * expects actual newline characters in text content.
+ */
+const replaceBrTagsWithNewlines = (text: string): string => {
+  return text.replace(/<br\s*\/?>/gi, "\n");
+};
+
+/**
+ * Sanitizes text fields in Mermaid-to-Excalidraw skeleton elements by
+ * converting HTML <br> tags to newline characters. This handles the case
+ * where Mermaid diagrams use <br> for multi-line labels (e.g.
+ * `A["Line 1<br>Line 2"]`), which the mermaid-to-excalidraw parser passes
+ * through as literal "<br>" text.
+ */
+export const sanitizeMermaidElementText = <
+  T extends { text?: string; label?: { text: string } },
+>(
+  elements: readonly T[],
+): T[] => {
+  return elements.map((element) => {
+    const result = { ...element };
+
+    // Sanitize direct text property (text elements)
+    if (typeof result.text === "string") {
+      result.text = replaceBrTagsWithNewlines(result.text) as T["text"];
+    }
+
+    // Sanitize label.text property (containers: rectangle, ellipse, diamond, arrow)
+    if (result.label && typeof result.label.text === "string") {
+      result.label = {
+        ...result.label,
+        text: replaceBrTagsWithNewlines(result.label.text),
+      };
+    }
+
+    return result;
+  });
+};
+
 /** heuristically checks whether the text may be a mermaid diagram definition */
 export const isMaybeMermaidDefinition = (text: string) => {
   const chartTypes = [


### PR DESCRIPTION
## Summary
- When importing Mermaid diagrams with `<br>` tags in node labels (e.g. `A["User Registration<br>Process"]`), the text was rendered with literal `<br>` instead of actual line breaks
- Added `sanitizeMermaidElementText()` utility that converts `<br>`, `<br/>`, and `<br />` tags to newline characters (`\n`) in skeleton element text fields (`text` and `label.text`)
- Applied the sanitization in both import paths: clipboard paste (`App.tsx`) and the Text-to-Diagram dialog (`TTDDialog/common.ts`)

## Test plan
- [x] Added 7 unit tests for `sanitizeMermaidElementText` covering: `<br>`, `<br/>`, `<br />`, case-insensitive `<BR>`, elements without text, text without `<br>` tags, and immutability of input
- [x] All existing mermaid tests pass (`mermaid.test.ts`, `MermaidToExcalidraw.test.tsx`, `TTDDialog/common.test.ts`)
- [x] TypeScript type check passes with no errors
- [ ] Manual test: paste the following Mermaid diagram and verify line breaks render correctly:
```
graph TD
    A["User Registration<br>Process"] --> B["Validate Input<br>Data"]
    B --> C{"Is Data<br>Valid?"}
    C -->|Yes| D["Create User<br>Account"]
    C -->|No| E["Display Error<br>Message"]
    D --> F["Send Welcome<br>Email"]
    E --> A
    F --> G["Registration<br>Complete"]
```

Fixes #9708

🤖 Generated with [Claude Code](https://claude.com/claude-code)