### PR TITLE
fix: show real-time validation error for invalid hex color input

### DIFF
--- a/packages/excalidraw/components/ColorPicker/ColorInput.tsx
+++ b/packages/excalidraw/components/ColorPicker/ColorInput.tsx
@@ -29,21 +29,31 @@ export const ColorInput = ({
 }) => {
   const editorInterface = useEditorInterface();
   const [innerValue, setInnerValue] = useState(color);
+  const [isInvalid, setIsInvalid] = useState(false); 
   const [activeSection, setActiveColorPickerSection] = useAtom(
     activeColorPickerSectionAtom,
   );
 
+  
   useEffect(() => {
     setInnerValue(color);
+    setIsInvalid(false);
   }, [color]);
 
+  
   const changeColor = useCallback(
     (inputValue: string) => {
       const value = inputValue.toLowerCase();
       const color = normalizeInputColor(value);
 
+      
       if (color) {
         onChange(color);
+        setIsInvalid(false);
+      } else if (value.length > 0) {
+        setIsInvalid(true);
+      } else {
+        setIsInvalid(false);
       }
       setInnerValue(value);
     },
@@ -68,7 +78,8 @@ export const ColorInput = ({
   }, [setEyeDropperState]);
 
   return (
-    <div className="color-picker__input-label">
+    
+    <div className={clsx("color-picker__input-label", { "is-invalid": isInvalid })}>
       <div className="color-picker__input-hash">#</div>
       <input
         ref={activeSection === "hex" ? inputRef : undefined}
@@ -80,11 +91,28 @@ export const ColorInput = ({
           changeColor(event.target.value);
         }}
         value={(innerValue || "").replace(/^#/, "")}
+        
         onBlur={() => {
-          setInnerValue(color);
+          const trimmed = innerValue.trim();
+          if (trimmed && trimmed !== "transparent") {
+            if (!normalizeInputColor(trimmed)) {
+              setIsInvalid(true);
+            } else {
+              setIsInvalid(false);
+              setInnerValue(color);
+            }
+          } else {
+            setIsInvalid(false);
+            setInnerValue(color);
+          }
         }}
         tabIndex={-1}
-        onFocus={() => setActiveColorPickerSection("hex")}
+        aria-invalid={isInvalid}
+        title={isInvalid ? "Invalid hex color — use #RGB or #RRGGBB" : undefined}
+        onFocus={() => {
+          setIsInvalid(false);
+          setActiveColorPickerSection("hex");
+        }}
         onKeyDown={(event) => {
           if (event.key === KEYS.TAB) {
             return;

--- a/packages/excalidraw/components/ColorPicker/ColorPicker.scss
+++ b/packages/excalidraw/components/ColorPicker/ColorPicker.scss
@@ -385,6 +385,20 @@
     }
   }
 
+  
+  .color-picker__input-label.is-invalid {
+    border-color: var(--color-danger, #e03131) !important;
+    box-shadow: 0 0 0 1px var(--color-danger, #e03131) !important;
+
+    .color-picker__input-hash {
+      color: var(--color-danger, #e03131);
+    }
+
+    .color-picker-input {
+      color: var(--color-danger, #e03131);
+    }
+  }
+
   .color-picker__input-hash {
     padding: 0 0.25rem;
   }


### PR DESCRIPTION
Closes #11183
Problem:
When a user typed an invalid hex value (e.g. `#GGGGGG`, `#ZZZ`, or a partial string like `#FF`) into the color picker input, nothing happened. The field silently ignored the input with no feedback, leaving users confused about why their color wasn't applying.

Solution
Added real-time invalid state tracking to ColorInput. On every keystroke, if the current value is non-empty and doesn't resolve to a valid color via normalizeInputColor, the input wrapper receives an is-invalid class that triggers a red border and red ` prefix. The error clears immediately when the user types a valid color or empties the field. On blur, invalid input is preserved visibly (not silently reverted) so the user can see and fix what they typed.

Changes
- ColorInput.tsx : added isInvalid state, real-time validation in  changeColor, blur/focus handling, aria-invalid and tooltip for
  accessibility
- ColorPicker.scss : added .is-invalid modifier with red border, box-shadow, and text color



https://github.com/user-attachments/assets/16375a71-b365-4e62-8b1b-7c15d3b2c4f3

