### PR TITLE
feat: add GitHub integration

### DIFF
--- a/excalidraw-app/App.tsx
+++ b/excalidraw-app/App.tsx
@@ -935,7 +935,8 @@ const ExcalidrawWrapper = () => {
     keywords: ["plus", "cloud", "server"],
     perform: () => {
       window.open(
-        `${import.meta.env.VITE_APP_PLUS_LP
+        `${
+          import.meta.env.VITE_APP_PLUS_LP
         }/plus?utm_source=excalidraw&utm_medium=app&utm_content=command_palette`,
         "_blank",
       );
@@ -957,7 +958,8 @@ const ExcalidrawWrapper = () => {
     ],
     perform: () => {
       window.open(
-        `${import.meta.env.VITE_APP_PLUS_APP
+        `${
+          import.meta.env.VITE_APP_PLUS_APP
         }?utm_source=excalidraw&utm_medium=app&utm_content=command_palette`,
         "_blank",
       );
@@ -985,52 +987,52 @@ const ExcalidrawWrapper = () => {
               onExportToBackend,
               renderCustomUI: excalidrawAPI
                 ? (elements, appState, files) => {
-                  return (
-                    <>
-                      <ExportToExcalidrawPlus
-                        elements={elements}
-                        appState={appState}
-                        files={files}
-                        name={excalidrawAPI.getName()}
-                        onError={(error) => {
-                          excalidrawAPI?.updateScene({
-                            appState: {
-                              errorMessage: error.message,
-                            },
-                          });
-                        }}
-                        onSuccess={() => {
-                          excalidrawAPI.updateScene({
-                            appState: { openDialog: null },
-                          });
-                        }}
-                      />
-                      <Card color="primary">
-                        <div className="Card-icon">
-                          <GitHubIcon />
-                        </div>
-                        <h2>GitHub</h2>
-                        <div className="Card-details">
-                          Save to your GitHub repository
-                        </div>
-                        <ToolButton
-                          className="Card-button"
-                          type="button"
-                          title="Save to GitHub"
-                          aria-label="Save to GitHub"
-                          showAriaLabel={true}
-                          onClick={() => {
-                            setGitHubSaveQuickMode(!!activeGitHubConfig);
-                            setGitHubSaveDialogOpen(true);
+                    return (
+                      <>
+                        <ExportToExcalidrawPlus
+                          elements={elements}
+                          appState={appState}
+                          files={files}
+                          name={excalidrawAPI.getName()}
+                          onError={(error) => {
                             excalidrawAPI?.updateScene({
+                              appState: {
+                                errorMessage: error.message,
+                              },
+                            });
+                          }}
+                          onSuccess={() => {
+                            excalidrawAPI.updateScene({
                               appState: { openDialog: null },
                             });
                           }}
                         />
-                      </Card>
-                    </>
-                  );
-                }
+                        <Card color="primary">
+                          <div className="Card-icon">
+                            <GitHubIcon />
+                          </div>
+                          <h2>GitHub</h2>
+                          <div className="Card-details">
+                            Save to your GitHub repository
+                          </div>
+                          <ToolButton
+                            className="Card-button"
+                            type="button"
+                            title="Save to GitHub"
+                            aria-label="Save to GitHub"
+                            showAriaLabel={true}
+                            onClick={() => {
+                              setGitHubSaveQuickMode(!!activeGitHubConfig);
+                              setGitHubSaveDialogOpen(true);
+                              excalidrawAPI?.updateScene({
+                                appState: { openDialog: null },
+                              });
+                            }}
+                          />
+                        </Card>
+                      </>
+                    );
+                  }
                 : undefined,
             },
           },
@@ -1298,11 +1300,11 @@ const ExcalidrawWrapper = () => {
             },
             ...(isExcalidrawPlusSignedUser
               ? [
-                {
-                  ...ExcalidrawPlusAppCommand,
-                  label: "Sign in / Go to Excalidraw+",
-                },
-              ]
+                  {
+                    ...ExcalidrawPlusAppCommand,
+                    label: "Sign in / Go to Excalidraw+",
+                  },
+                ]
               : [ExcalidrawPlusCommand, ExcalidrawPlusAppCommand]),
 
             {

--- a/excalidraw-app/App.tsx
+++ b/excalidraw-app/App.tsx
@@ -19,6 +19,8 @@ import { OverwriteConfirmDialog } from "@excalidraw/excalidraw/components/Overwr
 import { openConfirmModal } from "@excalidraw/excalidraw/components/OverwriteConfirm/OverwriteConfirmState";
 import { ShareableLinkDialog } from "@excalidraw/excalidraw/components/ShareableLinkDialog";
 import Trans from "@excalidraw/excalidraw/components/Trans";
+import { Card } from "@excalidraw/excalidraw/components/Card";
+import { ToolButton } from "@excalidraw/excalidraw/components/ToolButton";
 import {
   APP_NAME,
   EVENT,
@@ -81,12 +83,14 @@ import type { ResolutionType } from "@excalidraw/common/utility-types";
 import type { ResolvablePromise } from "@excalidraw/common/utils";
 
 import CustomStats from "./CustomStats";
+
 import {
   Provider,
   useAtom,
   useAtomValue,
   useAtomWithInitialValue,
   appJotaiStore,
+  useSetAtom,
 } from "./app-jotai";
 import {
   FIREBASE_STORAGE_PREFIXES,
@@ -131,6 +135,17 @@ import {
 } from "./data/LocalData";
 import { isBrowserStorageStateNewer } from "./data/tabSync";
 import { ShareDialog, shareDialogStateAtom } from "./share/ShareDialog";
+import {
+  GitHubSaveDialog,
+  activeGitHubConfigAtom,
+  gitHubSaveQuickModeAtom,
+  gitHubSaveDialogOpenAtom,
+  GitHubIcon,
+} from "./components/GitHubSaveDialog";
+import {
+  GitHubLoadDialog,
+  type LoadedScene,
+} from "./components/GitHubLoadDialog";
 import CollabError, { collabErrorIndicatorAtom } from "./collab/CollabError";
 import { useHandleAppTheme } from "./useHandleAppTheme";
 import { getPreferredLanguage } from "./app-language/language-detector";
@@ -361,11 +376,11 @@ const initializeScene = async (opts: {
   } else if (scene) {
     return isExternalScene && jsonBackendMatch
       ? {
-          scene,
-          isExternalScene,
-          id: jsonBackendMatch[1],
-          key: jsonBackendMatch[2],
-        }
+        scene,
+        isExternalScene,
+        id: jsonBackendMatch[1],
+        key: jsonBackendMatch[2],
+      }
       : { scene, isExternalScene: false };
   }
   return { scene: null, isExternalScene: false };
@@ -377,11 +392,46 @@ const ExcalidrawWrapper = () => {
   const [errorMessage, setErrorMessage] = useState("");
   const isCollabDisabled = isRunningInIframe();
 
+  const [activeGitHubConfig] = useAtom(activeGitHubConfigAtom);
+  const setGitHubSaveQuickMode = useSetAtom(gitHubSaveQuickModeAtom);
+  const setGitHubSaveDialogOpen = useSetAtom(gitHubSaveDialogOpenAtom);
+
   const { editorTheme, appTheme, setAppTheme } = useHandleAppTheme();
 
   const [langCode, setLangCode] = useAppLangCode();
 
   const editorInterface = useEditorInterface();
+
+  const handleGitHubLoad = useCallback(
+    async ({ json }: LoadedScene) => {
+      if (!excalidrawAPI) {
+        return;
+      }
+      try {
+        const blob = new Blob([json], {
+          type: "application/vnd.excalidraw+json",
+        });
+        const data = await loadFromBlob(
+          blob,
+          excalidrawAPI.getAppState(),
+          excalidrawAPI.getSceneElements(),
+        );
+        excalidrawAPI.updateScene({
+          elements: restoreElements(data.elements, null, {
+            repairBindings: true,
+          }),
+          appState: restoreAppState(data.appState, null),
+          captureUpdate: CaptureUpdateAction.IMMEDIATELY,
+        });
+        excalidrawAPI.scrollToContent(undefined, {
+          fitToContent: true,
+        });
+      } catch (error: any) {
+        setErrorMessage(error.message);
+      }
+    },
+    [excalidrawAPI],
+  );
 
   // initial state
   // ---------------------------------------------------------------------------
@@ -395,7 +445,6 @@ const ExcalidrawWrapper = () => {
   }
 
   const debugCanvasRef = useRef<HTMLCanvasElement>(null);
-
   useEffect(() => {
     trackEvent("load", "frame", getFrame());
     // Delayed so that the app has a time to load the latest SW
@@ -403,6 +452,22 @@ const ExcalidrawWrapper = () => {
       trackEvent("load", "version", getVersion());
     }, VERSION_TIMEOUT);
   }, []);
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === "s") {
+        if (activeGitHubConfig) {
+          e.preventDefault();
+          e.stopPropagation();
+          setGitHubSaveQuickMode(true);
+          setGitHubSaveDialogOpen(true);
+        }
+      }
+    };
+    // Use capture phase to intercept before Excalidraw's built-in shortcuts
+    window.addEventListener("keydown", handleKeyDown, true);
+    return () => window.removeEventListener("keydown", handleKeyDown, true);
+  }, [activeGitHubConfig, setGitHubSaveQuickMode, setGitHubSaveDialogOpen]);
 
   const [, setShareDialogState] = useAtom(shareDialogStateAtom);
   const [collabAPI] = useAtom(collabAPIAtom);
@@ -870,8 +935,7 @@ const ExcalidrawWrapper = () => {
     keywords: ["plus", "cloud", "server"],
     perform: () => {
       window.open(
-        `${
-          import.meta.env.VITE_APP_PLUS_LP
+        `${import.meta.env.VITE_APP_PLUS_LP
         }/plus?utm_source=excalidraw&utm_medium=app&utm_content=command_palette`,
         "_blank",
       );
@@ -893,13 +957,13 @@ const ExcalidrawWrapper = () => {
     ],
     perform: () => {
       window.open(
-        `${
-          import.meta.env.VITE_APP_PLUS_APP
+        `${import.meta.env.VITE_APP_PLUS_APP
         }?utm_source=excalidraw&utm_medium=app&utm_content=command_palette`,
         "_blank",
       );
     },
   };
+
 
   return (
     <div
@@ -921,7 +985,8 @@ const ExcalidrawWrapper = () => {
               onExportToBackend,
               renderCustomUI: excalidrawAPI
                 ? (elements, appState, files) => {
-                    return (
+                  return (
+                    <>
                       <ExportToExcalidrawPlus
                         elements={elements}
                         appState={appState}
@@ -940,8 +1005,32 @@ const ExcalidrawWrapper = () => {
                           });
                         }}
                       />
-                    );
-                  }
+                      <Card color="primary">
+                        <div className="Card-icon">
+                          <GitHubIcon />
+                        </div>
+                        <h2>GitHub</h2>
+                        <div className="Card-details">
+                          Save to your GitHub repository
+                        </div>
+                        <ToolButton
+                          className="Card-button"
+                          type="button"
+                          title="Save to GitHub"
+                          aria-label="Save to GitHub"
+                          showAriaLabel={true}
+                          onClick={() => {
+                            setGitHubSaveQuickMode(!!activeGitHubConfig);
+                            setGitHubSaveDialogOpen(true);
+                            excalidrawAPI?.updateScene({
+                              appState: { openDialog: null },
+                            });
+                          }}
+                        />
+                      </Card>
+                    </>
+                  );
+                }
                 : undefined,
             },
           },
