### PR TITLE
fix(editor): stabilize canvas search results order

### DIFF
--- a/packages/excalidraw/components/SearchMenu.tsx
+++ b/packages/excalidraw/components/SearchMenu.tsx
@@ -804,9 +804,6 @@ const handleSearch = debounce(
       isFrameLikeElement(el),
     ) as ExcalidrawFrameLikeElement[];
 
-    texts.sort((a, b) => a.y - b.y);
-    frames.sort((a, b) => a.y - b.y);
-
     const textMatches: SearchMatchItem[] = [];
 
     const regex = new RegExp(escapeSpecialCharacters(searchQuery), "gi");

--- a/packages/excalidraw/tests/search.test.tsx
+++ b/packages/excalidraw/tests/search.test.tsx
@@ -161,6 +161,37 @@ describe("search", () => {
     });
   });
 
+  it("should maintain stable search results order when elements are repositioned", async () => {
+    const scrollIntoViewMock = jest.fn();
+    window.HTMLElement.prototype.scrollIntoView = scrollIntoViewMock;
+
+    const el1 = API.createElement({ type: "text", text: "test alpha", y: 100 });
+    const el2 = API.createElement({ type: "text", text: "test beta", y: 200 });
+
+    API.setElements([el1, el2]);
+
+    Keyboard.withModifierKeys({ ctrl: true }, () => {
+      Keyboard.keyPress(KEYS.F);
+    });
+
+    const searchInput = await querySearchInput();
+    updateTextEditor(searchInput, "test");
+
+    let firstResultId: string;
+
+    await waitFor(() => {
+      expect(h.app.state.searchMatches?.matches.length).toBe(2);
+      firstResultId = h.app.state.searchMatches!.matches[0].id;
+    });
+
+    API.updateElement(el2 as ExcalidrawTextElement, { y: 0 });
+
+    await waitFor(() => {
+      expect(h.app.state.searchMatches?.matches.length).toBe(2);
+      expect(h.app.state.searchMatches!.matches[0].id).toBe(firstResultId!);
+    });
+  });
+
   it("should match frame names", async () => {
     const scrollIntoViewMock = jest.fn();
     window.HTMLElement.prototype.scrollIntoView = scrollIntoViewMock;


### PR DESCRIPTION
## Summary

- Remove y-position based sorting from canvas search results so the order remains constant when elements are repositioned on the canvas
- Results now follow the scene's element order (z-index), which is stable across drag operations
- Adds regression test verifying results don't reorder when an element's position changes

Fixes #9503

## Context

As discussed in #9503, search results were sorting by y-position which caused the list to reorder when dragging elements on canvas. Per @dwelle's [comment](https://github.com/excalidraw/excalidraw/issues/9503#issuecomment-2879821830):

> we now decided to maintain the results ordering constant so that the list of results doesn't change under your hands if someone does changes on canvas

The fix removes the two `.sort((a, b) => a.y - b.y)` calls in `handleSearch()`. Since `getNonDeletedElements()` already returns elements in a deterministic z-index order, and `Array.filter()` preserves that order, no replacement sort is needed.

## Test plan

- [x] Added test: "should maintain stable search results order when elements are repositioned"
- [x] All existing search tests pass
- [x] TypeScript typecheck passes
- [x] Manual: create two text elements with "test", search "test", drag one element vertically → results list should not reorder