### PR TITLE
fix(wysiwyg): prevent container scroll when editing text near viewport edge

### DIFF
--- a/packages/excalidraw/wysiwyg/textWysiwyg.tsx
+++ b/packages/excalidraw/wysiwyg/textWysiwyg.tsx
@@ -857,6 +857,10 @@ export const textWysiwyg = ({
     unbindUpdate();
     unsubOnChange();
     unbindOnScroll();
+    excalidrawContainer?.removeEventListener(
+      "scroll",
+      preventContainerScroll,
+    );
 
     editable.remove();
   };
@@ -982,6 +986,18 @@ export const textWysiwyg = ({
   const unbindOnScroll = app.onScrollChangeEmitter.on(() => {
     updateWysiwygStyle();
   });
+
+  // Prevent the browser from scrolling the excalidraw container when the
+  // WYSIWYG textarea is focused near the viewport edge. The container has
+  // overflow:hidden, but browsers still scroll it to keep focused elements
+  // visible, which shifts the toolbar and menus (see #8936).
+  const preventContainerScroll = () => {
+    if (excalidrawContainer) {
+      excalidrawContainer.scrollTop = 0;
+      excalidrawContainer.scrollLeft = 0;
+    }
+  };
+  excalidrawContainer?.addEventListener("scroll", preventContainerScroll);
 
   // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Added a `scroll` event listener on `.excalidraw-container` that resets `scrollTop`/`scrollLeft` to 0 while the WYSIWYG editor is active
- Prevents the browser from auto-scrolling `overflow:hidden` containers to keep focused textarea visible
- Properly cleans up the listener on editor close

Closes #8936

## Test plan
- [x] TypeScript type check passes
- [ ] Open text editor near the bottom/right edge of the viewport and type — toolbar should not shift