### PR TITLE
fix: filter NaN points from freedraw SVG path data

### DIFF
--- a/packages/element/src/shape.ts
+++ b/packages/element/src/shape.ts
@@ -1213,9 +1213,20 @@ const getSvgPathFromStroke = (points: number[][]): string => {
     return "";
   }
 
-  const max = points.length - 1;
+  // Filter out points containing NaN/Infinity values which can be produced
+  // by the perfect-freehand library in edge cases (e.g., overlapping input
+  // points or zero-length vectors). NaN in SVG path data produces invalid output.
+  const validPoints = points.filter((point) =>
+    point.every((coord) => Number.isFinite(coord)),
+  );
 
-  return points
+  if (!validPoints.length) {
+    return "";
+  }
+
+  const max = validPoints.length - 1;
+
+  return validPoints
     .reduce(
       (acc, point, i, arr) => {
         if (i === max) {
@@ -1225,7 +1236,7 @@ const getSvgPathFromStroke = (points: number[][]): string => {
         }
         return acc;
       },
-      ["M", points[0], "Q"],
+      ["M", validPoints[0], "Q"],
     )
     .join(" ")
     .replace(TO_FIXED_PRECISION, "$1");


### PR DESCRIPTION
## Summary
- Filter out points with NaN/Infinity coordinates in `getSvgPathFromStroke` before constructing SVG path
- The `perfect-freehand` library can produce NaN values in edge cases (overlapping input points, zero-length vectors)
- These NaN values propagated into SVG path data, producing invalid/broken SVG output

Closes #3566

## Test plan
- [x] TypeScript type check passes
- [x] Existing export tests pass (15/15)
- [ ] Create a freedraw element with overlapping points and export to SVG — should produce valid SVG