### PR TITLE
fix: use selectionColor for group selection border instead of hardcoded black

### DIFF
--- a/packages/excalidraw/renderer/interactiveScene.ts
+++ b/packages/excalidraw/renderer/interactiveScene.ts
@@ -1869,7 +1869,7 @@ const _renderInteractiveScene = ({
           y2,
           selectionColors: groupElements.some((el) => el.locked)
             ? ["#ced4da"]
-            : ["#000"],
+            : [selectionColor],
           dashed: true,
           cx: x1 + (x2 - x1) / 2,
           cy: y1 + (y2 - y1) / 2,


### PR DESCRIPTION
Group selection bounding boxes were using a hardcoded "#000" (black) color, making the dashed border invisible on dark backgrounds. Now uses the app's primary selectionColor, consistent with how individual element selection borders are rendered.

  Fixes #7177