### PR TITLE
fix: show canvas background color palette on mobile

### DIFF
--- a/packages/excalidraw/components/ColorPicker/ColorPicker.tsx
+++ b/packages/excalidraw/components/ColorPicker/ColorPicker.tsx
@@ -303,10 +303,10 @@ export const ColorPicker = ({
         role="dialog"
         aria-modal="true"
         className={clsx("color-picker-container", {
-          "color-picker-container--no-top-picks": isCompactMode,
+          "color-picker-container--no-top-picks": isCompactMode && type !== "canvasBackground",
         })}
       >
-        {!isCompactMode && (
+        {(!isCompactMode || type === "canvasBackground") && (
           <TopPicks
             activeColor={color}
             onChange={onChange}
@@ -314,7 +314,7 @@ export const ColorPicker = ({
             topPicks={topPicks}
           />
         )}
-        {!isCompactMode && <ButtonSeparator />}
+        {(!isCompactMode || type === "canvasBackground") && <ButtonSeparator />}
         <Popover.Root
           open={appState.openPopup === type}
           onOpenChange={(open) => {


### PR DESCRIPTION
Fixes #11152 

## Problem
On mobile, the canvas background color picker only showed 
a hex input field. The visual color palette (TopPicks) was 
hidden because it was conditionally rendered only in "full" 
styles panel mode.

## Fix
- Show TopPicks for canvasBackground type regardless of stylesPanelMode
- Show ButtonSeparator for canvasBackground type on mobile
- Keep correct grid layout by not applying 
  color-picker-container--no-top-picks for canvasBackground

## Screenshots

### Before
![beforecanvasbackground](https://github.com/user-attachments/assets/12ef8e2b-d477-4c6d-90e7-a16f72c0e725)


### After  
![aftercanvasbackground](https://github.com/user-attachments/assets/982f052a-8151-43ef-881d-80b0994f1265)
