### PR TITLE
Add SVG title support for export name

### DIFF
--- a/packages/excalidraw/scene/export.ts
+++ b/packages/excalidraw/scene/export.ts
@@ -306,6 +306,7 @@ export const exportToSvg = async (
     exportingFrame?: ExcalidrawFrameLikeElement | null;
     skipInliningFonts?: true;
     reuseImages?: boolean;
+    name?: string;
   },
 ): Promise<SVGSVGElement> => {
   const frameRendering = getFrameRenderingConfig(
@@ -351,6 +352,17 @@ export const exportToSvg = async (
   svgRoot.setAttribute("version", "1.1");
   svgRoot.setAttribute("xmlns", SVG_NS);
   svgRoot.setAttribute("viewBox", `0 0 ${width} ${height}`);
+
+  // Add title for accessibility and GitHub searchability
+  if (opts?.name) {
+    const titleElement = svgRoot.ownerDocument.createElementNS(
+      SVG_NS,
+      "title",
+    );
+    titleElement.textContent = opts.name;
+    svgRoot.insertBefore(titleElement, svgRoot.firstChild);
+  }
+
   svgRoot.setAttribute("width", `${width * exportScale}`);
   svgRoot.setAttribute("height", `${height * exportScale}`);
 


### PR DESCRIPTION
Adds a <title> element to exported SVGs when an export name is provided.

This improves accessibility and allows SVG exports to carry meaningful metadata.

Changes:
- Inserts <title> as first child of SVG root
- Uses opts.name when available
- No changes to rendering logic or export behavior

Closes #8301 