### PR TITLE
Add searchable shortcuts to the help dialog

### DIFF
--- a/packages/excalidraw/components/HelpDialog.scss
+++ b/packages/excalidraw/components/HelpDialog.scss
@@ -18,6 +18,17 @@
       gap: 0.75rem;
     }
 
+    &__search {
+      margin-top: 1rem;
+      margin-bottom: 1.5rem;
+    }
+
+    &__search-icon {
+      display: flex;
+      align-items: center;
+      color: var(--color-primary);
+    }
+
     &__btn {
       --background: var(--color-surface-mid);
 
@@ -126,6 +137,13 @@
       align-items: center;
       font-family: inherit;
       line-height: 1;
+    }
+
+    &__empty {
+      margin: 2rem 0 0;
+      text-align: center;
+      color: var(--text-secondary-color);
+      font-size: 0.875rem;
     }
   }
 }

--- a/packages/excalidraw/components/HelpDialog.tsx
+++ b/packages/excalidraw/components/HelpDialog.tsx
@@ -1,3 +1,4 @@
+import fuzzy from "fuzzy";
 import React from "react";
 
 import { isDarwin, isFirefox, isWindows } from "@excalidraw/common";
@@ -6,15 +7,35 @@ import { KEYS } from "@excalidraw/common";
 
 import { getShortcutFromShortcutName } from "../actions/shortcuts";
 import { probablySupportsClipboardBlob } from "../clipboard";
+import { deburr } from "../deburr";
 import { t } from "../i18n";
 import { getShortcutKey } from "../shortcut";
 
 import { Dialog } from "./Dialog";
-import { ExternalLinkIcon, GithubIcon, youtubeIcon } from "./icons";
+import { ExternalLinkIcon, GithubIcon, searchIcon, youtubeIcon } from "./icons";
+import { TextField } from "./TextField";
 
 import "./HelpDialog.scss";
 
 import type { JSX } from "react";
