### PR TITLE
fix(editor): only show collaborators popup when avatars overflow

### DIFF
--- a/packages/excalidraw/components/UserList.tsx
+++ b/packages/excalidraw/components/UserList.tsx
@@ -169,9 +169,10 @@ export const UserList = React.memo(
 
     const [maxAvatars, setMaxAvatars] = React.useState(DEFAULT_MAX_AVATARS);
 
+    const needsOverflow = uniqueCollaboratorsArray.length > maxAvatars;
     const firstNCollaborators = uniqueCollaboratorsArray.slice(
       0,
-      maxAvatars - 1,
+      needsOverflow ? maxAvatars - 1 : maxAvatars,
     );
 
     const firstNAvatarsJSX = firstNCollaborators.map((collaborator) =>
@@ -204,7 +205,7 @@ export const UserList = React.memo(
         >
           {firstNAvatarsJSX}
 
-          {uniqueCollaboratorsArray.length > maxAvatars - 1 && (
+          {needsOverflow && (
             <Popover.Root>
               <Popover.Trigger className="UserList__more">
                 +{uniqueCollaboratorsArray.length - maxAvatars + 1}


### PR DESCRIPTION
## Summary
- Fixes the collaborators popup showing even when all avatars fit in the available space
- Previously, one slot was always reserved for the "+N" overflow button, causing the popup to appear when `collaborators.length >= maxAvatars` instead of `> maxAvatars`
- Now the "+N" button only renders when there are genuinely more collaborators than available slots
- When all collaborators fit, all slots are used for avatars with no popup

## Test plan
- [ ] Open a collaboration session with exactly N users where N equals the available avatar slots
- [ ] Verify all avatars are shown directly without a "+N" overflow button
- [ ] Add one more collaborator so N + 1 > available slots
- [ ] Verify the "+N" button now appears and the popup works correctly
- [ ] Resize the window to change available slots and verify the threshold updates correctly

Resolves #9515