### PR TITLE
fix: snap to angle broken when pointer is over another element

### DIFF
--- a/packages/excalidraw/actions/actionFinalize.tsx
+++ b/packages/excalidraw/actions/actionFinalize.tsx
@@ -93,32 +93,62 @@ export const actionFinalize = register<FormData>({
             ? [element.points.length - 1] // New arrow creation
             : appState.selectedLinearElement.selectedPointsIndices;
 
+        const angleLocked = shouldRotateWithDiscreteAngle(event);
+
+        // When angleLocked (Shift held), handlePointerMove has already
+        // snapped the element's points to the discrete angle. Use those
+        // snapped points directly instead of the raw mouse position so
+        // that binding doesn't pull the endpoint to an element that is
+        // merely under the cursor rather than under the snapped endpoint.
+        const useSnappedPoints =
+          angleLocked && selectedPointsIndices.length === 1;
+
         const draggedPoints: PointsPositionUpdates =
           selectedPointsIndices.reduce((map, index) => {
             map.set(index, {
-              point: LinearElementEditor.pointFromAbsoluteCoords(
-                element,
-                pointFrom<GlobalPoint>(
-                  sceneCoords.x - linearElementEditor.pointerOffset.x,
-                  sceneCoords.y - linearElementEditor.pointerOffset.y,
-                ),
-                elementsMap,
-              ),
+              point: useSnappedPoints
+                ? element.points[index]
+                : LinearElementEditor.pointFromAbsoluteCoords(
+                    element,
+                    pointFrom<GlobalPoint>(
+                      sceneCoords.x - linearElementEditor.pointerOffset.x,
+                      sceneCoords.y - linearElementEditor.pointerOffset.y,
+                    ),
+                    elementsMap,
+                  ),
             });
 
             return map;
           }, new Map()) ?? new Map();
+
+        // Derive the effective scene pointer from the snapped endpoint so
+        // that the binding hit-test also uses the snapped position.
+        const snappedGlobalPoint = useSnappedPoints
+          ? LinearElementEditor.getPointAtIndexGlobalCoordinates(
+              element,
+              selectedPointsIndices[0],
+              elementsMap,
+            )
+          : null;
+
+        const bindingSceneX =
+          snappedGlobalPoint?.[0] ??
+          sceneCoords.x - linearElementEditor.pointerOffset.x;
+        const bindingSceneY =
+          snappedGlobalPoint?.[1] ??
+          sceneCoords.y - linearElementEditor.pointerOffset.y;
+
         bindOrUnbindBindingElement(
           element,
           draggedPoints,
-          sceneCoords.x - linearElementEditor.pointerOffset.x,
-          sceneCoords.y - linearElementEditor.pointerOffset.y,
+          bindingSceneX,
+          bindingSceneY,
           scene,
           appState,
           {
             newArrow,
             altKey: event.altKey,
-            angleLocked: shouldRotateWithDiscreteAngle(event),
+            angleLocked,
           },
         );
       } else if (isLineElement(element)) {


### PR DESCRIPTION
## Summary

Fixes #11223

When drawing an arrow with Shift held (discrete angle snap), releasing the mouse button over another element would ignore the angle snap and instead bind/move the endpoint to that element's outline.

## Root cause

In `actionFinalize`, `draggedPoints` and the binding scene-pointer were always derived from the **raw mouse position** (`sceneCoords`). By the time `actionFinalize` runs, `handlePointerMove` has already applied the discrete angle snap and updated `element.points` accordingly. But the finalize step re-ran binding logic against the cursor position — so if the cursor was over a bindable element, the endpoint would be pulled to its outline, breaking the snapped angle.

## Fix

https://github.com/user-attachments/assets/2a8be9c9-8f83-486d-a56d-995af51d4077

When `angleLocked` (Shift held) and a single endpoint is being dragged:
- Reuse the element's already-snapped local point (`element.poin- Reuse the element's already-snapped local point (`element.po- - Reuse the element's already-snapped local point (`element.poin- Reuseion so the hit-test runs ag- Reuse thenap- Reuse the element's already-snapped local point (`element.poin- Reuse the element's already-snapped local point (`element.po- - Reuse the element's already-snapped local point (`element.poin hold Shift, and draw an arrow that ends with its tip over the rectangle.
3. Release the mouse — the arrow should maintain its snapped angle and **not** snap to the rectangle's outline.
4. Repeat without Shift — binding to the rectangle should still work normally.