### PR TITLE
Add SVG title export option for GitHub keyword searchability

### DIFF
--- a/packages/excalidraw/data/index.ts
+++ b/packages/excalidraw/data/index.ts
@@ -127,7 +127,7 @@ export const exportCanvas = async (
         exportEmbedScene: appState.exportEmbedScene && type === "svg",
       },
       files,
-      { exportingFrame },
+      { exportingFrame, name },
     );
 
     if (type === "svg") {

--- a/packages/excalidraw/scene/export.ts
+++ b/packages/excalidraw/scene/export.ts
@@ -302,6 +302,10 @@ export const exportToSvg = async (
     exportingFrame?: ExcalidrawFrameLikeElement | null;
     skipInliningFonts?: true;
     reuseImages?: boolean;
+    /**
+     * title to add to the exported SVG, used for accessibility and GitHub searchability.
+     */
+    name?: string;
   },
 ): Promise<SVGSVGElement> => {
   const frameRendering = getFrameRenderingConfig(
@@ -349,6 +353,16 @@ export const exportToSvg = async (
   svgRoot.setAttribute("viewBox", `0 0 ${width} ${height}`);
   svgRoot.setAttribute("width", `${width * exportScale}`);
   svgRoot.setAttribute("height", `${height * exportScale}`);
+
+  // Add title for accessibility and GitHub searchability
+  if (opts?.name) {
+    const titleElement = svgRoot.ownerDocument.createElementNS(
+      SVG_NS,
+      "title",
+    );
+    titleElement.textContent = opts.name;
+    svgRoot.insertBefore(titleElement, svgRoot.firstChild);
+  }
 
   const defsElement = svgRoot.ownerDocument.createElementNS(SVG_NS, "defs");
 

--- a/packages/excalidraw/tests/scene/export.test.ts
+++ b/packages/excalidraw/tests/scene/export.test.ts
@@ -530,5 +530,17 @@ describe("exporting frames", () => {
       expect(svg.getAttribute("width")).toBe(frame1.width.toString());
       expect(svg.getAttribute("height")).toBe(frame1.height.toString());
     });
+
+    it("with title", async () => {
+      const svg = await exportUtils.exportToSvg(ELEMENTS, DEFAULT_OPTIONS, null, {
+        name: "My Excalidraw Drawing",
+      });
+
+      const titleElement = svg.querySelector("title");
+      expect(titleElement).not.toBeNull();
+      expect(titleElement?.textContent).toBe("My Excalidraw Drawing");
+      // title should be first child
+      expect(svg.firstChild).toBe(titleElement);
+    });
   });
 });


### PR DESCRIPTION
## Problem

Excalidraw SVG exports lack a title element, making exported SVG files not searchable by keywords on GitHub. This reduces discoverability and accessibility of exported diagrams.

## Solution

Added an export option to include a `<title>` element in SVG exports. Users can now add a custom title during export, making SVG content searchable on GitHub and improving accessibility.

## Validation

```xml
<!-- Exported SVG now includes -->
<svg>
  <title>My Diagram Title</title>
  ...
</svg>

<!-- Title is searchable on GitHub -->
```

Fixes #8301