### PR TITLE
fix(editor): make save shortcut tolerate CapsLock (#9281)

### DIFF
--- a/packages/excalidraw/actions/actionExport.test.tsx
+++ b/packages/excalidraw/actions/actionExport.test.tsx
@@ -1,0 +1,56 @@
+import { actionSaveToActiveFile, actionSaveFileToDisk } from "./actionExport";
+
+const makeEvent = (
+  key: string,
+  modifiers: { ctrlOrCmd?: boolean; shift?: boolean } = {},
+) =>
+  ({
+    key,
+    ctrlKey: !!modifiers.ctrlOrCmd,
+    metaKey: !!modifiers.ctrlOrCmd,
+    shiftKey: !!modifiers.shift,
+  } as unknown as KeyboardEvent);
+
+describe("actionSaveToActiveFile.keyTest", () => {
+  it("matches Ctrl/Cmd+S with lowercase key", () => {
+    expect(
+      actionSaveToActiveFile.keyTest!(makeEvent("s", { ctrlOrCmd: true })),
+    ).toBe(true);
+  });
+
+  // CapsLock-on (or other layouts where the modifier-applied key arrives
+  // uppercased) used to fall through, letting the browser's native Ctrl+S
+  // dialog fire. See issue #9281.
+  it("matches Ctrl/Cmd+S with uppercase key (CapsLock on)", () => {
+    expect(
+      actionSaveToActiveFile.keyTest!(makeEvent("S", { ctrlOrCmd: true })),
+    ).toBe(true);
+  });
+
+  it("does not match Ctrl/Cmd+Shift+S (reserved for save-as)", () => {
+    expect(
+      actionSaveToActiveFile.keyTest!(
+        makeEvent("S", { ctrlOrCmd: true, shift: true }),
+      ),
+    ).toBe(false);
+  });
+
+  it("does not match plain S without modifier", () => {
+    expect(actionSaveToActiveFile.keyTest!(makeEvent("s"))).toBe(false);
+  });
+});
+
+describe("actionSaveFileToDisk.keyTest (regression guard)", () => {
+  it("matches Ctrl/Cmd+Shift+S regardless of letter case", () => {
+    expect(
+      actionSaveFileToDisk.keyTest!(
+        makeEvent("S", { ctrlOrCmd: true, shift: true }),
+      ),
+    ).toBe(true);
+    expect(
+      actionSaveFileToDisk.keyTest!(
+        makeEvent("s", { ctrlOrCmd: true, shift: true }),
+      ),
+    ).toBe(true);
+  });
+});

--- a/packages/excalidraw/actions/actionExport.tsx
+++ b/packages/excalidraw/actions/actionExport.tsx
@@ -369,7 +369,9 @@ export const actionSaveToActiveFile = register({
     }
   },
   keyTest: (event) =>
-    event.key === KEYS.S && event[KEYS.CTRL_OR_CMD] && !event.shiftKey,
+    event.key.toLowerCase() === KEYS.S &&
+    event[KEYS.CTRL_OR_CMD] &&
+    !event.shiftKey,
 });
 
 export const actionSaveFileToDisk = register({


### PR DESCRIPTION
## Summary

`actionSaveToActiveFile.keyTest` strictly checks `event.key === "s"`, so when CapsLock is on the browser delivers `event.key === "S"` and the shortcut silently fails — the action manager never matches Ctrl+S, no `preventDefault()` is called, and the browser's native "save webpage as HTML" dialog fires instead. This is exactly the symptom reported in #9281.

The sibling action `actionSaveFileToDisk` (Ctrl+Shift+S) already normalizes via `.toLowerCase()`. This PR brings `actionSaveToActiveFile` in line with that pattern.

## Why not the approach in #10615

That PR adds an `actionSaveFileToDisk` fallback when `actionSaveToActiveFile` is disabled (no `fileHandle`). But the bug is **not** about the predicate — `keyTest` returns `false` first, so the matching pipeline never runs and `preventDefault()` is never called. A fallback inside the never-entered branch wouldn't fix the CapsLock case.

## Changes

- `packages/excalidraw/actions/actionExport.tsx`: use `event.key.toLowerCase() === KEYS.S` (matches the sibling `actionSaveFileToDisk.keyTest` pattern)
- `packages/excalidraw/actions/actionExport.test.tsx` (new): unit tests covering lowercase, uppercase (CapsLock), Ctrl+Shift+S, and unmodified S

## Test plan

- [x] `yarn test:typecheck`
- [x] `yarn fix` (no lint errors)
- [x] `yarn vitest run packages/excalidraw/actions packages/excalidraw/wysiwyg` — 115 passed, 1 skipped
- [x] Reverted the one-line fix locally to confirm the new CapsLock test fails at exactly the assertion intended

Closes #9281
