### PR TITLE
fix(editor): zoom to cursor position after window regains focus

### DIFF
--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -12582,6 +12582,15 @@ class App extends React.Component<AppProps, AppState> {
       }
 
       const { deltaX, deltaY } = event;
+
+      // Update last viewport position from the wheel event so zoom targets
+      // the actual cursor position, even if the window regained focus without
+      // a preceding pointermove event (see #10549).
+      this.lastViewportPosition = {
+        x: event.clientX,
+        y: event.clientY,
+      };
+
       // note that event.ctrlKey is necessary to handle pinch zooming
       if (event.metaKey || event.ctrlKey) {
         const sign = Math.sign(deltaY);


### PR DESCRIPTION
## Summary
- Update `lastViewportPosition` from `WheelEvent.clientX/clientY` at the start of `handleWheel`
- Ensures Cmd+scroll zoom always targets the actual cursor position, even after the window regains focus without a preceding `pointermove`

Closes #10549

## Test plan
- [x] TypeScript type check passes
- [ ] Switch to another window, switch back, and Cmd+scroll — zoom should target cursor position