### PR TITLE
fix: snap rotation to 90° in grid mode

### DIFF
--- a/packages/common/src/constants.ts
+++ b/packages/common/src/constants.ts
@@ -23,6 +23,7 @@ export const ELEMENT_SHIFT_TRANSLATE_AMOUNT = 5;
 export const ELEMENT_TRANSLATE_AMOUNT = 1;
 export const TEXT_TO_CENTER_SNAP_THRESHOLD = 30;
 export const SHIFT_LOCKING_ANGLE = Math.PI / 12;
+export const GRID_LOCKING_ANGLE = Math.PI / 2;
 export const DEFAULT_LASER_COLOR = "red";
 export const CURSOR_TYPE = {
   TEXT: "text",

--- a/packages/element/src/resizeElements.ts
+++ b/packages/element/src/resizeElements.ts
@@ -10,6 +10,7 @@ import {
 import {
   MIN_FONT_SIZE,
   SHIFT_LOCKING_ANGLE,
+  GRID_LOCKING_ANGLE,
   rescalePoints,
   getFontString,
 } from "@excalidraw/common";
@@ -96,6 +97,7 @@ export const transformElements = (
   pointerY: number,
   centerX: number,
   centerY: number,
+  gridModeEnabled: boolean,
 ): boolean => {
   const elementsMap = scene.getNonDeletedElementsMap();
   if (selectedElements.length === 1) {
@@ -108,6 +110,7 @@ export const transformElements = (
           pointerX,
           pointerY,
           shouldRotateWithDiscreteAngle,
+          gridModeEnabled,
         );
         updateBoundElements(element, scene);
       }
@@ -160,6 +163,7 @@ export const transformElements = (
         shouldRotateWithDiscreteAngle,
         centerX,
         centerY,
+        gridModeEnabled,
       );
       return true;
     } else if (transformHandleType) {
@@ -206,6 +210,7 @@ const rotateSingleElement = (
   pointerX: number,
   pointerY: number,
   shouldRotateWithDiscreteAngle: boolean,
+  gridModeEnabled: boolean,
 ) => {
   const [x1, y1, x2, y2] = getElementAbsoluteCoords(
     element,
@@ -219,7 +224,10 @@ const rotateSingleElement = (
   } else {
     angle = ((5 * Math.PI) / 2 +
       Math.atan2(pointerY - cy, pointerX - cx)) as Radians;
-    if (shouldRotateWithDiscreteAngle) {
+    if (gridModeEnabled) {
+      angle = (angle + GRID_LOCKING_ANGLE / 2) as Radians;
+      angle = (angle - (angle % GRID_LOCKING_ANGLE)) as Radians;
+    } else if (shouldRotateWithDiscreteAngle) {
       angle = (angle + SHIFT_LOCKING_ANGLE / 2) as Radians;
       angle = (angle - (angle % SHIFT_LOCKING_ANGLE)) as Radians;
     }
@@ -410,11 +418,15 @@ const rotateMultipleElements = (
   shouldRotateWithDiscreteAngle: boolean,
   centerX: number,
   centerY: number,
+  gridModeEnabled: boolean,
 ) => {
   const elementsMap = scene.getNonDeletedElementsMap();
   let centerAngle =
     (5 * Math.PI) / 2 + Math.atan2(pointerY - centerY, pointerX - centerX);
-  if (shouldRotateWithDiscreteAngle) {
+  if (gridModeEnabled) {
+    centerAngle += GRID_LOCKING_ANGLE / 2;
+    centerAngle -= centerAngle % GRID_LOCKING_ANGLE;
+  } else if (shouldRotateWithDiscreteAngle) {
     centerAngle += SHIFT_LOCKING_ANGLE / 2;
     centerAngle -= centerAngle % SHIFT_LOCKING_ANGLE;
   }

--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -12430,6 +12430,7 @@ class App extends React.Component<AppProps, AppState> {
         resizeY,
         pointerDownState.resize.center.x,
         pointerDownState.resize.center.y,
+        this.state.gridModeEnabled,
       )
     ) {
       const elementsToHighlight = new Set<ExcalidrawElement>();


### PR DESCRIPTION
## Problem

When grid mode is enabled, rotating elements does not snap to 90° increments. Elements end up at arbitrary angles, producing visually crooked text and shapes — even though the user expects grid-aligned rotation.

Currently, angle snapping only works when holding the Shift key (15° increments). Grid mode is completely ignored during rotation.

## Solution

Add rotation snapping to 90° increments (0°, 90°, 180°, 270°) when grid mode is enabled:

- Add `GRID_LOCKING_ANGLE` constant (`Math.PI / 2` = 90°) alongside the existing `SHIFT_LOCKING_ANGLE`
- Thread `gridModeEnabled` through `transformElements` → `rotateSingleElement` / `rotateMultipleElements`
- Apply the same snapping math pattern already used for Shift key, but with the 90° angle
- Grid mode snapping takes precedence over Shift key (15°) — the stricter constraint wins
- Pass `this.state.gridModeEnabled` from the `App.tsx` call site

## Changes

| File | Change |
|------|--------|
| `packages/common/src/constants.ts` | Add `GRID_LOCKING_ANGLE = Math.PI / 2` |
| `packages/element/src/resizeElements.ts` | Add `gridModeEnabled` param to 3 functions, add grid snap logic |
| `packages/excalidraw/components/App.tsx` | Pass `this.state.gridModeEnabled` to `transformElements` |

**3 files changed, +16/-2 lines**

## Testing

- TypeScript: 0 errors
- Vitest resize tests: 53 passed, 2 skipped (pre-existing)
- ESLint: pass

Fixes #4057