+
+type ShortcutConfig = {
+  label: string;
+  shortcuts: string[];
+  isOr?: boolean;
+  keywords?: string[];
+};
+
+type ShortcutIslandConfig = {
+  caption: string;
+  className?: string;
+  shortcuts: ShortcutConfig[];
+};
+
+type ShortcutSectionConfig = {
+  title: string;
+  islands: ShortcutIslandConfig[];
+};
 
 const Header = () => (
   <div className="HelpDialog__header">
@@ -124,391 +145,484 @@ const ShortcutKey = (props: { children: React.ReactNode }) => (
 );
 
 export const HelpDialog = ({ onClose }: { onClose?: () => void }) => {
+  const [searchQuery, setSearchQuery] = React.useState("");
+  const searchInputRef = React.useRef<HTMLInputElement>(null);
+
   const handleClose = React.useCallback(() => {
     if (onClose) {
       onClose();
     }
   }, [onClose]);
 
-  return (
-    <>
-      <Dialog
-        onCloseRequest={handleClose}
-        title={t("helpDialog.title")}
-        className={"HelpDialog"}
-      >
-        <Header />
-        <Section title={t("helpDialog.shortcuts")}>
-          <ShortcutIsland
-            className="HelpDialog__island--tools"
-            caption={t("helpDialog.tools")}
-          >
-            <Shortcut label={t("toolBar.hand")} shortcuts={[KEYS.H]} />
-            <Shortcut
-              label={t("toolBar.selection")}
-              shortcuts={[KEYS.V, KEYS["1"]]}
-            />
-            <Shortcut
-              label={t("toolBar.rectangle")}
-              shortcuts={[KEYS.R, KEYS["2"]]}
-            />
-            <Shortcut
-              label={t("toolBar.diamond")}
-              shortcuts={[KEYS.D, KEYS["3"]]}
-            />
-            <Shortcut
-              label={t("toolBar.ellipse")}
-              shortcuts={[KEYS.O, KEYS["4"]]}
-            />
-            <Shortcut
-              label={t("toolBar.arrow")}
-              shortcuts={[KEYS.A, KEYS["5"]]}
-            />
-            <Shortcut
-              label={t("toolBar.line")}
-              shortcuts={[KEYS.L, KEYS["6"]]}
-            />
-            <Shortcut
-              label={t("toolBar.freedraw")}
-              shortcuts={[KEYS.P, KEYS["7"]]}
-            />
-            <Shortcut
-              label={t("toolBar.text")}
-              shortcuts={[KEYS.T, KEYS["8"]]}
-            />
-            <Shortcut label={t("toolBar.image")} shortcuts={[KEYS["9"]]} />
-            <Shortcut
-              label={t("toolBar.eraser")}
-              shortcuts={[KEYS.E, KEYS["0"]]}
-            />
-            <Shortcut label={t("toolBar.frame")} shortcuts={[KEYS.F]} />
-            <Shortcut label={t("toolBar.laser")} shortcuts={[KEYS.K]} />
-            <Shortcut
-              label={t("labels.eyeDropper")}
-              shortcuts={[KEYS.I, "Shift+S", "Shift+G"]}
-            />
-            <Shortcut
-              label={t("helpDialog.editLineArrowPoints")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+Enter")]}
-            />
-            <Shortcut
-              label={t("helpDialog.editText")}
-              shortcuts={[getShortcutKey("Enter")]}
-            />
-            <Shortcut
-              label={t("helpDialog.textNewLine")}
-              shortcuts={[
+  React.useEffect(() => {
+    const handleFindShortcut = (event: KeyboardEvent) => {
+      if (
+        !event[KEYS.CTRL_OR_CMD] ||
+        event.altKey ||
+        event.key.toLowerCase() !== KEYS.F
+      ) {
+        return;
+      }
+
+      event.preventDefault();
+      event.stopPropagation();
+      searchInputRef.current?.focus();
+      searchInputRef.current?.select();
+    };
+
+    window.addEventListener("keydown", handleFindShortcut, {
+      capture: true,
+    });
+
+    return () =>
+      window.removeEventListener("keydown", handleFindShortcut, {
+        capture: true,
+      });
+  }, []);
+
+  const shortcutSections: ShortcutSectionConfig[] = [
+    {
+      title: t("helpDialog.shortcuts"),
+      islands: [
+        {
+          className: "HelpDialog__island--tools",
+          caption: t("helpDialog.tools"),
+          shortcuts: [
+            { label: t("toolBar.hand"), shortcuts: [KEYS.H] },
+            { label: t("toolBar.selection"), shortcuts: [KEYS.V, KEYS["1"]] },
+            { label: t("toolBar.rectangle"), shortcuts: [KEYS.R, KEYS["2"]] },
+            { label: t("toolBar.diamond"), shortcuts: [KEYS.D, KEYS["3"]] },
+            { label: t("toolBar.ellipse"), shortcuts: [KEYS.O, KEYS["4"]] },
+            { label: t("toolBar.arrow"), shortcuts: [KEYS.A, KEYS["5"]] },
+            { label: t("toolBar.line"), shortcuts: [KEYS.L, KEYS["6"]] },
+            {
+              label: t("toolBar.freedraw"),
+              shortcuts: [KEYS.P, KEYS["7"]],
+              keywords: ["draw", "pen"],
+            },
+            { label: t("toolBar.text"), shortcuts: [KEYS.T, KEYS["8"]] },
+            { label: t("toolBar.image"), shortcuts: [KEYS["9"]] },
+            { label: t("toolBar.eraser"), shortcuts: [KEYS.E, KEYS["0"]] },
+            { label: t("toolBar.frame"), shortcuts: [KEYS.F] },
+            { label: t("toolBar.laser"), shortcuts: [KEYS.K] },
+            {
+              label: t("labels.eyeDropper"),
+              shortcuts: [KEYS.I, "Shift+S", "Shift+G"],
+              keywords: ["picker", "color"],
+            },
+            {
+              label: t("helpDialog.editLineArrowPoints"),
+              shortcuts: [getShortcutKey("CtrlOrCmd+Enter")],
+            },
+            {
+              label: t("helpDialog.editText"),
+              shortcuts: [getShortcutKey("Enter")],
+            },
+            {
+              label: t("helpDialog.textNewLine"),
+              shortcuts: [
                 getShortcutKey("Enter"),
                 getShortcutKey("Shift+Enter"),
-              ]}
-            />
-            <Shortcut
-              label={t("helpDialog.textFinish")}
-              shortcuts={[
+              ],
+            },
+            {
+              label: t("helpDialog.textFinish"),
+              shortcuts: [
                 getShortcutKey("Esc"),
                 getShortcutKey("CtrlOrCmd+Enter"),
-              ]}
-            />
-            <Shortcut
-              label={t("helpDialog.curvedArrow")}
-              shortcuts={[
+              ],
+            },
+            {
+              label: t("helpDialog.curvedArrow"),
+              shortcuts: [
                 "A",
                 t("helpDialog.click"),
                 t("helpDialog.click"),
                 t("helpDialog.click"),
-              ]}
-              isOr={false}
-            />
-            <Shortcut
-              label={t("helpDialog.curvedLine")}
-              shortcuts={[
+              ],
+              isOr: false,
+            },
+            {
+              label: t("helpDialog.curvedLine"),
+              shortcuts: [
                 "L",
                 t("helpDialog.click"),
                 t("helpDialog.click"),
                 t("helpDialog.click"),
-              ]}
-              isOr={false}
-            />
-            <Shortcut
-              label={t("helpDialog.cropStart")}
-              shortcuts={[t("helpDialog.doubleClick"), getShortcutKey("Enter")]}
-              isOr={true}
-            />
-            <Shortcut
-              label={t("helpDialog.cropFinish")}
-              shortcuts={[getShortcutKey("Enter"), getShortcutKey("Escape")]}
-              isOr={true}
-            />
-            <Shortcut label={t("toolBar.lock")} shortcuts={[KEYS.Q]} />
-            <Shortcut
-              label={t("helpDialog.preventBinding")}
-              shortcuts={[getShortcutKey("CtrlOrCmd")]}
-            />
-            <Shortcut
-              label={t("toolBar.link")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+K")]}
-            />
-            <Shortcut
-              label={t("toolBar.convertElementType")}
-              shortcuts={["Tab", "Shift+Tab"]}
-              isOr={true}
-            />
-          </ShortcutIsland>
-          <ShortcutIsland
-            className="HelpDialog__island--view"
-            caption={t("helpDialog.view")}
-          >
-            <Shortcut
-              label={t("buttons.zoomIn")}
-              shortcuts={[getShortcutKey("CtrlOrCmd++")]}
-            />
-            <Shortcut
-              label={t("buttons.zoomOut")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+-")]}
-            />
-            <Shortcut
-              label={t("buttons.resetZoom")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+0")]}
-            />
-            <Shortcut
-              label={t("helpDialog.zoomToFit")}
-              shortcuts={["Shift+1"]}
-            />
-            <Shortcut
-              label={t("helpDialog.zoomToSelection")}
-              shortcuts={["Shift+2"]}
-            />
-            <Shortcut
-              label={t("helpDialog.movePageUpDown")}
-              shortcuts={["PgUp/PgDn"]}
-            />
-            <Shortcut
-              label={t("helpDialog.movePageLeftRight")}
-              shortcuts={["Shift+PgUp/PgDn"]}
-            />
-            <Shortcut
-              label={t("buttons.zenMode")}
-              shortcuts={[getShortcutKey("Alt+Z")]}
-            />
-            <Shortcut
-              label={t("buttons.objectsSnapMode")}
-              shortcuts={[getShortcutKey("Alt+S")]}
-            />
-            <Shortcut
-              label={t("labels.toggleGrid")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+'")]}
-            />
-            <Shortcut
-              label={t("labels.viewMode")}
-              shortcuts={[getShortcutKey("Alt+R")]}
-            />
-            <Shortcut
-              label={t("labels.toggleTheme")}
-              shortcuts={[getShortcutKey("Alt+Shift+D")]}
-            />
-            <Shortcut
-              label={t("stats.fullTitle")}
-              shortcuts={[getShortcutKey("Alt+/")]}
-            />
-            <Shortcut
-              label={t("search.title")}
-              shortcuts={[getShortcutFromShortcutName("searchMenu")]}
-            />
-            <Shortcut
-              label={t("commandPalette.title")}
-              shortcuts={
-                isFirefox
-                  ? [getShortcutFromShortcutName("commandPalette")]
-                  : [
-                      getShortcutFromShortcutName("commandPalette"),
-                      getShortcutFromShortcutName("commandPalette", 1),
-                    ]
-              }
-            />
-          </ShortcutIsland>
-          <ShortcutIsland
-            className="HelpDialog__island--editor"
-            caption={t("helpDialog.editor")}
-          >
-            <Shortcut
-              label={t("helpDialog.createFlowchart")}
-              shortcuts={[getShortcutKey(`CtrlOrCmd+Arrow Key`)]}
-              isOr={true}
-            />
-            <Shortcut
-              label={t("helpDialog.navigateFlowchart")}
-              shortcuts={[getShortcutKey(`Alt+Arrow Key`)]}
-              isOr={true}
-            />
-            <Shortcut
-              label={t("labels.moveCanvas")}
-              shortcuts={[
+              ],
+              isOr: false,
+            },
+            {
+              label: t("helpDialog.cropStart"),
+              shortcuts: [t("helpDialog.doubleClick"), getShortcutKey("Enter")],
+            },
+            {
+              label: t("helpDialog.cropFinish"),
+              shortcuts: [getShortcutKey("Enter"), getShortcutKey("Escape")],
+            },
+            { label: t("toolBar.lock"), shortcuts: [KEYS.Q] },
+            {
+              label: t("helpDialog.preventBinding"),
+              shortcuts: [getShortcutKey("CtrlOrCmd")],
+              keywords: ["bind"],
+            },
+            {
+              label: t("toolBar.link"),
+              shortcuts: [getShortcutKey("CtrlOrCmd+K")],
+            },
+            {
+              label: t("toolBar.convertElementType"),
+              shortcuts: ["Tab", "Shift+Tab"],
+            },
+          ],
+        },
+        {
+          className: "HelpDialog__island--view",
+          caption: t("helpDialog.view"),
+          shortcuts: [
+            {
+              label: t("buttons.zoomIn"),
+              shortcuts: [getShortcutKey("CtrlOrCmd++")],
+            },
+            {
+              label: t("buttons.zoomOut"),
+              shortcuts: [getShortcutKey("CtrlOrCmd+-")],
+            },
+            {
+              label: t("buttons.resetZoom"),
+              shortcuts: [getShortcutKey("CtrlOrCmd+0")],
+            },
+            { label: t("helpDialog.zoomToFit"), shortcuts: ["Shift+1"] },
+            { label: t("helpDialog.zoomToSelection"), shortcuts: ["Shift+2"] },
+            {
+              label: t("helpDialog.movePageUpDown"),
+              shortcuts: ["PgUp/PgDn"],
+            },
+            {
+              label: t("helpDialog.movePageLeftRight"),
+              shortcuts: ["Shift+PgUp/PgDn"],
+            },
+            {
+              label: t("buttons.zenMode"),
+              shortcuts: [getShortcutKey("Alt+Z")],
+            },
+            {
+              label: t("buttons.objectsSnapMode"),
+              shortcuts: [getShortcutKey("Alt+S")],
+              keywords: ["snap"],
+            },
+            {
+              label: t("labels.toggleGrid"),
+              shortcuts: [getShortcutKey("CtrlOrCmd+'")],
+              keywords: ["grid"],
+            },
+            {
+              label: t("labels.viewMode"),
+              shortcuts: [getShortcutKey("Alt+R")],
+            },
+            {
+              label: t("labels.toggleTheme"),
+              shortcuts: [getShortcutKey("Alt+Shift+D")],
+              keywords: ["dark", "light"],
+            },
+            {
+              label: t("stats.fullTitle"),
+              shortcuts: [getShortcutKey("Alt+/")],
+              keywords: ["stats"],
+            },
+            {
+              label: t("search.title"),
+              shortcuts: [getShortcutFromShortcutName("searchMenu")],
+              keywords: ["find", "canvas"],
+            },
+            {
+              label: t("commandPalette.title"),
+              shortcuts: isFirefox
+                ? [getShortcutFromShortcutName("commandPalette")]
+                : [
+                    getShortcutFromShortcutName("commandPalette"),
+                    getShortcutFromShortcutName("commandPalette", 1),
+                  ],
+              keywords: ["commands", "actions"],
+            },
+          ],
+        },
+        {
+          className: "HelpDialog__island--editor",
+          caption: t("helpDialog.editor"),
+          shortcuts: [
+            {
+              label: t("helpDialog.createFlowchart"),
+              shortcuts: [getShortcutKey("CtrlOrCmd+Arrow Key")],
+              keywords: ["flowchart"],
+            },
+            {
+              label: t("helpDialog.navigateFlowchart"),
+              shortcuts: [getShortcutKey("Alt+Arrow Key")],
+              keywords: ["flowchart"],
+            },
+            {
+              label: t("labels.moveCanvas"),
+              shortcuts: [
                 getShortcutKey(`Space+${t("helpDialog.drag")}`),
                 getShortcutKey(`Wheel+${t("helpDialog.drag")}`),
-              ]}
-              isOr={true}
-            />
-            <Shortcut
-              label={t("buttons.clearReset")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+Delete")]}
-            />
-            <Shortcut
-              label={t("labels.delete")}
-              shortcuts={[getShortcutKey("Delete")]}
-            />
-            <Shortcut
-              label={t("labels.cut")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+X")]}
-            />
-            <Shortcut
-              label={t("labels.copy")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+C")]}
-            />
-            <Shortcut
-              label={t("labels.paste")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+V")]}
-            />
-            <Shortcut
-              label={t("labels.pasteAsPlaintext")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+Shift+V")]}
-            />
-            <Shortcut
-              label={t("labels.selectAll")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+A")]}
-            />
-            <Shortcut
-              label={t("labels.multiSelect")}
-              shortcuts={[getShortcutKey(`Shift+${t("helpDialog.click")}`)]}
-            />
-            <Shortcut
-              label={t("helpDialog.deepSelect")}
-              shortcuts={[getShortcutKey(`CtrlOrCmd+${t("helpDialog.click")}`)]}
-            />
-            <Shortcut
-              label={t("helpDialog.deepBoxSelect")}
-              shortcuts={[getShortcutKey(`CtrlOrCmd+${t("helpDialog.drag")}`)]}
-            />
-            {/* firefox supports clipboard API under a flag, so we'll
-                show users what they can do in the error message */}
-            {(probablySupportsClipboardBlob || isFirefox) && (
-              <Shortcut
-                label={t("labels.copyAsPng")}
-                shortcuts={[getShortcutKey("Shift+Alt+C")]}
-              />
-            )}
-            <Shortcut
-              label={t("labels.copyStyles")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+Alt+C")]}
-            />
-            <Shortcut
-              label={t("labels.pasteStyles")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+Alt+V")]}
-            />
-            <Shortcut
-              label={t("labels.sendToBack")}
-              shortcuts={[
+              ],
+              keywords: ["pan"],
+            },
+            {
+              label: t("buttons.clearReset"),
+              shortcuts: [getShortcutKey("CtrlOrCmd+Delete")],
+              keywords: ["clear", "reset"],
+            },
+            {
+              label: t("labels.delete"),
+              shortcuts: [getShortcutKey("Delete")],
+            },
+            {
+              label: t("labels.cut"),
+              shortcuts: [getShortcutKey("CtrlOrCmd+X")],
+            },
+            {
+              label: t("labels.copy"),
+              shortcuts: [getShortcutKey("CtrlOrCmd+C")],
+            },
+            {
+              label: t("labels.paste"),
+              shortcuts: [getShortcutKey("CtrlOrCmd+V")],
+            },
+            {
+              label: t("labels.pasteAsPlaintext"),
+              shortcuts: [getShortcutKey("CtrlOrCmd+Shift+V")],
+              keywords: ["paste", "text"],
+            },
+            {
+              label: t("labels.selectAll"),
+              shortcuts: [getShortcutKey("CtrlOrCmd+A")],
+            },
+            {
+              label: t("labels.multiSelect"),
+              shortcuts: [getShortcutKey(`Shift+${t("helpDialog.click")}`)],
+            },
+            {
+              label: t("helpDialog.deepSelect"),
+              shortcuts: [getShortcutKey(`CtrlOrCmd+${t("helpDialog.click")}`)],
+            },
+            {
+              label: t("helpDialog.deepBoxSelect"),
+              shortcuts: [getShortcutKey(`CtrlOrCmd+${t("helpDialog.drag")}`)],
+            },
+            ...(probablySupportsClipboardBlob || isFirefox
+              ? [
+                  {
+                    label: t("labels.copyAsPng"),
+                    shortcuts: [getShortcutKey("Shift+Alt+C")],
+                    keywords: ["png", "clipboard"],
+                  },
+                ]
+              : []),
+            {
+              label: t("labels.copyStyles"),
+              shortcuts: [getShortcutKey("CtrlOrCmd+Alt+C")],
+              keywords: ["styles", "copy"],
+            },
+            {
+              label: t("labels.pasteStyles"),
+              shortcuts: [getShortcutKey("CtrlOrCmd+Alt+V")],
+              keywords: ["styles", "paste"],
+            },
+            {
+              label: t("labels.sendToBack"),
+              shortcuts: [
                 isDarwin
                   ? getShortcutKey("CtrlOrCmd+Alt+[")
                   : getShortcutKey("CtrlOrCmd+Shift+["),
-              ]}
-            />
-            <Shortcut
-              label={t("labels.bringToFront")}
-              shortcuts={[
+              ],
+              keywords: ["back", "layer", "z-index"],
+            },
+            {
+              label: t("labels.bringToFront"),
+              shortcuts: [
                 isDarwin
                   ? getShortcutKey("CtrlOrCmd+Alt+]")
                   : getShortcutKey("CtrlOrCmd+Shift+]"),
-              ]}
-            />
-            <Shortcut
-              label={t("labels.sendBackward")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+[")]}
-            />
-            <Shortcut
-              label={t("labels.bringForward")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+]")]}
-            />
-            <Shortcut
-              label={t("labels.alignTop")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+Shift+Up")]}
-            />
-            <Shortcut
-              label={t("labels.alignBottom")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+Shift+Down")]}
-            />
-            <Shortcut
-              label={t("labels.alignLeft")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+Shift+Left")]}
-            />
-            <Shortcut
-              label={t("labels.alignRight")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+Shift+Right")]}
-            />
-            <Shortcut
-              label={t("labels.duplicateSelection")}
-              shortcuts={[
+              ],
+              keywords: ["front", "layer", "z-index"],
+            },
+            {
+              label: t("labels.sendBackward"),
+              shortcuts: [getShortcutKey("CtrlOrCmd+[")],
+              keywords: ["backward", "layer", "z-index"],
+            },
+            {
+              label: t("labels.bringForward"),
+              shortcuts: [getShortcutKey("CtrlOrCmd+]")],
+              keywords: ["forward", "layer", "z-index"],
+            },
+            {
+              label: t("labels.alignTop"),
+              shortcuts: [getShortcutKey("CtrlOrCmd+Shift+Up")],
+            },
+            {
+              label: t("labels.alignBottom"),
+              shortcuts: [getShortcutKey("CtrlOrCmd+Shift+Down")],
+            },
+            {
+              label: t("labels.alignLeft"),
+              shortcuts: [getShortcutKey("CtrlOrCmd+Shift+Left")],
+            },
+            {
+              label: t("labels.alignRight"),
+              shortcuts: [getShortcutKey("CtrlOrCmd+Shift+Right")],
+            },
+            {
+              label: t("labels.duplicateSelection"),
+              shortcuts: [
                 getShortcutKey("CtrlOrCmd+D"),
                 getShortcutKey(`Alt+${t("helpDialog.drag")}`),
-              ]}
-            />
-            <Shortcut
-              label={t("helpDialog.toggleElementLock")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+Shift+L")]}
-            />
-            <Shortcut
-              label={t("buttons.undo")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+Z")]}
-            />
-            <Shortcut
-              label={t("buttons.redo")}
-              shortcuts={
-                isWindows
-                  ? [
-                      getShortcutKey("CtrlOrCmd+Y"),
-                      getShortcutKey("CtrlOrCmd+Shift+Z"),
-                    ]
-                  : [getShortcutKey("CtrlOrCmd+Shift+Z")]
-              }
-            />
-            <Shortcut
-              label={t("labels.group")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+G")]}
-            />
-            <Shortcut
-              label={t("labels.ungroup")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+Shift+G")]}
-            />
-            <Shortcut
-              label={t("labels.flipHorizontal")}
-              shortcuts={[getShortcutKey("Shift+H")]}
-            />
-            <Shortcut
-              label={t("labels.flipVertical")}
-              shortcuts={[getShortcutKey("Shift+V")]}
-            />
-            <Shortcut
-              label={t("labels.showStroke")}
-              shortcuts={[getShortcutKey("S")]}
-            />
-            <Shortcut
-              label={t("labels.showBackground")}
-              shortcuts={[getShortcutKey("G")]}
-            />
-            <Shortcut
-              label={t("labels.showFonts")}
-              shortcuts={[getShortcutKey("Shift+F")]}
-            />
-            <Shortcut
-              label={t("labels.decreaseFontSize")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+Shift+<")]}
-            />
-            <Shortcut
-              label={t("labels.increaseFontSize")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+Shift+>")]}
-            />
-          </ShortcutIsland>
-        </Section>
-      </Dialog>
-    </>
+              ],
+              keywords: ["duplicate"],
+            },
+            {
+              label: t("helpDialog.toggleElementLock"),
+              shortcuts: [getShortcutKey("CtrlOrCmd+Shift+L")],
+              keywords: ["lock"],
+            },
+            {
+              label: t("buttons.undo"),
+              shortcuts: [getShortcutKey("CtrlOrCmd+Z")],
+            },
+            {
+              label: t("buttons.redo"),
+              shortcuts: isWindows
+                ? [
+                    getShortcutKey("CtrlOrCmd+Y"),
+                    getShortcutKey("CtrlOrCmd+Shift+Z"),
+                  ]
+                : [getShortcutKey("CtrlOrCmd+Shift+Z")],
+            },
+            {
+              label: t("labels.group"),
+              shortcuts: [getShortcutKey("CtrlOrCmd+G")],
+            },
+            {
+              label: t("labels.ungroup"),
+              shortcuts: [getShortcutKey("CtrlOrCmd+Shift+G")],
+            },
+            {
+              label: t("labels.flipHorizontal"),
+              shortcuts: [getShortcutKey("Shift+H")],
+            },
+            {
+              label: t("labels.flipVertical"),
+              shortcuts: [getShortcutKey("Shift+V")],
+            },
+            {
+              label: t("labels.showStroke"),
+              shortcuts: [getShortcutKey("S")],
+              keywords: ["stroke"],
+            },
+            {
+              label: t("labels.showBackground"),
+              shortcuts: [getShortcutKey("G")],
+              keywords: ["background", "fill"],
+            },
+            {
+              label: t("labels.showFonts"),
+              shortcuts: [getShortcutKey("Shift+F")],
+              keywords: ["font"],
+            },
+            {
+              label: t("labels.decreaseFontSize"),
+              shortcuts: [getShortcutKey("CtrlOrCmd+Shift+<")],
+              keywords: ["font", "text"],
+            },
+            {
+              label: t("labels.increaseFontSize"),
+              shortcuts: [getShortcutKey("CtrlOrCmd+Shift+>")],
+              keywords: ["font", "text"],
+            },
+          ],
+        },
+      ],
+    },
+  ];
+
+  const filteredShortcutSections = React.useMemo(() => {
+    if (!searchQuery.trim()) {
+      return shortcutSections;
+    }
+
+    const normalizedSearchQuery = deburr(
+      searchQuery.toLocaleLowerCase().replace(/[<>_| -]/g, ""),
+    );
+
+    return shortcutSections
+      .map((section) => ({
+        ...section,
+        islands: section.islands
+          .map((island) => ({
+            ...island,
+            shortcuts: island.shortcuts.filter((shortcut) => {
+              const haystack = deburr(
+                `${shortcut.label.toLocaleLowerCase()} ${shortcut.shortcuts
+                  .join(" ")
+                  .toLocaleLowerCase()} ${(shortcut.keywords || []).join(
+                  " ",
+                )}`.replace(/[<>_| -]/g, ""),
+              );
+
+              return fuzzy.test(normalizedSearchQuery, haystack);
+            }),
+          }))
+          .filter((island) => island.shortcuts.length > 0),
+      }))
+      .filter((section) => section.islands.length > 0);
+  }, [searchQuery, shortcutSections]);
+
+  return (
+    <Dialog
+      onCloseRequest={handleClose}
+      title={t("helpDialog.title")}
+      className={"HelpDialog"}
+    >
+      <Header />
+      <div className="HelpDialog__search">
+        <TextField
+          ref={searchInputRef}
+          value={searchQuery}
+          onChange={setSearchQuery}
+          placeholder={t("commandPalette.search.placeholder")}
+          type="search"
+          fullWidth
+          icon={<div className="HelpDialog__search-icon">{searchIcon}</div>}
+        />
+      </div>
+      {filteredShortcutSections.length ? (
+        filteredShortcutSections.map((section) => (
+          <Section key={section.title} title={section.title}>
+            {section.islands.map((island) => (
+              <ShortcutIsland
+                key={island.caption}
+                className={island.className}
+                caption={island.caption}
+              >
+                {island.shortcuts.map((shortcut) => (
+                  <Shortcut
+                    key={`${shortcut.label}-${shortcut.shortcuts.join("-")}`}
+                    label={shortcut.label}
+                    shortcuts={shortcut.shortcuts}
+                    isOr={shortcut.isOr}
+                  />
+                ))}
+              </ShortcutIsland>
+            ))}
+          </Section>
+        ))
+      ) : (
+        <div className="HelpDialog__empty">
+          {t("commandPalette.search.noMatch")}
+        </div>
+      )}
+    </Dialog>
   );
 };

--- a/packages/excalidraw/tests/helpDialog.test.tsx
+++ b/packages/excalidraw/tests/helpDialog.test.tsx
@@ -1,0 +1,61 @@
+import React from "react";
+
+import { KEYS } from "@excalidraw/common";
+
+import { t } from "../i18n";
+import { Excalidraw } from "../index";
+
+import { Keyboard } from "./helpers/ui";
+import { act, fireEvent, render, screen, waitFor } from "./test-utils";
+
+describe("help dialog", () => {
+  const renderHelpDialog = async () => {
+    await render(<Excalidraw handleKeyboardGlobally />);
+
+    act(() => {
+      window.h.setState({ openDialog: { name: "help" } });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(t("helpDialog.title"))).toBeInTheDocument();
+    });
+
+    const searchInput = document.querySelector<HTMLInputElement>(
+      '.HelpDialog input[type="search"]',
+    );
+
+    expect(searchInput).not.toBe(null);
+
+    return searchInput!;
+  };
+
+  it("should focus help search when cmd+f is pressed", async () => {
+    const searchInput = await renderHelpDialog();
+
+    expect(searchInput.matches(":focus")).toBe(false);
+    expect(window.h.state.openSidebar).toBe(null);
+
+    Keyboard.withModifierKeys({ ctrl: true }, () => {
+      Keyboard.keyDown(KEYS.F, window);
+    });
+
+    await waitFor(() => {
+      expect(searchInput.matches(":focus")).toBe(true);
+    });
+    expect(window.h.state.openSidebar).toBe(null);
+  });
+
+  it("should filter shortcuts using the help search input", async () => {
+    const searchInput = await renderHelpDialog();
+
+    fireEvent.change(searchInput, {
+      target: { value: t("labels.toggleTheme") },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(t("labels.toggleTheme"))).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText(t("toolBar.rectangle"))).toBe(null);
+  });
+});


### PR DESCRIPTION
## Summary
- add a search field to the help dialog and filter shortcut rows in place
- route `Ctrl/Cmd + F` to the help dialog search while the dialog is open
- add regression coverage for focusing help search and filtering results

Closes #9276