### PR TITLE
fix(editor): allow unlocking elements inside frames

### DIFF
--- a/packages/excalidraw/actions/actionElementLock.ts
+++ b/packages/excalidraw/actions/actionElementLock.ts
@@ -27,6 +27,7 @@ export const actionToggleElementLock = register({
     const selected = app.scene.getSelectedElements({
       selectedElementIds: appState.selectedElementIds,
       includeBoundTextElement: false,
+      includeElementsInFrames: true,
     });
 
     return shouldLock(selected)
@@ -34,16 +35,15 @@ export const actionToggleElementLock = register({
       : "labels.elementLock.unlock";
   },
   icon: (appState, elements) => {
-    const selectedElements = getSelectedElements(elements, appState);
+    const selectedElements = getSelectedElements(elements, appState, {
+      includeElementsInFrames: true,
+    });
     return shouldLock(selectedElements) ? LockedIcon : UnlockedIcon;
   },
   trackEvent: { category: "element" },
   predicate: (elements, appState, _, app) => {
     const selectedElements = app.scene.getSelectedElements(appState);
-    return (
-      selectedElements.length > 0 &&
-      !selectedElements.some((element) => element.locked && element.frameId)
-    );
+    return selectedElements.length > 0;
   },
   perform: (elements, appState, _, app) => {
     const selectedElements = app.scene.getSelectedElements({


### PR DESCRIPTION
## Summary
- Added `includeElementsInFrames: true` to `label` and `icon` functions so lock state is computed correctly for framed elements
- Removed predicate restriction that prevented unlocking locked elements inside frames via context menu

## Test plan
- [x] TypeScript type check passes
- [ ] Lock an element inside a frame, right-click — unlock option should appear
- [ ] Lock/unlock icon should reflect correct state for framed elements