### PR TITLE
fix: display error message for invalid hex color codes

### DIFF
--- a/packages/excalidraw/components/ColorPicker/ColorInput.tsx
+++ b/packages/excalidraw/components/ColorPicker/ColorInput.tsx
@@ -14,6 +14,17 @@ import { activeColorPickerSectionAtom } from "./colorPickerUtils";
 
 import type { ColorPickerType } from "./colorPickerUtils";
 
+const isValidHexColorInput = (value: string): boolean => {
+  if (value === "") return true;
+  const hex = value.replace(/^#/, "");
+  return (
+    /^[0-9a-fA-F]{3}$/.test(hex) ||
+    /^[0-9a-fA-F]{4}$/.test(hex) ||
+    /^[0-9a-fA-F]{6}$/.test(hex) ||
+    /^[0-9a-fA-F]{8}$/.test(hex)
+  );
+};
+
 export const ColorInput = ({
   color,
   onChange,
@@ -32,6 +43,7 @@ export const ColorInput = ({
   const [activeSection, setActiveColorPickerSection] = useAtom(
     activeColorPickerSectionAtom,
   );
+  const [hexError, setHexError] = useState<string | null>(null);
 
   useEffect(() => {
     setInnerValue(color);
@@ -40,6 +52,16 @@ export const ColorInput = ({
   const changeColor = useCallback(
     (inputValue: string) => {
       const value = inputValue.toLowerCase();
+
+      // Validate hex format before accepting
+      if (value !== "" && !isValidHexColorInput(value)) {
+        setHexError(t("colorPicker.invalidHex"));
+        setInnerValue(value);
+        return;
+      }
+
+      setHexError(null);
+
       const color = normalizeInputColor(value);
 
       if (color) {
@@ -128,6 +150,11 @@ export const ColorInput = ({
             {eyeDropperIcon}
           </div>
         </>
+      )}
+      {hexError && (
+        <div className="color-picker__hex-error" role="alert">
+          {hexError}
+        </div>
       )}
     </div>
   );

--- a/packages/excalidraw/components/ColorPicker/ColorPicker.scss
+++ b/packages/excalidraw/components/ColorPicker/ColorPicker.scss
@@ -368,6 +368,17 @@
     }
   }
 
+  .color-picker__hex-error {
+    grid-column: 1 / -1;
+    color: var(--color-red);
+    font-size: 0.75rem;
+    padding: 0.25rem 0.5rem;
+    margin: 0 8px 4px;
+    background: rgba(255, 0, 0, 0.08);
+    border-radius: 4px;
+    text-align: left;
+  }
+
   .color-picker__input-label {
     display: grid;
     grid-template-columns: auto 1fr auto auto;

--- a/packages/excalidraw/locales/en.json
+++ b/packages/excalidraw/locales/en.json
@@ -598,7 +598,8 @@
     "colors": "Colors",
     "shades": "Shades",
     "hexCode": "Hex code",
-    "noShades": "No shades available for this color"
+    "noShades": "No shades available for this color",
+    "invalidHex": "Invalid hex color code"
   },
   "overwriteConfirm": {
     "action": {

--- a/packages/excalidraw/tests/colorInput.test.ts
+++ b/packages/excalidraw/tests/colorInput.test.ts
@@ -1,5 +1,76 @@
 import { normalizeInputColor } from "@excalidraw/common";
 
+const isValidHexColorInput = (value: string): boolean => {
+  if (value === "") return true;
+  const hex = value.replace(/^#/, "");
+  return (
+    /^[0-9a-fA-F]{3}$/.test(hex) ||
+    /^[0-9a-fA-F]{4}$/.test(hex) ||
+    /^[0-9a-fA-F]{6}$/.test(hex) ||
+    /^[0-9a-fA-F]{8}$/.test(hex)
+  );
+};
+
+describe("isValidHexColorInput", () => {
+  describe("valid inputs", () => {
+    it("accepts 3-digit hex", () => {
+      expect(isValidHexColorInput("abc")).toBe(true);
+      expect(isValidHexColorInput("ABC")).toBe(true);
+      expect(isValidHexColorInput("123")).toBe(true);
+    });
+
+    it("accepts 4-digit hex with alpha", () => {
+      expect(isValidHexColorInput("abcd")).toBe(true);
+      expect(isValidHexColorInput("ABCD")).toBe(true);
+    });
+
+    it("accepts 6-digit hex", () => {
+      expect(isValidHexColorInput("ff0000")).toBe(true);
+      expect(isValidHexColorInput("FF0000")).toBe(true);
+      expect(isValidHexColorInput("abc123")).toBe(true);
+    });
+
+    it("accepts 8-digit hex with alpha", () => {
+      expect(isValidHexColorInput("ff000080")).toBe(true);
+      expect(isValidHexColorInput("FF0000FF")).toBe(true);
+    });
+
+    it("accepts with hash prefix", () => {
+      expect(isValidHexColorInput("#ff0000")).toBe(true);
+      expect(isValidHexColorInput("#abc")).toBe(true);
+      expect(isValidHexColorInput("#ff000080")).toBe(true);
+    });
+
+    it("accepts empty string", () => {
+      expect(isValidHexColorInput("")).toBe(true);
+    });
+  });
+
+  describe("invalid inputs", () => {
+    it("rejects too few characters", () => {
+      expect(isValidHexColorInput("1")).toBe(false);
+      expect(isValidHexColorInput("12")).toBe(false);
+      expect(isValidHexColorInput("12ab")).toBe(false);
+    });
+
+    it("rejects too many characters", () => {
+      expect(isValidHexColorInput("123456789")).toBe(false);
+      expect(isValidHexColorInput("fffffffff")).toBe(false);
+    });
+
+    it("rejects non-hex characters", () => {
+      expect(isValidHexColorInput("gggggg")).toBe(false);
+      expect(isValidHexColorInput("zzzzzz")).toBe(false);
+      expect(isValidHexColorInput("xyz123")).toBe(false);
+    });
+
+    it("rejects invalid characters with hash", () => {
+      expect(isValidHexColorInput("#gggggg")).toBe(false);
+      expect(isValidHexColorInput("#zzzzzz")).toBe(false);
+    });
+  });
+});
+
 describe("normalizeInputColor", () => {
   describe("hex colors", () => {
     it("returns hex color with hash as-is", () => {


### PR DESCRIPTION
## Description

Currently, Excalidraw accepts some invalid or malformed hexadecimal color values in the color input field without providing any visual or textual feedback to the user. This may cause confusion as users may not realize why the color hasn't changed.

## Changes

- Add `isValidHexColorInput()` validation function that checks for valid hex lengths (3, 4, 6, or 8 characters)
- Show inline error message below the hex input when an invalid value is entered
- Add `invalidHex` localization string for the error message
- Add SCSS styles for the error message display (red text with subtle background)
- Add comprehensive unit tests for the validation function

## Testing

```bash
# Run the color input tests
yarn test:app --testPathPattern=colorInput --run
```

## Related Issue

Fixes #9527
