### PR TITLE
fix(editor): add State diagram to mermaid description and link

### DIFF
--- a/packages/element/src/shape.ts
+++ b/packages/element/src/shape.ts
@@ -1213,9 +1213,20 @@ const getSvgPathFromStroke = (points: number[][]): string => {
     return "";
   }
 
-  const max = points.length - 1;
+  // Filter out points containing NaN/Infinity values which can be produced
+  // by the perfect-freehand library in edge cases (e.g., overlapping input
+  // points or zero-length vectors). NaN in SVG path data produces invalid output.
+  const validPoints = points.filter((point) =>
+    point.every((coord) => Number.isFinite(coord)),
+  );
 
-  return points
+  if (!validPoints.length) {
+    return "";
+  }
+
+  const max = validPoints.length - 1;
+
+  return validPoints
     .reduce(
       (acc, point, i, arr) => {
         if (i === max) {
@@ -1225,7 +1236,7 @@ const getSvgPathFromStroke = (points: number[][]): string => {
         }
         return acc;
       },
-      ["M", points[0], "Q"],
+      ["M", validPoints[0], "Q"],
     )
     .join(" ")
     .replace(TO_FIXED_PRECISION, "$1");

--- a/packages/excalidraw/components/TTDDialog/MermaidToExcalidraw.tsx
+++ b/packages/excalidraw/components/TTDDialog/MermaidToExcalidraw.tsx
@@ -262,6 +262,15 @@ const MermaidToExcalidraw = ({
               {el}
             </a>
           )}
+          stateLink={(el) => (
+            <a
+              href="https://mermaid.js.org/syntax/stateDiagram.html"
+              target="_blank"
+              rel="noreferrer"
+            >
+              {el}
+            </a>
+          )}
           erdLink={(el) => (
             <a
               href="https://mermaid.js.org/syntax/entityRelationshipDiagram.html"

--- a/packages/excalidraw/locales/en.json
+++ b/packages/excalidraw/locales/en.json
@@ -631,7 +631,7 @@
   "mermaid": {
     "title": "Mermaid to Excalidraw",
     "button": "Insert",
-    "description": "Currently only <flowchartLink>Flowchart</flowchartLink>, <sequenceLink>Sequence</sequenceLink>, <classLink>Class</classLink>, and <erdLink>Entity Relationship</erdLink> Diagrams are supported. The other types will be rendered as image in Excalidraw.",
+    "description": "Currently only <flowchartLink>Flowchart</flowchartLink>, <sequenceLink>Sequence</sequenceLink>, <classLink>Class</classLink>, <stateLink>State</stateLink>, and <erdLink>Entity Relationship</erdLink> Diagrams are supported. The other types will be rendered as image in Excalidraw.",
     "syntax": "Mermaid Syntax",
     "preview": "Preview",
     "label": "Mermaid",


### PR DESCRIPTION
Follow-up to c1082923 (#11031). Adds State to the mermaid.description locale string and a stateLink in MermaidToExcalidraw.tsx.