### PR TITLE
fix: restore Arabic locale by bypassing completion threshold

### DIFF
--- a/packages/excalidraw/i18n.ts
+++ b/packages/excalidraw/i18n.ts
@@ -68,6 +68,7 @@ export const languages: Language[] = [
   ]
     .filter(
       (lang) =>
+        lang.code ==="ar-SA"||
         (percentages as Record<string, number>)[lang.code] >=
         COMPLETION_THRESHOLD,
     )


### PR DESCRIPTION
### Description
Restores the Arabic (`ar-SA`) locale by allowing it to bypass the `COMPLETION_THRESHOLD` in the i18n registry. This fixes the regression where the UI was falling back to raw translation keys (e.g., `[[buttons.load]]`) instead of rendering the localized strings.

### Changes
- Updated the filtering logic in `packages/excalidraw/i18n.ts` to explicitly include the Arabic language entry regardless of its current completion percentage.

### Manual Testing
- Verified that "العربية" now correctly appears in the language selection menu.
- Confirmed that the UI successfully transitions to a Right-to-Left (RTL) layout.
- Validated that translation strings are properly fetched from the `ar-SA.json` dictionary without bracketed fallbacks.

**Fixes #8081**
<img width="1918" height="903" alt="alo" src="https://github.com/user-attachments/assets/1bbec6cb-a44f-44eb-8903-1ed729954717" />

<img width="2826" height="1080" alt="img" src="https://github.com/user-attachments/assets/a87b82b7-77bf-4b37-8a15-bd6c1e4047d4" />
