### PR TITLE
feat(editor): add AI smart connector labels

### DIFF
--- a/excalidraw-app/components/AI.tsx
+++ b/excalidraw-app/components/AI.tsx
@@ -1,4 +1,5 @@
 import {
+  AISmartConnectorLabelsPlugin,
   DiagramToCodePlugin,
   exportToBlob,
   getTextFromElements,
@@ -98,6 +99,51 @@ export const AIComponents = ({
           } catch (error: any) {
             throw new Error("Generation failed (invalid response)");
           }
+        }}
+      />
+
+      <AISmartConnectorLabelsPlugin
+        suggest={async ({ selectedArrows, allElements, appState }) => {
+          const response = await fetch(
+            `${import.meta.env.VITE_APP_AI_BACKEND}/v1/ai/smart-connector-labels`,
+            {
+              method: "POST",
+              headers: {
+                Accept: "application/json",
+                "Content-Type": "application/json",
+              },
+              body: JSON.stringify({
+                appState: {
+                  theme: appState.theme,
+                },
+                selectedArrows,
+                allElements,
+              }),
+            },
+          );
+
+          if (!response.ok) {
+            const text = await response.text();
+            const errorJSON = safelyParseJSON(text);
+            throw new Error(
+              errorJSON?.message || text || "AI connector labeling failed",
+            );
+          }
+
+          const parsed = safelyParseJSON(await response.text()) as
+            | {
+                labels?: {
+                  arrowId: string;
+                  text: string;
+                }[];
+              }
+            | null;
+
+          if (!parsed?.labels?.length) {
+            throw new Error("AI connector labeling returned no labels");
+          }
+
+          return { labels: parsed.labels };
         }}
       />
 

--- a/packages/excalidraw/actions/actionAISmartConnectorLabels.test.tsx
+++ b/packages/excalidraw/actions/actionAISmartConnectorLabels.test.tsx
@@ -1,0 +1,76 @@
+import { waitFor } from "@testing-library/react";
+
+import { Excalidraw, AISmartConnectorLabelsPlugin } from "../index";
+import { API } from "../tests/helpers/api";
+import { render } from "../tests/test-utils";
+
+import { actionAISmartConnectorLabels } from "./actionAISmartConnectorLabels";
+
+describe("actionAISmartConnectorLabels", () => {
+  it("creates bound text for selected arrows without labels", async () => {
+    const suggest = vi.fn(async ({ selectedArrows }) => ({
+      labels: selectedArrows.map((arrow: (typeof selectedArrows)[number]) => ({
+        arrowId: arrow.id,
+        text: "Approves",
+      })),
+    }));
+
+    await render(
+      <Excalidraw>
+        <AISmartConnectorLabelsPlugin suggest={suggest} />
+      </Excalidraw>,
+    );
+
+    const start = API.createElement({ id: "start", type: "rectangle" });
+    const end = API.createElement({ id: "end", type: "rectangle", x: 240 });
+    const arrow = API.createElement({
+      id: "arrow-1",
+      type: "arrow",
+    });
+
+    API.setElements([start, end, arrow]);
+    API.setSelectedElements([arrow]);
+    API.executeAction(actionAISmartConnectorLabels);
+
+    await waitFor(() => {
+      const createdText = API.getSnapshot().find(
+        (element) => element.type === "text" && element.containerId === arrow.id,
+      ) as { text: string } | undefined;
+      expect(createdText?.text).toBe("Approves");
+    });
+
+    expect(suggest).toHaveBeenCalledTimes(1);
+  });
+
+  it("updates existing bound text for selected arrows", async () => {
+    const suggest = vi.fn(async () => ({
+      labels: [{ arrowId: "arrow-1", text: "Triggers sync" }],
+    }));
+
+    await render(
+      <Excalidraw>
+        <AISmartConnectorLabelsPlugin suggest={suggest} />
+      </Excalidraw>,
+    );
+
+    const arrow = API.createElement({
+      id: "arrow-1",
+      type: "arrow",
+      boundElements: [{ id: "label-1", type: "text" }],
+    });
+    const label = API.createElement({
+      id: "label-1",
+      type: "text",
+      containerId: "arrow-1",
+      text: "Old label",
+    });
+
+    API.setElements([arrow, label]);
+    API.setSelectedElements([arrow]);
+    API.executeAction(actionAISmartConnectorLabels);
+
+    await waitFor(() => {
+      expect(API.getElement(label).text).toBe("Triggers sync");
+    });
+  });
+});

