### PR TITLE
Fix typo in Discord badge URL parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
   <a href="https://docs.excalidraw.com/docs/introduction/contributing">
     <img alt="PRs welcome!" src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat"  /></a>
   <a href="https://discord.gg/UexuTaE">
-    <img alt="Chat on Discord" src="https://img.shields.io/discord/723672430744174682?color=738ad6&label=Chat%20on%20Discord&logo=discord&logoColor=ffffff&widge=false"/></a>
+    <img alt="Chat on Discord" src="https://img.shields.io/discord/723672430744174682?color=738ad6&label=Chat%20on%20Discord&logo=discord&logoColor=ffffff&widget=false"/></a>
   <a href="https://deepwiki.com/excalidraw/excalidraw">
     <img alt="Ask DeepWiki" src="https://deepwiki.com/badge.svg" /></a>
   <a href="https://twitter.com/excalidraw">


### PR DESCRIPTION
## What
Fixed typo in Discord badge query parameter on line 34 of README.md

## Change
- `widge=false` → `widget=false`

## Why
The correct shields.io parameter name is `widget`, not `widge`. This typo doesn't break functionality but should be corrected for accuracy.