### PR TITLE
refactor: add generic point types to math package

### DIFF
--- a/packages/math/src/angle.ts
+++ b/packages/math/src/angle.ts
@@ -1,12 +1,6 @@
 import { PRECISION } from "./utils";
 
-import type {
-  Degrees,
-  GlobalPoint,
-  LocalPoint,
-  PolarCoords,
-  Radians,
-} from "./types";
+import type { Degrees, GenericPoint, PolarCoords, Radians } from "./types";
 
 export const normalizeRadians = (angle: Radians): Radians =>
   angle < 0
@@ -18,7 +12,7 @@ export const normalizeRadians = (angle: Radians): Radians =>
  * (x, y) for the center point 0,0 where the first number returned is the radius,
  * the second is the angle in radians.
  */
-export const cartesian2Polar = <P extends GlobalPoint | LocalPoint>([
+export const cartesian2Polar = <P extends GenericPoint>([
   x,
   y,
 ]: P): PolarCoords => [

--- a/packages/math/src/curve.ts
+++ b/packages/math/src/curve.ts
@@ -2,7 +2,13 @@ import { isPoint, pointDistance, pointFrom, pointFromVector } from "./point";
 import { vector, vectorNormal, vectorNormalize, vectorScale } from "./vector";
 import { LegendreGaussN24CValues, LegendreGaussN24TValues } from "./constants";
 
-import type { Curve, GlobalPoint, LineSegment, LocalPoint } from "./types";
+import type {
+  Curve,
+  GenericPoint,
+  GlobalPoint,
+  LineSegment,
+  LocalPoint,
+} from "./types";
 
 /**
  *
@@ -12,7 +18,7 @@ import type { Curve, GlobalPoint, LineSegment, LocalPoint } from "./types";
  * @param d
  * @returns
  */
-export function curve<Point extends GlobalPoint | LocalPoint>(
+export function curve<Point extends GenericPoint = GlobalPoint | LocalPoint>(
   a: Point,
   b: Point,
   c: Point,
@@ -21,7 +27,7 @@ export function curve<Point extends GlobalPoint | LocalPoint>(
   return [a, b, c, d] as Curve<Point>;
 }
 
-function solveWithAnalyticalJacobian<Point extends GlobalPoint | LocalPoint>(
+function solveWithAnalyticalJacobian<Point extends GenericPoint>(
   curve: Curve<Point>,
   lineSegment: LineSegment<Point>,
   t0: number,
@@ -112,7 +118,7 @@ function solveWithAnalyticalJacobian<Point extends GlobalPoint | LocalPoint>(
   return [t0, s0];
 }
 
-export const bezierEquation = <Point extends GlobalPoint | LocalPoint>(
+export const bezierEquation = <Point extends GenericPoint>(
   c: Curve<Point>,
   t: number,
 ) =>
@@ -133,7 +139,7 @@ const initial_guesses: [number, number][] = [
   [0.8, 0],
 ];
 
-const calculate = <Point extends GlobalPoint | LocalPoint>(
+const calculate = <Point extends GenericPoint>(
   [t0, s0]: [number, number],
   l: LineSegment<Point>,
   c: Curve<Point>,
@@ -165,9 +171,7 @@ const calculate = <Point extends GlobalPoint | LocalPoint>(
 /**
  * Computes the intersection between a cubic spline and a line segment.
  */
-export function curveIntersectLineSegment<
-  Point extends GlobalPoint | LocalPoint,
->(
+export function curveIntersectLineSegment<Point extends GenericPoint>(
   c: Curve<Point>,
   l: LineSegment<Point>,
   opts?: {
@@ -224,7 +228,7 @@ export function curveIntersectLineSegment<
  * @param maxLevel
  * @returns
  */
-export function curveClosestPoint<Point extends GlobalPoint | LocalPoint>(
+export function curveClosestPoint<Point extends GenericPoint>(
   c: Curve<Point>,
   p: Point,
   tolerance: number = 1e-3,
@@ -281,7 +285,7 @@ export function curveClosestPoint<Point extends GlobalPoint | LocalPoint>(
  * @param c The curve to test
  * @param p The point to measure from
  */
-export function curvePointDistance<Point extends GlobalPoint | LocalPoint>(
+export function curvePointDistance<Point extends GenericPoint>(
   c: Curve<Point>,
   p: Point,
 ) {
@@ -297,7 +301,7 @@ export function curvePointDistance<Point extends GlobalPoint | LocalPoint>(
 /**
  * Determines if the parameter is a Curve
  */
-export function isCurve<P extends GlobalPoint | LocalPoint>(
+export function isCurve<P extends GenericPoint = GlobalPoint | LocalPoint>(
   v: unknown,
 ): v is Curve<P> {
   return (
@@ -310,7 +314,7 @@ export function isCurve<P extends GlobalPoint | LocalPoint>(
   );
 }
 
-export function curveTangent<Point extends GlobalPoint | LocalPoint>(
+export function curveTangent<Point extends GenericPoint>(
   [p0, p1, p2, p3]: Curve<Point>,
   t: number,
 ) {
@@ -355,9 +359,10 @@ export function curveCatmullRomQuadraticApproxPoints(
   return pointSets;
 }
 
-export function curveCatmullRomCubicApproxPoints<
-  Point extends GlobalPoint | LocalPoint,
->(points: Point[], tension = 0.5) {
+export function curveCatmullRomCubicApproxPoints<Point extends GenericPoint>(
+  points: Point[],
+  tension = 0.5,
+) {
   if (points.length < 2) {
     return;
   }
@@ -377,10 +382,10 @@ export function curveCatmullRomCubicApproxPoints<
 
     pointSets.push(
       curve(
-        pointFrom(p1[0], p1[1]),
-        pointFrom(cp1x, cp1y),
-        pointFrom(cp2x, cp2y),
-        pointFrom(p2[0], p2[1]),
+        pointFrom<Point>(p1[0], p1[1]),
+        pointFrom<Point>(cp1x, cp1y),
+        pointFrom<Point>(cp2x, cp2y),
+        pointFrom<Point>(p2[0], p2[1]),
       ),
     );
   }
@@ -444,9 +449,7 @@ export function offsetPointsForQuadraticBezier(
  * @param c The curve to calculate the length of
  * @returns The approximated length of the curve
  */
-export function curveLength<P extends GlobalPoint | LocalPoint>(
-  c: Curve<P>,
-): number {
+export function curveLength<P extends GenericPoint>(c: Curve<P>): number {
   const z2 = 0.5;
   let sum = 0;
 
@@ -471,7 +474,7 @@ export function curveLength<P extends GlobalPoint | LocalPoint>(
  * @param t The parameter value (0 to 1) to calculate length up to
  * @returns The length of the curve from beginning to parameter t
  */
-export function curveLengthAtParameter<P extends GlobalPoint | LocalPoint>(
+export function curveLengthAtParameter<P extends GenericPoint>(
   c: Curve<P>,
   t: number,
 ): number {
@@ -510,7 +513,7 @@ export function curveLengthAtParameter<P extends GlobalPoint | LocalPoint>(
  * @param percent A value between 0 and 1 representing the percentage of the curve's length
  * @returns The point at the specified percentage of curve length
  */
-export function curvePointAtLength<P extends GlobalPoint | LocalPoint>(
+export function curvePointAtLength<P extends GenericPoint>(
   c: Curve<P>,
   percent: number,
 ): P {

--- a/packages/math/src/ellipse.ts
+++ b/packages/math/src/ellipse.ts
@@ -13,13 +13,7 @@ import {
   vectorScale,
 } from "./vector";
 
-import type {
-  Ellipse,
-  GlobalPoint,
-  Line,
-  LineSegment,
-  LocalPoint,
-} from "./types";
+import type { Ellipse, GenericPoint, Line, LineSegment } from "./types";
 
 /**
  * Construct an Ellipse object from the parameters
@@ -30,7 +24,7 @@ import type {
  * @param halfHeight Half of the height of a non-slanted version of the ellipse
  * @returns The constructed Ellipse object
  */
-export function ellipse<Point extends GlobalPoint | LocalPoint>(
+export function ellipse<Point extends GenericPoint>(
   center: Point,
   halfWidth: number,
   halfHeight: number,
@@ -49,7 +43,7 @@ export function ellipse<Point extends GlobalPoint | LocalPoint>(
  * @param ellipse The ellipse to compare against
  * @returns TRUE if the point is inside or on the outline of the ellipse
  */
-export const ellipseIncludesPoint = <Point extends GlobalPoint | LocalPoint>(
+export const ellipseIncludesPoint = <Point extends GenericPoint>(
   p: Point,
   ellipse: Ellipse<Point>,
 ) => {
@@ -69,7 +63,7 @@ export const ellipseIncludesPoint = <Point extends GlobalPoint | LocalPoint>(
  * @param threshold The distance to consider a point close enough to be "on" the outline
  * @returns TRUE if the point is on the ellise outline
  */
-export const ellipseTouchesPoint = <Point extends GlobalPoint | LocalPoint>(
+export const ellipseTouchesPoint = <Point extends GenericPoint>(
   point: Point,
   ellipse: Ellipse<Point>,
   threshold = PRECISION,
@@ -85,9 +79,7 @@ export const ellipseTouchesPoint = <Point extends GlobalPoint | LocalPoint>(
  * @param ellipse The ellipse to calculate the distance to
  * @returns The eucledian distance
  */
-export const ellipseDistanceFromPoint = <
-  Point extends GlobalPoint | LocalPoint,
->(
+export const ellipseDistanceFromPoint = <Point extends GenericPoint>(
   p: Point,
   ellipse: Ellipse<Point>,
 ): number => {
@@ -133,16 +125,20 @@ export const ellipseDistanceFromPoint = <
     b * ty * Math.sign(translatedPoint[1]),
   ];
 
-  return pointDistance(pointFromVector(translatedPoint), pointFrom(minX, minY));
+  return pointDistance(
+    pointFromVector<Point>(translatedPoint),
+    pointFrom<Point>(minX, minY),
+  );
 };
 
 /**
  * Calculate a maximum of two intercept points for a line going throug an
  * ellipse.
  */
-export function ellipseSegmentInterceptPoints<
-  Point extends GlobalPoint | LocalPoint,
->(e: Readonly<Ellipse<Point>>, s: Readonly<LineSegment<Point>>): Point[] {
+export function ellipseSegmentInterceptPoints<Point extends GenericPoint>(
+  e: Readonly<Ellipse<Point>>,
+  s: Readonly<LineSegment<Point>>,
+): Point[] {
   const rx = e.halfWidth;
   const ry = e.halfHeight;
 
@@ -164,7 +160,7 @@ export function ellipseSegmentInterceptPoints<
 
     if (0 <= t_a && t_a <= 1) {
       intersections.push(
-        pointFrom(
+        pointFrom<Point>(
           s[0][0] + (s[1][0] - s[0][0]) * t_a,
           s[0][1] + (s[1][1] - s[0][1]) * t_a,
         ),
@@ -173,7 +169,7 @@ export function ellipseSegmentInterceptPoints<
 
     if (0 <= t_b && t_b <= 1) {
       intersections.push(
-        pointFrom(
+        pointFrom<Point>(
           s[0][0] + (s[1][0] - s[0][0]) * t_b,
           s[0][1] + (s[1][1] - s[0][1]) * t_b,
         ),
@@ -183,7 +179,7 @@ export function ellipseSegmentInterceptPoints<
     const t = -b / a;
     if (0 <= t && t <= 1) {
       intersections.push(
-        pointFrom(
+        pointFrom<Point>(
           s[0][0] + (s[1][0] - s[0][0]) * t,
           s[0][1] + (s[1][1] - s[0][1]) * t,
         ),
@@ -194,9 +190,7 @@ export function ellipseSegmentInterceptPoints<
   return intersections;
 }
 
-export function ellipseLineIntersectionPoints<
-  Point extends GlobalPoint | LocalPoint,
->(
+export function ellipseLineIntersectionPoints<Point extends GenericPoint>(
   { center, halfWidth, halfHeight }: Ellipse<Point>,
   [g, h]: Line<Point>,
 ): Point[] {

--- a/packages/math/src/line.ts
+++ b/packages/math/src/line.ts
@@ -1,6 +1,6 @@
 import { pointFrom } from "./point";
 
-import type { GlobalPoint, Line, LocalPoint } from "./types";
+import type { GenericPoint, GlobalPoint, Line, LocalPoint } from "./types";
 
 /**
  * Create a line from two points.
@@ -8,7 +8,10 @@ import type { GlobalPoint, Line, LocalPoint } from "./types";
  * @param points The two points lying on the line
  * @returns The line on which the points lie
  */
-export function line<P extends GlobalPoint | LocalPoint>(a: P, b: P): Line<P> {
+export function line<P extends GenericPoint = GlobalPoint | LocalPoint>(
+  a: P,
+  b: P,
+): Line<P> {
   return [a, b] as Line<P>;
 }
 
@@ -20,7 +23,7 @@ export function line<P extends GlobalPoint | LocalPoint>(a: P, b: P): Line<P> {
  * @param b
  * @returns
  */
-export function linesIntersectAt<Point extends GlobalPoint | LocalPoint>(
+export function linesIntersectAt<Point extends GenericPoint>(
   a: Line<Point>,
   b: Line<Point>,
 ): Point | null {

--- a/packages/math/src/point.ts
+++ b/packages/math/src/point.ts
@@ -3,8 +3,9 @@ import { PRECISION } from "./utils";
 import { vectorFromPoint, vectorScale } from "./vector";
 
 import type {
-  LocalPoint,
+  GenericPoint,
   GlobalPoint,
+  LocalPoint,
   Radians,
   Degrees,
   Vector,
@@ -19,23 +20,20 @@ import type {
  * @param y The Y coordinate
  * @returns The branded and created point
  */
-export function pointFrom<Point extends GlobalPoint | LocalPoint>(
-  x: number,
-  y: number,
-): Point;
+export function pointFrom<
+  Point extends GenericPoint = GlobalPoint | LocalPoint,
+>(x: number, y: number): Point;
 // TODO remove the overload once we migrate to using Point tuples everywhere
 export function pointFrom<Coord extends GlobalCoord | LocalCoord>(
   coords: Coord,
 ): Coord extends GlobalCoord ? GlobalPoint : LocalPoint;
 // TODO remove the overload once we migrate to using Point tuples everywhere
-export function pointFrom<Point extends GlobalPoint | LocalPoint>(coords: {
-  x: number;
-  y: number;
-}): Point;
-export function pointFrom<Point extends GlobalPoint | LocalPoint>(
-  xOrCoords: number | { x: number; y: number },
-  y?: number,
-): Point {
+export function pointFrom<
+  Point extends GenericPoint = GlobalPoint | LocalPoint,
+>(coords: { x: number; y: number }): Point;
+export function pointFrom<
+  Point extends GenericPoint = GlobalPoint | LocalPoint,
+>(xOrCoords: number | { x: number; y: number }, y?: number): Point {
   return typeof xOrCoords === "object"
     ? ([xOrCoords.x, xOrCoords.y] as Point)
     : ([xOrCoords, y!] as Point);
@@ -47,9 +45,9 @@ export function pointFrom<Point extends GlobalPoint | LocalPoint>(
  * @param numberArray The number array to check and to convert to Point
  * @returns The point instance
  */
-export function pointFromArray<Point extends GlobalPoint | LocalPoint>(
-  numberArray: number[],
-): Point | undefined {
+export function pointFromArray<
+  Point extends GenericPoint = GlobalPoint | LocalPoint,
+>(numberArray: number[]): Point | undefined {
   return numberArray.length === 2
     ? pointFrom<Point>(numberArray[0], numberArray[1])
     : undefined;
@@ -61,9 +59,9 @@ export function pointFromArray<Point extends GlobalPoint | LocalPoint>(
  * @param pair A number pair to convert to Point
  * @returns The point instance
  */
-export function pointFromPair<Point extends GlobalPoint | LocalPoint>(
-  pair: [number, number],
-): Point {
+export function pointFromPair<
+  Point extends GenericPoint = GlobalPoint | LocalPoint,
+>(pair: [number, number]): Point {
   return pair as Point;
 }
 
@@ -73,10 +71,9 @@ export function pointFromPair<Point extends GlobalPoint | LocalPoint>(
  * @param v The vector to convert
  * @returns The point the vector points at with origin 0,0
  */
-export function pointFromVector<P extends GlobalPoint | LocalPoint>(
-  v: Vector,
-  offset: P = pointFrom(0, 0),
-): P {
+export function pointFromVector<
+  P extends GenericPoint = GlobalPoint | LocalPoint,
+>(v: Vector, offset: P = pointFrom<P>(0, 0)): P {
   return pointFrom<P>(offset[0] + v[0], offset[1] + v[1]);
 }
 
@@ -84,9 +81,9 @@ export function pointFromVector<P extends GlobalPoint | LocalPoint>(
  * Checks if the provided value has the shape of a Point.
  *
  * @param p The value to attempt verification on
- * @returns TRUE if the provided value has the shape of a local or global point
+ * @returns TRUE if the provided value has the shape of a point
  */
-export function isPoint(p: unknown): p is LocalPoint | GlobalPoint {
+export function isPoint(p: unknown): p is GenericPoint {
   return (
     Array.isArray(p) &&
     p.length === 2 &&
@@ -105,7 +102,7 @@ export function isPoint(p: unknown): p is LocalPoint | GlobalPoint {
  * @param b Point The second point to compare
  * @returns TRUE if the points are sufficiently close to each other
  */
-export function pointsEqual<Point extends GlobalPoint | LocalPoint>(
+export function pointsEqual<Point extends GenericPoint>(
   a: Point,
   b: Point,
   tolerance: number = PRECISION,
@@ -122,7 +119,7 @@ export function pointsEqual<Point extends GlobalPoint | LocalPoint>(
  * @param angle The radians to rotate the point by
  * @returns The rotated point
  */
-export function pointRotateRads<Point extends GlobalPoint | LocalPoint>(
+export function pointRotateRads<Point extends GenericPoint>(
   point: Point,
   center: Point,
   angle: Radians,
@@ -132,7 +129,7 @@ export function pointRotateRads<Point extends GlobalPoint | LocalPoint>(
   }
   const [x, y] = point;
   const [cx, cy] = center;
-  return pointFrom(
+  return pointFrom<Point>(
     (x - cx) * Math.cos(angle) - (y - cy) * Math.sin(angle) + cx,
     (x - cx) * Math.sin(angle) + (y - cy) * Math.cos(angle) + cy,
   );
@@ -146,7 +143,7 @@ export function pointRotateRads<Point extends GlobalPoint | LocalPoint>(
  * @param angle The degree to rotate the point by
  * @returns The rotated point
  */
-export function pointRotateDegs<Point extends GlobalPoint | LocalPoint>(
+export function pointRotateDegs<Point extends GenericPoint>(
   point: Point,
   center: Point,
   angle: Degrees,
@@ -168,10 +165,10 @@ export function pointRotateDegs<Point extends GlobalPoint | LocalPoint>(
  */
 // TODO 99% of use is translating between global and local coords, which need to be formalized
 export function pointTranslate<
-  From extends GlobalPoint | LocalPoint,
-  To extends GlobalPoint | LocalPoint,
+  From extends GenericPoint,
+  To extends GenericPoint,
 >(p: From, v: Vector = [0, 0] as Vector): To {
-  return pointFrom(p[0] + v[0], p[1] + v[1]);
+  return pointFrom<To>(p[0] + v[0], p[1] + v[1]);
 }
 
 /**
@@ -181,8 +178,8 @@ export function pointTranslate<
  * @param b The other point to create the middle point for
  * @returns The middle point
  */
-export function pointCenter<P extends LocalPoint | GlobalPoint>(a: P, b: P): P {
-  return pointFrom((a[0] + b[0]) / 2, (a[1] + b[1]) / 2);
+export function pointCenter<P extends GenericPoint>(a: P, b: P): P {
+  return pointFrom<P>((a[0] + b[0]) / 2, (a[1] + b[1]) / 2);
 }
 
 /**
@@ -192,10 +189,7 @@ export function pointCenter<P extends LocalPoint | GlobalPoint>(a: P, b: P): P {
  * @param b Second point
  * @returns The euclidean distance between the two points.
  */
-export function pointDistance<P extends LocalPoint | GlobalPoint>(
-  a: P,
-  b: P,
-): number {
+export function pointDistance<P extends GenericPoint>(a: P, b: P): number {
   return Math.hypot(b[0] - a[0], b[1] - a[1]);
 }
 
@@ -208,10 +202,7 @@ export function pointDistance<P extends LocalPoint | GlobalPoint>(
  * @param b Second point
  * @returns The euclidean distance between the two points.
  */
-export function pointDistanceSq<P extends LocalPoint | GlobalPoint>(
-  a: P,
-  b: P,
-): number {
+export function pointDistanceSq<P extends GenericPoint>(a: P, b: P): number {
   const xDiff = b[0] - a[0];
   const yDiff = b[1] - a[1];
 
@@ -226,11 +217,12 @@ export function pointDistanceSq<P extends LocalPoint | GlobalPoint>(
  * @param multiplier The scaling factor
  * @returns
  */
-export const pointScaleFromOrigin = <P extends GlobalPoint | LocalPoint>(
+export const pointScaleFromOrigin = <P extends GenericPoint>(
   p: P,
   mid: P,
   multiplier: number,
-) => pointTranslate(mid, vectorScale(vectorFromPoint(p, mid), multiplier));
+): P =>
+  pointTranslate<P, P>(mid, vectorScale(vectorFromPoint(p, mid), multiplier));
 
 /**
  * Returns whether `q` lies inside the segment/rectangle defined by `p` and `r`.
@@ -241,7 +233,7 @@ export const pointScaleFromOrigin = <P extends GlobalPoint | LocalPoint>(
  * @param r The other point to compare against
  * @returns TRUE if q is indeed between p and r
  */
-export const isPointWithinBounds = <P extends GlobalPoint | LocalPoint>(
+export const isPointWithinBounds = <P extends GenericPoint>(
   p: P,
   q: P,
   r: P,

--- a/packages/math/src/polygon.ts
+++ b/packages/math/src/polygon.ts
@@ -2,21 +2,21 @@ import { pointsEqual } from "./point";
 import { lineSegment, pointOnLineSegment } from "./segment";
 import { PRECISION } from "./utils";
 
-import type { GlobalPoint, LocalPoint, Polygon } from "./types";
+import type { GenericPoint, GlobalPoint, LocalPoint, Polygon } from "./types";
 
-export function polygon<Point extends GlobalPoint | LocalPoint>(
+export function polygon<Point extends GenericPoint = GlobalPoint | LocalPoint>(
   ...points: Point[]
 ) {
   return polygonClose(points) as Polygon<Point>;
 }
 
-export function polygonFromPoints<Point extends GlobalPoint | LocalPoint>(
-  points: Point[],
-) {
+export function polygonFromPoints<
+  Point extends GenericPoint = GlobalPoint | LocalPoint,
+>(points: Point[]) {
   return polygonClose(points) as Polygon<Point>;
 }
 
-export const polygonIncludesPoint = <Point extends LocalPoint | GlobalPoint>(
+export const polygonIncludesPoint = <Point extends GenericPoint>(
   point: Point,
   polygon: Polygon<Point>,
 ) => {
@@ -69,7 +69,7 @@ export const polygonIncludesPointNonZero = <Point extends [number, number]>(
   return windingNumber !== 0;
 };
 
-export const pointOnPolygon = <Point extends LocalPoint | GlobalPoint>(
+export const pointOnPolygon = <Point extends GenericPoint>(
   p: Point,
   poly: Polygon<Point>,
   threshold = PRECISION,
@@ -86,16 +86,12 @@ export const pointOnPolygon = <Point extends LocalPoint | GlobalPoint>(
   return on;
 };
 
-function polygonClose<Point extends LocalPoint | GlobalPoint>(
-  polygon: Point[],
-) {
+function polygonClose<Point extends GenericPoint>(polygon: Point[]) {
   return polygonIsClosed(polygon)
     ? polygon
     : ([...polygon, polygon[0]] as Polygon<Point>);
 }
 
-function polygonIsClosed<Point extends LocalPoint | GlobalPoint>(
-  polygon: Point[],
-) {
+function polygonIsClosed<Point extends GenericPoint>(polygon: Point[]) {
   return pointsEqual(polygon[0], polygon[polygon.length - 1]);
 }

--- a/packages/math/src/rectangle.ts
+++ b/packages/math/src/rectangle.ts
@@ -1,37 +1,42 @@
 import { pointFrom } from "./point";
 import { lineSegment, lineSegmentIntersectionPoints } from "./segment";
 
-import type { GlobalPoint, LineSegment, LocalPoint, Rectangle } from "./types";
+import type { GenericPoint, LineSegment, Rectangle } from "./types";
 
-export function rectangle<P extends GlobalPoint | LocalPoint>(
+export function rectangle<P extends GenericPoint>(
   topLeft: P,
   bottomRight: P,
 ): Rectangle<P> {
   return [topLeft, bottomRight] as Rectangle<P>;
 }
 
-export function rectangleFromNumberSequence<
-  Point extends LocalPoint | GlobalPoint,
->(minX: number, minY: number, maxX: number, maxY: number) {
+export function rectangleFromNumberSequence<Point extends GenericPoint>(
+  minX: number,
+  minY: number,
+  maxX: number,
+  maxY: number,
+) {
   return rectangle(pointFrom<Point>(minX, minY), pointFrom<Point>(maxX, maxY));
 }
 
-export function rectangleIntersectLineSegment<
-  Point extends LocalPoint | GlobalPoint,
->(r: Rectangle<Point>, l: LineSegment<Point>): Point[] {
+export function rectangleIntersectLineSegment<Point extends GenericPoint>(
+  r: Rectangle<Point>,
+  l: LineSegment<Point>,
+): Point[] {
   return [
-    lineSegment(r[0], pointFrom(r[1][0], r[0][1])),
-    lineSegment(pointFrom(r[1][0], r[0][1]), r[1]),
-    lineSegment(r[1], pointFrom(r[0][0], r[1][1])),
-    lineSegment(pointFrom(r[0][0], r[1][1]), r[0]),
+    lineSegment(r[0], pointFrom<Point>(r[1][0], r[0][1])),
+    lineSegment(pointFrom<Point>(r[1][0], r[0][1]), r[1]),
+    lineSegment(r[1], pointFrom<Point>(r[0][0], r[1][1])),
+    lineSegment(pointFrom<Point>(r[0][0], r[1][1]), r[0]),
   ]
     .map((s) => lineSegmentIntersectionPoints(l, s))
     .filter((i): i is Point => !!i);
 }
 
-export function rectangleIntersectRectangle<
-  Point extends LocalPoint | GlobalPoint,
->(rectangle1: Rectangle<Point>, rectangle2: Rectangle<Point>): boolean {
+export function rectangleIntersectRectangle<Point extends GenericPoint>(
+  rectangle1: Rectangle<Point>,
+  rectangle2: Rectangle<Point>,
+): boolean {
   const [[minX1, minY1], [maxX1, maxY1]] = rectangle1;
   const [[minX2, minY2], [maxX2, maxY2]] = rectangle2;
 

--- a/packages/math/src/segment.ts
+++ b/packages/math/src/segment.ts
@@ -14,7 +14,13 @@ import {
   vectorSubtract,
 } from "./vector";
 
-import type { GlobalPoint, LineSegment, LocalPoint, Radians } from "./types";
+import type {
+  GenericPoint,
+  GlobalPoint,
+  LineSegment,
+  LocalPoint,
+  Radians,
+} from "./types";
 
 /**
  * Create a line segment from two points.
@@ -22,7 +28,7 @@ import type { GlobalPoint, LineSegment, LocalPoint, Radians } from "./types";
  * @param points The two points delimiting the line segment on each end
  * @returns The line segment delineated by the points
  */
-export function lineSegment<P extends GlobalPoint | LocalPoint>(
+export function lineSegment<P extends GenericPoint = GlobalPoint | LocalPoint>(
   a: P,
   b: P,
 ): LineSegment<P> {
@@ -34,7 +40,9 @@ export function lineSegment<P extends GlobalPoint | LocalPoint>(
  * @param segment
  * @returns
  */
-export const isLineSegment = <Point extends GlobalPoint | LocalPoint>(
+export const isLineSegment = <
+  Point extends GenericPoint = GlobalPoint | LocalPoint,
+>(
   segment: unknown,
 ): segment is LineSegment<Point> =>
   Array.isArray(segment) &&
@@ -51,7 +59,7 @@ export const isLineSegment = <Point extends GlobalPoint | LocalPoint>(
  * @param origin
  * @returns
  */
-export const lineSegmentRotate = <Point extends LocalPoint | GlobalPoint>(
+export const lineSegmentRotate = <Point extends GenericPoint>(
   l: LineSegment<Point>,
   angle: Radians,
   origin?: Point,
@@ -66,7 +74,7 @@ export const lineSegmentRotate = <Point extends LocalPoint | GlobalPoint>(
  * Calculates the point two line segments with a definite start and end point
  * intersect at.
  */
-export const segmentsIntersectAt = <Point extends GlobalPoint | LocalPoint>(
+export const segmentsIntersectAt = <Point extends GenericPoint>(
   a: Readonly<LineSegment<Point>>,
   b: Readonly<LineSegment<Point>>,
 ): Point | null => {
@@ -99,7 +107,7 @@ export const segmentsIntersectAt = <Point extends GlobalPoint | LocalPoint>(
   return null;
 };
 
-export const pointOnLineSegment = <Point extends LocalPoint | GlobalPoint>(
+export const pointOnLineSegment = <Point extends GenericPoint>(
   point: Point,
   line: LineSegment<Point>,
   threshold = PRECISION,
@@ -113,7 +121,7 @@ export const pointOnLineSegment = <Point extends LocalPoint | GlobalPoint>(
   return distance < threshold;
 };
 
-export const distanceToLineSegment = <Point extends LocalPoint | GlobalPoint>(
+export const distanceToLineSegment = <Point extends GenericPoint>(
   point: Point,
   line: LineSegment<Point>,
 ) => {
@@ -158,9 +166,7 @@ export const distanceToLineSegment = <Point extends LocalPoint | GlobalPoint>(
  * @param s
  * @returns
  */
-export function lineSegmentIntersectionPoints<
-  Point extends GlobalPoint | LocalPoint,
->(
+export function lineSegmentIntersectionPoints<Point extends GenericPoint>(
   l: LineSegment<Point>,
   s: LineSegment<Point>,
   threshold?: number,
@@ -178,7 +184,7 @@ export function lineSegmentIntersectionPoints<
   return candidate;
 }
 
-export function lineSegmentsDistance<Point extends GlobalPoint | LocalPoint>(
+export function lineSegmentsDistance<Point extends GenericPoint>(
   s1: LineSegment<Point>,
   s2: LineSegment<Point>,
 ): number {

--- a/packages/math/src/triangle.ts
+++ b/packages/math/src/triangle.ts
@@ -1,4 +1,4 @@
-import type { GlobalPoint, LocalPoint, Triangle } from "./types";
+import type { GenericPoint, Triangle } from "./types";
 
 // Types
 
@@ -11,7 +11,7 @@ import type { GlobalPoint, LocalPoint, Triangle } from "./types";
  * @param p The point to test whether is in the triangle
  * @returns TRUE if the point is inside of the triangle
  */
-export function triangleIncludesPoint<P extends GlobalPoint | LocalPoint>(
+export function triangleIncludesPoint<P extends GenericPoint>(
   [a, b, c]: Triangle<P>,
   p: P,
 ): boolean {

--- a/packages/math/src/types.ts
+++ b/packages/math/src/types.ts
@@ -54,6 +54,16 @@ export type LocalPoint = [x: number, y: number] & {
 };
 
 /**
+ * Represents a 2D position in viewport/client space. A
+ * viewport coordinate.
+ */
+export type ViewportPoint = [x: number, y: number] & {
+  _brand: "excalimath__viewportpoint";
+};
+
+export type GenericPoint = GlobalPoint | LocalPoint | ViewportPoint;
+
+/**
  * Represents a 2D position in whatever local space it's needed.
  * A local coordinate.
  *
@@ -68,7 +78,7 @@ export type LocalCoord = { x: number; y: number } & {
 /**
  * A line is an infinitely long object with no width, depth, or curvature.
  */
-export type Line<P extends GlobalPoint | LocalPoint> = [p: P, q: P] & {
+export type Line<P extends GenericPoint> = [p: P, q: P] & {
   _brand: "excalimath_line";
 };
 
@@ -77,7 +87,7 @@ export type Line<P extends GlobalPoint | LocalPoint> = [p: P, q: P] & {
  * line that is bounded by two distinct end points, and
  * contains every point on the line that is between its endpoints.
  */
-export type LineSegment<P extends GlobalPoint | LocalPoint> = [a: P, b: P] & {
+export type LineSegment<P extends GenericPoint> = [a: P, b: P] & {
   _brand: "excalimath_linesegment";
 };
 
@@ -97,18 +107,14 @@ export type Vector = [u: number, v: number] & {
 /**
  * A triangle represented by 3 points
  */
-export type Triangle<P extends GlobalPoint | LocalPoint> = [
-  a: P,
-  b: P,
-  c: P,
-] & {
+export type Triangle<P extends GenericPoint> = [a: P, b: P, c: P] & {
   _brand: "excalimath__triangle";
 };
 
 /**
  * A rectangular shape represented by 4 points at its corners
  */
-export type Rectangle<P extends GlobalPoint | LocalPoint> = [a: P, b: P] & {
+export type Rectangle<P extends GenericPoint> = [a: P, b: P] & {
   _brand: "excalimath__rectangle";
 };
 
@@ -120,7 +126,7 @@ export type Rectangle<P extends GlobalPoint | LocalPoint> = [a: P, b: P] & {
  * A polygon is a closed shape by connecting the given points
  * rectangles and diamonds are modelled by polygons
  */
-export type Polygon<Point extends GlobalPoint | LocalPoint> = Point[] & {
+export type Polygon<Point extends GenericPoint> = Point[] & {
   _brand: "excalimath_polygon";
 };
 
@@ -131,12 +137,7 @@ export type Polygon<Point extends GlobalPoint | LocalPoint> = Point[] & {
 /**
  * Cubic bezier curve with four control points
  */
-export type Curve<Point extends GlobalPoint | LocalPoint> = [
-  Point,
-  Point,
-  Point,
-  Point,
-] & {
+export type Curve<Point extends GenericPoint> = [Point, Point, Point, Point] & {
   _brand: "excalimath_curve";
 };
 
@@ -151,7 +152,7 @@ export type PolarCoords = [
   but for the sake of simplicity, we've used halfWidth and halfHeight instead
   in replace of semi major and semi minor axes
  */
-export type Ellipse<Point extends GlobalPoint | LocalPoint> = {
+export type Ellipse<Point extends GenericPoint> = {
   center: Point;
   halfWidth: number;
   halfHeight: number;

--- a/packages/math/src/vector.ts
+++ b/packages/math/src/vector.ts
@@ -1,4 +1,4 @@
-import type { GlobalPoint, LocalPoint, Vector } from "./types";
+import type { GenericPoint, Vector } from "./types";
 
 /**
  * Create a vector from the x and y coordiante elements.
@@ -25,7 +25,7 @@ export function vector(
  * @param defaultValue The default value to return if the vector is 'undefined'
  * @returns The created vector from the point and the origin or default
  */
-export function vectorFromPoint<Point extends GlobalPoint | LocalPoint>(
+export function vectorFromPoint<Point extends GenericPoint>(
   p: Point,
   origin: Point = [0, 0] as Point,
   threshold?: number,


### PR DESCRIPTION
## Summary

- add `ViewportPoint` and `GenericPoint` to `@excalidraw/math`
- update math package point-based helpers and geometry types to use `GenericPoint` constraints
- keep existing call sites compatible by defaulting generic helpers to the previous `GlobalPoint | LocalPoint` behavior

Part of #9297.

## Checks

- `tsc -p .\packages\math\tsconfig.json`
- `tsc -p .\tsconfig.json`