--- a/packages/excalidraw/actions/actionAISmartConnectorLabels.ts
+++ b/packages/excalidraw/actions/actionAISmartConnectorLabels.ts
@@ -1,0 +1,38 @@
+import { CaptureUpdateAction, isArrowElement } from "@excalidraw/element";
+
+import { register } from "./register";
+
+export const actionAISmartConnectorLabels = register({
+  name: "aiSmartConnectorLabels",
+  label: "AI suggest connector labels",
+  keywords: ["ai", "connector", "arrow", "label", "text"],
+  trackEvent: {
+    category: "menu",
+    action: "aiSmartConnectorLabels",
+  },
+  viewMode: false,
+  predicate: (_elements, appState, appProps, app) => {
+    if (
+      appProps.aiEnabled === false ||
+      !app.plugins.aiSmartConnectorLabels?.suggest ||
+      appState.editingTextElement
+    ) {
+      return false;
+    }
+
+    const selectedArrows = app.scene
+      .getSelectedElements({
+        selectedElementIds: appState.selectedElementIds,
+      })
+      .filter(isArrowElement);
+
+    return selectedArrows.length > 0;
+  },
+  perform: async (_elements, appState, _formData, app) => {
+    await app.onAISmartConnectorLabels();
+    return {
+      appState,
+      captureUpdate: CaptureUpdateAction.EVENTUALLY,
+    };
+  },
+});

--- a/packages/excalidraw/actions/index.ts
+++ b/packages/excalidraw/actions/index.ts
@@ -92,3 +92,4 @@ export { actionToggleLinearEditor } from "./actionLinearEditor";
 export { actionToggleSearchMenu } from "./actionToggleSearchMenu";
 
 export { actionToggleCropEditor } from "./actionCropEditor";
+export { actionAISmartConnectorLabels } from "./actionAISmartConnectorLabels";

--- a/packages/excalidraw/actions/types.ts
+++ b/packages/excalidraw/actions/types.ts
@@ -145,7 +145,8 @@ export type ActionName =
   | "wrapSelectionInFrame"
   | "toggleLassoTool"
   | "toggleShapeSwitch"
