### PR TITLE
fix(editor): recalculate roundness type for all shape conversions

### DIFF
--- a/packages/excalidraw/components/ConvertElementTypePopup.tsx
+++ b/packages/excalidraw/components/ConvertElementTypePopup.tsx
@@ -831,14 +831,13 @@ const convertElementType = <
       newElement({
         ...element,
         type: targetType,
-        roundness:
-          targetType === "diamond" && element.roundness
-            ? {
-                type: isUsingAdaptiveRadius(targetType)
-                  ? ROUNDNESS.ADAPTIVE_RADIUS
-                  : ROUNDNESS.PROPORTIONAL_RADIUS,
-              }
-            : element.roundness,
+        roundness: element.roundness
+          ? {
+              type: isUsingAdaptiveRadius(targetType)
+                ? ROUNDNESS.ADAPTIVE_RADIUS
+                : ROUNDNESS.PROPORTIONAL_RADIUS,
+            }
+          : element.roundness,
       }),
     ) as typeof element;
 


### PR DESCRIPTION
## Summary
- Removes the `targetType === "diamond"` guard in `ConvertElementTypePopup.tsx` so the correct roundness algorithm (ADAPTIVE_RADIUS vs PROPORTIONAL_RADIUS) is applied for **all** target element types during shape conversion
- Previously, converting from diamond back to rectangle preserved PROPORTIONAL_RADIUS (25% of size), resulting in excessively round corners on large elements
- Now the roundness type is always recalculated based on the target type via `isUsingAdaptiveRadius()`

## Test plan
- [ ] Create a rectangle with rounded corners
- [ ] Convert it to diamond via the shape switcher
- [ ] Convert it back to rectangle
- [ ] Verify corners use the correct adaptive radius (fixed 32px), not proportional radius
- [ ] Repeat with other shape combinations (ellipse, etc.)

Resolves #9662