### PR TITLE
fix: make element links clickable on whole element in view mode on mobile

### DIFF
--- a/packages/excalidraw/components/hyperlink/helpers.ts
+++ b/packages/excalidraw/components/hyperlink/helpers.ts
@@ -90,7 +90,6 @@ export const isPointHittingLink = (
     return false;
   }
   if (
-    !isMobile &&
     appState.viewModeEnabled &&
     hitElementBoundingBox(pointFrom(x, y), element, elementsMap)
   ) {


### PR DESCRIPTION
## Description

Fixes #9637

This PR removes the `!isMobile` check that prevented the whole element from being clickable in view mode on mobile devices. Previously, only the small link icon was clickable on mobile, while desktop allowed clicking anywhere on the element when in view mode.

### Changes
- Removed `!isMobile` condition from `isPointHittingLink` function in `packages/excalidraw/components/hyperlink/helpers.ts`

### Behavior Change
- **Before**: On mobile, only the link icon (small indicator in top-right) was clickable
- **After**: On mobile in view mode, the entire element is clickable (same as desktop)

This makes the behavior consistent between desktop and mobile, which is the expected behavior described in the issue.

## Testing
- [ ] Test clicking on element body in view mode on mobile device
- [ ] Test clicking on link icon still works
- [ ] Verify non-view mode behavior unchanged