### PR TITLE
feat(ui): elastic-drop tooltip animation for toolbar

### DIFF
--- a/packages/excalidraw/components/Actions.tsx
+++ b/packages/excalidraw/components/Actions.tsx
@@ -1139,44 +1139,48 @@ export const ShapesSwitcher = ({
           }
 
           return (
-            <ToolButton
-              className={clsx("Shape", { fillable })}
+            <Tooltip
+              label={`${capitalizeString(label)} — ${shortcut}`}
               key={value}
-              type="radio"
-              icon={icon}
-              checked={activeTool.type === value}
-              name="editor-current-shape"
-              title={`${capitalizeString(label)} — ${shortcut}`}
-              keyBindingLabel={keybindingLabel}
-              aria-label={capitalizeString(label)}
-              aria-keyshortcuts={shortcut}
-              data-testid={`toolbar-${value}`}
-              onPointerDown={({ pointerType }) => {
-                if (!app.state.penDetected && pointerType === "pen") {
-                  app.togglePenMode(true);
-                }
-
-                if (value === "selection") {
-                  if (app.state.activeTool.type === "selection") {
-                    app.setActiveTool({ type: "lasso" });
-                  } else {
-                    app.setActiveTool({ type: "selection" });
+              delay={350}
+            >
+              <ToolButton
+                className={clsx("Shape", { fillable })}
+                type="radio"
+                icon={icon}
+                checked={activeTool.type === value}
+                name="editor-current-shape"
+                keyBindingLabel={keybindingLabel}
+                aria-label={capitalizeString(label)}
+                aria-keyshortcuts={shortcut}
+                data-testid={`toolbar-${value}`}
+                onPointerDown={({ pointerType }) => {
+                  if (!app.state.penDetected && pointerType === "pen") {
+                    app.togglePenMode(true);
                   }
-                }
-              }}
-              onChange={({ pointerType }) => {
-                if (app.state.activeTool.type !== value) {
-                  trackEvent("toolbar", value, "ui");
-                }
-                if (value === "image") {
-                  app.setActiveTool({
-                    type: value,
-                  });
-                } else {
-                  app.setActiveTool({ type: value });
-                }
-              }}
-            />
+
+                  if (value === "selection") {
+                    if (app.state.activeTool.type === "selection") {
+                      app.setActiveTool({ type: "lasso" });
+                    } else {
+                      app.setActiveTool({ type: "selection" });
+                    }
+                  }
+                }}
+                onChange={({ pointerType }) => {
+                  if (app.state.activeTool.type !== value) {
+                    trackEvent("toolbar", value, "ui");
+                  }
+                  if (value === "image") {
+                    app.setActiveTool({
+                      type: value,
+                    });
+                  } else {
+                    app.setActiveTool({ type: value });
+                  }
+                }}
+              />
+            </Tooltip>
           );
         },
       )}

--- a/packages/excalidraw/components/Tooltip.scss
+++ b/packages/excalidraw/components/Tooltip.scss
@@ -26,12 +26,33 @@
 
   &.excalidraw-tooltip--visible {
     display: block;
+    animation: elastic-drop 0.55s cubic-bezier(0.22, 1, 0.36, 1) both;
   }
 }
 
 // wraps the element we want to apply the tooltip to
 .excalidraw-tooltip-wrapper {
   display: flex;
+}
+
+@keyframes elastic-drop {
+  0% {
+    opacity: 0;
+    transform: translateY(-20px) scaleY(1.3) scaleX(0.8);
+  }
+  30% {
+    opacity: 1;
+    transform: translateY(4px) scaleY(0.9) scaleX(1.05);
+  }
+  50% {
+    transform: translateY(-3px) scaleY(1.05) scaleX(0.98);
+  }
+  70% {
+    transform: translateY(1px) scaleY(0.98) scaleX(1.01);
+  }
+  100% {
+    transform: translateY(0) scaleY(1) scaleX(1);
+  }
 }
 
 .excalidraw-tooltip-icon {

--- a/packages/excalidraw/components/Tooltip.tsx
+++ b/packages/excalidraw/components/Tooltip.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useRef } from "react";
 
 import "./Tooltip.scss";
 
