### PR TITLE
fix: make caret color match text color in wysiwyg editor

### DIFF
--- a/packages/excalidraw/wysiwyg/textWysiwyg.tsx
+++ b/packages/excalidraw/wysiwyg/textWysiwyg.tsx
@@ -396,6 +396,10 @@ export const textWysiwyg = ({
           appState.theme === THEME.DARK
             ? applyDarkModeFilter(updatedTextElement.strokeColor)
             : updatedTextElement.strokeColor,
+        caretColor:
+          appState.theme === THEME.DARK
+            ? applyDarkModeFilter(updatedTextElement.strokeColor)
+            : updatedTextElement.strokeColor,
         opacity: updatedTextElement.opacity / 100,
         maxHeight: `${editorMaxHeight}px`,
       });


### PR DESCRIPTION
## Description

This PR fixes issue #11018 where the caret (text cursor) color does not match the text color, making it invisible when typing white text on dark backgrounds.

## Changes

- Added `caretColor` CSS property to the wysiwyg textarea style, using the same color logic as the text color (including dark mode filter application)

## Testing

- Manually verified the fix addresses the reported issue
- The caret now follows the same color as the text being typed

Fixes #11018