### PR TITLE
fix: upgrade Dockerfile to Node 20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=${BUILDPLATFORM} node:18 AS build
+FROM --platform=${BUILDPLATFORM} node:20 AS build
 
 WORKDIR /opt/node_app
 


### PR DESCRIPTION
`marked@16.4.2` (a transitive dependency) requires Node >= 20, causing the Docker build to fail with Node 18:

  error marked@16.4.2: The engine "node" is incompatible with
  this module. Expected version ">= 20". Got "18.x"

Bumping the build stage to node:20 fixes this.