### PR TITLE
feat: add "Purge deleted items" menu action

### DIFF
--- a/excalidraw-app/components/AppMainMenu.tsx
+++ b/excalidraw-app/components/AppMainMenu.tsx
@@ -9,6 +9,12 @@ import React from "react";
 
 import { isDevEnv } from "@excalidraw/common";
 
+import { useI18n } from "@excalidraw/excalidraw/i18n";
+
+import { activeConfirmDialogAtom } from "@excalidraw/excalidraw/components/ActiveConfirmDialog";
+
+import { useSetAtom } from "@excalidraw/excalidraw/editor-jotai";
+
 import type { Theme } from "@excalidraw/element/types";
 
 import { LanguageList } from "../app-language/LanguageList";
@@ -24,6 +30,8 @@ export const AppMainMenu: React.FC<{
   setTheme: (theme: Theme | "system") => void;
   refresh: () => void;
 }> = React.memo((props) => {
+  const { t } = useI18n();
+  const setActiveConfirmDialog = useSetAtom(activeConfirmDialogAtom);
   return (
     <MainMenu>
       <MainMenu.DefaultItems.LoadScene />
@@ -44,10 +52,10 @@ export const AppMainMenu: React.FC<{
         <MainMenu.Item
           icon={TrashIcon}
           className="highlighted"
-          title="Removes elements marked as deleted to reduce file size"
-          onSelect={() => alert("Purge deleted items")}
+          title={t("labels.purgeDeletedItemsTooltip")}
+          onSelect={() => setActiveConfirmDialog("purgeDeletedElements")}
         >
-          Purge deleted items
+          {t("buttons.purgeDeletedItems")}
         </MainMenu.Item>
       )}
       <MainMenu.Separator />

--- a/excalidraw-app/components/AppMainMenu.tsx
+++ b/excalidraw-app/components/AppMainMenu.tsx
@@ -2,6 +2,7 @@ import {
   loginIcon,
   ExcalLogo,
   eyeIcon,
+  TrashIcon,
 } from "@excalidraw/excalidraw/components/icons";
 import { MainMenu } from "@excalidraw/excalidraw/index";
 import React from "react";
@@ -39,6 +40,16 @@ export const AppMainMenu: React.FC<{
       <MainMenu.DefaultItems.SearchMenu />
       <MainMenu.DefaultItems.Help />
       <MainMenu.DefaultItems.ClearCanvas />
+      {!props.isCollaborating && (
+        <MainMenu.Item
+          icon={TrashIcon}
+          className="highlighted"
+          title="Removes elements marked as deleted to reduce file size"
+          onSelect={() => alert("Purge deleted items")}
+        >
+          Purge deleted items
+        </MainMenu.Item>
+      )}
       <MainMenu.Separator />
       <MainMenu.ItemLink
         icon={ExcalLogo}

--- a/packages/excalidraw/actions/actionCanvas.tsx
+++ b/packages/excalidraw/actions/actionCanvas.tsx
@@ -602,3 +602,20 @@ export const actionToggleHandTool = register({
   keyTest: (event) =>
     !event.altKey && !event[KEYS.CTRL_OR_CMD] && event.key === KEYS.H,
 });
+
+export const actionPurgeDeletedElements = register({
+  name: "purgeDeletedElements",
+  label: "buttons.purgeDeletedItems",
+  trackEvent: { category: "canvas" },
+  perform: (elements, appState) => {
+    return {
+      elements: elements.filter((element) => !element.isDeleted),
+      appState: {
+        ...appState,
+        selectedElementIds: {},
+        selectedGroupIds: {},
+      },
+      captureUpdate: CaptureUpdateAction.NEVER,
+    };
+  },
+});

--- a/packages/excalidraw/actions/index.ts
+++ b/packages/excalidraw/actions/index.ts
@@ -29,6 +29,7 @@ export {
   actionResetZoom,
   actionZoomToFit,
   actionToggleTheme,
+  actionPurgeDeletedElements,
 } from "./actionCanvas";
 
 export { actionSetEmbeddableAsActiveTool } from "./actionEmbeddable";

--- a/packages/excalidraw/actions/types.ts
+++ b/packages/excalidraw/actions/types.ts
@@ -145,7 +145,8 @@ export type ActionName =
   | "wrapSelectionInFrame"
   | "toggleLassoTool"
   | "toggleShapeSwitch"
-  | "togglePolygon";
+  | "togglePolygon"
+  | "purgeDeletedElements";
 
 export type PanelComponentProps = {
   elements: readonly ExcalidrawElement[];

--- a/packages/excalidraw/components/ActiveConfirmDialog.tsx
+++ b/packages/excalidraw/components/ActiveConfirmDialog.tsx
@@ -40,15 +40,10 @@ export const ActiveConfirmDialog = () => {
           setActiveConfirmDialog(null);
         }}
         onCancel={() => setActiveConfirmDialog(null)}
-        title="Purge deleted items"
-        confirmText="Purge"
+        title={t("purgeDeletedItemsDialog.title")}
+        confirmText={t("purgeDeletedItemsDialog.confirm")}
       >
-        <p>
-          This will permanently remove all deleted elements from the file.
-          <br />
-          <br />
-          <strong>This action cannot be undone:</strong> your undo/redo history will be cleared.
-        </p>
+        <p>{t("purgeDeletedItemsDialog.description")}</p>
       </ConfirmDialog>
     );
   }

--- a/packages/excalidraw/components/ActiveConfirmDialog.tsx
+++ b/packages/excalidraw/components/ActiveConfirmDialog.tsx
@@ -1,11 +1,11 @@
-import { actionClearCanvas } from "../actions";
+import { actionClearCanvas, actionPurgeDeletedElements } from "../actions";
 import { atom, useAtom } from "../editor-jotai";
 import { t } from "../i18n";
 
 import { useExcalidrawActionManager } from "./App";
 import ConfirmDialog from "./ConfirmDialog";
 
-export const activeConfirmDialogAtom = atom<"clearCanvas" | null>(null);
+export const activeConfirmDialogAtom = atom<"clearCanvas" | "purgeDeletedElements" | null>(null);
 
 export const ActiveConfirmDialog = () => {
   const [activeConfirmDialog, setActiveConfirmDialog] = useAtom(
@@ -28,6 +28,27 @@ export const ActiveConfirmDialog = () => {
         title={t("clearCanvasDialog.title")}
       >
         <p className="clear-canvas__content"> {t("alerts.clearReset")}</p>
+      </ConfirmDialog>
+    );
+  }
+
+  if (activeConfirmDialog === "purgeDeletedElements") {
+    return (
+      <ConfirmDialog
+        onConfirm={() => {
+          actionManager.executeAction(actionPurgeDeletedElements);
+          setActiveConfirmDialog(null);
+        }}
+        onCancel={() => setActiveConfirmDialog(null)}
+        title="Purge deleted items"
+        confirmText="Purge"
+      >
+        <p>
+          This will permanently remove all deleted elements from the file.
+          <br />
+          <br />
+          <strong>This action cannot be undone:</strong> your undo/redo history will be cleared.
+        </p>
       </ConfirmDialog>
     );
   }

--- a/packages/excalidraw/locales/en.json
+++ b/packages/excalidraw/locales/en.json
@@ -94,6 +94,7 @@
     "canvasBackground": "Canvas background",
     "drawingCanvas": "Drawing canvas",
     "clearCanvas": "Clear canvas",
+    "purgeDeletedItemsTooltip": "Removes elements marked as deleted to reduce file size",
     "layers": "Layers",
     "actions": "Actions",
     "language": "Language",
@@ -218,6 +219,7 @@
   },
   "buttons": {
     "clearReset": "Reset the canvas",
+    "purgeDeletedItems": "Purge deleted items",
     "exportJSON": "Export to file",
     "exportImage": "Export image...",
     "export": "Save to...",
@@ -463,6 +465,11 @@
   },
   "clearCanvasDialog": {
     "title": "Clear canvas"
+  },
+  "purgeDeletedItemsDialog": {
+    "title": "Purge deleted items",
+    "description": "This will permanently remove all deleted elements from the file. This action cannot be undone: your undo/redo history will be cleared.",
+    "confirm": "Purge"
   },
   "publishDialog": {
     "title": "Publish library",


### PR DESCRIPTION
Closes #11120 

### What

Adds a new "Purge deleted items" action to the main menu that permanently removes all soft-deleted elements from the scene file.

### Why

Excalidraw never physically removes elements when the user deletes them. They are kept in the file with `isDeleted: true` to support undo/redo and live collaboration sync. Over time, this causes files to grow significantly, degrading load and save performance. There was previously no way to clean this up short of manually editing the JSON or starting from scratch.

### Changes

- **`excalidraw-app/components/AppMainMenu.tsx`**: new menu item "Purge deleted items", using the same trash icon and highlighted style as "Command palette" and "Sign up". The item is hidden when a live collaboration session is active, since purging in that context could cause inconsistencies for other participants.
- **`packages/excalidraw/actions/actionCanvas.tsx`**: new `actionPurgeDeletedElements` action that filters out all `isDeleted` elements and returns `CaptureUpdateAction.NEVER` to clear the undo/redo history, consistent with the warning shown to the user.
- **`packages/excalidraw/actions/types.ts`**: `purgeDeletedElements` added to the `ActionName` union.
- **`packages/excalidraw/actions/index.ts`**: new action exported.
- **`packages/excalidraw/components/ActiveConfirmDialog.tsx`**: new confirmation dialog case warning the user that the action is irreversible and will clear undo/redo history.
- **`packages/excalidraw/locales/en.json`**: new i18n keys for the menu item, tooltip, and confirmation dialog.