### PR TITLE
fix: reset isTouchScreen when pointer switches from pen to mouse

### DIFF
--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -7630,12 +7630,15 @@ class App extends React.Component<AppProps, AppState> {
       });
     }
 
-    if (
-      !this.editorInterface.isTouchScreen &&
-      ["pen", "touch"].includes(event.pointerType)
-    ) {
+    if (["pen", "touch"].includes(event.pointerType)) {
+      if (!this.editorInterface.isTouchScreen) {
+        this.editorInterface = updateObject(this.editorInterface, {
+          isTouchScreen: true,
+        });
+      }
+    } else if (event.pointerType === "mouse" && this.editorInterface.isTouchScreen) {
       this.editorInterface = updateObject(this.editorInterface, {
-        isTouchScreen: true,
+        isTouchScreen: false,
       });
     }
 

--- a/packages/excalidraw/tests/multiPointCreate.test.tsx
+++ b/packages/excalidraw/tests/multiPointCreate.test.tsx
@@ -182,4 +182,26 @@ describe("multi point mode in linear elements", () => {
 
     h.elements.forEach((element) => expect(element).toMatchSnapshot());
   });
+
+  it("arrow should enter multipoint mode after switching from pen to mouse", async () => {
+    const { getByToolName, container } = await render(<Excalidraw />);
+    const tool = getByToolName("arrow");
+    fireEvent.click(tool);
+
+    const canvas = container.querySelector("canvas.interactive")!;
+
+    // draw an arrow with a pen and sets isTouchScreen to true
+    fireEvent.pointerDown(canvas, { clientX: 30, clientY: 30, pointerType: "pen" });
+    fireEvent.pointerUp(canvas, { clientX: 30, clientY: 30, pointerType: "pen" });
+    fireEvent.keyDown(document, { key: KEYS.ENTER });
+
+    // select arrow tool again
+    fireEvent.click(tool);
+
+    // draw with mouse so it enters the multipoint mode
+    fireEvent.pointerDown(canvas, { clientX: 100, clientY: 100, pointerType: "mouse" });
+    fireEvent.pointerUp(canvas, { clientX: 100, clientY: 100, pointerType: "mouse" });
+
+    expect(h.state.multiElement).not.toBeNull();
+  });
 });


### PR DESCRIPTION
Fixes #11173 - 'BUG: Multi point creation with pen broken'

After drawing an arrow with a pen tablet, switching back to a mouse and trying to create another arrow would immediately finalize it as a 2-point arrow instead of entering multipoint mode.

The issue is in `handleCanvasPointerDown` — `isTouchScreen` gets set to `true` on the first pen event but never gets reset when the pointer switches back to a mouse. Since `onPointerUpFromPointerDownHandler` branches on `isTouchScreen` to decide between multipoint and drag mode, it stays stuck treating mouse clicks as touch input.

Fix is to reset `isTouchScreen` to `false` when `event.pointerType === "mouse"`. Also added a regression test in `multiPointCreate.test.tsx`.