### PR TITLE
fix: correctly handle moving elements across multiple frames

### DIFF
--- a/packages/element/src/frame.ts
+++ b/packages/element/src/frame.ts
@@ -663,8 +663,25 @@ export const updateFrameMembershipOfSelectedElements = <
   const elementsMap = arrayToMap(allElements);
 
   elementsToFilter.forEach((element) => {
+    if (!element.frameId) {
+      return;
+    }
+
+    const maybeFrame = elementsMap.get(element.frameId);
+    const frame =
+      maybeFrame && isFrameLikeElement(maybeFrame) ? maybeFrame : null;
+
     if (
-      element.frameId &&
+      elementsToFilter.size > 1 &&
+      frame &&
+      isElementInFrame(element, elementsMap, appState, {
+        targetFrame: frame,
+      })
+    ) {
+      return;
+    }
+
+    if (
       !isFrameLikeElement(element) &&
       !isElementInFrame(element, elementsMap, appState)
     ) {

--- a/packages/element/tests/frame.test.tsx
+++ b/packages/element/tests/frame.test.tsx
@@ -560,4 +560,100 @@ describe("adding elements to frames", () => {
       expect(h.elements.length).toBe(4);
     });
   });
+
+  describe("dragging multiple elements across multiple frames", () => {
+    it("should keep elements on frames", () => {
+      const frame1 = API.createElement({
+        type: "frame",
+        x: 0,
+        y: 0,
+        width: 200,
+        height: 200,
+      });
+
+      const frame2 = API.createElement({
+        type: "frame",
+        x: 300,
+        y: 0,
+        width: 200,
+        height: 200,
+      });
+
+      const rectangle1 = API.createElement({
+        type: "rectangle",
+        x: 50,
+        y: 50,
+        width: 50,
+        height: 50,
+        frameId: frame1.id,
+      });
+
+      const rectangle2 = API.createElement({
+        type: "rectangle",
+        x: 450,
+        y: 50,
+        width: 50,
+        height: 50,
+        frameId: frame2.id,
+      });
+
+      API.setElements([frame1, frame2, rectangle1, rectangle2]);
+
+      API.setSelectedElements([rectangle1, rectangle2]);
+
+      mouse.downAt(rectangle1.x, rectangle1.y);
+      mouse.moveTo(10, 10);
+      mouse.up();
+
+      expect(rectangle1.frameId).toBe(frame1.id);
+      expect(rectangle2.frameId).toBe(frame2.id);
+    });
+
+    it("should remove one element on frames", () => {
+      const frame1 = API.createElement({
+        type: "frame",
+        x: 0,
+        y: 0,
+        width: 200,
+        height: 200,
+      });
+
+      const frame2 = API.createElement({
+        type: "frame",
+        x: 300,
+        y: 0,
+        width: 200,
+        height: 200,
+      });
+
+      const rectangle1 = API.createElement({
+        type: "rectangle",
+        x: 50,
+        y: 50,
+        width: 50,
+        height: 50,
+        frameId: frame1.id,
+      });
+
+      const rectangle2 = API.createElement({
+        type: "rectangle",
+        x: 450,
+        y: 50,
+        width: 50,
+        height: 50,
+        frameId: frame2.id,
+      });
+
+      API.setElements([frame1, frame2, rectangle1, rectangle2]);
+
+      API.setSelectedElements([rectangle1, rectangle2]);
+
+      mouse.downAt(rectangle1.x, rectangle1.y);
+      mouse.moveTo(150, 50);
+      mouse.up();
+
+      expect(rectangle1.frameId).toBe(frame1.id);
+      expect(rectangle2.frameId).toBe(null);
+    });
+  });
 });


### PR DESCRIPTION
Closes #6847

Previously, elements could be removed from their original frames when moved.
This occurred because only the mouse position was considered during frame resolution.