### PR TITLE
fix(math): use inclusive inequalities for rectangle intersection logic

### DIFF
--- a/packages/math/src/rectangle.ts
+++ b/packages/math/src/rectangle.ts
@@ -35,5 +35,5 @@ export function rectangleIntersectRectangle<
   const [[minX1, minY1], [maxX1, maxY1]] = rectangle1;
   const [[minX2, minY2], [maxX2, maxY2]] = rectangle2;
 
-  return minX1 < maxX2 && maxX1 > minX2 && minY1 < maxY2 && maxY1 > minY2;
+  return minX1 <= maxX2 && maxX1 >= minX2 && minY1 <= maxY2 && maxY1 >= minY2;
 }


### PR DESCRIPTION
This PR addresses a bug in the @excalidraw/math package where rectangleIntersectRectangle returned false for rectangles that were perfectly adjacent (touching at an edge or corner).

The intersection logic previously relied on strict inequalities (< and >), which failed to account for these exact boundary overlaps. This has been updated to use inclusive inequalities (<= and >=) to correctly identify these scenarios as valid intersections.

Changes:

- Updated bounds checking in packages/math/src/rectangle.ts to include boundary edges.
- Ensures touching elements are accurately detected by the math helpers.

closes: #11032 

