### PR TITLE
feat: add Cursor agent safety hooks for env, destructive git, and rm -rf

### DIFF
--- a/.cursor/hooks.json
+++ b/.cursor/hooks.json
@@ -1,0 +1,18 @@
+{
+  "version": 1,
+  "hooks": {
+    "beforeReadFile": [
+      {
+        "command": ".cursor/hooks/block-env.sh",
+        "matcher": "\\.env",
+        "failClosed": true
+      }
+    ],
+    "beforeShellExecution": [
+      {
+        "command": ".cursor/hooks/block-destructive.sh",
+        "failClosed": true
+      }
+    ]
+  }
+}

--- a/.cursor/hooks/block-destructive.sh
+++ b/.cursor/hooks/block-destructive.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+input=$(cat)
+cmd=$(echo "$input" | jq -r '.command // ""')
+
+# Destructive git commands
+if echo "$cmd" | grep -qE 'git push.*(--force|-f)( |$)|git reset --hard|git branch -D|git clean -fd'; then
+  echo '{"permission":"deny","reason":"Blocked: destructive git command.","user_message":"I was about to run a destructive git command but a safety hook blocked it. Please confirm explicitly if you want to proceed: `'"$cmd"'`"}'
+  exit 0
+fi
+
+# rm -rf: allow only known safe build artifact paths (matched by basename)
+if echo "$cmd" | grep -qE 'rm -[rRfF]*f[rRfF]*|-[rRfF]*r[rRfF]*'; then
+  # Use awk to extract path arguments: skip argv[0] (rm) and any flag tokens (start with -)
+  paths=$(echo "$cmd" | awk '{for(i=2;i<=NF;i++) if(substr($i,1,1)!="-") print $i}')
+
+  all_allowed=true
+  while IFS= read -r p; do
+    [ -z "$p" ] && continue
+    base=$(basename "$p")
+    case "$base" in
+      node_modules|dist|build|.cache|.next|coverage|tmp) ;;
+      *) all_allowed=false; break ;;
+    esac
+  done <<< "$paths"
+
+  if [ "$all_allowed" = false ]; then
+    echo '{"permission":"deny","reason":"Blocked: rm -rf against a non-allowlisted path.","user_message":"I tried to run `'"$cmd"'` but a safety hook blocked it. Only these basenames are allowlisted for rm -rf: node_modules, dist, build, .cache, .next, coverage, tmp. Ask me explicitly if you really want this."}'
+    exit 0
+  fi
+fi
+
+echo '{"permission":"allow"}'
+exit 0

--- a/.cursor/hooks/block-env.sh
+++ b/.cursor/hooks/block-env.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+read -r input
+echo '{"permission":"deny","reason":"Blocked: .env files contain secrets and must not be read by agents.","user_message":"I tried to read an .env file but a safety hook blocked it — these files may contain secrets (API keys, tokens, credentials). If you need specific config values, please share them manually."}'
+exit 0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,5 @@
 # Contributing
 
 Head over to the [docs](https://docs.excalidraw.com/docs/introduction/contributing)
+
+<!-- hook demo: added this line -->


### PR DESCRIPTION
## Summary

- Adds `beforeReadFile` hook to block agents from reading `.env*` files (secrets protection)
- Adds `beforeShellExecution` hook to block destructive git commands (`--force` push, `reset --hard`, `branch -D`, `clean -fd`)
- Adds `rm -rf` guard that allows only safe build artifact paths (`node_modules`, `dist`, `build`, `.cache`, `.next`, `coverage`, `tmp`) and blocks everything else

## Test plan

- [ ] Ask agent to read `.env` or `.env.development` — hook should deny with a message about secrets
- [ ] Ask agent to run `git reset --hard` or `git push --force` — hook should deny
- [ ] Ask agent to `rm -rf dist` — should pass through
- [ ] Ask agent to `rm -rf packages` — should be blocked

Made with [Cursor](https://cursor.com)