### PR TITLE
fix: hide collaborators popup when all avatars fit without overflow

### DIFF
--- a/packages/excalidraw/components/UserList.tsx
+++ b/packages/excalidraw/components/UserList.tsx
@@ -169,10 +169,11 @@ export const UserList = React.memo(
 
     const [maxAvatars, setMaxAvatars] = React.useState(DEFAULT_MAX_AVATARS);
 
-    const firstNCollaborators = uniqueCollaboratorsArray.slice(
-      0,
-      maxAvatars - 1,
-    );
+    const allFitWithoutOverflow = uniqueCollaboratorsArray.length <= maxAvatars;
+
+    const firstNCollaborators = allFitWithoutOverflow
+      ? uniqueCollaboratorsArray
+      : uniqueCollaboratorsArray.slice(0, maxAvatars - 1);
 
     const firstNAvatarsJSX = firstNCollaborators.map((collaborator) =>
       renderCollaborator({
@@ -204,7 +205,7 @@ export const UserList = React.memo(
         >
           {firstNAvatarsJSX}
 
-          {uniqueCollaboratorsArray.length > maxAvatars - 1 && (
+          {!allFitWithoutOverflow && (
             <Popover.Root>
               <Popover.Trigger className="UserList__more">
                 +{uniqueCollaboratorsArray.length - maxAvatars + 1}


### PR DESCRIPTION
## Summary

- The collaborators popup ("+N" overflow button) was appearing too eagerly, even when all collaborators could fit as individual avatars in the available space
- The root cause was that the code always reserved one avatar slot for the overflow button (`maxAvatars - 1`), regardless of whether overflow was actually needed
- Added an `allFitWithoutOverflow` check: when total collaborators <= `maxAvatars`, all avatars render directly; the "+N" popup only appears when there are genuinely more collaborators than available slots

Fixes #9515

## Test plan

- [ ] With 1-4 collaborators and default `maxAvatars=4`: all avatars should render inline, no "+N" button
- [ ] With 5+ collaborators and default `maxAvatars=4`: first 3 avatars render inline, "+2" (or more) overflow button appears
- [ ] Resize the window to change `maxAvatars` dynamically — popup should appear/disappear correctly at the threshold
- [ ] Mobile view continues to show all collaborators in a list (unchanged behavior)
- [ ] TypeScript type check passes (`yarn test:typecheck`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)