### PR TITLE
[FIX] Dafault theme follow system preference instead of light theme

### DIFF
--- a/excalidraw-app/useHandleAppTheme.ts
+++ b/excalidraw-app/useHandleAppTheme.ts
@@ -15,10 +15,16 @@ export const useHandleAppTheme = () => {
       (localStorage.getItem(STORAGE_KEYS.LOCAL_STORAGE_THEME) as
         | Theme
         | "system"
-        | null) || THEME.LIGHT
+        | null) || "system"
     );
   });
-  const [editorTheme, setEditorTheme] = useState<Theme>(THEME.LIGHT);
+
+  const [editorTheme, setEditorTheme] = useState<Theme>(() => {
+    if (appTheme === "system") {
+      return getDarkThemeMediaQuery()?.matches ? THEME.DARK : THEME.LIGHT;
+    }
+    return appTheme as Theme;
+  });
 
   useEffect(() => {
     const mediaQuery = getDarkThemeMediaQuery();


### PR DESCRIPTION
Fixes: https://github.com/excalidraw/excalidraw/issues/11205
Previously, Excalidraw forced the light theme for first-time users, which caused a jarring bright flash for users who prefer dark mode.
To fix this, I made the following changes in excalidraw-app/useHandleAppTheme.ts:
Changed the localStorage fallback from "light" to "system" so it tracks the OS theme on the very first visit.
Updated the editorTheme initialization to check the prefers-color-scheme: dark media query synchronously on the first render. This ensures the app boots directly into dark mode without any initial bright flash.