### PR TITLE
fix: opt out of browser auto dark mode to prevent text visibility issues

### DIFF
--- a/packages/element/src/shape.ts
+++ b/packages/element/src/shape.ts
@@ -1213,9 +1213,20 @@ const getSvgPathFromStroke = (points: number[][]): string => {
     return "";
   }
 
-  const max = points.length - 1;
+  // Filter out points containing NaN/Infinity values which can be produced
+  // by the perfect-freehand library in edge cases (e.g., overlapping input
+  // points or zero-length vectors). NaN in SVG path data produces invalid output.
+  const validPoints = points.filter((point) =>
+    point.every((coord) => Number.isFinite(coord)),
+  );
 
-  return points
+  if (!validPoints.length) {
+    return "";
+  }
+
+  const max = validPoints.length - 1;
+
+  return validPoints
     .reduce(
       (acc, point, i, arr) => {
         if (i === max) {
@@ -1225,7 +1236,7 @@ const getSvgPathFromStroke = (points: number[][]): string => {
         }
         return acc;
       },
-      ["M", points[0], "Q"],
+      ["M", validPoints[0], "Q"],
     )
     .join(" ")
     .replace(TO_FIXED_PRECISION, "$1");

--- a/packages/excalidraw/css/theme.scss
+++ b/packages/excalidraw/css/theme.scss
@@ -3,6 +3,13 @@
 @forward "./variables.module";
 
 .excalidraw {
+  // Prevent browser auto dark mode (e.g. Chrome's "Auto Dark Mode for Web
+  // Contents") from inverting colors on the canvas. Excalidraw manages its own
+  // dark theme via custom properties and CSS filters, so browser-level color
+  // overrides cause visual glitches such as invisible text during editing.
+  // See https://github.com/excalidraw/excalidraw/issues/9263
+  color-scheme: only light;
+
   --theme-filter: none;
   --button-destructive-bg-color: #{$color-red-1};
   --button-destructive-color: #{$color-red-9};


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When browsers have auto dark mode features enabled (e.g. Chrome's "Auto Dark Mode for Web Contents" flag at `chrome://flags`, or Brave's equivalent), the browser independently inverts colors on the Excalidraw canvas. This causes text to become invisible during editing because the wysiwyg editor text color and canvas background get inverted independently by the browser, resulting in white-on-white or black-on-black text.

Closes #9263

## What is the new behavior?

Adds `color-scheme: only light` to the `.excalidraw` container CSS. This is the [standard CSS mechanism](https://developer.mozilla.org/en-US/docs/Web/CSS/color-scheme#only) to opt out of browser auto dark theme color overrides on a per-element basis:

> Can be used to turn off color overrides caused by Chrome's Auto Dark Theme, by applying `color-scheme: only light` on a specific element or `:root`.

Excalidraw already manages its own dark mode via custom CSS properties and CSS filters (`--theme-filter: invert(93%) hue-rotate(180deg)`), so browser-level color overrides are undesirable and cause visual glitches.

This change has no effect on:
- Excalidraw's own light/dark theme toggle (which uses `.theme--dark` class and custom properties)
- Users who don't have browser auto dark mode enabled
- Standard browser dark mode preferences (`prefers-color-scheme`)

## Additional context

The fix was suggested by @dangerman in the [issue discussion](https://github.com/excalidraw/excalidraw/issues/9263#issuecomment-2728616340), referencing the [Mozilla documentation for `color-scheme`](https://developer.mozilla.org/en-US/docs/Web/CSS/color-scheme#only).

The issue was also reported independently for Brave browser in a related context.