### PR TITLE
feat: add sync for linked library instances

### DIFF
--- a/packages/element/src/types.ts
+++ b/packages/element/src/types.ts
@@ -79,6 +79,12 @@ type _ExcalidrawElementBase = Readonly<{
   link: string | null;
   locked: boolean;
   customData?: Record<string, any>;
+  /**
+   * If set, this element was placed from a library item with this ID.
+   * Used to propagate style updates from the library item to all canvas instances.
+   * Null/undefined means the element is not linked to any library item.
+   */
+  libraryItemId?: string | null;
 }>;
 
 export type ExcalidrawSelectionElement = _ExcalidrawElementBase & {

--- a/packages/excalidraw/actions/actionSyncLibraryInstances.ts
+++ b/packages/excalidraw/actions/actionSyncLibraryInstances.ts
@@ -1,0 +1,100 @@
+import { newElementWith } from "@excalidraw/element";
+import { CaptureUpdateAction } from "@excalidraw/element";
+
+import { t } from "../i18n";
+import { libraryItemsAtom } from "../data/library";
+import { editorJotaiStore } from "../editor-jotai";
+
+import { register } from "./register";
+
+/**
+ * Style properties that are safe to propagate from a library item to its
+ * canvas instances. Structural/positional properties are intentionally
+ * excluded so each instance retains its own position, size and shape.
+ */
+const SYNCABLE_STYLE_PROPS = [
+  "strokeColor",
+  "backgroundColor",
+  "fillStyle",
+  "strokeWidth",
+  "strokeStyle",
+  "roughness",
+  "opacity",
+] as const;
+
+type SyncableStyleProp = typeof SYNCABLE_STYLE_PROPS[number];
+
+export const actionSyncLibraryInstances = register({
+  name: "syncLibraryInstances",
+  trackEvent: { category: "element" },
+  perform: (elements, appState, _value, _app) => {
+    const { libraryItems } = editorJotaiStore.get(libraryItemsAtom);
+
+    if (!libraryItems.length) {
+      return {
+        appState: {
+          ...appState,
+          toast: { message: t("toast.noLibraryInstancesToSync") },
+        },
+        captureUpdate: CaptureUpdateAction.EVENTUALLY,
+      };
+    }
+
+    // Build a lookup: libraryItemId → style snapshot from the item's first element.
+    // The first element is used as the style authority for the whole library item.
+    const styleByLibraryItemId = new Map<
+      string,
+      Record<SyncableStyleProp, unknown>
+    >();
+
+    for (const item of libraryItems) {
+      if (!item.elements.length) {
+        continue;
+      }
+      const source = item.elements[0];
+      const styleSnapshot = {} as Record<SyncableStyleProp, unknown>;
+      for (const prop of SYNCABLE_STYLE_PROPS) {
+        styleSnapshot[prop] = (source as Record<string, unknown>)[prop];
+      }
+      styleByLibraryItemId.set(item.id, styleSnapshot);
+    }
+
+    let syncedCount = 0;
+
+    const nextElements = elements.map((el) => {
+      if (!el.libraryItemId) {
+        return el;
+      }
+      const styleSnapshot = styleByLibraryItemId.get(el.libraryItemId);
+      if (!styleSnapshot) {
+        return el;
+      }
+      syncedCount++;
+      return newElementWith(el, styleSnapshot as any);
+    });
+
+    if (syncedCount === 0) {
+      return {
+        appState: {
+          ...appState,
+          toast: { message: t("toast.noLibraryInstancesToSync") },
+        },
+        captureUpdate: CaptureUpdateAction.EVENTUALLY,
+      };
+    }
+
+    return {
+      elements: nextElements,
+      appState: {
+        ...appState,
+        toast: {
+          message: t("toast.syncedLibraryInstances", {
+            count: String(syncedCount),
+          }),
+        },
+      },
+      captureUpdate: CaptureUpdateAction.IMMEDIATELY,
+    };
+  },
+  label: "labels.syncLibraryInstances",
+});

--- a/packages/excalidraw/actions/index.ts
+++ b/packages/excalidraw/actions/index.ts
@@ -52,6 +52,7 @@ export { actionGroup, actionUngroup } from "./actionGroup";
 export { actionGoToCollaborator } from "./actionNavigate";
 
 export { actionAddToLibrary } from "./actionAddToLibrary";
+export { actionSyncLibraryInstances } from "./actionSyncLibraryInstances";
 
 export {
   actionAlignTop,

--- a/packages/excalidraw/actions/types.ts
+++ b/packages/excalidraw/actions/types.ts
@@ -145,7 +145,8 @@ export type ActionName =
   | "wrapSelectionInFrame"
   | "toggleLassoTool"
   | "toggleShapeSwitch"
-  | "togglePolygon";
+  | "togglePolygon"
+  | "syncLibraryInstances";
 
 export type PanelComponentProps = {
   elements: readonly ExcalidrawElement[];

--- a/packages/excalidraw/components/LibraryMenuHeaderContent.tsx
+++ b/packages/excalidraw/components/LibraryMenuHeaderContent.tsx
@@ -10,8 +10,13 @@ import { libraryItemsAtom } from "../data/library";
 import { useAtom } from "../editor-jotai";
 import { useLibraryCache } from "../hooks/useLibraryItemSvg";
 import { t } from "../i18n";
+import { actionSyncLibraryInstances } from "../actions/actionSyncLibraryInstances";
 
-import { useApp, useExcalidrawSetAppState } from "./App";
+import {
+  useApp,
+  useExcalidrawActionManager,
+  useExcalidrawSetAppState,
+} from "./App";
 import ConfirmDialog from "./ConfirmDialog";
 import { Dialog } from "./Dialog";
 import { isLibraryMenuOpenAtom } from "./LibraryMenu";
@@ -24,6 +29,7 @@ import {
   ExportIcon,
   LoadIcon,
   publishIcon,
+  syncIcon,
   TrashIcon,
 } from "./icons";
 
@@ -42,6 +48,7 @@ export const LibraryDropdownMenuButton: React.FC<{
   onRemoveFromLibrary: () => void;
   resetLibrary: () => void;
   onSelectItems: (items: LibraryItem["id"][]) => void;
+  onSyncInstances: () => void;
   appState: UIAppState;
   className?: string;
 }> = ({
@@ -51,6 +58,7 @@ export const LibraryDropdownMenuButton: React.FC<{
   onRemoveFromLibrary,
   resetLibrary,
   onSelectItems,
+  onSyncInstances,
   appState,
   className,
 }) => {
@@ -229,6 +237,13 @@ export const LibraryDropdownMenuButton: React.FC<{
               {t("buttons.publishLibrary")}
             </DropdownMenu.Item>
           )}
+          <DropdownMenu.Item
+            onSelect={onSyncInstances}
+            icon={syncIcon}
+            data-testid="lib-dropdown--sync"
+          >
+            {t("labels.syncLibraryInstances")}
+          </DropdownMenu.Item>
           {!!items.length && (
             <DropdownMenu.Item
               onSelect={() => setShowRemoveLibAlert(true)}
@@ -284,6 +299,7 @@ export const LibraryDropdownMenu = ({
   className?: string;
 }) => {
   const { library } = useApp();
+  const actionManager = useExcalidrawActionManager();
   const { clearLibraryCache, deleteItemsFromLibraryCache } = useLibraryCache();
   const appState = useUIAppState();
   const setAppState = useExcalidrawSetAppState();
@@ -308,6 +324,10 @@ export const LibraryDropdownMenu = ({
     clearLibraryCache();
   };
 
+  const onSyncInstances = useCallback(() => {
+    actionManager.executeAction(actionSyncLibraryInstances);
+  }, [actionManager]);
+
   return (
     <LibraryDropdownMenuButton
       appState={appState}
@@ -319,6 +339,7 @@ export const LibraryDropdownMenu = ({
         removeFromLibrary(libraryItemsData.libraryItems)
       }
       resetLibrary={resetLibrary}
+      onSyncInstances={onSyncInstances}
       className={className}
     />
   );

--- a/packages/excalidraw/components/LibraryMenuItems.tsx
+++ b/packages/excalidraw/components/LibraryMenuItems.tsx
@@ -199,7 +199,11 @@ export default function LibraryMenuItems({
             type: "everything",
             elements: item.elements,
             randomizeSeed: true,
-          }).duplicatedElements,
+          }).duplicatedElements.map((el) => ({
+            ...el,
+            // stamp the source library item ID so instances can be synced later
+            libraryItemId: item.id,
+          })),
         };
       });
     },

--- a/packages/excalidraw/components/icons.tsx
+++ b/packages/excalidraw/components/icons.tsx
@@ -1794,6 +1794,16 @@ export const publishIcon = createIcon(
   { width: 640, height: 512 },
 );
 
+// tabler-icons: refresh (sync/update instances icon)
+export const syncIcon = createIcon(
+  <g strokeWidth="1.5">
+    <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+    <path d="M20 11a8.1 8.1 0 0 0 -15.5 -2m-.5 -4v4h4" />
+    <path d="M4 13a8.1 8.1 0 0 0 15.5 2m.5 4v-4h-4" />
+  </g>,
+  tablerIconProps,
+);
+
 export const eraser = createIcon(
   <path d="M480 416C497.7 416 512 430.3 512 448C512 465.7 497.7 480 480 480H150.6C133.7 480 117.4 473.3 105.4 461.3L25.37 381.3C.3786 356.3 .3786 315.7 25.37 290.7L258.7 57.37C283.7 32.38 324.3 32.38 349.3 57.37L486.6 194.7C511.6 219.7 511.6 260.3 486.6 285.3L355.9 416H480zM265.4 416L332.7 348.7L195.3 211.3L70.63 336L150.6 416L265.4 416z" />,
 );

--- a/packages/excalidraw/data/restore.ts
+++ b/packages/excalidraw/data/restore.ts
@@ -262,8 +262,11 @@ const repairBinding = <T extends ExcalidrawArrowElement>(
 };
 
 const restoreElementWithProperties = <
-  T extends Required<Omit<ExcalidrawElement, "customData">> & {
+  T extends Required<
+    Omit<ExcalidrawElement, "customData" | "libraryItemId">
+  > & {
     customData?: ExcalidrawElement["customData"];
+    libraryItemId?: ExcalidrawElement["libraryItemId"];
     /** @deprecated */
     boundElementIds?: readonly ExcalidrawElement["id"][];
     /** @deprecated */
@@ -328,6 +331,10 @@ const restoreElementWithProperties = <
   if ("customData" in element || "customData" in extra) {
     base.customData =
       "customData" in extra ? extra.customData : element.customData;
+  }
+
+  if ("libraryItemId" in element) {
+    base.libraryItemId = element.libraryItemId ?? null;
   }
 
   const ret = {

--- a/packages/excalidraw/locales/en.json
+++ b/packages/excalidraw/locales/en.json
@@ -186,7 +186,8 @@
     "preferences": "Preferences",
     "preferences_toolLock": "Tool lock",
     "arrowBinding": "Arrow binding",
-    "midpointSnapping": "Snap to midpoints"
+    "midpointSnapping": "Snap to midpoints",
+    "syncLibraryInstances": "Sync library instances"
   },
   "elementLink": {
     "title": "Link to object",
@@ -544,6 +545,8 @@
   },
   "toast": {
     "addedToLibrary": "Added to library",
+    "syncedLibraryInstances": "Synced {{count}} element(s) from library",
+    "noLibraryInstancesToSync": "No linked library instances found on canvas",
     "copyStyles": "Copied styles.",
     "copyToClipboard": "Copied to clipboard.",
     "copyToClipboardAsPng": "Copied {{exportSelection}} to clipboard as PNG\n({{exportColorScheme}})",


### PR DESCRIPTION
## Summary

Closes #11038

While exploring the codebase, I noticed that library items once inserted
on the canvas become completely independent copies with no back reference
to their source. This makes it impossible to propagate style changes from
the library to existing canvas instances something designers using Figma
or Miro expect as a standard workflow.

## What this PR does

1. **Tags elements on insert**  every element placed from the library now
   carries a `libraryItemId` field pointing to its source library item
2. **Sync action**  a new "Sync library instances" option in the library
   `⋯` dropdown applies the current library item's styles to all matching
   canvas instances in one click, with full undo/redo support

## How to test

1. Draw a shape → right-click → **Add to library**
2. Insert it 2–3 times from the library panel
3. Edit the library item's color/stroke
4. Library panel → `⋯` menu → **"Sync library instances"**
5. Toast: "Synced X element(s) from library"
6. Press `Cmd+Z` → all instances revert 

## Synced properties
`strokeColor`, `backgroundColor`, `fillStyle`, `strokeWidth`,
`strokeStyle`, `roughness`, `opacity`