@@ -65,6 +65,9 @@ const updateTooltip = (
   label: string,
   long: boolean,
 ) => {
+  // Remove and re-add the visible class to restart the entrance animation
+  tooltip.classList.remove("excalidraw-tooltip--visible");
+  void tooltip.offsetWidth;
   tooltip.classList.add("excalidraw-tooltip--visible");
   tooltip.style.minWidth = long ? "50ch" : "10ch";
   tooltip.style.maxWidth = long ? "50ch" : "15ch";
@@ -81,6 +84,8 @@ type TooltipProps = {
   long?: boolean;
   style?: React.CSSProperties;
   disabled?: boolean;
+  /** Delay in ms before the tooltip appears on hover (default: 0) */
+  delay?: number;
 };
 
 export const Tooltip = ({
@@ -89,28 +94,49 @@ export const Tooltip = ({
   long = false,
   style,
   disabled,
+  delay = 0,
 }: TooltipProps) => {
+  const delayTimerRef = useRef<number | null>(null);
+
   useEffect(() => {
-    return () =>
+    return () => {
+      if (delayTimerRef.current !== null) {
+        window.clearTimeout(delayTimerRef.current);
+      }
       getTooltipDiv().classList.remove("excalidraw-tooltip--visible");
+    };
   }, []);
+
   if (disabled) {
     return null;
   }
+
   return (
     <div
       className="excalidraw-tooltip-wrapper"
-      onPointerEnter={(event) =>
-        updateTooltip(
-          event.currentTarget as HTMLDivElement,
-          getTooltipDiv(),
-          label,
-          long,
-        )
-      }
-      onPointerLeave={() =>
-        getTooltipDiv().classList.remove("excalidraw-tooltip--visible")
-      }
+      onPointerEnter={(event) => {
+        const target = event.currentTarget as HTMLDivElement;
+        const tooltipDiv = getTooltipDiv();
+
+        if (delay > 0) {
+          if (delayTimerRef.current !== null) {
+            window.clearTimeout(delayTimerRef.current);
+          }
+          delayTimerRef.current = window.setTimeout(() => {
+            updateTooltip(target, tooltipDiv, label, long);
+            delayTimerRef.current = null;
+          }, delay);
+        } else {
+          updateTooltip(target, tooltipDiv, label, long);
+        }
+      }}
+      onPointerLeave={() => {
+        if (delayTimerRef.current !== null) {
+          window.clearTimeout(delayTimerRef.current);
+          delayTimerRef.current = null;
+        }
+        getTooltipDiv().classList.remove("excalidraw-tooltip--visible");
+      }}
       style={style}
     >
       {children}


### PR DESCRIPTION
## Summary
- Replaces native `title` tooltips on toolbar tool buttons with the existing `Tooltip` component
- Adds a **350ms hover delay** so tooltips don't flash on quick mouse passes
- Adds a whimsical **elastic-drop entrance animation** (0.55s bounce) when the tooltip appears
- Extends the `Tooltip` component with an optional `delay` prop (backward-compatible, defaults to 0)

## Changes
- **`Tooltip.tsx`** — added `delay` prop with `useRef`-based timer; reflow trick to restart animation on re-show
- **`Tooltip.scss`** — added `@keyframes elastic-drop` with squish/stretch bounce; applied to `--visible` state
- **`Actions.tsx`** — wrapped toolbar `ToolButton`s in `<Tooltip delay={350}>`, removed native `title` prop

## Test plan
- [ ] Hover over each toolbar tool — tooltip appears after ~350ms with bounce animation
- [ ] Move quickly between tools — no tooltip flash, previous timer cancels cleanly
- [ ] Move cursor away before 350ms — no tooltip appears
- [ ] Undo/Redo tooltips still work (no delay, instant show)
- [ ] Tooltip positions correctly and doesn't clip off-screen
- [ ] No TypeScript errors (`yarn test:typecheck`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)