### PR TITLE
fix(editor): make opacity slider compatible with RTL layout

### DIFF
--- a/packages/excalidraw/components/Range.scss
+++ b/packages/excalidraw/components/Range.scss
@@ -44,12 +44,16 @@
     transform: translateX(-50%);
     font-size: 12px;
     color: var(--text-primary-color);
+
+    :root[dir="rtl"] & {
+      transform: translateX(50%);
+    }
   }
 
   .zero-label {
     position: absolute;
     bottom: 0;
-    left: 4px;
+    inset-inline-start: 4px;
     font-size: 12px;
     color: var(--text-primary-color);
   }

--- a/packages/excalidraw/components/Range.tsx
+++ b/packages/excalidraw/components/Range.tsx
@@ -39,11 +39,20 @@ export const Range = ({
             "--slider-thumb-size",
           ),
         ) || 16;
+      const isRTL =
+        document.documentElement.getAttribute("dir") === "rtl";
       const progress = ((value - min) / (max - min || 1)) * 100;
       const position =
         (progress / 100) * (inputWidth - thumbWidth) + thumbWidth / 2;
-      valueElement.style.left = `${position}px`;
-      rangeElement.style.background = `linear-gradient(to right, var(--color-slider-track) 0%, var(--color-slider-track) ${progress}%, var(--button-bg) ${progress}%, var(--button-bg) 100%)`;
+      if (isRTL) {
+        valueElement.style.right = `${position}px`;
+        valueElement.style.left = "auto";
+      } else {
+        valueElement.style.left = `${position}px`;
+        valueElement.style.right = "auto";
+      }
+      const direction = isRTL ? "to left" : "to right";
+      rangeElement.style.background = `linear-gradient(${direction}, var(--color-slider-track) 0%, var(--color-slider-track) ${progress}%, var(--button-bg) ${progress}%, var(--button-bg) 100%)`;
     }
   }, [max, min, value]);
 


### PR DESCRIPTION
## Summary
- Fixes the Range (opacity/transparency) slider to properly handle RTL (right-to-left) layouts
- Uses `inset-inline-start` instead of `left` for the zero label positioning
- Flips the value bubble `translateX` direction in RTL mode
- Positions the value bubble with `right` instead of `left` in RTL
- Reverses the linear-gradient direction for the track fill in RTL

## Test plan
- [ ] Switch language to an RTL language (e.g., Arabic, Hebrew)
- [ ] Select an element and adjust the opacity slider
- [ ] Verify the slider track fill direction is correct (fills from right to left)
- [ ] Verify the value bubble follows the thumb correctly
- [ ] Verify the "0" label is positioned on the correct side
- [ ] Switch back to LTR and verify normal behavior is preserved

Resolves #9710