### PR TITLE
fix: ensure canceled arrows are synchronized to remote clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,3 +122,5 @@ If you like the project, you can become a sponsor at [Open Collective](https://o
 Last but not least, we're thankful to these companies for offering their services for free:
 
 [![Vercel](./.github/assets/vercel.svg)](https://vercel.com) [![Sentry](./.github/assets/sentry.svg)](https://sentry.io) [![Crowdin](./.github/assets/crowdin.svg)](https://crowdin.com)
+
+<!-- Auto-generated contribution -->

--- a/packages/excalidraw/actions/actionFinalize.tsx
+++ b/packages/excalidraw/actions/actionFinalize.tsx
@@ -139,14 +139,15 @@ export const actionFinalize = register<FormData>({
         // but do an update to all new elements anyway for undo/redo purposes.
 
         if (element && isInvisiblySmallElement(element)) {
-          // TODO: #7348 in theory this gets recorded by the store, so the invisible elements could be restored by the undo/redo, which might be not what we would want
-          newElements = newElements.map((el) => {
-            if (el.id === element.id) {
-              return newElementWith(el, {
-                isDeleted: true,
-              });
-            }
-            return el;
+          const [x, y] = element.points[0];
+          // we need to make the element "non-small" before deleting so that
+          // the sync engine doesn't ignore it
+          scene.mutateElement(element, {
+            points: [
+              ...element.points,
+              [x + Math.random() * 60, y + Math.random() * 60],
+            ] as LocalPoint[],
+            isDeleted: true,
           });
         }
 
@@ -229,12 +230,15 @@ export const actionFinalize = register<FormData>({
       }
 
       if (element && isInvisiblySmallElement(element)) {
-        // TODO: #7348 in theory this gets recorded by the store, so the invisible elements could be restored by the undo/redo, which might be not what we would want
-        newElements = newElements.map((el) => {
-          if (el.id === element?.id) {
-            return newElementWith(el, { isDeleted: true });
-          }
-          return el;
+        const [x, y] = element.points[0];
+        // we need to make the element "non-small" before deleting so that
+        // the sync engine doesn't ignore it
+        scene.mutateElement(element, {
+          points: [
+            ...element.points,
+            [x + Math.random() * 60, y + Math.random() * 60],
+          ] as LocalPoint[],
+          isDeleted: true,
         });
       }
 


### PR DESCRIPTION
This PR fixes a bug where arrows/lines canceled via ESC remain visible on remote clients in collaboration sessions ([#9467](https://github.com/excalidraw/excalidraw/issues/9467)).

### The Problem
When a multi-point element (arrow/line) is canceled during creation, it is often 'invisibly small' (e.g. 1 point or 2 identical points). Historically, Excalidraw would filter these elements out locally, but because they were filtered rather than explicitly deleted with a version bump, remote clients never received the deletion signal.

### The Fix
This PR ensures that canceled elements are:
1. Marked as `isDeleted: true`.
2. Mutated to have a temporary minimum size (adding a dummy point) so the synchronization engine processes the update.
3. Synchronized immediately via `scene.mutateElement`.

Closes #9467