### PR TITLE
fix: remove incorrect width override in WYSIWYG paste handler

### DIFF
--- a/packages/element/src/shape.ts
+++ b/packages/element/src/shape.ts
@@ -1213,9 +1213,20 @@ const getSvgPathFromStroke = (points: number[][]): string => {
     return "";
   }
 
-  const max = points.length - 1;
+  // Filter out points containing NaN/Infinity values which can be produced
+  // by the perfect-freehand library in edge cases (e.g., overlapping input
+  // points or zero-length vectors). NaN in SVG path data produces invalid output.
+  const validPoints = points.filter((point) =>
+    point.every((coord) => Number.isFinite(coord)),
+  );
 
-  return points
+  if (!validPoints.length) {
+    return "";
+  }
+
+  const max = validPoints.length - 1;
+
+  return validPoints
     .reduce(
       (acc, point, i, arr) => {
         if (i === max) {
@@ -1225,7 +1236,7 @@ const getSvgPathFromStroke = (points: number[][]): string => {
         }
         return acc;
       },
-      ["M", points[0], "Q"],
+      ["M", validPoints[0], "Q"],
     )
     .join(" ")
     .replace(TO_FIXED_PRECISION, "$1");

--- a/packages/excalidraw/wysiwyg/textWysiwyg.tsx
+++ b/packages/excalidraw/wysiwyg/textWysiwyg.tsx
@@ -32,13 +32,10 @@ import {
   getBoundTextMaxWidth,
   computeContainerDimensionForBoundText,
   computeBoundTextPosition,
-  getBoundTextElement,
 } from "@excalidraw/element";
-import { getTextWidth } from "@excalidraw/element";
 import { getLineHeightInPx } from "@excalidraw/element";
 import { getLineWidth } from "@excalidraw/element";
 import { normalizeText } from "@excalidraw/element";
-import { wrapText } from "@excalidraw/element";
 import { getWrappedTextLines } from "@excalidraw/element";
 import {
   isArrowElement,
@@ -578,38 +575,20 @@ export const textWysiwyg = ({
         }
       }
 
-      dataList = dataList || (await parseDataTransferEvent(event));
-
-      const textItem = dataList.findByType(MIME_TYPES.text);
-      if (!textItem) {
-        return;
-      }
-      const text = normalizeText(textItem.value);
-      if (!text) {
-        return;
-      }
-      const container = getContainerElement(
-        element,
-        app.scene.getNonDeletedElementsMap(),
-      );
-
-      const font = getFontString({
-        fontSize: app.state.currentItemFontSize,
-        fontFamily: app.state.currentItemFontFamily,
-      });
-      if (container) {
-        const boundTextElement = getBoundTextElement(
-          container,
-          app.scene.getNonDeletedElementsMap(),
-        );
-        const wrappedText = wrapText(
-          `${editable.value}${text}`,
-          font,
-          getBoundTextMaxWidth(container, boundTextElement),
-        );
-        const width = getTextWidth(wrappedText, font);
-        editable.style.width = `${width}px`;
-      }
+      // For regular text paste, let the browser handle the insertion
+      // (we did not call event.preventDefault()). The browser's default
+      // paste will fire `oninput`, which calls `onChange` and triggers
+      // `updateWysiwygStyle()` to correctly resize the container and
+      // reposition the editor.
+      //
+      // We intentionally do NOT manually set the editable width here
+      // because this code runs asynchronously (after `await`) and would
+      // execute after `oninput`/`onChange`/`updateWysiwygStyle` have
+      // already computed the correct dimensions. Overwriting the width
+      // here previously caused text to overflow the container, as it
+      // used stale font properties (currentItem* instead of the actual
+      // element's font) and assumed text was appended at the end rather
+      // than inserted at the cursor position.
     };
 
     editable.oninput = () => {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When pasting text into a bound text container (e.g., a rectangle or sticky note) that needs to grow to accommodate the pasted text, the text overflows and is positioned incorrectly outside the container boundary.

Closes #8433

## What is the new behavior?

The text container correctly auto-grows and the WYSIWYG editor is properly repositioned when text is pasted.

## Root cause

The WYSIWYG `onpaste` handler had code that manually computed and set the textarea width after pasting. This code had three problems:

1. **Wrong font properties**: It used `app.state.currentItemFontSize` and `currentItemFontFamily` (the current tool settings) instead of the actual text element's font properties. If the text element had a different font than the current tool, the width calculation was wrong.

2. **Wrong text concatenation**: It computed the wrapped text as `${editable.value}${text}`, assuming the pasted text is appended at the end. But paste inserts at the cursor position, so this was incorrect.

3. **Async timing issue**: Because the paste handler is `async` (it `await`s `parseDataTransferEvent`), the width-setting code ran in a microtask _after_ the browser had already inserted the text and the `oninput` -> `onChange` -> `updateWysiwygStyle()` pipeline had already computed and applied the correct dimensions. The paste handler then overwrote the correct width with an incorrectly computed value.

## Fix

Remove the redundant width override from the paste handler. The existing `oninput` -> `onChange` -> `updateWysiwygStyle()` pipeline already correctly handles:
- Wrapping text to the container's max width using the actual element font
- Auto-growing the container height when text exceeds it
- Repositioning the WYSIWYG editor to match the container

This also removes three now-unused imports: `getBoundTextElement`, `getTextWidth`, and `wrapText`.

## Additional context

The removed code was originally added in commit `af3b93c41` (Dec 2022). At that time, the `updateWysiwygStyle` function and the scene update pipeline may not have been as robust. The current codebase handles all dimension updates through the `oninput` -> `onChange` -> scene update -> `updateWysiwygStyle` flow, making the manual width override unnecessary and harmful.