### PR TITLE
[Feature] Implement Bounded Canvas Constraints

### DIFF
--- a/excalidraw-app/App.tsx
+++ b/excalidraw-app/App.tsx
@@ -909,6 +909,7 @@ const ExcalidrawWrapper = () => {
       })}
     >
       <Excalidraw
+        canvasLimit={{ minX: 0, maxX: 2000, minY: 0, maxY: 1000 }}
         onChange={onChange}
         onExport={onExport}
         initialData={initialStatePromiseRef.current.promise}

--- a/packages/element/src/dragElements.ts
+++ b/packages/element/src/dragElements.ts
@@ -42,6 +42,7 @@ export const dragSelectedElements = (
     y: number;
   },
   gridSize: NullableGridSize,
+  canvasLimit?: { minX?: number; minY?: number; maxX?: number; maxY?: number }
 ) => {
   if (
     _selectedElements.length === 1 &&
@@ -96,12 +97,33 @@ export const dragSelectedElements = (
     origElements.push(origElement);
   }
 
-  const adjustedOffset = calculateOffset(
+  let adjustedOffset = calculateOffset(
     getCommonBounds(origElements),
     offset,
     snapOffset,
     gridSize,
   );
+
+  if (canvasLimit) {
+    const defaultMinX = canvasLimit.minX ?? -Infinity;
+    const defaultMaxX = canvasLimit.maxX ?? Infinity;
+    const defaultMinY = canvasLimit.minY ?? -Infinity;
+    const defaultMaxY = canvasLimit.maxY ?? Infinity;
+    const [minX, minY, maxX, maxY] = getCommonBounds(origElements);
+
+    if (minX + adjustedOffset.x < defaultMinX) {
+      adjustedOffset.x = defaultMinX - minX;
+    }
+    if (maxX + adjustedOffset.x > defaultMaxX) {
+      adjustedOffset.x = defaultMaxX - maxX;
+    }
+    if (minY + adjustedOffset.y < defaultMinY) {
+      adjustedOffset.y = defaultMinY - minY;
+    }
+    if (maxY + adjustedOffset.y > defaultMaxY) {
+      adjustedOffset.y = defaultMaxY - maxY;
+    }
+  }
 
   const elementsToUpdateIds = new Set(
     Array.from(elementsToUpdate, (el) => el.id),
@@ -244,6 +266,7 @@ export const dragNewElement = ({
   widthAspectRatio = null,
   originOffset = null,
   informMutation = true,
+  canvasLimit,
 }: {
   newElement: NonDeletedExcalidrawElement;
   elementType: AppState["activeTool"]["type"];
@@ -265,6 +288,7 @@ export const dragNewElement = ({
     y: number;
   } | null;
   informMutation?: boolean;
+  canvasLimit?: { minX?: number; minY?: number; maxX?: number; maxY?: number };
 }) => {
   if (shouldMaintainAspectRatio && newElement.type !== "selection") {
     if (widthAspectRatio) {
@@ -301,6 +325,27 @@ export const dragNewElement = ({
     height += height;
     newX = originX - width / 2;
     newY = originY - height / 2;
+  }
+
+  if (canvasLimit) {
+    const defaultMinX = canvasLimit.minX ?? -Infinity;
+    const defaultMaxX = canvasLimit.maxX ?? Infinity;
+    const defaultMinY = canvasLimit.minY ?? -Infinity;
+    const defaultMaxY = canvasLimit.maxY ?? Infinity;
+    if (newX < defaultMinX) {
+      width -= (defaultMinX - newX);
+      newX = defaultMinX;
+    }
+    if (newX + width > defaultMaxX) {
+      width = defaultMaxX - newX;
+    }
+    if (newY < defaultMinY) {
+      height -= (defaultMinY - newY);
+      newY = defaultMinY;
+    }
+    if (newY + height > defaultMaxY) {
+      height = defaultMaxY - newY;
+    }
   }
 
   let textAutoResize = null;

--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -2164,6 +2164,7 @@ class App extends React.Component<AppProps, AppState> {
                             }
                             UIOptions={this.props.UIOptions}
                             onExportImage={this.onExportImage}
+                            canvasLimit={this.props.canvasLimit}
                             renderWelcomeScreen={
                               !this.state.isLoading &&
                               this.state.showWelcomeScreen &&
@@ -4391,6 +4392,13 @@ class App extends React.Component<AppProps, AppState> {
       scrollY = scroll.scrollY;
     }
 
+    const clamped = this.getClampedScroll(scrollX, scrollY, zoom.value, this.state.width, Math.max(this.state.height, 1));
+    scrollX = clamped.scrollX;
+    scrollY = clamped.scrollY;
+    if (clamped.zoom) {
+      zoom = clamped.zoom;
+    }
+
     // when animating, we use RequestAnimationFrame to prevent the animation
     // from slowing down other processes
     if (opts?.animate) {
@@ -4437,7 +4445,7 @@ class App extends React.Component<AppProps, AppState> {
         this.cancelInProgressAnimation = null;
       };
     } else {
-      this.setState({ scrollX, scrollY, zoom });
+      this.translateCanvas({ scrollX, scrollY, zoom });
     }
   };
 
@@ -4447,13 +4455,80 @@ class App extends React.Component<AppProps, AppState> {
     }
   };
 
+  private getClampedScroll = (
+    scrollX: number,
+    scrollY: number,
+    zoomValue: number,
+    width: number,
+    height: number
+  ) => {
+    let newScrollX = scrollX;
+    let newScrollY = scrollY;
+    let newZoom = zoomValue;
+    const canvasLimit = this.props.canvasLimit;
+
+    if (canvasLimit) {
+      const minX = canvasLimit.minX ?? -Infinity;
+      const maxX = canvasLimit.maxX ?? Infinity;
+      const minY = canvasLimit.minY ?? -Infinity;
+      const maxY = canvasLimit.maxY ?? Infinity;
+
+      if (minX !== -Infinity && maxX !== Infinity && maxX > minX) {
+        newZoom = Math.max(newZoom, width / (maxX - minX));
+      }
+      if (minY !== -Infinity && maxY !== Infinity && maxY > minY) {
+        newZoom = Math.max(newZoom, height / (maxY - minY));
+      }
+
+      if (canvasLimit.minX !== undefined) {
+        newScrollX = Math.min(newScrollX, -canvasLimit.minX);
+      }
+      if (canvasLimit.maxX !== undefined) {
+        newScrollX = Math.max(newScrollX, (width / newZoom) - canvasLimit.maxX);
+      }
+      if (canvasLimit.minY !== undefined) {
+        newScrollY = Math.min(newScrollY, -canvasLimit.minY);
+      }
+      if (canvasLimit.maxY !== undefined) {
+        newScrollY = Math.max(newScrollY, (height / newZoom) - canvasLimit.maxY);
+      }
+    }
+    
+    return { 
+      scrollX: newScrollX, 
+      scrollY: newScrollY,
+      ...(newZoom !== zoomValue ? { zoom: { value: newZoom as any } } : {})
+    };
+  };
+
   /** use when changing scrollX/scrollY/zoom based on user interaction */
   private translateCanvas: React.Component<any, AppState>["setState"] = (
     state,
+    callback,
   ) => {
     this.cancelInProgressAnimation?.();
     this.maybeUnfollowRemoteUser();
-    this.setState(state);
+    
+    if (typeof state === "function") {
+      this.setState((prevState, props) => {
+        const nextState = state(prevState, props) as Partial<AppState> | null;
+        if (!nextState) {
+          return null;
+        }
+        const scrollX = nextState.scrollX ?? prevState.scrollX;
+        const scrollY = nextState.scrollY ?? prevState.scrollY;
+        const zoom = nextState.zoom ?? prevState.zoom;
+        const clamped = this.getClampedScroll(scrollX, scrollY, zoom.value, prevState.width, Math.max(prevState.height, 1));
+        return { ...nextState, ...clamped } as Pick<AppState, keyof AppState>;
+      }, callback);
+    } else {
+      const nextState = state as Partial<AppState> | null;
+      const scrollX = nextState?.scrollX ?? this.state.scrollX;
+      const scrollY = nextState?.scrollY ?? this.state.scrollY;
+      const zoom = nextState?.zoom ?? this.state.zoom;
+      const clamped = this.getClampedScroll(scrollX, scrollY, zoom.value, this.state.width, Math.max(this.state.height, 1));
+      this.setState({ ...(state as any), ...clamped } as Pick<AppState, keyof AppState>, callback);
+    }
   };
 
   setToast = (toast: AppState["toast"]) => {
@@ -9966,6 +10041,7 @@ class App extends React.Component<AppProps, AppState> {
               this.scene,
               snapOffset,
               event[KEYS.CTRL_OR_CMD] ? null : this.getEffectiveGridSize(),
+              this.props.canvasLimit,
             );
           }
 
@@ -12157,6 +12233,7 @@ class App extends React.Component<AppProps, AppState> {
         scene: this.scene,
         zoom: this.state.zoom.value,
         informMutation: false,
+        canvasLimit: this.props.canvasLimit,
       });
       return;
     }
@@ -12225,6 +12302,7 @@ class App extends React.Component<AppProps, AppState> {
         widthAspectRatio: aspectRatio,
         originOffset: this.state.originSnapOffset,
         informMutation,
+        canvasLimit: this.props.canvasLimit,
       });
     }
 

--- a/packages/excalidraw/components/LayerUI.tsx
+++ b/packages/excalidraw/components/LayerUI.tsx
@@ -99,6 +99,7 @@ interface LayerUIProps {
   app: AppClassProperties;
   isCollaborating: boolean;
   generateLinkForSelection?: AppProps["generateLinkForSelection"];
+  canvasLimit?: ExcalidrawProps["canvasLimit"];
 }
 
 const DefaultMainMenu: React.FC<{
@@ -158,6 +159,7 @@ const LayerUI = ({
   app,
   isCollaborating,
   generateLinkForSelection,
+  canvasLimit,
 }: LayerUIProps) => {
   const editorInterface = useEditorInterface();
   const stylesPanelMode = useStylesPanelMode();
@@ -605,6 +607,7 @@ const LayerUI = ({
               actionManager={actionManager}
               showExitZenModeBtn={showExitZenModeBtn}
               renderWelcomeScreen={renderWelcomeScreen}
+              canvasLimit={canvasLimit}
             />
             {(appState.toast || appState.scrolledOutside) && (
               <div className="floating-status-stack">

--- a/packages/excalidraw/components/footer/Footer.tsx
+++ b/packages/excalidraw/components/footer/Footer.tsx
@@ -15,11 +15,13 @@ const Footer = ({
   actionManager,
   showExitZenModeBtn,
   renderWelcomeScreen,
+  canvasLimit,
 }: {
   appState: UIAppState;
   actionManager: ActionManager;
   showExitZenModeBtn: boolean;
   renderWelcomeScreen: boolean;
+  canvasLimit?: any;
 }) => {
   const { FooterCenterTunnel, WelcomeScreenHelpHintTunnel } = useTunnels();
 
@@ -36,10 +38,12 @@ const Footer = ({
       >
         <Stack.Col gap={2}>
           <Section heading="canvasActions">
-            <ZoomActions
-              renderAction={actionManager.renderAction}
-              zoom={appState.zoom}
-            />
+            {!canvasLimit && (
+              <ZoomActions
+                renderAction={actionManager.renderAction}
+                zoom={appState.zoom}
+              />
+            )}
 
             {!appState.viewModeEnabled && (
               <UndoRedoActions

--- a/packages/excalidraw/index.tsx
+++ b/packages/excalidraw/index.tsx
@@ -208,6 +208,7 @@ const ExcalidrawBase = (props: ExcalidrawProps) => {
           aiEnabled={aiEnabled !== false}
           showDeprecatedFonts={showDeprecatedFonts}
           renderScrollbars={renderScrollbars}
+          canvasLimit={props.canvasLimit}
         >
           {children}
         </App>

--- a/packages/excalidraw/types.ts
+++ b/packages/excalidraw/types.ts
@@ -626,6 +626,15 @@ export interface ExcalidrawProps {
     appState: UIAppState,
   ) => JSX.Element | null;
   langCode?: Language["code"];
+  /**
+   * Constrains the canvas view and panning within the specified boundaries.
+   */
+  canvasLimit?: {
+    minX?: number;
+    minY?: number;
+    maxX?: number;
+    maxY?: number;
+  };
   viewModeEnabled?: boolean;
   zenModeEnabled?: boolean;
   gridModeEnabled?: boolean;


### PR DESCRIPTION
Closes: #10660  

Overview
This PR introduces a new canvasLimit prop on the main <Excalidraw> component, allowing host applications to optionally restrict the typical "infinite canvas" into a strict, predefined coordinate boundary box.

What it does:
When canvasLimit is provided to the Excalidraw component, the engine automatically:

- Restricts Camera Panning: You cannot pan the camera (Space + Drag or scrollbars/trackpad) to view the "void" outside of the specified logical limits.
- Restricts Zooming Out: The minimum allowed zoom scale is automatically bounded mathematically against the user's viewport width/height, preventing the camera from zooming out past the boundary.
- Constrains Element Dragging: Elements being dragged around the scene hit an invisible wall at your bounds and cannot be forced over it.
- Constrains Drawing Boundaries: Drawing a new shape clamps its width, height, and origin vectors gracefully at the borders.
- Hides Zoom Controls: If a strict limit is defined, the standard bottom-left <ZoomActions /> widget is unrendered since arbitrary zoom-out levels break the constraints.

Testing Instructions
You can test this feat passing a prop into your app <Excalidraw> initialization:

```code
<Excalidraw
  canvasLimit={{ minX: 0, maxX: 2000, minY: 0, maxY: 1000 }}
/>
```