### PR TITLE
fix(security): prevent XSS in Mermaid diagram rendering

### DIFF
--- a/.codesandbox/Dockerfile
+++ b/.codesandbox/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-bullseye
+FROM node:24-bullseye
 
 # Vite wants to open the browser using `open`, so we
 # need to install those utils.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=${BUILDPLATFORM} node:18 AS build
+FROM --platform=${BUILDPLATFORM} node:24 AS build
 
 WORKDIR /opt/node_app
 

--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -3753,8 +3753,9 @@ class App extends React.Component<AppProps, AppState> {
     if (!isPlainPaste && isMaybeMermaidDefinition(data.text)) {
       const api = await import("@excalidraw/mermaid-to-excalidraw");
       try {
+        const { SECURE_MERMAID_CONFIG } = await import("./TTDDialog/common");
         const { elements: skeletonElements, files = {} } =
-          await api.parseMermaidToExcalidraw(data.text);
+          await api.parseMermaidToExcalidraw(data.text, SECURE_MERMAID_CONFIG);
 
         const elements = convertToExcalidrawElements(skeletonElements, {
           regenerateIds: true,

--- a/packages/excalidraw/components/TTDDialog/MermaidToExcalidraw.tsx
+++ b/packages/excalidraw/components/TTDDialog/MermaidToExcalidraw.tsx
@@ -27,6 +27,7 @@ import {
   insertToEditor,
   saveMermaidDataToStorage,
   resetPreview,
+  SECURE_MERMAID_CONFIG,
 } from "./common";
 
 import "./MermaidToExcalidraw.scss";
@@ -173,7 +174,10 @@ const MermaidToExcalidraw = ({
           triedCandidates += 1;
 
           try {
-            await api.parseMermaidToExcalidraw(current.text);
+            await api.parseMermaidToExcalidraw(
+              current.text,
+              SECURE_MERMAID_CONFIG,
+            );
             if (!cancelled) {
               setAutoFixCandidate(current.text);
             }

--- a/packages/excalidraw/components/TTDDialog/common.test.ts
+++ b/packages/excalidraw/components/TTDDialog/common.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { convertMermaidToExcalidraw } from "./common";
+import { convertMermaidToExcalidraw, SECURE_MERMAID_CONFIG } from "./common";
 
 type ConvertMermaidArgs = Parameters<typeof convertMermaidToExcalidraw>[0];
 type ParseMermaidToExcalidraw = Awaited<
@@ -54,10 +54,12 @@ describe("convertMermaidToExcalidraw", () => {
     expect(parseMermaidToExcalidraw).toHaveBeenNthCalledWith(
       1,
       mermaidDefinition,
+      SECURE_MERMAID_CONFIG,
     );
     expect(parseMermaidToExcalidraw).toHaveBeenNthCalledWith(
       2,
       mermaidDefinition.replace(/"/g, "'"),
+      SECURE_MERMAID_CONFIG,
     );
 
     expect(result.success).toBe(false);
@@ -79,7 +81,10 @@ describe("convertMermaidToExcalidraw", () => {
     );
 
     expect(parseMermaidToExcalidraw).toHaveBeenCalledTimes(1);
-    expect(parseMermaidToExcalidraw).toHaveBeenCalledWith(mermaidDefinition);
+    expect(parseMermaidToExcalidraw).toHaveBeenCalledWith(
+      mermaidDefinition,
+      SECURE_MERMAID_CONFIG,
+    );
 
     expect(result.success).toBe(false);
     if (!result.success) {

--- a/packages/excalidraw/components/TTDDialog/common.ts
+++ b/packages/excalidraw/components/TTDDialog/common.ts
@@ -13,11 +13,29 @@ import type {
   Theme,
 } from "@excalidraw/element/types";
 
+import type { MermaidConfig } from "@excalidraw/mermaid-to-excalidraw";
+
 import { EditorLocalStorage } from "../../data/EditorLocalStorage";
 
 import type { MermaidToExcalidrawLibProps } from "./types";
 
 import type { AppClassProperties, BinaryFiles } from "../../types";
+
+/**
+ * Secure mermaid config that prevents HTML injection in labels.
+ *
+ * Mermaid's default securityLevel allows raw HTML in diagram labels,
+ * which can lead to XSS when combined with KaTeX math rendering
+ * (e.g. `<img onerror="...">` in participant labels).
+ *
+ * Setting `securityLevel: "strict"` encodes HTML tags in text,
+ * preventing script injection.
+ */
+export const SECURE_MERMAID_CONFIG: MermaidConfig & {
+  securityLevel: string;
+} = {
+  securityLevel: "strict",
+};
 
 export const resetPreview = ({
   canvasRef,
@@ -75,7 +93,10 @@ export const convertMermaidToExcalidraw = async ({
     const api = await mermaidToExcalidrawLib.api;
 
     try {
-      ret = await api.parseMermaidToExcalidraw(mermaidDefinition);
+      ret = await api.parseMermaidToExcalidraw(
+        mermaidDefinition,
+        SECURE_MERMAID_CONFIG,
+      );
     } catch (err: unknown) {
       const originalParseError = err as Error;
 
@@ -86,6 +107,7 @@ export const convertMermaidToExcalidraw = async ({
       try {
         ret = await api.parseMermaidToExcalidraw(
           mermaidDefinition.replace(/"/g, "'"),
+          SECURE_MERMAID_CONFIG,
         );
       } catch {
         // Keep the original error so line/column references stay aligned with

--- a/packages/excalidraw/components/TTDDialog/hooks/useTextGeneration.ts
+++ b/packages/excalidraw/components/TTDDialog/hooks/useTextGeneration.ts
@@ -1,6 +1,9 @@
 import { useRef } from "react";
 import { parseMermaidToExcalidraw } from "@excalidraw/mermaid-to-excalidraw";
+
 import { isFiniteNumber } from "@excalidraw/math";
+
+import { SECURE_MERMAID_CONFIG } from "../common";
 
 import { useAtom } from "../../../editor-jotai";
 
@@ -191,7 +194,10 @@ export const useTextGeneration = ({
       }
 
       try {
-        await parseMermaidToExcalidraw(generatedResponse ?? "");
+        await parseMermaidToExcalidraw(
+          generatedResponse ?? "",
+          SECURE_MERMAID_CONFIG,
+        );
         trackEvent("ai", "mermaid parse success", "ttd");
       } catch (error: any) {
         trackEvent("ai", "mermaid parse failed", "ttd");


### PR DESCRIPTION
## Summary
- Set mermaid `securityLevel: "strict"` for all `parseMermaidToExcalidraw` calls, preventing XSS via HTML injection in diagram labels
- Update Dockerfiles from Node 18 to Node 24 LTS (required — `marked@16.4.2` needs Node >= 20, breaking Docker builds)

## Security Issue
Mermaid's default security level allows raw HTML in diagram labels. When a sequence diagram participant label contains both HTML and KaTeX math expressions (`$$...$$`), the non-math HTML portion bypasses DOMPurify sanitization and executes as JavaScript when mermaid renders the SVG into the DOM:

```
sequenceDiagram
    participant A as Alice<img src="x" onerror="alert('xss')">$$\text{Alice}$$
```

Setting `securityLevel: "strict"` causes mermaid to encode HTML tags in text, preventing injection at the source.

## Changes
- **`common.ts`** — Define `SECURE_MERMAID_CONFIG` with `securityLevel: "strict"`, pass to both parse calls (primary + quote-fallback)
- **`MermaidToExcalidraw.tsx`** — Pass config to auto-fix probe calls
- **`useTextGeneration.ts`** — Pass config to AI text generation validation
- **`App.tsx`** — Pass config to clipboard paste handler
- **`common.test.ts`** — Updated test assertions for new config argument
- **`Dockerfile`**, **`.codesandbox/Dockerfile`** — Node 18 → Node 24 LTS

## Test plan
- [x] `yarn test:typecheck` passes
- [x] `common.test.ts` and `MermaidToExcalidraw.test.tsx` pass
- [x] Local Docker build — XSS payload produces no alert
- [x] Verified XSS reproduces on unpatched v0.18.0 deployment