### PR TITLE
fix(editor): ensure font picker font names are not quoted

### DIFF
--- a/packages/excalidraw/components/FontPicker/FontPickerList.tsx
+++ b/packages/excalidraw/components/FontPicker/FontPickerList.tsx
@@ -46,6 +46,7 @@ import {
 import { fontPickerKeyHandler } from "./keyboardNavHandlers";
 
 import type { JSX } from "react";
+import type { ExcalidrawFontFace } from "../../fonts/ExcalidrawFontFace";
 
 export interface FontDescriptor {
   value: number;
@@ -86,6 +87,15 @@ const getFontFamilyIcon = (fontFamily: FontFamilyValues): JSX.Element => {
   }
 };
 
+const getFontFamilyLabel = (
+  fontFamily: FontFamilyValues,
+  fontFaces: ExcalidrawFontFace[],
+) =>
+  // prefer our config as the browser resolved names may be wrapped in quotes and such
+  Object.entries(FONT_FAMILY).find(([, id]) => id === fontFamily)?.[0] ??
+  fontFaces[0]?.fontFace?.family ??
+  "Unknown";
+
 export const FontPickerList = React.memo(
   ({
     selectedFontFamily,
@@ -114,7 +124,7 @@ export const FontPickerList = React.memo(
             const fontDescriptor = {
               value: familyId,
               icon: getFontFamilyIcon(familyId),
-              text: fontFaces[0]?.fontFace?.family ?? "Unknown",
+              text: getFontFamilyLabel(familyId, fontFaces),
             };
 
             if (metadata.deprecated) {


### PR DESCRIPTION
before:

<img width="534" height="537" alt="2026-03-25_17 42 30-6OV0c9rgZo" src="https://github.com/user-attachments/assets/7843af07-0e7c-4384-8525-75a03aba08db" />


after:

<img width="534" height="537" alt="2026-03-25_17 42 09-chrome_Kb5TvambMe" src="https://github.com/user-attachments/assets/4a67c409-5e4c-4981-a607-3c796aad69f5" />
