### PR TITLE
feat(editor): add AI tidy selection

### DIFF
--- a/excalidraw-app/components/AI.tsx
+++ b/excalidraw-app/components/AI.tsx
@@ -1,4 +1,5 @@
 import {
+  AITidySelectionPlugin,
   DiagramToCodePlugin,
   exportToBlob,
   getTextFromElements,
@@ -98,6 +99,52 @@ export const AIComponents = ({
           } catch (error: any) {
             throw new Error("Generation failed (invalid response)");
           }
+        }}
+      />
+
+      <AITidySelectionPlugin
+        tidy={async ({ selectedElements, allElements, appState }) => {
+          const response = await fetch(
+            `${import.meta.env.VITE_APP_AI_BACKEND}/v1/ai/tidy-selection`,
+            {
+              method: "POST",
+              headers: {
+                Accept: "application/json",
+                "Content-Type": "application/json",
+              },
+              body: JSON.stringify({
+                appState: {
+                  theme: appState.theme,
+                  gridModeEnabled: appState.gridModeEnabled,
+                  gridSize: appState.gridSize,
+                },
+                selectedElements,
+                allElements,
+              }),
+            },
+          );
+
+          if (!response.ok) {
+            const text = await response.text();
+            const errorJSON = safelyParseJSON(text);
+            throw new Error(errorJSON?.message || text || "AI tidy failed");
+          }
+
+          const parsed = safelyParseJSON(await response.text()) as
+            | {
+                positions?: {
+                  id: string;
+                  x: number;
+                  y: number;
+                }[];
+              }
+            | null;
+
+          if (!parsed?.positions?.length) {
+            throw new Error("AI tidy returned no positions");
+          }
+
+          return { positions: parsed.positions };
         }}
       />
 

