### PR TITLE
docs: add Vitest testing and coverage guide for contributors

### DIFF
--- a/dev-docs/docs/codebase/testing.md
+++ b/dev-docs/docs/codebase/testing.md
@@ -1,0 +1,63 @@
+# Testing and Coverage Guide
+
+This guide explains how to run tests and verify code coverage within the Excalidraw monorepo using **Vitest**.
+
+## Transition to Vitest
+
+Excalidraw has migrated from Jest to **Vitest**. All new contributions should be verified using the Vitest runner.
+
+## Running Tests
+
+To run tests locally, first ensure you have installed dependencies with:
+
+```bash
+yarn install
+```
+
+### Running specific tests
+
+To avoid running the entire suite, you can target a specific file:
+
+```bash
+yarn test packages/common/tests/your-file.test.ts
+```
+
+## Coverage Guidelines
+
+New utilities and shared logic should have adequate test coverage for new or modified code.
+Running global coverage checks can fail due to unrelated files affecting thresholds.
+
+### Single-file Coverage (Recommended)
+
+To verify coverage only for the files affected by a change, use coverage filtering options provided by the Vitest test configuration in the monorepo:
+
+```bash
+yarn test --coverage <path-to-test-file> --coverage.include <path-to-source-file>
+```
+
+Example:
+
+```bash
+yarn test --coverage packages/common/src/utils.test.ts \
+  --coverage.include packages/common/src/utils.ts
+```
+
+This approach ensures coverage requirements are evaluated only for the modified code without being blocked by global thresholds.
+
+## Common Issues
+
+**Environment Errors**  
+
+If you encounter an error such as:
+
+```bash
+jest-environment-jsdom cannot be found
+```
+
+It is likely that tests are being executed with Jest instead of Vitest. Always use yarn test to invoke the correct test environment.
+
+**Node Version**  
+
+The Excalidraw monorepo requires Node.js 20 or later. Older versions may cause test failures or unexpected behavior.
+
+This guide focuses on practical workflows for contributors and is intended to complement existing documentation.


### PR DESCRIPTION
Resolves #11481

### Overview
I realized while working on my last fix that it's a bit tricky to figure out the new Vitest setup, especially with the JSDOM errors. I wanted to put everything I learned in one place so the next person doesn't have to waste time debugging their environment.  It covers how to run specific tests and, more importantly,  how to check coverage for just your changes without hitting those global errors that can be really frustrating in a monorepo.

### Why I’m adding this
Since the project moved to Vitest, it’s not always obvious which commands to use. I noticed a few common points of confusion:
- Trying to use npx jest (the old way) leads to environment crashes.
- Running tests for the whole repo is slow when you just want to check one file.
- It’s hard to tell if your specific code meets the coverage requirements because the global report is so huge.

### What's inside
I’ve consolidated the workflow into a single guide in the dev-docs folder:
- **The right commands**: Clear instructions on using yarn test instead of deprecated test commands or runners.
- **Speed tips**: How to target specific files so you get a faster feedback loop.
- **Coverage "Hack"**: A tutorial on using the --coverage.include flag to see your own logic's coverage clearly.
- **Troubleshooting**: Quick fixes for Node version issues and JSDOM errors.

### Impact
The goal is to make onboarding a lot smoother. If a new contributor can catch test failures or coverage gaps on their own machine in seconds, it saves the maintaners from having to leave comments or failed CI runs.

### Notes
This is a documentation-only change and does not affect runtime behavior.