### PR TITLE
fix(editor): make initial text container resize undoable

### DIFF
--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -6199,6 +6199,9 @@ class App extends React.Component<AppProps, AppState> {
       const minHeight = getApproxMinLineHeight(fontSize, lineHeight);
       const newHeight = Math.max(container.height, minHeight);
       const newWidth = Math.max(container.width, minWidth);
+      if (newHeight !== container.height || newWidth !== container.width) {
+        this.store.scheduleCapture();
+      }
       this.scene.mutateElement(container, {
         height: newHeight,
         width: newWidth,


### PR DESCRIPTION
## Summary
- Captures the current state to the undo history (via `store.scheduleCapture()`) before resizing a container when entering text editing mode
- Previously, if a small rectangle was double-clicked to add text (causing it to resize), exiting without typing left the dimension change impossible to undo
- The capture is conditional — only triggered when dimensions actually change

## Test plan
- [ ] Create a small rectangle (smaller than the minimum text container size)
- [ ] Double-click it to enter text editing (observe it resizes)
- [ ] Press Escape or click outside without typing any text
- [ ] Press Ctrl+Z (undo) — verify the rectangle restores to its original dimensions
- [ ] Verify normal text editing + undo still works correctly

Resolves #9006