### PR TITLE
fix(editor): restore undo/redo after exiting line editor by click

### DIFF
--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -8534,6 +8534,7 @@ class App extends React.Component<AppProps, AppState> {
         }
 
         if (this.state.selectedLinearElement?.isEditing) {
+          this.store.scheduleCapture();
           this.setState((prevState) => ({
             selectedLinearElement: prevState.selectedLinearElement
               ? {


### PR DESCRIPTION
## Summary
- Adds `this.store.scheduleCapture()` before the `setState` call when exiting the linear element editor via clicking outside
- Without this, the state transition (editing → not editing) was not captured in the undo history, causing undo/redo to stop working after exiting the line editor
- Follows the same pattern used consistently throughout the codebase for state changes that should be undoable

## Test plan
- [ ] Select the arrow or line tool and draw a multi-point line
- [ ] Double-click the line to enter line editing mode
- [ ] Click outside the line to exit the editor
- [ ] Press Ctrl+Z (undo) — verify it works correctly
- [ ] Press Ctrl+Shift+Z (redo) — verify it also works
- [ ] Repeat with different element types (arrows, lines)

Resolves #9495