### PR TITLE
fix: Speculative fixes for arrow invariant failures

### DIFF
--- a/packages/element/src/binding.ts
+++ b/packages/element/src/binding.ts
@@ -734,12 +734,11 @@ const getBindingStrategyForDraggingBindingElementEndpoints_simple = (
     });
 
   // Handle outside-outside binding to the same element
-  if (otherBinding && otherBinding.elementId === hit?.id) {
-    invariant(
-      !opts?.newArrow || appState.selectedLinearElement?.initialState.origin,
-      "appState.selectedLinearElement.initialState.origin must be defined for new arrows",
-    );
-
+  if (
+    otherBinding &&
+    otherBinding.elementId === hit?.id &&
+    appState.selectedLinearElement?.initialState.origin
+  ) {
     return {
       start: {
         mode: "inside",

--- a/packages/element/src/binding.ts
+++ b/packages/element/src/binding.ts
@@ -737,7 +737,7 @@ const getBindingStrategyForDraggingBindingElementEndpoints_simple = (
   if (
     otherBinding &&
     otherBinding.elementId === hit?.id &&
-    appState.selectedLinearElement?.initialState.origin
+    (!opts?.newArrow || appState.selectedLinearElement?.initialState.origin)
   ) {
     return {
       start: {

--- a/packages/element/src/linearElementEditor.ts
+++ b/packages/element/src/linearElementEditor.ts
@@ -486,7 +486,7 @@ export class LinearElementEditor {
           selectedPointsIndices,
         )}) points(0..${
           element.points.length - 1
-        }) lastClickedPoint(${lastClickedPoint})`,
+        }) lastClickedPoint(${lastClickedPoint}) isElbowArrow: ${elbowed}`,
       );
 
       // Fall back to the actual last point as a last resort.

--- a/packages/element/src/linearElementEditor.ts
+++ b/packages/element/src/linearElementEditor.ts
@@ -2139,13 +2139,14 @@ const pointDraggingUpdates = (
 } => {
   const naiveDraggingPoints = new Map(
     selectedPointsIndices.map((pointIndex) => {
+      // NOTE: Avoid stale point index issue potentially caused by elbow
+      // arrows unpredictably changing the number of points during dragging
+      const point =
+        element.points[pointIndex] ?? element.points[element.points.length - 1];
       return [
         pointIndex,
         {
-          point: pointFrom<LocalPoint>(
-            element.points[pointIndex][0] + deltaX,
-            element.points[pointIndex][1] + deltaY,
-          ),
+          point: pointFrom<LocalPoint>(point[0] + deltaX, point[1] + deltaY),
           isDragging: true,
         },
       ];

--- a/packages/element/src/linearElementEditor.ts
+++ b/packages/element/src/linearElementEditor.ts
@@ -2141,8 +2141,7 @@ const pointDraggingUpdates = (
     selectedPointsIndices.map((pointIndex) => {
       // NOTE: Avoid stale point index issue potentially caused by elbow
       // arrows unpredictably changing the number of points during dragging
-      const point =
-        element.points[pointIndex] ?? element.points[element.points.length - 1];
+      const point = element.points[pointIndex] ?? element.points.at(-1);
       return [
         pointIndex,
         {

--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -10210,7 +10210,10 @@ class App extends React.Component<AppProps, AppState> {
           );
 
           let linearElementEditor = this.state.selectedLinearElement;
-          if (!linearElementEditor) {
+          if (
+            !linearElementEditor ||
+            linearElementEditor.initialState.lastClickedPoint < 0
+          ) {
             linearElementEditor = new LinearElementEditor(
               newElement,
               this.scene.getNonDeletedElementsMap(),

--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -10210,9 +10210,17 @@ class App extends React.Component<AppProps, AppState> {
           );
 
           let linearElementEditor = this.state.selectedLinearElement;
+          const isNewElement =
+            !linearElementEditor ||
+            linearElementEditor.elementId !== newElement.id;
+          const lastClickedPointOutOfBounds =
+            linearElementEditor &&
+            linearElementEditor.initialState.lastClickedPoint >= 0 &&
+            linearElementEditor.initialState.lastClickedPoint >= points.length;
           if (
             !linearElementEditor ||
-            linearElementEditor.initialState.lastClickedPoint < 0
+            isNewElement ||
+            lastClickedPointOutOfBounds
           ) {
             linearElementEditor = new LinearElementEditor(
               newElement,

--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -10211,10 +10211,10 @@ class App extends React.Component<AppProps, AppState> {
 
           let linearElementEditor = this.state.selectedLinearElement;
 
-          const newLinearEditorNeeded =
+          if (
             !linearElementEditor ||
-            linearElementEditor.elementId !== newElement.id;
-          if (!linearElementEditor || newLinearEditorNeeded) {
+            linearElementEditor.elementId !== newElement.id
+          ) {
             linearElementEditor = new LinearElementEditor(
               newElement,
               this.scene.getNonDeletedElementsMap(),
@@ -10223,8 +10223,9 @@ class App extends React.Component<AppProps, AppState> {
 
           const lastClickedPointOutOfBounds =
             linearElementEditor &&
-            linearElementEditor.initialState.lastClickedPoint >= 0 &&
-            linearElementEditor.initialState.lastClickedPoint < points.length;
+            (linearElementEditor.initialState.lastClickedPoint < 0 ||
+              linearElementEditor.initialState.lastClickedPoint >=
+                points.length);
           if (lastClickedPointOutOfBounds) {
             console.warn(
               "Last clicked point is out of bounds. Attempting to fix it.",

--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -10210,16 +10210,16 @@ class App extends React.Component<AppProps, AppState> {
           );
 
           let linearElementEditor = this.state.selectedLinearElement;
-          const isNewElement =
+          const newLinearEditorNeeded =
             !linearElementEditor ||
             linearElementEditor.elementId !== newElement.id;
           const lastClickedPointOutOfBounds =
             linearElementEditor &&
-            linearElementEditor.initialState.lastClickedPoint >= 0 &&
+            linearElementEditor.initialState.lastClickedPoint < 0 &&
             linearElementEditor.initialState.lastClickedPoint >= points.length;
           if (
             !linearElementEditor ||
-            isNewElement ||
+            newLinearEditorNeeded ||
             lastClickedPointOutOfBounds
           ) {
             linearElementEditor = new LinearElementEditor(

--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -10210,31 +10210,37 @@ class App extends React.Component<AppProps, AppState> {
           );
 
           let linearElementEditor = this.state.selectedLinearElement;
+
           const newLinearEditorNeeded =
             !linearElementEditor ||
             linearElementEditor.elementId !== newElement.id;
-          const lastClickedPointOutOfBounds =
-            linearElementEditor &&
-            linearElementEditor.initialState.lastClickedPoint < 0 &&
-            linearElementEditor.initialState.lastClickedPoint >= points.length;
-          if (
-            !linearElementEditor ||
-            newLinearEditorNeeded ||
-            lastClickedPointOutOfBounds
-          ) {
+          if (!linearElementEditor || newLinearEditorNeeded) {
             linearElementEditor = new LinearElementEditor(
               newElement,
               this.scene.getNonDeletedElementsMap(),
             );
+          }
+
+          const lastClickedPointOutOfBounds =
+            linearElementEditor &&
+            linearElementEditor.initialState.lastClickedPoint >= 0 &&
+            linearElementEditor.initialState.lastClickedPoint < points.length;
+          if (lastClickedPointOutOfBounds) {
+            console.warn(
+              "Last clicked point is out of bounds. Attempting to fix it.",
+            );
             linearElementEditor = {
               ...linearElementEditor,
-              selectedPointsIndices: [1],
+              selectedPointsIndices: [points.length - 1],
               initialState: {
                 ...linearElementEditor.initialState,
-                lastClickedPoint: 1,
+                prevSelectedPointsIndices: null,
+                lastClickedPoint: points.length - 1,
               },
+              hoverPointIndex: points.length - 1,
             };
           }
+
           this.setState({
             newElement,
             ...LinearElementEditor.handlePointDragging(


### PR DESCRIPTION
Attempting to handle invariant violations from Sentry regarding arrow dragging:
"There must be a valid lastClickedPoint in order to drag it."