### PR TITLE
fix(editor): preserve text editor focus when switching browser tabs

### DIFF
--- a/packages/excalidraw/wysiwyg/textWysiwyg.tsx
+++ b/packages/excalidraw/wysiwyg/textWysiwyg.tsx
@@ -788,6 +788,13 @@ export const textWysiwyg = ({
       return;
     }
 
+    // If the page is being hidden (e.g. tab switch via Alt+Tab), don't
+    // submit — keep the editor alive so the user can resume editing when
+    // they return. The visibilitychange listener below will refocus.
+    if (document.hidden) {
+      return;
+    }
+
     isDestroyed = true;
     // cleanup must be run before onSubmit otherwise when app blurs the wysiwyg
     // it'd get stuck in an infinite loop of blur→onSubmit after we re-focus the
@@ -854,6 +861,7 @@ export const textWysiwyg = ({
     window.removeEventListener("pointerup", bindBlurEvent);
     window.removeEventListener("blur", handleSubmit);
     window.removeEventListener("beforeunload", handleSubmit);
+    document.removeEventListener("visibilitychange", onVisibilityChange);
     unbindUpdate();
     unsubOnChange();
     unbindOnScroll();
@@ -960,6 +968,16 @@ export const textWysiwyg = ({
       });
     }
   };
+
+  // Restore focus when the user returns after switching tabs so
+  // they can continue editing immediately.
+  const onVisibilityChange = () => {
+    if (!document.hidden && !isDestroyed) {
+      editable.onblur = handleSubmit;
+      editable.focus();
+    }
+  };
+  document.addEventListener("visibilitychange", onVisibilityChange);
 
   // FIXME after we start emitting updates from Store for appState.theme
   const unsubOnChange = app.onChangeEmitter.on((elements) => {


### PR DESCRIPTION
## Summary
- Prevents the WYSIWYG text editor from being submitted/destroyed when the user switches tabs via Alt+Tab or Cmd+Tab
- Checks `document.hidden` in `handleSubmit` to skip submission during tab switches
- Adds a `visibilitychange` listener that refocuses the textarea when the user returns to the tab
- Properly cleans up the listener when the editor is destroyed

## Test plan
- [ ] Open Excalidraw and create a text element, start typing
- [ ] Press Alt+Tab (or Cmd+Tab) to switch to another application
- [ ] Switch back to Excalidraw
- [ ] Verify the text editor is still open and focused — you can continue typing immediately
- [ ] Verify that clicking outside the text box still properly closes/submits the editor
- [ ] Verify that pressing Escape still properly closes the editor

Resolves #9304