### PR TITLE
Show validation feedback for invalid hex colors

### DIFF
--- a/packages/excalidraw/components/ColorPicker/ColorInput.tsx
+++ b/packages/excalidraw/components/ColorPicker/ColorInput.tsx
@@ -29,12 +29,14 @@ export const ColorInput = ({
 }) => {
   const editorInterface = useEditorInterface();
   const [innerValue, setInnerValue] = useState(color);
+  const [isInvalid, setIsInvalid] = useState(false);
   const [activeSection, setActiveColorPickerSection] = useAtom(
     activeColorPickerSectionAtom,
   );
 
   useEffect(() => {
     setInnerValue(color);
+    setIsInvalid(false);
   }, [color]);
 
   const changeColor = useCallback(
@@ -44,6 +46,9 @@ export const ColorInput = ({
 
       if (color) {
         onChange(color);
+        setIsInvalid(false);
+      } else {
+        setIsInvalid(value.trim().length > 0);
       }
       setInnerValue(value);
     },
@@ -68,20 +73,29 @@ export const ColorInput = ({
   }, [setEyeDropperState]);
 
   return (
-    <div className="color-picker__input-label">
+    <div
+      className={clsx("color-picker__input-label", {
+        "color-picker__input-label--invalid": isInvalid,
+      })}
+    >
       <div className="color-picker__input-hash">#</div>
       <input
         ref={activeSection === "hex" ? inputRef : undefined}
         style={{ border: 0, padding: 0 }}
         spellCheck={false}
-        className="color-picker-input"
+        className={clsx("color-picker-input", {
+          "color-picker-input--invalid": isInvalid,
+        })}
         aria-label={label}
+        aria-invalid={isInvalid || undefined}
         onChange={(event) => {
           changeColor(event.target.value);
         }}
         value={(innerValue || "").replace(/^#/, "")}
         onBlur={() => {
-          setInnerValue(color);
+          if (!isInvalid) {
+            setInnerValue(color);
+          }
         }}
         tabIndex={-1}
         onFocus={() => setActiveColorPickerSection("hex")}

--- a/packages/excalidraw/components/ColorPicker/ColorPicker.scss
+++ b/packages/excalidraw/components/ColorPicker/ColorPicker.scss
@@ -383,6 +383,14 @@
       box-shadow: 0 0 0 1px var(--color-primary-darkest);
       border-radius: var(--border-radius-lg);
     }
+
+    &--invalid {
+      border-color: var(--color-danger);
+
+      &:focus-within {
+        box-shadow: 0 0 0 1px var(--color-danger);
+      }
+    }
   }
 
   .color-picker__input-hash {
@@ -420,6 +428,10 @@
 
     &:focus-visible {
       box-shadow: none;
+    }
+
+    &--invalid {
+      color: var(--color-danger-darkest);
     }
   }
 

--- a/packages/excalidraw/tests/colorPicker.test.tsx
+++ b/packages/excalidraw/tests/colorPicker.test.tsx
@@ -1,0 +1,62 @@
+import React from "react";
+
+import { Excalidraw } from "../index";
+import { t } from "../i18n";
+import { API } from "../tests/helpers/api";
+import { Pointer, UI } from "../tests/helpers/ui";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  togglePopover,
+} from "../tests/test-utils";
+
+const mouse = new Pointer("mouse");
+
+describe("color picker", () => {
+  beforeEach(async () => {
+    await render(<Excalidraw handleKeyboardGlobally={true} />);
+  });
+
+  afterEach(async () => {
+    // https://github.com/floating-ui/floating-ui/issues/1908#issuecomment-1301553793
+    await act(async () => {});
+  });
+
+  it("should keep invalid hex input visible without changing the selected color", () => {
+    UI.clickTool("rectangle");
+    mouse.down(10, 10);
+    mouse.up(20, 20);
+
+    const originalStrokeColor = API.getSelectedElement().strokeColor;
+
+    togglePopover("Stroke");
+
+    const input = screen.getByRole("textbox", { name: t("labels.stroke") });
+
+    fireEvent.change(input, {
+      target: { value: "gggggg" },
+    });
+
+    expect(input).toHaveValue("gggggg");
+    expect(input).toHaveAttribute("aria-invalid", "true");
+    expect(input.closest(".color-picker__input-label")).toHaveClass(
+      "color-picker__input-label--invalid",
+    );
+    expect(API.getSelectedElement().strokeColor).toBe(originalStrokeColor);
+
+    fireEvent.blur(input);
+
+    expect(input).toHaveValue("gggggg");
+    expect(API.getSelectedElement().strokeColor).toBe(originalStrokeColor);
+
+    fireEvent.change(input, {
+      target: { value: "fa5252" },
+    });
+
+    expect(input).toHaveValue("fa5252");
+    expect(input).not.toHaveAttribute("aria-invalid");
+    expect(API.getSelectedElement().strokeColor).toBe("#fa5252");
+  });
+});


### PR DESCRIPTION
## Summary
- keep invalid hex input visible so it can be corrected instead of silently resetting
- mark invalid color input with invalid UI state and aria-invalid without changing the selected element color
- add regression coverage for invalid and corrected hex input in the color picker

Closes #11183