### PR TITLE
feat: add bullet list and numbered list support to the text editor Closes #11118

### DIFF
--- a/packages/excalidraw/actions/actionProperties.tsx
+++ b/packages/excalidraw/actions/actionProperties.tsx
@@ -131,6 +131,8 @@ import {
   ArrowheadCardinalityOneOrManyIcon,
   ArrowheadCardinalityZeroOrManyIcon,
   ArrowheadCardinalityZeroOrOneIcon,
+  BulletListIcon, 
+  NumberedListIcon,
 } from "../components/icons";
 
 import { Fonts } from "../fonts";
@@ -2036,6 +2038,87 @@ export const actionChangeArrowType = register<keyof typeof ARROW_TYPE>({
             )}
             onChange={(value) => updateData(value)}
           />
+        </div>
+      </fieldset>
+    );
+  },
+});
+export const actionToggleBulletList = register({
+  name: "toggleBulletList",
+  label: "Toggle bullet list",
+  trackEvent: false,
+  perform: () => {
+    return false;
+  },
+  PanelComponent: ({ appState }) => {
+    if (!appState.editingTextElement) {
+      return null;
+    }
+
+    return (
+      <fieldset>
+        <legend>List</legend>
+        <div className="buttonList">
+          <button
+            className="ToolIcon_type_button ToolIcon"
+            type="button"
+            title="Toggle bullet list"
+            aria-label="Toggle bullet list"
+            onPointerDown={(e: React.PointerEvent<HTMLButtonElement>) => {
+              e.preventDefault();
+              const editable = document.querySelector(
+                ".excalidraw-wysiwyg",
+              ) as any;
+              if (editable?.__toggleBulletPoints) {
+                editable.__toggleBulletPoints();
+              }
+            }}
+          >
+            <div className="ToolIcon__icon">
+              <BulletListIcon />
+            </div>
+          </button>
+        </div>
+      </fieldset>
+    );
+  },
+});
+
+export const actionToggleNumberedList = register({
+  name: "toggleNumberedList",
+  label: "Toggle numbered list",
+  trackEvent: false,
+  perform: () => {
+    return false;
+  },
+  PanelComponent: ({ appState }) => {
+    if (!appState.editingTextElement) {
+      return null;
+    }
+
+    return (
+      <fieldset>
+        <legend>Numbered list</legend>
+        <div className="buttonList">
+          <button
+            className="ToolIcon_type_button ToolIcon"
+            type="button"
+            title="Toggle numbered list"
+            aria-label="Toggle numbered list"
+            onPointerDown={(e: React.PointerEvent<HTMLButtonElement>) => {
+              e.preventDefault();
+              const editable = document.querySelector(
+                ".excalidraw-wysiwyg",
+              ) as any;
+              if (editable?.__toggleNumberedList) {
+                editable.__toggleNumberedList();
+              }
+            }}
+          >
+            <div className="ToolIcon__icon">
+              <NumberedListIcon />
+            </div>
+          </button>
         </div>
       </fieldset>
     );

--- a/packages/excalidraw/actions/index.ts
+++ b/packages/excalidraw/actions/index.ts
@@ -19,6 +19,8 @@ export {
   actionChangeTextAlign,
   actionChangeVerticalAlign,
   actionChangeArrowProperties,
+  actionToggleBulletList,
+  actionToggleNumberedList, 
 } from "./actionProperties";
 
 export {

--- a/packages/excalidraw/actions/types.ts
+++ b/packages/excalidraw/actions/types.ts
@@ -128,6 +128,8 @@ export type ActionName =
   | "toggleLinearEditor"
   | "toggleEraserTool"
   | "toggleHandTool"
+  | "toggleBulletList" 
+  | "toggleNumberedList" 
   | "selectAllElementsInFrame"
   | "removeAllElementsFromFrame"
   | "updateFrameRendering"

--- a/packages/excalidraw/components/Actions.tsx
+++ b/packages/excalidraw/components/Actions.tsx
@@ -231,6 +231,8 @@ export const SelectedShapeActions = ({
           {(appState.activeTool.type === "text" ||
             suppportsHorizontalAlign(targetElements, elementsMap)) &&
             renderAction("changeTextAlign")}
+           {renderAction("toggleBulletList")}
+           {renderAction("toggleNumberedList")}
         </>
       )}
 
@@ -595,6 +597,8 @@ const CombinedTextProperties = ({
               {(appState.activeTool.type === "text" ||
                 suppportsHorizontalAlign(targetElements, elementsMap)) &&
                 renderAction("changeTextAlign")}
+                {renderAction("toggleBulletList")} 
+                {renderAction("toggleNumberedList")} 
               {shouldAllowVerticalAlign(targetElements, elementsMap) &&
                 renderAction("changeVerticalAlign")}
             </div>

--- a/packages/excalidraw/components/dropdownMenu/DropdownMenuSub.tsx
+++ b/packages/excalidraw/components/dropdownMenu/DropdownMenuSub.tsx
@@ -1,4 +1,7 @@
 import { DropdownMenu as DropdownMenuPrimitive } from "radix-ui";
+import React, { useState, useRef } from "react";
+
+import { useEditorInterface } from "../App";
 
 import DropdownMenuSubContent from "./DropdownMenuSubContent";
 import DropdownMenuSubTrigger from "./DropdownMenuSubTrigger";
@@ -10,9 +13,48 @@ import {
 const DropdownMenuSub = ({ children }: { children?: React.ReactNode }) => {
   const MenuTriggerComp = getSubMenuTriggerComponent(children);
   const MenuContentComp = getSubMenuContentComponent(children);
+  const editorInterface = useEditorInterface();
+  const isMobile = editorInterface.formFactor === "phone";
+  const [open, setOpen] = useState(false);
+  const wasOpenOnTouchStart = useRef(false);
+  const closedAtRef = useRef<number>(0);
+
+  if (!isMobile) {
+    return (
+      <DropdownMenuPrimitive.Sub>
+        {MenuTriggerComp}
+        {MenuContentComp}
+      </DropdownMenuPrimitive.Sub>
+    );
+  }
+
   return (
-    <DropdownMenuPrimitive.Sub>
-      {MenuTriggerComp}
+    <DropdownMenuPrimitive.Sub
+      open={open}
+      onOpenChange={(isOpen) => {
+        if (isOpen) {
+          const timeSinceClosed = Date.now() - closedAtRef.current;
+          if (timeSinceClosed < 500) {
+            return;
+          }
+          setOpen(true);
+        }
+      }}
+    >
+      <div
+        onTouchStart={() => {      
+          wasOpenOnTouchStart.current = open;
+        }}
+        onTouchEnd={() => {
+          if (wasOpenOnTouchStart.current) {
+            closedAtRef.current = Date.now();
+            setOpen(false);
+          }
+        }}
+        style={{ display: "contents" }}
+      >
+        {MenuTriggerComp}
+      </div>
       {MenuContentComp}
     </DropdownMenuPrimitive.Sub>
   );
@@ -20,7 +62,6 @@ const DropdownMenuSub = ({ children }: { children?: React.ReactNode }) => {
 
 DropdownMenuSub.Trigger = DropdownMenuSubTrigger;
 DropdownMenuSub.Content = DropdownMenuSubContent;
-
 DropdownMenuSub.displayName = "DropdownMenuSub";
 
 export default DropdownMenuSub;

--- a/packages/excalidraw/components/icons.tsx
+++ b/packages/excalidraw/components/icons.tsx
@@ -2492,3 +2492,58 @@ export const settingsIcon = createIcon(
   </g>,
   tablerIconProps,
 );
+
+// Bullet list icon: three filled circles with horizontal bars
+export const BulletListIcon = React.memo(() =>
+  React.createElement(
+    "svg",
+    {
+      viewBox: "0 0 24 24",
+      xmlns: "http://www.w3.org/2000/svg",
+      fill: "currentColor",
+      width: 16,
+      height: 16,
+    },
+    React.createElement("circle", { cx: "3.5", cy: "6", r: "1.5" }),
+    React.createElement("rect", { x: "7", y: "5", width: "14", height: "2", rx: "1" }),
+    React.createElement("circle", { cx: "3.5", cy: "12", r: "1.5" }),
+    React.createElement("rect", { x: "7", y: "11", width: "14", height: "2", rx: "1" }),
+    React.createElement("circle", { cx: "3.5", cy: "18", r: "1.5" }),
+    React.createElement("rect", { x: "7", y: "17", width: "14", height: "2", rx: "1" }),
+  ),
+);
+
+// Numbered list icon: digits 1, 2, 3 with horizontal bars
+export const NumberedListIcon = React.memo(() =>
+  React.createElement(
+    "svg",
+    {
+      viewBox: "0 0 24 24",
+      xmlns: "http://www.w3.org/2000/svg",
+      fill: "currentColor",
+      width: 16,
+      height: 16,
+    },
+    React.createElement("text", {
+      x: "1", y: "7",
+      fontSize: "6",
+      fontFamily: "sans-serif",
+      fontWeight: "bold",
+    }, "1"),
+    React.createElement("rect", { x: "8", y: "5", width: "13", height: "2", rx: "1" }),
+    React.createElement("text", {
+      x: "1", y: "13",
+      fontSize: "6",
+      fontFamily: "sans-serif",
+      fontWeight: "bold",
+    }, "2"),
+    React.createElement("rect", { x: "8", y: "11", width: "13", height: "2", rx: "1" }),
+    React.createElement("text", {
+      x: "1", y: "19",
+      fontSize: "6",
+      fontFamily: "sans-serif",
+      fontWeight: "bold",
+    }, "3"),
+    React.createElement("rect", { x: "8", y: "17", width: "13", height: "2", rx: "1" }),
+  ),
+);

--- a/packages/excalidraw/wysiwyg/textWysiwyg.tsx
+++ b/packages/excalidraw/wysiwyg/textWysiwyg.tsx
@@ -618,10 +618,47 @@ export const textWysiwyg = ({
         const selectionStart = editable.selectionStart;
         editable.value = normalized;
         // put the cursor at some position close to where it was before
-        // normalization (otherwise it'll end up at the end of the text)
+        // normalization otherwise it'll end up at the end of the text
         editable.selectionStart = selectionStart;
         editable.selectionEnd = selectionStart;
       }
+ 
+      // Auto-convert list shorthand at the start of a line:
+      //   "."  + char  becomes "• char"   (bullet list)
+      //   "-"  + char  becomes "- char"   (dash list)
+      //   "1." + char  becomes "1. char"  (numbered list)
+      // Triggers as soon as the user types the first character after the
+      // shorthand prefix, so the conversion feels instant.
+      const { selectionStart, value } = editable;
+      const lineStart = value.lastIndexOf("\n", selectionStart - 1) + 1;
+      const lineUpToCursor = value.slice(lineStart, selectionStart);
+ 
+      if (/^\.\S$/.test(lineUpToCursor)) {
+        const typedChar = lineUpToCursor[1];
+        editable.value =
+          value.slice(0, lineStart) +
+          "• " +
+          typedChar +
+          value.slice(selectionStart);
+        editable.selectionStart = editable.selectionEnd = lineStart + 3;
+      } else if (/^-\S$/.test(lineUpToCursor)) {
+        const typedChar = lineUpToCursor[1];
+        editable.value =
+          value.slice(0, lineStart) +
+          "- " +
+          typedChar +
+          value.slice(selectionStart);
+        editable.selectionStart = editable.selectionEnd = lineStart + 3;
+      } else if (/^1\.\S$/.test(lineUpToCursor)) {
+        const typedChar = lineUpToCursor[2];
+        editable.value =
+          value.slice(0, lineStart) +
+          "1. " +
+          typedChar +
+          value.slice(selectionStart);
+        editable.selectionStart = editable.selectionEnd = lineStart + 4;
+      }
+ 
       onChange(editable.value);
     };
   }
@@ -658,6 +695,68 @@ export const textWysiwyg = ({
       }
       submittedViaKeyboard = true;
       handleSubmit();
+    } else if (
+      // Auto-continue list formatting on plain Enter (no Ctrl/Shift).
+      // Continues the prefix on the new line, or exits list mode if the line is empty.
+      event.key === KEYS.ENTER &&
+      !event[KEYS.CTRL_OR_CMD] &&
+      !event.shiftKey
+    ) {
+      const { selectionStart, value } = editable;
+      const lineStart = value.lastIndexOf("\n", selectionStart - 1) + 1;
+      const currentLine = value.slice(lineStart, selectionStart);
+      const bulletMatch = currentLine.match(/^(\s*)(•\s|-\s)/);
+      const numberedMatch = currentLine.match(/^(\s*)(\d+)\.\s/);
+      if (bulletMatch) {
+        event.preventDefault();
+        const bullet = bulletMatch[0];
+        const contentAfterBullet = currentLine.slice(bullet.length);
+
+        if (contentAfterBullet.trim() === "") {
+          // Empty bullet line — exit list mode
+          editable.value =
+            value.slice(0, lineStart) +
+            value.slice(lineStart + bullet.length);
+          editable.selectionStart = editable.selectionEnd = lineStart;
+          editable.dispatchEvent(new Event("input"));
+          return;
+        }
+
+        const insertion = "\n" + bullet;
+        editable.value =
+          value.slice(0, selectionStart) +
+          insertion +
+          value.slice(editable.selectionEnd);
+        const newPos = selectionStart + insertion.length;
+        editable.selectionStart = editable.selectionEnd = newPos;
+        editable.dispatchEvent(new Event("input"));
+      } else if (numberedMatch) {
+        event.preventDefault();
+        const prefix = numberedMatch[0];
+        const currentNumber = parseInt(numberedMatch[2], 10);
+        const indent = numberedMatch[1];
+        const contentAfterPrefix = currentLine.slice(prefix.length);
+
+        if (contentAfterPrefix.trim() === "") {
+          // Empty numbered line — exit list mode
+          editable.value =
+            value.slice(0, lineStart) +
+            value.slice(lineStart + prefix.length);
+          editable.selectionStart = editable.selectionEnd = lineStart;
+          editable.dispatchEvent(new Event("input"));
+          return;
+        }
+
+        const nextPrefix = `${indent}${currentNumber + 1}. `;
+        const insertion = "\n" + nextPrefix;
+        editable.value =
+          value.slice(0, selectionStart) +
+          insertion +
+          value.slice(editable.selectionEnd);
+        const newPos = selectionStart + insertion.length;
+        editable.selectionStart = editable.selectionEnd = newPos;
+        editable.dispatchEvent(new Event("input"));
+      }
     } else if (
       event.key === KEYS.TAB ||
       (event[KEYS.CTRL_OR_CMD] &&
@@ -740,6 +839,101 @@ export const textWysiwyg = ({
         selectionEnd - TAB_SIZE * removedTabs.length,
       );
     }
+  };
+
+  // Toggles "• " prefix on every selected line.
+  // If all lines already have it, removes it. Otherwise adds it.
+  // Strips any existing numbered prefix first to prevent mixing formats.
+  // Exposed on the DOM element so the toolbar button can call it directly.
+  const toggleBulletPoints = () => {
+    const { selectionStart, selectionEnd, value } = editable;
+    const linesStartIndices = getSelectedLinesStartIndices().reverse();
+
+    const allHaveBullets = linesStartIndices.every((startIndex) =>
+      value.slice(startIndex).startsWith("• "),
+    );
+
+    let newValue = value;
+    let offset = 0;
+
+    linesStartIndices.forEach((startIndex) => {
+      const adjustedIndex = startIndex + offset;
+
+      if (allHaveBullets) {
+        // Remove "• " (2 characters)
+        newValue =
+          newValue.slice(0, adjustedIndex) +
+          newValue.slice(adjustedIndex + 2);
+        offset -= 2;
+      } else {
+        // Strip any existing numbered prefix before inserting bullet
+        // so lines can never end up with both formats simultaneously
+        const numberedPrefix = newValue.slice(adjustedIndex).match(/^\d+\.\s/);
+        const stripLength = numberedPrefix ? numberedPrefix[0].length : 0;
+
+        newValue =
+          newValue.slice(0, adjustedIndex) +
+          "• " +
+          newValue.slice(adjustedIndex + stripLength);
+        offset += 2 - stripLength;
+      }
+    });
+
+    editable.value = newValue;
+    editable.selectionStart = selectionStart + (allHaveBullets ? -2 : 2);
+    editable.selectionEnd = selectionEnd + offset;
+    editable.dispatchEvent(new Event("input"));
+  };
+
+  const toggleNumberedList = () => {
+    const { selectionStart, selectionEnd, value } = editable;
+    const linesStartIndices = getSelectedLinesStartIndices().reverse();
+
+    const allHaveNumbers = linesStartIndices.every((startIndex) =>
+      /^\d+\.\s/.test(value.slice(startIndex)),
+    );
+
+    let newValue = value;
+    let offset = 0;
+
+    if (allHaveNumbers) {
+      // Remove numbered prefixes
+      linesStartIndices.forEach((startIndex) => {
+        const adjustedIndex = startIndex + offset;
+        const prefixMatch = newValue.slice(adjustedIndex).match(/^\d+\.\s/);
+        if (prefixMatch) {
+          const prefixLength = prefixMatch[0].length;
+          newValue =
+            newValue.slice(0, adjustedIndex) +
+            newValue.slice(adjustedIndex + prefixLength);
+          offset -= prefixLength;
+        }
+      });
+    } else {
+      // Add numbered prefixes, stripping any existing bullet prefix first
+      // so lines can never end up with both formats simultaneously
+      linesStartIndices.forEach((startIndex, idx) => {
+        const adjustedIndex = startIndex + offset;
+        const bulletPrefix = newValue.slice(adjustedIndex).match(/^(•\s|-\s)/);
+        const stripLength = bulletPrefix ? bulletPrefix[0].length : 0;
+        const number = idx + 1;
+        const prefix = `${number}. `;
+
+        newValue =
+          newValue.slice(0, adjustedIndex) +
+          prefix +
+          newValue.slice(adjustedIndex + stripLength);
+        offset += prefix.length - stripLength;
+      });
+    }
+
+    editable.value = newValue;
+    const firstPrefixLength = allHaveNumbers
+      ? -(value.slice(linesStartIndices[0]).match(/^\d+\.\s/)?.[0].length ?? 0)
+      : `${1}. `.length;
+    editable.selectionStart = selectionStart + firstPrefixLength;
+    editable.selectionEnd = selectionEnd + offset;
+    editable.dispatchEvent(new Event("input"));
   };
 
   /**
@@ -1017,6 +1211,11 @@ export const textWysiwyg = ({
   excalidrawContainer
     ?.querySelector(".excalidraw-textEditorContainer")!
     .appendChild(editable);
+
+  // Expose list toggle functions so the toolbar buttons in
+  // actionProperties.tsx can reach them through the DOM element.
+  (editable as any).__toggleBulletPoints = toggleBulletPoints;
+  (editable as any).__toggleNumberedList = toggleNumberedList;
 
   return handleSubmit;
 };


### PR DESCRIPTION
What this adds:

List formatting for the Excalidraw text editor. Users can create bullet and numbered lists via toolbar buttons or keyboard shortcuts 

Features:
- Toolbar buttons : bullet (•) and numbered (1. 2. 3.) list toggles in the text formatting panel, available on both desktop and mobile 
- Typing shortcuts auto-triggered at the start of a line:
  - "."+ char → "• char"
  - "-" + char → "- char"
  - "1." + char → "1. char"
- Enter continues the list: pressing Enter on a list line adds a new line with the same prefix/ numbered lists auto-increment
- Enter exits list mode: pressing Enter on an empty list line removes the prefix and returns to normal text
- Mutually exclusive formats: switching between bullet and numbered automatically strips the existing prefix, preventing mixed formatting like "• 1. text"

Implementation notes:

List state is stored as plain text with prefix characters ("• ", "- ", "N. "). No new element types or schema changes are needed

toggleBulletPoints() and toggleNumberedList() live inside the textWysiwyg closure and are exposed on the textarea DOM element, allowing toolbar buttons in actionProperties.tsx to call them via onPointerDown with preventDefault, keeping the textarea focused during the operation.


Files changed:
- packages/excalidraw/wysiwyg/textWysiwyg.tsx
- packages/excalidraw/actions/actionProperties.tsx
- packages/excalidraw/actions/types.ts
- packages/excalidraw/actions/index.ts
- packages/excalidraw/components/Actions.tsx
- packages/excalidraw/components/icons.tsx

Known limitation
On Android, the toolbar list buttons may lose the text selection when the virtual keyboard dismisses before the popover is visible. This is a known mobile focus/selection lifecycle issue and can be addressed in a follow-up.


https://github.com/user-attachments/assets/6c7639f7-81dd-4585-bcbb-2b704bef3676



