### PR TITLE
fix: allow closing submenu by tapping trigger again on mobile

### DIFF
--- a/packages/excalidraw/components/dropdownMenu/DropdownMenuSub.tsx
+++ b/packages/excalidraw/components/dropdownMenu/DropdownMenuSub.tsx
@@ -1,4 +1,7 @@
 import { DropdownMenu as DropdownMenuPrimitive } from "radix-ui";
+import React, { useState, useRef } from "react";
+
+import { useEditorInterface } from "../App";
 
 import DropdownMenuSubContent from "./DropdownMenuSubContent";
 import DropdownMenuSubTrigger from "./DropdownMenuSubTrigger";
@@ -10,9 +13,48 @@ import {
 const DropdownMenuSub = ({ children }: { children?: React.ReactNode }) => {
   const MenuTriggerComp = getSubMenuTriggerComponent(children);
   const MenuContentComp = getSubMenuContentComponent(children);
+  const editorInterface = useEditorInterface();
+  const isMobile = editorInterface.formFactor === "phone";
+  const [open, setOpen] = useState(false);
+  const wasOpenOnTouchStart = useRef(false);
+  const closedAtRef = useRef<number>(0);
+
+  if (!isMobile) {
+    return (
+      <DropdownMenuPrimitive.Sub>
+        {MenuTriggerComp}
+        {MenuContentComp}
+      </DropdownMenuPrimitive.Sub>
+    );
+  }
+
   return (
-    <DropdownMenuPrimitive.Sub>
-      {MenuTriggerComp}
+    <DropdownMenuPrimitive.Sub
+      open={open}
+      onOpenChange={(isOpen) => {
+        if (isOpen) {
+          const timeSinceClosed = Date.now() - closedAtRef.current;
+          if (timeSinceClosed < 500) {
+            return;
+          }
+          setOpen(true);
+        }
+      }}
+    >
+      <div
+        onTouchStart={() => {      
+          wasOpenOnTouchStart.current = open;
+        }}
+        onTouchEnd={() => {
+          if (wasOpenOnTouchStart.current) {
+            closedAtRef.current = Date.now();
+            setOpen(false);
+          }
+        }}
+        style={{ display: "contents" }}
+      >
+        {MenuTriggerComp}
+      </div>
       {MenuContentComp}
     </DropdownMenuPrimitive.Sub>
   );
@@ -20,7 +62,6 @@ const DropdownMenuSub = ({ children }: { children?: React.ReactNode }) => {
 
 DropdownMenuSub.Trigger = DropdownMenuSubTrigger;
 DropdownMenuSub.Content = DropdownMenuSubContent;
-
 DropdownMenuSub.displayName = "DropdownMenuSub";
 
 export default DropdownMenuSub;


### PR DESCRIPTION
Closes #11111

Problem:
On mobile, DropdownMenuSub relies on Radix UI's SubTrigger which only handles hover on desktop. On touch devices tapping the trigger opens the submenu but tapping again does not close it. Radix does not fire onOpenChange(false) on a second tap on mobile

Solution
On mobile (formFactor === "phone"), take manual control of the open state:
 On touchStart, snapshot whether the menu was already open
On touchEnd, if menu was open when finger touched:close it
Block Radix from reopening within 500ms of closing
Desktop behavior remains completely unchanged 

Files Changed
packages/excalidraw/components/dropdownMenu/DropdownMenuSub.tsx

Testing:
Tap to open works
Tap again to close works
 Sidebar stays open after closing submenu
Desktop hover behavior completely unchanged
No other submenus affected 



https://github.com/user-attachments/assets/578c1b80-422e-426e-9674-0f469afd4344



Tested on OnePlus 10 Pro 5G (Android 15) using Chrome/Firefox/Brave