### PR TITLE
fix: use CSS logical properties for RTL support in Dialog and Modal

### DIFF
--- a/packages/excalidraw/components/Dialog.scss
+++ b/packages/excalidraw/components/Dialog.scss
@@ -8,7 +8,7 @@
 
   .Dialog__title {
     margin: 0;
-    text-align: left;
+    text-align: start;
     font-size: 1.25rem;
     border-bottom: 1px solid var(--dialog-border-color);
     padding: 0 0 0.75rem;
@@ -20,7 +20,7 @@
     margin: 0;
     position: absolute;
     top: 0.75rem;
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     border: 0;
     background-color: transparent;
     line-height: 0;
@@ -48,7 +48,7 @@
   .Dialog--fullscreen {
     .Dialog__close {
       top: 1.25rem;
-      right: 1.25rem;
+      inset-inline-end: 1.25rem;
     }
   }
 }

--- a/packages/excalidraw/components/Modal.scss
+++ b/packages/excalidraw/components/Modal.scss
@@ -105,7 +105,7 @@
     padding: 0.375rem;
     position: absolute;
     top: 1rem;
-    right: 1rem;
+    inset-inline-end: 1rem;
     border: 0;
     background-color: transparent;
     line-height: 0;


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix (RTL layout)

## What is the current behavior?

In RTL locales (e.g., Arabic, Hebrew), the Dialog and Modal components display incorrectly:

- The Dialog title is left-aligned instead of right-aligned
- The close button is pinned to the right instead of the inline-end (which should be left in RTL)

This causes the title and close button to overlap or be positioned on the same side, making the dialog hard to use in RTL layouts.

Closes #6210

## What is the new behavior?

Replaced hardcoded directional CSS properties with CSS logical property equivalents that automatically respect the text direction:

| Property | Before | After |
|----------|--------|-------|
| `Dialog__title` text-align | `left` | `start` |
| `Dialog__close` position | `right: 0.5rem` | `inset-inline-end: 0.5rem` |
| `Dialog__close` (fullscreen) | `right: 1.25rem` | `inset-inline-end: 1.25rem` |
| `Modal__close` position | `right: 1rem` | `inset-inline-end: 1rem` |

These CSS logical properties are well-supported in all modern browsers and are already used elsewhere in the codebase (e.g., `ContextMenu.scss` uses `text-align: start`, various components use `margin-inline-start/end`).

## Additional context

- In LTR mode, `text-align: start` behaves identically to `text-align: left`, and `inset-inline-end` behaves identically to `right` — so there is no visual change for LTR users.
- In RTL mode, the title will now correctly align to the right, and the close button will correctly position on the left (inline-end in RTL).
- This follows the same pattern already established in `ContextMenu.scss` and other components in the codebase.