--- a/packages/excalidraw/actions/actionAITidySelection.test.tsx
+++ b/packages/excalidraw/actions/actionAITidySelection.test.tsx
@@ -1,0 +1,55 @@
+import { waitFor } from "@testing-library/react";
+
+import { AITidySelectionPlugin, Excalidraw } from "../index";
+import { API } from "../tests/helpers/api";
+import { render } from "../tests/test-utils";
+
+import { actionAITidySelection } from "./actionAITidySelection";
+
+describe("actionAITidySelection", () => {
+  it("repositions selected elements from plugin response", async () => {
+    const tidy = vi.fn(async ({ selectedElements }) => ({
+      positions: selectedElements.map((element: (typeof selectedElements)[number]) => ({
+        id: element.id,
+        x: element.x + 10,
+        y: element.y + 20,
+      })),
+    }));
+
+    await render(
+      <Excalidraw>
+        <AITidySelectionPlugin tidy={tidy} />
+      </Excalidraw>,
+    );
+
+    const first = API.createElement({
+      id: "rect-a",
+      type: "rectangle",
+      x: 100,
+      y: 100,
+      width: 120,
+      height: 80,
+    });
+    const second = API.createElement({
+      id: "rect-b",
+      type: "rectangle",
+      x: 320,
+      y: 120,
+      width: 120,
+      height: 80,
+    });
+
+    API.setElements([first, second]);
+    API.setSelectedElements([first, second]);
+    API.executeAction(actionAITidySelection);
+
+    await waitFor(() => {
+      expect(API.getElement(first).x).toBe(110);
+      expect(API.getElement(first).y).toBe(120);
+      expect(API.getElement(second).x).toBe(330);
+      expect(API.getElement(second).y).toBe(140);
+    });
+
+    expect(tidy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/excalidraw/actions/actionAITidySelection.ts
+++ b/packages/excalidraw/actions/actionAITidySelection.ts
@@ -1,0 +1,38 @@
+import { CaptureUpdateAction } from "@excalidraw/element";
+
+import { register } from "./register";
+
+export const actionAITidySelection = register({
+  name: "aiTidySelection",
+  label: "AI tidy selection",
+  keywords: ["ai", "tidy", "layout", "organize", "selection"],
+  trackEvent: {
+    category: "menu",
+    action: "aiTidySelection",
+  },
+  viewMode: false,
+  predicate: (_elements, appState, appProps, app) => {
+    if (appProps.aiEnabled === false || !app.plugins.aiTidySelection?.tidy) {
+      return false;
+    }
+
+    if (
+      appState.newElement ||
+      appState.editingTextElement ||
+      appState.selectedElementsAreBeingDragged ||
+      appState.selectionElement ||
+      appState.multiElement
+    ) {
+      return false;
+    }
+
+    return Object.keys(appState.selectedElementIds).length >= 2;
+  },
+  perform: async (_elements, appState, _formData, app) => {
+    await app.onAITidySelection();
+    return {
+      appState,
+      captureUpdate: CaptureUpdateAction.EVENTUALLY,
+    };
+  },
+});

--- a/packages/excalidraw/actions/index.ts
+++ b/packages/excalidraw/actions/index.ts
@@ -92,3 +92,4 @@ export { actionToggleLinearEditor } from "./actionLinearEditor";
 export { actionToggleSearchMenu } from "./actionToggleSearchMenu";
 
 export { actionToggleCropEditor } from "./actionCropEditor";
+export { actionAITidySelection } from "./actionAITidySelection";

--- a/packages/excalidraw/actions/types.ts
+++ b/packages/excalidraw/actions/types.ts
@@ -145,7 +145,8 @@ export type ActionName =
   | "wrapSelectionInFrame"
   | "toggleLassoTool"
   | "toggleShapeSwitch"
-  | "togglePolygon";
+  | "togglePolygon"
+  | "aiTidySelection";
 
 export type PanelComponentProps = {
   elements: readonly ExcalidrawElement[];

--- a/packages/excalidraw/components/AITidySelectionPlugin/AITidySelectionPlugin.tsx
+++ b/packages/excalidraw/components/AITidySelectionPlugin/AITidySelectionPlugin.tsx
@@ -1,0 +1,19 @@
+import { useLayoutEffect } from "react";
+
+import { useApp } from "../App";
+
+import type { GenerateAITidySelection } from "../../types";
+
+export const AITidySelectionPlugin = (props: {
+  tidy: GenerateAITidySelection;
+}) => {
+  const app = useApp();
+
+  useLayoutEffect(() => {
+    app.setPlugins({
+      aiTidySelection: { tidy: props.tidy },
+    });
+  }, [app, props.tidy]);
+
+  return null;
+};

--- a/packages/excalidraw/components/Actions.tsx
+++ b/packages/excalidraw/components/Actions.tsx
@@ -73,6 +73,7 @@ import {
   mermaidLogoIcon,
   laserPointerToolIcon,
   MagicIcon,
+  brainIconThin,
   LassoIcon,
   sharpArrowIcon,
   roundArrowIcon,
@@ -1255,6 +1256,18 @@ export const ShapesSwitcher = ({
             Generate
           </div>
           {app.props.aiEnabled !== false && <TTDDialogTriggerTunnel.Out />}
+          {app.props.aiEnabled !== false &&
+            app.plugins.aiTidySelection &&
+            Object.keys(app.state.selectedElementIds).length >= 2 && (
+              <DropdownMenu.Item
+                onSelect={() => app.onAITidySelection()}
+                icon={brainIconThin}
+                data-testid="toolbar-ai-tidy-selection"
+                badge={<DropdownMenu.Item.Badge>AI</DropdownMenu.Item.Badge>}
+              >
+                AI tidy selection
+              </DropdownMenu.Item>
+            )}
           <DropdownMenu.Item
             onSelect={() => app.setOpenDialog({ name: "ttd", tab: "mermaid" })}
             icon={mermaidLogoIcon}

--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -325,6 +325,7 @@ import {
   actionToggleMidpointSnapping,
   actionToggleCropEditor,
 } from "../actions";
+import "../actions/actionAITidySelection";
 import { actionWrapTextInContainer } from "../actions/actionBoundText";
 import { actionToggleHandTool, zoomToFit } from "../actions/actionCanvas";
 import { actionPaste } from "../actions/actionClipboard";
@@ -492,6 +493,7 @@ import type {
   EmbedsValidationStatus,
   ElementsPendingErasure,
   ExcalidrawImperativeAPIEventMap,
+  GenerateAITidySelection,
   GenerateDiagramToCode,
   NullableGridSize,
   Offsets,
@@ -2503,6 +2505,9 @@ class App extends React.Component<AppProps, AppState> {
     diagramToCode?: {
       generate: GenerateDiagramToCode;
     };
+    aiTidySelection?: {
+      tidy: GenerateAITidySelection;
+    };
   } = {};
 
   public setPlugins(plugins: Partial<App["plugins"]>) {
@@ -2614,6 +2619,94 @@ class App extends React.Component<AppProps, AppState> {
       });
     }
   }
+
+  public onAITidySelection = async () => {
+    const tidySelection = this.plugins.aiTidySelection?.tidy;
+
+    if (!tidySelection) {
+      this.setState({
+        errorMessage: "No AI tidy selection plugin found",
+      });
+      return;
+    }
+
+    const selectedElements = this.scene.getSelectedElements({
+      selectedElementIds: this.state.selectedElementIds,
+      includeBoundTextElement: true,
+    });
+
+    if (selectedElements.length < 2) {
+      this.setState({
+        errorMessage: "Select at least 2 elements to tidy",
+      });
+      return;
+    }
+
+    const selectedElementIds = new Set(selectedElements.map((el) => el.id));
+    trackEvent("ai", "tidy-selection (start)", "layout");
+
+    try {
+      const { positions } = await tidySelection({
+        selectedElements,
+        allElements: this.scene.getNonDeletedElements(),
+        appState: this.state,
+      });
+
+      if (!positions?.length) {
+        this.setState({
+          errorMessage: "AI tidy didn't return any layout changes",
+        });
+        return;
+      }
+
+      const nextPositionById = new Map(
+        positions
+          .filter(
+            (item) =>
+              selectedElementIds.has(item.id) &&
+              Number.isFinite(item.x) &&
+              Number.isFinite(item.y),
+          )
+          .map((item) => [item.id, item]),
+      );
+
+      if (nextPositionById.size === 0) {
+        this.setState({
+          errorMessage: "AI tidy response is invalid for current selection",
+        });
+        return;
+      }
+
+      this.updateScene({
+        elements: this.scene.getElementsIncludingDeleted().map((element) => {
+          const next = nextPositionById.get(element.id);
+          if (!next) {
+            return element;
+          }
+          if (element.x === next.x && element.y === next.y) {
+            return element;
+          }
+          return newElementWith(element, {
+            x: next.x,
+            y: next.y,
+          });
+        }),
+        captureUpdate: CaptureUpdateAction.IMMEDIATELY,
+      });
+
+      this.setToast({
+        message: "Selection tidied",
+        closable: false,
+        duration: 1500,
+      });
+      trackEvent("ai", "tidy-selection (success)", "layout");
+    } catch (error: any) {
+      trackEvent("ai", "tidy-selection (failed)", "layout");
+      this.setState({
+        errorMessage: error?.message || "AI tidy failed",
+      });
+    }
+  };
 
   public onMagicframeToolSelect = () => {
     const selectedElements = this.scene.getSelectedElements({

--- a/packages/excalidraw/components/CommandPalette/CommandPalette.tsx
+++ b/packages/excalidraw/components/CommandPalette/CommandPalette.tsx
@@ -16,6 +16,7 @@ import { actionToggleShapeSwitch } from "../../actions/actionToggleShapeSwitch";
 import { getShortcutKey } from "../../shortcut";
 
 import {
+  actionAITidySelection,
   actionClearCanvas,
   actionLink,
   actionToggleSearchMenu,
@@ -593,6 +594,16 @@ function CommandPaletteInner({
                 tab: "mermaid",
               },
             }));
+          },
+        },
+        {
+          label: "AI tidy selection",
+          category: DEFAULT_CATEGORIES.tools,
+          icon: brainIconThin,
+          viewMode: false,
+          predicate: () => actionManager.isActionEnabled(actionAITidySelection),
+          perform: () => {
+            actionManager.executeAction(actionAITidySelection, "commandPalette");
           },
         },
         // {

--- a/packages/excalidraw/components/MobileToolBar.tsx
+++ b/packages/excalidraw/components/MobileToolBar.tsx
@@ -34,6 +34,7 @@ import {
   LassoIcon,
   mermaidLogoIcon,
   MagicIcon,
+  brainIconThin,
 } from "./icons";
 
 import "./ToolIcon.scss";
@@ -459,6 +460,16 @@ export const MobileToolBar = ({
             Generate
           </div>
           {app.props.aiEnabled !== false && <TTDDialogTriggerTunnel.Out />}
+          {app.props.aiEnabled !== false && app.plugins.aiTidySelection && (
+            <DropdownMenu.Item
+              onSelect={() => app.onAITidySelection()}
+              icon={brainIconThin}
+              data-testid="toolbar-ai-tidy-selection"
+              badge={<DropdownMenu.Item.Badge>AI</DropdownMenu.Item.Badge>}
+            >
+              AI tidy selection
+            </DropdownMenu.Item>
+          )}
           <DropdownMenu.Item
             onSelect={() => app.setOpenDialog({ name: "ttd", tab: "mermaid" })}
             icon={mermaidLogoIcon}

--- a/packages/excalidraw/index.tsx
+++ b/packages/excalidraw/index.tsx
@@ -379,6 +379,7 @@ export {
 } from "@excalidraw/utils/withinBounds";
 
 export { DiagramToCodePlugin } from "./components/DiagramToCodePlugin/DiagramToCodePlugin";
+export { AITidySelectionPlugin } from "./components/AITidySelectionPlugin/AITidySelectionPlugin";
 export { getDataURL } from "./data/blob";
 export { isElementLink } from "@excalidraw/element";
 

--- a/packages/excalidraw/types.ts
+++ b/packages/excalidraw/types.ts
@@ -812,6 +812,7 @@ export type AppClassProperties = {
   setOpenDialog: App["setOpenDialog"];
   insertEmbeddableElement: App["insertEmbeddableElement"];
   onMagicframeToolSelect: App["onMagicframeToolSelect"];
+  onAITidySelection: App["onAITidySelection"];
   getName: App["getName"];
   dismissLinearEditor: App["dismissLinearEditor"];
   flowChartCreator: App["flowChartCreator"];
@@ -1047,6 +1048,18 @@ export type GenerateDiagramToCode = (props: {
   frame: ExcalidrawMagicFrameElement;
   children: readonly ExcalidrawElement[];
 }) => MaybePromise<{ html: string }>;
+
+export type GenerateAITidySelection = (props: {
+  selectedElements: readonly NonDeletedExcalidrawElement[];
+  allElements: readonly NonDeletedExcalidrawElement[];
+  appState: AppState;
+}) => MaybePromise<{
+  positions: readonly {
+    id: ExcalidrawElement["id"];
+    x: number;
+    y: number;
+  }[];
+}>;
 
 export type Offsets = Partial<{
   top: number;


### PR DESCRIPTION
## Summary
- introduce a new `AITidySelectionPlugin` API in `@excalidraw/excalidraw` so host apps can provide AI-assisted layout suggestions for current selections
- add a first-class `AI tidy selection` action in the editor that validates plugin responses, updates selected element positions atomically, and records changes in undo/redo history
- wire the app runtime to a new backend endpoint (`/v1/ai/tidy-selection`) and expose the feature in command palette + Generate menus (desktop and mobile)
- add focused coverage for the new action to verify plugin-returned positions are applied to selected elements

## Why this approach
- keeps AI logic pluggable and host-owned, matching existing Excalidraw AI extension patterns (`DiagramToCodePlugin`, `TTDDialog`)
- avoids coupling core editor internals to a specific provider/backend while still shipping a polished end-user workflow
- minimizes regression risk by constraining updates to selected elements and reusing existing scene/update/history primitives

## API contract
`AITidySelectionPlugin` receives:
- `selectedElements`: the current non-deleted selected elements (including bound text)
- `allElements`: all non-deleted scene elements for context
- `appState`: current app state

It returns:
- `positions`: array of `{ id, x, y }` for elements to reposition

Invalid/empty responses are guarded with user-visible errors and do not mutate the scene.

## Test plan
- [x] `yarn test:typecheck`
- [x] `yarn test:app packages/excalidraw/actions/actionAITidySelection.test.tsx --watch=false`
- [x] `yarn test:app excalidraw-app/tests/MobileMenu.test.tsx packages/excalidraw/tests/MermaidToExcalidraw.test.tsx --watch=false` (passed in a clean run; one subsequent combined rerun showed existing flaky behavior unrelated to this change)
