### PR TITLE
Fix Mermaid diagram <br> tags not resolving to line breaks

### DIFF
--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -423,6 +423,7 @@ import { textWysiwyg } from "../wysiwyg/textWysiwyg";
 import { isOverScrollBars } from "../scene/scrollbars";
 
 import { isMaybeMermaidDefinition } from "../mermaid";
+import { sanitizeMermaidElementText } from "./TTDDialog/common";
 
 import { LassoTrail } from "../lasso";
 
@@ -3756,9 +3757,10 @@ class App extends React.Component<AppProps, AppState> {
         const { elements: skeletonElements, files = {} } =
           await api.parseMermaidToExcalidraw(data.text);
 
-        const elements = convertToExcalidrawElements(skeletonElements, {
-          regenerateIds: true,
-        });
+        const elements = convertToExcalidrawElements(
+          sanitizeMermaidElementText(skeletonElements),
+          { regenerateIds: true },
+        );
 
         this.addElementsFromPasteOrLibrary({
           elements,

--- a/packages/excalidraw/components/TTDDialog/common.ts
+++ b/packages/excalidraw/components/TTDDialog/common.ts
@@ -15,9 +15,35 @@ import type {
 
 import { EditorLocalStorage } from "../../data/EditorLocalStorage";
 
+import type { ExcalidrawElementSkeleton } from "@excalidraw/element/transform";
+
 import type { MermaidToExcalidrawLibProps } from "./types";
 
 import type { AppClassProperties, BinaryFiles } from "../../types";
+
+const BR_TAG_RE = /<br\s*\/?>/gi;
+
+/**
+ * Replaces `<br>` / `<br/>` / `<br />` tags with newlines in Mermaid
+ * skeleton element text, since Mermaid supports them for multiline
+ * labels but Excalidraw renders them as literal text.
+ */
+export const sanitizeMermaidElementText = (
+  elements: ExcalidrawElementSkeleton[],
+): ExcalidrawElementSkeleton[] =>
+  elements.map((el) => {
+    const result = { ...el } as any;
+    if ("text" in result && typeof result.text === "string") {
+      result.text = result.text.replace(BR_TAG_RE, "\n");
+    }
+    if (result.label?.text) {
+      result.label = {
+        ...result.label,
+        text: result.label.text.replace(BR_TAG_RE, "\n"),
+      };
+    }
+    return result;
+  });
 
 export const resetPreview = ({
   canvasRef,
@@ -98,9 +124,10 @@ export const convertMermaidToExcalidraw = async ({
     setError(null);
 
     data.current = {
-      elements: convertToExcalidrawElements(elements, {
-        regenerateIds: true,
-      }),
+      elements: convertToExcalidrawElements(
+        sanitizeMermaidElementText(elements),
+        { regenerateIds: true },
+      ),
       files,
     };
 


### PR DESCRIPTION
## Summary

- When importing Mermaid diagrams with `<br>`, `<br/>`, or `<br />` tags in node labels, Excalidraw rendered the literal tag text instead of treating it as a line break
- Added `sanitizeMermaidElementText()` utility that replaces `<br>` tags with `\n` in skeleton element text properties before converting to Excalidraw elements
- Applied the sanitization in both entry points: TTDDialog (Mermaid panel) and App.tsx (paste)

Closes #9708

## Test plan

- [ ] Open Excalidraw and paste this Mermaid code:
  ```
  graph TD
      A["User Registration<br>Process"] --> B["Validate Input<br>Data"]
  ```
- [ ] Verify "User Registration" and "Process" appear on separate lines
- [ ] Verify `<br/>` and `<br />` variants also work
- [ ] Test via the Mermaid to Excalidraw dialog (TTD)
- [ ] Test via direct paste on canvas