### PR TITLE
feat: add *.minimaxi.com to web embed whitelist

### DIFF
--- a/packages/element/src/embeddable.ts
+++ b/packages/element/src/embeddable.ts
@@ -147,6 +147,7 @@ const ALLOWED_DOMAINS = new Set([
   "giphy.com",
   "reddit.com",
   "forms.microsoft.com",
+  "*.minimaxi.com",
 ]);
 
 const ALLOW_SAME_ORIGIN = new Set([
@@ -162,6 +163,7 @@ const ALLOW_SAME_ORIGIN = new Set([
   "stackblitz.com",
   "reddit.com",
   "forms.microsoft.com",
+  "*.minimaxi.com",
 ]);
 
 export const createSrcDoc = (body: string) => {

--- a/packages/element/tests/embeddable.test.ts
+++ b/packages/element/tests/embeddable.test.ts
@@ -230,4 +230,10 @@ describe("Google Drive video embedding", () => {
       ),
     ).toBe(true);
   });
+
+  it("should validate minimaxi.com subdomains", () => {
+    expect(
+      embeddableURLValidator("https://example.minimaxi.com/slides", undefined),
+    ).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary

Adds `*.minimaxi.com` to the web embed domain whitelist, enabling users to embed interactive slides from minimaxi.com subdomains in Excalidraw and Excalicord.

## Changes

- Added `"*.minimaxi.com"` to `ALLOWED_DOMAINS` in `packages/element/src/embeddable.ts`
- Added `"*.minimaxi.com"` to `ALLOW_SAME_ORIGIN` (consistent with other interactive embed providers)
- Added test case for minimaxi.com subdomain validation

## Test plan

- All 15 existing embeddable tests pass
- New test verifies that `https://example.minimaxi.com/slides` passes `embeddableURLValidator`

## Related

- Fixes #11239