### PR TITLE
fix(editor): prevent browser default for Ctrl+Z inside WYSIWYG

### DIFF
--- a/packages/excalidraw/wysiwyg/textWysiwyg.tsx
+++ b/packages/excalidraw/wysiwyg/textWysiwyg.tsx
@@ -659,6 +659,13 @@ export const textWysiwyg = ({
       submittedViaKeyboard = true;
       handleSubmit();
     } else if (
+      event[KEYS.CTRL_OR_CMD] &&
+      event.key.toLowerCase() === KEYS.Z
+    ) {
+      // Prevent the browser default (e.g. reopening closed tab) while
+      // inside the WYSIWYG editor. The app-level undo/redo handles this.
+      event.preventDefault();
+    } else if (
       event.key === KEYS.TAB ||
       (event[KEYS.CTRL_OR_CMD] &&
         (event.code === CODES.BRACKET_LEFT ||


### PR DESCRIPTION
## Summary
- Adds `event.preventDefault()` for Ctrl+Z and Ctrl+Shift+Z inside the WYSIWYG text editor's `onkeydown` handler
- Prevents the browser from performing its default undo behavior (which on some platforms can reopen closed tabs or trigger other unintended actions)
- The app-level undo/redo system handles the actual undo functionality

## Test plan
- [ ] Double-click to create/edit a text element (opens WYSIWYG editor)
- [ ] Type some text
- [ ] Press Ctrl+Z (or Cmd+Z on Mac)
- [ ] Verify the browser does NOT reopen a closed tab or perform other default behavior
- [ ] Verify that the app's undo still works correctly after exiting the text editor
- [ ] Test Ctrl+Shift+Z (redo) as well

Resolves #7936