### PR TITLE
fix: prevent tool flickering when holding shortcut key

### DIFF
--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -5042,6 +5042,7 @@ class App extends React.Component<AppProps, AppState> {
 
       if (
         !shouldPreventToolSwitching &&
+        !event.repeat &&
         !event.ctrlKey &&
         !event.altKey &&
         !event.metaKey &&


### PR DESCRIPTION
## Summary

When a user holds down a tool shortcut key (like H for hand tool), the keydown event fires repeatedly due to key repeat. This caused the tool to rapidly switch between the current tool and the new tool, making it impossible to use the temporary tool switch feature.

## Changes

Added check for `event.repeat` to skip tool switching on repeated keydown events, allowing the tool to remain stable while the key is held down.

Fixes #10855

## Test plan

- [ ] Select any tool (e.g., selection tool with V)
- [ ] Hold down H key to temporarily switch to hand tool
- [ ] Verify the tool stays on hand tool while H is held (no flickering)
- [ ] Release H key and verify tool returns to previous tool
- [ ] Test with other tool shortcuts (R, D, O, A, L, P, T, E, K)