### PR TITLE
fix: prevent popover overflow on small viewports

### DIFF
--- a/packages/excalidraw/components/IconPicker.tsx
+++ b/packages/excalidraw/components/IconPicker.tsx
@@ -255,6 +255,8 @@ function Picker<T>({
       aria-label={label}
       side={"bottom"}
       align="start"
+      avoidCollisions
+      collisionPadding={10}
       sideOffset={12}
       alignOffset={12}
       style={{ zIndex: "var(--zIndex-ui-styles-popup)" }}

--- a/packages/excalidraw/components/PropertiesPopover.tsx
+++ b/packages/excalidraw/components/PropertiesPopover.tsx
@@ -54,6 +54,7 @@ export const PropertiesPopover = React.forwardRef<
           alignOffset={-16}
           sideOffset={20}
           collisionBoundary={container ?? undefined}
+          collisionPadding={10}
           style={{
             zIndex: "var(--zIndex-ui-styles-popup)",
             marginLeft:


### PR DESCRIPTION
## Summary
- Added `collisionPadding={10}` and `avoidCollisions` to `Popover.Content` in `IconPicker.tsx` (arrowhead picker)
- Added `collisionPadding={10}` to `Popover.Content` in `PropertiesPopover.tsx` (color/font pickers)
- Radix now repositions these popovers to stay within the viewport instead of overflowing

Closes #8992

## Test plan
- [x] TypeScript type check passes
- [ ] Resize window to small viewport, open arrowhead picker — should not overflow
- [ ] Resize window, open color picker — should reposition within viewport