### PR TITLE
docs: add note for users who cannot install Yarn globally

### DIFF
--- a/dev-docs/docs/introduction/development.mdx
+++ b/dev-docs/docs/introduction/development.mdx
@@ -36,6 +36,26 @@ yarn start
 
 Now you can open [http://localhost:3000](http://localhost:3000) and start coding in your favorite code editor.
 
+_Can't run `yarn` directly?_
+
+If you don't have Yarn installed globally and can't (or don't want to) install it system-wide, you can install it locally via npm and invoke it through npm:
+
+```bash
+npm install yarn
+npx yarn        # equivalent to: yarn
+npx yarn start  # equivalent to: yarn start
+```
+
+This works because `npx` resolves binaries from `node_modules/.bin`, picking up the locally installed Yarn automatically. All commands listed in the [Commands](#commands) section below can be used this way — just replace `yarn <command>` with `npx yarn <command>`.
+
+Alternatively, if you're on Node.js v16 or later, you can use [Corepack](https://nodejs.org/api/corepack.html) (bundled with Node) to enable Yarn globally without any extra install:
+
+```bash
+corepack enable
+```
+
+After this, the `yarn` command will work directly in your terminal.
+
 ## Collaboration
 
 For collaboration, you will need to set up [collab server](https://github.com/excalidraw/excalidraw-room) in local.

--- a/dev-docs/docs/introduction/development.mdx
+++ b/dev-docs/docs/introduction/development.mdx
@@ -56,6 +56,11 @@ corepack enable
 
 After this, the `yarn` command will work directly in your terminal.
 
+> **Windows users:** `corepack enable` requires running your terminal as Administrator. Additionally, if you see a script execution policy error when running `yarn`, you can fix it by running the following in PowerShell as Administrator:
+> ```powershell
+> Set-ExecutionPolicy -Scope CurrentUser -ExecutionPolicy RemoteSigned
+> ```
+
 ## Collaboration
 
 For collaboration, you will need to set up [collab server](https://github.com/excalidraw/excalidraw-room) in local.


### PR DESCRIPTION
Closes #11123 

### What

Adds a note to the Local Installation section of the development documentation for users who cannot install Yarn globally in their environment.

### Why

The current instructions assume Yarn is available globally in the terminal. In environments with restricted permissions or certain OS configurations, this is not always possible. Users following the docs as written end up with a `command not found: yarn` error and no guidance on how to proceed.

### Changes

- Added an admonition block in `dev-docs/docs/introduction/development.mdx`, right after the "Start the server" step, describing two alternatives:
  - Installing Yarn locally via npm and invoking it with `npx`
  - Enabling Yarn through Corepack (bundled with Node.js v16+)

The primary workflow (`yarn` / `yarn start`) remains unchanged.