-  | "togglePolygon";
+  | "togglePolygon"
+  | "aiSmartConnectorLabels";
 
 export type PanelComponentProps = {
   elements: readonly ExcalidrawElement[];

--- a/packages/excalidraw/components/AISmartConnectorLabelsPlugin/AISmartConnectorLabelsPlugin.tsx
+++ b/packages/excalidraw/components/AISmartConnectorLabelsPlugin/AISmartConnectorLabelsPlugin.tsx
@@ -1,0 +1,19 @@
+import { useLayoutEffect } from "react";
+
+import { useApp } from "../App";
+
+import type { GenerateAISmartConnectorLabels } from "../../types";
+
+export const AISmartConnectorLabelsPlugin = (props: {
+  suggest: GenerateAISmartConnectorLabels;
+}) => {
+  const app = useApp();
+
+  useLayoutEffect(() => {
+    app.setPlugins({
+      aiSmartConnectorLabels: { suggest: props.suggest },
+    });
+  }, [app, props.suggest]);
+
+  return null;
+};

--- a/packages/excalidraw/components/Actions.tsx
+++ b/packages/excalidraw/components/Actions.tsx
@@ -73,6 +73,7 @@ import {
   mermaidLogoIcon,
   laserPointerToolIcon,
   MagicIcon,
+  brainIconThin,
   LassoIcon,
   sharpArrowIcon,
   roundArrowIcon,
@@ -1255,6 +1256,22 @@ export const ShapesSwitcher = ({
             Generate
           </div>
           {app.props.aiEnabled !== false && <TTDDialogTriggerTunnel.Out />}
+          {app.props.aiEnabled !== false &&
+            app.plugins.aiSmartConnectorLabels &&
+            app.scene
+              .getSelectedElements({
+                selectedElementIds: app.state.selectedElementIds,
+              })
+              .some(isArrowElement) && (
+              <DropdownMenu.Item
+                onSelect={() => app.onAISmartConnectorLabels()}
+                icon={brainIconThin}
+                data-testid="toolbar-ai-smart-connector-labels"
+                badge={<DropdownMenu.Item.Badge>AI</DropdownMenu.Item.Badge>}
+              >
+                AI suggest connector labels
+              </DropdownMenu.Item>
+            )}
           <DropdownMenu.Item
             onSelect={() => app.setOpenDialog({ name: "ttd", tab: "mermaid" })}
             icon={mermaidLogoIcon}

--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -325,6 +325,7 @@ import {
   actionToggleMidpointSnapping,
   actionToggleCropEditor,
 } from "../actions";
+import "../actions/actionAISmartConnectorLabels";
 import { actionWrapTextInContainer } from "../actions/actionBoundText";
 import { actionToggleHandTool, zoomToFit } from "../actions/actionCanvas";
 import { actionPaste } from "../actions/actionClipboard";
@@ -492,6 +493,7 @@ import type {
   EmbedsValidationStatus,
   ElementsPendingErasure,
   ExcalidrawImperativeAPIEventMap,
+  GenerateAISmartConnectorLabels,
   GenerateDiagramToCode,
   NullableGridSize,
   Offsets,
@@ -2503,6 +2505,9 @@ class App extends React.Component<AppProps, AppState> {
     diagramToCode?: {
       generate: GenerateDiagramToCode;
     };
+    aiSmartConnectorLabels?: {
+      suggest: GenerateAISmartConnectorLabels;
+    };
   } = {};
 
   public setPlugins(plugins: Partial<App["plugins"]>) {
@@ -2614,6 +2619,173 @@ class App extends React.Component<AppProps, AppState> {
       });
     }
   }
+
+  public onAISmartConnectorLabels = async () => {
+    const suggestLabels = this.plugins.aiSmartConnectorLabels?.suggest;
+
+    if (!suggestLabels) {
+      this.setState({
+        errorMessage: "No AI smart connector labels plugin found",
+      });
+      return;
+    }
+
+    const selectedArrows = this.scene
+      .getSelectedElements({
+        selectedElementIds: this.state.selectedElementIds,
+      })
+      .filter(isArrowElement);
+
+    if (!selectedArrows.length) {
+      this.setState({
+        errorMessage: "Select at least one arrow to suggest labels",
+      });
+      return;
+    }
+
+    trackEvent("ai", "smart-connector-labels (start)", "labels");
+
+    try {
+      const { labels } = await suggestLabels({
+        selectedArrows,
+        allElements: this.scene.getNonDeletedElements(),
+        appState: this.state,
+      });
+
+      if (!labels?.length) {
+        this.setState({
+          errorMessage: "AI label suggestions returned no updates",
+        });
+        return;
+      }
+
+      const selectedArrowIdSet = new Set(selectedArrows.map((arrow) => arrow.id));
+      const labelByArrowId = new Map(
+        labels
+          .map((item) => ({
+            arrowId: item.arrowId,
+            text: item.text.trim(),
+          }))
+          .filter(
+            (item) => selectedArrowIdSet.has(item.arrowId) && item.text.length > 0,
+          )
+          .map((item) => [item.arrowId, item.text]),
+      );
+
+      if (!labelByArrowId.size) {
+        this.setState({
+          errorMessage: "AI label suggestions were invalid for selection",
+        });
+        return;
+      }
+
+      const elements = this.scene.getElementsIncludingDeleted();
+      const elementsMap = this.scene.getElementsMapIncludingDeleted();
+      const updatedElementsById = new Map<
+        ExcalidrawElement["id"],
+        ExcalidrawElement
+      >();
+      const newTextByArrowId = new Map<
+        ExcalidrawElement["id"],
+        ExcalidrawTextElement
+      >();
+
+      for (const selectedArrow of selectedArrows) {
+        const labelText = labelByArrowId.get(selectedArrow.id);
+        if (!labelText) {
+          continue;
+        }
+
+        const latestArrow =
+          (updatedElementsById.get(selectedArrow.id) as ExcalidrawArrowElement) ||
+          selectedArrow;
+
+        const boundTextElement =
+          getBoundTextElement(latestArrow, elementsMap) ||
+          (updatedElementsById.get(
+            latestArrow.boundElements?.find((item) => item.type === "text")?.id || "",
+          ) as ExcalidrawTextElement | undefined);
+
+        if (boundTextElement) {
+          const nextBoundText = newElementWith(boundTextElement, {
+            text: labelText,
+            originalText: labelText,
+          });
+          redrawTextBoundingBox(nextBoundText, latestArrow, this.scene);
+          updatedElementsById.set(nextBoundText.id, nextBoundText);
+          continue;
+        }
+
+        const textElement = newTextElement({
+          x: latestArrow.x,
+          y: latestArrow.y,
+          strokeColor: latestArrow.strokeColor,
+          backgroundColor: "transparent",
+          fillStyle: latestArrow.fillStyle,
+          strokeWidth: latestArrow.strokeWidth,
+          strokeStyle: latestArrow.strokeStyle,
+          roughness: latestArrow.roughness,
+          opacity: latestArrow.opacity,
+          text: labelText,
+          originalText: labelText,
+          fontSize: this.state.currentItemFontSize,
+          fontFamily: this.state.currentItemFontFamily,
+          textAlign: "center",
+          verticalAlign: VERTICAL_ALIGN.MIDDLE,
+          autoResize: true,
+          lineHeight: getLineHeight(this.state.currentItemFontFamily),
+          angle: 0 as Radians,
+          containerId: latestArrow.id,
+          groupIds: latestArrow.groupIds,
+          frameId: latestArrow.frameId,
+        });
+
+        const nextArrow = newElementWith(latestArrow, {
+          boundElements: (latestArrow.boundElements || []).concat({
+            type: "text",
+            id: textElement.id,
+          }),
+        });
+
+        redrawTextBoundingBox(textElement, nextArrow, this.scene);
+        updatedElementsById.set(nextArrow.id, nextArrow);
+        newTextByArrowId.set(latestArrow.id, textElement);
+      }
+
+      if (!updatedElementsById.size && !newTextByArrowId.size) {
+        this.setState({
+          errorMessage: "AI label suggestions produced no actionable changes",
+        });
+        return;
+      }
+
+      const nextElements = elements.flatMap((element) => {
+        const maybeUpdated = updatedElementsById.get(element.id) || element;
+        const maybeNewLabel = newTextByArrowId.get(element.id);
+        if (!maybeNewLabel) {
+          return [maybeUpdated];
+        }
+        return [maybeUpdated, maybeNewLabel];
+      });
+
+      this.updateScene({
+        elements: nextElements,
+        captureUpdate: CaptureUpdateAction.IMMEDIATELY,
+      });
+
+      this.setToast({
+        message: "Connector labels suggested",
+        closable: false,
+        duration: 1500,
+      });
+      trackEvent("ai", "smart-connector-labels (success)", "labels");
+    } catch (error: any) {
+      trackEvent("ai", "smart-connector-labels (failed)", "labels");
+      this.setState({
+        errorMessage: error?.message || "AI smart connector labels failed",
+      });
+    }
+  };
 
   public onMagicframeToolSelect = () => {
     const selectedElements = this.scene.getSelectedElements({

--- a/packages/excalidraw/components/CommandPalette/CommandPalette.tsx
+++ b/packages/excalidraw/components/CommandPalette/CommandPalette.tsx
@@ -16,6 +16,7 @@ import { actionToggleShapeSwitch } from "../../actions/actionToggleShapeSwitch";
 import { getShortcutKey } from "../../shortcut";
 
 import {
+  actionAISmartConnectorLabels,
   actionClearCanvas,
   actionLink,
   actionToggleSearchMenu,
@@ -577,6 +578,20 @@ function CommandPaletteInner({
                 tab: "text-to-diagram",
               },
             }));
+          },
+        },
+        {
+          label: "AI suggest connector labels",
+          category: DEFAULT_CATEGORIES.tools,
+          icon: brainIconThin,
+          viewMode: false,
+          predicate: () =>
+            actionManager.isActionEnabled(actionAISmartConnectorLabels),
+          perform: () => {
+            actionManager.executeAction(
+              actionAISmartConnectorLabels,
+              "commandPalette",
+            );
           },
         },
         {

--- a/packages/excalidraw/components/MobileToolBar.tsx
+++ b/packages/excalidraw/components/MobileToolBar.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from "react";
 import clsx from "clsx";
+import { isArrowElement } from "@excalidraw/element";
 
 import { KEYS, capitalizeString } from "@excalidraw/common";
 
@@ -34,6 +35,7 @@ import {
   LassoIcon,
   mermaidLogoIcon,
   MagicIcon,
+  brainIconThin,
 } from "./icons";
 
 import "./ToolIcon.scss";
@@ -459,6 +461,22 @@ export const MobileToolBar = ({
             Generate
           </div>
           {app.props.aiEnabled !== false && <TTDDialogTriggerTunnel.Out />}
+          {app.props.aiEnabled !== false &&
+            app.plugins.aiSmartConnectorLabels &&
+            app.scene
+              .getSelectedElements({
+                selectedElementIds: app.state.selectedElementIds,
+              })
+              .some(isArrowElement) && (
+              <DropdownMenu.Item
+                onSelect={() => app.onAISmartConnectorLabels()}
+                icon={brainIconThin}
+                data-testid="toolbar-ai-smart-connector-labels"
+                badge={<DropdownMenu.Item.Badge>AI</DropdownMenu.Item.Badge>}
+              >
+                AI suggest connector labels
+              </DropdownMenu.Item>
+            )}
           <DropdownMenu.Item
             onSelect={() => app.setOpenDialog({ name: "ttd", tab: "mermaid" })}
             icon={mermaidLogoIcon}

--- a/packages/excalidraw/index.tsx
+++ b/packages/excalidraw/index.tsx
@@ -379,6 +379,7 @@ export {
 } from "@excalidraw/utils/withinBounds";
 
 export { DiagramToCodePlugin } from "./components/DiagramToCodePlugin/DiagramToCodePlugin";
+export { AISmartConnectorLabelsPlugin } from "./components/AISmartConnectorLabelsPlugin/AISmartConnectorLabelsPlugin";
 export { getDataURL } from "./data/blob";
 export { isElementLink } from "@excalidraw/element";
 

--- a/packages/excalidraw/types.ts
+++ b/packages/excalidraw/types.ts
@@ -812,6 +812,7 @@ export type AppClassProperties = {
   setOpenDialog: App["setOpenDialog"];
   insertEmbeddableElement: App["insertEmbeddableElement"];
   onMagicframeToolSelect: App["onMagicframeToolSelect"];
+  onAISmartConnectorLabels: App["onAISmartConnectorLabels"];
   getName: App["getName"];
   dismissLinearEditor: App["dismissLinearEditor"];
   flowChartCreator: App["flowChartCreator"];
@@ -1047,6 +1048,17 @@ export type GenerateDiagramToCode = (props: {
   frame: ExcalidrawMagicFrameElement;
   children: readonly ExcalidrawElement[];
 }) => MaybePromise<{ html: string }>;
+
+export type GenerateAISmartConnectorLabels = (props: {
+  selectedArrows: readonly ExcalidrawLinearElement[];
+  allElements: readonly NonDeletedExcalidrawElement[];
+  appState: AppState;
+}) => MaybePromise<{
+  labels: readonly {
+    arrowId: ExcalidrawElement["id"];
+    text: string;
+  }[];
+}>;
 
 export type Offsets = Partial<{
   top: number;


### PR DESCRIPTION
## Summary
- add a new pluggable AI API, `AISmartConnectorLabelsPlugin`, that lets hosts suggest labels for selected connectors (arrows)
- introduce `AI suggest connector labels` as a first-class editor action, available from both the command palette and the Generate menus (desktop + mobile)
- apply suggestions safely by updating existing bound labels when present, or creating bound text labels when missing, while preserving arrow binding semantics
- wire the app runtime to a dedicated backend endpoint (`/v1/ai/smart-connector-labels`) with strict response validation and user-facing error handling

## Why this is valuable
Connector labels are one of the highest-friction readability gaps in diagrams: users draw flows quickly, but often leave arrows unlabeled or inconsistently labeled. This feature reduces that friction to a single action and improves communication quality without changing Excalidraw’s core drawing model.

## Design notes
- the AI behavior is **host-provided** via plugin (same architecture direction as existing AI integrations)
- only selected arrows are affected
- suggestions are validated (`arrowId`, non-empty text) before mutation
- scene updates are captured with `CaptureUpdateAction.IMMEDIATELY` to keep undo/redo behavior intuitive

## API contract
`AISmartConnectorLabelsPlugin` receives:
- `selectedArrows`: selected arrow elements
- `allElements`: non-deleted scene elements for context
- `appState`: app state context

It returns:
- `labels`: `[{ arrowId, text }]`

## Test plan
- [x] `yarn test:typecheck`
- [x] `yarn test:app packages/excalidraw/actions/actionAISmartConnectorLabels.test.tsx --watch=false`
- [x] `yarn test:app excalidraw-app/tests/MobileMenu.test.tsx packages/excalidraw/tests/MermaidToExcalidraw.test.tsx --watch=false`
