### PR TITLE
feat: option to make laser drawings persistent

### DIFF
--- a/packages/excalidraw/animated-trail.ts
+++ b/packages/excalidraw/animated-trail.ts
@@ -149,11 +149,13 @@ export class AnimatedTrail implements Trail {
       paths.push(currentPath);
     }
 
-    this.pastTrails = this.pastTrails.filter((trail) => {
-      return trail.getStrokeOutline().length !== 0;
-    });
+    if (!this.app.state.persistentLaser) {
+      this.pastTrails = this.pastTrails.filter((trail) => {
+        return trail.getStrokeOutline().length !== 0;
+      });
+    }
 
-    if (paths.length === 0) {
+    if (paths.length === 0 && !this.app.state.persistentLaser) {
       this.stop();
     }
 

--- a/packages/excalidraw/appState.ts
+++ b/packages/excalidraw/appState.ts
@@ -129,6 +129,7 @@ export const getDefaultAppState = (): Omit<
     activeLockedId: null,
     bindMode: "orbit",
     boxSelectionMode: "contain",
+    persistentLaser: false,
   };
 };
 
@@ -256,6 +257,7 @@ const APP_STATE_STORAGE_CONF = (<
   lockedMultiSelections: { browser: true, export: true, server: true },
   activeLockedId: { browser: false, export: false, server: false },
   bindMode: { browser: true, export: false, server: false },
+  persistentLaser: { browser: true, export: false, server: false },
 });
 
 const _clearAppStateForStorage = <

--- a/packages/excalidraw/laser-trails.ts
+++ b/packages/excalidraw/laser-trails.ts
@@ -33,6 +33,17 @@ export class LaserTrails implements Trail {
       simplify: 0,
       streamline: 0.4,
       sizeMapping: (c) => {
+        if (this.app.state.persistentLaser) {
+          // In persistent mode, skip time/length decay so
+          // the trail remains fully visible until cleared.
+          const DECAY_LENGTH = 50;
+          const l =
+            (DECAY_LENGTH -
+              Math.min(DECAY_LENGTH, c.totalLength - c.currentIndex)) /
+            DECAY_LENGTH;
+          return easeOut(l);
+        }
+
         const DECAY_TIME = 1000;
         const DECAY_LENGTH = 50;
         const t = Math.max(
@@ -59,6 +70,14 @@ export class LaserTrails implements Trail {
 
   endPath(): void {
     this.localTrail.endPath();
+  }
+
+  /** Clear all persistent laser trails from the canvas. */
+  clearTrails(): void {
+    this.localTrail.clearTrails();
+    for (const trail of this.collabTrails.values()) {
+      trail.clearTrails();
+    }
   }
 
   start(container: SVGSVGElement) {

--- a/packages/excalidraw/types.ts
+++ b/packages/excalidraw/types.ts
@@ -473,6 +473,11 @@ export interface AppState {
   // and also remove groupId from this map
   lockedMultiSelections: { [groupId: string]: true };
   bindMode: BindMode;
+  /**
+   * When true, laser pointer trails persist on the canvas instead of
+   * fading out. Trails can be cleared manually via `clearLaserTrails`.
+   */
+  persistentLaser: boolean;
 }
 
 export type SearchMatch = {


### PR DESCRIPTION
Adds a `persistentLaser` flag that keeps laser trails visible until manually cleared instead of auto-fading. Handy for presentations where you want to leave a mark.

The animated trail checks the flag before starting its fade animation. When persistent mode is off, everything works exactly as before.

Closes #9884