### PR TITLE
feat(editor): add hover delay and animation to tooltips

### DIFF
--- a/packages/excalidraw/components/Tooltip.scss
+++ b/packages/excalidraw/components/Tooltip.scss
@@ -22,10 +22,17 @@
   font-weight: 500;
   color: #fff;
 
-  display: none;
+  // Use opacity + visibility instead of display so we can animate
+  opacity: 0;
+  visibility: hidden;
+  transform: translateY(4px);
+  transition: opacity 0.15s ease-out, visibility 0.15s ease-out,
+    transform 0.15s ease-out;
 
   &.excalidraw-tooltip--visible {
-    display: block;
+    opacity: 1;
+    visibility: visible;
+    transform: translateY(0);
   }
 }
 

--- a/packages/excalidraw/components/Tooltip.tsx
+++ b/packages/excalidraw/components/Tooltip.tsx
@@ -2,6 +2,9 @@ import React, { useEffect } from "react";
 
 import "./Tooltip.scss";
 
+// Timer for the hover delay before showing tooltips
+let showTooltipTimer: ReturnType<typeof setTimeout> | null = null;
+
 export const getTooltipDiv = () => {
   const existingDiv = document.querySelector<HTMLDivElement>(
     ".excalidraw-tooltip",
@@ -83,6 +86,8 @@ type TooltipProps = {
   disabled?: boolean;
 };
 
+const TOOLTIP_SHOW_DELAY_MS = 300;
+
 export const Tooltip = ({
   children,
   label,
@@ -91,8 +96,13 @@ export const Tooltip = ({
   disabled,
 }: TooltipProps) => {
   useEffect(() => {
-    return () =>
+    return () => {
+      if (showTooltipTimer) {
+        clearTimeout(showTooltipTimer);
+        showTooltipTimer = null;
+      }
       getTooltipDiv().classList.remove("excalidraw-tooltip--visible");
+    };
   }, []);
   if (disabled) {
     return null;
@@ -100,17 +110,28 @@ export const Tooltip = ({
   return (
     <div
       className="excalidraw-tooltip-wrapper"
-      onPointerEnter={(event) =>
-        updateTooltip(
-          event.currentTarget as HTMLDivElement,
-          getTooltipDiv(),
-          label,
-          long,
-        )
-      }
-      onPointerLeave={() =>
-        getTooltipDiv().classList.remove("excalidraw-tooltip--visible")
-      }
+      onPointerEnter={(event) => {
+        // Capture the target element before the async delay
+        const target = event.currentTarget as HTMLDivElement;
+
+        // Clear any existing timer (e.g. quickly moving between buttons)
+        if (showTooltipTimer) {
+          clearTimeout(showTooltipTimer);
+        }
+
+        showTooltipTimer = setTimeout(() => {
+          updateTooltip(target, getTooltipDiv(), label, long);
+          showTooltipTimer = null;
+        }, TOOLTIP_SHOW_DELAY_MS);
+      }}
+      onPointerLeave={() => {
+        // Cancel the pending show if the user leaves before the delay
+        if (showTooltipTimer) {
+          clearTimeout(showTooltipTimer);
+          showTooltipTimer = null;
+        }
+        getTooltipDiv().classList.remove("excalidraw-tooltip--visible");
+      }}
       style={style}
     >
       {children}


### PR DESCRIPTION
## Summary
- Adds a **300ms hover delay** before tooltips appear, preventing flashing when quickly moving the cursor across toolbar buttons
- Adds a smooth **fade-in + slide-up CSS animation** (0.15s ease-out) for a more polished feel
- Switches from `display: none/block` to `opacity/visibility/transform` to enable CSS transitions

## Test plan
- [ ] Hover over toolbar buttons — tooltip should appear after a brief delay with a smooth animation
- [ ] Quickly move cursor across multiple buttons — tooltips should not flash
- [ ] Hover over a button then move away before the delay — no tooltip should appear
- [ ] Verify hyperlink tooltips still work correctly (they share the same CSS)
- [ ] Test in both light and dark themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)