### PR TITLE
fix: add shortcut hint to Clear Canvas menu item

### DIFF
--- a/packages/excalidraw/components/main-menu/DefaultItems.tsx
+++ b/packages/excalidraw/components/main-menu/DefaultItems.tsx
@@ -215,6 +215,7 @@ export const ClearCanvas = () => {
       onSelect={() => setActiveConfirmDialog("clearCanvas")}
       data-testid="clear-canvas-button"
       aria-label={t("buttons.clearReset")}
+      shortcut={getShortcutFromShortcutName("clearCanvas")}
     >
       {t("buttons.clearReset")}
     </DropdownMenuItem>


### PR DESCRIPTION
## Summary
- Added `shortcut={getShortcutFromShortcutName("clearCanvas")}` to the Clear Canvas `DropdownMenuItem`
- Now displays Ctrl+Delete / Cmd+Delete inline, consistent with all other menu items

Closes #10558

## Test plan
- [x] TypeScript type check passes
- [ ] Open main menu — Clear Canvas should show its keyboard shortcut