### PR TITLE
Add remote project workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,30 @@ yarn add react react-dom @excalidraw/excalidraw
 
 Check out our [documentation](https://docs.excalidraw.com/docs/@excalidraw/excalidraw/installation) for more details!
 
+## Remote Projects Development
+
+This fork also includes a file-system-backed remote projects flow for the app layer.
+
+By default, local development stores remote-project data in `data/projects` under the workspace root.
+
+You can override that location by setting `EXCALIDRAW_PROJECTS_ROOT` before starting the app:
+
+```bash
+cd /Users/staky/workspace/excalidraw
+EXCALIDRAW_PROJECTS_ROOT=/tmp/excalidraw-projects COREPACK_HOME=/tmp/corepack corepack yarn start
+```
+
+The Vite dev server will expose:
+
+- `GET /api/projects`
+- `POST /api/projects`
+- `GET /api/projects/:projectId/files`
+- `POST /api/projects/:projectId/files`
+- `GET /api/projects/:projectId/files/:fileId`
+- `PUT /api/projects/:projectId/files/:fileId`
+
+Each project is a directory under `EXCALIDRAW_PROJECTS_ROOT`, and each file is persisted as a `.excalidraw` JSON file inside that directory.
+
 ## Contributing
 
 - Missing something or found a bug? [Report here](https://github.com/excalidraw/excalidraw/issues).

--- a/docs/superpowers/plans/2026-04-09-remote-projects.md
+++ b/docs/superpowers/plans/2026-04-09-remote-projects.md
@@ -1,0 +1,1195 @@
+# Remote Projects Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a file-system-backed remote projects workflow to the Excalidraw app so users can create projects, create files inside projects, open remote `.excalidraw` files, and save edits back through HTTP APIs.
+
+**Architecture:** Keep the feature in `excalidraw-app` and add a small HTTP server layer that maps logical project/file resources onto directories and `.excalidraw` files under `EXCALIDRAW_PROJECTS_ROOT`. Reuse existing Excalidraw scene serialization and restoration utilities instead of changing the editor core.
+
+**Tech Stack:** React 19, TypeScript, Vite app, existing Excalidraw data utilities, Node HTTP server support in the repo, Vitest
+
+---
+
+### Task 1: Add remote-project domain types and API client
+
+**Files:**
+- Create: `excalidraw-app/remote-projects/types.ts`
+- Create: `excalidraw-app/remote-projects/api.ts`
+- Test: `excalidraw-app/tests/remote-projects.api.test.ts`
+
+- [ ] **Step 1: Write the failing API client test**
+
+```ts
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+
+import {
+  createProject,
+  createProjectFile,
+  getProjectFile,
+  listProjectFiles,
+  listProjects,
+  saveProjectFile,
+} from "../remote-projects/api";
+
+describe("remote-projects api", () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    globalThis.fetch = vi.fn();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("lists projects from the resource endpoint", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          projects: [{ id: "demo-project", name: "demo-project" }],
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+
+    await expect(listProjects()).resolves.toEqual([
+      { id: "demo-project", name: "demo-project" },
+    ]);
+    expect(globalThis.fetch).toHaveBeenCalledWith("/api/projects", {
+      method: "GET",
+      headers: { Accept: "application/json" },
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `yarn vitest excalidraw-app/tests/remote-projects.api.test.ts --run`
+
+Expected: FAIL with module-not-found or missing export errors for `../remote-projects/api`
+
+- [ ] **Step 3: Write minimal shared types**
+
+```ts
+export type RemoteProject = {
+  id: string;
+  name: string;
+  createdAt?: string;
+  updatedAt?: string;
+};
+
+export type RemoteProjectFile = {
+  id: string;
+  projectId: string;
+  name: string;
+  createdAt?: string;
+  updatedAt?: string;
+};
+
+export type RemoteProjectScene = {
+  elements: readonly unknown[];
+  appState: Record<string, unknown>;
+  files: Record<string, unknown>;
+};
+```
+
+- [ ] **Step 4: Write minimal API client**
+
+```ts
+import type {
+  RemoteProject,
+  RemoteProjectFile,
+  RemoteProjectScene,
+} from "./types";
+
+const jsonHeaders = {
+  Accept: "application/json",
+  "Content-Type": "application/json",
+};
+
+const readJson = async <T>(response: Response): Promise<T> => {
+  if (!response.ok) {
+    throw new Error(`Remote projects request failed: ${response.status}`);
+  }
+  return response.json() as Promise<T>;
+};
+
+export const listProjects = async (): Promise<RemoteProject[]> => {
+  const response = await fetch("/api/projects", {
+    method: "GET",
+    headers: { Accept: "application/json" },
+  });
+  const data = await readJson<{ projects: RemoteProject[] }>(response);
+  return data.projects;
+};
+
+export const createProject = async (name: string): Promise<RemoteProject> => {
+  const response = await fetch("/api/projects", {
+    method: "POST",
+    headers: jsonHeaders,
+    body: JSON.stringify({ name }),
+  });
+  const data = await readJson<{ project: RemoteProject }>(response);
+  return data.project;
+};
+
+export const listProjectFiles = async (
+  projectId: string,
+): Promise<RemoteProjectFile[]> => {
+  const response = await fetch(`/api/projects/${projectId}/files`, {
+    method: "GET",
+    headers: { Accept: "application/json" },
+  });
+  const data = await readJson<{ files: RemoteProjectFile[] }>(response);
+  return data.files;
+};
+
+export const createProjectFile = async (
+  projectId: string,
+  name: string,
+): Promise<RemoteProjectFile> => {
+  const response = await fetch(`/api/projects/${projectId}/files`, {
+    method: "POST",
+    headers: jsonHeaders,
+    body: JSON.stringify({ name }),
+  });
+  const data = await readJson<{ file: RemoteProjectFile }>(response);
+  return data.file;
+};
+
+export const getProjectFile = async (
+  projectId: string,
+  fileId: string,
+): Promise<{ file: RemoteProjectFile; scene: RemoteProjectScene }> => {
+  const response = await fetch(`/api/projects/${projectId}/files/${fileId}`, {
+    method: "GET",
+    headers: { Accept: "application/json" },
+  });
+  return readJson<{ file: RemoteProjectFile; scene: RemoteProjectScene }>(
+    response,
+  );
+};
+
+export const saveProjectFile = async (
+  projectId: string,
+  fileId: string,
+  scene: RemoteProjectScene,
+): Promise<RemoteProjectFile> => {
+  const response = await fetch(`/api/projects/${projectId}/files/${fileId}`, {
+    method: "PUT",
+    headers: jsonHeaders,
+    body: JSON.stringify({ scene }),
+  });
+  const data = await readJson<{ file: RemoteProjectFile }>(response);
+  return data.file;
+};
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `yarn vitest excalidraw-app/tests/remote-projects.api.test.ts --run`
+
+Expected: PASS
+
+- [ ] **Step 6: Expand the test to cover create/list/read/save operations**
+
+```ts
+it("creates and saves project files through resource endpoints", async () => {
+  vi.mocked(globalThis.fetch)
+    .mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({ project: { id: "demo", name: "demo" } }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    )
+    .mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          file: { id: "homepage", projectId: "demo", name: "homepage.excalidraw" },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    )
+    .mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          file: { id: "homepage", projectId: "demo", name: "homepage.excalidraw" },
+          scene: { elements: [], appState: {}, files: {} },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    )
+    .mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          file: {
+            id: "homepage",
+            projectId: "demo",
+            name: "homepage.excalidraw",
+            updatedAt: "2026-04-09T09:15:00.000Z",
+          },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+
+  await expect(createProject("demo")).resolves.toEqual({
+    id: "demo",
+    name: "demo",
+  });
+
+  await expect(createProjectFile("demo", "homepage")).resolves.toEqual({
+    id: "homepage",
+    projectId: "demo",
+    name: "homepage.excalidraw",
+  });
+
+  await expect(getProjectFile("demo", "homepage")).resolves.toEqual({
+    file: {
+      id: "homepage",
+      projectId: "demo",
+      name: "homepage.excalidraw",
+    },
+    scene: { elements: [], appState: {}, files: {} },
+  });
+
+  await expect(
+    saveProjectFile("demo", "homepage", {
+      elements: [],
+      appState: {},
+      files: {},
+    }),
+  ).resolves.toEqual({
+    id: "homepage",
+    projectId: "demo",
+    name: "homepage.excalidraw",
+    updatedAt: "2026-04-09T09:15:00.000Z",
+  });
+});
+```
+
+- [ ] **Step 7: Run the API client test suite again**
+
+Run: `yarn vitest excalidraw-app/tests/remote-projects.api.test.ts --run`
+
+Expected: PASS
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add excalidraw-app/remote-projects/types.ts excalidraw-app/remote-projects/api.ts excalidraw-app/tests/remote-projects.api.test.ts
+git commit -m "feat: add remote project api client"
+```
+
+### Task 2: Add lightweight project-navigation state
+
+**Files:**
+- Create: `excalidraw-app/remote-projects/store.ts`
+- Modify: `excalidraw-app/app-jotai.ts`
+- Test: `excalidraw-app/tests/remote-projects.store.test.ts`
+
+- [ ] **Step 1: Write the failing store test**
+
+```ts
+import { describe, expect, it } from "vitest";
+
+import {
+  getRemoteProjectRouteState,
+  isRemoteProjectFileRoute,
+} from "../remote-projects/store";
+
+describe("remote project route state", () => {
+  it("parses a file route", () => {
+    expect(
+      getRemoteProjectRouteState("/projects/demo/files/homepage"),
+    ).toEqual({
+      mode: "file",
+      projectId: "demo",
+      fileId: "homepage",
+    });
+    expect(isRemoteProjectFileRoute("/projects/demo/files/homepage")).toBe(
+      true,
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `yarn vitest excalidraw-app/tests/remote-projects.store.test.ts --run`
+
+Expected: FAIL with module-not-found or missing export errors for `../remote-projects/store`
+
+- [ ] **Step 3: Write minimal route-state helpers**
+
+```ts
+export type RemoteProjectRouteState =
+  | { mode: "projects" }
+  | { mode: "project"; projectId: string }
+  | { mode: "file"; projectId: string; fileId: string }
+  | { mode: "editor" };
+
+export const getRemoteProjectRouteState = (
+  pathname: string,
+): RemoteProjectRouteState => {
+  const fileMatch = pathname.match(/^\/projects\/([^/]+)\/files\/([^/]+)$/);
+  if (fileMatch) {
+    return {
+      mode: "file",
+      projectId: decodeURIComponent(fileMatch[1]),
+      fileId: decodeURIComponent(fileMatch[2]),
+    };
+  }
+
+  const projectMatch = pathname.match(/^\/projects\/([^/]+)$/);
+  if (projectMatch) {
+    return {
+      mode: "project",
+      projectId: decodeURIComponent(projectMatch[1]),
+    };
+  }
+
+  if (pathname === "/projects") {
+    return { mode: "projects" };
+  }
+
+  return { mode: "editor" };
+};
+
+export const isRemoteProjectFileRoute = (pathname: string) =>
+  getRemoteProjectRouteState(pathname).mode === "file";
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `yarn vitest excalidraw-app/tests/remote-projects.store.test.ts --run`
+
+Expected: PASS
+
+- [ ] **Step 5: Extend the store helpers to support navigation helpers**
+
+```ts
+export const getProjectsPath = () => "/projects";
+
+export const getProjectPath = (projectId: string) =>
+  `/projects/${encodeURIComponent(projectId)}`;
+
+export const getProjectFilePath = (projectId: string, fileId: string) =>
+  `/projects/${encodeURIComponent(projectId)}/files/${encodeURIComponent(fileId)}`;
+```
+
+- [ ] **Step 6: Add a navigation helper test**
+
+```ts
+it("creates stable navigation paths", () => {
+  expect(getProjectsPath()).toBe("/projects");
+  expect(getProjectPath("demo")).toBe("/projects/demo");
+  expect(getProjectFilePath("demo", "homepage")).toBe(
+    "/projects/demo/files/homepage",
+  );
+});
+```
+
+- [ ] **Step 7: Run the store test suite again**
+
+Run: `yarn vitest excalidraw-app/tests/remote-projects.store.test.ts --run`
+
+Expected: PASS
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add excalidraw-app/remote-projects/store.ts excalidraw-app/app-jotai.ts excalidraw-app/tests/remote-projects.store.test.ts
+git commit -m "feat: add remote project route helpers"
+```
+
+### Task 3: Add projects list and project file list UI
+
+**Files:**
+- Create: `excalidraw-app/components/Projects/ProjectsPage.tsx`
+- Create: `excalidraw-app/components/Projects/ProjectFilesPage.tsx`
+- Create: `excalidraw-app/components/Projects/Projects.scss`
+- Modify: `excalidraw-app/components/AppWelcomeScreen.tsx`
+- Test: `excalidraw-app/tests/ProjectsPage.test.tsx`
+
+- [ ] **Step 1: Write the failing UI test for the projects page**
+
+```tsx
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { ProjectsPage } from "../components/Projects/ProjectsPage";
+
+describe("ProjectsPage", () => {
+  it("renders projects and forwards create-project actions", async () => {
+    const user = userEvent.setup();
+    const onCreateProject = vi.fn();
+    const onOpenProject = vi.fn();
+
+    render(
+      <ProjectsPage
+        projects={[{ id: "demo", name: "demo" }]}
+        isLoading={false}
+        errorMessage={null}
+        onCreateProject={onCreateProject}
+        onOpenProject={onOpenProject}
+      />,
+    );
+
+    await user.click(screen.getByText("demo"));
+    expect(onOpenProject).toHaveBeenCalledWith("demo");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `yarn vitest excalidraw-app/tests/ProjectsPage.test.tsx --run`
+
+Expected: FAIL with module-not-found or missing component errors
+
+- [ ] **Step 3: Write minimal projects and files page components**
+
+```tsx
+import React from "react";
+
+import type { RemoteProject, RemoteProjectFile } from "../../remote-projects/types";
+
+export const ProjectsPage: React.FC<{
+  projects: RemoteProject[];
+  isLoading: boolean;
+  errorMessage: string | null;
+  onCreateProject: (name: string) => void;
+  onOpenProject: (projectId: string) => void;
+}> = ({ projects, isLoading, errorMessage, onCreateProject, onOpenProject }) => {
+  return (
+    <section className="remote-projects-page">
+      <h1>Projects</h1>
+      {errorMessage ? <p>{errorMessage}</p> : null}
+      {isLoading ? <p>Loading...</p> : null}
+      <button onClick={() => onCreateProject("Untitled Project")}>
+        New project
+      </button>
+      <ul>
+        {projects.map((project) => (
+          <li key={project.id}>
+            <button onClick={() => onOpenProject(project.id)}>{project.name}</button>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+};
+
+export const ProjectFilesPage: React.FC<{
+  projectName: string;
+  files: RemoteProjectFile[];
+  isLoading: boolean;
+  errorMessage: string | null;
+  onCreateFile: (name: string) => void;
+  onOpenFile: (fileId: string) => void;
+}> = ({ projectName, files, isLoading, errorMessage, onCreateFile, onOpenFile }) => {
+  return (
+    <section className="remote-projects-page">
+      <h1>{projectName}</h1>
+      {errorMessage ? <p>{errorMessage}</p> : null}
+      {isLoading ? <p>Loading...</p> : null}
+      <button onClick={() => onCreateFile("Untitled")}>New file</button>
+      <ul>
+        {files.map((file) => (
+          <li key={file.id}>
+            <button onClick={() => onOpenFile(file.id)}>{file.name}</button>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+};
+```
+
+- [ ] **Step 4: Add a welcome-screen entry point**
+
+```tsx
+<WelcomeScreen.Center.MenuItemLink
+  href="/projects"
+  shortcut={null}
+>
+  Projects
+</WelcomeScreen.Center.MenuItemLink>
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `yarn vitest excalidraw-app/tests/ProjectsPage.test.tsx --run`
+
+Expected: PASS
+
+- [ ] **Step 6: Add a failing test for the files page**
+
+```tsx
+it("renders project files and forwards open-file actions", async () => {
+  const user = userEvent.setup();
+  const onOpenFile = vi.fn();
+
+  render(
+    <ProjectFilesPage
+      projectName="demo"
+      files={[{ id: "homepage", projectId: "demo", name: "homepage.excalidraw" }]}
+      isLoading={false}
+      errorMessage={null}
+      onCreateFile={() => {}}
+      onOpenFile={onOpenFile}
+    />,
+  );
+
+  await user.click(screen.getByText("homepage.excalidraw"));
+  expect(onOpenFile).toHaveBeenCalledWith("homepage");
+});
+```
+
+- [ ] **Step 7: Run the page test suite again**
+
+Run: `yarn vitest excalidraw-app/tests/ProjectsPage.test.tsx --run`
+
+Expected: PASS
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add excalidraw-app/components/Projects/ProjectsPage.tsx excalidraw-app/components/Projects/ProjectFilesPage.tsx excalidraw-app/components/Projects/Projects.scss excalidraw-app/components/AppWelcomeScreen.tsx excalidraw-app/tests/ProjectsPage.test.tsx
+git commit -m "feat: add remote project navigation screens"
+```
+
+### Task 4: Route between projects pages and editor mode in the app
+
+**Files:**
+- Modify: `excalidraw-app/App.tsx`
+- Modify: `excalidraw-app/index.scss`
+- Test: `excalidraw-app/tests/remote-projects.routing.test.tsx`
+
+- [ ] **Step 1: Write the failing routing test**
+
+```tsx
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../remote-projects/store", () => ({
+  getRemoteProjectRouteState: () => ({ mode: "projects" }),
+}));
+
+vi.mock("../components/Projects/ProjectsPage", () => ({
+  ProjectsPage: () => <div>Projects Page</div>,
+}));
+
+import App from "../App";
+
+describe("remote project routing", () => {
+  it("renders the projects page for the projects route", async () => {
+    render(<App />);
+    expect(await screen.findByText("Projects Page")).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `yarn vitest excalidraw-app/tests/remote-projects.routing.test.tsx --run`
+
+Expected: FAIL because `App` does not branch on remote project routes
+
+- [ ] **Step 3: Add route branching in `App.tsx`**
+
+```tsx
+const routeState = getRemoteProjectRouteState(window.location.pathname);
+
+if (routeState.mode === "projects") {
+  return (
+    <ProjectsPage
+      projects={projects}
+      isLoading={isProjectsLoading}
+      errorMessage={projectsError}
+      onCreateProject={handleCreateProject}
+      onOpenProject={(projectId) => {
+        window.history.pushState({}, "", getProjectPath(projectId));
+        rerenderRoute();
+      }}
+    />
+  );
+}
+
+if (routeState.mode === "project") {
+  return (
+    <ProjectFilesPage
+      projectName={currentProjectName}
+      files={projectFiles}
+      isLoading={isProjectFilesLoading}
+      errorMessage={projectFilesError}
+      onCreateFile={handleCreateFile}
+      onOpenFile={(fileId) => {
+        window.history.pushState(
+          {},
+          "",
+          getProjectFilePath(routeState.projectId, fileId),
+        );
+        rerenderRoute();
+      }}
+    />
+  );
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `yarn vitest excalidraw-app/tests/remote-projects.routing.test.tsx --run`
+
+Expected: PASS
+
+- [ ] **Step 5: Add a test for the project-files route**
+
+```tsx
+vi.mock("../remote-projects/store", () => ({
+  getRemoteProjectRouteState: () => ({ mode: "project", projectId: "demo" }),
+}));
+
+vi.mock("../components/Projects/ProjectFilesPage", () => ({
+  ProjectFilesPage: () => <div>Project Files Page</div>,
+}));
+
+it("renders the project files page for a project route", async () => {
+  render(<App />);
+  expect(await screen.findByText("Project Files Page")).toBeInTheDocument();
+});
+```
+
+- [ ] **Step 6: Run the routing test suite again**
+
+Run: `yarn vitest excalidraw-app/tests/remote-projects.routing.test.tsx --run`
+
+Expected: PASS
+
+- [ ] **Step 7: Refine styles so route pages feel native to the app**
+
+```scss
+.remote-projects-page {
+  margin: 0 auto;
+  max-width: 56rem;
+  padding: 2rem 1.5rem 4rem;
+}
+```
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add excalidraw-app/App.tsx excalidraw-app/index.scss excalidraw-app/tests/remote-projects.routing.test.tsx
+git commit -m "feat: route app through remote project screens"
+```
+
+### Task 5: Load remote file data into the editor
+
+**Files:**
+- Modify: `excalidraw-app/App.tsx`
+- Modify: `excalidraw-app/remote-projects/api.ts`
+- Test: `excalidraw-app/tests/remote-projects.load-file.test.tsx`
+
+- [ ] **Step 1: Write the failing remote-file load test**
+
+```tsx
+import { render, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../remote-projects/store", () => ({
+  getRemoteProjectRouteState: () => ({
+    mode: "file",
+    projectId: "demo",
+    fileId: "homepage",
+  }),
+}));
+
+const getProjectFile = vi.fn().mockResolvedValue({
+  file: { id: "homepage", projectId: "demo", name: "homepage.excalidraw" },
+  scene: { elements: [], appState: {}, files: {} },
+});
+
+vi.mock("../remote-projects/api", () => ({
+  getProjectFile,
+}));
+
+import App from "../App";
+
+describe("remote project file loading", () => {
+  it("loads a remote file before opening the editor", async () => {
+    render(<App />);
+    await waitFor(() => {
+      expect(getProjectFile).toHaveBeenCalledWith("demo", "homepage");
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `yarn vitest excalidraw-app/tests/remote-projects.load-file.test.tsx --run`
+
+Expected: FAIL because remote file loading is not wired to route initialization
+
+- [ ] **Step 3: Add remote-file initialization path**
+
+```ts
+if (routeState.mode === "file") {
+  const remote = await getProjectFile(routeState.projectId, routeState.fileId);
+  return {
+    scene: {
+      elements: restoreElements(remote.scene.elements as any, null, {
+        repairBindings: true,
+        deleteInvisibleElements: true,
+      }),
+      appState: restoreAppState(
+        remote.scene.appState as any,
+        localDataState?.appState,
+      ),
+      files: remote.scene.files as any,
+      scrollToContent: true,
+    },
+    isExternalScene: false,
+  };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `yarn vitest excalidraw-app/tests/remote-projects.load-file.test.tsx --run`
+
+Expected: PASS
+
+- [ ] **Step 5: Add a failure-state test**
+
+```tsx
+it("surfaces a load failure for a missing remote file", async () => {
+  getProjectFile.mockRejectedValueOnce(new Error("404"));
+  render(<App />);
+  await waitFor(() => {
+    expect(getProjectFile).toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 6: Add minimal load-failure UI wiring**
+
+```ts
+catch (error) {
+  return {
+    scene: {
+      appState: {
+        errorMessage: t("alerts.importBackendFailed"),
+      },
+    },
+    isExternalScene: false,
+  };
+}
+```
+
+- [ ] **Step 7: Run the remote-file load test suite again**
+
+Run: `yarn vitest excalidraw-app/tests/remote-projects.load-file.test.tsx --run`
+
+Expected: PASS
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add excalidraw-app/App.tsx excalidraw-app/remote-projects/api.ts excalidraw-app/tests/remote-projects.load-file.test.tsx
+git commit -m "feat: load remote project files into editor"
+```
+
+### Task 6: Save editor changes back to the remote file API
+
+**Files:**
+- Modify: `excalidraw-app/App.tsx`
+- Modify: `excalidraw-app/remote-projects/types.ts`
+- Test: `excalidraw-app/tests/remote-projects.save-file.test.tsx`
+
+- [ ] **Step 1: Write the failing remote-save test**
+
+```tsx
+import { render, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+const saveProjectFile = vi.fn().mockResolvedValue({
+  id: "homepage",
+  projectId: "demo",
+  name: "homepage.excalidraw",
+});
+
+vi.mock("../remote-projects/api", () => ({
+  getProjectFile: vi.fn().mockResolvedValue({
+    file: { id: "homepage", projectId: "demo", name: "homepage.excalidraw" },
+    scene: { elements: [], appState: {}, files: {} },
+  }),
+  saveProjectFile,
+}));
+
+describe("remote project file save", () => {
+  it("saves editor scene changes to the remote file endpoint", async () => {
+    render(<App />);
+    await waitFor(() => {
+      expect(saveProjectFile).toHaveBeenCalled();
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `yarn vitest excalidraw-app/tests/remote-projects.save-file.test.tsx --run`
+
+Expected: FAIL because editor updates are not persisted through `saveProjectFile`
+
+- [ ] **Step 3: Add a minimal remote-save bridge**
+
+```ts
+const saveRemoteProjectScene = async (
+  projectId: string,
+  fileId: string,
+  elements: readonly OrderedExcalidrawElement[],
+  appState: AppState,
+  files: BinaryFiles,
+) => {
+  await saveProjectFile(projectId, fileId, {
+    elements,
+    appState,
+    files,
+  });
+};
+```
+
+- [ ] **Step 4: Wire the bridge into editor updates for remote file routes**
+
+```ts
+if (routeState.mode === "file") {
+  void saveRemoteProjectScene(
+    routeState.projectId,
+    routeState.fileId,
+    elements,
+    appState,
+    files,
+  ).catch((error) => {
+    console.error(error);
+    excalidrawAPI.setToast({
+      message: "Failed to save remote file",
+      duration: 4000,
+      closable: true,
+    });
+  });
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `yarn vitest excalidraw-app/tests/remote-projects.save-file.test.tsx --run`
+
+Expected: PASS
+
+- [ ] **Step 6: Add a failure-path test**
+
+```tsx
+it("keeps the editor open when a remote save fails", async () => {
+  saveProjectFile.mockRejectedValueOnce(new Error("save failed"));
+  render(<App />);
+  await waitFor(() => {
+    expect(saveProjectFile).toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 7: Run the remote-save test suite again**
+
+Run: `yarn vitest excalidraw-app/tests/remote-projects.save-file.test.tsx --run`
+
+Expected: PASS
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add excalidraw-app/App.tsx excalidraw-app/remote-projects/types.ts excalidraw-app/tests/remote-projects.save-file.test.tsx
+git commit -m "feat: save remote project files"
+```
+
+### Task 7: Add Node HTTP handlers for file-system-backed project storage
+
+**Files:**
+- Create: `excalidraw-app/server/projects.ts`
+- Create: `excalidraw-app/server/projects.test.ts`
+- Modify: `excalidraw-app/package.json`
+- Modify: `excalidraw-app/vite.config.mts`
+
+- [ ] **Step 1: Write the failing backend test**
+
+```ts
+import { describe, expect, it } from "vitest";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  createProjectDirectory,
+  createProjectSceneFile,
+  listProjectDirectories,
+  readProjectSceneFile,
+  saveProjectSceneFile,
+} from "./projects";
+
+describe("projects file-system backend", () => {
+  it("creates and persists scene files under the configured root", async () => {
+    const root = mkdtempSync(join(tmpdir(), "excalidraw-projects-"));
+
+    await createProjectDirectory(root, "demo");
+    await createProjectSceneFile(root, "demo", "homepage");
+    await saveProjectSceneFile(root, "demo", "homepage", {
+      elements: [],
+      appState: {},
+      files: {},
+    });
+
+    await expect(listProjectDirectories(root)).resolves.toEqual([
+      expect.objectContaining({ id: "demo", name: "demo" }),
+    ]);
+
+    await expect(readProjectSceneFile(root, "demo", "homepage")).resolves.toEqual(
+      expect.objectContaining({
+        file: expect.objectContaining({
+          id: "homepage",
+          name: "homepage.excalidraw",
+        }),
+      }),
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `yarn vitest excalidraw-app/server/projects.test.ts --run`
+
+Expected: FAIL with module-not-found or missing export errors
+
+- [ ] **Step 3: Write minimal file-system helpers**
+
+```ts
+import { mkdir, readdir, readFile, stat, writeFile } from "node:fs/promises";
+import { join, resolve } from "node:path";
+
+const ensureSafeSegment = (value: string) => {
+  if (!/^[A-Za-z0-9._-]+$/.test(value) || value.includes("..")) {
+    throw new Error("Invalid path segment");
+  }
+  return value;
+};
+
+const getProjectDir = (root: string, projectId: string) =>
+  join(resolve(root), ensureSafeSegment(projectId));
+
+const getSceneFilePath = (root: string, projectId: string, fileId: string) =>
+  join(getProjectDir(root, projectId), `${ensureSafeSegment(fileId)}.excalidraw`);
+
+export const createProjectDirectory = async (root: string, name: string) => {
+  await mkdir(getProjectDir(root, name));
+  return { id: name, name };
+};
+
+export const createProjectSceneFile = async (
+  root: string,
+  projectId: string,
+  fileId: string,
+) => {
+  const path = getSceneFilePath(root, projectId, fileId);
+  await writeFile(path, JSON.stringify({ elements: [], appState: {}, files: {} }));
+  return { id: fileId, projectId, name: `${fileId}.excalidraw` };
+};
+
+export const saveProjectSceneFile = async (
+  root: string,
+  projectId: string,
+  fileId: string,
+  scene: unknown,
+) => {
+  await writeFile(
+    getSceneFilePath(root, projectId, fileId),
+    JSON.stringify(scene, null, 2),
+  );
+};
+
+export const readProjectSceneFile = async (
+  root: string,
+  projectId: string,
+  fileId: string,
+) => {
+  const raw = await readFile(getSceneFilePath(root, projectId, fileId), "utf8");
+  return {
+    file: { id: fileId, projectId, name: `${fileId}.excalidraw` },
+    scene: JSON.parse(raw),
+  };
+};
+
+export const listProjectDirectories = async (root: string) => {
+  const entries = await readdir(resolve(root), { withFileTypes: true });
+  return Promise.all(
+    entries
+      .filter((entry) => entry.isDirectory())
+      .map(async (entry) => {
+        const info = await stat(join(resolve(root), entry.name));
+        return {
+          id: entry.name,
+          name: entry.name,
+          createdAt: info.birthtime.toISOString(),
+          updatedAt: info.mtime.toISOString(),
+        };
+      }),
+  );
+};
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `yarn vitest excalidraw-app/server/projects.test.ts --run`
+
+Expected: PASS
+
+- [ ] **Step 5: Add traversal-rejection and file-list tests**
+
+```ts
+it("rejects traversal in project names", async () => {
+  const root = mkdtempSync(join(tmpdir(), "excalidraw-projects-"));
+  await expect(createProjectDirectory(root, "../evil")).rejects.toThrow(
+    "Invalid path segment",
+  );
+});
+```
+
+- [ ] **Step 6: Add HTTP handler adapter functions**
+
+```ts
+export const listProjectFiles = async (root: string, projectId: string) => {
+  const dir = await readdir(getProjectDir(root, projectId), { withFileTypes: true });
+  return Promise.all(
+    dir
+      .filter((entry) => entry.isFile() && entry.name.endsWith(".excalidraw"))
+      .map(async (entry) => {
+        const info = await stat(join(getProjectDir(root, projectId), entry.name));
+        return {
+          id: entry.name.replace(/\.excalidraw$/, ""),
+          projectId,
+          name: entry.name,
+          createdAt: info.birthtime.toISOString(),
+          updatedAt: info.mtime.toISOString(),
+        };
+      }),
+  );
+};
+```
+
+- [ ] **Step 7: Run the backend test suite again**
+
+Run: `yarn vitest excalidraw-app/server/projects.test.ts --run`
+
+Expected: PASS
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add excalidraw-app/server/projects.ts excalidraw-app/server/projects.test.ts excalidraw-app/package.json excalidraw-app/vite.config.mts
+git commit -m "feat: add filesystem-backed remote projects backend"
+```
+
+### Task 8: Wire HTTP routes and verify the end-to-end MVP flow
+
+**Files:**
+- Modify: `excalidraw-app/vite.config.mts`
+- Modify: `README.md`
+- Test: `excalidraw-app/tests/remote-projects.e2e-smoke.test.tsx`
+
+- [ ] **Step 1: Write the failing MVP smoke test**
+
+```tsx
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+describe("remote projects MVP flow", () => {
+  it("creates a project, creates a file, opens it, and saves it", async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    await user.click(await screen.findByText("Projects"));
+    await waitFor(() => {
+      expect(screen.getByText("Projects")).toBeInTheDocument();
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `yarn vitest excalidraw-app/tests/remote-projects.e2e-smoke.test.tsx --run`
+
+Expected: FAIL because the full projects flow is not yet stitched together
+
+- [ ] **Step 3: Add Vite dev-server route handlers or middleware**
+
+```ts
+server: {
+  middlewareMode: false,
+},
+plugins: [
+  {
+    name: "remote-projects-api",
+    configureServer(server) {
+      server.middlewares.use("/api/projects", async (req, res) => {
+        // dispatch GET/POST and nested file routes via filesystem helpers
+      });
+    },
+  },
+],
+```
+
+- [ ] **Step 4: Add root-directory documentation**
+
+```md
+### Remote projects
+
+Set `EXCALIDRAW_PROJECTS_ROOT` before starting the app:
+
+```bash
+EXCALIDRAW_PROJECTS_ROOT=/srv/excalidraw-projects yarn start
+```
+
+This enables the file-system-backed HTTP API used by the remote projects UI.
+```
+
+- [ ] **Step 5: Run the smoke test to verify it passes**
+
+Run: `yarn vitest excalidraw-app/tests/remote-projects.e2e-smoke.test.tsx --run`
+
+Expected: PASS
+
+- [ ] **Step 6: Run targeted verification for all new remote-project tests**
+
+Run: `yarn vitest excalidraw-app/tests/remote-projects.api.test.ts excalidraw-app/tests/remote-projects.store.test.ts excalidraw-app/tests/ProjectsPage.test.tsx excalidraw-app/tests/remote-projects.routing.test.tsx excalidraw-app/tests/remote-projects.load-file.test.tsx excalidraw-app/tests/remote-projects.save-file.test.tsx excalidraw-app/server/projects.test.ts excalidraw-app/tests/remote-projects.e2e-smoke.test.tsx --run`
+
+Expected: PASS
+
+- [ ] **Step 7: Run repo-level safety checks**
+
+Run: `yarn test:typecheck`
+Expected: PASS
+
+Run: `yarn test:update`
+Expected: PASS
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add excalidraw-app/vite.config.mts README.md excalidraw-app/tests/remote-projects.e2e-smoke.test.tsx
+git commit -m "feat: complete remote projects mvp"
+```

--- a/docs/superpowers/specs/2026-04-09-remote-projects-design.md
+++ b/docs/superpowers/specs/2026-04-09-remote-projects-design.md
@@ -1,0 +1,449 @@
+# Remote Projects Design
+
+**Date:** 2026-04-09
+
+**Status:** Draft for review
+
+## Goal
+
+Add a remote-project workflow to the Excalidraw web app so users can:
+
+- view remote projects
+- create a project
+- view files inside a project
+- create a file inside a project
+- open a remote `.excalidraw` file in the editor
+- save editor changes back to the remote file
+
+This MVP intentionally treats a "project" as a server-side directory and a "file" as a server-side `.excalidraw` file managed through an HTTP API.
+
+## Scope
+
+### In scope
+
+- Add a projects entry point in the app shell
+- Add a remote projects list page
+- Add a remote project file list page
+- Add create-project flow
+- Add create-file flow
+- Add open-file flow from project file list into the editor
+- Add save-file flow from the editor back to the HTTP API
+- Add API client code in `excalidraw-app`
+- Define a file-system-backed HTTP API contract
+
+### Out of scope
+
+- Database-backed project storage
+- Nested folders inside a project
+- Permissions and auth
+- Multi-user editing conflict resolution
+- Version history
+- Trash/recycle bin
+- Project sharing
+- Migrating current collab/share-link flows to the project model
+
+## Product Model
+
+The product keeps a project/file abstraction in the frontend, while the backend maps those abstractions to directories and files on disk.
+
+### Project
+
+A project is a directory located under a backend-configured root directory.
+
+Example:
+
+```text
+$EXCALIDRAW_PROJECTS_ROOT/demo-project/
+```
+
+### File
+
+A file is a `.excalidraw` document stored inside a project directory.
+
+Example:
+
+```text
+$EXCALIDRAW_PROJECTS_ROOT/demo-project/homepage.excalidraw
+```
+
+### Backend root
+
+The backend root directory must be configured through an environment variable.
+
+Example:
+
+```bash
+EXCALIDRAW_PROJECTS_ROOT=/srv/excalidraw-projects
+```
+
+The frontend must never know or construct absolute server-side paths.
+
+## UX Flow
+
+### Main flow
+
+1. User opens the app.
+2. User enters the projects area.
+3. User creates a project or opens an existing one.
+4. User sees the `.excalidraw` files in that project.
+5. User creates a new file or opens an existing file.
+6. The app loads the file contents into the Excalidraw editor.
+7. The user edits the scene.
+8. The app saves the updated scene back to the backend using the file API.
+
+### URL model
+
+The app should add app-level routes for project navigation:
+
+- `/projects`
+- `/projects/:projectId`
+- `/projects/:projectId/files/:fileId`
+
+These routes belong in `excalidraw-app` and must not require invasive editor-core changes.
+
+## Architecture
+
+The feature should live in the application layer, not the reusable editor package.
+
+### Why this boundary
+
+`packages/excalidraw` is the editor engine and UI library. Project navigation, remote file browsing, and backend integration are app concerns already consistent with the current repository split.
+
+The implementation should therefore:
+
+- keep project navigation in `excalidraw-app`
+- keep HTTP API integration in `excalidraw-app`
+- reuse existing Excalidraw serialization and restoration utilities
+- minimize changes to `packages/excalidraw`
+
+### High-level frontend structure
+
+Recommended new modules:
+
+- `excalidraw-app/remote-projects/types.ts`
+  Shared project/file/scene metadata types for the app layer
+- `excalidraw-app/remote-projects/api.ts`
+  HTTP client for project and file operations
+- `excalidraw-app/remote-projects/store.ts`
+  Current project/file/loading/saving state
+- `excalidraw-app/components/Projects/*`
+  Projects list and project files UI
+
+Recommended integration points:
+
+- `excalidraw-app/components/AppWelcomeScreen.tsx`
+  Add a projects entry point
+- `excalidraw-app/App.tsx`
+  Route between projects pages and editor mode, load remote file initial data, handle remote saves
+
+## Data Model
+
+The frontend should use stable logical resources, not raw file-system paths.
+
+### Project shape
+
+```ts
+type Project = {
+  id: string;
+  name: string;
+  createdAt?: string;
+  updatedAt?: string;
+};
+```
+
+### Project file shape
+
+```ts
+type ProjectFile = {
+  id: string;
+  projectId: string;
+  name: string;
+  createdAt?: string;
+  updatedAt?: string;
+};
+```
+
+### Remote scene payload
+
+For the MVP, the backend should return and persist Excalidraw scene JSON directly:
+
+```ts
+type RemoteScene = {
+  elements: readonly unknown[];
+  appState: Record<string, unknown>;
+  files: Record<string, unknown>;
+};
+```
+
+The precise element and app-state typing in code should reuse existing Excalidraw types instead of redefining them.
+
+## HTTP API Contract
+
+The frontend should talk to resource-oriented endpoints instead of direct file-system verbs.
+
+### List projects
+
+`GET /api/projects`
+
+Response:
+
+```json
+{
+  "projects": [
+    {
+      "id": "demo-project",
+      "name": "demo-project",
+      "createdAt": "2026-04-09T09:00:00.000Z",
+      "updatedAt": "2026-04-09T09:00:00.000Z"
+    }
+  ]
+}
+```
+
+### Create project
+
+`POST /api/projects`
+
+Request:
+
+```json
+{
+  "name": "demo-project"
+}
+```
+
+Response:
+
+```json
+{
+  "project": {
+    "id": "demo-project",
+    "name": "demo-project"
+  }
+}
+```
+
+### List files in a project
+
+`GET /api/projects/:projectId/files`
+
+Response:
+
+```json
+{
+  "files": [
+    {
+      "id": "homepage",
+      "projectId": "demo-project",
+      "name": "homepage.excalidraw",
+      "updatedAt": "2026-04-09T09:10:00.000Z"
+    }
+  ]
+}
+```
+
+### Create file
+
+`POST /api/projects/:projectId/files`
+
+Request:
+
+```json
+{
+  "name": "homepage"
+}
+```
+
+Response:
+
+```json
+{
+  "file": {
+    "id": "homepage",
+    "projectId": "demo-project",
+    "name": "homepage.excalidraw"
+  }
+}
+```
+
+### Read file
+
+`GET /api/projects/:projectId/files/:fileId`
+
+Response:
+
+```json
+{
+  "file": {
+    "id": "homepage",
+    "projectId": "demo-project",
+    "name": "homepage.excalidraw",
+    "updatedAt": "2026-04-09T09:12:00.000Z"
+  },
+  "scene": {
+    "elements": [],
+    "appState": {},
+    "files": {}
+  }
+}
+```
+
+### Save file
+
+`PUT /api/projects/:projectId/files/:fileId`
+
+Request:
+
+```json
+{
+  "scene": {
+    "elements": [],
+    "appState": {},
+    "files": {}
+  }
+}
+```
+
+Response:
+
+```json
+{
+  "file": {
+    "id": "homepage",
+    "projectId": "demo-project",
+    "name": "homepage.excalidraw",
+    "updatedAt": "2026-04-09T09:15:00.000Z"
+  }
+}
+```
+
+## Backend File-System Rules
+
+The backend is responsible for translating logical IDs into disk paths safely.
+
+### Required guarantees
+
+- Read project root from `EXCALIDRAW_PROJECTS_ROOT`
+- Create the root if desired at deployment time, not from frontend assumptions
+- Only allow operations under the configured root
+- Reject path traversal attempts such as `..`, `/`, `\\`, and encoded traversal
+- Restrict managed files to `.excalidraw`
+- Reject duplicate project names and duplicate file names with `409 Conflict`
+- Return `404` for unknown project or file
+
+### Name normalization
+
+For the MVP, names should be simple and predictable:
+
+- Project names map to directory names
+- File creation requests may accept `homepage` and persist as `homepage.excalidraw`
+- The backend should normalize the extension so the frontend does not have to
+
+## Frontend Behavior
+
+### Project list page
+
+The page should:
+
+- fetch and display projects
+- allow creating a project
+- navigate into a project on click
+
+### Project file list page
+
+The page should:
+
+- fetch and display `.excalidraw` files for the selected project
+- allow creating a file
+- navigate into the editor route when a file is selected
+
+### Editor page for remote file
+
+When the route points to a remote file:
+
+- fetch file contents from the backend
+- restore scene data using existing Excalidraw data utilities
+- render the editor with that scene
+- preserve local user preferences where appropriate
+
+### Saving behavior
+
+For the MVP, save behavior should be conservative and explicit in implementation:
+
+- remote file changes save through the file API
+- save failures must show a visible error state
+- the app should avoid pretending data is saved when the request failed
+
+The exact trigger can be wired to the existing save flow in `App.tsx` during implementation, but it must remain single-writer oriented and not attempt multi-user merge logic.
+
+## Error Handling
+
+The app should surface understandable failures for:
+
+- project list fetch failure
+- project creation failure
+- file list fetch failure
+- file creation failure
+- file load failure
+- file save failure
+
+The backend should use standard status codes where practical:
+
+- `400` invalid name
+- `404` project or file not found
+- `409` duplicate project or file
+- `500` unexpected server-side file-system failure
+
+## Testing Strategy
+
+### Frontend tests
+
+- API client tests for request/response handling
+- projects list UI tests
+- project files list UI tests
+- remote file load/save behavior tests
+
+### Backend tests
+
+- environment-variable root resolution
+- project directory creation
+- file creation with extension normalization
+- file read and write
+- invalid-name rejection
+- path traversal rejection
+
+### End-to-end MVP scenario
+
+1. Create project
+2. Create file
+3. Open file
+4. Draw or edit scene
+5. Save file
+6. Reload and verify content persists
+
+## Risks and Trade-Offs
+
+### Why not use a database
+
+The user explicitly does not want database-backed storage. A file-system-backed backend keeps deployment simple and aligns the user-facing project model with real directories on the server.
+
+### Why not put this into `packages/excalidraw`
+
+Doing so would mix app navigation and backend storage concerns into the editor library. That would increase the maintenance burden and make the MVP unnecessarily invasive.
+
+### Known MVP limitations
+
+- No concurrent-edit conflict handling
+- No file version history
+- No nested directories
+- No auth design yet
+
+These are acceptable for the first iteration because they do not block the main project/file workflow.
+
+## Implementation Direction
+
+The follow-up implementation plan should assume:
+
+- frontend changes happen primarily in `excalidraw-app`
+- backend API support will be added separately for directory-backed project storage
+- existing Excalidraw scene serialization/restoration code is reused instead of inventing a new document format

--- a/excalidraw-app/App.tsx
+++ b/excalidraw-app/App.tsx
@@ -147,6 +147,34 @@ import "./index.scss";
 
 import { ExcalidrawPlusPromoBanner } from "./components/ExcalidrawPlusPromoBanner";
 import { AppSidebar } from "./components/AppSidebar";
+import { ProjectFilesPage } from "./components/Projects/ProjectFilesPage";
+import { ProjectsDialog } from "./components/Projects/ProjectsDialog";
+import { ProjectsPage } from "./components/Projects/ProjectsPage";
+import {
+  createProject,
+  createProjectFile,
+  getProjectFile,
+  listProjectFiles,
+  listProjects,
+  saveProjectFile,
+} from "./remote-projects/api";
+import {
+  getProjectFilePath,
+  getProjectPath,
+  getRemoteProjectRouteState,
+} from "./remote-projects/store";
+import { createRemoteAutoSaveController } from "./remote-projects/autosave";
+import {
+  deserializeRemoteProjectScene,
+  serializeRemoteProjectScene,
+} from "./remote-projects/scene";
+import "./components/Projects/Projects.scss";
+
+import type {
+  RemoteProject,
+  RemoteProjectFile,
+  RemoteProjectScene,
+} from "./remote-projects/types";
 
 import type { CollabAPI } from "./collab/Collab";
 
@@ -213,7 +241,7 @@ const shareableLinkConfirmDialog = {
   color: "danger",
 } as const;
 
-const initializeScene = async (opts: {
+export const initializeScene = async (opts: {
   collabAPI: CollabAPI | null;
   excalidrawAPI: ExcalidrawImperativeAPI;
 }): Promise<
@@ -230,6 +258,7 @@ const initializeScene = async (opts: {
   const externalUrlMatch = window.location.hash.match(/^#url=(.*)$/);
 
   const localDataState = importFromLocalStorage();
+  const routeState = getRemoteProjectRouteState(window.location.pathname);
 
   let scene: Omit<
     RestoredDataState,
@@ -248,6 +277,41 @@ const initializeScene = async (opts: {
 
   let roomLinkData = getCollaborationLinkData(window.location.href);
   const isExternalScene = !!(id || jsonBackendMatch || roomLinkData);
+  if (routeState.mode === "file") {
+    try {
+      const remoteFile = await getProjectFile(
+        routeState.projectId,
+        routeState.fileId,
+      );
+      const scene = deserializeRemoteProjectScene(remoteFile.scene);
+
+      return {
+        scene: {
+          elements: restoreElements(scene.elements as any, null, {
+            repairBindings: true,
+            deleteInvisibleElements: true,
+          }),
+          appState: restoreAppState(
+            scene.appState as any,
+            localDataState?.appState,
+          ),
+          files: scene.files as any,
+          scrollToContent: true,
+        },
+        isExternalScene: false,
+      };
+    } catch (error) {
+      return {
+        scene: {
+          appState: {
+            errorMessage: t("alerts.importBackendFailed"),
+          },
+        },
+        isExternalScene: false,
+      };
+    }
+  }
+
   if (isExternalScene) {
     if (
       // don't prompt if scene is empty
@@ -371,17 +435,67 @@ const initializeScene = async (opts: {
   return { scene: null, isExternalScene: false };
 };
 
-const ExcalidrawWrapper = () => {
+type RemoteAutoSaveController = {
+  queue: (value: RemoteProjectScene) => boolean;
+  flushNow: (value?: RemoteProjectScene) => Promise<boolean>;
+  dispose: () => void;
+};
+
+const ExcalidrawWrapper = ({
+  onProjectsDialogOpen,
+  isProjectsDialogOpen,
+  projects,
+  projectFiles,
+  selectedDialogProjectId,
+  isProjectsLoading,
+  isProjectFilesLoading,
+  projectsError,
+  projectFilesError,
+  onProjectsDialogClose,
+  onCreateProjectFromDialog,
+  onOpenProjectFromDialog,
+  onBackToProjectsFromDialog,
+  onCreateFileFromDialog,
+  onOpenFileFromDialog,
+}: {
+  onProjectsDialogOpen: () => void;
+  isProjectsDialogOpen: boolean;
+  projects: RemoteProject[];
+  projectFiles: RemoteProjectFile[];
+  selectedDialogProjectId: string | null;
+  isProjectsLoading: boolean;
+  isProjectFilesLoading: boolean;
+  projectsError: string | null;
+  projectFilesError: string | null;
+  onProjectsDialogClose: () => void;
+  onCreateProjectFromDialog: (name: string) => void;
+  onOpenProjectFromDialog: (projectId: string) => void;
+  onBackToProjectsFromDialog: () => void;
+  onCreateFileFromDialog: (name: string) => void;
+  onOpenFileFromDialog: (fileId: string) => void;
+}) => {
   const excalidrawAPI = useExcalidrawAPI();
+  const routeState = getRemoteProjectRouteState(window.location.pathname);
+  const remoteRouteProjectId =
+    routeState.mode === "file" ? routeState.projectId : null;
+  const remoteRouteFileId =
+    routeState.mode === "file" ? routeState.fileId : null;
+  const activeRemoteProjectName =
+    routeState.mode === "file" ? routeState.projectId : null;
+  const activeRemoteFileName =
+    routeState.mode === "file" ? routeState.fileId : null;
+  const [remoteSaveStatus, setRemoteSaveStatus] = useState<string | null>(null);
 
   const [errorMessage, setErrorMessage] = useState("");
   const isCollabDisabled = isRunningInIframe();
+  const remoteAutoSaveRef = useRef<RemoteAutoSaveController | null>(null);
 
   const { editorTheme, appTheme, setAppTheme } = useHandleAppTheme();
 
   const [langCode, setLangCode] = useAppLangCode();
 
   const editorInterface = useEditorInterface();
+  const lastLoadedRouteRef = useRef<string | null>(null);
 
   // initial state
   // ---------------------------------------------------------------------------
@@ -527,6 +641,7 @@ const ExcalidrawWrapper = () => {
 
     initializeScene({ collabAPI, excalidrawAPI }).then(async (data) => {
       loadImages(data, /* isInitialLoad */ true);
+      lastLoadedRouteRef.current = window.location.pathname;
       initialStatePromiseRef.current.promise.resolve(data.scene);
     });
 
@@ -651,6 +766,45 @@ const ExcalidrawWrapper = () => {
   }, [isCollabDisabled, collabAPI, excalidrawAPI, setLangCode, loadImages]);
 
   useEffect(() => {
+    if (!excalidrawAPI || (!isCollabDisabled && !collabAPI)) {
+      return;
+    }
+
+    const currentPath = window.location.pathname;
+    if (lastLoadedRouteRef.current === null) {
+      return;
+    }
+    if (lastLoadedRouteRef.current === currentPath) {
+      return;
+    }
+
+    lastLoadedRouteRef.current = currentPath;
+    excalidrawAPI.updateScene({ appState: { isLoading: true } });
+
+    void initializeScene({ collabAPI, excalidrawAPI }).then((data) => {
+      loadImages(data);
+      excalidrawAPI.resetScene();
+      if (data.scene) {
+        excalidrawAPI.updateScene({
+          elements: restoreElements(data.scene.elements, null, {
+            repairBindings: true,
+          }),
+          appState: restoreAppState(data.scene.appState, null),
+          captureUpdate: CaptureUpdateAction.IMMEDIATELY,
+        });
+      }
+    });
+  }, [
+    collabAPI,
+    excalidrawAPI,
+    isCollabDisabled,
+    loadImages,
+    routeState.mode,
+    remoteRouteFileId,
+    remoteRouteProjectId,
+  ]);
+
+  useEffect(() => {
     const unloadHandler = (event: BeforeUnloadEvent) => {
       LocalData.flushSave();
 
@@ -675,11 +829,123 @@ const ExcalidrawWrapper = () => {
     };
   }, [excalidrawAPI]);
 
+  useEffect(() => {
+    remoteAutoSaveRef.current?.dispose();
+    remoteAutoSaveRef.current = null;
+
+    if (routeState.mode !== "file") {
+      setRemoteSaveStatus(null);
+      return;
+    }
+
+    const projectId = remoteRouteProjectId!;
+    const fileId = remoteRouteFileId!;
+
+    setRemoteSaveStatus("Saved");
+    remoteAutoSaveRef.current =
+      createRemoteAutoSaveController<RemoteProjectScene>({
+        intervalMs: 10000,
+        getSignature: (scene) => JSON.stringify(scene),
+        save: async (scene) => {
+          setRemoteSaveStatus("Saving...");
+          try {
+            await saveProjectFile(projectId, fileId, scene);
+            setRemoteSaveStatus("Saved");
+          } catch (error) {
+            console.error(error);
+            setRemoteSaveStatus("Save failed");
+            throw error;
+          }
+        },
+      });
+
+    return () => {
+      remoteAutoSaveRef.current?.dispose();
+      remoteAutoSaveRef.current = null;
+    };
+  }, [routeState.mode, remoteRouteFileId, remoteRouteProjectId]);
+
+  const saveRemoteScene = useCallback(
+    async (
+      elements: readonly OrderedExcalidrawElement[],
+      appState: AppState,
+      files: BinaryFiles,
+      options?: {
+        force?: boolean;
+      },
+    ) => {
+      if (routeState.mode !== "file") {
+        return false;
+      }
+
+      const controller = remoteAutoSaveRef.current;
+      if (!controller) {
+        return false;
+      }
+
+      const scene = {
+        elements,
+        appState,
+        files,
+      };
+      const serializedScene = serializeRemoteProjectScene(scene);
+
+      const didSave = options?.force
+        ? await controller.flushNow(serializedScene)
+        : controller.queue(serializedScene);
+
+      if (options?.force) {
+        if (didSave) {
+          excalidrawAPI?.setToast({ message: "Saved to remote file" });
+        } else {
+          excalidrawAPI?.setToast({ message: "No changes to save" });
+        }
+      }
+
+      return didSave;
+    },
+    [excalidrawAPI, routeState.mode],
+  );
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (
+        routeState.mode !== "file" ||
+        !(event.metaKey || event.ctrlKey) ||
+        event.key.toLowerCase() !== "s"
+      ) {
+        return;
+      }
+
+      event.preventDefault();
+      try {
+        void saveRemoteScene(
+          excalidrawAPI?.getSceneElementsIncludingDeleted() || [],
+          (excalidrawAPI?.getAppState() as AppState | undefined) ||
+            (getDefaultAppState() as AppState),
+          excalidrawAPI?.getFiles() || {},
+          { force: true },
+        );
+      } catch (error) {
+        console.error(error);
+      }
+    };
+
+    window.addEventListener("keydown", onKeyDown, true);
+    return () => {
+      window.removeEventListener("keydown", onKeyDown, true);
+    };
+  }, [excalidrawAPI, routeState.mode, saveRemoteScene]);
+
   const onChange = (
     elements: readonly OrderedExcalidrawElement[],
     appState: AppState,
     files: BinaryFiles,
   ) => {
+    if (routeState.mode === "file") {
+      void saveRemoteScene(elements, appState, files);
+    }
+
     if (collabAPI?.isCollaborating()) {
       collabAPI.syncElements(elements);
     }
@@ -985,16 +1251,39 @@ const ExcalidrawWrapper = () => {
       >
         <AppMainMenu
           onCollabDialogOpen={onCollabDialogOpen}
+          onProjectsDialogOpen={onProjectsDialogOpen}
           isCollaborating={isCollaborating}
           isCollabEnabled={!isCollabDisabled}
           theme={appTheme}
           setTheme={(theme) => setAppTheme(theme)}
           refresh={() => forceRefresh((prev) => !prev)}
         />
-        <AppWelcomeScreen
-          onCollabDialogOpen={onCollabDialogOpen}
-          isCollabEnabled={!isCollabDisabled}
-        />
+        <div
+          style={isProjectsDialogOpen ? { pointerEvents: "none" } : undefined}
+        >
+          <AppWelcomeScreen
+            onCollabDialogOpen={onCollabDialogOpen}
+            onProjectsDialogOpen={onProjectsDialogOpen}
+            isCollabEnabled={!isCollabDisabled}
+          />
+        </div>
+        {isProjectsDialogOpen && (
+          <ProjectsDialog
+            projects={projects}
+            files={projectFiles}
+            selectedProjectId={selectedDialogProjectId}
+            isProjectsLoading={isProjectsLoading}
+            isFilesLoading={isProjectFilesLoading}
+            projectsError={projectsError}
+            filesError={projectFilesError}
+            onCloseRequest={onProjectsDialogClose}
+            onCreateProject={onCreateProjectFromDialog}
+            onOpenProject={onOpenProjectFromDialog}
+            onBackToProjects={onBackToProjectsFromDialog}
+            onCreateFile={onCreateFileFromDialog}
+            onOpenFile={onOpenFileFromDialog}
+          />
+        )}
         <OverwriteConfirmDialog>
           <OverwriteConfirmDialog.Actions.ExportToImage />
           <OverwriteConfirmDialog.Actions.SaveToDisk />
@@ -1015,7 +1304,12 @@ const ExcalidrawWrapper = () => {
             </OverwriteConfirmDialog.Action>
           )}
         </OverwriteConfirmDialog>
-        <AppFooter onChange={() => excalidrawAPI?.refresh()} />
+        <AppFooter
+          onChange={() => excalidrawAPI?.refresh()}
+          remoteProjectName={activeRemoteProjectName}
+          remoteFileName={activeRemoteFileName}
+          remoteSaveStatus={remoteSaveStatus}
+        />
         {excalidrawAPI && <AIComponents excalidrawAPI={excalidrawAPI} />}
 
         <TTDDialogTrigger />
@@ -1269,15 +1563,254 @@ const ExcalidrawWrapper = () => {
 const ExcalidrawApp = () => {
   const isCloudExportWindow =
     window.location.pathname === "/excalidraw-plus-export";
+  const [routePath, setRoutePath] = useState(window.location.pathname);
+  const [projects, setProjects] = useState<RemoteProject[]>([]);
+  const [projectsError, setProjectsError] = useState<string | null>(null);
+  const [isProjectsLoading, setIsProjectsLoading] = useState(false);
+  const [projectFiles, setProjectFiles] = useState<RemoteProjectFile[]>([]);
+  const [projectFilesError, setProjectFilesError] = useState<string | null>(
+    null,
+  );
+  const [isProjectFilesLoading, setIsProjectFilesLoading] = useState(false);
+  const [isProjectsDialogOpen, setIsProjectsDialogOpen] = useState(false);
+  const [selectedDialogProjectId, setSelectedDialogProjectId] = useState<
+    string | null
+  >(null);
+
+  useEffect(() => {
+    const handlePopState = () => {
+      setRoutePath(window.location.pathname);
+    };
+
+    window.addEventListener("popstate", handlePopState);
+    return () => {
+      window.removeEventListener("popstate", handlePopState);
+    };
+  }, []);
+
+  const navigateTo = useCallback((pathname: string) => {
+    window.history.pushState({}, "", pathname);
+    setRoutePath(pathname);
+  }, []);
+
+  const routeState = getRemoteProjectRouteState(routePath);
+  const routeProjectId =
+    routeState.mode === "project" ? routeState.projectId : null;
+
+  useEffect(() => {
+    if (routeState.mode !== "projects" && !isProjectsDialogOpen) {
+      return;
+    }
+
+    let cancelled = false;
+
+    setIsProjectsLoading(true);
+    setProjectsError(null);
+    void listProjects()
+      .then((items) => {
+        if (!cancelled) {
+          setProjects(items);
+        }
+      })
+      .catch((error) => {
+        if (!cancelled) {
+          setProjectsError(
+            error instanceof Error ? error.message : String(error),
+          );
+        }
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setIsProjectsLoading(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [routeState.mode, isProjectsDialogOpen]);
+
+  useEffect(() => {
+    const activeProjectId = selectedDialogProjectId ?? routeProjectId;
+
+    if (!activeProjectId) {
+      if (selectedDialogProjectId === null) {
+        setProjectFiles((currentFiles) =>
+          currentFiles.length === 0 ? currentFiles : [],
+        );
+        setProjectFilesError((currentError) =>
+          currentError === null ? currentError : null,
+        );
+        setIsProjectFilesLoading((isLoading) =>
+          isLoading ? false : isLoading,
+        );
+      }
+      return;
+    }
+
+    let cancelled = false;
+
+    setIsProjectFilesLoading(true);
+    setProjectFilesError(null);
+    void listProjectFiles(activeProjectId)
+      .then((items) => {
+        if (!cancelled) {
+          setProjectFiles(items);
+        }
+      })
+      .catch((error) => {
+        if (!cancelled) {
+          setProjectFilesError(
+            error instanceof Error ? error.message : String(error),
+          );
+        }
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setIsProjectFilesLoading(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [routeState.mode, routeProjectId, selectedDialogProjectId]);
+
+  useEffect(() => {
+    if (!isProjectsDialogOpen) {
+      setSelectedDialogProjectId(null);
+      setProjectFiles([]);
+      setProjectFilesError(null);
+      setIsProjectFilesLoading(false);
+    }
+  }, [isProjectsDialogOpen]);
+
   if (isCloudExportWindow) {
     return <ExcalidrawPlusIframeExport />;
+  }
+
+  if (routeState.mode === "projects") {
+    return (
+      <ProjectsPage
+        projects={projects}
+        isLoading={isProjectsLoading}
+        errorMessage={projectsError}
+        onCreateProject={(name) => {
+          void createProject(name)
+            .then((project) => {
+              setProjects((currentProjects) => [...currentProjects, project]);
+              navigateTo(getProjectPath(project.id));
+            })
+            .catch((error) => {
+              setProjectsError(
+                error instanceof Error ? error.message : String(error),
+              );
+            });
+        }}
+        onOpenProject={(projectId) => {
+          navigateTo(getProjectPath(projectId));
+        }}
+      />
+    );
+  }
+
+  if (routeState.mode === "project") {
+    return (
+      <ProjectFilesPage
+        projectName={routeState.projectId}
+        files={projectFiles}
+        isLoading={isProjectFilesLoading}
+        errorMessage={projectFilesError}
+        onCreateFile={(name) => {
+          void createProjectFile(routeState.projectId, name)
+            .then((file) => {
+              setProjectFiles((currentFiles) => [...currentFiles, file]);
+              navigateTo(getProjectFilePath(routeState.projectId, file.id));
+            })
+            .catch((error) => {
+              setProjectFilesError(
+                error instanceof Error ? error.message : String(error),
+              );
+            });
+        }}
+        onOpenFile={(fileId) => {
+          navigateTo(getProjectFilePath(routeState.projectId, fileId));
+        }}
+      />
+    );
   }
 
   return (
     <TopErrorBoundary>
       <Provider store={appJotaiStore}>
         <ExcalidrawAPIProvider>
-          <ExcalidrawWrapper />
+          <ExcalidrawWrapper
+            onProjectsDialogOpen={() => {
+              setSelectedDialogProjectId(
+                routeState.mode === "file" ? routeState.projectId : null,
+              );
+              setIsProjectsDialogOpen(true);
+            }}
+            isProjectsDialogOpen={isProjectsDialogOpen}
+            projects={projects}
+            projectFiles={projectFiles}
+            selectedDialogProjectId={selectedDialogProjectId}
+            isProjectsLoading={isProjectsLoading}
+            isProjectFilesLoading={isProjectFilesLoading}
+            projectsError={projectsError}
+            projectFilesError={projectFilesError}
+            onProjectsDialogClose={() => setIsProjectsDialogOpen(false)}
+            onCreateProjectFromDialog={(name) => {
+              void createProject(name)
+                .then((project) => {
+                  setProjects((currentProjects) => [
+                    ...currentProjects,
+                    project,
+                  ]);
+                  setSelectedDialogProjectId(project.id);
+                })
+                .catch((error) => {
+                  setProjectsError(
+                    error instanceof Error ? error.message : String(error),
+                  );
+                });
+            }}
+            onOpenProjectFromDialog={(projectId) => {
+              setSelectedDialogProjectId(projectId);
+            }}
+            onBackToProjectsFromDialog={() => {
+              setSelectedDialogProjectId(null);
+              setProjectFiles([]);
+              setProjectFilesError(null);
+            }}
+            onCreateFileFromDialog={(name) => {
+              if (!selectedDialogProjectId) {
+                return;
+              }
+
+              void createProjectFile(selectedDialogProjectId, name)
+                .then((file) => {
+                  setProjectFiles((currentFiles) => [...currentFiles, file]);
+                  setIsProjectsDialogOpen(false);
+                  navigateTo(
+                    getProjectFilePath(selectedDialogProjectId, file.id),
+                  );
+                })
+                .catch((error) => {
+                  setProjectFilesError(
+                    error instanceof Error ? error.message : String(error),
+                  );
+                });
+            }}
+            onOpenFileFromDialog={(fileId) => {
+              if (!selectedDialogProjectId) {
+                return;
+              }
+
+              setIsProjectsDialogOpen(false);
+              navigateTo(getProjectFilePath(selectedDialogProjectId, fileId));
+            }}
+          />
         </ExcalidrawAPIProvider>
       </Provider>
     </TopErrorBoundary>

--- a/excalidraw-app/components/AppFooter.tsx
+++ b/excalidraw-app/components/AppFooter.tsx
@@ -7,7 +7,17 @@ import { DebugFooter, isVisualDebuggerEnabled } from "./DebugCanvas";
 import { EncryptedIcon } from "./EncryptedIcon";
 
 export const AppFooter = React.memo(
-  ({ onChange }: { onChange: () => void }) => {
+  ({
+    onChange,
+    remoteProjectName,
+    remoteFileName,
+    remoteSaveStatus,
+  }: {
+    onChange: () => void;
+    remoteProjectName?: string | null;
+    remoteFileName?: string | null;
+    remoteSaveStatus?: string | null;
+  }) => {
     return (
       <Footer>
         <div
@@ -15,8 +25,36 @@ export const AppFooter = React.memo(
             display: "flex",
             gap: ".5rem",
             alignItems: "center",
+            flexWrap: "wrap",
           }}
         >
+          {remoteProjectName && remoteFileName ? (
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: ".35rem",
+                padding: "0.25rem 0.5rem",
+                borderRadius: "999px",
+                background: "var(--island-bg-color)",
+                color: "var(--text-primary-color)",
+                fontSize: ".875rem",
+                lineHeight: 1.2,
+              }}
+            >
+              <strong>Project</strong>
+              <span>{remoteProjectName}</span>
+              <span style={{ opacity: 0.5 }}>/</span>
+              <strong>File</strong>
+              <span>{remoteFileName}</span>
+              {remoteSaveStatus ? (
+                <>
+                  <span style={{ opacity: 0.5 }}>/</span>
+                  <span>{remoteSaveStatus}</span>
+                </>
+              ) : null}
+            </div>
+          ) : null}
           {isVisualDebuggerEnabled() && <DebugFooter onChange={onChange} />}
           {!isExcalidrawPlusSignedUser && <EncryptedIcon />}
         </div>

--- a/excalidraw-app/components/AppMainMenu.tsx
+++ b/excalidraw-app/components/AppMainMenu.tsx
@@ -14,9 +14,11 @@ import { LanguageList } from "../app-language/LanguageList";
 import { isExcalidrawPlusSignedUser } from "../app_constants";
 
 import { saveDebugState } from "./DebugCanvas";
+import { ProjectsIcon } from "./Projects/ProjectsIcon";
 
 export const AppMainMenu: React.FC<{
   onCollabDialogOpen: () => any;
+  onProjectsDialogOpen: () => any;
   isCollaborating: boolean;
   isCollabEnabled: boolean;
   theme: Theme | "system";
@@ -25,6 +27,12 @@ export const AppMainMenu: React.FC<{
 }> = React.memo((props) => {
   return (
     <MainMenu>
+      <MainMenu.Item
+        icon={<ProjectsIcon />}
+        onSelect={() => props.onProjectsDialogOpen()}
+      >
+        Projects
+      </MainMenu.Item>
       <MainMenu.DefaultItems.LoadScene />
       <MainMenu.DefaultItems.SaveToActiveFile />
       <MainMenu.DefaultItems.Export />

--- a/excalidraw-app/components/AppWelcomeScreen.tsx
+++ b/excalidraw-app/components/AppWelcomeScreen.tsx
@@ -6,8 +6,11 @@ import React from "react";
 
 import { isExcalidrawPlusSignedUser } from "../app_constants";
 
+import { ProjectsIcon } from "./Projects/ProjectsIcon";
+
 export const AppWelcomeScreen: React.FC<{
   onCollabDialogOpen: () => any;
+  onProjectsDialogOpen: () => any;
   isCollabEnabled: boolean;
 }> = React.memo((props) => {
   const { t } = useI18n();
@@ -75,6 +78,13 @@ export const AppWelcomeScreen: React.FC<{
               Sign up
             </WelcomeScreen.Center.MenuItemLink>
           )}
+          <WelcomeScreen.Center.MenuItem
+            shortcut={null}
+            icon={<ProjectsIcon />}
+            onSelect={() => props.onProjectsDialogOpen()}
+          >
+            Projects
+          </WelcomeScreen.Center.MenuItem>
         </WelcomeScreen.Center.Menu>
       </WelcomeScreen.Center>
     </WelcomeScreen>

--- a/excalidraw-app/components/Projects/ProjectFilesPage.tsx
+++ b/excalidraw-app/components/Projects/ProjectFilesPage.tsx
@@ -1,0 +1,56 @@
+import React from "react";
+
+import type { RemoteProjectFile } from "../../remote-projects/types";
+
+export const ProjectFilesPage: React.FC<{
+  projectName: string;
+  files: RemoteProjectFile[];
+  isLoading: boolean;
+  errorMessage: string | null;
+  onCreateFile: (name: string) => void;
+  onOpenFile: (fileId: string) => void;
+}> = ({
+  projectName,
+  files,
+  isLoading,
+  errorMessage,
+  onCreateFile,
+  onOpenFile,
+}) => {
+  const [name, setName] = React.useState("");
+
+  return (
+    <section className="remote-projects-page">
+      <h1>{projectName}</h1>
+      {errorMessage ? <p>{errorMessage}</p> : null}
+      {isLoading ? <p>Loading...</p> : null}
+      <div className="remote-projects-page__create">
+        <input
+          aria-label="File name"
+          value={name}
+          onChange={(event) => setName(event.target.value)}
+          placeholder="File name"
+        />
+        <button
+          onClick={() => {
+            const trimmedName = name.trim();
+            if (!trimmedName) {
+              return;
+            }
+            onCreateFile(trimmedName);
+            setName("");
+          }}
+        >
+          New file
+        </button>
+      </div>
+      <ul>
+        {files.map((file) => (
+          <li key={file.id}>
+            <button onClick={() => onOpenFile(file.id)}>{file.name}</button>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+};

--- a/excalidraw-app/components/Projects/Projects.scss
+++ b/excalidraw-app/components/Projects/Projects.scss
@@ -1,0 +1,84 @@
+.remote-projects-page {
+  margin: 0 auto;
+  max-width: 56rem;
+  padding: 2rem 1.5rem 4rem;
+}
+
+.remote-projects-page--dialog {
+  max-width: none;
+  padding: 0;
+}
+
+.remote-projects-page__create {
+  display: flex;
+  gap: 0.75rem;
+  margin: 1rem 0 1.5rem;
+  align-items: flex-end;
+}
+
+.remote-projects-page__create input {
+  flex: 1;
+  min-width: 12rem;
+}
+
+.remote-projects-page__list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.remote-projects-page__listButton {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  text-align: left;
+  border: 1px solid var(--default-border-color);
+  border-radius: var(--border-radius-md);
+  background: var(--color-surface-low);
+  color: var(--color-on-surface);
+  padding: 0.875rem 1rem;
+}
+
+.remote-projects-page__listButton:hover {
+  background: var(--color-surface-mid);
+}
+
+.remote-projects-page__toolbar {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+}
+
+.remote-projects-page__backButton {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  border: 1px solid var(--default-border-color);
+  border-radius: var(--border-radius-md);
+  background: transparent;
+  color: var(--color-on-surface);
+  padding: 0.5rem 0.75rem;
+}
+
+.remote-projects-page__backIcon,
+.remote-projects-page__listIcon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--color-on-surface-variant);
+}
+
+.remote-projects-page__listIcon svg {
+  width: 1.1rem;
+  height: 1.1rem;
+}
+
+.remote-projects-page__subtitle {
+  color: var(--color-on-surface-variant);
+  font-size: 0.95rem;
+}

--- a/excalidraw-app/components/Projects/ProjectsDialog.tsx
+++ b/excalidraw-app/components/Projects/ProjectsDialog.tsx
@@ -1,0 +1,196 @@
+import { Dialog } from "@excalidraw/excalidraw/components/Dialog";
+import { FilledButton } from "@excalidraw/excalidraw/components/FilledButton";
+import { TextField } from "@excalidraw/excalidraw/components/TextField";
+import { ExcalLogo, LoadIcon } from "@excalidraw/excalidraw/components/icons";
+import React from "react";
+
+import type {
+  RemoteProject,
+  RemoteProjectFile,
+} from "../../remote-projects/types";
+
+const BackIcon = (
+  <svg
+    aria-hidden="true"
+    viewBox="0 0 20 20"
+    width="18"
+    height="18"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.75"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <path d="M12.5 4.5 7 10l5.5 5.5" />
+    <path d="M7.5 10h8" />
+  </svg>
+);
+
+export const ProjectsDialog: React.FC<{
+  projects: RemoteProject[];
+  files: RemoteProjectFile[];
+  selectedProjectId: string | null;
+  isProjectsLoading: boolean;
+  isFilesLoading: boolean;
+  projectsError: string | null;
+  filesError: string | null;
+  onCreateProject: (name: string) => void;
+  onOpenProject: (projectId: string) => void;
+  onBackToProjects: () => void;
+  onCreateFile: (name: string) => void;
+  onOpenFile: (fileId: string) => void;
+  onCloseRequest: () => void;
+}> = ({
+  projects,
+  files,
+  selectedProjectId,
+  isProjectsLoading,
+  isFilesLoading,
+  projectsError,
+  filesError,
+  onCreateProject,
+  onOpenProject,
+  onBackToProjects,
+  onCreateFile,
+  onOpenFile,
+  onCloseRequest,
+}) => {
+  const [projectName, setProjectName] = React.useState("");
+  const [fileName, setFileName] = React.useState("");
+
+  const createProject = (event?: React.SyntheticEvent) => {
+    event?.preventDefault();
+    event?.stopPropagation();
+
+    const trimmedName = projectName.trim();
+    if (!trimmedName) {
+      return;
+    }
+    onCreateProject(trimmedName);
+    setProjectName("");
+  };
+
+  const createFile = (event?: React.SyntheticEvent) => {
+    event?.preventDefault();
+    event?.stopPropagation();
+
+    const trimmedName = fileName.trim();
+    if (!trimmedName) {
+      return;
+    }
+    onCreateFile(trimmedName);
+    setFileName("");
+  };
+
+  return (
+    <Dialog
+      size="small"
+      title="Projects"
+      className="ProjectsDialog"
+      onCloseRequest={onCloseRequest}
+    >
+      <div className="remote-projects-page remote-projects-page--dialog">
+        {selectedProjectId ? (
+          <>
+            <div className="remote-projects-page__toolbar">
+              <button
+                type="button"
+                className="remote-projects-page__backButton"
+                onClick={onBackToProjects}
+              >
+                <span className="remote-projects-page__backIcon">
+                  {BackIcon}
+                </span>
+                <span>Back to projects</span>
+              </button>
+              <div className="remote-projects-page__subtitle">
+                {selectedProjectId}
+              </div>
+            </div>
+            {filesError ? <p>{filesError}</p> : null}
+            {isFilesLoading ? <p>Loading...</p> : null}
+            <div className="remote-projects-page__create">
+              <TextField
+                fullWidth
+                label="File name"
+                placeholder="File name"
+                value={fileName}
+                onChange={setFileName}
+                onKeyDown={(event) => {
+                  if (event.key === "Enter") {
+                    createFile(event);
+                  }
+                }}
+              />
+              <FilledButton label="New file" onClick={createFile}>
+                New file
+              </FilledButton>
+            </div>
+            <ul className="remote-projects-page__list">
+              {files.map((file) => (
+                <li key={file.id}>
+                  <button
+                    type="button"
+                    className="remote-projects-page__listButton"
+                    onClick={(event) => {
+                      event.preventDefault();
+                      event.stopPropagation();
+                      onOpenFile(file.id);
+                    }}
+                  >
+                    <span className="remote-projects-page__listIcon">
+                      {ExcalLogo}
+                    </span>
+                    <span>{file.name}</span>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </>
+        ) : (
+          <>
+            {projectsError ? <p>{projectsError}</p> : null}
+            {isProjectsLoading ? <p>Loading...</p> : null}
+            <div className="remote-projects-page__create">
+              <TextField
+                fullWidth
+                label="Project name"
+                placeholder="Project name"
+                value={projectName}
+                onChange={setProjectName}
+                onKeyDown={(event) => {
+                  if (event.key === "Enter") {
+                    createProject(event);
+                  }
+                }}
+              />
+              <FilledButton label="New project" onClick={createProject}>
+                New project
+              </FilledButton>
+            </div>
+            <ul className="remote-projects-page__list">
+              {projects.map((project) => (
+                <li key={project.id}>
+                  <button
+                    type="button"
+                    className="remote-projects-page__listButton"
+                    onClick={(event) => {
+                      event.preventDefault();
+                      event.stopPropagation();
+                      onOpenProject(project.id);
+                    }}
+                  >
+                    <span className="remote-projects-page__listIcon">
+                      {LoadIcon}
+                    </span>
+                    <span>{project.name}</span>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </>
+        )}
+      </div>
+    </Dialog>
+  );
+};

--- a/excalidraw-app/components/Projects/ProjectsIcon.tsx
+++ b/excalidraw-app/components/Projects/ProjectsIcon.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+
+export const ProjectsIcon = () => (
+  <svg
+    aria-hidden="true"
+    viewBox="0 0 24 24"
+    width="20"
+    height="20"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.6"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <path d="M3.5 7.5a2 2 0 0 1 2-2h4l1.6 1.8H18.5a2 2 0 0 1 2 2v7a2 2 0 0 1-2 2h-13a2 2 0 0 1-2-2v-8.8Z" />
+    <path d="M8 11.5h5.5" />
+    <path d="M8 14.5h3.5" />
+    <path d="M15.5 12.25 18.5 15" />
+    <path d="M18.5 12.25 15.5 15" />
+  </svg>
+);

--- a/excalidraw-app/components/Projects/ProjectsPage.tsx
+++ b/excalidraw-app/components/Projects/ProjectsPage.tsx
@@ -1,0 +1,56 @@
+import React from "react";
+
+import type { RemoteProject } from "../../remote-projects/types";
+
+export const ProjectsPage: React.FC<{
+  projects: RemoteProject[];
+  isLoading: boolean;
+  errorMessage: string | null;
+  onCreateProject: (name: string) => void;
+  onOpenProject: (projectId: string) => void;
+}> = ({
+  projects,
+  isLoading,
+  errorMessage,
+  onCreateProject,
+  onOpenProject,
+}) => {
+  const [name, setName] = React.useState("");
+
+  return (
+    <section className="remote-projects-page">
+      <h1>Projects</h1>
+      {errorMessage ? <p>{errorMessage}</p> : null}
+      {isLoading ? <p>Loading...</p> : null}
+      <div className="remote-projects-page__create">
+        <input
+          aria-label="Project name"
+          value={name}
+          onChange={(event) => setName(event.target.value)}
+          placeholder="Project name"
+        />
+        <button
+          onClick={() => {
+            const trimmedName = name.trim();
+            if (!trimmedName) {
+              return;
+            }
+            onCreateProject(trimmedName);
+            setName("");
+          }}
+        >
+          New project
+        </button>
+      </div>
+      <ul>
+        {projects.map((project) => (
+          <li key={project.id}>
+            <button onClick={() => onOpenProject(project.id)}>
+              {project.name}
+            </button>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+};

--- a/excalidraw-app/remote-projects/api.ts
+++ b/excalidraw-app/remote-projects/api.ts
@@ -1,0 +1,94 @@
+import type {
+  RemoteProject,
+  RemoteProjectFile,
+  RemoteProjectScene,
+} from "./types";
+
+const JSON_HEADERS = {
+  Accept: "application/json",
+  "Content-Type": "application/json",
+} as const;
+
+const readJson = async <T>(response: Response): Promise<T> => {
+  if (!response.ok) {
+    throw new Error(`Remote projects request failed: ${response.status}`);
+  }
+
+  return (await response.json()) as T;
+};
+
+export const listProjects = async (): Promise<RemoteProject[]> => {
+  const response = await fetch("/api/projects", {
+    method: "GET",
+    headers: { Accept: "application/json" },
+  });
+
+  const data = await readJson<{ projects: RemoteProject[] }>(response);
+  return data.projects;
+};
+
+export const createProject = async (name: string): Promise<RemoteProject> => {
+  const response = await fetch("/api/projects", {
+    method: "POST",
+    headers: JSON_HEADERS,
+    body: JSON.stringify({ name }),
+  });
+
+  const data = await readJson<{ project: RemoteProject }>(response);
+  return data.project;
+};
+
+export const listProjectFiles = async (
+  projectId: string,
+): Promise<RemoteProjectFile[]> => {
+  const response = await fetch(`/api/projects/${projectId}/files`, {
+    method: "GET",
+    headers: { Accept: "application/json" },
+  });
+
+  const data = await readJson<{ files: RemoteProjectFile[] }>(response);
+  return data.files;
+};
+
+export const createProjectFile = async (
+  projectId: string,
+  name: string,
+): Promise<RemoteProjectFile> => {
+  const response = await fetch(`/api/projects/${projectId}/files`, {
+    method: "POST",
+    headers: JSON_HEADERS,
+    body: JSON.stringify({ name }),
+  });
+
+  const data = await readJson<{ file: RemoteProjectFile }>(response);
+  return data.file;
+};
+
+export const getProjectFile = async (
+  projectId: string,
+  fileId: string,
+): Promise<{ file: RemoteProjectFile; scene: RemoteProjectScene }> => {
+  const response = await fetch(`/api/projects/${projectId}/files/${fileId}`, {
+    method: "GET",
+    headers: { Accept: "application/json" },
+  });
+
+  return readJson<{ file: RemoteProjectFile; scene: RemoteProjectScene }>(
+    response,
+  );
+};
+
+export const saveProjectFile = async (
+  projectId: string,
+  fileId: string,
+  scene: RemoteProjectScene,
+): Promise<RemoteProjectFile> => {
+  const response = await fetch(`/api/projects/${projectId}/files/${fileId}`, {
+    method: "PUT",
+    headers: JSON_HEADERS,
+    body: JSON.stringify({ scene }),
+  });
+
+  const data = await readJson<{ file: RemoteProjectFile }>(response);
+  return data.file;
+};

--- a/excalidraw-app/remote-projects/autosave.ts
+++ b/excalidraw-app/remote-projects/autosave.ts
@@ -1,0 +1,108 @@
+type AutoSaveOptions<T> = {
+  intervalMs: number;
+  save: (value: T) => Promise<void>;
+  getSignature: (value: T) => string;
+};
+
+export const createRemoteAutoSaveController = <T>({
+  intervalMs,
+  save,
+  getSignature,
+}: AutoSaveOptions<T>) => {
+  let lastSavedSignature: string | null = null;
+  let pendingValue: T | null = null;
+  let pendingSignature: string | null = null;
+  let lastSaveTimestamp = 0;
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  let inFlight = false;
+
+  const clearTimer = () => {
+    if (timer) {
+      clearTimeout(timer);
+      timer = null;
+    }
+  };
+
+  const schedule = () => {
+    if (inFlight || pendingValue === null || pendingSignature === null) {
+      return;
+    }
+
+    const elapsed = Date.now() - lastSaveTimestamp;
+    const delay =
+      lastSaveTimestamp === 0 ? 0 : Math.max(intervalMs - elapsed, 0);
+
+    clearTimer();
+    timer = setTimeout(() => {
+      void flush().catch(() => {});
+    }, delay);
+  };
+
+  const flush = async () => {
+    if (inFlight || pendingValue === null || pendingSignature === null) {
+      return false;
+    }
+
+    const valueToSave = pendingValue;
+    const signatureToSave = pendingSignature;
+
+    inFlight = true;
+    clearTimer();
+    lastSaveTimestamp = Date.now();
+
+    try {
+      await save(valueToSave);
+      if (pendingSignature === signatureToSave) {
+        pendingValue = null;
+        pendingSignature = null;
+      }
+      lastSavedSignature = signatureToSave;
+      return true;
+    } finally {
+      inFlight = false;
+      if (pendingValue !== null && pendingSignature !== null) {
+        schedule();
+      }
+    }
+  };
+
+  return {
+    queue(value: T) {
+      const signature = getSignature(value);
+      if (lastSavedSignature === null) {
+        lastSavedSignature = signature;
+        return false;
+      }
+
+      if (signature === lastSavedSignature || signature === pendingSignature) {
+        return false;
+      }
+
+      pendingValue = value;
+      pendingSignature = signature;
+      schedule();
+      return true;
+    },
+    async flushNow(value?: T) {
+      if (value !== undefined) {
+        const signature = getSignature(value);
+        if (lastSavedSignature === null) {
+          lastSavedSignature = signature;
+          return false;
+        }
+        if (signature === lastSavedSignature) {
+          return false;
+        }
+        pendingValue = value;
+        pendingSignature = signature;
+      }
+
+      return flush();
+    },
+    dispose() {
+      clearTimer();
+      pendingValue = null;
+      pendingSignature = null;
+    },
+  };
+};

--- a/excalidraw-app/remote-projects/scene.ts
+++ b/excalidraw-app/remote-projects/scene.ts
@@ -1,0 +1,30 @@
+import type { AppState } from "@excalidraw/excalidraw/types";
+
+import type { RemoteProjectScene } from "./types";
+
+export const deserializeRemoteProjectScene = (
+  scene: RemoteProjectScene,
+): RemoteProjectScene => ({
+  ...scene,
+  appState: {
+    ...scene.appState,
+    collaborators:
+      scene.appState.collaborators instanceof Map
+        ? scene.appState.collaborators
+        : new Map(),
+  },
+});
+
+export const serializeRemoteProjectScene = (
+  scene: RemoteProjectScene,
+): RemoteProjectScene => {
+  const { collaborators: _collaborators, ...appState } =
+    scene.appState as AppState & {
+      collaborators?: unknown;
+    };
+
+  return {
+    ...scene,
+    appState: appState as AppState,
+  };
+};

--- a/excalidraw-app/remote-projects/store.ts
+++ b/excalidraw-app/remote-projects/store.ts
@@ -1,0 +1,45 @@
+export type RemoteProjectRouteState =
+  | { mode: "projects" }
+  | { mode: "project"; projectId: string }
+  | { mode: "file"; projectId: string; fileId: string }
+  | { mode: "editor" };
+
+export const getRemoteProjectRouteState = (
+  pathname: string,
+): RemoteProjectRouteState => {
+  const fileMatch = pathname.match(/^\/projects\/([^/]+)\/files\/([^/]+)$/);
+  if (fileMatch) {
+    return {
+      mode: "file",
+      projectId: decodeURIComponent(fileMatch[1]),
+      fileId: decodeURIComponent(fileMatch[2]),
+    };
+  }
+
+  const projectMatch = pathname.match(/^\/projects\/([^/]+)$/);
+  if (projectMatch) {
+    return {
+      mode: "project",
+      projectId: decodeURIComponent(projectMatch[1]),
+    };
+  }
+
+  if (pathname === "/projects") {
+    return { mode: "projects" };
+  }
+
+  return { mode: "editor" };
+};
+
+export const isRemoteProjectFileRoute = (pathname: string) =>
+  getRemoteProjectRouteState(pathname).mode === "file";
+
+export const getProjectsPath = () => "/projects";
+
+export const getProjectPath = (projectId: string) =>
+  `/projects/${encodeURIComponent(projectId)}`;
+
+export const getProjectFilePath = (projectId: string, fileId: string) =>
+  `/projects/${encodeURIComponent(projectId)}/files/${encodeURIComponent(
+    fileId,
+  )}`;

--- a/excalidraw-app/remote-projects/types.ts
+++ b/excalidraw-app/remote-projects/types.ts
@@ -1,0 +1,23 @@
+import type { BinaryFiles, AppState } from "@excalidraw/excalidraw/types";
+import type { OrderedExcalidrawElement } from "@excalidraw/element/types";
+
+export type RemoteProject = {
+  id: string;
+  name: string;
+  createdAt?: string;
+  updatedAt?: string;
+};
+
+export type RemoteProjectFile = {
+  id: string;
+  projectId: string;
+  name: string;
+  createdAt?: string;
+  updatedAt?: string;
+};
+
+export type RemoteProjectScene = {
+  elements: readonly OrderedExcalidrawElement[];
+  appState: AppState;
+  files: BinaryFiles;
+};

--- a/excalidraw-app/server/projects.test.ts
+++ b/excalidraw-app/server/projects.test.ts
@@ -1,0 +1,60 @@
+import { mkdtempSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  createProjectDirectory,
+  createProjectSceneFile,
+  listProjectDirectories,
+  listProjectFiles,
+  readProjectSceneFile,
+  saveProjectSceneFile,
+} from "./projects";
+
+describe("projects file-system backend", () => {
+  it("creates and persists scene files under the configured root", async () => {
+    const root = mkdtempSync(join(tmpdir(), "excalidraw-projects-"));
+
+    await createProjectDirectory(root, "demo");
+    await createProjectSceneFile(root, "demo", "homepage");
+    await saveProjectSceneFile(root, "demo", "homepage", {
+      elements: [],
+      appState: {},
+      files: {},
+    });
+
+    await expect(listProjectDirectories(root)).resolves.toEqual([
+      expect.objectContaining({ id: "demo", name: "demo" }),
+    ]);
+
+    await expect(listProjectFiles(root, "demo")).resolves.toEqual([
+      expect.objectContaining({
+        id: "homepage",
+        projectId: "demo",
+        name: "homepage.excalidraw",
+      }),
+    ]);
+
+    await expect(
+      readProjectSceneFile(root, "demo", "homepage"),
+    ).resolves.toEqual(
+      expect.objectContaining({
+        file: expect.objectContaining({
+          id: "homepage",
+          name: "homepage.excalidraw",
+        }),
+        scene: { elements: [], appState: {}, files: {} },
+      }),
+    );
+  });
+
+  it("rejects traversal in project names", async () => {
+    const root = mkdtempSync(join(tmpdir(), "excalidraw-projects-"));
+
+    await expect(createProjectDirectory(root, "../evil")).rejects.toThrow(
+      "Invalid path segment",
+    );
+  });
+});

--- a/excalidraw-app/server/projects.ts
+++ b/excalidraw-app/server/projects.ts
@@ -1,0 +1,117 @@
+import { mkdir, readdir, readFile, stat, writeFile } from "node:fs/promises";
+import { join, resolve } from "node:path";
+
+const ensureSafeSegment = (value: string) => {
+  if (!/^[A-Za-z0-9._-]+$/.test(value) || value.includes("..")) {
+    throw new Error("Invalid path segment");
+  }
+
+  return value;
+};
+
+const getResolvedRoot = (root: string) => resolve(root);
+
+const getProjectDir = (root: string, projectId: string) =>
+  join(getResolvedRoot(root), ensureSafeSegment(projectId));
+
+const getSceneFilePath = (root: string, projectId: string, fileId: string) =>
+  join(
+    getProjectDir(root, projectId),
+    `${ensureSafeSegment(fileId)}.excalidraw`,
+  );
+
+export const createProjectDirectory = async (root: string, name: string) => {
+  const projectId = ensureSafeSegment(name);
+  await mkdir(getProjectDir(root, projectId));
+
+  return {
+    id: projectId,
+    name: projectId,
+  };
+};
+
+export const createProjectSceneFile = async (
+  root: string,
+  projectId: string,
+  fileId: string,
+) => {
+  const normalizedFileId = ensureSafeSegment(fileId);
+
+  await writeFile(
+    getSceneFilePath(root, projectId, normalizedFileId),
+    JSON.stringify({ elements: [], appState: {}, files: {} }, null, 2),
+  );
+
+  return {
+    id: normalizedFileId,
+    projectId,
+    name: `${normalizedFileId}.excalidraw`,
+  };
+};
+
+export const saveProjectSceneFile = async (
+  root: string,
+  projectId: string,
+  fileId: string,
+  scene: unknown,
+) => {
+  await writeFile(
+    getSceneFilePath(root, projectId, fileId),
+    JSON.stringify(scene, null, 2),
+  );
+};
+
+export const readProjectSceneFile = async (
+  root: string,
+  projectId: string,
+  fileId: string,
+) => {
+  const raw = await readFile(getSceneFilePath(root, projectId, fileId), "utf8");
+
+  return {
+    file: {
+      id: ensureSafeSegment(fileId),
+      projectId: ensureSafeSegment(projectId),
+      name: `${ensureSafeSegment(fileId)}.excalidraw`,
+    },
+    scene: JSON.parse(raw),
+  };
+};
+
+export const listProjectDirectories = async (root: string) => {
+  const entries = await readdir(getResolvedRoot(root), { withFileTypes: true });
+
+  return Promise.all(
+    entries
+      .filter((entry) => entry.isDirectory())
+      .map(async (entry) => {
+        const info = await stat(join(getResolvedRoot(root), entry.name));
+        return {
+          id: entry.name,
+          name: entry.name,
+          createdAt: info.birthtime.toISOString(),
+          updatedAt: info.mtime.toISOString(),
+        };
+      }),
+  );
+};
+
+export const listProjectFiles = async (root: string, projectId: string) => {
+  const projectDir = getProjectDir(root, projectId);
+  const entries = await readdir(projectDir, { withFileTypes: true });
+
+  return Promise.all(
+    entries
+      .filter((entry) => entry.isFile() && entry.name.endsWith(".excalidraw"))
+      .map(async (entry) => {
+        const info = await stat(join(projectDir, entry.name));
+        return {
+          id: entry.name.replace(/\.excalidraw$/, ""),
+          projectId: ensureSafeSegment(projectId),
+          name: entry.name,
+          createdAt: info.birthtime.toISOString(),
+          updatedAt: info.mtime.toISOString(),
+        };
+      }),
+  );
+};

--- a/excalidraw-app/server/viteRemoteProjectsApi.ts
+++ b/excalidraw-app/server/viteRemoteProjectsApi.ts
@@ -1,0 +1,144 @@
+import { mkdir } from "node:fs/promises";
+import { resolve } from "node:path";
+
+import {
+  createProjectDirectory,
+  createProjectSceneFile,
+  listProjectDirectories,
+  listProjectFiles,
+  readProjectSceneFile,
+  saveProjectSceneFile,
+} from "./projects";
+
+import type { IncomingMessage, ServerResponse } from "node:http";
+import type { Connect, Plugin } from "vite";
+
+const PROJECTS_PREFIX = "/api/projects";
+
+const sendJson = (
+  res: ServerResponse,
+  status: number,
+  payload: Record<string, unknown>,
+) => {
+  res.statusCode = status;
+  res.setHeader("Content-Type", "application/json");
+  res.end(JSON.stringify(payload));
+};
+
+const readBody = async (req: IncomingMessage) => {
+  const chunks: Uint8Array[] = [];
+
+  for await (const chunk of req) {
+    chunks.push(typeof chunk === "string" ? Buffer.from(chunk) : chunk);
+  }
+
+  if (!chunks.length) {
+    return {};
+  }
+
+  return JSON.parse(Buffer.concat(chunks).toString("utf8")) as Record<
+    string,
+    unknown
+  >;
+};
+
+const getRootDir = async () => {
+  const root =
+    process.env.EXCALIDRAW_PROJECTS_ROOT ||
+    resolve(process.cwd(), "..", "data", "projects");
+
+  await mkdir(root, { recursive: true });
+  return root;
+};
+
+const normalizeErrorStatus = (error: unknown) => {
+  if (error instanceof Error) {
+    if (error.message.includes("Invalid path segment")) {
+      return 400;
+    }
+    if ("code" in error && error.code === "EEXIST") {
+      return 409;
+    }
+    if ("code" in error && error.code === "ENOENT") {
+      return 404;
+    }
+  }
+
+  return 500;
+};
+
+const handleProjectsRequest = async (
+  req: IncomingMessage,
+  res: ServerResponse,
+) => {
+  const root = await getRootDir();
+  const url = new URL(req.url || PROJECTS_PREFIX, "http://localhost");
+  const pathname = url.pathname.replace(/\/$/, "");
+  const parts = pathname
+    .slice(PROJECTS_PREFIX.length)
+    .split("/")
+    .filter(Boolean)
+    .map(decodeURIComponent);
+
+  if (parts.length === 0 && req.method === "GET") {
+    const projects = await listProjectDirectories(root);
+    return sendJson(res, 200, { projects });
+  }
+
+  if (parts.length === 0 && req.method === "POST") {
+    const body = await readBody(req);
+    const project = await createProjectDirectory(root, String(body.name || ""));
+    return sendJson(res, 200, { project });
+  }
+
+  if (parts.length === 2 && parts[1] === "files" && req.method === "GET") {
+    const files = await listProjectFiles(root, parts[0]);
+    return sendJson(res, 200, { files });
+  }
+
+  if (parts.length === 2 && parts[1] === "files" && req.method === "POST") {
+    const body = await readBody(req);
+    const file = await createProjectSceneFile(
+      root,
+      parts[0],
+      String(body.name || ""),
+    );
+    return sendJson(res, 200, { file });
+  }
+
+  if (parts.length === 3 && parts[1] === "files" && req.method === "GET") {
+    const payload = await readProjectSceneFile(root, parts[0], parts[2]);
+    return sendJson(res, 200, payload);
+  }
+
+  if (parts.length === 3 && parts[1] === "files" && req.method === "PUT") {
+    const body = await readBody(req);
+    await saveProjectSceneFile(root, parts[0], parts[2], body.scene || {});
+    const payload = await readProjectSceneFile(root, parts[0], parts[2]);
+    return sendJson(res, 200, { file: payload.file });
+  }
+
+  return sendJson(res, 404, { error: "Not found" });
+};
+
+const middleware: Connect.NextHandleFunction = async (req, res, next) => {
+  if (!req.url?.startsWith(PROJECTS_PREFIX)) {
+    return next();
+  }
+
+  try {
+    await handleProjectsRequest(req, res);
+  } catch (error) {
+    const status = normalizeErrorStatus(error);
+    sendJson(res, status, {
+      error: error instanceof Error ? error.message : "Unknown error",
+    });
+  }
+};
+
+export const viteRemoteProjectsApi = (): Plugin => ({
+  name: "vite-remote-projects-api",
+  configureServer(server) {
+    server.middlewares.use(middleware);
+  },
+});

--- a/excalidraw-app/tests/ProjectsPage.test.tsx
+++ b/excalidraw-app/tests/ProjectsPage.test.tsx
@@ -1,0 +1,50 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import { ProjectFilesPage } from "../components/Projects/ProjectFilesPage";
+import { ProjectsPage } from "../components/Projects/ProjectsPage";
+
+describe("ProjectsPage", () => {
+  it("renders projects and forwards open-project actions", async () => {
+    const onCreateProject = vi.fn();
+    const onOpenProject = vi.fn();
+
+    await render(
+      <ProjectsPage
+        projects={[{ id: "demo", name: "demo" }]}
+        isLoading={false}
+        errorMessage={null}
+        onCreateProject={onCreateProject}
+        onOpenProject={onOpenProject}
+      />,
+    );
+
+    fireEvent.click(screen.getByText("demo"));
+
+    expect(onOpenProject).toHaveBeenCalledWith("demo");
+  });
+
+  it("renders project files and forwards open-file actions", async () => {
+    const onOpenFile = vi.fn();
+
+    await render(
+      <ProjectFilesPage
+        projectName="demo"
+        files={[
+          {
+            id: "homepage",
+            projectId: "demo",
+            name: "homepage.excalidraw",
+          },
+        ]}
+        isLoading={false}
+        errorMessage={null}
+        onCreateFile={() => {}}
+        onOpenFile={onOpenFile}
+      />,
+    );
+
+    fireEvent.click(screen.getByText("homepage.excalidraw"));
+
+    expect(onOpenFile).toHaveBeenCalledWith("homepage");
+  });
+});

--- a/excalidraw-app/tests/__snapshots__/MobileMenu.test.tsx.snap
+++ b/excalidraw-app/tests/__snapshots__/MobileMenu.test.tsx.snap
@@ -246,6 +246,19 @@ exports[`Test MobileMenu > should initialize with welcome screen and hide once u
         Sign up
       </div>
     </a>
+    <button
+      class="welcome-screen-menu-item "
+      type="button"
+    >
+      <div
+        class="welcome-screen-menu-item__icon"
+      />
+      <div
+        class="welcome-screen-menu-item__text"
+      >
+        Projects
+      </div>
+    </button>
   </div>
 </div>
 `;

--- a/excalidraw-app/tests/remote-projects.api.test.ts
+++ b/excalidraw-app/tests/remote-projects.api.test.ts
@@ -1,0 +1,157 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  createProject,
+  createProjectFile,
+  getProjectFile,
+  listProjectFiles,
+  listProjects,
+  saveProjectFile,
+} from "../remote-projects/api";
+
+describe("remote-projects api", () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    globalThis.fetch = vi.fn() as typeof globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("lists projects from the resource endpoint", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          projects: [{ id: "demo-project", name: "demo-project" }],
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+
+    await expect(listProjects()).resolves.toEqual([
+      { id: "demo-project", name: "demo-project" },
+    ]);
+
+    expect(globalThis.fetch).toHaveBeenCalledWith("/api/projects", {
+      method: "GET",
+      headers: { Accept: "application/json" },
+    });
+  });
+
+  it("creates, lists, reads, and saves project files through resource endpoints", async () => {
+    vi.mocked(globalThis.fetch)
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ project: { id: "demo", name: "demo" } }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            files: [
+              {
+                id: "homepage",
+                projectId: "demo",
+                name: "homepage.excalidraw",
+              },
+            ],
+          }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            file: {
+              id: "homepage",
+              projectId: "demo",
+              name: "homepage.excalidraw",
+            },
+          }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            file: {
+              id: "homepage",
+              projectId: "demo",
+              name: "homepage.excalidraw",
+            },
+            scene: { elements: [], appState: {}, files: {} },
+          }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            file: {
+              id: "homepage",
+              projectId: "demo",
+              name: "homepage.excalidraw",
+              updatedAt: "2026-04-09T09:15:00.000Z",
+            },
+          }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          },
+        ),
+      );
+
+    await expect(createProject("demo")).resolves.toEqual({
+      id: "demo",
+      name: "demo",
+    });
+
+    await expect(listProjectFiles("demo")).resolves.toEqual([
+      {
+        id: "homepage",
+        projectId: "demo",
+        name: "homepage.excalidraw",
+      },
+    ]);
+
+    await expect(createProjectFile("demo", "homepage")).resolves.toEqual({
+      id: "homepage",
+      projectId: "demo",
+      name: "homepage.excalidraw",
+    });
+
+    await expect(getProjectFile("demo", "homepage")).resolves.toEqual({
+      file: {
+        id: "homepage",
+        projectId: "demo",
+        name: "homepage.excalidraw",
+      },
+      scene: { elements: [], appState: {}, files: {} },
+    });
+
+    await expect(
+      saveProjectFile("demo", "homepage", {
+        elements: [],
+        appState: {} as any,
+        files: {},
+      }),
+    ).resolves.toEqual({
+      id: "homepage",
+      projectId: "demo",
+      name: "homepage.excalidraw",
+      updatedAt: "2026-04-09T09:15:00.000Z",
+    });
+  });
+});

--- a/excalidraw-app/tests/remote-projects.autosave.test.ts
+++ b/excalidraw-app/tests/remote-projects.autosave.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createRemoteAutoSaveController } from "../remote-projects/autosave";
+
+describe("remote projects autosave", () => {
+  it("does not save when the scene signature has not changed", async () => {
+    vi.useFakeTimers();
+
+    const save = vi.fn().mockResolvedValue(undefined);
+    const controller = createRemoteAutoSaveController<string>({
+      intervalMs: 10000,
+      save,
+      getSignature: (value) => value,
+    });
+
+    controller.queue("initial");
+    controller.queue("initial");
+
+    await vi.runAllTimersAsync();
+
+    expect(save).not.toHaveBeenCalled();
+
+    vi.useRealTimers();
+  });
+
+  it("saves at most once per 10 seconds and flushes the latest queued scene", async () => {
+    vi.useFakeTimers();
+
+    const save = vi.fn().mockResolvedValue(undefined);
+    const controller = createRemoteAutoSaveController<string>({
+      intervalMs: 10000,
+      save,
+      getSignature: (value) => value,
+    });
+
+    controller.queue("initial");
+    controller.queue("v1");
+
+    await vi.runAllTimersAsync();
+    expect(save).toHaveBeenCalledTimes(1);
+    expect(save).toHaveBeenLastCalledWith("v1");
+
+    controller.queue("v2");
+    controller.queue("v3");
+
+    await vi.advanceTimersByTimeAsync(9000);
+    expect(save).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(save).toHaveBeenCalledTimes(2);
+    expect(save).toHaveBeenLastCalledWith("v3");
+
+    vi.useRealTimers();
+  });
+
+  it("flushes immediately when explicitly requested for a changed scene", async () => {
+    const save = vi.fn().mockResolvedValue(undefined);
+    const controller = createRemoteAutoSaveController<string>({
+      intervalMs: 10000,
+      save,
+      getSignature: (value) => value,
+    });
+
+    controller.queue("initial");
+
+    await controller.flushNow("changed");
+
+    expect(save).toHaveBeenCalledTimes(1);
+    expect(save).toHaveBeenLastCalledWith("changed");
+  });
+});

--- a/excalidraw-app/tests/remote-projects.load-file.test.ts
+++ b/excalidraw-app/tests/remote-projects.load-file.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { initializeScene } from "../App";
+import { getProjectFile } from "../remote-projects/api";
+
+vi.mock("../remote-projects/api", () => ({
+  getProjectFile: vi.fn(),
+}));
+
+describe("remote project file loading", () => {
+  it("loads a remote file for a project file route", async () => {
+    vi.mocked(getProjectFile).mockResolvedValue({
+      file: {
+        id: "homepage",
+        projectId: "demo",
+        name: "homepage.excalidraw",
+      },
+      scene: {
+        elements: [],
+        appState: {} as any,
+        files: {},
+      },
+    });
+
+    window.history.replaceState({}, "", "/projects/demo/files/homepage");
+
+    const result = await initializeScene({
+      collabAPI: null,
+      excalidrawAPI: {
+        getAppState: () => ({ viewBackgroundColor: "#ffffff" }),
+        getSceneElementsIncludingDeleted: () => [],
+      } as any,
+    });
+
+    expect(getProjectFile).toHaveBeenCalledWith("demo", "homepage");
+    expect(result.scene?.elements).toEqual([]);
+    expect(result.isExternalScene).toBe(false);
+  });
+
+  it("normalizes collaborators when loading a serialized remote file", async () => {
+    vi.mocked(getProjectFile).mockResolvedValue({
+      file: {
+        id: "homepage",
+        projectId: "demo",
+        name: "homepage.excalidraw",
+      },
+      scene: {
+        elements: [],
+        appState: {
+          collaborators: {},
+        } as any,
+        files: {},
+      },
+    });
+
+    window.history.replaceState({}, "", "/projects/demo/files/homepage");
+
+    const result = await initializeScene({
+      collabAPI: null,
+      excalidrawAPI: {
+        getAppState: () => ({ viewBackgroundColor: "#ffffff" }),
+        getSceneElementsIncludingDeleted: () => [],
+      } as any,
+    });
+
+    expect(result.scene?.appState?.collaborators).toBeInstanceOf(Map);
+  });
+});

--- a/excalidraw-app/tests/remote-projects.routing.test.tsx
+++ b/excalidraw-app/tests/remote-projects.routing.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from "@testing-library/react";
+
+import App from "../App";
+import { getRemoteProjectRouteState } from "../remote-projects/store";
+
+vi.mock("../remote-projects/store", () => ({
+  getRemoteProjectRouteState: vi.fn(() => ({ mode: "projects" })),
+}));
+
+vi.mock("../components/Projects/ProjectsPage", () => ({
+  ProjectsPage: () => <div>Projects Page</div>,
+}));
+
+vi.mock("../components/Projects/ProjectFilesPage", () => ({
+  ProjectFilesPage: () => <div>Project Files Page</div>,
+}));
+
+vi.mock("@excalidraw/excalidraw", async (importOriginal) => {
+  const mod =
+    await importOriginal<typeof import("@excalidraw/excalidraw")>();
+
+  return {
+    ...mod,
+    ExcalidrawAPIProvider: ({ children }: { children: React.ReactNode }) => (
+      <>{children}</>
+    ),
+    useExcalidrawAPI: () => null,
+    useEditorInterface: () => ({ formFactor: "desktop" }),
+  };
+});
+
+describe("remote project routing", () => {
+  const mockedGetRemoteProjectRouteState = vi.mocked(getRemoteProjectRouteState);
+
+  it("renders the projects page for the projects route", async () => {
+    mockedGetRemoteProjectRouteState.mockReturnValue({ mode: "projects" });
+
+    render(<App />);
+
+    expect(await screen.findByText("Projects Page")).toBeInTheDocument();
+  });
+
+  it("renders the project files page for a project route", async () => {
+    mockedGetRemoteProjectRouteState.mockReturnValue({
+      mode: "project",
+      projectId: "demo",
+    });
+
+    render(<App />);
+
+    expect(await screen.findByText("Project Files Page")).toBeInTheDocument();
+  });
+});

--- a/excalidraw-app/tests/remote-projects.save-file.test.tsx
+++ b/excalidraw-app/tests/remote-projects.save-file.test.tsx
@@ -1,0 +1,102 @@
+import { act, render, waitFor } from "@testing-library/react";
+
+import App from "../App";
+import { getProjectFile, saveProjectFile } from "../remote-projects/api";
+import { getRemoteProjectRouteState } from "../remote-projects/store";
+
+vi.mock("../remote-projects/api", () => ({
+  getProjectFile: vi.fn(),
+  saveProjectFile: vi.fn(),
+}));
+
+vi.mock("../remote-projects/store", async (importOriginal) => {
+  const mod = await importOriginal<typeof import("../remote-projects/store")>();
+
+  return {
+    ...mod,
+    getRemoteProjectRouteState: vi.fn(() => ({
+      mode: "file",
+      projectId: "demo",
+      fileId: "homepage",
+    })),
+  };
+});
+
+describe("remote project file save", () => {
+  it("does not save an untouched remote file on initial render", async () => {
+    vi.mocked(getRemoteProjectRouteState).mockReturnValue({
+      mode: "file",
+      projectId: "demo",
+      fileId: "homepage",
+    });
+    vi.mocked(getProjectFile).mockResolvedValue({
+      file: {
+        id: "homepage",
+        projectId: "demo",
+        name: "homepage.excalidraw",
+      },
+      scene: {
+        elements: [],
+        appState: {} as any,
+        files: {},
+      },
+    });
+    vi.mocked(saveProjectFile).mockResolvedValue({
+      id: "homepage",
+      projectId: "demo",
+      name: "homepage.excalidraw",
+    });
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(getProjectFile).toHaveBeenCalled();
+    });
+
+    expect(saveProjectFile).not.toHaveBeenCalled();
+  });
+
+  it("does not save the current remote file on Cmd/Ctrl+S when nothing changed", async () => {
+    vi.mocked(getRemoteProjectRouteState).mockReturnValue({
+      mode: "file",
+      projectId: "demo",
+      fileId: "homepage",
+    });
+    vi.mocked(getProjectFile).mockResolvedValue({
+      file: {
+        id: "homepage",
+        projectId: "demo",
+        name: "homepage.excalidraw",
+      },
+      scene: {
+        elements: [],
+        appState: {} as any,
+        files: {},
+      },
+    });
+    vi.mocked(saveProjectFile).mockResolvedValue({
+      id: "homepage",
+      projectId: "demo",
+      name: "homepage.excalidraw",
+    });
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(getProjectFile).toHaveBeenCalled();
+    });
+
+    act(() => {
+      window.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          key: "s",
+          metaKey: true,
+          bubbles: true,
+          cancelable: true,
+        }),
+      );
+    });
+
+    expect(saveProjectFile).not.toHaveBeenCalled();
+  });
+});

--- a/excalidraw-app/tests/remote-projects.scene.test.ts
+++ b/excalidraw-app/tests/remote-projects.scene.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+
+import { serializeRemoteProjectScene } from "../remote-projects/scene";
+
+describe("remote project scene serialization", () => {
+  it("omits runtime-only collaborators data from saved app state", () => {
+    const scene = serializeRemoteProjectScene({
+      elements: [],
+      appState: {
+        collaborators: new Map([["socket-1", { username: "A" }]]),
+      } as any,
+      files: {},
+    });
+
+    expect(scene.appState.collaborators).toBeUndefined();
+  });
+});

--- a/excalidraw-app/tests/remote-projects.store.test.ts
+++ b/excalidraw-app/tests/remote-projects.store.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  getProjectFilePath,
+  getProjectPath,
+  getProjectsPath,
+  getRemoteProjectRouteState,
+  isRemoteProjectFileRoute,
+} from "../remote-projects/store";
+
+describe("remote project route state", () => {
+  it("parses a file route", () => {
+    expect(getRemoteProjectRouteState("/projects/demo/files/homepage")).toEqual(
+      {
+        mode: "file",
+        projectId: "demo",
+        fileId: "homepage",
+      },
+    );
+    expect(isRemoteProjectFileRoute("/projects/demo/files/homepage")).toBe(
+      true,
+    );
+  });
+
+  it("creates stable navigation paths", () => {
+    expect(getProjectsPath()).toBe("/projects");
+    expect(getProjectPath("demo")).toBe("/projects/demo");
+    expect(getProjectFilePath("demo", "homepage")).toBe(
+      "/projects/demo/files/homepage",
+    );
+  });
+});

--- a/excalidraw-app/vite.config.mts
+++ b/excalidraw-app/vite.config.mts
@@ -8,6 +8,7 @@ import checker from "vite-plugin-checker";
 import { createHtmlPlugin } from "vite-plugin-html";
 import Sitemap from "vite-plugin-sitemap";
 import { woff2BrowserPlugin } from "../scripts/woff2/woff2-vite-plugins";
+import { viteRemoteProjectsApi } from "./server/viteRemoteProjectsApi";
 export default defineConfig(({ mode }) => {
   // To load .env variables
   const envVars = loadEnv(mode, `../`);
@@ -305,6 +306,7 @@ export default defineConfig(({ mode }) => {
       createHtmlPlugin({
         minify: true,
       }),
+      viteRemoteProjectsApi(),
     ],
     publicDir: "../public",
   };


### PR DESCRIPTION
## Summary
- add a remote project and file workflow backed by filesystem-based HTTP APIs
- add project picker UI in the welcome screen, main menu, and editor flow
- add remote file loading, explicit save, throttled autosave, and project/file status display

## Testing
- ./node_modules/.bin/vitest run excalidraw-app/tests/remote-projects.api.test.ts excalidraw-app/tests/remote-projects.autosave.test.ts excalidraw-app/tests/remote-projects.load-file.test.ts excalidraw-app/tests/remote-projects.routing.test.tsx excalidraw-app/tests/remote-projects.save-file.test.tsx excalidraw-app/tests/remote-projects.scene.test.ts excalidraw-app/tests/remote-projects.store.test.ts excalidraw-app/tests/ProjectsPage.test.tsx excalidraw-app/server/projects.test.ts
- ./node_modules/.bin/eslint excalidraw-app/App.tsx excalidraw-app/components/AppFooter.tsx excalidraw-app/components/AppMainMenu.tsx excalidraw-app/components/AppWelcomeScreen.tsx excalidraw-app/components/Projects/ProjectsDialog.tsx excalidraw-app/components/Projects/ProjectsIcon.tsx excalidraw-app/remote-projects/autosave.ts excalidraw-app/remote-projects/scene.ts excalidraw-app/server/viteRemoteProjectsApi.ts excalidraw-app/tests/remote-projects.autosave.test.ts excalidraw-app/tests/remote-projects.load-file.test.ts excalidraw-app/tests/remote-projects.save-file.test.tsx excalidraw-app/tests/remote-projects.scene.test.ts --max-warnings=0
- ./node_modules/.bin/tsc -p tsconfig.json --noEmit