### PR TITLE
fix(ttd): sanitize mermaid renderer runtime errors into user-friendly messages

### DIFF
--- a/packages/excalidraw/components/TTDDialog/common.ts
+++ b/packages/excalidraw/components/TTDDialog/common.ts
@@ -15,8 +15,6 @@ import type {
 
 import { EditorLocalStorage } from "../../data/EditorLocalStorage";
 
-import { sanitizeMermaidRenderingError } from "./utils/mermaidError";
-
 import type { MermaidToExcalidrawLibProps } from "./types";
 
 import type { AppClassProperties, BinaryFiles } from "../../types";
@@ -124,11 +122,11 @@ export const convertMermaidToExcalidraw = async ({
   } catch (err: any) {
     parent.style.background = "var(--default-bg-color)";
     if (mermaidDefinition) {
-      setError(sanitizeMermaidRenderingError(err, mermaidDefinition));
+      setError(err);
     }
 
     // Return error so caller can display meaningful error message
-    return { success: false, error: sanitizeMermaidRenderingError(err, mermaidDefinition) };
+    return { success: false, error: err };
   }
 };
 export const saveMermaidDataToStorage = (mermaidDefinition: string) => {

--- a/packages/excalidraw/components/TTDDialog/common.ts
+++ b/packages/excalidraw/components/TTDDialog/common.ts
@@ -15,6 +15,8 @@ import type {
 
 import { EditorLocalStorage } from "../../data/EditorLocalStorage";
 
+import { sanitizeMermaidRenderingError } from "./utils/mermaidError";
+
 import type { MermaidToExcalidrawLibProps } from "./types";
 
 import type { AppClassProperties, BinaryFiles } from "../../types";
@@ -122,11 +124,11 @@ export const convertMermaidToExcalidraw = async ({
   } catch (err: any) {
     parent.style.background = "var(--default-bg-color)";
     if (mermaidDefinition) {
-      setError(err);
+      setError(sanitizeMermaidRenderingError(err, mermaidDefinition));
     }
 
     // Return error so caller can display meaningful error message
-    return { success: false, error: err };
+    return { success: false, error: sanitizeMermaidRenderingError(err, mermaidDefinition) };
   }
 };
 export const saveMermaidDataToStorage = (mermaidDefinition: string) => {

--- a/packages/excalidraw/components/TTDDialog/hooks/useTextGeneration.ts
+++ b/packages/excalidraw/components/TTDDialog/hooks/useTextGeneration.ts
@@ -2,8 +2,6 @@ import { useRef } from "react";
 import { parseMermaidToExcalidraw } from "@excalidraw/mermaid-to-excalidraw";
 import { isFiniteNumber } from "@excalidraw/math";
 
-import { sanitizeMermaidRenderingError } from "../utils/mermaidError";
-
 import { useAtom } from "../../../editor-jotai";
 
 import { trackEvent } from "../../../analytics";
@@ -197,12 +195,8 @@ export const useTextGeneration = ({
         trackEvent("ai", "mermaid parse success", "ttd");
       } catch (error: any) {
         trackEvent("ai", "mermaid parse failed", "ttd");
-        const sanitized = sanitizeMermaidRenderingError(
-          error instanceof Error ? error : new Error(error.message),
-          generatedResponse ?? "",
-        );
         const _error = new Error(
-          sanitized.message || t("chat.errors.mermaidParseError"),
+          error.message || t("chat.errors.mermaidParseError"),
         );
         setAssistantError(_error.message, "parse");
         setError(_error);

--- a/packages/excalidraw/components/TTDDialog/hooks/useTextGeneration.ts
+++ b/packages/excalidraw/components/TTDDialog/hooks/useTextGeneration.ts
@@ -2,6 +2,8 @@ import { useRef } from "react";
 import { parseMermaidToExcalidraw } from "@excalidraw/mermaid-to-excalidraw";
 import { isFiniteNumber } from "@excalidraw/math";
 
+import { sanitizeMermaidRenderingError } from "../utils/mermaidError";
+
 import { useAtom } from "../../../editor-jotai";
 
 import { trackEvent } from "../../../analytics";
@@ -195,8 +197,12 @@ export const useTextGeneration = ({
         trackEvent("ai", "mermaid parse success", "ttd");
       } catch (error: any) {
         trackEvent("ai", "mermaid parse failed", "ttd");
+        const sanitized = sanitizeMermaidRenderingError(
+          error instanceof Error ? error : new Error(error.message),
+          generatedResponse ?? "",
+        );
         const _error = new Error(
-          error.message || t("chat.errors.mermaidParseError"),
+          sanitized.message || t("chat.errors.mermaidParseError"),
         );
         setAssistantError(_error.message, "parse");
         setError(_error);

--- a/packages/excalidraw/components/TTDDialog/utils/mermaidError.test.ts
+++ b/packages/excalidraw/components/TTDDialog/utils/mermaidError.test.ts
@@ -8,8 +8,6 @@ import {
   isMermaidAutoFixableError,
   isMermaidParseSyntaxError,
   isMermaidCaretLine,
-  isMermaidRenderingError,
-  sanitizeMermaidRenderingError,
 } from "./mermaidError";
 
 describe("formatMermaidParseErrorMessage", () => {
@@ -128,67 +126,6 @@ describe("getMermaidErrorLineNumber", () => {
         sourceText,
       ),
     ).toBe(5);
-  });
-});
-
-describe("isMermaidRenderingError", () => {
-  it("returns true for minified runtime errors containing uppercase bracket access", () => {
-    expect(
-      isMermaidRenderingError(
-        "can't access property \"type\", Z[e].raw.startTime is undefined",
-      ),
-    ).toBe(true);
-  });
-
-  it("returns true for dot-path undefined property errors", () => {
-    expect(
-      isMermaidRenderingError("raw.endTime is undefined"),
-    ).toBe(true);
-  });
-
-  it("returns false for mermaid parse syntax errors", () => {
-    expect(
-      isMermaidRenderingError("Parse error on line 3: some snippet"),
-    ).toBe(false);
-  });
-
-  it("returns false for unrelated error messages", () => {
-    expect(isMermaidRenderingError("Network request failed")).toBe(false);
-  });
-});
-
-describe("sanitizeMermaidRenderingError", () => {
-  it("replaces a minified gantt startTime error with a helpful message", () => {
-    const raw = new Error(
-      "can't access property \"type\", Z[e].raw.startTime is undefined",
-    );
-    const definition = `gantt
-  title Daily Timeline
-  dateFormat HH:mm
-  section Night
-  Overnight :crit, 22:00, 06:00`;
-
-    const result = sanitizeMermaidRenderingError(raw, definition);
-    expect(result.message).toContain("gantt diagram");
-    expect(result.message).toContain("midnight");
-  });
-
-  it("provides gantt guidance when error mentions startTime even without definition", () => {
-    const raw = new Error("Z[e].raw.startTime is undefined");
-    const result = sanitizeMermaidRenderingError(raw);
-    expect(result.message).toContain("gantt diagram");
-  });
-
-  it("returns a generic internal error message for other rendering errors", () => {
-    const raw = new Error("X[i].someOtherProp is null");
-    const result = sanitizeMermaidRenderingError(raw, "flowchart TD\n  A --> B");
-    expect(result.message).toContain("internal rendering error");
-  });
-
-  it("returns the original error unchanged when it is not a rendering error", () => {
-    const raw = new Error("Parse error on line 2: unexpected token");
-    const result = sanitizeMermaidRenderingError(raw, "graph TD");
-    expect(result).toBe(raw);
   });
 });
 

--- a/packages/excalidraw/components/TTDDialog/utils/mermaidError.test.ts
+++ b/packages/excalidraw/components/TTDDialog/utils/mermaidError.test.ts
@@ -8,6 +8,8 @@ import {
   isMermaidAutoFixableError,
   isMermaidParseSyntaxError,
   isMermaidCaretLine,
+  isMermaidRenderingError,
+  sanitizeMermaidRenderingError,
 } from "./mermaidError";
 
 describe("formatMermaidParseErrorMessage", () => {
@@ -126,6 +128,67 @@ describe("getMermaidErrorLineNumber", () => {
         sourceText,
       ),
     ).toBe(5);
+  });
+});
+
+describe("isMermaidRenderingError", () => {
+  it("returns true for minified runtime errors containing uppercase bracket access", () => {
+    expect(
+      isMermaidRenderingError(
+        "can't access property \"type\", Z[e].raw.startTime is undefined",
+      ),
+    ).toBe(true);
+  });
+
+  it("returns true for dot-path undefined property errors", () => {
+    expect(
+      isMermaidRenderingError("raw.endTime is undefined"),
+    ).toBe(true);
+  });
+
+  it("returns false for mermaid parse syntax errors", () => {
+    expect(
+      isMermaidRenderingError("Parse error on line 3: some snippet"),
+    ).toBe(false);
+  });
+
+  it("returns false for unrelated error messages", () => {
+    expect(isMermaidRenderingError("Network request failed")).toBe(false);
+  });
+});
+
+describe("sanitizeMermaidRenderingError", () => {
+  it("replaces a minified gantt startTime error with a helpful message", () => {
+    const raw = new Error(
+      "can't access property \"type\", Z[e].raw.startTime is undefined",
+    );
+    const definition = `gantt
+  title Daily Timeline
+  dateFormat HH:mm
+  section Night
+  Overnight :crit, 22:00, 06:00`;
+
+    const result = sanitizeMermaidRenderingError(raw, definition);
+    expect(result.message).toContain("gantt diagram");
+    expect(result.message).toContain("midnight");
+  });
+
+  it("provides gantt guidance when error mentions startTime even without definition", () => {
+    const raw = new Error("Z[e].raw.startTime is undefined");
+    const result = sanitizeMermaidRenderingError(raw);
+    expect(result.message).toContain("gantt diagram");
+  });
+
+  it("returns a generic internal error message for other rendering errors", () => {
+    const raw = new Error("X[i].someOtherProp is null");
+    const result = sanitizeMermaidRenderingError(raw, "flowchart TD\n  A --> B");
+    expect(result.message).toContain("internal rendering error");
+  });
+
+  it("returns the original error unchanged when it is not a rendering error", () => {
+    const raw = new Error("Parse error on line 2: unexpected token");
+    const result = sanitizeMermaidRenderingError(raw, "graph TD");
+    expect(result).toBe(raw);
   });
 });
 

--- a/packages/excalidraw/components/TTDDialog/utils/mermaidError.ts
+++ b/packages/excalidraw/components/TTDDialog/utils/mermaidError.ts
@@ -3,20 +3,6 @@ const MERMAID_INACTIVE_PARTICIPANT_ERROR =
   /Trying to inactivate an inactive participant \((.+)\)/i;
 const MERMAID_CARET_LINE = /^\s*-+\^\s*$/;
 
-/**
- * Matches minified runtime errors thrown by the mermaid renderer, e.g.:
- *   "can't access property \"type\", Z[e].raw.startTime is undefined"
- * These contain uppercase single-letter variables followed by bracket access.
- */
-const MERMAID_MINIFIED_RUNTIME_ERROR = /\b[A-Z]\[/;
-
-/**
- * Matches any "X is undefined/null" message that references a dot-path
- * property, which indicates a mermaid-internal rendering failure.
- */
-const MERMAID_PROPERTY_UNDEFINED_ERROR =
-  /\b\w+(?:\.\w+)+\s+is\s+(?:undefined|null)\b/i;
-
 export const isMermaidParseSyntaxError = (message: string) =>
   MERMAID_SYNTAX_ERROR_LINE.test(message);
 
@@ -144,50 +130,4 @@ export const formatMermaidParseErrorMessage = (message: string) => {
   }
 
   return message.replace(/\n\s*Expecting[\s\S]*$/, "").trimEnd();
-};
-
-/**
- * Returns true when the error originates from mermaid's internal rendering
- * pipeline rather than its parser/lexer. These errors typically contain
- * minified variable names (e.g. "Z[e].raw.startTime is undefined") and are
- * not meaningful to end users.
- */
-export const isMermaidRenderingError = (message: string): boolean => {
-  if (isMermaidParseSyntaxError(message)) {
-    return false;
-  }
-  return (
-    MERMAID_MINIFIED_RUNTIME_ERROR.test(message) ||
-    MERMAID_PROPERTY_UNDEFINED_ERROR.test(message)
-  );
-};
-
-/**
- * Converts a mermaid internal rendering error into a user-friendly Error.
- * Pass the original mermaid definition so that diagram-specific guidance can
- * be included where possible.
- */
-export const sanitizeMermaidRenderingError = (
-  err: Error,
-  mermaidDefinition?: string,
-): Error => {
-  if (!isMermaidRenderingError(err.message)) {
-    return err;
-  }
-
-  const isGantt = /^\s*gantt\b/i.test(mermaidDefinition ?? "");
-  const mentionsTime = /(?:start|end)Time/i.test(err.message);
-
-  if (isGantt || mentionsTime) {
-    return new Error(
-      "Unable to render gantt diagram: one or more tasks have an invalid time " +
-        "range. If a task crosses midnight (e.g. 22:00 → 06:00), split it into " +
-        "two separate tasks ending at 23:59 and starting at 00:00.",
-    );
-  }
-
-  return new Error(
-    "Unable to render diagram: an internal rendering error occurred. The " +
-      "diagram definition may contain unsupported syntax or values.",
-  );
 };

--- a/packages/excalidraw/components/TTDDialog/utils/mermaidError.ts
+++ b/packages/excalidraw/components/TTDDialog/utils/mermaidError.ts
@@ -3,6 +3,20 @@ const MERMAID_INACTIVE_PARTICIPANT_ERROR =
   /Trying to inactivate an inactive participant \((.+)\)/i;
 const MERMAID_CARET_LINE = /^\s*-+\^\s*$/;
 
+/**
+ * Matches minified runtime errors thrown by the mermaid renderer, e.g.:
+ *   "can't access property \"type\", Z[e].raw.startTime is undefined"
+ * These contain uppercase single-letter variables followed by bracket access.
+ */
+const MERMAID_MINIFIED_RUNTIME_ERROR = /\b[A-Z]\[/;
+
+/**
+ * Matches any "X is undefined/null" message that references a dot-path
+ * property, which indicates a mermaid-internal rendering failure.
+ */
+const MERMAID_PROPERTY_UNDEFINED_ERROR =
+  /\b\w+(?:\.\w+)+\s+is\s+(?:undefined|null)\b/i;
+
 export const isMermaidParseSyntaxError = (message: string) =>
   MERMAID_SYNTAX_ERROR_LINE.test(message);
 
@@ -130,4 +144,50 @@ export const formatMermaidParseErrorMessage = (message: string) => {
   }
 
   return message.replace(/\n\s*Expecting[\s\S]*$/, "").trimEnd();
+};
+
+/**
+ * Returns true when the error originates from mermaid's internal rendering
+ * pipeline rather than its parser/lexer. These errors typically contain
+ * minified variable names (e.g. "Z[e].raw.startTime is undefined") and are
+ * not meaningful to end users.
+ */
+export const isMermaidRenderingError = (message: string): boolean => {
+  if (isMermaidParseSyntaxError(message)) {
+    return false;
+  }
+  return (
+    MERMAID_MINIFIED_RUNTIME_ERROR.test(message) ||
+    MERMAID_PROPERTY_UNDEFINED_ERROR.test(message)
+  );
+};
+
+/**
+ * Converts a mermaid internal rendering error into a user-friendly Error.
+ * Pass the original mermaid definition so that diagram-specific guidance can
+ * be included where possible.
+ */
+export const sanitizeMermaidRenderingError = (
+  err: Error,
+  mermaidDefinition?: string,
+): Error => {
+  if (!isMermaidRenderingError(err.message)) {
+    return err;
+  }
+
+  const isGantt = /^\s*gantt\b/i.test(mermaidDefinition ?? "");
+  const mentionsTime = /(?:start|end)Time/i.test(err.message);
+
+  if (isGantt || mentionsTime) {
+    return new Error(
+      "Unable to render gantt diagram: one or more tasks have an invalid time " +
+        "range. If a task crosses midnight (e.g. 22:00 → 06:00), split it into " +
+        "two separate tasks ending at 23:59 and starting at 00:00.",
+    );
+  }
+
+  return new Error(
+    "Unable to render diagram: an internal rendering error occurred. The " +
+      "diagram definition may contain unsupported syntax or values.",
+  );
 };


### PR DESCRIPTION
Fixes #11285

## Problem

When a user asks the text-to-diagram AI to draw a timeline with a segment
crossing midnight (e.g. 22:00 → 06:00), the mermaid gantt renderer crashes
with a cryptic internal error message:

  can't access property "type", Z[e].raw.startTime is undefined

This raw minified message was shown directly to the user with no filtering,
making it impossible to understand what went wrong.

## Root Cause

Mermaid uses dayjs to parse times in HH:mm format without a date anchor.
When an end time (06:00) is numerically less than the start time (22:00),
dayjs places both on the same calendar day, making endTime < startTime.
Mermaid's task compilation then leaves raw.startTime as undefined, causing
a TypeError when the renderer tries to access .type on it.

## Fix

Added two helper functions in mermaidError.ts:

- isMermaidRenderingError() — detects whether an error came from mermaid's
  internal renderer (minified patterns like Z[e].) vs a normal syntax mistake
- sanitizeMermaidRenderingError() — replaces the cryptic message with a clear,
  actionable one tailored to the diagram type

Both error-surfacing paths now run through the sanitizer before showing
anything to the user:
- common.ts (Mermaid tab)
- useTextGeneration.ts (AI chat tab)

## Before / After

Before: can't access property "type", Z[e].raw.startTime is undefined

After: Unable to render gantt diagram: one or more tasks have an invalid
time range. If a task crosses midnight (e.g. 22:00 → 06:00), split it into
two separate tasks ending at 23:59 and starting at 00:00.

## Testing

- Unit tests added in mermaidError.test.ts
- All 27 tests pass