### PR TITLE
feat: auto-detect markdown links in text elements

### DIFF
--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -420,6 +420,7 @@ import { withBatchedUpdates, withBatchedUpdatesThrottled } from "../reactUtils";
 import { isPointHittingTextAutoResizeHandle } from "../textAutoResizeHandle";
 import { textWysiwyg } from "../wysiwyg/textWysiwyg";
 import { isOverScrollBars } from "../scene/scrollbars";
+import { parseMarkdownLink } from "../utils/markdownLink";
 
 import { isMaybeMermaidDefinition } from "../mermaid";
 
@@ -5722,8 +5723,39 @@ class App extends React.Component<AppProps, AppState> {
         }
       }),
       onSubmit: withBatchedUpdates(({ viaKeyboard, nextOriginalText }) => {
-        const isDeleted = !nextOriginalText.trim();
-        updateElement(nextOriginalText, isDeleted);
+        // ── Markdown link auto-detection ──────────────────────────────────
+        // If the user types a complete markdown link `[label](url)` as the
+        // sole content of a text element, we:
+        //   • display only the label as the element's text
+        //   • attach the URL to element.link (the existing hyperlink field)
+        //
+        // This lets users write `[Open docs](https://example.com)` and get a
+        // labelled, clickable element without touching the hyperlink editor.
+        //
+        // NOTE: Only whole-text matches are handled. Inline partial links such
+        // as "See [here](url) for details" are intentionally left as-is so we
+        // never silently mutate text the user did not intend as a pure link.
+        // For full inline link rendering see the comment block in
+        // packages/excalidraw/utils/markdownLink.ts (Option B).
+        const parsedLink = parseMarkdownLink(nextOriginalText);
+        let resolvedText = nextOriginalText;
+
+        if (parsedLink) {
+          resolvedText = parsedLink.label;
+          // Apply the extracted URL to the element using the existing link API.
+          // We do this inside a micro-task so the element already exists in the
+          // scene when mutateElement is called.
+          const elementId = element.id;
+          Promise.resolve().then(() => {
+            const el = this.scene.getElement(elementId);
+            if (el) {
+              this.scene.mutateElement(el, { link: parsedLink.url });
+            }
+          });
+        }
+
+        const isDeleted = !resolvedText.trim();
+        updateElement(resolvedText, isDeleted);
 
         // keyboard-submit keeps focus on the edited object. For bound text, keep
         // the container selected even if the text becomes empty and is deleted.

--- a/packages/excalidraw/locales/en.json
+++ b/packages/excalidraw/locales/en.json
@@ -544,6 +544,7 @@
   },
   "toast": {
     "addedToLibrary": "Added to library",
+    "markdownLinkDetected": "Markdown link detected — label set as text, URL attached as link",
     "copyStyles": "Copied styles.",
     "copyToClipboard": "Copied to clipboard.",
     "copyToClipboardAsPng": "Copied {{exportSelection}} to clipboard as PNG\n({{exportColorScheme}})",

--- a/packages/excalidraw/tests/markdownLink.test.ts
+++ b/packages/excalidraw/tests/markdownLink.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+
+import { parseMarkdownLink } from "../utils/markdownLink";
+
+describe("parseMarkdownLink", () => {
+  // ── Valid whole-text markdown links ───────────────────────────────────────
+
+  it("parses a standard markdown link", () => {
+    const result = parseMarkdownLink("[Excalidraw](https://excalidraw.com)");
+    expect(result).toEqual({
+      label: "Excalidraw",
+      url: "https://excalidraw.com",
+    });
+  });
+
+  it("parses a link with extra whitespace around the whole string", () => {
+    const result = parseMarkdownLink(
+      "  [Open docs](https://docs.example.com)  ",
+    );
+    expect(result).toEqual({
+      label: "Open docs",
+      url: "https://docs.example.com",
+    });
+  });
+
+  it("uses the raw URL as label when label is empty", () => {
+    const result = parseMarkdownLink("[](https://example.com)");
+    expect(result).toEqual({
+      label: "https://example.com",
+      url: "https://example.com",
+    });
+  });
+
+  it("parses a link with a relative URL", () => {
+    const result = parseMarkdownLink("[Home](/home)");
+    expect(result).not.toBeNull();
+    expect(result!.label).toBe("Home");
+    // normalizeLink keeps relative URLs as-is
+    expect(result!.url).toBe("/home");
+  });
+
+  // ── Partial / multi-link text — must return null ──────────────────────────
+
+  it("returns null for partial inline link (text before the link)", () => {
+    expect(
+      parseMarkdownLink("See [here](https://example.com) for details"),
+    ).toBeNull();
+  });
+
+  it("returns null for plain text without any link syntax", () => {
+    expect(parseMarkdownLink("Hello world")).toBeNull();
+  });
+
+  it("returns null for an empty string", () => {
+    expect(parseMarkdownLink("")).toBeNull();
+  });
+
+  it("returns null for a bare URL with no label", () => {
+    expect(parseMarkdownLink("https://example.com")).toBeNull();
+  });
+
+  it("returns null when the URL part is empty", () => {
+    expect(parseMarkdownLink("[label]()")).toBeNull();
+  });
+
+  it("returns null for two markdown links in one string", () => {
+    expect(
+      parseMarkdownLink("[A](https://a.com)[B](https://b.com)"),
+    ).toBeNull();
+  });
+
+  // ── Security — malicious / malformed URLs ─────────────────────────────────
+
+  it("returns null for a javascript: URL (sanitize-url blocks it)", () => {
+    // sanitize-url returns "about:blank" for javascript: URLs
+    expect(parseMarkdownLink("[click me](javascript:alert(1))")).toBeNull();
+  });
+
+  it("returns null for a data: URL (sanitize-url blocks it)", () => {
+    expect(parseMarkdownLink("[img](data:text/html,<h1>XSS</h1>)")).toBeNull();
+  });
+});

--- a/packages/excalidraw/utils/markdownLink.ts
+++ b/packages/excalidraw/utils/markdownLink.ts
@@ -1,0 +1,108 @@
+/**
+ * Markdown-style inline link parser for Excalidraw text elements.
+ *
+ * ## What this module does (Option A — safe, minimal)
+ *
+ * When a user finishes editing a text element whose entire content is a
+ * single markdown link  `[label](url)`, we:
+ *   1. Extract the visible label and the URL.
+ *   2. Replace the element's display text with just the label.
+ *   3. Set `element.link` to the extracted URL (the existing hyperlink field).
+ *
+ * This reuses the battle-tested hyperlink system (link icon, tooltip, Cmd+K
+ * editing, onLinkOpen callback, sanitize-url, undo/redo) without any new
+ * infrastructure.
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * ## Why not full inline rendering (Option B)?
+ *
+ * True inline clickable links inside canvas text would require:
+ *
+ *  1. **Rich text layer** — The canvas 2D API (`fillText`) has no concept of
+ *     hyperlinks. We'd need to split each text line into "runs", measure every
+ *     run individually, and overlay transparent DOM hit-areas (or an SVG layer)
+ *     that are kept in sync with zoom / scroll / rotation transforms.
+ *     Estimated new files: ~6–8 (tokenizer, run renderer, hit-area manager,
+ *     updated renderElement, updated textMeasurements, updated textWrapping).
+ *
+ *  2. **Multiple links per element** — The current `element.link: string | null`
+ *     field only holds a single URL. Multi-link text needs a new
+ *     `inlineLinks: { start, end, url }[]` field, versioning, restore.ts
+ *     passthrough, serialisation tests, and collab delta handling.
+ *
+ *  3. **Editing UX** — The wysiwyg textarea would need to show raw markdown
+ *     syntax while editing but rendered anchors while viewing, requiring a
+ *     contenteditable-based editor (or a custom overlay).
+ *
+ *  4. **Export** — SVG/PNG export would need to emit `<a>` tags or styled
+ *     text spans, which currently export via a flat canvas draw call.
+ *
+ *  5. **Accessibility** — Screen-reader traversal of canvas is not supported;
+ *     inline links need ARIA live-regions or a parallel DOM structure.
+ *
+ * Rough estimate for Option B: ~15 files changed, 600–900 lines, 3–5 days
+ * of engineering, significant design/API review before merging.
+ * ─────────────────────────────────────────────────────────────────────────────
+ */
+
+import { normalizeLink } from "@excalidraw/common";
+
+/**
+ * Regex that matches a *complete* markdown link occupying the whole text:
+ *   `[label](url)`
+ *
+ * Capturing groups:
+ *   1 — label (the visible text, may be empty)
+ *   2 — raw URL (before sanitisation)
+ *
+ * We intentionally only match when the pattern consumes the entire trimmed
+ * string. Partial matches (e.g. "see [here](url) for details") are left as
+ * plain text — they do not get auto-linked because that would silently mangle
+ * the user's text.
+ */
+const FULL_MARKDOWN_LINK_RE = /^\[([^\]]*)\]\(([^)]+)\)$/;
+
+export interface ParsedMarkdownLink {
+  /** The display label extracted from `[label](url)`. */
+  label: string;
+  /** The sanitised URL extracted from `[label](url)`. */
+  url: string;
+}
+
+/**
+ * If `text` is exactly a single markdown link `[label](url)`, returns the
+ * parsed label and sanitised URL. Otherwise returns `null`.
+ *
+ * @example
+ * parseMarkdownLink("[Excalidraw](https://excalidraw.com)")
+ * // → { label: "Excalidraw", url: "https://excalidraw.com" }
+ *
+ * parseMarkdownLink("See [this](https://example.com) for details")
+ * // → null  (partial match — not auto-linked)
+ *
+ * parseMarkdownLink("Hello world")
+ * // → null
+ */
+export const parseMarkdownLink = (text: string): ParsedMarkdownLink | null => {
+  const match = FULL_MARKDOWN_LINK_RE.exec(text.trim());
+  if (!match) {
+    return null;
+  }
+
+  const label = match[1].trim();
+  const rawUrl = match[2].trim();
+
+  if (!rawUrl) {
+    return null;
+  }
+
+  const url = normalizeLink(rawUrl);
+
+  // normalizeLink returns "about:blank" for malformed/dangerous URLs —
+  // treat those as invalid so we don't silently set a bad link.
+  if (!url || url === "about:blank") {
+    return null;
+  }
+
+  return { label: label || rawUrl, url };
+};


### PR DESCRIPTION
## Summary

Closes #11024

When a text element's entire content is written as a markdown link
`[label](url)`, Excalidraw now automatically:
- Displays just the **label** as the element's visible text
- Attaches the **URL** to `element.link` (the existing hyperlink system)

## How to use

Type `[Open Docs](https://example.com)` in any text element → press `Escape`.
The text becomes `Open Docs` with a 🔗 link icon attached.

## What's NOT changed (intentionally)

Partial inline text like `"See [here](url) for details"` is left exactly
as typed we never silently mutate text that isn't a pure link.

## Security

`javascript:` and `data:` URLs are blocked via `@braintree/sanitize-url`
(same library used by the existing hyperlink system).

## Testing

- 12 unit tests in `packages/excalidraw/tests/markdownLink.test.ts`
- Manually verified: label extraction, link icon, undo/redo, `Cmd