### PR TITLE
fix: cancel multi-point arrows on ESC in collaboration (#9467)

### DIFF
--- a/packages/excalidraw/actions/actionFinalize.tsx
+++ b/packages/excalidraw/actions/actionFinalize.tsx
@@ -74,6 +74,8 @@ export const actionFinalize = register<FormData>({
         sceneCoords,
         "sceneCoords should be defined if actionFinalize is called with event",
       );
+      // Check if ESC was pressed to cancel the arrow creation
+      const isCanceled = event.key === KEYS.ESCAPE;
 
       const linearElementEditor = LinearElementEditor.handlePointerUp(
         event,
@@ -154,7 +156,7 @@ export const actionFinalize = register<FormData>({
 
         return {
           elements:
-            element.points.length < 2 || isInvisiblySmallElement(element)
+            (element.points.length < 2 || isInvisiblySmallElement(element) || isCanceled)
               ? elements.map((el) => {
                   if (el.id === element.id) {
                     return newElementWith(el, { isDeleted: true });


### PR DESCRIPTION
## Fixes Issue #9467

**Problem**:
When a user creates a multi-point arrow/line and cancels it with ESC on client A, the arrow persists on client B. This is a collaboration sync bug where canceled elements are not properly deleted across clients.

**Root Cause**:
In actionFinalize.tsx, elements were only deleted when points.length < 2 || isInvisiblySmallElement(element). This meant that multi-point arrows (2+ points) created and then canceled with ESC were not deleted, causing them to persist on remote clients.

**Solution**:
Added an isCanceled check that detects when ESC is pressed and ensures the element is deleted regardless of point count.

**Changes**:
1. Added isCanceled variable to detect ESC key press in the finalize action
2. Modified the deletion condition to include || isCanceled so canceled arrows are always deleted
3. This ensures proper version bumping and sync to all collaborators

**Maintainers to review:** @dwelle @zsviczian