### PR TITLE
fix(editor): resolve HTML br tags in mermaid diagram text

### DIFF
--- a/packages/excalidraw/components/TTDDialog/common.ts
+++ b/packages/excalidraw/components/TTDDialog/common.ts
@@ -97,6 +97,22 @@ export const convertMermaidToExcalidraw = async ({
     const { elements, files = {} } = ret;
     setError(null);
 
+    // Sanitize HTML <br> tags in element text that mermaid may produce
+    for (const el of elements) {
+      if ("text" in el && typeof el.text === "string") {
+        el.text = el.text.replace(/<br\s*\/?>/gi, "\n");
+      }
+      if (
+        "label" in el &&
+        el.label &&
+        typeof el.label === "object" &&
+        "text" in el.label &&
+        typeof el.label.text === "string"
+      ) {
+        el.label.text = el.label.text.replace(/<br\s*\/?>/gi, "\n");
+      }
+    }
+
     data.current = {
       elements: convertToExcalidrawElements(elements, {
         regenerateIds: true,


### PR DESCRIPTION
## Summary
- Sanitizes HTML `<br>`, `<br/>`, and `<br />` tags in element text and label text after parsing mermaid definitions
- Converts these tags to newline characters (`\n`) before passing elements to `convertToExcalidrawElements`
- Handles both direct element `text` properties and nested `label.text` properties

## Test plan
- [ ] Open the Mermaid-to-Excalidraw dialog
- [ ] Paste a mermaid definition containing `<br>` tags in node labels, e.g.:
  ```
  graph TD
    A[First line<br>Second line] --> B[Another<br/>node]
  ```
- [ ] Verify the rendered text shows proper line breaks instead of literal `<br>` tags
- [ ] Test with `<br>`, `<br/>`, and `<br />` variants

Resolves #9708