### PR TITLE
fix(packages/excalidraw): use --color-selection for linear element point handles

### DIFF
--- a/packages/common/src/colors.ts
+++ b/packages/common/src/colors.ts
@@ -291,6 +291,10 @@ export const colorToHex = (color: string): string | null => {
   return rgbToHex(r, g, b, a);
 };
 
+/** Return a CSS color string with the given alpha applied. Accepts any valid CSS color. */
+export const colorWithAlpha = (color: string, alpha: number): string =>
+  tinycolor(color).setAlpha(alpha).toRgbString();
+
 export const isTransparent = (color: string) => {
   return tinycolor(color).getAlpha() === 0;
 };

--- a/packages/excalidraw/renderer/interactiveScene.ts
+++ b/packages/excalidraw/renderer/interactiveScene.ts
@@ -13,6 +13,7 @@ import {
 import {
   arrayToMap,
   BIND_MODE_TIMEOUT,
+  colorWithAlpha,
   DEFAULT_TRANSFORM_HANDLE_SPACING,
   FRAME_STYLE,
   getFeatureFlag,
@@ -115,6 +116,7 @@ import type {
 const renderElbowArrowMidPointHighlight = (
   context: CanvasRenderingContext2D,
   appState: InteractiveCanvasAppState,
+  selectionColor: InteractiveCanvasRenderConfig["selectionColor"],
 ) => {
   invariant(appState.selectedLinearElement, "selectedLinearElement is null");
 
@@ -125,7 +127,7 @@ const renderElbowArrowMidPointHighlight = (
   context.save();
   context.translate(appState.scrollX, appState.scrollY);
 
-  highlightPoint(segmentMidPointHoveredCoords, context, appState);
+  highlightPoint(segmentMidPointHoveredCoords, context, appState, selectionColor);
 
   context.restore();
 };
@@ -134,6 +136,7 @@ const renderLinearElementPointHighlight = (
   context: CanvasRenderingContext2D,
   appState: InteractiveCanvasAppState,
   elementsMap: ElementsMap,
+  selectionColor: InteractiveCanvasRenderConfig["selectionColor"],
 ) => {
   const { elementId, hoverPointIndex } = appState.selectedLinearElement!;
   if (
@@ -160,7 +163,7 @@ const renderLinearElementPointHighlight = (
   context.save();
   context.translate(appState.scrollX, appState.scrollY);
 
-  highlightPoint(point, context, appState);
+  highlightPoint(point, context, appState, selectionColor);
   context.restore();
 };
 
@@ -168,8 +171,9 @@ const highlightPoint = <Point extends LocalPoint | GlobalPoint>(
   point: Point,
   context: CanvasRenderingContext2D,
   appState: InteractiveCanvasAppState,
+  selectionColor: InteractiveCanvasRenderConfig["selectionColor"],
 ) => {
-  context.fillStyle = "rgba(105, 101, 219, 0.4)";
+  context.fillStyle = colorWithAlpha(selectionColor, 0.4);
 
   fillCircle(
     context,
@@ -184,11 +188,12 @@ const renderFocusPointHighlight = (
   context: CanvasRenderingContext2D,
   appState: InteractiveCanvasAppState,
   focusPoint: GlobalPoint,
+  selectionColor: InteractiveCanvasRenderConfig["selectionColor"],
 ) => {
   context.save();
   context.translate(appState.scrollX, appState.scrollY);
 
-  highlightPoint(focusPoint, context, appState);
+  highlightPoint(focusPoint, context, appState, selectionColor);
 
   context.restore();
 };
@@ -201,14 +206,15 @@ const renderSingleLinearPoint = <Point extends GlobalPoint | LocalPoint>(
   isSelected: boolean,
   isPhantomPoint: boolean,
   isOverlappingPoint: boolean,
+  selectionColor: InteractiveCanvasRenderConfig["selectionColor"],
 ) => {
-  context.strokeStyle = "#5e5ad8";
+  context.strokeStyle = selectionColor;
   context.setLineDash([]);
   context.fillStyle = "rgba(255, 255, 255, 0.9)";
   if (isSelected) {
-    context.fillStyle = "rgba(134, 131, 226, 0.9)";
+    context.fillStyle = colorWithAlpha(selectionColor, 0.9);
   } else if (isPhantomPoint) {
-    context.fillStyle = "rgba(177, 151, 252, 0.7)";
+    context.fillStyle = colorWithAlpha(selectionColor, 0.7);
   }
 
   fillCircle(
@@ -1082,6 +1088,7 @@ const renderLinearPointHandles = (
   appState: InteractiveCanvasAppState,
   element: NonDeleted<ExcalidrawLinearElement>,
   elementsMap: RenderableElementsMap,
+  selectionColor: InteractiveCanvasRenderConfig["selectionColor"],
 ) => {
   if (!appState.selectedLinearElement) {
     return;
@@ -1141,6 +1148,7 @@ const renderLinearPointHandles = (
       isSelected,
       false,
       isOverlappingPoint,
+      selectionColor,
     );
   });
 
@@ -1169,6 +1177,7 @@ const renderLinearPointHandles = (
           false,
           !fixedSegments.includes(idx + 1),
           false,
+          selectionColor,
         );
       }
     });
@@ -1193,6 +1202,7 @@ const renderLinearPointHandles = (
           false,
           true,
           false,
+          selectionColor,
         );
       }
     });
@@ -1206,11 +1216,13 @@ const renderFocusPointConnectionLine = (
   appState: InteractiveCanvasAppState,
   fromPoint: GlobalPoint,
   toPoint: GlobalPoint,
+  selectionColor: InteractiveCanvasRenderConfig["selectionColor"],
 ) => {
   context.save();
   context.translate(appState.scrollX, appState.scrollY);
 
-  context.strokeStyle = "rgba(134, 131, 226, 0.6)";
+  context.strokeStyle =
+    colorWithAlpha(selectionColor, 0.6);
   context.lineWidth = 1 / appState.zoom.value;
   context.setLineDash([4 / appState.zoom.value, 4 / appState.zoom.value]);
 
@@ -1228,14 +1240,16 @@ const renderFocusPointCicle = (
   point: GlobalPoint,
   radius: number,
   isHovered: boolean,
+  selectionColor: InteractiveCanvasRenderConfig["selectionColor"],
 ) => {
   context.save();
   context.translate(appState.scrollX, appState.scrollY);
-  context.strokeStyle = "rgba(134, 131, 226, 0.6)";
+  context.strokeStyle =
+    colorWithAlpha(selectionColor, 0.6);
   context.lineWidth = 1 / appState.zoom.value;
   context.setLineDash([]);
   context.fillStyle = isHovered
-    ? "rgba(134, 131, 226, 0.9)"
+    ? colorWithAlpha(selectionColor, 0.9)
     : "rgba(255, 255, 255, 0.9)";
 
   fillCircle(
@@ -1255,12 +1269,14 @@ const renderFocusPointIndicator = ({
   type,
   context,
   elementsMap,
+  selectionColor,
 }: {
   arrow: NonDeleted<ExcalidrawArrowElement>;
   appState: InteractiveCanvasAppState;
   context: CanvasRenderingContext2D;
   elementsMap: NonDeletedSceneElementsMap;
   type: "start" | "end";
+  selectionColor: InteractiveCanvasRenderConfig["selectionColor"];
 }) => {
   const binding = type === "start" ? arrow.startBinding : arrow.endBinding;
   const bindableElement =
@@ -1307,7 +1323,7 @@ const renderFocusPointIndicator = ({
     linearState?.hoveredFocusPointBinding === type &&
     !linearState.draggedFocusPointBinding
   ) {
-    renderFocusPointHighlight(context, appState, focusPoint);
+    renderFocusPointHighlight(context, appState, focusPoint, selectionColor);
   }
 
   // render focus point
@@ -1329,7 +1345,13 @@ const renderFocusPointIndicator = ({
       elementsMap,
     );
 
-    renderFocusPointConnectionLine(context, appState, arrowPoint, focusPoint);
+    renderFocusPointConnectionLine(
+      context,
+      appState,
+      arrowPoint,
+      focusPoint,
+      selectionColor,
+    );
 
     renderFocusPointCicle(
       context,
@@ -1337,6 +1359,7 @@ const renderFocusPointIndicator = ({
       focusPoint,
       FOCUS_POINT_SIZE / 1.5,
       isHovered,
+      selectionColor,
     );
   }
 };
@@ -1611,6 +1634,7 @@ const _renderInteractiveScene = ({
       appState,
       editingLinearElement,
       elementsMap,
+      renderConfig.selectionColor,
     );
   }
 
@@ -1715,6 +1739,7 @@ const _renderInteractiveScene = ({
       appState,
       selectedElements[0] as NonDeleted<ExcalidrawLinearElement>,
       elementsMap,
+      renderConfig.selectionColor,
     );
   }
 
@@ -1727,7 +1752,11 @@ const _renderInteractiveScene = ({
   if (selectedLinearElement) {
     if (!appState.selectedLinearElement.isDragging) {
       if (linearState.segmentMidPointHoveredCoords) {
-        renderElbowArrowMidPointHighlight(context, appState);
+        renderElbowArrowMidPointHighlight(
+          context,
+          appState,
+          renderConfig.selectionColor,
+        );
       } else if (
         isElbowArrow(selectedLinearElement)
           ? linearState.hoverPointIndex === 0 ||
@@ -1735,7 +1764,12 @@ const _renderInteractiveScene = ({
               selectedLinearElement.points.length - 1
           : linearState.hoverPointIndex >= 0
       ) {
-        renderLinearElementPointHighlight(context, appState, elementsMap);
+        renderLinearElementPointHighlight(
+          context,
+          appState,
+          elementsMap,
+          renderConfig.selectionColor,
+        );
       }
     }
 
@@ -1746,6 +1780,7 @@ const _renderInteractiveScene = ({
         appState,
         context,
         type: "start",
+        selectionColor: renderConfig.selectionColor,
       });
 
       renderFocusPointIndicator({
@@ -1754,6 +1789,7 @@ const _renderInteractiveScene = ({
         appState,
         context,
         type: "end",
+        selectionColor: renderConfig.selectionColor,
       });
     }
   }
@@ -1783,6 +1819,7 @@ const _renderInteractiveScene = ({
         appState,
         selectedElements[0] as ExcalidrawLinearElement,
         elementsMap,
+        renderConfig.selectionColor,
       );
     }
     const selectionColor = renderConfig.selectionColor || "#000";


### PR DESCRIPTION
## Problem

Overriding `--color-selection` via CSS customizes bounding boxes and resize handles, but linear element point handles (lines, arrows, elbow arrows, focus points) remain hardcoded purple — making the selection UI inconsistent for embedders who customize the theme.

## Solution

Thread `renderConfig.selectionColor` (already resolved from `--color-selection`) through to all linear point handle rendering functions, following the same pattern used by `renderTransformHandles`, `renderTextBox`, etc.

Add `colorWithAlpha` to `@excalidraw/common` (using existing `tinycolor2`) for deriving semi-transparent variants needed by point handle fills.

**Files changed:** `packages/common/src/colors.ts` (+4 lines), `packages/excalidraw/renderer/interactiveScene.ts` (+55/-14)

## Before / After

With `--color-selection` overridden to orange:

| Selection Color | Before | After |
|-|-|-|
| Default color | <img width="201" height="101" alt="image" src="https://github.com/user-attachments/assets/44a0023b-9c7b-4481-966c-4489d8af1a44" /><img width="238" height="45" alt="image" src="https://github.com/user-attachments/assets/0768353c-9766-4bc2-99b0-45a27e41d1ec" /><img width="232" height="48" alt="image" src="https://github.com/user-attachments/assets/e5a07b73-d69e-4699-8812-e96d653b3063" /> | <img width="173" height="78" alt="image" src="https://github.com/user-attachments/assets/ff08930d-94b1-492f-9c3d-fe7374298349" /><img width="245" height="53" alt="image" src="https://github.com/user-attachments/assets/1ee1f931-3d8b-4201-a4f1-bff51c23cd81" /><img width="215" height="43" alt="image" src="https://github.com/user-attachments/assets/bab58f1b-9613-4778-84ec-539689c077be" /> |
| Custom `--color-selection: #e8590c;` | <img width="195" height="84" alt="image" src="https://github.com/user-attachments/assets/e0d71788-913c-4a22-845e-e09314342b87" /><img width="238" height="45" alt="image" src="https://github.com/user-attachments/assets/0768353c-9766-4bc2-99b0-45a27e41d1ec" /><img width="232" height="48" alt="image" src="https://github.com/user-attachments/assets/e5a07b73-d69e-4699-8812-e96d653b3063" /> | <img width="195" height="84" alt="image" src="https://github.com/user-attachments/assets/329db77d-2bf3-4a9b-a579-44f557221efa" /><img width="211" height="43" alt="image" src="https://github.com/user-attachments/assets/91567947-13d1-4130-bcc4-378524d58c88" /><img width="212" height="45" alt="image" src="https://github.com/user-attachments/assets/cf5013d7-2fc1-499f-a015-39ce81e56dc5" /> |

## Note on default appearance

The original code used hand-picked lighter tints (e.g. `rgba(134,131,226)`) rather than alpha-reduced `--color-selection`. This PR derives all colors from `selectionColor` with alpha, which slightly shifts the default fills. The stroke, highlight, and overall hue remain visually consistent. This aligns linear handles with how all other selection UI already works (single color source). The before/after screenshots above show the default color comparison so you can assess the visual difference directly.