### PR TITLE
Default theme should follow system preference instead of light theme

### DIFF
--- a/excalidraw-app/useHandleAppTheme.ts
+++ b/excalidraw-app/useHandleAppTheme.ts
@@ -54,17 +54,20 @@ export const useHandleAppTheme = () => {
     };
   }, [appTheme, editorTheme, setAppTheme]);
 
-  useLayoutEffect(() => {
-    localStorage.setItem(STORAGE_KEYS.LOCAL_STORAGE_THEME, appTheme);
+  const resolveTheme = (theme: Theme | "system"): Theme => {
+  if (theme === "system") {
+    return getDarkThemeMediaQuery()?.matches
+      ? THEME.DARK
+      : THEME.LIGHT;
+  }
+  return theme;
+};
 
-    if (appTheme === "system") {
-      setEditorTheme(
-        getDarkThemeMediaQuery()?.matches ? THEME.DARK : THEME.LIGHT,
-      );
-    } else {
-      setEditorTheme(appTheme);
-    }
-  }, [appTheme]);
+useLayoutEffect(() => {
+  localStorage.setItem(STORAGE_KEYS.LOCAL_STORAGE_THEME, appTheme);
+
+  setEditorTheme(resolveTheme(appTheme));
+}, [appTheme]);
 
   return { editorTheme, appTheme, setAppTheme };
 };


### PR DESCRIPTION
This PR refactors the theme handling logic in useHandleAppTheme to improve clarity and reduce duplicated logic.
Changes:
Introduced a resolveTheme helper function to centralize theme resolution logic
Simplified useLayoutEffect by delegating theme resolution to the helper
Preserved existing behavior for light, dark, and system themes
Why:
Improves code readability and makes theme resolution easier to maintain, especially when handling system preference changes.