### PR TITLE
fix(app): resolve app-jotai import path in LocalData

### DIFF
--- a/excalidraw-app/data/LocalData.ts
+++ b/excalidraw-app/data/LocalData.ts
@@ -26,7 +26,6 @@ import {
   get,
 } from "idb-keyval";
 
-import { appJotaiStore, atom } from "excalidraw-app/app-jotai";
 import { getNonDeletedElements } from "@excalidraw/element";
 
 import type { LibraryPersistedData } from "@excalidraw/excalidraw/data/library";
@@ -39,6 +38,7 @@ import type {
 } from "@excalidraw/excalidraw/types";
 import type { MaybePromise } from "@excalidraw/common/utility-types";
 
+import { appJotaiStore, atom } from "../app-jotai";
 import { SAVE_TO_LOCAL_STORAGE_TIMEOUT, STORAGE_KEYS } from "../app_constants";
 
 import { FileManager } from "./FileManager";


### PR DESCRIPTION
LocalData.ts imported "excalidraw-app/app-jotai", which Vitest/Vite do not resolve (no alias). Switched to ../app-jotai like the rest of the app. Fixes failing excalidraw-app tests and avoids flaky package tests stuck in isLoading.

