### PR TITLE
fix: close hex popover when preferences submenu is activated

### DIFF
--- a/packages/excalidraw/components/dropdownMenu/DropdownMenuSubTrigger.tsx
+++ b/packages/excalidraw/components/dropdownMenu/DropdownMenuSubTrigger.tsx
@@ -14,17 +14,22 @@ const DropdownMenuSubTrigger = ({
   icon,
   shortcut,
   className,
+  ...rest
 }: {
   children: React.ReactNode;
   icon?: JSX.Element;
   shortcut?: string;
   className?: string;
-}) => {
+} & Omit<
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubTrigger>,
+  "children" | "className"
+>) => {
   return (
     <DropdownMenuPrimitive.SubTrigger
       className={`${getDropdownMenuItemClassName(
         className,
       )} dropdown-menu__submenu-trigger`}
+      {...rest}
     >
       <MenuItemContent icon={icon} shortcut={shortcut}>
         {children}

--- a/packages/excalidraw/components/main-menu/DefaultItems.tsx
+++ b/packages/excalidraw/components/main-menu/DefaultItems.tsx
@@ -560,9 +560,14 @@ export const Preferences = ({
   additionalItems?: React.ReactNode;
 }) => {
   const { t } = useI18n();
+  const setAppState = useExcalidrawSetAppState();
   return (
     <DropdownMenuSub>
-      <DropdownMenuSub.Trigger icon={settingsIcon}>
+      <DropdownMenuSub.Trigger
+        icon={settingsIcon}
+        onPointerMove={() => setAppState({ openPopup: null })}
+        onFocus={() => setAppState({ openPopup: null })}
+      >
         {t("labels.preferences")}
       </DropdownMenuSub.Trigger>
       <DropdownMenuSub.Content className="excalidraw-main-menu-preferences-submenu">


### PR DESCRIPTION
Fixes #10863

When the canvas background hex color popover is open, moving the pointer back to the Preferences submenu can cause the popover to overlap the menu and interfere with interaction.

This happens because the popover and the submenu are managed independently, allowing both to remain active at the same time.

This change ensures that any open popover is closed as soon as the Preferences trigger becomes active. As a result, the submenu opens smoothly without overlap or flicker, and the interaction feels more consistent.

### Before

https://github.com/user-attachments/assets/d996a809-e54a-43b2-97df-2d77456a3081


### After

https://github.com/user-attachments/assets/fd46b900-de77-494c-ba5c-c651a512afc1

