### PR TITLE
feat(editor): add transaction API for grouping scene changes

### DIFF
--- a/packages/element/src/delta.ts
+++ b/packages/element/src/delta.ts
@@ -1527,9 +1527,11 @@ export class ElementsDelta implements DeltaContainer<SceneElementsMap> {
 
       if (!prevDelta) {
         this.removed[id] = nextDelta;
+      } else if (this.added[id]) {
+        // element was added then removed within the same squash = net zero, cancel out
+        delete this.added[id];
       } else {
         const mergedDelta = mergeBoundElements(prevDelta, nextDelta);
-        delete this.added[id];
         delete this.updated[id];
 
         this.removed[id] = Delta.merge(prevDelta, nextDelta, mergedDelta);

--- a/packages/element/tests/delta.test.tsx
+++ b/packages/element/tests/delta.test.tsx
@@ -279,6 +279,38 @@ describe("ElementsDelta", () => {
       expect(elementsDelta.updated).toEqual({});
     });
 
+    it("should cancel out when element is added then removed", () => {
+      // id1: added -> removed => net zero (neither added nor removed)
+      const elementsDelta1 = ElementsDelta.create(
+        {
+          id1: Delta.create(
+            { x: 100, version: 1, versionNonce: 1, isDeleted: true },
+            { x: 101, version: 2, versionNonce: 2, isDeleted: false },
+          ),
+        },
+        {},
+        {},
+      );
+
+      const elementsDelta2 = ElementsDelta.create(
+        {},
+        {
+          id1: Delta.create(
+            { x: 101, version: 2, versionNonce: 2, isDeleted: false },
+            { x: 101, version: 3, versionNonce: 3, isDeleted: true },
+          ),
+        },
+        {},
+      );
+
+      const elementsDelta = elementsDelta1.squash(elementsDelta2);
+
+      expect(elementsDelta.added).toEqual({});
+      expect(elementsDelta.removed).toEqual({});
+      expect(elementsDelta.updated).toEqual({});
+      expect(elementsDelta.isEmpty()).toBeTruthy();
+    });
+
     it("should squash bound elements", () => {
       const elementsDelta1 = ElementsDelta.create(
         {},

--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -363,6 +363,7 @@ import Library, { distributeLibraryItemsOnSquareGrid } from "../data/library";
 import { restoreAppState, restoreElements } from "../data/restore";
 import { getCenter, getDistance } from "../gesture";
 import { History } from "../history";
+import { Transaction } from "../transaction";
 import { defaultLang, getLanguage, languages, setLanguage, t } from "../i18n";
 
 import {
@@ -467,7 +468,6 @@ import type {
   RenderInteractiveSceneCallback,
   ScrollBars,
 } from "../scene/types";
-
 import type { ClipboardData, PastedMixedContent } from "../clipboard";
 import type { ExportedElements } from "../data";
 import type { ContextMenuItems } from "./ContextMenu";
@@ -644,6 +644,7 @@ class App extends React.Component<AppProps, AppState> {
   public id: string;
   private store: Store;
   private history: History;
+  public transaction: Transaction;
   public excalidrawContainerValue: {
     container: HTMLDivElement | null;
     id: string;
@@ -786,6 +787,7 @@ class App extends React.Component<AppProps, AppState> {
       onUserFollow: (cb) => this.onUserFollowEmitter.on(cb),
       onStateChange: this.onStateChange,
       onEvent: this.onEvent,
+      transaction: this.transaction,
     };
     return api;
   }
@@ -845,6 +847,19 @@ class App extends React.Component<AppProps, AppState> {
 
     this.fonts = new Fonts(this.scene);
     this.history = new History(this.store);
+    this.transaction = new Transaction({
+      getSnapshot: () => this.store.snapshot,
+      handleRecord: (delta) => this.history.record(delta),
+      getSceneElements: () =>
+        new Map(
+          this.scene.getElementsMapIncludingDeleted(),
+        ) as SceneElementsMap,
+      handleRestore: (elements) =>
+        this.updateScene({
+          elements,
+          captureUpdate: CaptureUpdateAction.NEVER,
+        }),
+    });
 
     this.actionManager.registerAll(actions);
     this.actionManager.registerAction(createUndoAction(this.history));
@@ -3137,7 +3152,9 @@ class App extends React.Component<AppProps, AppState> {
     }
 
     this.store.onDurableIncrementEmitter.on((increment) => {
-      this.history.record(increment.delta);
+      if (!this.transaction.isActive) {
+        this.history.record(increment.delta);
+      }
     });
 
     // per. optimmisation, only subscribe if there is the `onIncrement` prop registered, to avoid unnecessary computation

--- a/packages/excalidraw/global.d.ts
+++ b/packages/excalidraw/global.d.ts
@@ -4,6 +4,7 @@ interface Window {
   EXCALIDRAW_ASSET_PATH: string | string[] | undefined;
   EXCALIDRAW_THROTTLE_RENDER: boolean | undefined;
   DEBUG_FRACTIONAL_INDICES: boolean | undefined;
+  DEBUG_TRANSACTIONS: boolean | undefined;
   EXCALIDRAW_EXPORT_SOURCE: string;
   gtag: Function;
   sa_event: Function;

--- a/packages/excalidraw/tests/transaction.test.tsx
+++ b/packages/excalidraw/tests/transaction.test.tsx
@@ -1,0 +1,379 @@
+import React from "react";
+
+import { reseed } from "@excalidraw/common";
+
+import { CaptureUpdateAction, newElementWith } from "@excalidraw/element";
+
+import { Excalidraw } from "../index";
+
+import { API } from "./helpers/api";
+import { Keyboard } from "./helpers/ui";
+import { act, render, unmountComponent } from "./test-utils";
+
+const { h } = window;
+
+beforeEach(async () => {
+  unmountComponent();
+  reseed(7);
+  await render(<Excalidraw handleKeyboardGlobally={true} />);
+});
+
+describe("Transaction", () => {
+  describe("begin()", () => {
+    it("marks transaction as active", () => {
+      h.app.transaction.begin();
+      expect(h.app.transaction.isActive).toBe(true);
+    });
+
+    it("throws when already active", () => {
+      h.app.transaction.begin();
+      expect(() => h.app.transaction.begin()).toThrow(
+        "A transaction is already active",
+      );
+    });
+
+    it("can begin again after commit", async () => {
+      const tx = h.app.transaction.begin();
+      await act(async () => tx.commit());
+      expect(() => h.app.transaction.begin()).not.toThrow();
+    });
+
+    it("can begin again after rollback", async () => {
+      const tx = h.app.transaction.begin();
+      await act(async () => tx.rollback());
+      expect(() => h.app.transaction.begin()).not.toThrow();
+    });
+  });
+
+  describe("commit()", () => {
+    it("groups multiple element changes into one undo entry", async () => {
+      const rect1 = API.createElement({ type: "rectangle", x: 0, y: 0 });
+      const rect2 = API.createElement({ type: "rectangle", x: 100, y: 0 });
+
+      const tx = h.app.transaction.begin();
+
+      await act(async () => {
+        API.updateScene({
+          elements: [rect1],
+          captureUpdate: CaptureUpdateAction.IMMEDIATELY,
+        });
+      });
+
+      await act(async () => {
+        API.updateScene({
+          elements: [rect1, rect2],
+          captureUpdate: CaptureUpdateAction.IMMEDIATELY,
+        });
+      });
+
+      await act(async () => tx.commit());
+
+      expect(API.getUndoStack().length).toBe(1);
+    });
+
+    it("does not create an undo entry when there are no changes", async () => {
+      const tx = h.app.transaction.begin();
+      await act(async () => tx.commit());
+      expect(API.getUndoStack().length).toBe(0);
+    });
+
+    it("marks transaction as inactive", async () => {
+      const tx = h.app.transaction.begin();
+      await act(async () => tx.commit());
+      expect(h.app.transaction.isActive).toBe(false);
+    });
+  });
+
+  describe("rollback()", () => {
+    it("restores scene to pre-transaction state", async () => {
+      const rect = API.createElement({ type: "rectangle" });
+
+      await act(async () => {
+        API.updateScene({
+          elements: [rect],
+          captureUpdate: CaptureUpdateAction.IMMEDIATELY,
+        });
+      });
+
+      const tx = h.app.transaction.begin();
+
+      await act(async () => {
+        API.updateScene({
+          elements: [],
+          captureUpdate: CaptureUpdateAction.IMMEDIATELY,
+        });
+      });
+
+      expect(h.elements.filter((el) => !el.isDeleted).length).toBe(0);
+
+      await act(async () => tx.rollback());
+
+      expect(h.elements.filter((el) => !el.isDeleted).length).toBe(1);
+      expect(h.elements[0].id).toBe(rect.id);
+    });
+
+    it("does not create an undo entry", async () => {
+      const rect = API.createElement({ type: "rectangle" });
+
+      const tx = h.app.transaction.begin();
+
+      await act(async () => {
+        API.updateScene({
+          elements: [rect],
+          captureUpdate: CaptureUpdateAction.IMMEDIATELY,
+        });
+      });
+
+      await act(async () => tx.rollback());
+
+      expect(API.getUndoStack().length).toBe(0);
+    });
+
+    it("marks transaction as inactive", async () => {
+      const tx = h.app.transaction.begin();
+      await act(async () => tx.rollback());
+      expect(h.app.transaction.isActive).toBe(false);
+    });
+
+    it("undo works correctly after rollback", async () => {
+      const rect = API.createElement({ type: "rectangle" });
+
+      // pre-transaction action — creates an undo entry
+      await act(async () => {
+        API.updateScene({
+          elements: [rect],
+          captureUpdate: CaptureUpdateAction.IMMEDIATELY,
+        });
+      });
+
+      expect(API.getUndoStack().length).toBe(1);
+
+      const tx = h.app.transaction.begin();
+
+      // erase the element inside the transaction
+      await act(async () => {
+        API.updateScene({
+          elements: [],
+          captureUpdate: CaptureUpdateAction.IMMEDIATELY,
+        });
+      });
+
+      await act(async () => tx.rollback());
+
+      // rollback must not change the undo stack
+      expect(API.getUndoStack().length).toBe(1);
+      // element must be back
+      expect(h.elements.filter((el) => !el.isDeleted).length).toBe(1);
+
+      // undo the pre-transaction add — must not throw
+      await act(async () => Keyboard.undo());
+
+      expect(API.getUndoStack().length).toBe(0);
+      expect(h.elements.filter((el) => !el.isDeleted).length).toBe(0);
+    });
+  });
+
+  describe("net change correctness", () => {
+    it("element added then removed within transaction produces no undo entry", async () => {
+      const rect = API.createElement({ type: "rectangle" });
+
+      const tx = h.app.transaction.begin();
+
+      await act(async () => {
+        API.updateScene({
+          elements: [rect],
+          captureUpdate: CaptureUpdateAction.IMMEDIATELY,
+        });
+      });
+
+      await act(async () => {
+        API.updateScene({
+          elements: [],
+          captureUpdate: CaptureUpdateAction.IMMEDIATELY,
+        });
+      });
+
+      await act(async () => tx.commit());
+
+      expect(API.getUndoStack().length).toBe(0);
+      expect(h.elements.length).toBe(0);
+    });
+
+    it("element added then removed does not reappear on undo", async () => {
+      const existing = API.createElement({ type: "rectangle", x: 0, y: 0 });
+
+      await act(async () => {
+        API.updateScene({
+          elements: [existing],
+          captureUpdate: CaptureUpdateAction.IMMEDIATELY,
+        });
+      });
+
+      const rect = API.createElement({ type: "rectangle", x: 100, y: 0 });
+      const tx = h.app.transaction.begin();
+
+      await act(async () => {
+        API.updateScene({
+          elements: [existing, rect],
+          captureUpdate: CaptureUpdateAction.IMMEDIATELY,
+        });
+      });
+
+      await act(async () => {
+        API.updateScene({
+          elements: [existing],
+          captureUpdate: CaptureUpdateAction.IMMEDIATELY,
+        });
+      });
+
+      await act(async () => tx.commit());
+
+      // transaction had net zero effect on `rect` — it should not appear in the undo stack
+      expect(API.getUndoStack().length).toBe(1);
+      expect(
+        h.elements.map((el) => ({ id: el.id, isDeleted: el.isDeleted })),
+      ).toEqual([
+        expect.objectContaining({ id: existing.id, isDeleted: false }),
+      ]);
+
+      // undo the pre-transaction add of `existing`
+      await act(async () => Keyboard.undo());
+
+      // verify undo fired
+      expect(API.getUndoStack().length).toBe(0);
+
+      // `rect` must not reappear — it was never committed to history
+      expect(h.elements.filter((el) => !el.isDeleted).length).toBe(0);
+    });
+
+    it("pre-existing element removed within transaction creates an undo entry", async () => {
+      const rect = API.createElement({ type: "rectangle" });
+
+      await act(async () => {
+        API.updateScene({
+          elements: [rect],
+          captureUpdate: CaptureUpdateAction.IMMEDIATELY,
+        });
+      });
+
+      const tx = h.app.transaction.begin();
+
+      await act(async () => {
+        API.updateScene({
+          elements: [],
+          captureUpdate: CaptureUpdateAction.IMMEDIATELY,
+        });
+      });
+
+      await act(async () => tx.commit());
+
+      expect(API.getUndoStack().length).toBe(2);
+    });
+  });
+
+  describe("property change correctness", () => {
+    it("undo restores original property value, not an intermediate one", async () => {
+      const rect = API.createElement({
+        type: "rectangle",
+        strokeColor: "#000000",
+      });
+
+      await act(async () => {
+        API.updateScene({
+          elements: [rect],
+          captureUpdate: CaptureUpdateAction.IMMEDIATELY,
+        });
+      });
+
+      const tx = h.app.transaction.begin();
+
+      await act(async () => {
+        API.updateScene({
+          elements: [newElementWith(h.elements[0], { strokeColor: "#ff0000" })],
+          captureUpdate: CaptureUpdateAction.IMMEDIATELY,
+        });
+      });
+
+      await act(async () => {
+        API.updateScene({
+          elements: [newElementWith(h.elements[0], { strokeColor: "#0000ff" })],
+          captureUpdate: CaptureUpdateAction.IMMEDIATELY,
+        });
+      });
+
+      await act(async () => tx.commit());
+
+      expect(h.elements[0].strokeColor).toBe("#0000ff");
+
+      await act(async () => Keyboard.undo());
+
+      expect(h.elements.filter((el) => !el.isDeleted)[0].strokeColor).toBe(
+        "#000000",
+      );
+    });
+
+    it("rollback restores original property value, not an intermediate one", async () => {
+      const rect = API.createElement({
+        type: "rectangle",
+        strokeColor: "#000000",
+      });
+
+      await act(async () => {
+        API.updateScene({
+          elements: [rect],
+          captureUpdate: CaptureUpdateAction.IMMEDIATELY,
+        });
+      });
+
+      const tx = h.app.transaction.begin();
+
+      await act(async () => {
+        API.updateScene({
+          elements: [newElementWith(h.elements[0], { strokeColor: "#ff0000" })],
+          captureUpdate: CaptureUpdateAction.IMMEDIATELY,
+        });
+      });
+
+      await act(async () => {
+        API.updateScene({
+          elements: [newElementWith(h.elements[0], { strokeColor: "#0000ff" })],
+          captureUpdate: CaptureUpdateAction.IMMEDIATELY,
+        });
+      });
+
+      await act(async () => tx.rollback());
+
+      expect(h.elements.filter((el) => !el.isDeleted)[0].strokeColor).toBe(
+        "#000000",
+      );
+    });
+  });
+
+  describe("sequential transactions", () => {
+    it("creates a separate undo entry for each transaction", async () => {
+      const rect = API.createElement({ type: "rectangle", x: 0, y: 0 });
+
+      const tx1 = h.app.transaction.begin();
+      await act(async () => {
+        API.updateScene({
+          elements: [rect],
+          captureUpdate: CaptureUpdateAction.IMMEDIATELY,
+        });
+      });
+      await act(async () => tx1.commit());
+
+      expect(API.getUndoStack().length).toBe(1);
+
+      const tx2 = h.app.transaction.begin();
+      await act(async () => {
+        API.updateScene({
+          elements: [newElementWith(h.elements[0], { x: 100 })],
+          captureUpdate: CaptureUpdateAction.IMMEDIATELY,
+        });
+      });
+      await act(async () => tx2.commit());
+
+      expect(API.getUndoStack().length).toBe(2);
+    });
+  });
+});

--- a/packages/excalidraw/transaction.ts
+++ b/packages/excalidraw/transaction.ts
@@ -1,0 +1,125 @@
+import { StoreDelta, ElementsDelta } from "@excalidraw/element";
+
+import type { StoreSnapshot } from "@excalidraw/element";
+import type {
+  SceneElementsMap,
+  ExcalidrawElement,
+} from "@excalidraw/element/types";
+
+export interface TransactionHandlers {
+  getSnapshot: () => StoreSnapshot;
+  handleRecord: (delta: StoreDelta) => void;
+  getSceneElements: () => SceneElementsMap;
+  handleRestore: (elements: readonly ExcalidrawElement[]) => void;
+}
+
+export interface TransactionHandle {
+  commit(): void;
+  rollback(): void;
+}
+
+export class Transaction {
+  private _isActive = false;
+  private preTransactionSnapshot: StoreSnapshot | null = null;
+  private id = 0;
+
+  public get isActive(): boolean {
+    return this._isActive;
+  }
+
+  constructor(private readonly handlers: TransactionHandlers) {}
+
+  public begin(): TransactionHandle {
+    if (this._isActive) {
+      throw new Error(
+        "A transaction is already active. Call commit() or rollback() before starting a new one.",
+      );
+    }
+
+    this._isActive = true;
+    // StoreSnapshot.maybeClone always creates a new instance on change,
+    // so this reference stays stable even as the store snapshot advances.
+    this.preTransactionSnapshot = this.handlers.getSnapshot();
+    ++this.id;
+
+    this.log(`begin`);
+
+    return {
+      commit: () => this.commit(),
+      rollback: () => this.rollback(),
+    };
+  }
+
+  public commit(): void {
+    this._isActive = false;
+
+    const delta = this.computeDelta();
+    if (delta) {
+      this.handlers.handleRecord(delta);
+      this.log(`commit`, { delta });
+    } else {
+      this.log(`commit (no changes)`);
+    }
+  }
+
+  public rollback(): void {
+    this._isActive = false;
+
+    const delta = this.computeDelta();
+    if (delta) {
+      const inverse = StoreDelta.inverse(delta);
+      const [nextElements] = inverse.elements.applyTo(
+        this.handlers.getSceneElements(),
+        undefined,
+        {
+          excludedProperties: new Set(["version", "versionNonce"]),
+        },
+      );
+      this.handlers.handleRestore([...nextElements.values()]);
+      this.log(`rollback`, { delta, inverse });
+    } else {
+      this.log(`rollback (no changes)`);
+    }
+  }
+
+  private computeDelta(): StoreDelta | null {
+    const preSnapshot = this.preTransactionSnapshot;
+    if (!preSnapshot) {
+      return null;
+    }
+
+    this.preTransactionSnapshot = null;
+    const raw = StoreDelta.calculate(preSnapshot, this.handlers.getSnapshot());
+    const updates = Object.entries(raw.elements.updated);
+
+    // ElementsDelta.calculate places elements born and died within the transaction
+    // (absent from preSnapshot, isDeleted: true in postSnapshot) into `updated`
+    // with both sides isDeleted: true. These are invisible to the user and must
+    // not produce an undo entry.
+    const filteredUpdates = updates.filter(
+      ([, d]) =>
+        !(d.deleted.isDeleted === true && d.inserted.isDeleted === true),
+    );
+    if (filteredUpdates.length === updates.length) {
+      return raw.isEmpty() ? null : raw;
+    }
+
+    const delta = StoreDelta.create(
+      ElementsDelta.create(
+        raw.elements.added,
+        raw.elements.removed,
+        Object.fromEntries(filteredUpdates),
+      ),
+      raw.appState,
+    );
+
+    return delta.isEmpty() ? null : delta;
+  }
+
+  private log(message: string, data?: unknown): void {
+    if (window?.DEBUG_TRANSACTIONS) {
+      // eslint-disable-next-line no-console
+      console.log(`[Transaction#${this.id}] ${message}`, data);
+    }
+  }
+}

--- a/packages/excalidraw/types.ts
+++ b/packages/excalidraw/types.ts
@@ -827,6 +827,7 @@ export type AppClassProperties = {
   getEditorUIOffsets: App["getEditorUIOffsets"];
   visibleElements: App["visibleElements"];
   excalidrawContainerValue: App["excalidrawContainerValue"];
+  transaction: App["transaction"];
 
   onPointerUpEmitter: App["onPointerUpEmitter"];
   updateEditorAtom: App["updateEditorAtom"];
@@ -1000,6 +1001,7 @@ export interface ExcalidrawImperativeAPI {
   ) => UnsubscribeCallback;
   onStateChange: InstanceType<typeof App>["onStateChange"];
   onEvent: InstanceType<typeof App>["onEvent"];
+  transaction: App["transaction"];
 }
 
 export type FrameNameBounds = {


### PR DESCRIPTION
## Summary

Introduces `Transaction` class with `begin()`/`commit()`/`rollback()` that accumulates multiple `updateScene` calls and records them as one history entry. Uses snapshot-based delta calculation to capture the true before/after diff, avoiding squash bugs with intermediate property values. Rollback applies the inverse delta without touching version counters so `detectChangedElements` picks up the restore correctly. Ghost elements (born and died within one transaction) are filtered out to prevent spurious undo entries.

## Testing

- Manually tested
- Ran `yarn test:all`