### PR TITLE
fix: z-index shortcuts miss bracket keys on some layouts

### DIFF
--- a/packages/common/src/keys.ts
+++ b/packages/common/src/keys.ts
@@ -140,6 +140,26 @@ export const isArrowKey = (key: string) =>
   key === KEYS.ARROW_DOWN ||
   key === KEYS.ARROW_UP;
 
+/**
+ * `]` / `}` for z-order shortcuts: `code` stays on the physical key (e.g. `Digit9`
+ * with AltGr on DE layout) while `key` is the produced character.
+ */
+export const isBracketRightKey = (
+  event: KeyboardEvent | React.KeyboardEvent<Element>,
+) =>
+  event.code === CODES.BRACKET_RIGHT ||
+  event.key === "]" ||
+  event.key === "}";
+
+/** `[` / `{` — same layout caveat as {@link isBracketRightKey}. */
+export const isBracketLeftKey = (
+  event: KeyboardEvent | React.KeyboardEvent<Element>,
+) =>
+  event.code === CODES.BRACKET_LEFT ||
+  event.key === "[" ||
+  event.key === "{";
+
+
 export const shouldResizeFromCenter = (event: MouseEvent | KeyboardEvent) =>
   event.altKey;
 

--- a/packages/excalidraw/actions/actionZindex.test.tsx
+++ b/packages/excalidraw/actions/actionZindex.test.tsx
@@ -1,0 +1,87 @@
+import { vi } from "vitest";
+
+import {
+  actionBringForward,
+  actionBringToFront,
+  actionSendBackward,
+  actionSendToBack,
+} from "./actionZindex";
+
+vi.mock("@excalidraw/common", async (importOriginal) => {
+  const module = await importOriginal<typeof import("@excalidraw/common")>();
+  return {
+    __esModule: true,
+    ...module,
+    isDarwin: false,
+  };
+});
+
+const stubCtx = [{} as any, [] as any, {} as any] as const;
+
+describe("actionZindex keyTest (non-mac)", () => {
+  it("bringForward matches BracketRight and key-based ] (e.g. AltGr layouts)", () => {
+    expect(
+      actionBringForward.keyTest!(
+        new KeyboardEvent("keydown", {
+          key: "]",
+          code: "BracketRight",
+          ctrlKey: true,
+        }),
+        ...stubCtx,
+      ),
+    ).toBe(true);
+
+    expect(
+      actionBringForward.keyTest!(
+        new KeyboardEvent("keydown", {
+          key: "]",
+          code: "Digit9",
+          ctrlKey: true,
+          altKey: true,
+        }),
+        ...stubCtx,
+      ),
+    ).toBe(true);
+  });
+
+  it("bringToFront matches BracketRight and key }", () => {
+    expect(
+      actionBringToFront.keyTest!(
+        new KeyboardEvent("keydown", {
+          key: "}",
+          code: "BracketRight",
+          ctrlKey: true,
+          shiftKey: true,
+        }),
+        ...stubCtx,
+      ),
+    ).toBe(true);
+  });
+
+  it("sendBackward matches BracketLeft and key [", () => {
+    expect(
+      actionSendBackward.keyTest!(
+        new KeyboardEvent("keydown", {
+          key: "[",
+          code: "BracketLeft",
+          ctrlKey: true,
+        }),
+        ...stubCtx,
+      ),
+    ).toBe(true);
+  });
+
+  it("sendToBack matches shifted {", () => {
+    expect(
+      actionSendToBack.keyTest!(
+        new KeyboardEvent("keydown", {
+          key: "{",
+          code: "BracketLeft",
+          ctrlKey: true,
+          shiftKey: true,
+        }),
+        ...stubCtx,
+      ),
+    ).toBe(true);
+  });
+});

--- a/packages/excalidraw/actions/actionZindex.tsx
+++ b/packages/excalidraw/actions/actionZindex.tsx
@@ -1,4 +1,8 @@
-import { KEYS, CODES, isDarwin } from "@excalidraw/common";
+import {
+  isBracketLeftKey,
+  isBracketRightKey,
+  isDarwin,
+} from "@excalidraw/common";
 
 import {
   moveOneLeft,
@@ -37,7 +41,7 @@ export const actionSendBackward = register({
   keyTest: (event) =>
     event[KEYS.CTRL_OR_CMD] &&
     !event.shiftKey &&
-    event.code === CODES.BRACKET_LEFT,
+    isBracketLeftKey(event),
   PanelComponent: ({ updateData, appState }) => (
     <button
       type="button"
@@ -67,7 +71,7 @@ export const actionBringForward = register({
   keyTest: (event) =>
     event[KEYS.CTRL_OR_CMD] &&
     !event.shiftKey &&
-    event.code === CODES.BRACKET_RIGHT,
+    isBracketRightKey(event),
   PanelComponent: ({ updateData, appState }) => (
     <button
       type="button"
@@ -97,10 +101,10 @@ export const actionSendToBack = register({
     isDarwin
       ? event[KEYS.CTRL_OR_CMD] &&
         event.altKey &&
-        event.code === CODES.BRACKET_LEFT
+        isBracketLeftKey(event)
       : event[KEYS.CTRL_OR_CMD] &&
         event.shiftKey &&
-        event.code === CODES.BRACKET_LEFT,
+        isBracketLeftKey(event),
   PanelComponent: ({ updateData, appState }) => (
     <button
       type="button"
@@ -135,10 +139,10 @@ export const actionBringToFront = register({
     isDarwin
       ? event[KEYS.CTRL_OR_CMD] &&
         event.altKey &&
-        event.code === CODES.BRACKET_RIGHT
+        isBracketRightKey(event)
       : event[KEYS.CTRL_OR_CMD] &&
         event.shiftKey &&
-        event.code === CODES.BRACKET_RIGHT,
+        isBracketRightKey(event),
   PanelComponent: ({ updateData, appState }) => (
     <button
       type="button"


### PR DESCRIPTION
## Summary
Fixes #9535.
**Root cause:** Z-order actions only matched `event.code` `BracketLeft` / `BracketRight`. On several layouts (e.g. `]` via AltGr), the code stays on the digit key while `event.key` is correct.
**Fix:** Also match `event.key` for `[]` and shifted `{}` so the same shortcuts work across layouts.
## Changes
- `packages/common/src/keys.ts`: `isBracketLeftKey` / `isBracketRightKey` helpers.
- `packages/excalidraw/actions/actionZindex.tsx`: use them in all four `keyTest` handlers.
- `packages/excalidraw/actions/actionZindex.test.tsx`: unit tests (non-mac).
## Testing
- Added tests for `]` with `Digit9` code and for `}` / `{` keys.
