### PR TITLE
feat: inline math calculator for text elements

### DIFF
--- a/packages/excalidraw/wysiwyg/textWysiwyg.tsx
+++ b/packages/excalidraw/wysiwyg/textWysiwyg.tsx
@@ -622,6 +622,56 @@ export const textWysiwyg = ({
         editable.selectionStart = selectionStart;
         editable.selectionEnd = selectionStart;
       }
+
+      // --- 🪄 MAGIC MATH AUTO-SOLVER (V2) ---
+      const box = editable as any; // Fixed TypeScript strictness
+      const currentText = box.value;
+
+      // 1. Fix the Backspace Bug: Only solve if we are ADDING text, not deleting
+      const isDeleting = box._lastLength && currentText.length < box._lastLength;
+      box._lastLength = currentText.length;
+
+      if (!isDeleting && currentText.endsWith('=')) { // Fixed capital 'W' typo
+        // 2. Expand filter to allow letters, commas, and power symbols (^)
+        const match = currentText.match(/([a-zA-Z0-9+\-*/(). \t^,]+)=$/);
+
+        if (match && match[1].trim() !== '') {
+          try {
+            // 3. Translate human math to Computer math
+            // 3. Translate human math to Computer math
+            let equation = match[1]
+              .toLowerCase()
+              // 🌟 NEW: Capture the number inside () and convert Degrees to Radians!
+              .replace(/sin\(([^)]+)\)/g, 'Math.sin(($1) * Math.PI / 180)')
+              .replace(/cos\(([^)]+)\)/g, 'Math.cos(($1) * Math.PI / 180)')
+              .replace(/tan\(([^)]+)\)/g, 'Math.tan(($1) * Math.PI / 180)')
+              // Standard math functions
+              .replace(/sqrt\(/g, 'Math.sqrt(')
+              .replace(/log\(/g, 'Math.log(')
+              .replace(/pi/g, 'Math.PI')
+              .replace(/\^/g, '**'); // Turns 2^3 into 2**3 for JS
+
+            // Calculate the answer
+            let result = new Function(`return ${equation}`)();
+
+            // Round to 4 decimal places to fix weird computer math
+            if (typeof result === 'number') {
+              result = Math.round(result * 10000) / 10000;
+            }
+
+            // If valid, inject the answer!
+            if (result !== undefined && !isNaN(result)) {
+              box.value = currentText + result;
+              // Update length memory so we don't accidentally trigger the deleting bug
+              box._lastLength = box.value.length;
+            }
+          } catch (e) {
+            // Ignore incomplete or broken math silently
+          }
+        }
+      }
+      // --------------------------------------
+
       onChange(editable.value);
     };
   }


### PR DESCRIPTION
### Summary
This PR adds an inline calculator to the text tool. It allows users to evaluate simple mathematical expressions directly within a text element.

### Changes
- Added logic to detect math patterns (e.g., `5 + 5 =`).
- Implemented an evaluator that appends the result to the text.
- Ensured it doesn't trigger during normal typing or for non-mathematical text.

### Related Issue
Closes #9627  <!-- Replace with the actual issue number if different -->

### Demo
https://www.loom.com/share/f82584cceabe4906999dd11a0d5e0ab5