### PR TITLE
Use highlight color for grouped outlines

### DIFF
--- a/packages/excalidraw/renderer/interactiveScene.ts
+++ b/packages/excalidraw/renderer/interactiveScene.ts
@@ -1869,7 +1869,7 @@ const _renderInteractiveScene = ({
           y2,
           selectionColors: groupElements.some((el) => el.locked)
             ? ["#ced4da"]
-            : ["#000"],
+            : [selectionColor],
           dashed: true,
           cx: x1 + (x2 - x1) / 2,
           cy: y1 + (y2 - y1) / 2,

--- a/packages/excalidraw/tests/selection.test.tsx
+++ b/packages/excalidraw/tests/selection.test.tsx
@@ -20,6 +20,7 @@ import {
   mockBoundingClientRect,
   restoreOriginalGetBoundingClientRect,
   assertSelectedElements,
+  GlobalTestState,
   unmountComponent,
 } from "./test-utils";
 
@@ -733,6 +734,46 @@ describe("inner box-selection", () => {
       expect(h.state.selectedGroupIds).toEqual({});
       mouse.up();
     });
+  });
+
+  it("uses the selection highlight color for grouped outlines", async () => {
+    const rect1 = API.createElement({
+      type: "rectangle",
+      x: 50,
+      y: 50,
+      width: 50,
+      height: 50,
+      strokeColor: "#ff0000",
+      groupIds: ["A"],
+    });
+    const rect2 = API.createElement({
+      type: "rectangle",
+      x: 150,
+      y: 150,
+      width: 50,
+      height: 50,
+      strokeColor: "#00ff00",
+      groupIds: ["A"],
+    });
+
+    API.setElements([rect1, rect2]);
+
+    const interactiveContext = GlobalTestState.interactiveCanvas.getContext(
+      "2d",
+    )!;
+    interactiveContext.__clearEvents();
+
+    API.setSelectedElements([rect1, rect2]);
+
+    expect(h.state.selectedGroupIds).toEqual({ A: true });
+
+    const strokeStyleEvents = interactiveContext
+      .__getEvents()
+      .filter((event) => event.type === "strokeStyle")
+      .map((event) => event.props.value);
+
+    expect(strokeStyleEvents).toContain("#6965db");
+    expect(strokeStyleEvents).not.toContain("#000000");
   });
 });
 

--- a/packages/excalidraw/tests/selection.test.tsx
+++ b/packages/excalidraw/tests/selection.test.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 import { vi } from "vitest";
 
+import type { CanvasRenderingContext2DEvent } from "jest-canvas-mock";
+
 import { KEYS, ROUNDNESS, reseed } from "@excalidraw/common";
 import { getElementBounds, getElementLineSegments } from "@excalidraw/element";
 import { pointFrom, pointRotateRads, type LocalPoint } from "@excalidraw/math";
@@ -42,6 +44,11 @@ beforeEach(() => {
 const { h } = window;
 
 const mouse = new Pointer("mouse");
+
+type MockedCanvasRenderingContext2D = CanvasRenderingContext2D & {
+  __getEvents(): CanvasRenderingContext2DEvent[];
+  __clearEvents(): void;
+};
 
 const getOutlineBounds = (element: ReturnType<typeof API.createElement>) => {
   const sceneElement = API.getElement(element);
@@ -760,7 +767,7 @@ describe("inner box-selection", () => {
 
     const interactiveContext = GlobalTestState.interactiveCanvas.getContext(
       "2d",
-    )!;
+    )! as MockedCanvasRenderingContext2D;
     interactiveContext.__clearEvents();
 
     API.setSelectedElements([rect1, rect2]);


### PR DESCRIPTION
## Summary
- use the active selection highlight color for grouped selection outlines instead of a hard-coded black stroke
- add a regression test covering grouped selection outline color in the interactive canvas renderer

## Root Cause
Grouped selection outlines in `interactiveScene.ts` were still using `#000`, which could disappear against dark content even in light theme.

## Validation
- `env COREPACK_HOME=~/.corepack corepack yarn test packages/excalidraw/tests/selection.test.tsx --watch=false`