### PR TITLE
fix(ui): prevent Tab key default behavior in arrowhead picker

### DIFF
--- a/packages/excalidraw/components/IconPicker.tsx
+++ b/packages/excalidraw/components/IconPicker.tsx
@@ -104,6 +104,7 @@ function Picker<T>({
         ? (allOptions.length + index - 1) % allOptions.length
         : (index + 1) % allOptions.length;
       onChange(allOptions[nextIndex].value);
+      event.preventDefault();
     } else if (isArrowKey(event.key)) {
       // Arrow navigation
       const isRTL = getLanguage().rtl;


### PR DESCRIPTION
Fixes #9656

## Summary
When using Tab to cycle through arrowhead options in the arrow type picker panel, the browser was also moving focus to the next focusable element outside the picker because `event.preventDefault()` was not called.

This fix adds `event.preventDefault()` to the Tab key handler in `IconPicker.tsx`, preventing the default focus-shift while still performing the arrowhead selection via Tab cycling.