### PR TITLE
chore: remove legacy mobile detection comment

### DIFF
--- a/packages/common/src/editorInterface.ts
+++ b/packages/common/src/editorInterface.ts
@@ -53,13 +53,6 @@ export const isIOS =
 export const isBrave = () =>
   (navigator as any).brave?.isBrave?.name === "isBrave";
 
-// export const isMobile =
-//   isIOS ||
-//   /android|webos|ipod|blackberry|iemobile|opera mini/i.test(
-//     navigator.userAgent,
-//   ) ||
-//   /android|ios|ipod|blackberry|windows phone/i.test(navigator.platform);
-
 // utilities
 export const isMobileBreakpoint = (width: number, height: number) => {
   return (


### PR DESCRIPTION
## Summary
Removes an obsolete commented mobile-detection snippet from `packages/common/src/editorInterface.ts`.

## Root cause
`editorInterface.ts` still contained a legacy commented-out `isMobile` implementation even though the file now uses `isMobileOrTablet()` for active user-agent detection. The dead block adds noise without affecting runtime behavior.

## Changes
- delete the unused commented `isMobile` block
- keep the active mobile/tablet detection logic unchanged

## Verification
- `corepack yarn eslint --max-warnings=0 packages/common/src/editorInterface.ts`
- `corepack yarn prettier --check packages/common/src/editorInterface.ts`

Closes #10798
