### PR TITLE
feat: Default theme should follow system preference instead of light theme #11205

### DIFF
--- a/excalidraw-app/useHandleAppTheme.ts
+++ b/excalidraw-app/useHandleAppTheme.ts
@@ -9,16 +9,31 @@ import { STORAGE_KEYS } from "./app_constants";
 const getDarkThemeMediaQuery = (): MediaQueryList | undefined =>
   window.matchMedia?.("(prefers-color-scheme: dark)");
 
+const readStoredAppTheme = (): Theme | "system" | null => {
+  try {
+    return localStorage.getItem(STORAGE_KEYS.LOCAL_STORAGE_THEME) as
+      | Theme
+      | "system"
+      | null;
+  } catch {
+    return null;
+  }
+};
+
+const resolveEditorTheme = (stored: Theme | "system"): Theme => {
+  if (stored === "system") {
+    return getDarkThemeMediaQuery()?.matches ? THEME.DARK : THEME.LIGHT;
+  }
+  return stored;
+};
+
 export const useHandleAppTheme = () => {
   const [appTheme, setAppTheme] = useState<Theme | "system">(() => {
-    return (
-      (localStorage.getItem(STORAGE_KEYS.LOCAL_STORAGE_THEME) as
-        | Theme
-        | "system"
-        | null) || THEME.LIGHT
-    );
+    return readStoredAppTheme() || "system";
   });
-  const [editorTheme, setEditorTheme] = useState<Theme>(THEME.LIGHT);
+  const [editorTheme, setEditorTheme] = useState<Theme>(() =>
+    resolveEditorTheme(readStoredAppTheme() || "system"),
+  );
 
   useEffect(() => {
     const mediaQuery = getDarkThemeMediaQuery();

--- a/packages/excalidraw/appState.ts
+++ b/packages/excalidraw/appState.ts
@@ -19,13 +19,27 @@ const defaultExportScale = EXPORT_SCALES.includes(devicePixelRatio)
   ? devicePixelRatio
   : 1;
 
+/**
+ * Initial editor theme before any user preference is applied.
+ * Follows `prefers-color-scheme` in the browser; tests and non-browser
+ * environments default to light for stable output.
+ */
+export const getDefaultInitialTheme = (): AppState["theme"] => {
+  if (isTestEnv() || typeof window === "undefined") {
+    return THEME.LIGHT;
+  }
+  return window.matchMedia?.("(prefers-color-scheme: dark)")?.matches
+    ? THEME.DARK
+    : THEME.LIGHT;
+};
+
 export const getDefaultAppState = (): Omit<
   AppState,
   "offsetTop" | "offsetLeft" | "width" | "height"
 > => {
   return {
     showWelcomeScreen: false,
-    theme: THEME.LIGHT,
+    theme: getDefaultInitialTheme(),
     collaborators: new Map(),
     currentItemBackgroundColor: DEFAULT_ELEMENT_PROPS.backgroundColor,
     currentItemEndArrowhead: "arrow",

--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -345,6 +345,7 @@ import { trackEvent } from "../analytics";
 import { AnimationFrameHandler } from "../animation-frame-handler";
 import {
   getDefaultAppState,
+  getDefaultInitialTheme,
   isEraserActive,
   isHandToolActive,
 } from "../appState";
@@ -2758,7 +2759,9 @@ class App extends React.Component<AppProps, AppState> {
       let viewModeEnabled = actionResult?.appState?.viewModeEnabled || false;
       let zenModeEnabled = actionResult?.appState?.zenModeEnabled || false;
       const theme =
-        actionResult?.appState?.theme || this.props.theme || THEME.LIGHT;
+        actionResult?.appState?.theme ||
+        this.props.theme ||
+        getDefaultInitialTheme();
       const name = actionResult?.appState?.name ?? this.state.name;
       const errorMessage =
         actionResult?.appState?.errorMessage ?? this.state.errorMessage;


### PR DESCRIPTION
Closes #11205 

### What this is about
New visitors were always starting in light mode until something else kicked in. If your OS/browser is set to dark, that meant a bright canvas for a moment and an extra step to get things feeling right. The issue asked for respecting system preference from the start, including treating “no saved choice yet” like system mode.

### What I changed
Web app (excalidraw-app)
We fixed the theme hook so it doesn’t “think” light on the first paint and then correct itself. If there’s nothing in localStorage for the theme key, we default to system instead of light, and we set the resolved editor theme (light vs dark) from prefers-color-scheme right in the initial state, not only after layout effects. That removes the flash for dark-mode users and matches the product expectation: first visit = follow the OS unless you’ve already picked something.
localStorage reads are wrapped in try/catch so weird storage failures don’t blow up the hook.

### Library (packages/excalidraw)
Default app state no longer hard-codes light. We added a small helper that picks light vs dark from prefers-color-scheme in real browsers, but keeps light in tests and anywhere there’s no window (so tests and Node-style usage stay predictable). The same helper is used where the app was falling back to light after actions, so behavior stays consistent.

### What I didn’t do
We didn’t add a third value to core AppState.theme (still light/dark). The app continues to store "system" in its own storage and passes the resolved theme into the editor; the package just picks a sensible first paint when no host passes theme.

### How to check
Clear excalidraw-theme (or use a fresh profile), set OS to dark, reload: you should land in dark immediately, no white flash.
Toggle system / light / dark in the menu; keyboard shortcut and persistence should behave as before.
Embedded <Excalidraw /> without a theme prop should open matching the OS on first load (not forced light).

Light default on MacOS
<img width="1469" height="995" alt="light" src="https://github.com/user-attachments/assets/9edfbd83-fb1c-407e-9b9c-864f8c493661" />

Dark default on MacOS
<img width="1482" height="971" alt="dark" src="https://github.com/user-attachments/assets/0971dc49-a93c-4dfe-8902-5a87f46a1e91" />
