### PR TITLE
feat: graceful downscaling for large canvas exports to prevent browser crashes

### DIFF
--- a/packages/excalidraw/data/blob.ts
+++ b/packages/excalidraw/data/blob.ts
@@ -234,17 +234,23 @@ export const loadLibraryFromBlob = async (
 };
 
 export const canvasToBlob = async (
-  canvas: HTMLCanvasElement | Promise<HTMLCanvasElement>,
+  canvasOrPromise: HTMLCanvasElement | Promise<HTMLCanvasElement>, //
 ): Promise<Blob> => {
-  return new Promise(async (resolve, reject) => {
+  const canvas = isPromiseLike(canvasOrPromise)
+    ? await canvasOrPromise
+    : canvasOrPromise;
+
+  return new Promise((resolve, reject) => {
     try {
-      if (isPromiseLike(canvas)) {
-        canvas = await canvas;
-      }
       canvas.toBlob((blob) => {
         if (!blob) {
+          // Failure to create a blob usually indicates that browser hardware limits
+          // (VRAM/Memory) have been exceeded for the given canvas dimensions.
           return reject(
-            new CanvasError("Error: Canvas too big", "CANVAS_POSSIBLY_TOO_BIG"),
+            new CanvasError(
+              `Error: Canvas too big (${canvas.width}x${canvas.height})`,
+              "CANVAS_POSSIBLY_TOO_BIG",
+            ),
           );
         }
         resolve(blob);

--- a/packages/excalidraw/scene/export.ts
+++ b/packages/excalidraw/scene/export.ts
@@ -62,6 +62,41 @@ import type { RenderableElementsMap } from "./types";
 
 import type { AppState, BinaryFiles } from "../types";
 
+// Hardware limits for browser canvas elements (standard for Chrome/Safari)
+const MAX_CANVAS_DIMENSION = 16384;
+const MAX_CANVAS_AREA = 268435456; // 16384 * 16384
+
+/**
+ * Calculates a scale that ensures the final canvas dimensions
+ * do not exceed browser hardware limits (either individual dimension or total area).
+ */
+const getSafeScale = (width: number, height: number, scale: number): number => {
+  const scaledWidth = width * scale;
+  const scaledHeight = height * scale;
+
+  if (
+    scaledWidth > MAX_CANVAS_DIMENSION ||
+    scaledHeight > MAX_CANVAS_DIMENSION ||
+    scaledWidth * scaledHeight > MAX_CANVAS_AREA
+  ) {
+    const safeScale = Math.min(
+      MAX_CANVAS_DIMENSION / width,
+      MAX_CANVAS_DIMENSION / height,
+      Math.sqrt(MAX_CANVAS_AREA / (width * height)),
+    );
+
+    console.info(
+      `Excalidraw Export: Requested scale (${scale}x) exceeds browser limits. ` +
+        `Automatically adjusted to ${
+          Math.floor(safeScale * 100) / 100
+        }x to prevent crash.`,
+    );
+    return safeScale;
+  }
+
+  return scale;
+};
+
 const truncateText = (
   element: NonDeleted<ExcalidrawTextElement>,
   maxWidth: number,
@@ -192,14 +227,20 @@ export const exportToCanvas = async (
     viewBackgroundColor: string;
     exportingFrame?: NonDeleted<ExcalidrawFrameLikeElement> | null;
   },
+
   createCanvas: (
     width: number,
     height: number,
   ) => { canvas: HTMLCanvasElement; scale: number } = (width, height) => {
     const canvas = document.createElement("canvas");
-    canvas.width = width * appState.exportScale;
-    canvas.height = height * appState.exportScale;
-    return { canvas, scale: appState.exportScale };
+
+    // Ensure we don't exceed browser hardware limits during export
+    const safeScale = getSafeScale(width, height, appState.exportScale);
+
+    canvas.width = Math.floor(width * safeScale);
+    canvas.height = Math.floor(height * safeScale);
+
+    return { canvas, scale: safeScale };
   },
   loadFonts: () => Promise<void> = async () => {
     await Fonts.loadElementsFonts(elements);

--- a/packages/excalidraw/scene/export.ts
+++ b/packages/excalidraw/scene/export.ts
@@ -62,6 +62,41 @@ import type { RenderableElementsMap } from "./types";
 
 import type { AppState, BinaryFiles } from "../types";
 
+// Hardware limits for browser canvas elements (standard for Chrome/Safari)
+const MAX_CANVAS_DIMENSION = 16384;
+const MAX_CANVAS_AREA = 268435456; // 16384 * 16384
+
+/**
+ * Calculates a scale that ensures the final canvas dimensions
+ * do not exceed browser hardware limits (either individual dimension or total area).
+ */
+const getSafeScale = (width: number, height: number, scale: number): number => {
+  const scaledWidth = width * scale;
+  const scaledHeight = height * scale;
+
+  if (
+    scaledWidth > MAX_CANVAS_DIMENSION ||
+    scaledHeight > MAX_CANVAS_DIMENSION ||
+    scaledWidth * scaledHeight > MAX_CANVAS_AREA
+  ) {
+    const safeScale = Math.min(
+      MAX_CANVAS_DIMENSION / width,
+      MAX_CANVAS_DIMENSION / height,
+      Math.sqrt(MAX_CANVAS_AREA / (width * height)),
+    );
+
+    console.info(
+      `Excalidraw Export: Requested scale (${scale}x) exceeds browser limits. ` +
+        `Automatically adjusted to ${
+          Math.floor(safeScale * 100) / 100
+        }x to prevent crash.`,
+    );
+    return safeScale;
+  }
+
+  return scale;
+};
+
 const truncateText = (element: ExcalidrawTextElement, maxWidth: number) => {
   if (element.width <= maxWidth) {
     return element;
@@ -188,14 +223,20 @@ export const exportToCanvas = async (
     viewBackgroundColor: string;
     exportingFrame?: ExcalidrawFrameLikeElement | null;
   },
+
   createCanvas: (
     width: number,
     height: number,
   ) => { canvas: HTMLCanvasElement; scale: number } = (width, height) => {
     const canvas = document.createElement("canvas");
-    canvas.width = width * appState.exportScale;
-    canvas.height = height * appState.exportScale;
-    return { canvas, scale: appState.exportScale };
+
+    // Ensure we don't exceed browser hardware limits during export
+    const safeScale = getSafeScale(width, height, appState.exportScale);
+
+    canvas.width = Math.floor(width * safeScale);
+    canvas.height = Math.floor(height * safeScale);
+
+    return { canvas, scale: safeScale };
   },
   loadFonts: () => Promise<void> = async () => {
     await Fonts.loadElementsFonts(elements);


### PR DESCRIPTION
Resolves #10985

## Summary
This PR implements a Graceful Downscaling mechanism for canvas exports to prevent browser crashes and memory exhaustion.

### The Problem
Currently, when users attempt to export massive diagrams or use high-resolution scales (2x, 3x), Excalidraw attempts to render the canvas regardless of the user's hardware limits. When dimensions exceed browser capabilities (typically 16,384px), the operation fails, often causing the browser tab to hang or crash entirely. This results in a frustrating experience where users risk losing their current session right at the moment of export.

## The Solution
Instead of allowing a render that is guaranteed to fail, this PR introduces a proactive safety check:
- Threshold Detection: Identifies if the requested Dimensions × Scale exceed the industry-standard browser limits.
- Proactive Capping: Automatically calculates the maximum safe scale allowed by the current hardware and applies it _before_ the canvas is created.
- Predictable Success: Ensures the user always receives a successful export file, even if at a slightly lower resolution than requested, instead of a crash.

## Technical Implementation
- `packages/excalidraw/scene/export.ts`: Implemented `getSafeScale` to validate dimensions against hardware thresholds and updated the core `exportToCanvas` to apply this scale during the build process.
- `packages/excalidraw/data/blob.ts`: Enhanced error messaging to include failing dimensions for better observability during debugging.

## How to Test

### Scenario 1: Large scene with high scale
1. Create a scene around **10,000 px** in height.
2. Select **2x** or **3x** export scale.
3. **Observation:** Previously, this would crash. Now, it succeeds by automatically capping the scale at the hardware limit (~1.63x).

### Scenario 2: Massive scene at 1x
1. Create a scene exceeding 16,384 px.
3. **Observation:** Previously, this would crash immediately. Now, it succeeds by downscaling the base scene slightly to fit the browser's maximum supported dimensions.