### PR TITLE
fix: frame selection and membership

### DIFF
--- a/packages/element/src/frame.ts
+++ b/packages/element/src/frame.ts
@@ -19,6 +19,7 @@ import {
   getElementAbsoluteCoords,
   doBoundsIntersect,
   getElementBounds,
+  boundsContainBounds,
 } from "./bounds";
 import { mutateElement } from "./mutateElement";
 import { getBoundTextElement, getContainerElement } from "./textElement";
@@ -101,8 +102,9 @@ export const isElementContainingFrame = (
   frame: ExcalidrawFrameLikeElement,
   elementsMap: ElementsMap,
 ) => {
-  return getElementsWithinSelection([frame], element, elementsMap).some(
-    (e) => e.id === frame.id,
+  return boundsContainBounds(
+    getElementBounds(element, elementsMap),
+    getElementBounds(frame, elementsMap),
   );
 };
 

--- a/packages/element/src/selection.ts
+++ b/packages/element/src/selection.ts
@@ -34,7 +34,6 @@ import {
   elementOverlapsWithFrame,
   getContainingFrame,
   getFrameChildren,
-  isElementIntersectingFrame,
 } from "./frame";
 
 import { LinearElementEditor } from "./linearElementEditor";
@@ -170,7 +169,7 @@ export const getElementsWithinSelection = (
     const associatedFrame = getContainingFrame(element, elementsMap);
     if (
       associatedFrame &&
-      isElementIntersectingFrame(element, associatedFrame, elementsMap)
+      elementOverlapsWithFrame(element, associatedFrame, elementsMap)
     ) {
       const frameAABB = getElementBounds(associatedFrame, elementsMap);
       elementAABB = [
@@ -209,10 +208,9 @@ export const getElementsWithinSelection = (
     if (boundsContainBounds(selectionBounds, commonAABB)) {
       if (framesInSelection && isFrameLikeElement(element)) {
         framesInSelection.add(element.id);
-      } else {
-        elementsInSelection.push(element);
-        continue;
       }
+      elementsInSelection.push(element);
+      continue;
     }
 
     // 2. Handle the case where the label is overlapped by the selection box

--- a/packages/element/tests/frame.test.tsx
+++ b/packages/element/tests/frame.test.tsx
@@ -2,6 +2,7 @@ import {
   convertToExcalidrawElements,
   Excalidraw,
 } from "@excalidraw/excalidraw";
+import { arrayToMap } from "@excalidraw/common";
 
 import { API } from "@excalidraw/excalidraw/tests/helpers/api";
 import { Keyboard, Pointer } from "@excalidraw/excalidraw/tests/helpers/ui";
@@ -10,7 +11,12 @@ import {
   render,
 } from "@excalidraw/excalidraw/tests/test-utils";
 
-import type { ExcalidrawElement } from "../src/types";
+import { elementOverlapsWithFrame } from "../src/frame";
+
+import type {
+  ExcalidrawElement,
+  ExcalidrawFrameLikeElement,
+} from "../src/types";
 
 const { h } = window;
 const mouse = new Pointer("mouse");
@@ -123,6 +129,26 @@ describe("adding elements to frames", () => {
       x: 100,
       boundElements: [{ id: text.id, type: "text" }],
     });
+  });
+
+  it("should treat an element fully containing a frame as overlapping the frame", () => {
+    const containingRect = API.createElement({
+      type: "rectangle",
+      x: -50,
+      y: -50,
+      width: 250,
+      height: 250,
+    });
+
+    API.setElements([containingRect, frame]);
+
+    expect(
+      elementOverlapsWithFrame(
+        containingRect,
+        frame as ExcalidrawFrameLikeElement,
+        arrayToMap(h.elements),
+      ),
+    ).toBe(true);
   });
 
   const commonTestCases = async (
@@ -414,6 +440,22 @@ describe("adding elements to frames", () => {
 
   describe("dragging elements into the frame", async () => {
     await commonTestCases(dragElementIntoFrame);
+
+    it("should add a dragged element fully containing the frame", () => {
+      const containingRect = API.createElement({
+        type: "rectangle",
+        x: 220,
+        y: 20,
+        width: 300,
+        height: 300,
+      });
+
+      API.setElements([frame, containingRect]);
+
+      dragElementIntoFrame(frame, containingRect);
+
+      expect(API.getElement(containingRect).frameId).toBe(frame.id);
+    });
 
     it.skip("should drag element inside, duplicate it and keep it in frame", () => {
       API.setElements([frame, rect2]);

--- a/packages/excalidraw/tests/selection.test.tsx
+++ b/packages/excalidraw/tests/selection.test.tsx
@@ -615,6 +615,32 @@ describe("box-selection overlap mode", () => {
 
     assertSelectedElements([]);
   });
+
+  it("should not select a framed element when selection only overlaps its clipped-out outline", () => {
+    const frame = API.createElement({
+      type: "frame",
+      x: 100,
+      y: 100,
+      width: 100,
+      height: 100,
+    });
+    const rect1 = API.createElement({
+      type: "rectangle",
+      x: 50,
+      y: 50,
+      width: 200,
+      height: 200,
+      frameId: frame.id,
+      backgroundColor: "red",
+      fillStyle: "solid",
+    });
+
+    API.setElements([frame, rect1]);
+
+    boxSelect(40, 170, 70, 220);
+
+    assertSelectedElements([]);
+  });
 });
 
 describe("inner box-selection", () => {


### PR DESCRIPTION
fixes two cases:

1. elements fully containing the frame cannot be added as frame children
2. overlap selection allowed selecting such an element even by its clipped part