### PR TITLE
feat: deferred json share link preview and modal dismiss

### DIFF
--- a/excalidraw-app/App.tsx
+++ b/excalidraw-app/App.tsx
@@ -71,6 +71,7 @@ import type {
 } from "@excalidraw/element/types";
 import type {
   AppState,
+  BinaryFileData,
   ExcalidrawImperativeAPI,
   BinaryFiles,
   ExcalidrawInitialDataState,
@@ -147,6 +148,7 @@ import "./index.scss";
 
 import { ExcalidrawPlusPromoBanner } from "./components/ExcalidrawPlusPromoBanner";
 import { AppSidebar } from "./components/AppSidebar";
+import { SharedLinkDeferredNotice } from "./components/SharedLinkDeferredNotice";
 
 import type { CollabAPI } from "./collab/Collab";
 
@@ -217,7 +219,10 @@ const initializeScene = async (opts: {
   collabAPI: CollabAPI | null;
   excalidrawAPI: ExcalidrawImperativeAPI;
 }): Promise<
-  { scene: ExcalidrawInitialDataState | null } & (
+  {
+    scene: ExcalidrawInitialDataState | null;
+    pendingJsonShareLink?: { id: string; key: string };
+  } & (
     | { isExternalScene: true; id: string; key: string }
     | { isExternalScene: false; id?: null; key?: null }
   )
@@ -248,6 +253,24 @@ const initializeScene = async (opts: {
 
   let roomLinkData = getCollaborationLinkData(window.location.href);
   const isExternalScene = !!(id || jsonBackendMatch || roomLinkData);
+
+  // New tab / shared URL: keep local canvas until user taps notice → then same "Load from link" modal
+  if (
+    jsonBackendMatch &&
+    !roomLinkData &&
+    scene.elements.length > 0
+  ) {
+    window.history.replaceState({}, APP_NAME, window.location.origin);
+    return {
+      scene,
+      isExternalScene: false,
+      pendingJsonShareLink: {
+        id: jsonBackendMatch[1],
+        key: jsonBackendMatch[2],
+      },
+    };
+  }
+
   if (isExternalScene) {
     if (
       // don't prompt if scene is empty
@@ -395,6 +418,18 @@ const ExcalidrawWrapper = () => {
   }
 
   const debugCanvasRef = useRef<HTMLCanvasElement>(null);
+  const [pendingJsonShareLink, setPendingJsonShareLink] = useState<{
+    id: string;
+    key: string;
+  } | null>(null);
+
+  /** Local canvas before shared-link preview; used to revert on dismiss / modal cancel. */
+  const localCanvasRevertRef = useRef<{
+    elements: readonly OrderedExcalidrawElement[];
+    appState: AppState;
+    files: BinaryFiles;
+  } | null>(null);
+  const sharedPreviewKeyRef = useRef<string | null>(null);
 
   useEffect(() => {
     trackEvent("load", "frame", getFrame());
@@ -520,6 +555,174 @@ const ExcalidrawWrapper = () => {
     [collabAPI, excalidrawAPI],
   );
 
+  /** PR #11199-style: pause persisting shared external scene until user interacts (avoids clobbering other tabs). */
+  const attachSharedLinkImplicitSaveGate = useCallback(
+    (data: ResolutionType<typeof initializeScene>) => {
+      if (data.pendingJsonShareLink) {
+        return;
+      }
+      if (data.isExternalScene && !collabAPI?.isCollaborating()) {
+        LocalData.pauseSave("sharedLink");
+        const resume = () => {
+          LocalData.resumeSave("sharedLink");
+        };
+        window.addEventListener("pointerdown", resume, {
+          once: true,
+          capture: true,
+        });
+        window.addEventListener("keydown", resume, {
+          once: true,
+          capture: true,
+        });
+      }
+    },
+    [collabAPI],
+  );
+
+  const revertPendingSharedPreview = useCallback(() => {
+    const snap = localCanvasRevertRef.current;
+    if (!snap || !excalidrawAPI) {
+      LocalData.resumeSave("sharedLink");
+      return;
+    }
+    excalidrawAPI.updateScene({
+      elements: restoreElements(snap.elements, null, {
+        repairBindings: true,
+        deleteInvisibleElements: true,
+      }),
+      appState: {
+        ...restoreAppState(snap.appState, null),
+        viewModeEnabled: false,
+      },
+      captureUpdate: CaptureUpdateAction.IMMEDIATELY,
+    });
+    const filesToRestore = Object.values(snap.files).filter(
+      (f): f is BinaryFileData => !!f,
+    );
+    if (filesToRestore.length) {
+      excalidrawAPI.addFiles(filesToRestore);
+    }
+    LocalData.resumeSave("sharedLink");
+    localCanvasRevertRef.current = null;
+    sharedPreviewKeyRef.current = null;
+  }, [excalidrawAPI]);
+
+  useEffect(() => {
+    if (!pendingJsonShareLink || !excalidrawAPI) {
+      sharedPreviewKeyRef.current = null;
+      return;
+    }
+
+    const previewKey = `${pendingJsonShareLink.id}:${pendingJsonShareLink.key}`;
+    if (sharedPreviewKeyRef.current === previewKey) {
+      return;
+    }
+
+    let cancelled = false;
+
+    const run = async () => {
+      LocalData.pauseSave("sharedLink");
+
+      localCanvasRevertRef.current = {
+        elements: excalidrawAPI.getSceneElementsIncludingDeleted(),
+        appState: excalidrawAPI.getAppState(),
+        files: { ...excalidrawAPI.getFiles() },
+      };
+
+      // Lock editing before import finishes — prop alone is overwritten by updateScene(appState).
+      excalidrawAPI.updateScene({
+        appState: { viewModeEnabled: true },
+        captureUpdate: CaptureUpdateAction.NEVER,
+      });
+
+      const { id, key } = pendingJsonShareLink;
+      const imported = await importFromBackend(id, key);
+      if (cancelled) {
+        return;
+      }
+
+      const localDataState = importFromLocalStorage();
+      const elements = bumpElementVersions(
+        restoreElements(imported.elements, null, {
+          repairBindings: true,
+          deleteInvisibleElements: true,
+        }),
+        localDataState?.elements,
+      );
+      const appState = restoreAppState(
+        imported.appState,
+        localDataState?.appState,
+      );
+      const nextScene = {
+        elements,
+        appState,
+        scrollToContent: true as const,
+      };
+
+      excalidrawAPI.updateScene({
+        elements: restoreElements(elements, null, {
+          repairBindings: true,
+          deleteInvisibleElements: true,
+        }),
+        appState: {
+          ...restoreAppState(appState, excalidrawAPI.getAppState()),
+          viewModeEnabled: true,
+        },
+        captureUpdate: CaptureUpdateAction.IMMEDIATELY,
+      });
+
+      const loadPayload = {
+        scene: nextScene,
+        isExternalScene: true as const,
+        id,
+        key,
+      } satisfies ResolutionType<typeof initializeScene>;
+
+      loadImages(loadPayload, false);
+
+      if (!cancelled) {
+        sharedPreviewKeyRef.current = previewKey;
+      }
+    };
+
+    void run();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [pendingJsonShareLink?.id, pendingJsonShareLink?.key, excalidrawAPI, loadImages]);
+
+  const onDeferredSharedLinkSeeOptions = useCallback(async () => {
+    const link = pendingJsonShareLink;
+    if (!link || !excalidrawAPI) {
+      return;
+    }
+
+    const result = await openConfirmModal(shareableLinkConfirmDialog);
+    if (result === true) {
+      LocalData.resumeSave("sharedLink");
+      setPendingJsonShareLink(null);
+      excalidrawAPI.updateScene({
+        appState: { viewModeEnabled: false },
+        captureUpdate: CaptureUpdateAction.NEVER,
+      });
+      LocalData.save(
+        excalidrawAPI.getSceneElementsIncludingDeleted(),
+        excalidrawAPI.getAppState(),
+        excalidrawAPI.getFiles(),
+        () => {},
+      );
+      localCanvasRevertRef.current = null;
+      sharedPreviewKeyRef.current = null;
+      window.history.replaceState({}, APP_NAME, window.location.origin);
+    } else if (result === false) {
+      setPendingJsonShareLink(null);
+      revertPendingSharedPreview();
+      window.history.replaceState({}, APP_NAME, window.location.origin);
+    }
+    // `null`: closed modal via backdrop/escape — stay in shared preview + view mode
+  }, [pendingJsonShareLink, excalidrawAPI, revertPendingSharedPreview]);
+
   useEffect(() => {
     if (!excalidrawAPI || (!isCollabDisabled && !collabAPI)) {
       return;
@@ -528,6 +731,8 @@ const ExcalidrawWrapper = () => {
     initializeScene({ collabAPI, excalidrawAPI }).then(async (data) => {
       loadImages(data, /* isInitialLoad */ true);
       initialStatePromiseRef.current.promise.resolve(data.scene);
+      setPendingJsonShareLink(data.pendingJsonShareLink ?? null);
+      attachSharedLinkImplicitSaveGate(data);
     });
 
     const onHashChange = async (event: HashChangeEvent) => {
@@ -544,6 +749,8 @@ const ExcalidrawWrapper = () => {
 
         initializeScene({ collabAPI, excalidrawAPI }).then((data) => {
           loadImages(data);
+          setPendingJsonShareLink(data.pendingJsonShareLink ?? null);
+          attachSharedLinkImplicitSaveGate(data);
           if (data.scene) {
             excalidrawAPI.updateScene({
               elements: restoreElements(data.scene.elements, null, {
@@ -559,6 +766,9 @@ const ExcalidrawWrapper = () => {
 
     const syncData = debounce(() => {
       if (isTestEnv()) {
+        return;
+      }
+      if (LocalData.isSharedLinkSaveLocked()) {
         return;
       }
       if (
@@ -647,8 +857,16 @@ const ExcalidrawWrapper = () => {
         visibilityChange,
         false,
       );
+      LocalData.resumeSave("sharedLink");
     };
-  }, [isCollabDisabled, collabAPI, excalidrawAPI, setLangCode, loadImages]);
+  }, [
+    isCollabDisabled,
+    collabAPI,
+    excalidrawAPI,
+    setLangCode,
+    loadImages,
+    attachSharedLinkImplicitSaveGate,
+  ]);
 
   useEffect(() => {
     const unloadHandler = (event: BeforeUnloadEvent) => {
@@ -903,7 +1121,7 @@ const ExcalidrawWrapper = () => {
 
   return (
     <div
-      style={{ height: "100%" }}
+      style={{ height: "100%", position: "relative" }}
       className={clsx("excalidraw-app", {
         "is-collaborating": isCollaborating,
       })}
@@ -913,6 +1131,7 @@ const ExcalidrawWrapper = () => {
         onExport={onExport}
         initialData={initialStatePromiseRef.current.promise}
         isCollaborating={isCollaborating}
+        viewModeEnabled={!!pendingJsonShareLink}
         onPointerUpdate={collabAPI?.onPointerUpdate}
         UIOptions={{
           canvasActions: {
@@ -995,6 +1214,16 @@ const ExcalidrawWrapper = () => {
           onCollabDialogOpen={onCollabDialogOpen}
           isCollabEnabled={!isCollabDisabled}
         />
+        {pendingJsonShareLink && (
+          <SharedLinkDeferredNotice
+            onSeeOptions={onDeferredSharedLinkSeeOptions}
+            onDismiss={() => {
+              setPendingJsonShareLink(null);
+              revertPendingSharedPreview();
+              window.history.replaceState({}, APP_NAME, window.location.origin);
+            }}
+          />
+        )}
         <OverwriteConfirmDialog>
           <OverwriteConfirmDialog.Actions.ExportToImage />
           <OverwriteConfirmDialog.Actions.SaveToDisk />

--- a/excalidraw-app/components/SharedLinkDeferredNotice.scss
+++ b/excalidraw-app/components/SharedLinkDeferredNotice.scss
@@ -1,0 +1,57 @@
+@import "../../packages/excalidraw/css/variables.module.scss";
+
+.shared-link-deferred-notice {
+  pointer-events: auto;
+  position: absolute;
+  top: 6.5rem;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: var(--zIndex-layerUI);
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 0.75rem;
+  max-width: min(36rem, calc(100% - 2rem));
+  padding: 0.75rem 1rem;
+  font-size: 0.875rem;
+  line-height: 1.45;
+  text-align: center;
+  border-radius: var(--border-radius-md);
+  background-color: var(--island-bg-color);
+  color: var(--color-on-surface);
+  box-shadow: 0 1px 3px rgb(0 0 0 / 12%),
+    0 0 0 1px var(--color-surface-lowest);
+}
+
+.shared-link-deferred-notice__text {
+  margin: 0;
+}
+
+.shared-link-deferred-notice__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  justify-content: center;
+}
+
+.shared-link-deferred-notice__btn {
+  cursor: pointer;
+  border-radius: var(--border-radius-md);
+  padding: 0.4rem 0.85rem;
+  font: inherit;
+  font-size: 0.8125rem;
+  border: 1px solid var(--color-surface-lowest);
+  background: transparent;
+  color: var(--color-on-surface);
+
+  &--primary {
+    border: none;
+    font-weight: 600;
+    background-color: var(--color-primary);
+    color: #fff;
+  }
+
+  &:hover {
+    filter: brightness(1.05);
+  }
+}

--- a/excalidraw-app/components/SharedLinkDeferredNotice.tsx
+++ b/excalidraw-app/components/SharedLinkDeferredNotice.tsx
@@ -1,0 +1,37 @@
+import { t } from "@excalidraw/excalidraw/i18n";
+
+import "./SharedLinkDeferredNotice.scss";
+
+type SharedLinkDeferredNoticeProps = {
+  onSeeOptions: () => void;
+  onDismiss: () => void;
+};
+
+export const SharedLinkDeferredNotice = ({
+  onSeeOptions,
+  onDismiss,
+}: SharedLinkDeferredNoticeProps) => {
+  return (
+    <div className="shared-link-deferred-notice">
+      <p className="shared-link-deferred-notice__text">
+        {t("labels.sharedLinkDeferredNotice")}
+      </p>
+      <div className="shared-link-deferred-notice__actions">
+        <button
+          type="button"
+          className="shared-link-deferred-notice__btn shared-link-deferred-notice__btn--primary"
+          onClick={onSeeOptions}
+        >
+          {t("buttons.sharedLinkSeeOptions")}
+        </button>
+        <button
+          type="button"
+          className="shared-link-deferred-notice__btn"
+          onClick={onDismiss}
+        >
+          {t("labels.sharedLinkDismiss")}
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/excalidraw-app/data/LocalData.ts
+++ b/excalidraw-app/data/LocalData.ts
@@ -112,7 +112,7 @@ const isQuotaExceededError = (error: any) => {
   return error instanceof DOMException && error.name === "QuotaExceededError";
 };
 
-type SavingLockTypes = "collaboration";
+type SavingLockTypes = "collaboration" | "sharedLink";
 
 export class LocalData {
   private static _save = debounce(
@@ -158,6 +158,11 @@ export class LocalData {
 
   static resumeSave = (lockType: SavingLockTypes) => {
     this.locker.unlock(lockType);
+  };
+
+  /** True while implicit "shared link" gate is holding persistence (see App.tsx). */
+  static isSharedLinkSaveLocked = () => {
+    return this.locker.isLocked("sharedLink");
   };
 
   static isSavePaused = () => {

--- a/excalidraw-app/tests/LocalData.test.ts
+++ b/excalidraw-app/tests/LocalData.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, afterEach } from "vitest";
+
+import { LocalData } from "../data/LocalData";
+
+describe("LocalData shared link save lock", () => {
+  afterEach(() => {
+    LocalData.resumeSave("sharedLink");
+    LocalData.resumeSave("collaboration");
+  });
+
+  it("isSharedLinkSaveLocked is true only while sharedLink pause is active", () => {
+    expect(LocalData.isSharedLinkSaveLocked()).toBe(false);
+
+    LocalData.pauseSave("sharedLink");
+    expect(LocalData.isSharedLinkSaveLocked()).toBe(true);
+
+    LocalData.resumeSave("sharedLink");
+    expect(LocalData.isSharedLinkSaveLocked()).toBe(false);
+  });
+
+  it("isSavePaused reflects sharedLink lock (when tab is visible)", () => {
+    const hiddenDesc = Object.getOwnPropertyDescriptor(document, "hidden");
+    Object.defineProperty(document, "hidden", {
+      configurable: true,
+      value: false,
+    });
+
+    expect(LocalData.isSavePaused()).toBe(false);
+
+    LocalData.pauseSave("sharedLink");
+    expect(LocalData.isSavePaused()).toBe(true);
+
+    LocalData.resumeSave("sharedLink");
+    expect(LocalData.isSavePaused()).toBe(false);
+
+    if (hiddenDesc) {
+      Object.defineProperty(document, "hidden", hiddenDesc);
+    } else {
+      delete (document as { hidden?: boolean }).hidden;
+    }
+  });
+});

--- a/packages/excalidraw/components/OverwriteConfirm/OverwriteConfirmState.ts
+++ b/packages/excalidraw/components/OverwriteConfirm/OverwriteConfirmState.ts
@@ -20,6 +20,9 @@ export const overwriteConfirmStateAtom = atom<OverwriteConfirmState>({
   active: false,
 });
 
+/** `true` confirm, `null` dismissed (backdrop / escape), `false` explicit reject */
+export type OverwriteConfirmResult = true | false | null;
+
 export async function openConfirmModal({
   title,
   description,
@@ -30,12 +33,12 @@ export async function openConfirmModal({
   description: React.ReactNode;
   actionLabel: string;
   color: "danger" | "warning";
-}) {
-  return new Promise<boolean>((resolve) => {
+}): Promise<OverwriteConfirmResult> {
+  return new Promise<OverwriteConfirmResult>((resolve) => {
     editorJotaiStore.set(overwriteConfirmStateAtom, {
       active: true,
       onConfirm: () => resolve(true),
-      onClose: () => resolve(false),
+      onClose: () => resolve(null),
       onReject: () => resolve(false),
       title,
       description,

--- a/packages/excalidraw/locales/en.json
+++ b/packages/excalidraw/locales/en.json
@@ -189,7 +189,9 @@
     "boxSelectionContain": "Wrap",
     "boxSelectionOverlap": "Overlap",
     "arrowBinding": "Arrow binding",
-    "midpointSnapping": "Snap to midpoints"
+    "midpointSnapping": "Snap to midpoints",
+    "sharedLinkDeferredNotice": "You're viewing a shared link. Your canvas here stays as-is until you choose what to do.",
+    "sharedLinkDismiss": "Not now"
   },
   "elementLink": {
     "title": "Link to object",
@@ -255,7 +257,8 @@
     "publishLibrary": "Rename or publish",
     "submit": "Submit",
     "confirm": "Confirm",
-    "embeddableInteractionButton": "Click to interact"
+    "embeddableInteractionButton": "Click to interact",
+    "sharedLinkSeeOptions": "See options"
   },
   "alerts": {
     "clearReset": "This will clear the whole canvas. Are you sure?",


### PR DESCRIPTION
### Context:
Opening a #json=… share link in a new tab while the tab already has a non-empty local drawing used to risk clobbering local storage / confusing UX versus another tab on the same origin. The app also needed a clear “load from link” step instead of silently changing behavior.

### Solution:
Defer loading the shared scene until the user chooses: keep the local canvas for first paint, strip the hash, show a banner with actions: See options / dismiss, preview the shared file in view mode with LocalData save paused, and only persist after explicit confirmation.


View mode:

<img width="1493" height="613" alt="Image" src="https://github.com/user-attachments/assets/1d242314-ac26-4e76-a8c9-4d9f08c2a721" />

See options:

<img width="1461" height="717" alt="Image" src="https://github.com/user-attachments/assets/434af69c-5460-43df-91e4-6f743fc0fb59" />




Out of scope either way: #room=… collaboration, JSON API shape, multi-device (no shared localStorage).