### PR TITLE
fix: add missing shortcut label (H) to hand tool in toolbar

### DIFF
--- a/packages/excalidraw/components/Actions.tsx
+++ b/packages/excalidraw/components/Actions.tsx
@@ -1100,8 +1100,7 @@ export const ShapesSwitcher = ({
           const shortcut = letter
             ? `${letter} ${t("helpDialog.or")} ${numericKey}`
             : `${numericKey}`;
-          const keybindingLabel =
-            value === "hand" ? undefined : numericKey || letter;
+          const keybindingLabel = numericKey || letter;
 
           // when in compact styles panel mode (tablet)
           // use a ToolPopover for selection/lasso toggle as well


### PR DESCRIPTION
Fixes #11020

The hand (pan) tool does not show its keyboard shortcut in the toolbar, while other tools do.

I tested this locally and confirmed that pressing "H" correctly activates the hand tool, but the label is missing.

This change removes the condition that hides the shortcut label for the hand tool, so it now displays "H" like the other tools.

This makes the toolbar more consistent and improves discoverability of the shortcut.

### Before

<img width="1123" height="385" alt="567725149-19c29835-dab1-4bd4-9ea0-3861b96a19e5" src="https://github.com/user-attachments/assets/35696aaa-d47b-4ef8-8389-64620b0469f3" />

### After

<img width="951" height="146" alt="Capture d&#39;écran 2026-03-24 164022" src="https://github.com/user-attachments/assets/591084ef-bf43-4e41-8fd2-28157b1832e4" />
