### PR TITLE
fix(editor): allow free text drag inside shapes when not editing label

### DIFF
--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -8770,22 +8770,38 @@ class App extends React.Component<AppProps, AppState> {
     let sceneX = pointerDownState.origin.x;
     let sceneY = pointerDownState.origin.y;
 
-    const element = this.getElementAtPosition(sceneX, sceneY, {
-      includeBoundTextElement: true,
-    });
+    const containerAtPosition = this.getTextBindableContainerAtPosition(
+      sceneX,
+      sceneY,
+    );
+    let container: ExcalidrawTextContainer | null = null;
 
-    // FIXME
-    let container = this.getTextBindableContainerAtPosition(sceneX, sceneY);
+    if (containerAtPosition && !event[KEYS.CTRL_OR_CMD]) {
+      const existingBoundText = getBoundTextElement(
+        containerAtPosition,
+        this.scene.getNonDeletedElementsMap(),
+      );
 
-    if (hasBoundTextElement(element)) {
-      container = element as ExcalidrawTextContainer;
-      sceneX = element.x + element.width / 2;
-      sceneY = element.y + element.height / 2;
+      if (existingBoundText) {
+        container = containerAtPosition;
+        sceneX = existingBoundText.x + existingBoundText.width / 2;
+        sceneY = existingBoundText.y + existingBoundText.height / 2;
+      } else if (
+        this.getTextWysiwygSnappedToCenterPosition(
+          sceneX,
+          sceneY,
+          this.state,
+          containerAtPosition,
+        )
+      ) {
+        container = containerAtPosition;
+      }
     }
+
     this.startTextEditing({
       sceneX,
       sceneY,
-      insertAtParentCenter: !event.altKey,
+      insertAtParentCenter: !event[KEYS.CTRL_OR_CMD],
       container,
       autoEdit: false,
       initialCaretSceneCoords: { x: sceneX, y: sceneY },

--- a/packages/excalidraw/wysiwyg/textWysiwyg.test.tsx
+++ b/packages/excalidraw/wysiwyg/textWysiwyg.test.tsx
@@ -1707,7 +1707,7 @@ describe("textWysiwyg", () => {
       );
     });
 
-    it("shouldn't bind to container if container has bound text not centered and text tool is used", async () => {
+    it("should edit the existing label anywhere inside a labeled container unless ctrl/cmd is held", async () => {
       expect(h.elements.length).toBe(1);
 
       Keyboard.keyPress(KEYS.ENTER);
@@ -1733,12 +1733,28 @@ describe("textWysiwyg", () => {
       expect(
         (h.elements[1] as ExcalidrawTextElementWithContainer).verticalAlign,
       ).toBe(VERTICAL_ALIGN.BOTTOM);
-      // Attempt to Bind 2nd text using text tool
+
+      // Clicking anywhere inside the shape should keep editing the existing label.
       UI.clickTool("text");
-      mouse.clickAt(
-        rectangle.x + rectangle.width / 2,
-        rectangle.y + rectangle.height / 2,
-      );
+      mouse.clickAt(rectangle.x + 10, rectangle.y + 10);
+      editor = await getTextEditor();
+      expect(h.state.editingTextElement?.id).toBe(text.id);
+      updateTextEditor(editor, "Hello again!");
+      Keyboard.exitTextEditor(editor);
+
+      expect(h.elements.length).toBe(2);
+      expect(rectangle.boundElements).toStrictEqual([
+        { id: h.elements[1].id, type: "text" },
+      ]);
+      text = h.elements[1] as ExcalidrawTextElementWithContainer;
+      expect(text.containerId).toBe(rectangle.id);
+      expect(text.originalText).toBe("Hello again!");
+
+      // Holding ctrl/cmd should opt out and create a new free text element instead.
+      UI.clickTool("text");
+      Keyboard.withModifierKeys({ ctrl: true }, () => {
+        mouse.clickAt(rectangle.x + 10, rectangle.y + 10);
+      });
       editor = await getTextEditor();
       updateTextEditor(editor, "Excalidraw");
       Keyboard.exitTextEditor(editor);
@@ -1747,9 +1763,26 @@ describe("textWysiwyg", () => {
       expect(rectangle.boundElements).toStrictEqual([
         { id: h.elements[1].id, type: "text" },
       ]);
-      text = h.elements[2] as ExcalidrawTextElementWithContainer;
+      const newText = h.elements[2] as ExcalidrawTextElementWithContainer;
+      expect(newText.containerId).toBe(null);
+      expect(newText.text).toBe("Excalidraw");
+    });
+
+    it("should allow dragging a free text box inside a container away from the label center", async () => {
+      UI.clickTool("text");
+      mouse.downAt(rectangle.x + 10, rectangle.y + 10);
+      mouse.moveTo(rectangle.x + 140, rectangle.y + 10);
+      mouse.up();
+
+      const editor = await getTextEditor();
+      updateTextEditor(editor, "Excalidraw");
+      Keyboard.exitTextEditor(editor);
+
+      expect(h.elements.length).toBe(2);
+
+      const text = h.elements[1] as ExcalidrawTextElementWithContainer;
       expect(text.containerId).toBe(null);
-      expect(text.text).toBe("Excalidraw");
+      expect(text.autoResize).toBe(false);
     });
 
     it("should reset the text element angle to the container's when binding to rotated non-arrow container", async () => {


### PR DESCRIPTION
I ran into this while using the text tool and expecting the same click-and-drag behavior I'm used to from tldraw. In Excalidraw, dragging with the text tool works fine outside of shapes, but inside a shape, it gets hijacked by the shape text logic, even when I wasn't actually trying to edit the main label. After discussing it with @dwelle on Discord, the conclusion was that this was indeed a bug: when you're not editing the main shape label, the text tool should still be allowed to behave like normal free text, including click-and-drag.

Here is the Excalidraw behavior:

[excalidraw_text_drag.webm](https://github.com/user-attachments/assets/efdaf9b6-2fef-458f-a76f-1f16778fd5db)

And here is the same in tldraw:

[tldraw_text_drag.webm](https://github.com/user-attachments/assets/ed7c06c3-c4dc-4c95-97f0-a851d2631739)

The main thing I wanted to preserve was the existing habit that, if a shape already has a label, clicking anywhere inside that shape still edits/selects that label. I didn't want to break that. So the fix keeps that behavior for normal clicks.

The difference is that now `Cmd/Ctrl` is the modifier to bypass the automatic shape text behavior and create normal free text instead. That seemed to fit better with the rest of the app. `Cmd/Ctrl` is already used in places where Excalidraw temporarily disables helpful automatic behavior, for example:

- It disables arrow binding
- It disables grid snapping in many drag flows

So I reused that same idea here: `Cmd/Ctrl` means "don't do the smart inferred thing, let me do the unconstrained version instead".

This means two things. First, if there is no label yet and the cursor is near the shape center, `Cmd/Ctrl` now lets you create free text instead of turning it into the shape label. Before this was done with `Alt`, so that part is a small breaking change, although I'm guessing it's probably not a super common interaction.

Second, if a shape already has a label, `Cmd/Ctrl` lets you create a new text element anywhere inside the shape instead of always selecting the existing label.

So the original goal was to fix the broken click-and-drag behavior inside shapes, and the final patch does that while still preserving the existing "click inside a labeled shape edits the label" behavior for the default case.

Here is another screencast to demonstrate the result:

[control_behavior.webm](https://github.com/user-attachments/assets/ff325b7f-4d8f-40c5-949d-bdaf496cecc5)

I have also added two new tests to try to encode that new behavior. Hope this is fine.