### PR TITLE
[feat] add titles to exported SVGs

### DIFF
--- a/packages/excalidraw/data/index.ts
+++ b/packages/excalidraw/data/index.ts
@@ -125,6 +125,7 @@ export const exportCanvas = async (
         exportPadding,
         exportScale: appState.exportScale,
         exportEmbedScene: appState.exportEmbedScene && type === "svg",
+        name,
       },
       files,
       { exportingFrame },

--- a/packages/excalidraw/scene/export.ts
+++ b/packages/excalidraw/scene/export.ts
@@ -292,6 +292,7 @@ export const exportToSvg = async (
     exportWithDarkMode?: boolean;
     exportEmbedScene?: boolean;
     frameRendering?: AppState["frameRendering"];
+    name?: string | null;
   },
   files: BinaryFiles | null,
   opts?: {
@@ -359,6 +360,13 @@ export const exportToSvg = async (
 
   svgRoot.appendChild(createHTMLComment("svg-source:excalidraw"));
   svgRoot.appendChild(metadataElement);
+
+  if (appState.name) {
+    const titleElement = svgRoot.ownerDocument.createElementNS(SVG_NS, "title");
+    titleElement.textContent = appState.name;
+    svgRoot.appendChild(titleElement);
+  }
+
   svgRoot.appendChild(defsElement);
 
   // ---------------------------------------------------------------------------

--- a/packages/excalidraw/tests/scene/export.test.ts
+++ b/packages/excalidraw/tests/scene/export.test.ts
@@ -184,6 +184,32 @@ describe("exportToSvg", () => {
     expect(svgElement.innerHTML).toMatchSnapshot();
   });
 
+  it("with title from name", async () => {
+    const svgElement = await exportUtils.exportToSvg(
+      ELEMENTS,
+      {
+        ...DEFAULT_OPTIONS,
+        name: "My Drawing",
+      },
+      null,
+    );
+
+    const titleEl = svgElement.querySelector("title");
+    expect(titleEl).not.toBeNull();
+    expect(titleEl!.textContent).toBe("My Drawing");
+  });
+
+  it("without title when name is not provided", async () => {
+    const svgElement = await exportUtils.exportToSvg(
+      ELEMENTS,
+      DEFAULT_OPTIONS,
+      null,
+    );
+
+    const titleEl = svgElement.querySelector("title");
+    expect(titleEl).toBeNull();
+  });
+
   it("with elements that have a link", async () => {
     const svgElement = await exportUtils.exportToSvg(
       [rectangleWithLinkFixture],


### PR DESCRIPTION
### Summary

Adds a `<title>` element to exported SVGs using the existing project name (`AppState.name`). This makes SVGs searchable on GitHub, which indexes `<title>` content (see discussion in #8213).

---

### Approach

Instead of adding a new UI input (as attempted in #8566), this just threads the already-available name through to the SVG export pipeline:

* Added `name?: string | null` to `exportToSvg`'s `appState` parameter
* `exportCanvas` already destructures `name` from `appState`, so just passing it along
* Title element is inserted via `createElementNS` / `textContent` (not string interpolation) right after the metadata element
* Only adds `<title>` when `name` is non-empty — no hardcoded fallback

The public `exportToSvg` in `@excalidraw/utils` already passes the full restored `appState`, so it picks up `name` automatically without any changes there.

---

### Not included

* No `<desc>` element — could be a follow-up if there's interest
* No changes to the export dialog UI — the project name field already exists and is editable

---

### Test plan

* Added two test cases: one verifying `<title>` is present with correct content when `name` is set, one verifying it's absent when `name` is omitted
* Existing snapshot tests unaffected since `name` isn't set in `DEFAULT_OPTIONS`
* `yarn test:typecheck` passes
* All 17 export tests pass

---

Closes #8301
