### PR TITLE
fix: resolve image loading in example code

### DIFF
--- a/examples/with-script-in-browser/components/ExampleApp.tsx
+++ b/examples/with-script-in-browser/components/ExampleApp.tsx
@@ -288,6 +288,11 @@ export default function ExampleApp({
     const contents = await loadSceneOrLibraryFromBlob(file, null, null);
     if (contents.type === MIME_TYPES.excalidraw) {
       excalidrawAPI?.updateScene(contents.data as any);
+      if (contents.data.files) {
+        excalidrawAPI?.addFiles(
+          Object.values(contents.data.files) as BinaryFileData[],
+        );
+      }
     } else if (contents.type === MIME_TYPES.excalidrawlib) {
       excalidrawAPI?.updateLibrary({
         libraryItems: (contents.data as ImportedLibraryData).libraryItems!,


### PR DESCRIPTION
## Summary

- Fix image loading when using "Load Scene or Library" in the `with-script-in-browser` example
- The `loadSceneOrLibraryFromBlob` function returns embedded image data in `contents.data.files`, but `updateScene` does not accept a `files` property — it only handles `elements`, `appState`, and `collaborators`
- Added an `addFiles()` call after `updateScene()` to register embedded image files with the Excalidraw instance, matching how the main application (`App.tsx`) handles scene loading via `syncActionResult`

## Test plan

- [ ] Open the [with-script-in-browser example](https://codesandbox.io/p/sandbox/github/excalidraw/excalidraw/tree/master/examples/with-script-in-browser)
- [ ] Click "Load Scene or Library" and open an `.excalidraw` file that contains embedded images
- [ ] Verify that images are now rendered correctly on the canvas
- [ ] Verify that scenes without images still load correctly
- [ ] Verify that library files (`.excalidrawlib`) still load correctly

Fixes #9578

🤖 Generated with [Claude Code](https://claude.com/claude-code)