### PR TITLE
fix: matchHostname always checked ALLOWED_DOMAINS instead of the passed-in Set

### DIFF
--- a/packages/element/src/embeddable.ts
+++ b/packages/element/src/embeddable.ts
@@ -447,7 +447,7 @@ const matchHostname = (
     const bareDomain = hostname.replace(/^www\./, "");
 
     if (allowedHostnames instanceof Set) {
-      if (ALLOWED_DOMAINS.has(bareDomain)) {
+      if (allowedHostnames.has(bareDomain)) {
         return bareDomain;
       }
 
@@ -455,7 +455,7 @@ const matchHostname = (
         /^([^.]+)/,
         "*",
       );
-      if (ALLOWED_DOMAINS.has(bareDomainWithFirstSubdomainWildcarded)) {
+      if (allowedHostnames.has(bareDomainWithFirstSubdomainWildcarded)) {
         return bareDomainWithFirstSubdomainWildcarded;
       }
       return null;


### PR DESCRIPTION
Fixes #11130

## What's the bug?

`matchHostname(url, allowedHostnames)` accepts a `Set<string>` or a `string` as its second argument. When a `Set` is passed, the implementation was querying the module-level `ALLOWED_DOMAINS` constant instead of the provided `allowedHostnames` set — completely ignoring the caller's intent.

```typescript
// before (buggy)
if (allowedHostnames instanceof Set) {
  if (ALLOWED_DOMAINS.has(bareDomain)) { // wrong Set!
    return bareDomain;
  }
  if (ALLOWED_DOMAINS.has(bareDomainWithFirstSubdomainWildcarded)) { // wrong Set!
    return bareDomainWithFirstSubdomainWildcarded;
  }
```

The main visible consequence is in `getEmbedLink`, which calls
`matchHostname(link, ALLOW_SAME_ORIGIN)` to determine the `allowSameOrigin`
iframe sandbox flag. Any domain present in `ALLOW_SAME_ORIGIN` but missing
from `ALLOWED_DOMAINS` would silently get `allowSameOrigin: false`. The two
sets happen to overlap almost entirely today, which is why this hasn't caused
an obvious regression — but the contract is broken and will bite us whenever
the two sets diverge.

## Fix

Two-line change: replace both `ALLOWED_DOMAINS.has(…)` calls inside the
`instanceof Set` branch with `allowedHostnames.has(…)`:

```diff
-      if (ALLOWED_DOMAINS.has(bareDomain)) {
+      if (allowedHostnames.has(bareDomain)) {
         return bareDomain;
       }
       ...
-      if (ALLOWED_DOMAINS.has(bareDomainWithFirstSubdomainWildcarded)) {
+      if (allowedHostnames.has(bareDomainWithFirstSubdomainWildcarded)) {
```

No behaviour change for the current default configuration (all same-origin
domains are also in the allowed domains list), but the function now correctly
uses whichever set is passed in.