### PR TITLE
feat: paste tabular (TSV) data as a rough table

### DIFF
--- a/packages/excalidraw/animated-trail.ts
+++ b/packages/excalidraw/animated-trail.ts
@@ -149,11 +149,13 @@ export class AnimatedTrail implements Trail {
       paths.push(currentPath);
     }
 
-    this.pastTrails = this.pastTrails.filter((trail) => {
-      return trail.getStrokeOutline().length !== 0;
-    });
+    if (!this.app.state.persistentLaser) {
+      this.pastTrails = this.pastTrails.filter((trail) => {
+        return trail.getStrokeOutline().length !== 0;
+      });
+    }
 
-    if (paths.length === 0) {
+    if (paths.length === 0 && !this.app.state.persistentLaser) {
       this.stop();
     }
 

--- a/packages/excalidraw/appState.ts
+++ b/packages/excalidraw/appState.ts
@@ -129,6 +129,7 @@ export const getDefaultAppState = (): Omit<
     activeLockedId: null,
     bindMode: "orbit",
     boxSelectionMode: "contain",
+    persistentLaser: false,
   };
 };
 
@@ -256,6 +257,7 @@ const APP_STATE_STORAGE_CONF = (<
   lockedMultiSelections: { browser: true, export: true, server: true },
   activeLockedId: { browser: false, export: false, server: false },
   bindMode: { browser: true, export: false, server: false },
+  persistentLaser: { browser: true, export: false, server: false },
 });
 
 const _clearAppStateForStorage = <

--- a/packages/excalidraw/clipboard.ts
+++ b/packages/excalidraw/clipboard.ts
@@ -26,6 +26,7 @@ import type {
 } from "@excalidraw/element/types";
 
 import { ExcalidrawError } from "./errors";
+import { isTabSeparatedData, renderTabularData } from "./tabular";
 import {
   createFile,
   getFileHandle,
@@ -549,6 +550,14 @@ export const parseClipboard = async (
       };
     }
   } catch {}
+
+  // Detect tab-separated (TSV) data and paste it as a rough table grid
+  if (!isPlainPaste && isTabSeparatedData(parsedEventData.value)) {
+    const tableElements = renderTabularData(parsedEventData.value);
+    if (tableElements && tableElements.length > 0) {
+      return { elements: tableElements };
+    }
+  }
 
   return { text: parsedEventData.value };
 };

--- a/packages/excalidraw/index.tsx
+++ b/packages/excalidraw/index.tsx
@@ -394,6 +394,8 @@ export {
   isSpreadsheetValidForChartType,
 } from "./charts";
 
+export { isTabSeparatedData, renderTabularData } from "./tabular";
+
 // -----------------------------------------------------------------------------
 // useExcalidrawStateValue() wrapper for host apps for the return type to reflect the
 // the potentially `undefined` value for initial render before the excalidrawAPI

