### PR TITLE
fix: improve Mermaid text sanitization (line breaks, HTML tags, entity decoding)

### DIFF
--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -423,6 +423,7 @@ import { textWysiwyg } from "../wysiwyg/textWysiwyg";
 import { isOverScrollBars } from "../scene/scrollbars";
 
 import { isMaybeMermaidDefinition } from "../mermaid";
+import { sanitizeMermaidElementText } from "./TTDDialog/common";
 
 import { LassoTrail } from "../lasso";
 
@@ -3756,9 +3757,12 @@ class App extends React.Component<AppProps, AppState> {
         const { elements: skeletonElements, files = {} } =
           await api.parseMermaidToExcalidraw(data.text);
 
-        const elements = convertToExcalidrawElements(skeletonElements, {
-          regenerateIds: true,
-        });
+        const elements = convertToExcalidrawElements(
+          sanitizeMermaidElementText(skeletonElements),
+          {
+            regenerateIds: true,
+          },
+        );
 
         this.addElementsFromPasteOrLibrary({
           elements,

--- a/packages/excalidraw/components/TTDDialog/common.test.ts
+++ b/packages/excalidraw/components/TTDDialog/common.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { convertMermaidToExcalidraw } from "./common";
+import { convertMermaidToExcalidraw, sanitizeMermaidElementText } from "./common";
 
 type ConvertMermaidArgs = Parameters<typeof convertMermaidToExcalidraw>[0];
 type ParseMermaidToExcalidraw = Awaited<
@@ -85,5 +85,93 @@ describe("convertMermaidToExcalidraw", () => {
     if (!result.success) {
       expect(result.error).toBe(originalError);
     }
+  });
+});
+
+describe("sanitizeMermaidElementText", () => {
+  it("converts <br> tags to newlines and strips other HTML", () => {
+    const elements = [
+      {
+        type: "rectangle",
+        id: "1",
+        label: { text: "Hello<br/>World" },
+      },
+      {
+        type: "text",
+        id: "2",
+        text: "Line 1<br>Line 2",
+      },
+      {
+        type: "arrow",
+        id: "3",
+        start: { type: "text", text: "Start<br>Point" },
+        end: { type: "text", text: "End<br>Point" },
+        label: { text: "<b>Bold</b> Label" },
+      },
+    ] as any;
+
+    const sanitized = sanitizeMermaidElementText(elements) as any[];
+
+    expect(sanitized[0].label.text).toBe("Hello\nWorld");
+    expect(sanitized[1].text).toBe("Line 1\nLine 2");
+    expect(sanitized[2].label.text).toBe("Bold Label");
+  });
+
+  it("converts literal \\n to actual newlines", () => {
+    const elements = [
+      {
+        type: "text",
+        id: "1",
+        text: "Line 1\\nLine 2",
+      },
+      {
+        type: "rectangle",
+        id: "2",
+        label: { text: "Label\\nNewline" },
+      },
+    ] as any;
+
+    const sanitized = sanitizeMermaidElementText(elements) as any[];
+
+    expect(sanitized[0].text).toBe("Line 1\nLine 2");
+    expect(sanitized[1].label.text).toBe("Label\nNewline");
+  });
+
+  it("decodes HTML entities and strips resulting tags", () => {
+    const elements = [
+      {
+        type: "text",
+        id: "1",
+        text: "&lt;b&gt;Bold&lt;/b&gt; &amp; &quot;Quotes&quot;",
+      },
+      {
+        type: "rectangle",
+        id: "2",
+        label: { text: "A &gt; B" },
+      },
+    ] as any;
+
+    const sanitized = sanitizeMermaidElementText(elements) as any[];
+
+    expect(sanitized[0].text).toBe("Bold & \"Quotes\"");
+    expect(sanitized[1].label.text).toBe("A > B");
+  });
+
+  it("handles missing text fields gracefully", () => {
+    const elements = [
+      {
+        type: "rectangle",
+        id: "1",
+      },
+      {
+        type: "arrow",
+        id: "2",
+        label: {},
+      },
+    ] as any;
+
+    const sanitized = sanitizeMermaidElementText(elements) as any[];
+    expect(sanitized[0].id).toBe("1");
+    expect(sanitized[1].id).toBe("2");
   });
 });

--- a/packages/excalidraw/components/TTDDialog/common.ts
+++ b/packages/excalidraw/components/TTDDialog/common.ts
@@ -4,7 +4,10 @@ import {
   THEME,
 } from "@excalidraw/common";
 
-import { convertToExcalidrawElements } from "@excalidraw/element";
+import {
+  convertToExcalidrawElements,
+  type ExcalidrawElementSkeleton,
+} from "@excalidraw/element";
 
 import { exportToCanvas } from "@excalidraw/utils";
 
@@ -39,6 +42,60 @@ export const resetPreview = ({
   setError(null);
   canvasNode.replaceChildren();
 };
+
+const BR_TAG_RE = /<br\s*\/?>/gi;
+const HTML_TAG_RE = /<\/?[^>]+(>|$)/g;
+
+const decodeHTMLEntities = (text: string) => {
+  return text
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&amp;/g, "&")
+    .replace(/&nbsp;/g, " ");
+};
+
+export const sanitizeMermaidElementText = (
+  elements: ExcalidrawElementSkeleton[],
+): ExcalidrawElementSkeleton[] =>
+  elements.map((el) => {
+    const result = { ...el } as any;
+
+    const cleanText = (text?: string) => {
+      if (!text) {
+        return text;
+      }
+      return decodeHTMLEntities(text)
+        .replace(BR_TAG_RE, "\n")
+        .replace(/\\n/g, "\n")
+        .replace(HTML_TAG_RE, "");
+    };
+
+    if ("text" in result && typeof result.text === "string") {
+      result.text = cleanText(result.text);
+    }
+
+    if (result.label?.text) {
+      result.label = {
+        ...result.label,
+        text: cleanText(result.label.text),
+      };
+    }
+
+    if (result.start?.text) {
+      result.start = { ...result.start, text: cleanText(result.start.text) };
+    }
+
+    if (result.end?.text) {
+      result.end = { ...result.end, text: cleanText(result.end.text) };
+    }
+
+    if ("name" in result && typeof result.name === "string") {
+      result.name = cleanText(result.name);
+    }
+
+    return result;
+  });
 
 export const convertMermaidToExcalidraw = async ({
   canvasRef,
@@ -98,9 +155,10 @@ export const convertMermaidToExcalidraw = async ({
     setError(null);
 
     data.current = {
-      elements: convertToExcalidrawElements(elements, {
-        regenerateIds: true,
-      }),
+      elements: convertToExcalidrawElements(
+        sanitizeMermaidElementText(elements),
+        { regenerateIds: true },
+      ),
       files,
     };
 


### PR DESCRIPTION
## Summary

Fixes incorrect rendering of Mermaid node labels in Excalidraw, where HTML-like tags (e.g., `<br/>`, `<b>`) and escaped entities appear as raw text instead of being properly interpreted or cleaned.

---

## Problem

As reported in #11165, Mermaid diagrams containing HTML-like syntax behave differently in Excalidraw compared to standard Mermaid rendering:

* `<br/>` does not produce a line break
* Tags like `<b>`, `<i>`, `<sub>` appear as literal text
* Escaped entities like `&lt;b&gt;` are not decoded
* Literal `\\n` is not interpreted as a newline

This results in poor readability and inconsistent rendering of diagrams.

---

## Solution

Enhanced the Mermaid → Excalidraw sanitization pipeline to normalize and clean text before rendering.

### Key Improvements

#### 1. Line Break Handling

* `<br>`, `<br/>`, `<br />` → `\n`
* literal `\\n` → newline

#### 2. HTML Entity Decoding

* `&lt;`, `&gt;`, `&quot;`, `&amp;`, `&nbsp;` → decoded characters

#### 3. HTML Tag Removal

* All HTML-like tags are stripped after decoding
* Prevents raw tags from appearing in Excalidraw text

#### 4. Correct Processing Order

* Decode entities → then strip HTML
* Ensures cases like `&lt;b&gt;` are handled properly

#### 5. Extended Coverage

Sanitization is applied to:

* element.text
* element.label.text
* arrow labels / endpoints
* frame names

#### 6. Direct Paste Support

* Integrated sanitization into the paste/import flow (`App.tsx`)
* Ensures consistency between dialog import and paste behavior

---

## Example

### Input (Mermaid)

```
flowchart TD
    A[Christmas <br/> hello] -->|Get money| B(Go shopping)
    B --> C{Let me think}
    C -->|One| D[Laptop]
    C -->|Two| E[iPhone]
    C -->|Three| F[Car]
```

### Before

```
Christmas <br/> hello
```

### After

```
Christmas
hello
```

---

## Notes

* HTML formatting (e.g., `<b>`, `<i>`) is intentionally **not rendered**

  * Excalidraw does not support rich HTML text
  * Avoids security risks (XSS)
  * Keeps rendering consistent

* This PR focuses on **sanitization and readability**, not HTML rendering support

---

## Related Issue

Closes #11165

---

## Impact

* Fixes incorrect Mermaid label rendering
* Improves compatibility with Mermaid syntax
* Ensures consistent behavior across import and paste flows
