### PR TITLE
fix(editor): add aria-label to main menu trigger button

### DIFF
--- a/packages/excalidraw/components/main-menu/MainMenu.tsx
+++ b/packages/excalidraw/components/main-menu/MainMenu.tsx
@@ -45,6 +45,7 @@ const MainMenu = Object.assign(
               }}
               data-testid="main-menu-trigger"
               className="main-menu-trigger"
+              aria-label={t("buttons.menu")}
             >
               {HamburgerMenuIcon}
             </DropdownMenu.Trigger>


### PR DESCRIPTION
added "Menu" accessibility label

Closes #11297 

<img width="2060" height="1910" alt="CleanShot 2026-05-07 at 06 50 53@2x" src="https://github.com/user-attachments/assets/00bd2fc9-b05a-409d-a264-753d596b8c14" />