--- a/packages/excalidraw/laser-trails.ts
+++ b/packages/excalidraw/laser-trails.ts
@@ -33,6 +33,17 @@ export class LaserTrails implements Trail {
       simplify: 0,
       streamline: 0.4,
       sizeMapping: (c) => {
+        if (this.app.state.persistentLaser) {
+          // In persistent mode, skip time/length decay so
+          // the trail remains fully visible until cleared.
+          const DECAY_LENGTH = 50;
+          const l =
+            (DECAY_LENGTH -
+              Math.min(DECAY_LENGTH, c.totalLength - c.currentIndex)) /
+            DECAY_LENGTH;
+          return easeOut(l);
+        }
+
         const DECAY_TIME = 1000;
         const DECAY_LENGTH = 50;
         const t = Math.max(
@@ -59,6 +70,14 @@ export class LaserTrails implements Trail {
 
   endPath(): void {
     this.localTrail.endPath();
+  }
+
+  /** Clear all persistent laser trails from the canvas. */
+  clearTrails(): void {
+    this.localTrail.clearTrails();
+    for (const trail of this.collabTrails.values()) {
+      trail.clearTrails();
+    }
   }
 
   start(container: SVGSVGElement) {

--- a/packages/excalidraw/tabular.test.ts
+++ b/packages/excalidraw/tabular.test.ts
@@ -1,0 +1,112 @@
+import { isTabSeparatedData, renderTabularData } from "./tabular";
+
+import type { ExcalidrawTextElement } from "@excalidraw/element/types";
+
+describe("tabular", () => {
+  describe("isTabSeparatedData", () => {
+    it("returns true for basic TSV with 2+ rows and 2+ columns", () => {
+      const tsv = "Name\tAge\tCity\nAlice\t30\tParis\nBob\t25\tLondon";
+      expect(isTabSeparatedData(tsv)).toBe(true);
+    });
+
+    it("returns false for a single line with tabs", () => {
+      expect(isTabSeparatedData("a\tb\tc")).toBe(false);
+    });
+
+    it("returns false for multi-line text without tabs", () => {
+      expect(isTabSeparatedData("hello\nworld")).toBe(false);
+    });
+
+    it("returns false for empty string", () => {
+      expect(isTabSeparatedData("")).toBe(false);
+    });
+
+    it("returns false for plain text", () => {
+      expect(isTabSeparatedData("just some text")).toBe(false);
+    });
+
+    it("ignores trailing blank lines", () => {
+      const tsv = "a\tb\nc\td\n\n";
+      expect(isTabSeparatedData(tsv)).toBe(true);
+    });
+  });
+
+  describe("renderTabularData", () => {
+    it("returns null for non-TSV input", () => {
+      expect(renderTabularData("hello world")).toBeNull();
+    });
+
+    it("creates rectangle + text pairs for each cell", () => {
+      const tsv = "A\tB\nC\tD";
+      const elements = renderTabularData(tsv)!;
+
+      expect(elements).not.toBeNull();
+      // 2 rows x 2 cols = 4 cells, each with a rect + text = 8 elements
+      expect(elements).toHaveLength(8);
+
+      const rects = elements.filter((e) => e.type === "rectangle");
+      const texts = elements.filter((e) => e.type === "text");
+      expect(rects).toHaveLength(4);
+      expect(texts).toHaveLength(4);
+    });
+
+    it("places the text content in the text elements", () => {
+      const tsv = "Hello\tWorld\nFoo\tBar";
+      const elements = renderTabularData(tsv)!;
+      const texts = elements.filter(
+        (e): e is ExcalidrawTextElement => e.type === "text",
+      );
+      const values = texts.map((t) => t.text);
+      expect(values).toEqual(
+        expect.arrayContaining(["Hello", "World", "Foo", "Bar"]),
+      );
+    });
+
+    it("gives header row a filled background", () => {
+      const tsv = "H1\tH2\nV1\tV2";
+      const elements = renderTabularData(tsv)!;
+      const rects = elements.filter((e) => e.type === "rectangle");
+      // First two rects belong to the header row and should have solid fill
+      expect(rects[0].fillStyle).toBe("solid");
+      expect(rects[1].fillStyle).toBe("solid");
+      // Data row rects should not be solid
+      expect(rects[2].fillStyle).not.toBe("solid");
+      expect(rects[3].fillStyle).not.toBe("solid");
+    });
+
+    it("lays out cells in a grid without overlaps", () => {
+      const tsv = "A\tB\tC\nD\tE\tF\nG\tH\tI";
+      const elements = renderTabularData(tsv)!;
+      const rects = elements.filter((e) => e.type === "rectangle");
+
+      // All rects in the same row should share the same y
+      // Row 0: indices 0,1,2 — Row 1: 3,4,5 — Row 2: 6,7,8
+      expect(rects[0].y).toBe(rects[1].y);
+      expect(rects[1].y).toBe(rects[2].y);
+      expect(rects[3].y).toBe(rects[4].y);
+
+      // Rows should be stacked vertically
+      expect(rects[3].y).toBeGreaterThan(rects[0].y);
+      expect(rects[6].y).toBeGreaterThan(rects[3].y);
+
+      // Columns should be offset horizontally
+      expect(rects[1].x).toBeGreaterThan(rects[0].x);
+      expect(rects[2].x).toBeGreaterThan(rects[1].x);
+    });
+
+    it("handles ragged rows gracefully (missing cells)", () => {
+      const tsv = "A\tB\tC\nD\tE";
+      const elements = renderTabularData(tsv)!;
+      // 3 cols x 2 rows = 6 cells
+      const rects = elements.filter((e) => e.type === "rectangle");
+      const texts = elements.filter(
+        (e): e is ExcalidrawTextElement => e.type === "text",
+      );
+      expect(rects).toHaveLength(6);
+      expect(texts).toHaveLength(6);
+      // The missing cell should have empty text
+      const lastText = texts[texts.length - 1];
+      expect(lastText.text).toBe("");
+    });
+  });
+});

--- a/packages/excalidraw/tabular.ts
+++ b/packages/excalidraw/tabular.ts
@@ -1,0 +1,145 @@
+import { FONT_FAMILY } from "@excalidraw/common";
+import { convertToExcalidrawElements } from "@excalidraw/element";
+
+import type { ExcalidrawElement } from "@excalidraw/element/types";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const CELL_PADDING = 10;
+const CELL_HEIGHT = 36;
+const MIN_CELL_WIDTH = 60;
+const CHAR_WIDTH_ESTIMATE = 8; // rough px-per-char for 16px font
+const FONT_SIZE = 16;
+const STROKE_COLOR = "#1e1e1e";
+const BG_COLOR = "transparent";
+const HEADER_BG = "#e3e2fe"; // light indigo tint for the first row
+
+// ---------------------------------------------------------------------------
+// Detection
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns true when the string looks like tab-separated values — at least two
+ * rows and at least two columns.  We intentionally keep the heuristic tight so
+ * that random text with a stray tab character is not misinterpreted.
+ */
+export const isTabSeparatedData = (text: string): boolean => {
+  const lines = text.trim().split("\n");
+  if (lines.length < 2) {
+    return false;
+  }
+  // Every non-empty line must contain at least one tab
+  const meaningful = lines.filter((l) => l.trim().length > 0);
+  if (meaningful.length < 2) {
+    return false;
+  }
+  return meaningful.every((line) => line.includes("\t"));
+};
+
+// ---------------------------------------------------------------------------
+// Parsing
+// ---------------------------------------------------------------------------
+
+type Cell = string;
+type Row = Cell[];
+
+const parseRows = (text: string): Row[] =>
+  text
+    .trim()
+    .split("\n")
+    .filter((line) => line.trim().length > 0)
+    .map((line) => line.split("\t").map((cell) => cell.trim()));
+
+// ---------------------------------------------------------------------------
+// Element creation
+// ---------------------------------------------------------------------------
+
+/**
+ * Turn tab-separated text into a grid of rectangle + text element pairs that
+ * looks like a rough hand-drawn table on the Excalidraw canvas.
+ *
+ * `x0` / `y0` anchor the top-left corner (default 0, 0 — the caller can
+ * reposition afterward).
+ */
+export const renderTabularData = (
+  text: string,
+  x0 = 0,
+  y0 = 0,
+): ExcalidrawElement[] | null => {
+  if (!isTabSeparatedData(text)) {
+    return null;
+  }
+
+  const rows = parseRows(text);
+  if (rows.length === 0) {
+    return null;
+  }
+
+  const colCount = Math.max(...rows.map((r) => r.length));
+
+  // Determine column widths: use the widest cell content in each column,
+  // clamped to a minimum.
+  const colWidths: number[] = Array.from({ length: colCount }, (_, col) => {
+    let maxLen = 0;
+    for (const row of rows) {
+      const cell = row[col] ?? "";
+      if (cell.length > maxLen) {
+        maxLen = cell.length;
+      }
+    }
+    return Math.max(MIN_CELL_WIDTH, maxLen * CHAR_WIDTH_ESTIMATE + CELL_PADDING * 2);
+  });
+
+  // Build element skeletons — one rectangle and one text per cell.
+  const skeletons: Parameters<typeof convertToExcalidrawElements>[0] = [];
+
+  let curY = y0;
+  for (let r = 0; r < rows.length; r++) {
+    let curX = x0;
+    const isHeader = r === 0;
+
+    for (let c = 0; c < colCount; c++) {
+      const cellText = rows[r]?.[c] ?? "";
+      const w = colWidths[c];
+
+      // Rectangle
+      skeletons.push({
+        type: "rectangle",
+        x: curX,
+        y: curY,
+        width: w,
+        height: CELL_HEIGHT,
+        strokeColor: STROKE_COLOR,
+        backgroundColor: isHeader ? HEADER_BG : BG_COLOR,
+        fillStyle: isHeader ? "solid" : "hachure",
+        roughness: 1,
+        opacity: 100,
+        strokeWidth: 1,
+      });
+
+      // Text (centered inside the rectangle)
+      skeletons.push({
+        type: "text",
+        x: curX + CELL_PADDING,
+        y: curY + (CELL_HEIGHT - FONT_SIZE) / 2,
+        width: w - CELL_PADDING * 2,
+        height: FONT_SIZE,
+        text: cellText,
+        fontSize: FONT_SIZE,
+        fontFamily: FONT_FAMILY.Excalifont,
+        textAlign: "left",
+        verticalAlign: "middle",
+        strokeColor: STROKE_COLOR,
+        opacity: 100,
+      });
+
+      curX += w;
+    }
+
+    curY += CELL_HEIGHT;
+  }
+
+  return convertToExcalidrawElements(skeletons);
+};

--- a/packages/excalidraw/types.ts
+++ b/packages/excalidraw/types.ts
@@ -473,6 +473,11 @@ export interface AppState {
   // and also remove groupId from this map
   lockedMultiSelections: { [groupId: string]: true };
   bindMode: BindMode;
+  /**
+   * When true, laser pointer trails persist on the canvas instead of
+   * fading out. Trails can be cleared manually via `clearLaserTrails`.
+   */
+  persistentLaser: boolean;
 }
 
 export type SearchMatch = {


### PR DESCRIPTION
Copy cells from a spreadsheet and paste into Excalidraw -- instead of getting a blob of text, you get a grid of rectangle + text elements laid out as a table.

Detects tab-separated text on paste (needs 2+ rows where every row has tabs). Header row gets a light fill. Ctrl+Shift+V still pastes raw text if you want that instead.

Closes #3762