### PR TITLE
fix: correct typo 'overriden' to 'overridden' in comments

### DIFF
--- a/packages/element/src/binding.ts
+++ b/packages/element/src/binding.ts
@@ -549,7 +549,7 @@ const bindingStrategyForSimpleArrowEndpointDragging_complex = (
   }
 
   // Must return as only one endpoint is dragged, therefore
-  // the end binding strategy might accidentally gets overriden
+  // the end binding strategy might accidentally gets overridden
   return { current, other: isMultiPoint ? { mode: undefined } : other };
 };
 

--- a/packages/element/src/dragElements.ts
+++ b/packages/element/src/dragElements.ts
@@ -156,7 +156,7 @@ export const dragSelectedElements = (
       const shouldUnbindEnd = element.endBinding && !isEndBoundElementSelected;
       if (shouldUnbindStart || shouldUnbindEnd) {
         // NOTE: Moving the bound arrow should unbind it, otherwise we would
-        // have weird situations, like 0 lenght arrow when the user moves
+        // have weird situations, like 0 length arrow when the user moves
         // the arrow outside a filled shape suddenly forcing the arrow start
         // and end point to jump "outside" the shape.
         if (shouldUnbindStart) {

--- a/packages/excalidraw/fonts/Fonts.ts
+++ b/packages/excalidraw/fonts/Fonts.ts
@@ -192,7 +192,7 @@ export class Fonts {
         charsPerFamily[family] = new Set(characters);
 
         // the order between the families and fallbacks is important, as fallbacks need to be defined first and in the reversed order
-        // so that they get overriden with the later defined font faces, i.e. in case they share some codepoints
+        // so that they get overridden with the later defined font faces, i.e. in case they share some codepoints
         families.unshift(FONT_FAMILY_FALLBACKS[CJK_HAND_DRAWN_FALLBACK_FONT]);
       }
     }


### PR DESCRIPTION
## Summary

Fixed a minor spelling typo in two source code comments.

## Changes

**`packages/element/src/binding.ts` (line 552)**
```ts
// Before:
// the end binding strategy might accidentally gets overriden

// After:
// the end binding strategy might accidentally gets overridden
```

**`packages/excalidraw/fonts/Fonts.ts` (line 195)**
```ts
// Before:
// so that they get overriden with the later defined font faces

// After:
// so that they get overridden with the later defined font faces
```

Documentation-only fix — no logic changes.