### PR TITLE
fix(packages/excalidraw): add vertical scroll to canvas search result

### DIFF
--- a/packages/excalidraw/components/SearchMenu.scss
+++ b/packages/excalidraw/components/SearchMenu.scss
@@ -59,6 +59,12 @@
     }
   }
 
+  .layer-ui__search-result {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+  }
+
   .layer-ui__search-result-container {
     overflow-y: auto;
     flex: 1 1 0;

--- a/packages/excalidraw/components/SearchMenu.tsx
+++ b/packages/excalidraw/components/SearchMenu.tsx
@@ -497,7 +497,7 @@ const MatchListBase = (props: MatchListProps) => {
   );
 
   return (
-    <div>
+    <div className="layer-ui__search-result">
       {frameNameMatches.length > 0 && (
         <div className="layer-ui__search-result-container">
           <div className="layer-ui__search-result-title">


### PR DESCRIPTION
Issue https://github.com/excalidraw/excalidraw/issues/11092

## Problem
Unable to scroll canvas search result.

## Changes
Set style to wrapper of search result container to allow overflow-y
- added className `layer-ui__search-result` to the parent of `.layer-ui__search-result-container`
- applied style to `layer-ui__search-result`

## Test
All tests passed.