### PR TITLE
 feat(search): improve canvas search result handling and localization:  [issue-11092](https://github.com/excalidraw/excalidraw/issues/11092)

### DIFF
--- a/packages/excalidraw/components/SearchMenu.scss
+++ b/packages/excalidraw/components/SearchMenu.scss
@@ -2,10 +2,20 @@
 
 .excalidraw {
   .layer-ui__search {
-    flex: 1 0 auto;
+    flex: 1 1 auto;
+    min-height: 0;
     display: flex;
     flex-direction: column;
     padding: 8px 0 0 0;
+  }
+
+  .layer-ui__search-results-scroll {
+    flex: 1 1 0;
+    min-height: 0;
+    overflow-x: hidden;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
   }
 
   .layer-ui__search-header {
@@ -60,8 +70,7 @@
   }
 
   .layer-ui__search-result-container {
-    overflow-y: auto;
-    flex: 1 1 0;
+    flex: 0 0 auto;
     display: flex;
     flex-direction: column;
     padding: 0 0.75rem;

--- a/packages/excalidraw/components/SearchMenu.tsx
+++ b/packages/excalidraw/components/SearchMenu.tsx
@@ -1,7 +1,16 @@
 import { round } from "@excalidraw/math";
 import clsx from "clsx";
 import debounce from "lodash.debounce";
-import { Fragment, memo, useEffect, useMemo, useRef, useState } from "react";
+import {
+  Fragment,
+  memo,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 
 import {
   CLASSES,
@@ -49,6 +58,8 @@ import {
 } from "./icons";
 
 import "./SearchMenu.scss";
+
+import type { RefCallback } from "react";
 
 import type { AppClassProperties, SearchMatch } from "../types";
 
@@ -426,12 +437,18 @@ export const SearchMenu = () => {
           )}
       </div>
 
-      <MatchList
-        matches={searchMatches}
-        onItemClick={setFocusIndex}
-        focusIndex={focusIndex}
-        searchQuery={searchQuery}
-      />
+      <div
+        className="layer-ui__search-results-scroll"
+        role="region"
+        aria-label={t("search.resultsRegion")}
+      >
+        <MatchList
+          matches={searchMatches}
+          onItemClick={setFocusIndex}
+          focusIndex={focusIndex}
+          searchQuery={searchQuery}
+        />
+      </div>
     </div>
   );
 };
@@ -441,6 +458,7 @@ const ListItem = (props: {
   searchQuery: SearchQuery;
   highlighted: boolean;
   onClick?: () => void;
+  itemRef?: RefCallback<HTMLDivElement | null>;
 }) => {
   const preview = [
     props.preview.moreBefore ? "..." : "",
@@ -462,11 +480,7 @@ const ListItem = (props: {
         active: props.highlighted,
       })}
       onClick={props.onClick}
-      ref={(ref) => {
-        if (props.highlighted) {
-          ref?.scrollIntoView({ behavior: "auto", block: "nearest" });
-        }
-      }}
+      ref={props.itemRef}
     >
       <div className="preview-text">
         {preview.flatMap((text, idx) => (
@@ -485,6 +499,42 @@ interface MatchListProps {
 }
 
 const MatchListBase = (props: MatchListProps) => {
+  const itemRefs = useRef(new Map<number, HTMLDivElement | null>());
+  const itemRefCallbacksRef = useRef(
+    new Map<number, RefCallback<HTMLDivElement | null>>(),
+  );
+  const scrollIntoViewRafRef = useRef<number | null>(null);
+
+  const setItemRef = useCallback((index: number) => {
+    const callbacks = itemRefCallbacksRef.current;
+    let cb = callbacks.get(index);
+    if (!cb) {
+      cb = (el: HTMLDivElement | null) => {
+        const map = itemRefs.current;
+        if (el) {
+          map.set(index, el);
+        } else {
+          map.delete(index);
+          itemRefCallbacksRef.current.delete(index);
+        }
+      };
+      callbacks.set(index, cb);
+    }
+    return cb;
+  }, []);
+
+  useLayoutEffect(() => {
+    const len = props.matches.items.length;
+    const callbacks = itemRefCallbacksRef.current;
+    const elems = itemRefs.current;
+    for (const idx of [...callbacks.keys()]) {
+      if (idx < 0 || idx >= len) {
+        callbacks.delete(idx);
+        elems.delete(idx);
+      }
+    }
+  }, [props.matches.items.length, props.matches.nonce]);
+
   const frameNameMatches = useMemo(
     () =>
       props.matches.items.filter((match) => isFrameLikeElement(match.element)),
@@ -495,6 +545,40 @@ const MatchListBase = (props: MatchListProps) => {
     () => props.matches.items.filter((match) => isTextElement(match.element)),
     [props.matches],
   );
+
+  useLayoutEffect(() => {
+    const idx = props.focusIndex;
+    if (idx === null || idx < 0) {
+      return;
+    }
+
+    if (scrollIntoViewRafRef.current !== null) {
+      cancelAnimationFrame(scrollIntoViewRafRef.current);
+    }
+
+    scrollIntoViewRafRef.current = requestAnimationFrame(() => {
+      scrollIntoViewRafRef.current = null;
+      const el = itemRefs.current.get(idx);
+      if (!el) {
+        return;
+      }
+      const reduceMotion =
+        typeof window.matchMedia === "function" &&
+        window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+      el.scrollIntoView({
+        block: "nearest",
+        inline: "nearest",
+        behavior: reduceMotion ? "auto" : "smooth",
+      });
+    });
+
+    return () => {
+      if (scrollIntoViewRafRef.current !== null) {
+        cancelAnimationFrame(scrollIntoViewRafRef.current);
+        scrollIntoViewRafRef.current = null;
+      }
+    };
+  }, [props.focusIndex, props.matches.nonce]);
 
   return (
     <div>
@@ -511,6 +595,7 @@ const MatchListBase = (props: MatchListProps) => {
               preview={searchMatch.preview}
               highlighted={index === props.focusIndex}
               onClick={() => props.onItemClick(index)}
+              itemRef={setItemRef(index)}
             />
           ))}
 
@@ -531,6 +616,7 @@ const MatchListBase = (props: MatchListProps) => {
               preview={searchMatch.preview}
               highlighted={index + frameNameMatches.length === props.focusIndex}
               onClick={() => props.onItemClick(index + frameNameMatches.length)}
+              itemRef={setItemRef(index + frameNameMatches.length)}
             />
           ))}
         </div>

--- a/packages/excalidraw/components/Sidebar/Sidebar.scss
+++ b/packages/excalidraw/components/Sidebar/Sidebar.scss
@@ -99,6 +99,7 @@
     display: flex;
     flex-direction: column;
     flex: 1 1 auto;
+    min-height: 0;
     padding: 1rem 0;
 
     [role="tabpanel"] {
@@ -106,6 +107,7 @@
       outline: none;
 
       flex: 1 1 auto;
+      min-height: 0;
       display: flex;
       flex-direction: column;
       outline: none;

--- a/packages/excalidraw/locales/ar-SA.json
+++ b/packages/excalidraw/locales/ar-SA.json
@@ -191,6 +191,7 @@
   },
   "search": {
     "title": "البحث على اللوحة",
+    "resultsRegion": "نتائج البحث على اللوحة",
     "noMatch": "لم يتم العثور على تطابقات...",
     "singleResult": "نتيجة",
     "multipleResults": "نتائج",

--- a/packages/excalidraw/locales/az-AZ.json
+++ b/packages/excalidraw/locales/az-AZ.json
@@ -191,6 +191,7 @@
   },
   "search": {
     "title": "",
+    "resultsRegion": "Kanvas axtarışının nəticələri",
     "noMatch": "",
     "singleResult": "",
     "multipleResults": "",

--- a/packages/excalidraw/locales/bg-BG.json
+++ b/packages/excalidraw/locales/bg-BG.json
@@ -191,6 +191,7 @@
   },
   "search": {
     "title": "",
+    "resultsRegion": "Резултати от търсене върху платното",
     "noMatch": "",
     "singleResult": "резултат",
     "multipleResults": "резултати",

--- a/packages/excalidraw/locales/bn-BD.json
+++ b/packages/excalidraw/locales/bn-BD.json
@@ -191,6 +191,7 @@
   },
   "search": {
     "title": "",
+    "resultsRegion": "ক্যানভাস অনুসন্ধানের ফলাফল",
     "noMatch": "",
     "singleResult": "",
     "multipleResults": "",

--- a/packages/excalidraw/locales/bn-IN.json
+++ b/packages/excalidraw/locales/bn-IN.json
@@ -191,6 +191,7 @@
   },
   "search": {
     "title": "",
+    "resultsRegion": "ক্যানভাস অনুসন্ধানের ফলাফল",
     "noMatch": "",
     "singleResult": "",
     "multipleResults": "",

--- a/packages/excalidraw/locales/ca-ES.json
+++ b/packages/excalidraw/locales/ca-ES.json
@@ -191,6 +191,7 @@
   },
   "search": {
     "title": "Troba al llenç",
+    "resultsRegion": "Resultats de cerca al llenç",
     "noMatch": "No hem trobat coincidències...",
     "singleResult": "resultat",
     "multipleResults": "resultats",

--- a/packages/excalidraw/locales/cs-CZ.json
+++ b/packages/excalidraw/locales/cs-CZ.json
@@ -191,6 +191,7 @@
   },
   "search": {
     "title": "Najít na plátně",
+    "resultsRegion": "Výsledky vyhledávání na plátně",
     "noMatch": "Nebyla nalezena žádná shoda...",
     "singleResult": "výsledek",
     "multipleResults": "výsledky",

--- a/packages/excalidraw/locales/da-DK.json
+++ b/packages/excalidraw/locales/da-DK.json
@@ -191,6 +191,7 @@
   },
   "search": {
     "title": "",
+    "resultsRegion": "Søgeresultater på lærredet",
     "noMatch": "",
     "singleResult": "",
     "multipleResults": "",

--- a/packages/excalidraw/locales/de-CH.json
+++ b/packages/excalidraw/locales/de-CH.json
@@ -191,6 +191,7 @@
   },
   "search": {
     "title": "Auf Zeichenfläche suchen",
+    "resultsRegion": "Suchergebnisse auf der Zeichenfläche",
     "noMatch": "Keine Treffer gefunden...",
     "singleResult": "Ergebnis",
     "multipleResults": "Ergebnisse",

--- a/packages/excalidraw/locales/de-DE.json
+++ b/packages/excalidraw/locales/de-DE.json
@@ -191,6 +191,7 @@
   },
   "search": {
     "title": "Auf Zeichenfläche suchen",
+    "resultsRegion": "Suchergebnisse auf der Zeichenfläche",
     "noMatch": "Keine Treffer gefunden...",
     "singleResult": "Ergebnis",
     "multipleResults": "Ergebnisse",

--- a/packages/excalidraw/locales/el-GR.json
+++ b/packages/excalidraw/locales/el-GR.json
@@ -191,6 +191,7 @@
   },
   "search": {
     "title": "",
+    "resultsRegion": "Αποτελέσματα αναζήτησης στον καμβά",
     "noMatch": "",
     "singleResult": "",
     "multipleResults": "",

--- a/packages/excalidraw/locales/en.json
+++ b/packages/excalidraw/locales/en.json
@@ -209,6 +209,7 @@
   },
   "search": {
     "title": "Find on canvas",
+    "resultsRegion": "Canvas search results",
     "noMatch": "No matches found...",
     "singleResult": "result",
     "multipleResults": "results",

--- a/packages/excalidraw/locales/es-ES.json
+++ b/packages/excalidraw/locales/es-ES.json
@@ -191,6 +191,7 @@
   },
   "search": {
     "title": "Encontrar en lienzo",
+    "resultsRegion": "Resultados de búsqueda en el lienzo",
     "noMatch": "No hay coincidencias...",
     "singleResult": "resultado",
     "multipleResults": "resultados",

--- a/packages/excalidraw/locales/eu-ES.json
+++ b/packages/excalidraw/locales/eu-ES.json
@@ -191,6 +191,7 @@
   },
   "search": {
     "title": "",
+    "resultsRegion": "Mihisean bilaketaren emaitzak",
     "noMatch": "",
     "singleResult": "",
     "multipleResults": "",

--- a/packages/excalidraw/locales/fa-IR.json
+++ b/packages/excalidraw/locales/fa-IR.json
@@ -191,6 +191,7 @@
   },
   "search": {
     "title": "جستجو در بوم",
+    "resultsRegion": "نتایج جستجو روی بوم",
     "noMatch": "هیچ موردی یافت نشد...",
     "singleResult": "نتیجه",
     "multipleResults": "نتایج",

--- a/packages/excalidraw/locales/fi-FI.json
+++ b/packages/excalidraw/locales/fi-FI.json
@@ -191,6 +191,7 @@
   },
   "search": {
     "title": "",
+    "resultsRegion": "Canvaksen hakutulokset",
     "noMatch": "",
     "singleResult": "",
     "multipleResults": "",

--- a/packages/excalidraw/locales/fr-FR.json
+++ b/packages/excalidraw/locales/fr-FR.json
@@ -191,6 +191,7 @@
   },
   "search": {
     "title": "Rechercher sur le canevas",
+    "resultsRegion": "Résultats de recherche sur le canevas",
     "noMatch": "Aucun résultat trouvé...",
     "singleResult": "résultat",
     "multipleResults": "résultats",

--- a/packages/excalidraw/locales/gl-ES.json
+++ b/packages/excalidraw/locales/gl-ES.json
@@ -191,6 +191,7 @@
   },
   "search": {
     "title": "",
+    "resultsRegion": "Resultados da busca no lenzo",
     "noMatch": "",
     "singleResult": "",
     "multipleResults": "",

--- a/packages/excalidraw/locales/he-IL.json
+++ b/packages/excalidraw/locales/he-IL.json
@@ -191,6 +191,7 @@
   },
   "search": {
     "title": "איתור בלוח הציור",
+    "resultsRegion": "תוצאות חיפוש בלוח",
     "noMatch": "לא נמצאו תוצאות…",
     "singleResult": "תוצאה",
     "multipleResults": "תוצאות",

--- a/packages/excalidraw/locales/hi-IN.json
+++ b/packages/excalidraw/locales/hi-IN.json
@@ -191,6 +191,7 @@
   },
   "search": {
     "title": "पटल पर धूंडे",
+    "resultsRegion": "कैनवास खोज परिणाम",
     "noMatch": "कोई मिलता जुलता नहीं मिला",
     "singleResult": "परिणाम",
     "multipleResults": "परिणाम",

--- a/packages/excalidraw/locales/hu-HU.json
+++ b/packages/excalidraw/locales/hu-HU.json
@@ -191,6 +191,7 @@
   },
   "search": {
     "title": "Rajzvászonon használt",
+    "resultsRegion": "Keresési találatok a vásznon",
     "noMatch": "",
     "singleResult": "",
     "multipleResults": "",

--- a/packages/excalidraw/locales/id-ID.json
+++ b/packages/excalidraw/locales/id-ID.json
@@ -191,6 +191,7 @@
   },
   "search": {
     "title": "Temukan di kanvas",
+    "resultsRegion": "Hasil pencarian di kanvas",
     "noMatch": "Tidak ada kecocokan yang ditemukan...",
     "singleResult": "hasil",
     "multipleResults": "semua hasil",

--- a/packages/excalidraw/locales/it-IT.json
+++ b/packages/excalidraw/locales/it-IT.json
@@ -191,6 +191,7 @@
   },
   "search": {
     "title": "Trova sulla tela",
+    "resultsRegion": "Risultati di ricerca sulla lavagna",
     "noMatch": "Non è stato trovato nessun risultato...",
     "singleResult": "risultato",
     "multipleResults": "risultati",

--- a/packages/excalidraw/locales/ja-JP.json
+++ b/packages/excalidraw/locales/ja-JP.json
@@ -191,6 +191,7 @@
   },
   "search": {
     "title": "キャンバスで検索",
+    "resultsRegion": "キャンバスの検索結果",
     "noMatch": "一致なし…",
     "singleResult": "結果",
     "multipleResults": "結果数",

--- a/packages/excalidraw/locales/kaa.json
+++ b/packages/excalidraw/locales/kaa.json
@@ -191,6 +191,7 @@
   },
   "search": {
     "title": "",
+    "resultsRegion": "Canvas search results",
     "noMatch": "",
     "singleResult": "",
     "multipleResults": "",

--- a/packages/excalidraw/locales/kab-KAB.json
+++ b/packages/excalidraw/locales/kab-KAB.json
@@ -191,6 +191,7 @@
   },
   "search": {
     "title": "",
+    "resultsRegion": "Tasali n tettarrawt di teɣzut n usuneɣ",
     "noMatch": "",
     "singleResult": "",
     "multipleResults": "",

--- a/packages/excalidraw/locales/kk-KZ.json
+++ b/packages/excalidraw/locales/kk-KZ.json
@@ -191,6 +191,7 @@
   },
   "search": {
     "title": "",
+    "resultsRegion": "Кенбеңдегі іздеу нәтижелері",
     "noMatch": "",
     "singleResult": "",
     "multipleResults": "",

--- a/packages/excalidraw/locales/km-KH.json
+++ b/packages/excalidraw/locales/km-KH.json
@@ -191,6 +191,7 @@
   },
   "search": {
     "title": "",
+    "resultsRegion": "លទ្ធផលស្វែងរកលើផ្ទាំងគំនូរ",
     "noMatch": "",
     "singleResult": "",
     "multipleResults": "",

--- a/packages/excalidraw/locales/ko-KR.json
+++ b/packages/excalidraw/locales/ko-KR.json
@@ -191,6 +191,7 @@
   },
   "search": {
     "title": "캔버스에서 찾기",
+    "resultsRegion": "캔버스 검색 결과",
     "noMatch": "결과를 찾을 수 없습니다...",
     "singleResult": "개의 결과",
     "multipleResults": "개의 결과",

--- a/packages/excalidraw/locales/ku-TR.json
+++ b/packages/excalidraw/locales/ku-TR.json
@@ -191,6 +191,7 @@
   },
   "search": {
     "title": "",
+    "resultsRegion": "Tasali n tettarrawt di teɣzut n usuneɣ",
     "noMatch": "",
     "singleResult": "",
     "multipleResults": "",

--- a/packages/excalidraw/locales/lt-LT.json
+++ b/packages/excalidraw/locales/lt-LT.json
@@ -191,6 +191,7 @@
   },
   "search": {
     "title": "",
+    "resultsRegion": "Paieškos rezultatai drobėje",
     "noMatch": "",
     "singleResult": "",
     "multipleResults": "",

--- a/packages/excalidraw/locales/lv-LV.json
+++ b/packages/excalidraw/locales/lv-LV.json
@@ -191,6 +191,7 @@
   },
   "search": {
     "title": "",
+    "resultsRegion": "Meklēšanas rezultāti audeklī",
     "noMatch": "",
     "singleResult": "",
     "multipleResults": "",

--- a/packages/excalidraw/locales/mr-IN.json
+++ b/packages/excalidraw/locales/mr-IN.json
@@ -191,6 +191,7 @@
   },
   "search": {
     "title": "पटल वर पहा",
+    "resultsRegion": "कॅन्व्हास शोध निकाल",
     "noMatch": "मिळते जुळते काहिही सापडले नाही...",
     "singleResult": "निकाल",
     "multipleResults": "निकाल",

--- a/packages/excalidraw/locales/my-MM.json
+++ b/packages/excalidraw/locales/my-MM.json
@@ -191,6 +191,7 @@
   },
   "search": {
     "title": "",
+    "resultsRegion": "ပိတ်ချပေါ်ရှာဖွေမှုရလဒ်များ",
     "noMatch": "",
     "singleResult": "",
     "multipleResults": "",

--- a/packages/excalidraw/locales/nb-NO.json
+++ b/packages/excalidraw/locales/nb-NO.json
@@ -191,6 +191,7 @@
   },
   "search": {
     "title": "Finn på lerretet",
+    "resultsRegion": "Søkeresultater på lerretet",
     "noMatch": "Ingen treff funnet...",
     "singleResult": "resultat",
     "multipleResults": "resultater",

--- a/packages/excalidraw/locales/nl-NL.json
+++ b/packages/excalidraw/locales/nl-NL.json
@@ -191,6 +191,7 @@
   },
   "search": {
     "title": "Zoek op canvas",
+    "resultsRegion": "Zoekresultaten op het canvas",
     "noMatch": "Geen overeenkomsten gevonden...",
     "singleResult": "resultaat",
     "multipleResults": "resultaten",

--- a/packages/excalidraw/locales/nn-NO.json
+++ b/packages/excalidraw/locales/nn-NO.json
@@ -191,6 +191,7 @@
   },
   "search": {
     "title": "",
+    "resultsRegion": "Søkjeresultat på lerretet",
     "noMatch": "",
     "singleResult": "",
     "multipleResults": "",

--- a/packages/excalidraw/locales/oc-FR.json
+++ b/packages/excalidraw/locales/oc-FR.json
@@ -191,6 +191,7 @@
   },
   "search": {
     "title": "",
+    "resultsRegion": "Resultats de recèrca sul canabàs",
     "noMatch": "",
     "singleResult": "resultat",
     "multipleResults": "resultats",

--- a/packages/excalidraw/locales/pa-IN.json
+++ b/packages/excalidraw/locales/pa-IN.json
@@ -191,6 +191,7 @@
   },
   "search": {
     "title": "",
+    "resultsRegion": "ਕੈਨਵਾਸ ਖੋਜ ਦੇ ਨਤੀਜੇ",
     "noMatch": "",
     "singleResult": "",
     "multipleResults": "",

--- a/packages/excalidraw/locales/pl-PL.json
+++ b/packages/excalidraw/locales/pl-PL.json
@@ -191,6 +191,7 @@
   },
   "search": {
     "title": "Znajdź na płótnie",
+    "resultsRegion": "Wyniki wyszukiwania na płótnie",
     "noMatch": "Nie znaleziono pasujących elementów...",
     "singleResult": "wynik",
     "multipleResults": "wyniki",

--- a/packages/excalidraw/locales/pt-BR.json
+++ b/packages/excalidraw/locales/pt-BR.json
@@ -191,6 +191,7 @@
   },
   "search": {
     "title": "Procurar na tela",
+    "resultsRegion": "Resultados da busca na tela",
     "noMatch": "Nenhum resultado encontrado...",
     "singleResult": "resultado",
     "multipleResults": "resultados",

--- a/packages/excalidraw/locales/pt-PT.json
+++ b/packages/excalidraw/locales/pt-PT.json
@@ -191,6 +191,7 @@
   },
   "search": {
     "title": "Pesquisar na área de desenho",
+    "resultsRegion": "Resultados da pesquisa na tela",
     "noMatch": "Não foram encontrados resultados...",
     "singleResult": "resultado",
     "multipleResults": "resultados",

--- a/packages/excalidraw/locales/ro-RO.json
+++ b/packages/excalidraw/locales/ro-RO.json
@@ -191,6 +191,7 @@
   },
   "search": {
     "title": "Găsire pe pânză",
+    "resultsRegion": "Rezultatele căutării pe pânză",
     "noMatch": "Nicio potrivire găsită...",
     "singleResult": "rezultat",
     "multipleResults": "rezultate",

--- a/packages/excalidraw/locales/ru-RU.json
+++ b/packages/excalidraw/locales/ru-RU.json
@@ -191,6 +191,7 @@
   },
   "search": {
     "title": "Найти на холсте",
+    "resultsRegion": "Результаты поиска на холсте",
     "noMatch": "Совпадения не найдены...",
     "singleResult": "результат",
     "multipleResults": "результатов",

--- a/packages/excalidraw/locales/si-LK.json
+++ b/packages/excalidraw/locales/si-LK.json
@@ -191,6 +191,7 @@
   },
   "search": {
     "title": "",
+    "resultsRegion": "පුස්තකාලය හිස් බව පෙන්වයි",
     "noMatch": "",
     "singleResult": "",
     "multipleResults": "",

--- a/packages/excalidraw/locales/sk-SK.json
+++ b/packages/excalidraw/locales/sk-SK.json
@@ -191,6 +191,7 @@
   },
   "search": {
     "title": "Vyhľadať v plátne",
+    "resultsRegion": "Výsledky vyhľadávania v plátne",
     "noMatch": "Neboli nájdené žiadne výsledky...",
     "singleResult": "výsledok",
     "multipleResults": "výsledky",

--- a/packages/excalidraw/locales/sl-SI.json
+++ b/packages/excalidraw/locales/sl-SI.json
@@ -191,6 +191,7 @@
   },
   "search": {
     "title": "Poišči na platnu",
+    "resultsRegion": "Rezultati iskanja na platnu",
     "noMatch": "Ni zadetkov ...",
     "singleResult": "rezultat",
     "multipleResults": "rezultata/i/ov",

--- a/packages/excalidraw/locales/sv-SE.json
+++ b/packages/excalidraw/locales/sv-SE.json
@@ -191,6 +191,7 @@
   },
   "search": {
     "title": "Hitta på canvas",
+    "resultsRegion": "Sökresultat på canvas",
     "noMatch": "Inga träffar hittades...",
     "singleResult": "resultat",
     "multipleResults": "resultat",

--- a/packages/excalidraw/locales/ta-IN.json
+++ b/packages/excalidraw/locales/ta-IN.json
@@ -191,6 +191,7 @@
   },
   "search": {
     "title": "கன்வாஸில் தேடு",
+    "resultsRegion": "கன்வாஸ் தேடல் முடிவுகள்",
     "noMatch": "பொருத்தங்கள் எதுவும் இல்லை...",
     "singleResult": "முடிவு",
     "multipleResults": "முடிவுகள்",

--- a/packages/excalidraw/locales/th-TH.json
+++ b/packages/excalidraw/locales/th-TH.json
@@ -191,6 +191,7 @@
   },
   "search": {
     "title": "",
+    "resultsRegion": "ผลการค้นหาบนผืนผ้าใบ",
     "noMatch": "",
     "singleResult": "",
     "multipleResults": "",

--- a/packages/excalidraw/locales/tr-TR.json
+++ b/packages/excalidraw/locales/tr-TR.json
@@ -191,6 +191,7 @@
   },
   "search": {
     "title": "Tuvalde bul",
+    "resultsRegion": "Tuval arama sonuçları",
     "noMatch": "Sonuç bulunamadı...",
     "singleResult": "sonuç",
     "multipleResults": "sonuç",

--- a/packages/excalidraw/locales/uk-UA.json
+++ b/packages/excalidraw/locales/uk-UA.json
@@ -191,6 +191,7 @@
   },
   "search": {
     "title": "Знайти на полотні",
+    "resultsRegion": "Результати пошуку на полотні",
     "noMatch": "Збігів не знайдено...",
     "singleResult": "результат",
     "multipleResults": "результати",

--- a/packages/excalidraw/locales/uz-UZ.json
+++ b/packages/excalidraw/locales/uz-UZ.json
@@ -191,6 +191,7 @@
   },
   "search": {
     "title": "",
+    "resultsRegion": "Qatnaw retinde tasali",
     "noMatch": "",
     "singleResult": "",
     "multipleResults": "",

--- a/packages/excalidraw/locales/vi-VN.json
+++ b/packages/excalidraw/locales/vi-VN.json
@@ -191,6 +191,7 @@
   },
   "search": {
     "title": "Tìm trên vùng vẽ",
+    "resultsRegion": "Kết quả tìm kiếm trên bảng vẽ",
     "noMatch": "Không có kết quả phù hợp...",
     "singleResult": "kết quả",
     "multipleResults": "các kết quả",

--- a/packages/excalidraw/locales/zh-CN.json
+++ b/packages/excalidraw/locales/zh-CN.json
@@ -191,6 +191,7 @@
   },
   "search": {
     "title": "在画布上查找",
+    "resultsRegion": "画布搜索结果",
     "noMatch": "无匹配项…",
     "singleResult": "结果",
     "multipleResults": "结果",

--- a/packages/excalidraw/locales/zh-HK.json
+++ b/packages/excalidraw/locales/zh-HK.json
@@ -191,6 +191,7 @@
   },
   "search": {
     "title": "",
+    "resultsRegion": "畫布搜索結果",
     "noMatch": "",
     "singleResult": "",
     "multipleResults": "",

--- a/packages/excalidraw/locales/zh-TW.json
+++ b/packages/excalidraw/locales/zh-TW.json
@@ -191,6 +191,7 @@
   },
   "search": {
     "title": "在畫布上尋找",
+    "resultsRegion": "畫布搜尋結果",
     "noMatch": "未找到符合項目…",
     "singleResult": "結果",
     "multipleResults": "結果",


### PR DESCRIPTION
Search results live in a dedicated scroll region (.layer-ui__search-results-scroll) with flex layout, min-height: 0, and vertical overflow so long result lists scroll inside the sidebar instead of stretching the panel.
When the focused match changes, the corresponding row is scrolled into view (scrollIntoView with block: "nearest", smooth motion unless prefers-reduced-motion: reduce).
Focus & keyboard

Opening search (Ctrl/Cmd+F) focuses the search field and selects its contents; pressing Ctrl/Cmd+F again while the search sidebar stays open refocuses the input (even after blur).
From the search UI, Enter moves to the next match; ↑/↓ move previous/next. Escape closes the sidebar when no modal/popup is open.
Keyboard handling uses capture-phase listeners so shortcuts behave reliably with the rest of the app.
The canvas pans/zooms to keep the active hit readable: if the match is off-screen or too small at the current zoom, the editor scrolls/zooms to the match (scrollToContent with options for tiny text vs. normal cases).
Internationalization

User-visible strings for canvas search are under search.* in locale files (e.g. title “Find on canvas”, placeholder, single/multiple result labels, “No matches found…”, section headers Frames / Texts, accessible label for the results region “Canvas search results”).
When search has matches, the toolbar hint shows the localized dismiss message (hints.dismissSearch with Escape).