@@ -1039,6 +1128,10 @@ const ExcalidrawWrapper = () => {
         {excalidrawAPI && !isCollabDisabled && (
           <Collab excalidrawAPI={excalidrawAPI} />
         )}
+
+        <GitHubLoadDialog onLoad={handleGitHubLoad} />
+
+        <GitHubSaveDialog excalidrawAPI={excalidrawAPI} />
 
         <ShareDialog
           collabAPI={collabAPI}
@@ -1205,11 +1298,11 @@ const ExcalidrawWrapper = () => {
             },
             ...(isExcalidrawPlusSignedUser
               ? [
-                  {
-                    ...ExcalidrawPlusAppCommand,
-                    label: "Sign in / Go to Excalidraw+",
-                  },
-                ]
+                {
+                  ...ExcalidrawPlusAppCommand,
+                  label: "Sign in / Go to Excalidraw+",
+                },
+              ]
               : [ExcalidrawPlusCommand, ExcalidrawPlusAppCommand]),
 
             {

--- a/excalidraw-app/components/AppMainMenu.tsx
+++ b/excalidraw-app/components/AppMainMenu.tsx
@@ -13,6 +13,10 @@ import type { Theme } from "@excalidraw/element/types";
 import { LanguageList } from "../app-language/LanguageList";
 import { isExcalidrawPlusSignedUser } from "../app_constants";
 
+import { useSetAtom } from "../app-jotai";
+import { gitHubLoadDialogOpenAtom } from "./GitHubLoadDialog";
+import { GitHubIcon } from "./GitHubSaveDialog";
+
 import { saveDebugState } from "./DebugCanvas";
 
 export const AppMainMenu: React.FC<{
@@ -23,10 +27,21 @@ export const AppMainMenu: React.FC<{
   setTheme: (theme: Theme | "system") => void;
   refresh: () => void;
 }> = React.memo((props) => {
+  const openGitHubLoadDialog = useSetAtom(gitHubLoadDialogOpenAtom);
+  const appPlusApp = import.meta.env.VITE_APP_PLUS_APP;
+  const appPlusLp = import.meta.env.VITE_APP_PLUS_LP;
+
   return (
     <MainMenu>
       <MainMenu.DefaultItems.LoadScene />
       <MainMenu.DefaultItems.SaveToActiveFile />
+      <MainMenu.Item
+        icon={<GitHubIcon />}
+        onSelect={() => openGitHubLoadDialog(true)}
+      >
+        Load from GitHub
+      </MainMenu.Item>
+
       <MainMenu.DefaultItems.Export />
       <MainMenu.DefaultItems.SaveAsImage />
       {props.isCollabEnabled && (
@@ -42,9 +57,7 @@ export const AppMainMenu: React.FC<{
       <MainMenu.Separator />
       <MainMenu.ItemLink
         icon={ExcalLogo}
-        href={`${
-          import.meta.env.VITE_APP_PLUS_LP
-        }/plus?utm_source=excalidraw&utm_medium=app&utm_content=hamburger`}
+        href={`${appPlusLp}/plus?utm_source=excalidraw&utm_medium=app&utm_content=hamburger`}
         className=""
       >
         Excalidraw+
@@ -52,7 +65,8 @@ export const AppMainMenu: React.FC<{
       <MainMenu.DefaultItems.Socials />
       <MainMenu.ItemLink
         icon={loginIcon}
-        href={`${import.meta.env.VITE_APP_PLUS_APP}${
+        href={`${appPlusApp}
+        ${
           isExcalidrawPlusSignedUser ? "" : "/sign-up"
         }?utm_source=signin&utm_medium=app&utm_content=hamburger`}
         className="highlighted"

--- a/excalidraw-app/components/AppWelcomeScreen.tsx
+++ b/excalidraw-app/components/AppWelcomeScreen.tsx
@@ -4,13 +4,19 @@ import { useI18n } from "@excalidraw/excalidraw/i18n";
 import { WelcomeScreen } from "@excalidraw/excalidraw/index";
 import React from "react";
 
+import { useSetAtom } from "../app-jotai";
+
 import { isExcalidrawPlusSignedUser } from "../app_constants";
+
+import { gitHubLoadDialogOpenAtom } from "./GitHubLoadDialog";
+import { GitHubIcon } from "./GitHubSaveDialog";
 
 export const AppWelcomeScreen: React.FC<{
   onCollabDialogOpen: () => any;
   isCollabEnabled: boolean;
 }> = React.memo((props) => {
   const { t } = useI18n();
+  const openGitHubLoadDialog = useSetAtom(gitHubLoadDialogOpenAtom);
   let headingContent;
 
   if (isExcalidrawPlusSignedUser) {
@@ -58,6 +64,16 @@ export const AppWelcomeScreen: React.FC<{
         </WelcomeScreen.Center.Heading>
         <WelcomeScreen.Center.Menu>
           <WelcomeScreen.Center.MenuItemLoadScene />
+          <WelcomeScreen.Center.MenuItem
+            onSelect={() => openGitHubLoadDialog(true)}
+            icon={
+              <div style={{ width: "1.2rem", height: "1.2rem" }}>
+                <GitHubIcon />
+              </div>
+            }
+          >
+            Load from GitHub
+          </WelcomeScreen.Center.MenuItem>
           <WelcomeScreen.Center.MenuItemHelp />
           {props.isCollabEnabled && (
             <WelcomeScreen.Center.MenuItemLiveCollaborationTrigger

--- a/excalidraw-app/components/GitHubDialog.scss
+++ b/excalidraw-app/components/GitHubDialog.scss
@@ -1,0 +1,144 @@
+.GitHubDialog {
+  padding: 1rem 1.5rem 1.5rem;
+
+  &__step {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  &__description {
+    margin: 0;
+    line-height: 1.5;
+    color: var(--text-primary-color);
+  }
+
+  &__instructions {
+    margin: 0;
+    padding-left: 1.25rem;
+    line-height: 1.8;
+    color: var(--text-primary-color);
+
+    a {
+      color: var(--color-primary);
+      text-decoration: underline;
+    }
+
+    code {
+      background: var(--island-bg-color);
+      padding: 0.1em 0.3em;
+      border-radius: 3px;
+      font-size: 0.9em;
+    }
+  }
+
+  &__field {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+  }
+
+  &__label {
+    font-size: 0.85rem;
+    font-weight: 500;
+    color: var(--text-primary-color);
+  }
+
+  &__select {
+    width: 100%;
+    padding: 0.5rem 0.75rem;
+    border: 1px solid var(--default-border-color);
+    border-radius: var(--border-radius-md);
+    background: var(--island-bg-color);
+    color: var(--text-primary-color);
+    font-size: 0.9rem;
+    cursor: pointer;
+
+    &:focus {
+      outline: 2px solid var(--focus-highlight-color);
+      outline-offset: 1px;
+    }
+  }
+
+  &__actions {
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+    gap: 0.75rem;
+    margin-top: 0.5rem;
+  }
+
+  &__error {
+    margin: 0;
+    color: var(--color-danger);
+    font-size: 0.875rem;
+  }
+
+  &__disconnect,
+  &__back {
+    background: none;
+    border: none;
+    color: var(--text-primary-color);
+    cursor: pointer;
+    font-size: 0.875rem;
+    opacity: 0.7;
+    padding: 0.25rem 0.5rem;
+
+    &:hover {
+      opacity: 1;
+    }
+  }
+
+  // ---- Load dialog extensions ----
+
+  &__fileList {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    max-height: 280px;
+    overflow-y: auto;
+    border: 1px solid var(--default-border-color);
+    border-radius: var(--border-radius-md);
+    padding: 4px;
+  }
+
+  &__fileItem {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    width: 100%;
+    padding: 0.5rem 0.6rem;
+    border: none;
+    border-radius: var(--border-radius-sm);
+    background: transparent;
+    cursor: pointer;
+    text-align: left;
+    color: var(--text-primary-color);
+
+    &:hover {
+      background: var(--button-hover-bg);
+    }
+  }
+
+  &__fileIcon {
+    font-size: 0.9rem;
+    flex-shrink: 0;
+  }
+
+  &__filePath {
+    font-size: 0.85rem;
+    word-break: break-all;
+  }
+
+  &__success {
+    p {
+      font-size: 1rem;
+      margin: 0;
+
+      a {
+        color: var(--color-primary);
+        text-decoration: underline;
+      }
+    }
+  }
+}

--- a/excalidraw-app/components/GitHubLoadDialog.tsx
+++ b/excalidraw-app/components/GitHubLoadDialog.tsx
@@ -1,6 +1,7 @@
 import { Dialog } from "@excalidraw/excalidraw/components/Dialog";
 import { FilledButton } from "@excalidraw/excalidraw/components/FilledButton";
 import { TextField } from "@excalidraw/excalidraw/components/TextField";
+import { useI18n } from "@excalidraw/excalidraw/i18n";
 import React, { useCallback, useEffect, useRef, useState } from "react";
 
 import { atom, useAtom } from "../app-jotai";
@@ -40,6 +41,7 @@ type Props = {
 // Component
 // ---------------------------------------------------------------------------
 export const GitHubLoadDialog: React.FC<Props> = ({ onLoad }) => {
+  const { t } = useI18n();
   const [isOpen, setIsOpen] = useAtom(gitHubLoadDialogOpenAtom);
   const setActiveConfig = useSetAtom(activeGitHubConfigAtom);
 
@@ -157,12 +159,12 @@ export const GitHubLoadDialog: React.FC<Props> = ({ onLoad }) => {
         if (isMounted.current) {
           setFiles(data);
           if (data.length === 0) {
-            setFilesError("No .excalidraw files found in this branch.");
+            setFilesError(t("github.load.files.noFiles"));
           }
         }
       } catch (err: any) {
         if (isMounted.current) {
-          setFilesError(err?.message ?? "Failed to list files.");
+          setFilesError(err?.message ?? t("github.errors.listFailed"));
         }
       } finally {
         if (isMounted.current) {
@@ -170,25 +172,25 @@ export const GitHubLoadDialog: React.FC<Props> = ({ onLoad }) => {
         }
       }
     },
-    [],
+    [t],
   );
 
   // ---- Token step ----
   const handleConnect = async () => {
-    const t = tokenInput.trim();
-    if (!t) {
-      setTokenError("Please enter a token.");
+    const tok = tokenInput.trim();
+    if (!tok) {
+      setTokenError(t("github.errors.enterToken"));
       return;
     }
     setValidating(true);
     setTokenError("");
     try {
-      await GitHubManager.validateToken(t);
-      GitHubManager.setToken(t);
+      await GitHubManager.validateToken(tok);
+      GitHubManager.setToken(tok);
       await fetchRepos();
       setStep("repo");
     } catch (err: any) {
-      setTokenError(err?.message ?? "Invalid token.");
+      setTokenError(err?.message ?? t("github.errors.invalidToken"));
     } finally {
       if (isMounted.current) {
         setValidating(false);
@@ -242,7 +244,7 @@ export const GitHubLoadDialog: React.FC<Props> = ({ onLoad }) => {
       setIsOpen(false);
     } catch (err: any) {
       if (isMounted.current) {
-        setLoadError(err?.message ?? "Failed to load file.");
+        setLoadError(err?.message ?? t("github.errors.loadFailed"));
         setStep("files");
       }
     }
@@ -292,7 +294,7 @@ export const GitHubLoadDialog: React.FC<Props> = ({ onLoad }) => {
       setIsOpen(false);
     } catch (err: any) {
       if (isMounted.current) {
-        setLoadError(err?.message ?? "Failed to create file.");
+        setLoadError(err?.message ?? t("github.errors.createFailed"));
       }
     } finally {
       if (isMounted.current) {
@@ -322,7 +324,7 @@ export const GitHubLoadDialog: React.FC<Props> = ({ onLoad }) => {
   return (
     <Dialog
       onCloseRequest={() => setIsOpen(false)}
-      title="Load from GitHub"
+      title={t("github.load.dialogTitle")}
       size="small"
     >
       <div className="GitHubSaveDialog">
@@ -330,32 +332,38 @@ export const GitHubLoadDialog: React.FC<Props> = ({ onLoad }) => {
         {step === "token" && (
           <div className="GitHubDialog__step">
             <p className="GitHubDialog__description">
-              Connect with a GitHub <strong>Personal Access Token</strong> (
-              <code>repo</code> scope).
+              {t("github.load.token.description")}
             </p>
             <ol className="GitHubDialog__instructions">
               <li>
-                <a className="button button--secondary button--lg"
+                <a
+                  className="button button--secondary button--lg"
                   href="https://github.com/settings/tokens/new?scopes=repo&description=Excalidraw"
                   target="_blank"
                   rel="noopener noreferrer"
                 >
-                  Generate a token
+                  {t("github.load.token.step1")}
                 </a>{" "}
-                with <code>repo</code> scope
+                {t("github.load.token.step2")}
               </li>
-              <li>Paste it below</li>
+              <li>{t("github.load.token.step3")}</li>
             </ol>
             <TextField
-              label="Personal Access Token"
-              placeholder="ghp_xxxxxxxxxxxxxxxxxxxx"
+              label={t("github.save.token.label")}
+              placeholder={t("github.save.token.placeholder")}
               value={tokenInput}
               onChange={setTokenInput}
             />
-            {tokenError && <p className="GitHubDialog__error">{tokenError}</p>}
+            {tokenError && (
+              <p className="GitHubDialog__error">{tokenError}</p>
+            )}
             <div className="GitHubDialog__actions">
               <FilledButton
-                label={validating ? "Connecting…" : "Connect"}
+                label={
+                  validating
+                    ? t("github.load.token.connectingBtn")
+                    : t("github.load.token.connectBtn")
+                }
                 disabled={validating}
                 onClick={handleConnect}
               />
@@ -367,20 +375,24 @@ export const GitHubLoadDialog: React.FC<Props> = ({ onLoad }) => {
         {step === "repo" && (
           <div className="GitHubDialog__step">
             <p className="GitHubDialog__description">
-              Select the repository and branch to browse.
+              {t("github.load.repo.description")}
             </p>
 
             {loadingRepos ? (
-              <p>Loading repositories…</p>
+              <p>{t("github.load.repo.loadingRepos")}</p>
             ) : (
               <div className="GitHubDialog__field">
-                <label className="GitHubDialog__label">Repository</label>
+                <label className="GitHubDialog__label">
+                  {t("github.load.repo.repoLabel")}
+                </label>
                 <select
                   className="GitHubDialog__select"
                   value={owner && repo ? `${owner}/${repo}` : ""}
                   onChange={(e) => handleRepoSelect(e.target.value)}
                 >
-                  <option value="">— select a repo —</option>
+                  <option value="">
+                    {t("github.load.repo.repoPlaceholder")}
+                  </option>
                   {repos.map((r) => (
                     <option key={r.full_name} value={r.full_name}>
                       {r.full_name}
@@ -392,9 +404,11 @@ export const GitHubLoadDialog: React.FC<Props> = ({ onLoad }) => {
 
             {owner && repo && (
               <div className="GitHubDialog__field">
-                <label className="GitHubDialog__label">Branch</label>
+                <label className="GitHubDialog__label">
+                  {t("github.load.repo.branchLabel")}
+                </label>
                 {loadingBranches ? (
-                  <p>Loading branches…</p>
+                  <p>{t("github.load.repo.loadingBranches")}</p>
                 ) : (
                   <select
                     className="GitHubDialog__select"
@@ -416,10 +430,10 @@ export const GitHubLoadDialog: React.FC<Props> = ({ onLoad }) => {
                 className="GitHubDialog__disconnect"
                 onClick={handleDisconnect}
               >
-                Disconnect
+                {t("github.load.repo.disconnectBtn")}
               </button>
               <FilledButton
-                label="Browse files"
+                label={t("github.load.repo.browseBtn")}
                 disabled={!owner || !repo || !branch}
                 onClick={handleBrowseFiles}
               />
@@ -438,15 +452,50 @@ export const GitHubLoadDialog: React.FC<Props> = ({ onLoad }) => {
             </p>
 
             {loadingFiles ? (
-              <p>Scanning repository for .excalidraw files…</p>
+              <p>{t("github.load.files.loadingFiles")}</p>
             ) : filesError ? (
-              <p className="GitHubDialog__error">{filesError}</p>
+              <>
+                <p className="GitHubDialog__error">{filesError}</p>
+
+                <div
+                  style={{
+                    marginTop: "1rem",
+                    paddingTop: "1rem",
+                    borderTop: "1px solid var(--color-gray-30)",
+                  }}
+                >
+                  <p
+                    className="GitHubDialog__description"
+                    style={{ marginBottom: "0.5rem" }}
+                  >
+                    {t("github.load.files.createNewLabel")}
+                  </p>
+                  <div style={{ display: "flex", gap: "0.5rem" }}>
+                    <div style={{ flex: 1 }}>
+                      <TextField
+                        placeholder={t("github.load.files.newFilePlaceholder")}
+                        value={newFilePath}
+                        onChange={setNewFilePath}
+                      />
+                    </div>
+                    <FilledButton
+                      label={
+                        creatingFile
+                          ? t("github.load.files.creatingBtn")
+                          : t("github.load.files.createBtn")
+                      }
+                      disabled={creatingFile || !newFilePath.trim()}
+                      onClick={handleCreateFile}
+                    />
+                  </div>
+                </div>
+              </>
             ) : (
               <>
                 {files.length > 5 && (
                   <TextField
-                    label="Filter files"
-                    placeholder="Search…"
+                    label={t("github.load.files.filterLabel")}
+                    placeholder={t("github.load.files.filterPlaceholder")}
                     value={filter}
                     onChange={setFilter}
                   />
@@ -475,18 +524,22 @@ export const GitHubLoadDialog: React.FC<Props> = ({ onLoad }) => {
                     className="GitHubDialog__description"
                     style={{ marginBottom: "0.5rem" }}
                   >
-                    Or create a new file:
+                    {t("github.load.files.createNewLabel")}
                   </p>
                   <div style={{ display: "flex", gap: "0.5rem" }}>
                     <div style={{ flex: 1 }}>
                       <TextField
-                        placeholder="new-diagram.excalidraw"
+                        placeholder={t("github.load.files.newFilePlaceholder")}
                         value={newFilePath}
                         onChange={setNewFilePath}
                       />
                     </div>
                     <FilledButton
-                      label={creatingFile ? "Creating…" : "Create"}
+                      label={
+                        creatingFile
+                          ? t("github.load.files.creatingBtn")
+                          : t("github.load.files.createBtn")
+                      }
                       disabled={creatingFile || !newFilePath.trim()}
                       onClick={handleCreateFile}
                     />
@@ -495,14 +548,16 @@ export const GitHubLoadDialog: React.FC<Props> = ({ onLoad }) => {
               </>
             )}
 
-            {loadError && <p className="GitHubDialog__error">{loadError}</p>}
+            {loadError && (
+              <p className="GitHubDialog__error">{loadError}</p>
+            )}
 
             <div className="GitHubDialog__actions">
               <button
                 className="GitHubDialog__back"
                 onClick={() => setStep("repo")}
               >
-                ← Back
+                {t("github.load.files.backBtn")}
               </button>
             </div>
           </div>
@@ -511,10 +566,15 @@ export const GitHubLoadDialog: React.FC<Props> = ({ onLoad }) => {
         {/* ---- Loading ---- */}
         {step === "loading" && (
           <div className="GitHubDialog__step">
-            <p className="GitHubDialog__description">Loading file…</p>
+            <p className="GitHubDialog__description">
+              {t("github.load.loading.message")}
+            </p>
           </div>
         )}
       </div>
     </Dialog>
   );
 };
+
+// Re-export GitHubIcon so callers that only import from this module still work
+export { GitHubIcon };

--- a/excalidraw-app/components/GitHubLoadDialog.tsx
+++ b/excalidraw-app/components/GitHubLoadDialog.tsx
@@ -1,0 +1,520 @@
+import { Dialog } from "@excalidraw/excalidraw/components/Dialog";
+import { FilledButton } from "@excalidraw/excalidraw/components/FilledButton";
+import { TextField } from "@excalidraw/excalidraw/components/TextField";
+import React, { useCallback, useEffect, useRef, useState } from "react";
+
+import { atom, useAtom } from "../app-jotai";
+import {
+  GitHubManager,
+  type GitHubBranch,
+  type GitHubFile,
+  type GitHubRepo,
+} from "../data/GitHubManager";
+
+import { useSetAtom } from "../app-jotai";
+
+import { GitHubIcon } from "./GitHubSaveDialog";
+import { activeGitHubConfigAtom } from "./GitHubSaveDialog";
+
+// ---------------------------------------------------------------------------
+// Atom
+// ---------------------------------------------------------------------------
+export const gitHubLoadDialogOpenAtom = atom(false);
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+type Step = "token" | "repo" | "files" | "loading";
+
+export type LoadedScene = {
+  json: string;
+  /** Repo config at load time — pre-fills the save dialog */
+  config: { owner: string; repo: string; branch: string; path: string };
+};
+
+type Props = {
+  onLoad: (scene: LoadedScene) => void;
+};
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+export const GitHubLoadDialog: React.FC<Props> = ({ onLoad }) => {
+  const [isOpen, setIsOpen] = useAtom(gitHubLoadDialogOpenAtom);
+  const setActiveConfig = useSetAtom(activeGitHubConfigAtom);
+
+  const [step, setStep] = useState<Step>(() =>
+    GitHubManager.getToken() ? "repo" : "token",
+  );
+  const [tokenInput, setTokenInput] = useState("");
+  const [tokenError, setTokenError] = useState("");
+  const [validating, setValidating] = useState(false);
+
+  const [repos, setRepos] = useState<GitHubRepo[]>([]);
+  const [branches, setBranches] = useState<GitHubBranch[]>([]);
+  const [loadingRepos, setLoadingRepos] = useState(false);
+  const [loadingBranches, setLoadingBranches] = useState(false);
+
+  const [owner, setOwner] = useState("");
+  const [repo, setRepo] = useState("");
+  const [branch, setBranch] = useState("");
+
+  const [files, setFiles] = useState<GitHubFile[]>([]);
+  const [loadingFiles, setLoadingFiles] = useState(false);
+  const [filesError, setFilesError] = useState("");
+  const [filter, setFilter] = useState("");
+
+  const [loadError, setLoadError] = useState("");
+
+  const [newFilePath, setNewFilePath] = useState("");
+  const [creatingFile, setCreatingFile] = useState(false);
+
+  const isMounted = useRef(true);
+  useEffect(() => {
+    isMounted.current = true;
+    return () => {
+      isMounted.current = false;
+    };
+  }, []);
+
+  // Re-init on open
+  useEffect(() => {
+    if (isOpen) {
+      const hasToken = !!GitHubManager.getToken();
+      setStep(hasToken ? "repo" : "token");
+      setTokenInput("");
+      setTokenError("");
+      setLoadError("");
+      setFilesError("");
+      setFiles([]);
+      setFilter("");
+      if (hasToken) {
+        fetchRepos();
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen]);
+
+  const fetchRepos = useCallback(async () => {
+    const token = GitHubManager.getToken();
+    if (!token) {
+      return;
+    }
+    setLoadingRepos(true);
+    try {
+      const data = await GitHubManager.listRepos(token);
+      if (isMounted.current) {
+        setRepos(data);
+      }
+    } finally {
+      if (isMounted.current) {
+        setLoadingRepos(false);
+      }
+    }
+  }, []);
+
+  const fetchBranches = useCallback(
+    async (ownerVal: string, repoVal: string) => {
+      const token = GitHubManager.getToken();
+      if (!token) {
+        return;
+      }
+      setLoadingBranches(true);
+      try {
+        const data = await GitHubManager.listBranches(token, ownerVal, repoVal);
+        if (isMounted.current) {
+          setBranches(data);
+        }
+      } catch {
+        if (isMounted.current) {
+          setBranches([]);
+        }
+      } finally {
+        if (isMounted.current) {
+          setLoadingBranches(false);
+        }
+      }
+    },
+    [],
+  );
+
+  const fetchFiles = useCallback(
+    async (ownerVal: string, repoVal: string, branchVal: string) => {
+      const token = GitHubManager.getToken();
+      if (!token) {
+        return;
+      }
+      setLoadingFiles(true);
+      setFilesError("");
+      setFiles([]);
+      try {
+        const data = await GitHubManager.listExcalidrawFiles(
+          token,
+          ownerVal,
+          repoVal,
+          branchVal,
+        );
+        if (isMounted.current) {
+          setFiles(data);
+          if (data.length === 0) {
+            setFilesError("No .excalidraw files found in this branch.");
+          }
+        }
+      } catch (err: any) {
+        if (isMounted.current) {
+          setFilesError(err?.message ?? "Failed to list files.");
+        }
+      } finally {
+        if (isMounted.current) {
+          setLoadingFiles(false);
+        }
+      }
+    },
+    [],
+  );
+
+  // ---- Token step ----
+  const handleConnect = async () => {
+    const t = tokenInput.trim();
+    if (!t) {
+      setTokenError("Please enter a token.");
+      return;
+    }
+    setValidating(true);
+    setTokenError("");
+    try {
+      await GitHubManager.validateToken(t);
+      GitHubManager.setToken(t);
+      await fetchRepos();
+      setStep("repo");
+    } catch (err: any) {
+      setTokenError(err?.message ?? "Invalid token.");
+    } finally {
+      if (isMounted.current) {
+        setValidating(false);
+      }
+    }
+  };
+
+  // ---- Repo step ----
+  const handleRepoSelect = (value: string) => {
+    const found = repos.find((r) => r.full_name === value);
+    if (!found) {
+      return;
+    }
+    setOwner(found.owner.login);
+    setRepo(found.name);
+    setBranch(found.default_branch);
+    fetchBranches(found.owner.login, found.name);
+  };
+
+  const handleBrowseFiles = () => {
+    if (!owner || !repo || !branch) {
+      return;
+    }
+    setFilter("");
+    setStep("files");
+    fetchFiles(owner, repo, branch);
+  };
+
+  // ---- File selection ----
+  const handleSelectFile = async (filePath: string) => {
+    const token = GitHubManager.getToken();
+    if (!token) {
+      setStep("token");
+      return;
+    }
+    setStep("loading");
+    setLoadError("");
+    try {
+      const json = await GitHubManager.getFileContent(
+        token,
+        owner,
+        repo,
+        branch,
+        filePath,
+      );
+      const config = { owner, repo, branch, path: filePath };
+      // Persist config so the save dialog is pre-filled with this file
+      GitHubManager.setConfig(config);
+      setActiveConfig(config);
+      onLoad({ json, config });
+      setIsOpen(false);
+    } catch (err: any) {
+      if (isMounted.current) {
+        setLoadError(err?.message ?? "Failed to load file.");
+        setStep("files");
+      }
+    }
+  };
+
+  const handleCreateFile = async () => {
+    const token = GitHubManager.getToken();
+    if (!token) {
+      setStep("token");
+      return;
+    }
+
+    const submittedPath = newFilePath.trim();
+    if (!submittedPath) {
+      return;
+    }
+
+    const path = submittedPath.endsWith(".excalidraw")
+      ? submittedPath
+      : `${submittedPath}.excalidraw`;
+
+    setCreatingFile(true);
+    setLoadError("");
+    try {
+      const json = JSON.stringify(
+        {
+          type: "excalidraw",
+          version: 2,
+          source: "https://excalidraw.com",
+          elements: [],
+          appState: {
+            viewBackgroundColor: "#ffffff",
+            gridSize: null,
+          },
+          files: {},
+        },
+        null,
+        2,
+      );
+
+      const config = { owner, repo, branch, path };
+      await GitHubManager.commitFile(token, config, json, `Create ${path}`);
+
+      GitHubManager.setConfig(config);
+      setActiveConfig(config);
+      onLoad({ json, config });
+      setIsOpen(false);
+    } catch (err: any) {
+      if (isMounted.current) {
+        setLoadError(err?.message ?? "Failed to create file.");
+      }
+    } finally {
+      if (isMounted.current) {
+        setCreatingFile(false);
+      }
+    }
+  };
+
+  const handleDisconnect = () => {
+    GitHubManager.clearToken();
+    setRepos([]);
+    setBranches([]);
+    setOwner("");
+    setRepo("");
+    setBranch("");
+    setStep("token");
+  };
+
+  if (!isOpen) {
+    return null;
+  }
+
+  const filteredFiles = filter
+    ? files.filter((f) => f.path.toLowerCase().includes(filter.toLowerCase()))
+    : files;
+
+  return (
+    <Dialog
+      onCloseRequest={() => setIsOpen(false)}
+      title="Load from GitHub"
+      size="small"
+    >
+      <div className="GitHubSaveDialog">
+        {/* ---- Token ---- */}
+        {step === "token" && (
+          <div className="GitHubDialog__step">
+            <p className="GitHubDialog__description">
+              Connect with a GitHub <strong>Personal Access Token</strong> (
+              <code>repo</code> scope).
+            </p>
+            <ol className="GitHubDialog__instructions">
+              <li>
+                <a className="button button--secondary button--lg"
+                  href="https://github.com/settings/tokens/new?scopes=repo&description=Excalidraw"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Generate a token
+                </a>{" "}
+                with <code>repo</code> scope
+              </li>
+              <li>Paste it below</li>
+            </ol>
+            <TextField
+              label="Personal Access Token"
+              placeholder="ghp_xxxxxxxxxxxxxxxxxxxx"
+              value={tokenInput}
+              onChange={setTokenInput}
+            />
+            {tokenError && <p className="GitHubDialog__error">{tokenError}</p>}
+            <div className="GitHubDialog__actions">
+              <FilledButton
+                label={validating ? "Connecting…" : "Connect"}
+                disabled={validating}
+                onClick={handleConnect}
+              />
+            </div>
+          </div>
+        )}
+
+        {/* ---- Repo + branch ---- */}
+        {step === "repo" && (
+          <div className="GitHubDialog__step">
+            <p className="GitHubDialog__description">
+              Select the repository and branch to browse.
+            </p>
+
+            {loadingRepos ? (
+              <p>Loading repositories…</p>
+            ) : (
+              <div className="GitHubDialog__field">
+                <label className="GitHubDialog__label">Repository</label>
+                <select
+                  className="GitHubDialog__select"
+                  value={owner && repo ? `${owner}/${repo}` : ""}
+                  onChange={(e) => handleRepoSelect(e.target.value)}
+                >
+                  <option value="">— select a repo —</option>
+                  {repos.map((r) => (
+                    <option key={r.full_name} value={r.full_name}>
+                      {r.full_name}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            )}
+
+            {owner && repo && (
+              <div className="GitHubDialog__field">
+                <label className="GitHubDialog__label">Branch</label>
+                {loadingBranches ? (
+                  <p>Loading branches…</p>
+                ) : (
+                  <select
+                    className="GitHubDialog__select"
+                    value={branch}
+                    onChange={(e) => setBranch(e.target.value)}
+                  >
+                    {branches.map((b) => (
+                      <option key={b.name} value={b.name}>
+                        {b.name}
+                      </option>
+                    ))}
+                  </select>
+                )}
+              </div>
+            )}
+
+            <div className="GitHubDialog__actions">
+              <button
+                className="GitHubDialog__disconnect"
+                onClick={handleDisconnect}
+              >
+                Disconnect
+              </button>
+              <FilledButton
+                label="Browse files"
+                disabled={!owner || !repo || !branch}
+                onClick={handleBrowseFiles}
+              />
+            </div>
+          </div>
+        )}
+
+        {/* ---- File browser ---- */}
+        {step === "files" && (
+          <div className="GitHubDialog__step">
+            <p className="GitHubDialog__description">
+              <strong>
+                {owner}/{repo}
+              </strong>{" "}
+              — <em>{branch}</em>
+            </p>
+
+            {loadingFiles ? (
+              <p>Scanning repository for .excalidraw files…</p>
+            ) : filesError ? (
+              <p className="GitHubDialog__error">{filesError}</p>
+            ) : (
+              <>
+                {files.length > 5 && (
+                  <TextField
+                    label="Filter files"
+                    placeholder="Search…"
+                    value={filter}
+                    onChange={setFilter}
+                  />
+                )}
+                <div className="GitHubDialog__fileList">
+                  {filteredFiles.map((f) => (
+                    <button
+                      key={f.path}
+                      className="GitHubDialog__fileItem"
+                      onClick={() => handleSelectFile(f.path)}
+                    >
+                      <span className="GitHubDialog__fileIcon">📄</span>
+                      <span className="GitHubDialog__filePath">{f.path}</span>
+                    </button>
+                  ))}
+                </div>
+
+                <div
+                  style={{
+                    marginTop: "1rem",
+                    paddingTop: "1rem",
+                    borderTop: "1px solid var(--color-gray-30)",
+                  }}
+                >
+                  <p
+                    className="GitHubDialog__description"
+                    style={{ marginBottom: "0.5rem" }}
+                  >
+                    Or create a new file:
+                  </p>
+                  <div style={{ display: "flex", gap: "0.5rem" }}>
+                    <div style={{ flex: 1 }}>
+                      <TextField
+                        placeholder="new-diagram.excalidraw"
+                        value={newFilePath}
+                        onChange={setNewFilePath}
+                      />
+                    </div>
+                    <FilledButton
+                      label={creatingFile ? "Creating…" : "Create"}
+                      disabled={creatingFile || !newFilePath.trim()}
+                      onClick={handleCreateFile}
+                    />
+                  </div>
+                </div>
+              </>
+            )}
+
+            {loadError && <p className="GitHubDialog__error">{loadError}</p>}
+
+            <div className="GitHubDialog__actions">
+              <button
+                className="GitHubDialog__back"
+                onClick={() => setStep("repo")}
+              >
+                ← Back
+              </button>
+            </div>
+          </div>
+        )}
+
+        {/* ---- Loading ---- */}
+        {step === "loading" && (
+          <div className="GitHubDialog__step">
+            <p className="GitHubDialog__description">Loading file…</p>
+          </div>
+        )}
+      </div>
+    </Dialog>
+  );
+};

--- a/excalidraw-app/components/GitHubSaveDialog.tsx
+++ b/excalidraw-app/components/GitHubSaveDialog.tsx
@@ -2,6 +2,7 @@ import { Dialog } from "@excalidraw/excalidraw/components/Dialog";
 import { FilledButton } from "@excalidraw/excalidraw/components/FilledButton";
 import { TextField } from "@excalidraw/excalidraw/components/TextField";
 import { serializeAsJSON } from "@excalidraw/excalidraw";
+import { useI18n } from "@excalidraw/excalidraw/i18n";
 import React, { useCallback, useEffect, useRef, useState } from "react";
 
 import type { AppState, BinaryFiles } from "@excalidraw/excalidraw/types";
@@ -66,6 +67,7 @@ function buildCommitMessage(filename: string): string {
 // Dialog component
 // ---------------------------------------------------------------------------
 export const GitHubSaveDialog: React.FC<Props> = ({ excalidrawAPI }) => {
+  const { t } = useI18n();
   const [isOpen, setIsOpen] = useAtom(gitHubSaveDialogOpenAtom);
   const [isQuickMode, setIsQuickMode] = useAtom(gitHubSaveQuickModeAtom);
   const [, setActiveConfig] = useAtom(activeGitHubConfigAtom);
@@ -184,20 +186,20 @@ export const GitHubSaveDialog: React.FC<Props> = ({ excalidrawAPI }) => {
 
   // ---- Step: validate token ----
   const handleConnect = async () => {
-    const t = tokenInput.trim();
-    if (!t) {
-      setTokenError("Please enter a token.");
+    const tok = tokenInput.trim();
+    if (!tok) {
+      setTokenError(t("github.errors.enterToken"));
       return;
     }
     setValidating(true);
     setTokenError("");
     try {
-      await GitHubManager.validateToken(t);
-      GitHubManager.setToken(t);
+      await GitHubManager.validateToken(tok);
+      GitHubManager.setToken(tok);
       await fetchRepos();
       setStep("repo");
     } catch (err: any) {
-      setTokenError(err?.message ?? "Invalid token. Please try again.");
+      setTokenError(err?.message ?? t("github.errors.invalidToken"));
     } finally {
       if (isMounted.current) {
         setValidating(false);
@@ -259,7 +261,7 @@ export const GitHubSaveDialog: React.FC<Props> = ({ excalidrawAPI }) => {
       await GitHubManager.commitFile(token, config, content, commitMsg);
       setStep("success");
     } catch (err: any) {
-      setCommitError(err?.message ?? "Commit failed. Please try again.");
+      setCommitError(err?.message ?? t("github.errors.commitFailed"));
     } finally {
       if (isMounted.current) {
         setCommitting(false);
@@ -289,7 +291,11 @@ export const GitHubSaveDialog: React.FC<Props> = ({ excalidrawAPI }) => {
           setIsQuickMode(false);
         }
       }}
-      title={isQuickMode ? "Quick Save to GitHub" : "Save to GitHub"}
+      title={
+        isQuickMode
+          ? t("github.save.dialogTitleQuick")
+          : t("github.save.dialogTitle")
+      }
       size="small"
     >
       <div className="GitHubDialog">
@@ -299,37 +305,38 @@ export const GitHubSaveDialog: React.FC<Props> = ({ excalidrawAPI }) => {
         {step === "token" && (
           <div className="GitHubDialog__step">
             <p className="GitHubDialog__description">
-              Connect your GitHub account using a{" "}
-              <strong>Personal Access Token</strong> with <code>repo</code>{" "}
-              scope.
+              {t("github.save.token.description")}
             </p>
             <ol className="GitHubDialog__instructions">
               <li>
-                Go to{" "}
                 <a
                   href="https://github.com/settings/tokens/new?scopes=repo&description=Excalidraw"
                   target="_blank"
                   rel="noopener noreferrer"
                 >
-                  GitHub → Settings → Personal access tokens
+                  {t("github.save.token.step1")}
                 </a>
               </li>
-              <li>
-                Generate a new token (classic) with <code>repo</code> scope
-              </li>
-              <li>Paste the token below</li>
+              <li>{t("github.save.token.step2")}</li>
+              <li>{t("github.save.token.step3")}</li>
             </ol>
             <TextField
-              label="Personal Access Token"
-              placeholder="ghp_xxxxxxxxxxxxxxxxxxxx"
+              label={t("github.save.token.label")}
+              placeholder={t("github.save.token.placeholder")}
               value={tokenInput}
               onChange={setTokenInput}
               isRedacted
             />
-            {tokenError && <p className="GitHubDialog__error">{tokenError}</p>}
+            {tokenError && (
+              <p className="GitHubDialog__error">{tokenError}</p>
+            )}
             <div className="GitHubDialog__actions">
               <FilledButton
-                label={validating ? "Connecting…" : "Connect"}
+                label={
+                  validating
+                    ? t("github.save.token.connectingBtn")
+                    : t("github.save.token.connectBtn")
+                }
                 disabled={validating}
                 onClick={handleConnect}
               />
@@ -343,21 +350,24 @@ export const GitHubSaveDialog: React.FC<Props> = ({ excalidrawAPI }) => {
         {step === "repo" && (
           <div className="GitHubDialog__step">
             <p className="GitHubDialog__description">
-              Select the repository and branch where the file should be
-              committed.
+              {t("github.save.repo.description")}
             </p>
 
             {loadingRepos ? (
-              <p>Loading repositories…</p>
+              <p>{t("github.save.repo.loadingRepos")}</p>
             ) : (
               <div className="GitHubDialog__field">
-                <label className="GitHubDialog__label">Repository</label>
+                <label className="GitHubDialog__label">
+                  {t("github.save.repo.repoLabel")}
+                </label>
                 <select
                   className="GitHubDialog__select"
                   value={owner && repo ? `${owner}/${repo}` : ""}
                   onChange={(e) => handleRepoSelect(e.target.value)}
                 >
-                  <option value="">— select a repo —</option>
+                  <option value="">
+                    {t("github.save.repo.repoPlaceholder")}
+                  </option>
                   {repos.map((r) => (
                     <option key={r.full_name} value={r.full_name}>
                       {r.full_name}
@@ -369,9 +379,11 @@ export const GitHubSaveDialog: React.FC<Props> = ({ excalidrawAPI }) => {
 
             {owner && repo && (
               <div className="GitHubDialog__field">
-                <label className="GitHubDialog__label">Branch</label>
+                <label className="GitHubDialog__label">
+                  {t("github.save.repo.branchLabel")}
+                </label>
                 {loadingBranches ? (
-                  <p>Loading branches…</p>
+                  <p>{t("github.save.repo.loadingBranches")}</p>
                 ) : (
                   <select
                     className="GitHubDialog__select"
@@ -393,10 +405,10 @@ export const GitHubSaveDialog: React.FC<Props> = ({ excalidrawAPI }) => {
                 className="GitHubDialog__disconnect"
                 onClick={handleDisconnect}
               >
-                Disconnect
+                {t("github.save.repo.disconnectBtn")}
               </button>
               <FilledButton
-                label="Next"
+                label={t("github.save.repo.nextBtn")}
                 disabled={!owner || !repo || !branch}
                 onClick={handleProceedToCommit}
               />
@@ -410,17 +422,16 @@ export const GitHubSaveDialog: React.FC<Props> = ({ excalidrawAPI }) => {
         {step === "commit" && (
           <div className="GitHubDialog__step">
             <p className="GitHubDialog__description">
-              Committing to{" "}
-              <strong>
-                {owner}/{repo}
-              </strong>{" "}
-              on branch <strong>{branch}</strong>.
+              {t("github.save.commit.description")
+                .replace("{{owner}}", owner)
+                .replace("{{repo}}", repo)
+                .replace("{{branch}}", branch)}
             </p>
 
             {isQuickMode ? (
               <div className="GitHubDialog__field">
                 <label className="GitHubDialog__label">
-                  File path in repository
+                  {t("github.save.commit.filePathLabel")}
                 </label>
                 <p>
                   <strong>{filePath}</strong>
@@ -428,14 +439,14 @@ export const GitHubSaveDialog: React.FC<Props> = ({ excalidrawAPI }) => {
               </div>
             ) : (
               <TextField
-                label="File path in repository"
+                label={t("github.save.commit.filePathLabel")}
                 value={filePath}
                 onChange={setFilePath}
               />
             )}
 
             <TextField
-              label="Commit message"
+              label={t("github.save.commit.commitMsgLabel")}
               value={commitMsg}
               onChange={setCommitMsg}
             />
@@ -450,11 +461,15 @@ export const GitHubSaveDialog: React.FC<Props> = ({ excalidrawAPI }) => {
                   className="GitHubDialog__back"
                   onClick={() => setStep("repo")}
                 >
-                  ← Back
+                  {t("github.save.commit.backBtn")}
                 </button>
               )}
               <FilledButton
-                label={committing ? "Committing…" : "Commit"}
+                label={
+                  committing
+                    ? t("github.save.commit.committingBtn")
+                    : t("github.save.commit.commitBtn")
+                }
                 disabled={committing || !filePath || !commitMsg}
                 onClick={handleCommit}
               />
@@ -468,7 +483,7 @@ export const GitHubSaveDialog: React.FC<Props> = ({ excalidrawAPI }) => {
         {step === "success" && (
           <div className="GitHubDialog__step GitHubDialog__success">
             <p>
-              ✓ Committed to{" "}
+              {t("github.save.success.committed")}{" "}
               <a
                 href={`https://github.com/${owner}/${repo}/blob/${branch}/${filePath}`}
                 target="_blank"
@@ -479,7 +494,7 @@ export const GitHubSaveDialog: React.FC<Props> = ({ excalidrawAPI }) => {
             </p>
             <div className="GitHubDialog__actions">
               <FilledButton
-                label="Done"
+                label={t("github.save.success.doneBtn")}
                 onClick={() => {
                   setIsOpen(false);
                   if (isQuickMode) {

--- a/excalidraw-app/components/GitHubSaveDialog.tsx
+++ b/excalidraw-app/components/GitHubSaveDialog.tsx
@@ -1,0 +1,496 @@
+import { Dialog } from "@excalidraw/excalidraw/components/Dialog";
+import { FilledButton } from "@excalidraw/excalidraw/components/FilledButton";
+import { TextField } from "@excalidraw/excalidraw/components/TextField";
+import { serializeAsJSON } from "@excalidraw/excalidraw";
+import React, { useCallback, useEffect, useRef, useState } from "react";
+
+import type { AppState, BinaryFiles } from "@excalidraw/excalidraw/types";
+import type { OrderedExcalidrawElement } from "@excalidraw/element/types";
+
+import {
+  GitHubManager,
+  type GitHubBranch,
+  type GitHubConfig,
+  type GitHubRepo,
+} from "../data/GitHubManager";
+
+import { atom, useAtom } from "../app-jotai";
+
+import "./GitHubDialog.scss";
+
+// ---------------------------------------------------------------------------
+// Global dialog state atom
+// ---------------------------------------------------------------------------
+export const gitHubSaveDialogOpenAtom = atom(false);
+export const gitHubSaveQuickModeAtom = atom(false);
+export const activeGitHubConfigAtom = atom<GitHubConfig | null>(
+  GitHubManager.getConfig(),
+);
+
+// ---------------------------------------------------------------------------
+// GitHub SVG icon (simple Octocat outline)
+// ---------------------------------------------------------------------------
+export const GitHubIcon = () => (
+  <svg
+    aria-hidden="true"
+    focusable="false"
+    viewBox="0 0 24 24"
+    fill="currentColor"
+  >
+    <path d="M12 0C5.37 0 0 5.373 0 12c0 5.303 3.438 9.8 8.205 11.387.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61-.546-1.387-1.333-1.756-1.333-1.756-1.09-.745.083-.729.083-.729 1.205.084 1.84 1.237 1.84 1.237 1.07 1.834 2.807 1.304 3.492.997.108-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.93 0-1.31.468-2.382 1.236-3.222-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.3 1.23a11.5 11.5 0 0 1 3.003-.404c1.02.005 2.047.138 3.003.404 2.29-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.12 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222 0 1.606-.015 2.896-.015 3.286 0 .322.216.694.825.576C20.565 21.795 24 17.298 24 12c0-6.627-5.373-12-12-12z" />
+  </svg>
+);
+
+// ---------------------------------------------------------------------------
+// Types & helpers
+// ---------------------------------------------------------------------------
+type Step = "token" | "repo" | "commit" | "success";
+
+type Props = {
+  excalidrawAPI: {
+    getSceneElements: () => readonly OrderedExcalidrawElement[];
+    getAppState: () => AppState;
+    getFiles: () => BinaryFiles;
+    getName: () => string;
+  } | null;
+};
+
+function buildCommitMessage(filename: string): string {
+  const now = new Date();
+  const date = now.toISOString().slice(0, 10);
+  const time = now.toTimeString().slice(0, 5);
+  return `Save ${filename} @ ${date} ${time}`;
+}
+
+// ---------------------------------------------------------------------------
+// Dialog component
+// ---------------------------------------------------------------------------
+export const GitHubSaveDialog: React.FC<Props> = ({ excalidrawAPI }) => {
+  const [isOpen, setIsOpen] = useAtom(gitHubSaveDialogOpenAtom);
+  const [isQuickMode, setIsQuickMode] = useAtom(gitHubSaveQuickModeAtom);
+  const [, setActiveConfig] = useAtom(activeGitHubConfigAtom);
+
+  const [step, setStep] = useState<Step>(() =>
+    GitHubManager.getToken() ? "repo" : "token",
+  );
+  const [tokenInput, setTokenInput] = useState("");
+  const [tokenError, setTokenError] = useState("");
+  const [validating, setValidating] = useState(false);
+
+  const [repos, setRepos] = useState<GitHubRepo[]>([]);
+  const [branches, setBranches] = useState<GitHubBranch[]>([]);
+  const [loadingRepos, setLoadingRepos] = useState(false);
+  const [loadingBranches, setLoadingBranches] = useState(false);
+
+  const savedConfig = GitHubManager.getConfig();
+  const defaultFilename = excalidrawAPI?.getName() ?? "diagram.excalidraw";
+
+  const [owner, setOwner] = useState(savedConfig?.owner ?? "");
+  const [repo, setRepo] = useState(savedConfig?.repo ?? "");
+  const [branch, setBranch] = useState(savedConfig?.branch ?? "");
+  const [filePath, setFilePath] = useState(
+    savedConfig?.path ?? defaultFilename,
+  );
+  const [commitMsg, setCommitMsg] = useState(
+    buildCommitMessage(defaultFilename),
+  );
+
+  const [committing, setCommitting] = useState(false);
+  const [commitError, setCommitError] = useState("");
+  const isMounted = useRef(true);
+
+  useEffect(() => {
+    isMounted.current = true;
+    return () => {
+      isMounted.current = false;
+    };
+  }, []);
+
+  // Re-initialise step when dialog opens
+  useEffect(() => {
+    if (isOpen) {
+      if (isQuickMode) {
+        const hasToken = !!GitHubManager.getToken();
+        const cfg = GitHubManager.getConfig();
+        if (hasToken && cfg) {
+          setStep("commit");
+          setOwner(cfg.owner);
+          setRepo(cfg.repo);
+          setBranch(cfg.branch);
+          setFilePath(cfg.path);
+          setCommitMsg(buildCommitMessage(cfg.path));
+          setTokenInput("");
+          setTokenError("");
+          setCommitError("");
+          return;
+        }
+        setIsQuickMode(false);
+      }
+
+      const hasToken = !!GitHubManager.getToken();
+      setStep(hasToken ? "repo" : "token");
+      setTokenInput("");
+      setTokenError("");
+      setCommitError("");
+      if (hasToken) {
+        fetchRepos();
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen, isQuickMode]);
+
+  const fetchRepos = useCallback(async () => {
+    const token = GitHubManager.getToken();
+    if (!token) {
+      return;
+    }
+    setLoadingRepos(true);
+    try {
+      const data = await GitHubManager.listRepos(token);
+      if (isMounted.current) {
+        setRepos(data);
+      }
+    } catch {
+      // silently ignore — user will see empty list
+    } finally {
+      if (isMounted.current) {
+        setLoadingRepos(false);
+      }
+    }
+  }, []);
+
+  const fetchBranches = useCallback(
+    async (ownerVal: string, repoVal: string) => {
+      const token = GitHubManager.getToken();
+      if (!token || !ownerVal || !repoVal) {
+        return;
+      }
+      setLoadingBranches(true);
+      try {
+        const data = await GitHubManager.listBranches(token, ownerVal, repoVal);
+        if (isMounted.current) {
+          setBranches(data);
+        }
+      } catch {
+        setBranches([]);
+      } finally {
+        if (isMounted.current) {
+          setLoadingBranches(false);
+        }
+      }
+    },
+    [],
+  );
+
+  // ---- Step: validate token ----
+  const handleConnect = async () => {
+    const t = tokenInput.trim();
+    if (!t) {
+      setTokenError("Please enter a token.");
+      return;
+    }
+    setValidating(true);
+    setTokenError("");
+    try {
+      await GitHubManager.validateToken(t);
+      GitHubManager.setToken(t);
+      await fetchRepos();
+      setStep("repo");
+    } catch (err: any) {
+      setTokenError(err?.message ?? "Invalid token. Please try again.");
+    } finally {
+      if (isMounted.current) {
+        setValidating(false);
+      }
+    }
+  };
+
+  // ---- Step: repo selection → move to commit ----
+  const handleRepoSelect = (value: string) => {
+    const found = repos.find((r) => r.full_name === value);
+    if (!found) {
+      return;
+    }
+    setOwner(found.owner.login);
+    setRepo(found.name);
+    setBranch(found.default_branch);
+    fetchBranches(found.owner.login, found.name);
+  };
+
+  const handleProceedToCommit = () => {
+    if (!owner || !repo || !branch) {
+      return;
+    }
+    setFilePath(
+      (prev) => prev || excalidrawAPI?.getName() || "diagram.excalidraw",
+    );
+    setCommitMsg(
+      buildCommitMessage(excalidrawAPI?.getName() ?? "diagram.excalidraw"),
+    );
+    setCommitError("");
+    setStep("commit");
+  };
+
+  // ---- Step: commit ----
+  const handleCommit = async () => {
+    if (!excalidrawAPI) {
+      return;
+    }
+    const token = GitHubManager.getToken();
+    if (!token) {
+      setStep("token");
+      return;
+    }
+
+    const config: GitHubConfig = { owner, repo, branch, path: filePath };
+    GitHubManager.setConfig(config);
+    setActiveConfig(config);
+
+    const content = serializeAsJSON(
+      excalidrawAPI.getSceneElements(),
+      excalidrawAPI.getAppState(),
+      excalidrawAPI.getFiles(),
+      "local",
+    );
+
+    setCommitting(true);
+    setCommitError("");
+    try {
+      await GitHubManager.commitFile(token, config, content, commitMsg);
+      setStep("success");
+    } catch (err: any) {
+      setCommitError(err?.message ?? "Commit failed. Please try again.");
+    } finally {
+      if (isMounted.current) {
+        setCommitting(false);
+      }
+    }
+  };
+
+  const handleDisconnect = () => {
+    GitHubManager.clearToken();
+    setRepos([]);
+    setBranches([]);
+    setOwner("");
+    setRepo("");
+    setBranch("");
+    setStep("token");
+  };
+
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <Dialog
+      onCloseRequest={() => {
+        setIsOpen(false);
+        if (isQuickMode) {
+          setIsQuickMode(false);
+        }
+      }}
+      title={isQuickMode ? "Quick Save to GitHub" : "Save to GitHub"}
+      size="small"
+    >
+      <div className="GitHubDialog">
+        {/* ---------------------------------------------------------------- */}
+        {/* Step: Token                                                        */}
+        {/* ---------------------------------------------------------------- */}
+        {step === "token" && (
+          <div className="GitHubDialog__step">
+            <p className="GitHubDialog__description">
+              Connect your GitHub account using a{" "}
+              <strong>Personal Access Token</strong> with <code>repo</code>{" "}
+              scope.
+            </p>
+            <ol className="GitHubDialog__instructions">
+              <li>
+                Go to{" "}
+                <a
+                  href="https://github.com/settings/tokens/new?scopes=repo&description=Excalidraw"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  GitHub → Settings → Personal access tokens
+                </a>
+              </li>
+              <li>
+                Generate a new token (classic) with <code>repo</code> scope
+              </li>
+              <li>Paste the token below</li>
+            </ol>
+            <TextField
+              label="Personal Access Token"
+              placeholder="ghp_xxxxxxxxxxxxxxxxxxxx"
+              value={tokenInput}
+              onChange={setTokenInput}
+              isRedacted
+            />
+            {tokenError && <p className="GitHubDialog__error">{tokenError}</p>}
+            <div className="GitHubDialog__actions">
+              <FilledButton
+                label={validating ? "Connecting…" : "Connect"}
+                disabled={validating}
+                onClick={handleConnect}
+              />
+            </div>
+          </div>
+        )}
+
+        {/* ---------------------------------------------------------------- */}
+        {/* Step: Select repo & branch                                        */}
+        {/* ---------------------------------------------------------------- */}
+        {step === "repo" && (
+          <div className="GitHubDialog__step">
+            <p className="GitHubDialog__description">
+              Select the repository and branch where the file should be
+              committed.
+            </p>
+
+            {loadingRepos ? (
+              <p>Loading repositories…</p>
+            ) : (
+              <div className="GitHubDialog__field">
+                <label className="GitHubDialog__label">Repository</label>
+                <select
+                  className="GitHubDialog__select"
+                  value={owner && repo ? `${owner}/${repo}` : ""}
+                  onChange={(e) => handleRepoSelect(e.target.value)}
+                >
+                  <option value="">— select a repo —</option>
+                  {repos.map((r) => (
+                    <option key={r.full_name} value={r.full_name}>
+                      {r.full_name}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            )}
+
+            {owner && repo && (
+              <div className="GitHubDialog__field">
+                <label className="GitHubDialog__label">Branch</label>
+                {loadingBranches ? (
+                  <p>Loading branches…</p>
+                ) : (
+                  <select
+                    className="GitHubDialog__select"
+                    value={branch}
+                    onChange={(e) => setBranch(e.target.value)}
+                  >
+                    {branches.map((b) => (
+                      <option key={b.name} value={b.name}>
+                        {b.name}
+                      </option>
+                    ))}
+                  </select>
+                )}
+              </div>
+            )}
+
+            <div className="GitHubDialog__actions">
+              <button
+                className="GitHubDialog__disconnect"
+                onClick={handleDisconnect}
+              >
+                Disconnect
+              </button>
+              <FilledButton
+                label="Next"
+                disabled={!owner || !repo || !branch}
+                onClick={handleProceedToCommit}
+              />
+            </div>
+          </div>
+        )}
+
+        {/* ---------------------------------------------------------------- */}
+        {/* Step: Confirm commit                                              */}
+        {/* ---------------------------------------------------------------- */}
+        {step === "commit" && (
+          <div className="GitHubDialog__step">
+            <p className="GitHubDialog__description">
+              Committing to{" "}
+              <strong>
+                {owner}/{repo}
+              </strong>{" "}
+              on branch <strong>{branch}</strong>.
+            </p>
+
+            {isQuickMode ? (
+              <div className="GitHubDialog__field">
+                <label className="GitHubDialog__label">
+                  File path in repository
+                </label>
+                <p>
+                  <strong>{filePath}</strong>
+                </p>
+              </div>
+            ) : (
+              <TextField
+                label="File path in repository"
+                value={filePath}
+                onChange={setFilePath}
+              />
+            )}
+
+            <TextField
+              label="Commit message"
+              value={commitMsg}
+              onChange={setCommitMsg}
+            />
+
+            {commitError && (
+              <p className="GitHubDialog__error">{commitError}</p>
+            )}
+
+            <div className="GitHubDialog__actions">
+              {!isQuickMode && (
+                <button
+                  className="GitHubDialog__back"
+                  onClick={() => setStep("repo")}
+                >
+                  ← Back
+                </button>
+              )}
+              <FilledButton
+                label={committing ? "Committing…" : "Commit"}
+                disabled={committing || !filePath || !commitMsg}
+                onClick={handleCommit}
+              />
+            </div>
+          </div>
+        )}
+
+        {/* ---------------------------------------------------------------- */}
+        {/* Step: Success                                                     */}
+        {/* ---------------------------------------------------------------- */}
+        {step === "success" && (
+          <div className="GitHubDialog__step GitHubDialog__success">
+            <p>
+              ✓ Committed to{" "}
+              <a
+                href={`https://github.com/${owner}/${repo}/blob/${branch}/${filePath}`}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                {owner}/{repo}/{filePath}
+              </a>
+            </p>
+            <div className="GitHubDialog__actions">
+              <FilledButton
+                label="Done"
+                onClick={() => {
+                  setIsOpen(false);
+                  if (isQuickMode) {
+                    setIsQuickMode(false);
+                  }
+                }}
+              />
+            </div>
+          </div>
+        )}
+      </div>
+    </Dialog>
+  );
+};

--- a/excalidraw-app/data/GitHubManager.ts
+++ b/excalidraw-app/data/GitHubManager.ts
@@ -1,0 +1,207 @@
+const STORAGE_KEY_TOKEN = "excalidraw-github-token";
+const STORAGE_KEY_CONFIG = "excalidraw-github-config";
+const API_BASE = "https://api.github.com";
+
+export type GitHubConfig = {
+  owner: string;
+  repo: string;
+  branch: string;
+  path: string;
+};
+
+export type GitHubRepo = {
+  full_name: string;
+  name: string;
+  owner: { login: string };
+  default_branch: string;
+  private: boolean;
+};
+
+export type GitHubBranch = {
+  name: string;
+};
+
+export type GitHubFile = {
+  path: string;
+  sha: string;
+};
+
+const headers = (token: string) => ({
+  Authorization: `Bearer ${token}`,
+  Accept: "application/vnd.github+json",
+  "X-GitHub-Api-Version": "2022-11-28",
+  "Content-Type": "application/json",
+});
+
+async function ghFetch<T>(
+  token: string,
+  path: string,
+  options?: RequestInit,
+): Promise<T> {
+  const res = await fetch(`${API_BASE}${path}`, {
+    ...options,
+    headers: { ...headers(token), ...(options?.headers ?? {}) },
+  });
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    throw new Error(body?.message ?? `GitHub API error ${res.status}: ${path}`);
+  }
+  return res.json();
+}
+
+export const GitHubManager = {
+  // ---------------------------------------------------------------------------
+  // Token management
+  // ---------------------------------------------------------------------------
+
+  getToken(): string | null {
+    return localStorage.getItem(STORAGE_KEY_TOKEN);
+  },
+
+  setToken(token: string) {
+    localStorage.setItem(STORAGE_KEY_TOKEN, token);
+  },
+
+  clearToken() {
+    localStorage.removeItem(STORAGE_KEY_TOKEN);
+    localStorage.removeItem(STORAGE_KEY_CONFIG);
+  },
+
+  // ---------------------------------------------------------------------------
+  // Config management (last-used repo/branch/path)
+  // ---------------------------------------------------------------------------
+
+  getConfig(): GitHubConfig | null {
+    const raw = localStorage.getItem(STORAGE_KEY_CONFIG);
+    if (!raw) {
+      return null;
+    }
+    try {
+      return JSON.parse(raw) as GitHubConfig;
+    } catch {
+      return null;
+    }
+  },
+
+  setConfig(config: GitHubConfig) {
+    localStorage.setItem(STORAGE_KEY_CONFIG, JSON.stringify(config));
+  },
+
+  // ---------------------------------------------------------------------------
+  // GitHub API wrappers
+  // ---------------------------------------------------------------------------
+
+  /** Validate a token and return the authenticated user's login. */
+  async validateToken(token: string): Promise<string> {
+    const user = await ghFetch<{ login: string }>(token, "/user");
+    return user.login;
+  },
+
+  /** List repos accessible to the authenticated user (up to 100). */
+  async listRepos(token: string): Promise<GitHubRepo[]> {
+    return ghFetch<GitHubRepo[]>(
+      token,
+      "/user/repos?sort=pushed&per_page=100&affiliation=owner,collaborator",
+    );
+  },
+
+  /** List branches for a repo. */
+  async listBranches(
+    token: string,
+    owner: string,
+    repo: string,
+  ): Promise<GitHubBranch[]> {
+    return ghFetch<GitHubBranch[]>(
+      token,
+      `/repos/${owner}/${repo}/branches?per_page=100`,
+    );
+  },
+
+  /**
+   * List all `.excalidraw` files in a repo using the Git Trees API.
+   * Falls back to an empty array on oversized repos (truncated tree).
+   */
+  async listExcalidrawFiles(
+    token: string,
+    owner: string,
+    repo: string,
+    branch: string,
+  ): Promise<GitHubFile[]> {
+    // Resolve branch → tree SHA
+    const branchData = await ghFetch<{
+      commit: { commit: { tree: { sha: string } } };
+    }>(token, `/repos/${owner}/${repo}/branches/${branch}`);
+    const treeSha = branchData.commit.commit.tree.sha;
+
+    const tree = await ghFetch<{
+      tree: { path: string; type: string; sha: string }[];
+      truncated: boolean;
+    }>(token, `/repos/${owner}/${repo}/git/trees/${treeSha}?recursive=1`);
+
+    return tree.tree
+      .filter((f) => f.type === "blob" && f.path.endsWith(".excalidraw"))
+      .map((f) => ({ path: f.path, sha: f.sha }));
+  },
+
+  /**
+   * Fetch and decode the text content of a single file.
+   */
+  async getFileContent(
+    token: string,
+    owner: string,
+    repo: string,
+    branch: string,
+    path: string,
+  ): Promise<string> {
+    const data = await ghFetch<{ content: string; encoding: string }>(
+      token,
+      `/repos/${owner}/${repo}/contents/${path}?ref=${branch}`,
+    );
+    if (data.encoding !== "base64") {
+      throw new Error(`Unexpected encoding: ${data.encoding}`);
+    }
+    // GitHub returns base64 with newlines — strip them before decoding
+    const base64 = data.content.replace(/\n/g, "");
+    return decodeURIComponent(escape(atob(base64)));
+  },
+
+  /**
+   * Commit a file to a GitHub repo using the Contents API.
+   * Creates the file if it doesn't exist; updates it otherwise.
+   */
+  async commitFile(
+    token: string,
+    config: GitHubConfig,
+    content: string,
+    message: string,
+  ): Promise<void> {
+    const { owner, repo, branch, path } = config;
+    const endpoint = `/repos/${owner}/${repo}/contents/${path}`;
+
+    // Check if the file already exists so we can include its SHA (required for updates)
+    let sha: string | undefined;
+    try {
+      const existing = await ghFetch<{ sha: string }>(
+        token,
+        `${endpoint}?ref=${branch}`,
+      );
+      sha = existing.sha;
+    } catch {
+      // File does not exist yet — that's fine, we'll create it
+    }
+
+    const body: Record<string, string> = {
+      message,
+      content: btoa(unescape(encodeURIComponent(content))), // UTF-8 → base64
+      branch,
+    };
+    if (sha) {
+      body.sha = sha;
+    }
+
+    await ghFetch(token, endpoint, {
+      method: "PUT",
+      body: JSON.stringify(body),
+    });
+  },
+};

--- a/packages/excalidraw/actions/actionExport.tsx
+++ b/packages/excalidraw/actions/actionExport.tsx
@@ -29,8 +29,6 @@ import { t } from "../i18n";
 import { getSelectedElements, isSomeElementSelected } from "../scene";
 import { getExportSize } from "../scene/export";
 
-import "../components/ToolIcon.scss";
-
 import { register } from "./register";
 
 import type { JSONExportData } from "../data/json";

--- a/packages/excalidraw/locales/en.json
+++ b/packages/excalidraw/locales/en.json
@@ -734,5 +734,91 @@
     "spacebar": "Space",
     "delete": "Delete",
     "mmb": "Scroll wheel"
+  },
+  "github": {
+    "card": {
+      "title": "GitHub",
+      "details": "Save to your GitHub repository",
+      "buttonLabel": "Save to GitHub"
+    },
+    "save": {
+      "dialogTitle": "Save to GitHub",
+      "dialogTitleQuick": "Quick Save to GitHub",
+      "token": {
+        "description": "Connect your GitHub account using a Personal Access Token with repo scope.",
+        "step1": "Go to GitHub → Settings → Personal access tokens",
+        "step2": "Generate a new token (classic) with repo scope",
+        "step3": "Paste the token below",
+        "label": "Personal Access Token",
+        "placeholder": "ghp_xxxxxxxxxxxxxxxxxxxx",
+        "connectBtn": "Connect",
+        "connectingBtn": "Connecting…"
+      },
+      "repo": {
+        "description": "Select the repository and branch where the file should be committed.",
+        "repoLabel": "Repository",
+        "repoPlaceholder": "— select a repo —",
+        "branchLabel": "Branch",
+        "loadingRepos": "Loading repositories…",
+        "loadingBranches": "Loading branches…",
+        "disconnectBtn": "Disconnect",
+        "nextBtn": "Next"
+      },
+      "commit": {
+        "description": "Committing to {{owner}}/{{repo}} on branch {{branch}}.",
+        "filePathLabel": "File path in repository",
+        "commitMsgLabel": "Commit message",
+        "commitBtn": "Commit",
+        "committingBtn": "Committing…",
+        "backBtn": "← Back"
+      },
+      "success": {
+        "committed": "✓ Committed to",
+        "doneBtn": "Done"
+      }
+    },
+    "load": {
+      "dialogTitle": "Load from GitHub",
+      "token": {
+        "description": "Connect with a GitHub Personal Access Token (repo scope).",
+        "step1": "Generate a token",
+        "step2": "with repo scope",
+        "step3": "Paste it below",
+        "connectBtn": "Connect",
+        "connectingBtn": "Connecting…"
+      },
+      "repo": {
+        "description": "Select the repository and branch to browse.",
+        "repoLabel": "Repository",
+        "repoPlaceholder": "— select a repo —",
+        "branchLabel": "Branch",
+        "loadingRepos": "Loading repositories…",
+        "loadingBranches": "Loading branches…",
+        "disconnectBtn": "Disconnect",
+        "browseBtn": "Browse files"
+      },
+      "files": {
+        "loadingFiles": "Scanning repository for .excalidraw files…",
+        "noFiles": "No .excalidraw files found in this branch.",
+        "filterLabel": "Filter files",
+        "filterPlaceholder": "Search…",
+        "createNewLabel": "Or create a new file:",
+        "newFilePlaceholder": "new-diagram.excalidraw",
+        "createBtn": "Create",
+        "creatingBtn": "Creating…",
+        "backBtn": "← Back"
+      },
+      "loading": {
+        "message": "Loading file…"
+      }
+    },
+    "errors": {
+      "enterToken": "Please enter a token.",
+      "invalidToken": "Invalid token. Please try again.",
+      "commitFailed": "Commit failed. Please try again.",
+      "loadFailed": "Failed to load file.",
+      "createFailed": "Failed to create file.",
+      "listFailed": "Failed to list files."
+    }
   }
 }

--- a/test.excalidraw
+++ b/test.excalidraw
@@ -1,0 +1,11 @@
+{
+  "type": "excalidraw",
+  "version": 2,
+  "source": "https://excalidraw.com",
+  "elements": [],
+  "appState": {
+    "viewBackgroundColor": "#ffffff",
+    "gridSize": null
+  },
+  "files": {}
+}

--- a/test.excalidraw
+++ b/test.excalidraw
@@ -1,11 +1,105 @@
 {
   "type": "excalidraw",
   "version": 2,
-  "source": "https://excalidraw.com",
-  "elements": [],
+  "source": "http://localhost:3001",
+  "elements": [
+    {
+      "id": "lKHOL2IHfIJYzAuDQtQcf",
+      "type": "rectangle",
+      "x": -309.19921875,
+      "y": -167.23046875,
+      "width": 297.6328125,
+      "height": 213.6875,
+      "angle": 0,
+      "strokeColor": "#e03131",
+      "backgroundColor": "#ffec99",
+      "fillStyle": "solid",
+      "strokeWidth": 2,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "groupIds": [],
+      "frameId": null,
+      "index": "a0",
+      "roundness": {
+        "type": 3
+      },
+      "seed": 1472256857,
+      "version": 39,
+      "versionNonce": 1642470423,
+      "isDeleted": false,
+      "boundElements": null,
+      "updated": 1778356874291,
+      "link": null,
+      "locked": false
+    },
+    {
+      "id": "lB3aSEeyYScT6eAGiqAVF",
+      "type": "ellipse",
+      "x": -159.00390625,
+      "y": -192.30078125,
+      "width": 48.65625,
+      "height": 22.625,
+      "angle": 0,
+      "strokeColor": "#e03131",
+      "backgroundColor": "#ffec99",
+      "fillStyle": "solid",
+      "strokeWidth": 2,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "groupIds": [],
+      "frameId": null,
+      "index": "a1",
+      "roundness": {
+        "type": 2
+      },
+      "seed": 731156921,
+      "version": 219,
+      "versionNonce": 336556279,
+      "isDeleted": false,
+      "boundElements": null,
+      "updated": 1778356879121,
+      "link": null,
+      "locked": false
+    },
+    {
+      "id": "3lh_0N1d7JwAmT4lPHwBo",
+      "type": "ellipse",
+      "x": -77.625,
+      "y": -191.4921875,
+      "width": 48.65625,
+      "height": 22.625,
+      "angle": 0,
+      "strokeColor": "#e03131",
+      "backgroundColor": "#ffec99",
+      "fillStyle": "solid",
+      "strokeWidth": 2,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "groupIds": [],
+      "frameId": null,
+      "index": "a2",
+      "roundness": {
+        "type": 2
+      },
+      "seed": 464511063,
+      "version": 257,
+      "versionNonce": 690302455,
+      "isDeleted": false,
+      "boundElements": [],
+      "updated": 1778356881732,
+      "link": null,
+      "locked": false
+    }
+  ],
   "appState": {
+    "gridSize": 20,
+    "gridStep": 5,
+    "gridModeEnabled": false,
     "viewBackgroundColor": "#ffffff",
-    "gridSize": null
+    "lockedMultiSelections": {}
   },
   "files": {}
 }


### PR DESCRIPTION
Closes: https://github.com/excalidraw/excalidraw/issues/10975

### Summary

Adds native GitHub repository integration to Excalidraw, allowing users to save and load `.excalidraw` diagrams directly to/from their GitHub repositories — without leaving the editor.

### What's new

#### `GitHubManager` (`excalidraw-app/data/GitHubManager.ts`) — *new file*
A thin service layer that wraps the GitHub Contents API:
- **Token management** — stores/retrieves a Personal Access Token (PAT) via `localStorage`
- **Config persistence** — persists the last-used `owner/repo/branch/path` so the save dialog is pre-filled on subsequent opens
- **API helpers** — `listRepos`, `listBranches`, `listExcalidrawFiles` (via Git Trees API), `getFileContent`, `commitFile` (create or update via PUT)

#### `GitHubSaveDialog` (`excalidraw-app/components/GitHubSaveDialog.tsx`) — *new file*
A multi-step dialog for committing the current scene to GitHub:

| Step | Description |
|------|-------------|
| **Token** | Validates a PAT and stores it; links directly to the GitHub token generation page |
| **Repo / Branch** | Dropdown-driven selection loaded from the API |
| **Commit** | Editable file path and commit message (`Save <name> @ YYYY-MM-DD HH:MM`) |
| **Success** | Confirms commit with a direct link to the file on GitHub |

Includes a **Quick Save** mode — when a config is already stored, the dialog jumps straight to the commit step (pre-filled), saving several clicks.

Exposes three Jotai atoms consumed by `App.tsx`:
- `gitHubSaveDialogOpenAtom`
- `gitHubSaveQuickModeAtom`
- `activeGitHubConfigAtom`

#### `GitHubLoadDialog` (`excalidraw-app/components/GitHubLoadDialog.tsx`) — *new file*
A multi-step dialog for loading an `.excalidraw` file from GitHub:

| Step | Description |
|------|-------------|
| **Token** | Same PAT flow as the save dialog (shared token) |
| **Repo / Branch** | Dropdown selection |
| **File browser** | Lists all `.excalidraw` files in the branch (via the Git Trees API); filterable when > 5 files are present |
| **Loading** | Spinner while fetching file content |

Also supports **creating a new blank `.excalidraw` file** directly in the chosen repo — useful when starting a fresh diagram that should live in an existing repository.

On successful load the config is persisted, so `Ctrl+S` / `Cmd+S` immediately commits back to the same file.

#### `GitHubDialog.scss` (`excalidraw-app/components/GitHubDialog.scss`) — *new file*
Shared SCSS styles for both dialogs (uses Excalidraw CSS design tokens: `--color-primary`, `--island-bg-color`, `--default-border-color`, etc.) with full dark-mode support.

---

### Changes to `App.tsx`

- **Imports** — `GitHubSaveDialog`, `GitHubLoadDialog`, atoms, `GitHubIcon`, `Card`, `ToolButton`
- **State** — reads `activeGitHubConfigAtom`; writes `gitHubSaveQuickModeAtom` / `gitHubSaveDialogOpenAtom`
- **`handleGitHubLoad`** callback — deserialises the loaded JSON blob via `loadFromBlob`, restores elements & app state, and fits the viewport to content
- **Keyboard shortcut** — `Ctrl+S` / `Cmd+S` triggers Quick Save when a GitHub config is active; uses the capture phase to intercept before Excalidraw's built-in handler
- **Export dialog** — added a **"Save to GitHub"** card alongside the existing Excalidraw+ card in the `renderCustomUI` slot
- **Dialog mounts** — `<GitHubLoadDialog>` and `<GitHubSaveDialog>` are rendered inside the `<Excalidraw>` component tree

---

### User flow

```
First use
  Open export dialog → "Save to GitHub" card → enter PAT → select repo/branch → set path → Commit ✓

Subsequent saves (Quick Save)
  Ctrl+S (or Cmd+S) → dialog opens at Commit step pre-filled → one click → done ✓

Loading a diagram
  Main menu → "Load from GitHub" → select repo/branch → pick file → scene loads instantly ✓
```