### PR TITLE
fix: prevent accidental element duplication when using Alt+Tab

### DIFF
--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -8202,6 +8202,7 @@ class App extends React.Component<AppProps, AppState> {
         allHitElements: [],
         wasAddedToSelection: false,
         hasBeenDuplicated: false,
+        altKeyDragStarted: false,
         hasHitCommonBoundingBoxOfSelectedElements:
           this.isHittingCommonBoundingBoxOfSelectedElements(
             origin,
@@ -9759,6 +9760,9 @@ class App extends React.Component<AppProps, AppState> {
 
         // Marking that click was used for dragging to check
         // if elements should be deselected on pointerup
+        if (!pointerDownState.drag.hasOccurred && event.altKey) {
+          pointerDownState.hit.altKeyDragStarted = true;
+        }
         pointerDownState.drag.hasOccurred = true;
 
         // prevent immediate dragging during lasso selection to avoid element displacement
@@ -9958,7 +9962,13 @@ class App extends React.Component<AppProps, AppState> {
           });
 
           // We duplicate the selected element if alt is pressed on pointer move
-          if (event.altKey && !pointerDownState.hit.hasBeenDuplicated) {
+          // Only allow duplication if alt was held when dragging first started,
+          // to prevent accidental duplication when using Alt+Tab to switch windows (#8508)
+          if (
+            event.altKey &&
+            !pointerDownState.hit.hasBeenDuplicated &&
+            pointerDownState.hit.altKeyDragStarted
+          ) {
             // Move the currently selected elements to the top of the z index stack, and
             // put the duplicates where the selected elements used to be.
             // (the origin point where the dragging started)

--- a/packages/excalidraw/types.ts
+++ b/packages/excalidraw/types.ts
@@ -866,6 +866,9 @@ export type PointerDownState = Readonly<{
     // Whether selected element(s) were duplicated, might change during the
     // pointer interaction
     hasBeenDuplicated: boolean;
+    // Whether alt key was held when drag first started, used to prevent
+    // accidental duplication when using Alt+Tab to switch windows (#8508)
+    altKeyDragStarted: boolean;
     hasHitCommonBoundingBoxOfSelectedElements: boolean;
   };
   withCmdOrCtrl: boolean;


### PR DESCRIPTION
## Problem
When users Alt+Tab to switch windows while dragging elements, the Alt key state persists. On returning to excalidraw, the drag handler sees \vent.altKey === true\ and triggers unwanted element duplication.

Fixes #8508

## Solution
Track whether Alt was held when the drag **first started** (new \ltKeyDragStarted\ flag on \pointerDownState.hit\). Only allow alt-drag duplication if the user was holding Alt from the beginning of the drag, not if Alt happens to be pressed from an Alt+Tab window switch.

## Changes
- Added \ltKeyDragStarted\ boolean to \PointerDownState.hit\
- Set it to \	rue\ only when Alt is held at the moment dragging first begins
- Gated the duplication logic on this flag

## Testing
- Drag elements normally → no change in behavior
- Alt+drag → duplicates as expected
- Alt+Tab away during drag, return → no accidental duplication