### PR TITLE
fix(editor): prevent duplicate lasso toolbar item

### DIFF
--- a/packages/excalidraw/components/shapes.tsx
+++ b/packages/excalidraw/components/shapes.tsx
@@ -119,15 +119,12 @@ export const SHAPES = [
 export const getToolbarTools = (app: AppClassProperties) => {
   return app.state.preferredSelectionTool.type === "lasso"
     ? ([
+        SHAPES[0],
         {
+          ...SHAPES[1],
           value: "lasso",
-          icon: SelectionIcon,
-          key: KEYS.V,
-          numericKey: KEYS["1"],
-          fillable: true,
-          toolbar: true,
         },
-        ...SHAPES.slice(1),
+        ...SHAPES.slice(2),
       ] as const)
     : SHAPES;
 };

--- a/packages/excalidraw/tests/tool.test.tsx
+++ b/packages/excalidraw/tests/tool.test.tsx
@@ -4,10 +4,12 @@ import { resolvablePromise } from "@excalidraw/common";
 
 import { Excalidraw } from "../index";
 
+import { getToolbarTools } from "../components/shapes";
+
 import { Pointer } from "./helpers/ui";
 import { act, render } from "./test-utils";
 
-import type { ExcalidrawImperativeAPI } from "../types";
+import type { AppClassProperties, ExcalidrawImperativeAPI } from "../types";
 
 describe("setActiveTool()", () => {
   const h = window.h;
@@ -64,5 +66,29 @@ describe("setActiveTool()", () => {
     });
     expect(h.state.activeTool.type).toBe("custom");
     expect(h.state.activeTool.customType).toBe("comment");
+  });
+});
+describe("getToolbarTools()", () => {
+  const getToolValues = (preferredSelectionTool: "selection" | "lasso") =>
+    getToolbarTools({
+      state: {
+        preferredSelectionTool: {
+          type: preferredSelectionTool,
+        },
+      },
+    } as AppClassProperties).map((tool) => tool.value);
+
+  it("does not include lasso when selection is preferred", () => {
+    const toolValues = getToolValues("selection");
+
+    expect(toolValues.filter((value) => value === "selection")).toHaveLength(1);
+    expect(toolValues.filter((value) => value === "lasso")).toHaveLength(0);
+  });
+
+  it("replaces selection with lasso when lasso is preferred", () => {
+    const toolValues = getToolValues("lasso");
+
+    expect(toolValues.filter((value) => value === "lasso")).toHaveLength(1);
+    expect(toolValues.filter((value) => value === "selection")).toHaveLength(0);
   });
 });


### PR DESCRIPTION
Fixes #11281

## Summary

This fixes the duplicate lasso icon that could appear in the toolbar after switching between Selection and Lasso selection.

The issue was in `getToolbarTools()`. When lasso was the preferred selection tool, the toolbar was adding lasso as a new item but still keeping the normal selection item. This meant both tools could appear in the toolbar at the same time.

This PR changes that behavior so lasso replaces the selection slot instead of being added as an extra toolbar item.

## Testing

- Manually verified the issue at around 722px width.
- Confirmed that switching Selection → Lasso selection → Selection no longer leaves a duplicate lasso icon.
- Ran `yarn vitest run packages/excalidraw/tests/tool.test.tsx`
- Ran `yarn test:typecheck`
- Ran `yarn test:code`