### PR TITLE
fix: add explicit font-size and margin to context menu items

### DIFF
--- a/packages/excalidraw/components/ContextMenu.scss
+++ b/packages/excalidraw/components/ContextMenu.scss
@@ -36,6 +36,7 @@
     border: none;
     white-space: nowrap;
     font-family: inherit;
+    font-size: 0.875rem;
 
     display: grid;
     grid-template-columns: 1fr 0.2fr;
@@ -99,5 +100,6 @@
   .context-menu-item-separator {
     border: none;
     border-top: 1px solid $color-gray-5;
+    margin: 0.5rem 0;
   }
 }


### PR DESCRIPTION
## Summary
- Added explicit `font-size: 0.875rem` to `.context-menu-item` (matches dropdown menu's `.dropdown-menu-item-base`)
- Added explicit `margin: 0.5rem 0` to `.context-menu-item-separator` (`<hr>` elements)
- Prevents visual breakage when Excalidraw is embedded in projects with CSS resets (e.g., Tailwind Preflight)

Closes #8469

## Test plan
- [x] TypeScript type check passes
- [x] Context menu tests pass (17/17)
- [ ] Visually verify context menu appearance with and without CSS resets