### PR TITLE
fix(editor): allow browser Find in Page when a dialog is open

### DIFF
--- a/packages/excalidraw/actions/actionToggleSearchMenu.ts
+++ b/packages/excalidraw/actions/actionToggleSearchMenu.ts
@@ -25,10 +25,6 @@ export const actionToggleSearchMenu = register({
     predicate: (appState) => appState.gridModeEnabled,
   },
   perform(elements, appState, _, app) {
-    if (appState.openDialog) {
-      return false;
-    }
-
     if (
       appState.openSidebar?.name === DEFAULT_SIDEBAR.name &&
       appState.openSidebar.tab === CANVAS_SEARCH_TAB
@@ -56,5 +52,6 @@ export const actionToggleSearchMenu = register({
   predicate: (element, appState, props) => {
     return props.gridModeEnabled === undefined;
   },
-  keyTest: (event) => event[KEYS.CTRL_OR_CMD] && event.key === KEYS.F,
+  keyTest: (event, appState) =>
+    event[KEYS.CTRL_OR_CMD] && event.key === KEYS.F && !appState.openDialog,
 });


### PR DESCRIPTION
## Summary
- Moves the `openDialog` check from `perform()` to `keyTest()` in the search menu action
- When a dialog (e.g., Help modal) is open, the Ctrl+F shortcut is no longer intercepted by the "Find on Canvas" action
- This allows the browser's native "Find in Page" to work inside dialogs
- Previously, `event.preventDefault()` was called in `handleKeyDown` before `perform()` could return `false`, blocking the native shortcut even when the action didn't execute

## Test plan
- [ ] Open the Help dialog (press `?`)
- [ ] Press Ctrl+F (or Cmd+F on Mac)
- [ ] Verify the browser's native "Find in Page" opens (not the canvas search)
- [ ] Close the Help dialog
- [ ] Press Ctrl+F again
- [ ] Verify the canvas "Find on Canvas" search opens correctly
- [ ] Verify search works in other dialogs too (Settings, etc.)

Resolves #8534