### PR TITLE
docs: update footer copyright year to 2026

### DIFF
--- a/dev-docs/docusaurus.config.js
+++ b/dev-docs/docusaurus.config.js
@@ -120,7 +120,7 @@ const config = {
             ],
           },
         ],
-        copyright: `Copyright © 2023 Excalidraw community. Built with Docusaurus ❤️`,
+        copyright: `Copyright © 2026 Excalidraw community. Built with Docusaurus ❤️`,
       },
       prism: {
         theme: require("prism-react-renderer/themes/dracula"),


### PR DESCRIPTION
While reviewing the Excalidraw developer documentation, I noticed that the copyright year in the footer was outdated (showing 2023). This PR updates the copyright year to 2026 to ensure the documentation reflects the current year and remains professionally maintained.

Changes
Updated copyright string in dev-docs/docusaurus.config.js from 2023 to 2026.

Preview
The footer will now display:
Copyright © 2026 Excalidraw community. Built with Docusaurus ❤️