### PR TITLE
Fix opacity slider RTL compatibility

### DIFF
--- a/packages/excalidraw/components/Range.scss
+++ b/packages/excalidraw/components/Range.scss
@@ -44,12 +44,16 @@
     transform: translateX(-50%);
     font-size: 12px;
     color: var(--text-primary-color);
+
+    :root[dir="rtl"] & {
+      transform: translateX(50%);
+    }
   }
 
   .zero-label {
     position: absolute;
     bottom: 0;
-    left: 4px;
+    inset-inline-start: 4px;
     font-size: 12px;
     color: var(--text-primary-color);
   }

--- a/packages/excalidraw/components/Range.tsx
+++ b/packages/excalidraw/components/Range.tsx
@@ -42,8 +42,11 @@ export const Range = ({
       const progress = ((value - min) / (max - min || 1)) * 100;
       const position =
         (progress / 100) * (inputWidth - thumbWidth) + thumbWidth / 2;
-      valueElement.style.left = `${position}px`;
-      rangeElement.style.background = `linear-gradient(to right, var(--color-slider-track) 0%, var(--color-slider-track) ${progress}%, var(--button-bg) ${progress}%, var(--button-bg) 100%)`;
+      const isRTL =
+        document.documentElement.getAttribute("dir") === "rtl";
+      valueElement.style.insetInlineStart = `${position}px`;
+      const direction = isRTL ? "to left" : "to right";
+      rangeElement.style.background = `linear-gradient(${direction}, var(--color-slider-track) 0%, var(--color-slider-track) ${progress}%, var(--button-bg) ${progress}%, var(--button-bg) 100%)`;
     }
   }, [max, min, value]);
 


### PR DESCRIPTION
## Summary

- Fixed opacity slider positioning broken in RTL layouts by using `insetInlineStart` CSS logical property instead of hardcoded `left`
- Fixed gradient direction to reverse in RTL mode
- Fixed `.value-bubble` transform direction for RTL
- Fixed `.zero-label` positioning using `inset-inline-start` instead of `left`

Closes #9710

## Test plan

- [ ] Open Excalidraw with an RTL language (e.g. Arabic, Hebrew)
- [ ] Select an element and adjust the opacity slider
- [ ] Verify the slider track fill, thumb, value bubble, and zero label are correctly positioned
- [ ] Verify LTR languages still work correctly