### PR TITLE
fix(clipboard): await copy before delete in cut action to prevent data loss

### DIFF
--- a/packages/excalidraw/actions/actionClipboard.tsx
+++ b/packages/excalidraw/actions/actionClipboard.tsx
@@ -114,8 +114,18 @@ export const actionCut = register<ClipboardEvent | null>({
   label: "labels.cut",
   icon: cutIcon,
   trackEvent: { category: "element" },
-  perform: (elements, appState, event, app) => {
-    actionCopy.perform(elements, appState, event, app);
+  perform: async (elements, appState, event, app) => {
+    const copyResult = await actionCopy.perform(elements, appState, event, app);
+
+    // if copy failed, abort the cut so we don't lose data
+    if (
+      copyResult &&
+      typeof copyResult === "object" &&
+      copyResult.appState?.errorMessage
+    ) {
+      return copyResult;
+    }
+
     return actionDeleteSelected.perform(elements, appState, null, app);
   },
   keyTest: (event) => event[KEYS.CTRL_OR_CMD] && event.key === KEYS.X,


### PR DESCRIPTION
Fixes #11262.

`actionCut.perform` calls async `actionCopy.perform` without awaiting it, then immediately deletes elements. If the clipboard write fails, elements are gone but the clipboard is empty - silent data loss.

Awaited the copy result and only delete if copy succeeded. On failure, error is surfaced and elements are preserved. Reproduced by blocking all 3 clipboard fallback methods (navigator.clipboard.write, writeText, document.execCommand). All 465 existing tests pass.