### PR TITLE
fix: use selection color for grouped selection outlines

### DIFF
--- a/packages/excalidraw/renderer/interactiveScene.ts
+++ b/packages/excalidraw/renderer/interactiveScene.ts
@@ -944,6 +944,15 @@ type ElementSelectionBorder = {
   padding?: number;
 };
 
+const getGroupSelectionColors = (
+  groupElements: readonly ExcalidrawElement[],
+  selectionColor: string,
+) => {
+  return groupElements.some((element) => element.locked)
+    ? ["#ced4da"]
+    : [selectionColor];
+};
+
 const renderSelectionBorder = (
   context: CanvasRenderingContext2D,
   appState: InteractiveCanvasAppState,
@@ -1867,9 +1876,10 @@ const _renderInteractiveScene = ({
           x2,
           y1,
           y2,
-          selectionColors: groupElements.some((el) => el.locked)
-            ? ["#ced4da"]
-            : ["#000"],
+          selectionColors: getGroupSelectionColors(
+            groupElements,
+            selectionColor,
+          ),
           dashed: true,
           cx: x1 + (x2 - x1) / 2,
           cy: y1 + (y2 - y1) / 2,

--- a/packages/excalidraw/tests/selection.test.tsx
+++ b/packages/excalidraw/tests/selection.test.tsx
@@ -17,6 +17,7 @@ import {
   act,
   render,
   fireEvent,
+  GlobalTestState,
   mockBoundingClientRect,
   restoreOriginalGetBoundingClientRect,
   assertSelectedElements,
@@ -733,6 +734,71 @@ describe("inner box-selection", () => {
       expect(h.state.selectedGroupIds).toEqual({});
       mouse.up();
     });
+  });
+});
+
+describe("group selection outline", () => {
+  beforeEach(async () => {
+    await render(<Excalidraw />);
+  });
+
+  it("renders grouped selection border using the selection color", () => {
+    const rect1 = API.createElement({
+      type: "rectangle",
+      x: 0,
+      y: 0,
+      width: 50,
+      height: 50,
+      groupIds: ["A"],
+    });
+    const rect2 = API.createElement({
+      type: "rectangle",
+      x: 100,
+      y: 0,
+      width: 50,
+      height: 50,
+      groupIds: ["A"],
+    });
+
+    API.setElements([rect1, rect2]);
+
+    const interactiveContext =
+      GlobalTestState.interactiveCanvas.getContext("2d")!;
+    const originalStrokeRect =
+      interactiveContext.strokeRect.bind(interactiveContext);
+    const strokeRectCalls: {
+      strokeStyle: string | CanvasGradient;
+      lineDash: number[];
+    }[] = [];
+
+    interactiveContext.strokeRect = function (...args) {
+      strokeRectCalls.push({
+        strokeStyle: this.strokeStyle,
+        lineDash: this.getLineDash(),
+      });
+      return originalStrokeRect(...args);
+    };
+
+    const selectionColor =
+      getComputedStyle(
+        GlobalTestState.renderResult.container.querySelector(".excalidraw")!,
+      ).getPropertyValue("--color-selection") || "#6965db";
+
+    try {
+      strokeRectCalls.length = 0;
+      mouse.select(rect1);
+    } finally {
+      interactiveContext.strokeRect = originalStrokeRect;
+    }
+
+    expect(h.state.selectedGroupIds).toEqual({ A: true });
+
+    expect(strokeRectCalls).toContainEqual(
+      expect.objectContaining({
+        strokeStyle: selectionColor.trim(),
+        lineDash: [8, 4],
+      }),
+    );
   });
 });
 


### PR DESCRIPTION
 ## Summary

  Fixes the grouped selection outline color in light theme.

  Previously, grouped selections used a hardcoded black dashed outline. On dark canvas backgrounds, that made the grouping border hard to see or effectively
  invisible.

  This change makes grouped selections use the same selection color as other selection outlines, while preserving the existing locked-group styling.

  Closes #7177

  ## What Changed

  - replaced the hardcoded `#000` group selection outline color with the theme selection color
  - kept locked group outlines using the existing muted gray
  - added a regression test to verify grouped selection borders render with the selection color

  ## Why

  The current behavior is inconsistent with the rest of the selection UI and causes poor contrast on dark backgrounds in light theme.

  ## Testing

  - `corepack yarn vitest --run packages/excalidraw/tests/selection.test.tsx`
  - `corepack yarn eslint --max-warnings=0 packages/excalidraw/renderer/interactiveScene.ts packages/excalidraw/tests/selection.test.tsx`