### PR TITLE
fix(editor): prevent pasted text paragraphs from overlapping

### DIFF
--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -4139,12 +4139,11 @@ class App extends React.Component<AppProps, AppState> {
             : metrics;
 
           const startX = x - metrics.width / 2;
-          const startY = currentY - metrics.height / 2;
 
           const element = newTextElement({
             ...textElementProps,
             x: startX,
-            y: startY,
+            y: currentY,
             text,
             originalText,
             lineHeight,
@@ -4173,18 +4172,27 @@ class App extends React.Component<AppProps, AppState> {
       return;
     }
 
-    this.scene.insertElements(textElements);
+    // Center the group of text elements vertically at the paste point.
+    // Elements were placed top-aligned during layout to prevent overlap
+    // when consecutive elements have different heights (#8690).
+    const totalHeight = currentY - y - LINE_GAP;
+    const verticalOffset = totalHeight / 2;
+    const centeredTextElements = textElements.map((el) =>
+      newElementWith(el, { y: el.y - verticalOffset }),
+    );
+
+    this.scene.insertElements(centeredTextElements);
     this.store.scheduleCapture();
     this.setState({
       selectedElementIds: makeNextSelectedElementIds(
-        Object.fromEntries(textElements.map((el) => [el.id, true])),
+        Object.fromEntries(centeredTextElements.map((el) => [el.id, true])),
         this.state,
       ),
     });
 
     if (
       !isPlainPaste &&
-      textElements.length > 1 &&
+      centeredTextElements.length > 1 &&
       PLAIN_PASTE_TOAST_SHOWN === false &&
       this.editorInterface.formFactor !== "phone"
     ) {

--- a/packages/excalidraw/tests/clipboard.test.tsx
+++ b/packages/excalidraw/tests/clipboard.test.tsx
@@ -193,6 +193,27 @@ describe("paste text as single lines", () => {
       expect(lastElY).toEqual(firstElY + lineHeightPx * 2);
     });
   });
+
+  it("should not overlap elements when pasting paragraphs of different lengths", async () => {
+    // Short line followed by a long line that will wrap, producing
+    // elements of different heights (regression test for #8690)
+    const shortLine = "Short";
+    const longLine =
+      "This is a very long paragraph that should wrap to multiple lines when pasted producing an element taller than the short line above";
+    const text = `${shortLine}\n${longLine}`;
+    mouse.moveTo(100, 100);
+    pasteWithCtrlCmdV(text);
+
+    await waitFor(async () => {
+      expect(h.elements.length).toEqual(2);
+      const elMap = arrayToMap(h.elements);
+      const [, , , firstElBottom] = getElementBounds(h.elements[0], elMap);
+      const [, secondElTop] = getElementBounds(h.elements[1], elMap);
+      // The second element should start at or below the first element's
+      // bottom edge (no overlap)
+      expect(secondElTop).toBeGreaterThanOrEqual(firstElBottom);
+    });
+  });
 });
 
 describe("paste text as a single element", () => {


### PR DESCRIPTION
## Summary
- Fix vertical overlap when pasting multi-paragraph text onto the canvas
- Each paragraph becomes a separate text element; previously centering each at a running cursor caused overlap when heights differed
- Now places elements top-aligned during layout, then shifts the group to center at paste point

Closes #8690

## Test plan
- [x] All 20 clipboard tests pass (19 existing + 1 new regression test)
- [x] TypeScript type check passes
- [x] Linting/formatting passes