### PR TITLE
refactor(editor): simplifies snaplines 

### DIFF
--- a/packages/excalidraw/renderer/renderSnaps.ts
+++ b/packages/excalidraw/renderer/renderSnaps.ts
@@ -8,7 +8,6 @@ import type { InteractiveCanvasAppState } from "../types";
 const SNAP_COLOR_LIGHT = "#ff6b6b";
 const SNAP_COLOR_DARK = "#ff0000";
 const SNAP_WIDTH = 1;
-const SNAP_CROSS_SIZE = 2;
 
 export const renderSnaps = (
   context: CanvasRenderingContext2D,
@@ -19,8 +18,6 @@ export const renderSnaps = (
   }
 
   // in dark mode, we need to adjust the color to account for color inversion.
-  // Don't change if zen mode, because we draw only crosses, we want the
-  // colors to be more visible
   const snapColor =
     appState.theme === THEME.LIGHT || appState.zenModeEnabled
       ? SNAP_COLOR_LIGHT
@@ -38,7 +35,7 @@ export const renderSnaps = (
       context.lineWidth = snapWidth;
       context.strokeStyle = snapColor;
 
-      drawPointerSnapLine(snapLine, context, appState);
+      drawPointerSnapLine(snapLine, context);
     } else if (snapLine.type === "gap") {
       context.lineWidth = snapWidth;
       context.strokeStyle = snapColor;
@@ -53,7 +50,7 @@ export const renderSnaps = (
     } else if (snapLine.type === "points") {
       context.lineWidth = snapWidth;
       context.strokeStyle = snapColor;
-      drawPointsSnapLine(snapLine, context, appState);
+      drawPointsSnapLine(snapLine, context);
     }
   }
 
@@ -63,50 +60,18 @@ export const renderSnaps = (
 const drawPointsSnapLine = (
   pointSnapLine: PointSnapLine,
   context: CanvasRenderingContext2D,
-  appState: InteractiveCanvasAppState,
 ) => {
-  if (!appState.zenModeEnabled) {
-    const firstPoint = pointSnapLine.points[0];
-    const lastPoint = pointSnapLine.points[pointSnapLine.points.length - 1];
+  const firstPoint = pointSnapLine.points[0];
+  const lastPoint = pointSnapLine.points[pointSnapLine.points.length - 1];
 
-    drawLine(firstPoint, lastPoint, context);
-  }
-
-  for (const point of pointSnapLine.points) {
-    drawCross(point, appState, context);
-  }
+  drawLine(firstPoint, lastPoint, context);
 };
 
 const drawPointerSnapLine = (
   pointerSnapLine: PointerSnapLine,
   context: CanvasRenderingContext2D,
-  appState: InteractiveCanvasAppState,
 ) => {
-  drawCross(pointerSnapLine.points[0], appState, context);
-  if (!appState.zenModeEnabled) {
-    drawLine(pointerSnapLine.points[0], pointerSnapLine.points[1], context);
-  }
-};
-
-const drawCross = <Point extends LocalPoint | GlobalPoint>(
-  [x, y]: Point,
-  appState: InteractiveCanvasAppState,
-  context: CanvasRenderingContext2D,
-) => {
-  context.save();
-  const size =
-    (appState.zenModeEnabled ? SNAP_CROSS_SIZE * 1.5 : SNAP_CROSS_SIZE) /
-    appState.zoom.value;
-  context.beginPath();
-
-  context.moveTo(x - size, y - size);
-  context.lineTo(x + size, y + size);
-
-  context.moveTo(x + size, y - size);
-  context.lineTo(x - size, y + size);
-
-  context.stroke();
-  context.restore();
+  drawLine(pointerSnapLine.points[0], pointerSnapLine.points[1], context);
 };
 
 const drawLine = <Point extends LocalPoint | GlobalPoint>(

--- a/packages/excalidraw/renderer/renderSnaps.ts
+++ b/packages/excalidraw/renderer/renderSnaps.ts
@@ -8,6 +8,7 @@ import type { InteractiveCanvasAppState } from "../types";
 const SNAP_COLOR_LIGHT = "#ff6b6b";
 const SNAP_COLOR_DARK = "#ff0000";
 const SNAP_WIDTH = 1;
+const SNAP_CROSS_SIZE = 2;
 
 export const renderSnaps = (
   context: CanvasRenderingContext2D,
@@ -35,7 +36,7 @@ export const renderSnaps = (
       context.lineWidth = snapWidth;
       context.strokeStyle = snapColor;
 
-      drawPointerSnapLine(snapLine, context);
+      drawPointerSnapLine(snapLine, context, appState);
     } else if (snapLine.type === "gap") {
       context.lineWidth = snapWidth;
       context.strokeStyle = snapColor;
@@ -50,7 +51,7 @@ export const renderSnaps = (
     } else if (snapLine.type === "points") {
       context.lineWidth = snapWidth;
       context.strokeStyle = snapColor;
-      drawPointsSnapLine(snapLine, context);
+      drawPointsSnapLine(snapLine, context, appState);
     }
   }
 
@@ -60,18 +61,50 @@ export const renderSnaps = (
 const drawPointsSnapLine = (
   pointSnapLine: PointSnapLine,
   context: CanvasRenderingContext2D,
+  appState: InteractiveCanvasAppState,
 ) => {
-  const firstPoint = pointSnapLine.points[0];
-  const lastPoint = pointSnapLine.points[pointSnapLine.points.length - 1];
+  if (!appState.zenModeEnabled) {
+    const firstPoint = pointSnapLine.points[0];
+    const lastPoint = pointSnapLine.points[pointSnapLine.points.length - 1];
 
-  drawLine(firstPoint, lastPoint, context);
+    drawLine(firstPoint, lastPoint, context);
+  }
+
+  for (const point of pointSnapLine.points) {
+    drawCross(point, appState, context);
+  }
 };
 
 const drawPointerSnapLine = (
   pointerSnapLine: PointerSnapLine,
   context: CanvasRenderingContext2D,
+  appState: InteractiveCanvasAppState,
 ) => {
-  drawLine(pointerSnapLine.points[0], pointerSnapLine.points[1], context);
+  drawCross(pointerSnapLine.points[0], appState, context);
+  if (!appState.zenModeEnabled) {
+    drawLine(pointerSnapLine.points[0], pointerSnapLine.points[1], context);
+  }
+};
+
+const drawCross = <Point extends LocalPoint | GlobalPoint>(
+  [x, y]: Point,
+  appState: InteractiveCanvasAppState,
+  context: CanvasRenderingContext2D,
+) => {
+  context.save();
+  const size =
+    (appState.zenModeEnabled ? SNAP_CROSS_SIZE * 1.5 : SNAP_CROSS_SIZE) /
+    appState.zoom.value;
+  context.beginPath();
+
+  context.moveTo(x - size, y - size);
+  context.lineTo(x + size, y + size);
+
+  context.moveTo(x + size, y - size);
+  context.lineTo(x - size, y + size);
+
+  context.stroke();
+  context.restore();
 };
 
 const drawLine = <Point extends LocalPoint | GlobalPoint>(

--- a/packages/excalidraw/snapping.ts
+++ b/packages/excalidraw/snapping.ts
@@ -817,32 +817,7 @@ const filterPointSnapsToNearestCluster = (
       continue;
     }
 
-    if (offsetSnaps.length < 2) {
-      offsetSnaps.forEach((snap) => keptPointSnaps.add(snap));
-      continue;
-    }
-
-    const sortedSnaps = offsetSnaps
-      .slice()
-      .sort((a, b) => a.visualDistance - b.visualDistance);
-
-    let keepUntil = sortedSnaps.length;
-
-    // This runs after the winning snap offset is known. A big visual-distance
-    // gap means references after it belong to a separate, farther cluster.
-    for (let i = 1; i < sortedSnaps.length; i++) {
-      const distanceGap =
-        sortedSnaps[i].visualDistance - sortedSnaps[i - 1].visualDistance;
-
-      if (distanceGap > clusterBreakDistance) {
-        keepUntil = i;
-        break;
-      }
-    }
-
-    for (let i = 0; i < keepUntil; i++) {
-      keptPointSnaps.add(sortedSnaps[i]);
-    }
+    offsetSnaps.forEach((snap) => keptPointSnaps.add(snap));
   }
 
   let writeIndex = 0;
@@ -1128,23 +1103,19 @@ type OuterSnapLineCoordinateRange = {
 };
 
 /**
- * Only center-to-center snaps count as center snaplines for redundancy. A
- * center-to-outer snap still explains an outer edge or midpoint alignment.
- */
-const isCenterToCenterSnap = (snap: PointSnap) => {
-  return snap.pointTypes.every((pointType) => pointType === "center");
-};
-
-/**
  * Describes which snap source pair produced a rendered point snapline, so later
  * filtering can reason about redundancy without mixing unrelated references.
+ * Only center-to-center snaps count as center snaplines; a center-to-outer snap
+ * still explains an outer edge or midpoint alignment.
  */
 const getPointSnapLineSourcePair = (
   snap: PointSnap,
 ): PointSnapLineSourcePair => {
   return {
     snapSourcePairKey: snap.snapSourceIds.join("->"),
-    pointType: isCenterToCenterSnap(snap) ? "center" : "outer",
+    pointType: snap.pointTypes.every((pointType) => pointType === "center")
+      ? "center"
+      : "outer",
   };
 };
 

--- a/packages/excalidraw/snapping.ts
+++ b/packages/excalidraw/snapping.ts
@@ -55,10 +55,35 @@ type Vector2D = {
 };
 
 type PointPair = [GlobalPoint, GlobalPoint];
+type SnapPointType = "outer" | "center";
+type SnapPointSourceId = string;
+
+const SELECTION_SNAP_POINT_SOURCE_ID = "selection";
+
+// Source ids let us filter redundant snaplines only within one
+// selection-to-reference relationship, without mixing separate reference groups.
+// For example, "selection->rectA" may collapse to its outermost snaplines,
+// while "selection->rectB" still keeps its own independent snaplines.
+type SnapPoint = {
+  point: GlobalPoint;
+  type: SnapPointType;
+  sourceId: SnapPointSourceId;
+};
+
+const outerSnapPoint = (
+  point: GlobalPoint,
+  sourceId = SELECTION_SNAP_POINT_SOURCE_ID,
+): SnapPoint => ({
+  point,
+  type: "outer",
+  sourceId,
+});
 
 export type PointSnap = {
   type: "point";
   points: PointPair;
+  pointTypes: [SnapPointType, SnapPointType];
+  sourceIds: [SnapPointSourceId, SnapPointSourceId];
   offset: number;
 };
 
@@ -120,14 +145,14 @@ export type SnapLine = PointSnapLine | GapSnapLine | PointerSnapLine;
 // -----------------------------------------------------------------------------
 
 export class SnapCache {
-  private static referenceSnapPoints: GlobalPoint[] | null = null;
+  private static referenceSnapPoints: SnapPoint[] | null = null;
 
   private static visibleGaps: {
     verticalGaps: Gap[];
     horizontalGaps: Gap[];
   } | null = null;
 
-  public static setReferenceSnapPoints = (snapPoints: GlobalPoint[] | null) => {
+  public static setReferenceSnapPoints = (snapPoints: SnapPoint[] | null) => {
     SnapCache.referenceSnapPoints = snapPoints;
   };
 
@@ -310,6 +335,30 @@ export const getElementsCorners = (
   }
 
   return result.map((p) => pointFrom(round(p[0]), round(p[1])));
+};
+
+const getElementsSnapPoints = (
+  elements: ExcalidrawElement[],
+  elementsMap: ElementsMap,
+  options: Parameters<typeof getElementsCorners>[2] = {},
+  sourceId = SELECTION_SNAP_POINT_SOURCE_ID,
+): SnapPoint[] => {
+  const points = getElementsCorners(elements, elementsMap, options);
+  // getElementsCorners() appends the center point last unless omitCenter is set.
+  const hasCenterPoint = !options.omitCenter && points.length > 0;
+
+  return points.map((point, index) => ({
+    point,
+    type: hasCenterPoint && index === points.length - 1 ? "center" : "outer",
+    sourceId,
+  }));
+};
+
+const getSnapPointSourceId = (elements: ExcalidrawElement[]) => {
+  return elements
+    .map((element) => element.id)
+    .sort()
+    .join(",");
 };
 
 const getReferenceElements = (
@@ -630,12 +679,19 @@ export const getReferenceSnapPoints = (
       (elementsGroup) =>
         !(elementsGroup.length === 1 && isBoundToContainer(elementsGroup[0])),
     )
-    .flatMap((elementGroup) => getElementsCorners(elementGroup, elementsMap));
+    .flatMap((elementGroup) =>
+      getElementsSnapPoints(
+        elementGroup,
+        elementsMap,
+        {},
+        getSnapPointSourceId(elementGroup),
+      ),
+    );
 };
 
 const getPointSnaps = (
   selectedElements: ExcalidrawElement[],
-  selectionSnapPoints: GlobalPoint[],
+  selectionSnapPoints: SnapPoint[],
   app: AppClassProperties,
   event: KeyboardModifiersObject,
   nearestSnapsX: Snaps,
@@ -654,8 +710,8 @@ const getPointSnaps = (
   if (referenceSnapPoints) {
     for (const thisSnapPoint of selectionSnapPoints) {
       for (const otherSnapPoint of referenceSnapPoints) {
-        const offsetX = otherSnapPoint[0] - thisSnapPoint[0];
-        const offsetY = otherSnapPoint[1] - thisSnapPoint[1];
+        const offsetX = otherSnapPoint.point[0] - thisSnapPoint.point[0];
+        const offsetY = otherSnapPoint.point[1] - thisSnapPoint.point[1];
 
         if (Math.abs(offsetX) <= minOffset.x) {
           if (Math.abs(offsetX) < minOffset.x) {
@@ -664,7 +720,9 @@ const getPointSnaps = (
 
           nearestSnapsX.push({
             type: "point",
-            points: [thisSnapPoint, otherSnapPoint],
+            points: [thisSnapPoint.point, otherSnapPoint.point],
+            pointTypes: [thisSnapPoint.type, otherSnapPoint.type],
+            sourceIds: [thisSnapPoint.sourceId, otherSnapPoint.sourceId],
             offset: offsetX,
           });
 
@@ -678,7 +736,9 @@ const getPointSnaps = (
 
           nearestSnapsY.push({
             type: "point",
-            points: [thisSnapPoint, otherSnapPoint],
+            points: [thisSnapPoint.point, otherSnapPoint.point],
+            pointTypes: [thisSnapPoint.type, otherSnapPoint.type],
+            sourceIds: [thisSnapPoint.sourceId, otherSnapPoint.sourceId],
             offset: offsetY,
           });
 
@@ -720,7 +780,7 @@ export const snapDraggedElements = (
     y: snapDistance,
   };
 
-  const selectionPoints = getElementsCorners(selectedElements, elementsMap, {
+  const selectionPoints = getElementsSnapPoints(selectedElements, elementsMap, {
     dragOffset,
   });
 
@@ -770,7 +830,7 @@ export const snapDraggedElements = (
 
   getPointSnaps(
     selectedElements,
-    getElementsCorners(selectedElements, elementsMap, {
+    getElementsSnapPoints(selectedElements, elementsMap, {
       dragOffset: newDragOffset,
     }),
     app,
@@ -825,12 +885,124 @@ const dedupePoints = (points: GlobalPoint[]): GlobalPoint[] => {
   return Array.from(map.values());
 };
 
+type PointSnapLineMatch = {
+  sourceKey: string;
+  pointType: SnapPointType;
+};
+
+type PointSnapLineCandidate = PointSnapLine & {
+  matches: PointSnapLineMatch[];
+};
+
+type PointSnapLineBucket = {
+  points: GlobalPoint[];
+  matches: PointSnapLineMatch[];
+};
+
+const getPointSnapLineMatch = (snap: PointSnap): PointSnapLineMatch => {
+  return {
+    sourceKey: snap.sourceIds.join("->"),
+    pointType: snap.pointTypes.every((pointType) => pointType === "center")
+      ? "center"
+      : "outer",
+  };
+};
+
+const getOuterCoordinatesBySourceKey = (
+  snapLines: PointSnapLineCandidate[],
+  getCoordinate: (snapLine: PointSnapLine) => number,
+) => {
+  const outerCoordinates = new Map<string, number[]>();
+
+  for (const snapLine of snapLines) {
+    const coordinate = getCoordinate(snapLine);
+
+    for (const match of snapLine.matches) {
+      if (match.pointType === "center") {
+        continue;
+      }
+
+      const sourceCoordinates = outerCoordinates.get(match.sourceKey) ?? [];
+      sourceCoordinates.push(coordinate);
+      outerCoordinates.set(match.sourceKey, sourceCoordinates);
+    }
+  }
+
+  return outerCoordinates;
+};
+
+// A center snapline is redundant when outer snaplines from the same source pair
+// exist on both sides, because the outer lines already imply center alignment.
+const isRedundantCenterSnapLine = (
+  coordinate: number,
+  sourceOuterCoordinates: number[],
+) => {
+  const hasOuterBefore = sourceOuterCoordinates.some(
+    (outerCoordinate) => outerCoordinate < coordinate,
+  );
+  const hasOuterAfter = sourceOuterCoordinates.some(
+    (outerCoordinate) => outerCoordinate > coordinate,
+  );
+
+  return hasOuterBefore && hasOuterAfter;
+};
+
+// When more than two outer snaplines come from the same source pair, the inner
+// ones are redundant; the two extremes communicate the same shape alignment.
+const isRedundantOuterSnapLine = (
+  coordinate: number,
+  sourceOuterCoordinates: number[],
+) => {
+  if (sourceOuterCoordinates.length <= 2) {
+    return false;
+  }
+
+  const minCoordinate = Math.min(...sourceOuterCoordinates);
+  const maxCoordinate = Math.max(...sourceOuterCoordinates);
+
+  return coordinate !== minCoordinate && coordinate !== maxCoordinate;
+};
+
+const filterRedundantPointSnapLines = (
+  snapLines: PointSnapLineCandidate[],
+  getCoordinate: (snapLine: PointSnapLine) => number,
+): PointSnapLine[] => {
+  if (snapLines.length < 3) {
+    return snapLines.map(({ matches, ...snapLine }) => snapLine);
+  }
+
+  // Track outer-line coordinates per source pair. The same visual snapline can
+  // be produced by multiple source pairs, so a line is removed only when every
+  // pair represented by that line considers it redundant.
+  const outerCoordinatesBySourceKey = getOuterCoordinatesBySourceKey(
+    snapLines,
+    getCoordinate,
+  );
+
+  return snapLines
+    .filter((snapLine) => {
+      const coordinate = getCoordinate(snapLine);
+
+      return snapLine.matches.some((match) => {
+        const sourceOuterCoordinates =
+          outerCoordinatesBySourceKey.get(match.sourceKey) ?? [];
+
+        if (match.pointType === "center") {
+          return !isRedundantCenterSnapLine(coordinate, sourceOuterCoordinates);
+        }
+
+        return !isRedundantOuterSnapLine(coordinate, sourceOuterCoordinates);
+      });
+    })
+    .map(({ matches, ...snapLine }) => snapLine);
+};
+
 const createPointSnapLines = (
   nearestSnapsX: Snaps,
   nearestSnapsY: Snaps,
 ): PointSnapLine[] => {
-  const snapsX = {} as { [key: string]: GlobalPoint[] };
-  const snapsY = {} as { [key: string]: GlobalPoint[] };
+  const snapsX = {} as { [key: string]: PointSnapLineBucket };
+  const snapsY = {} as { [key: string]: PointSnapLineBucket };
 
   if (nearestSnapsX.length > 0) {
     for (const snap of nearestSnapsX) {
@@ -838,13 +1010,14 @@ const createPointSnapLines = (
         // key = thisPoint.x
         const key = round(snap.points[0][0]);
         if (!snapsX[key]) {
-          snapsX[key] = [];
+          snapsX[key] = { points: [], matches: [] };
         }
-        snapsX[key].push(
+        snapsX[key].points.push(
           ...snap.points.map((p) =>
             pointFrom<GlobalPoint>(round(p[0]), round(p[1])),
           ),
         );
+        snapsX[key].matches.push(getPointSnapLineMatch(snap));
       }
     }
   }
@@ -855,44 +1028,55 @@ const createPointSnapLines = (
         // key = thisPoint.y
         const key = round(snap.points[0][1]);
         if (!snapsY[key]) {
-          snapsY[key] = [];
+          snapsY[key] = { points: [], matches: [] };
         }
-        snapsY[key].push(
+        snapsY[key].points.push(
           ...snap.points.map((p) =>
             pointFrom<GlobalPoint>(round(p[0]), round(p[1])),
           ),
         );
+        snapsY[key].matches.push(getPointSnapLineMatch(snap));
       }
     }
   }
 
-  return Object.entries(snapsX)
-    .map(([key, points]) => {
-      return {
-        type: "points",
-        points: dedupePoints(
-          points
-            .map((p) => {
-              return pointFrom<GlobalPoint>(Number(key), p[1]);
-            })
-            .sort((a, b) => a[1] - b[1]),
-        ),
-      } as PointSnapLine;
-    })
-    .concat(
-      Object.entries(snapsY).map(([key, points]) => {
-        return {
-          type: "points",
-          points: dedupePoints(
-            points
-              .map((p) => {
-                return pointFrom<GlobalPoint>(p[0], Number(key));
-              })
-              .sort((a, b) => a[0] - b[0]),
-          ),
-        } as PointSnapLine;
-      }),
-    );
+  const snapLinesX = Object.entries(snapsX).map(([key, snap]) => {
+    return {
+      type: "points",
+      points: dedupePoints(
+        snap.points
+          .map((p) => {
+            return pointFrom<GlobalPoint>(Number(key), p[1]);
+          })
+          .sort((a, b) => a[1] - b[1]),
+      ),
+      matches: snap.matches,
+    } as PointSnapLineCandidate;
+  });
+
+  const snapLinesY = Object.entries(snapsY).map(([key, snap]) => {
+    return {
+      type: "points",
+      points: dedupePoints(
+        snap.points
+          .map((p) => {
+            return pointFrom<GlobalPoint>(p[0], Number(key));
+          })
+          .sort((a, b) => a[0] - b[0]),
+      ),
+      matches: snap.matches,
+    } as PointSnapLineCandidate;
+  });
+
+  return filterRedundantPointSnapLines(
+    snapLinesX,
+    (snapLine) => snapLine.points[0][0],
+  ).concat(
+    filterRedundantPointSnapLines(
+      snapLinesY,
+      (snapLine) => snapLine.points[0][1],
+    ),
+  );
 };
 
 const dedupeGapSnapLines = (gapSnapLines: GapSnapLine[]) => {
@@ -1143,40 +1327,52 @@ export const snapResizingElements = (
     }
   }
 
-  const selectionSnapPoints: GlobalPoint[] = [];
+  const selectionSnapPoints: SnapPoint[] = [];
 
   if (transformHandle) {
     switch (transformHandle) {
       case "e": {
-        selectionSnapPoints.push(pointFrom(maxX, minY), pointFrom(maxX, maxY));
+        selectionSnapPoints.push(
+          outerSnapPoint(pointFrom(maxX, minY)),
+          outerSnapPoint(pointFrom(maxX, maxY)),
+        );
         break;
       }
       case "w": {
-        selectionSnapPoints.push(pointFrom(minX, minY), pointFrom(minX, maxY));
+        selectionSnapPoints.push(
+          outerSnapPoint(pointFrom(minX, minY)),
+          outerSnapPoint(pointFrom(minX, maxY)),
+        );
         break;
       }
       case "n": {
-        selectionSnapPoints.push(pointFrom(minX, minY), pointFrom(maxX, minY));
+        selectionSnapPoints.push(
+          outerSnapPoint(pointFrom(minX, minY)),
+          outerSnapPoint(pointFrom(maxX, minY)),
+        );
         break;
       }
       case "s": {
-        selectionSnapPoints.push(pointFrom(minX, maxY), pointFrom(maxX, maxY));
+        selectionSnapPoints.push(
+          outerSnapPoint(pointFrom(minX, maxY)),
+          outerSnapPoint(pointFrom(maxX, maxY)),
+        );
         break;
       }
       case "ne": {
-        selectionSnapPoints.push(pointFrom(maxX, minY));
+        selectionSnapPoints.push(outerSnapPoint(pointFrom(maxX, minY)));
         break;
       }
       case "nw": {
-        selectionSnapPoints.push(pointFrom(minX, minY));
+        selectionSnapPoints.push(outerSnapPoint(pointFrom(minX, minY)));
         break;
       }
       case "se": {
-        selectionSnapPoints.push(pointFrom(maxX, maxY));
+        selectionSnapPoints.push(outerSnapPoint(pointFrom(maxX, maxY)));
         break;
       }
       case "sw": {
-        selectionSnapPoints.push(pointFrom(minX, maxY));
+        selectionSnapPoints.push(outerSnapPoint(pointFrom(minX, maxY)));
         break;
       }
     }
@@ -1218,11 +1414,11 @@ export const snapResizingElements = (
     round(bound),
   );
 
-  const corners: GlobalPoint[] = [
-    pointFrom(x1, y1),
-    pointFrom(x1, y2),
-    pointFrom(x2, y1),
-    pointFrom(x2, y2),
+  const corners: SnapPoint[] = [
+    outerSnapPoint(pointFrom(x1, y1)),
+    outerSnapPoint(pointFrom(x1, y2)),
+    outerSnapPoint(pointFrom(x2, y1)),
+    outerSnapPoint(pointFrom(x2, y2)),
   ];
 
   getPointSnaps(
@@ -1258,8 +1454,8 @@ export const snapNewElement = (
     };
   }
 
-  const selectionSnapPoints: GlobalPoint[] = [
-    pointFrom(origin.x + dragOffset.x, origin.y + dragOffset.y),
+  const selectionSnapPoints: SnapPoint[] = [
+    outerSnapPoint(pointFrom(origin.x + dragOffset.x, origin.y + dragOffset.y)),
   ];
 
   const snapDistance = getSnapDistance(app.state.zoom.value);
@@ -1292,7 +1488,7 @@ export const snapNewElement = (
   nearestSnapsX.length = 0;
   nearestSnapsY.length = 0;
 
-  const corners = getElementsCorners([newElement], elementsMap, {
+  const corners = getElementsSnapPoints([newElement], elementsMap, {
     boundingBoxCorners: true,
     omitCenter: true,
   });

--- a/packages/excalidraw/snapping.ts
+++ b/packages/excalidraw/snapping.ts
@@ -39,6 +39,10 @@ import type {
 } from "./types";
 
 const SNAP_DISTANCE = 8;
+// Keep snap candidates with effectively identical offsets together. This needs
+// to be wider than the 6-decimal rounding quantum to absorb JS floating-point
+// noise around values like 4 and 4.000001.
+const SNAP_OFFSET_TOLERANCE = 0.00001;
 // Point snaps can come from both nearby and distant references within snap
 // distance. If their visual distances have a large break, prefer the nearest
 // cluster before comparing offsets.
@@ -67,34 +71,34 @@ type Vector2D = {
 
 type PointPair = [GlobalPoint, GlobalPoint];
 type SnapPointType = "outer" | "center";
-type SnapPointSourceId = string;
+type SnapSourceId = string;
 
-const SELECTION_SNAP_POINT_SOURCE_ID = "selection";
+const SELECTION_SNAP_SOURCE_ID = "selection";
 
-// Source ids let us filter redundant snaplines only within one
+// Snap source ids let us filter redundant snaplines only within one
 // selection-to-reference relationship, without mixing separate reference groups.
 // For example, "selection->rectA" may collapse to its outermost snaplines,
 // while "selection->rectB" still keeps its own independent snaplines.
 type SnapPoint = {
   point: GlobalPoint;
   type: SnapPointType;
-  sourceId: SnapPointSourceId;
+  snapSourceId: SnapSourceId;
 };
 
 const outerSnapPoint = (
   point: GlobalPoint,
-  sourceId = SELECTION_SNAP_POINT_SOURCE_ID,
+  snapSourceId = SELECTION_SNAP_SOURCE_ID,
 ): SnapPoint => ({
   point,
   type: "outer",
-  sourceId,
+  snapSourceId,
 });
 
 export type PointSnap = {
   type: "point";
   points: PointPair;
   pointTypes: [SnapPointType, SnapPointType];
-  sourceIds: [SnapPointSourceId, SnapPointSourceId];
+  snapSourceIds: [SnapSourceId, SnapSourceId];
   // Distance along the rendered snapline, used to group visually nearby
   // references before choosing which point snaps should win.
   visualDistance: number;
@@ -234,6 +238,17 @@ export const areRoughlyEqual = (a: number, b: number, precision = 0.01) => {
   return Math.abs(a - b) <= precision;
 };
 
+/**
+ * Keeps nearly identical snap offsets in the same winner set. This prevents
+ * snapline flicker when rounded geometry differs by a tiny floating-point tail.
+ */
+const isWithinSnapOffset = (offset: number, minOffset: number) => {
+  return (
+    Math.abs(offset) <= minOffset ||
+    areRoughlyEqual(Math.abs(offset), minOffset, SNAP_OFFSET_TOLERANCE)
+  );
+};
+
 export const getElementsCorners = (
   elements: ExcalidrawElement[],
   elementsMap: ElementsMap,
@@ -355,7 +370,7 @@ const getElementsSnapPoints = (
   elements: ExcalidrawElement[],
   elementsMap: ElementsMap,
   options: Parameters<typeof getElementsCorners>[2] = {},
-  sourceId = SELECTION_SNAP_POINT_SOURCE_ID,
+  snapSourceId = SELECTION_SNAP_SOURCE_ID,
 ): SnapPoint[] => {
   const points = getElementsCorners(elements, elementsMap, options);
   // getElementsCorners() appends the center point last unless omitCenter is set.
@@ -364,17 +379,25 @@ const getElementsSnapPoints = (
   return points.map((point, index) => ({
     point,
     type: hasCenterPoint && index === points.length - 1 ? "center" : "outer",
-    sourceId,
+    snapSourceId,
   }));
 };
 
-const getSnapPointSourceId = (elements: ExcalidrawElement[]) => {
+/**
+ * Builds a stable identity for one snap reference group. Sorting keeps grouped
+ * elements represented by the same snap source id regardless of element order.
+ */
+const getSnapSourceId = (elements: ExcalidrawElement[]) => {
   return elements
     .map((element) => element.id)
     .sort()
     .join(",");
 };
 
+/**
+ * Finds frames that the current selection already belongs to. Their children
+ * are still valid snap references; children of unrelated frames are not.
+ */
 const getSelectedFrameIdsForSnapping = (
   selectedElements: readonly ExcalidrawElement[],
 ) => {
@@ -387,6 +410,18 @@ const getSelectedFrameIdsForSnapping = (
   }
 
   return selectedFrameIds;
+};
+
+/**
+ * Frame children are only snap references when the dragged selection is inside
+ * the same frame. This avoids snapping external elements to internals of a
+ * framed diagram.
+ */
+const canUseElementAsSnapReference = (
+  element: NonDeletedExcalidrawElement,
+  selectedFrameIds: Set<ExcalidrawElement["id"]>,
+) => {
+  return !element.frameId || selectedFrameIds.has(element.frameId);
 };
 
 const getReferenceElements = (
@@ -403,7 +438,7 @@ const getReferenceElements = (
     appState,
     elementsMap,
   ).filter((element) => {
-    return !element.frameId || selectedFrameIds.has(element.frameId);
+    return canUseElementAsSnapReference(element, selectedFrameIds);
   });
 };
 
@@ -564,7 +599,10 @@ const getGapSnaps = (
       const centerOffset = round(gapMidX - centerX);
       const gapIsLargerThanSelection = gap.length > maxX - minX;
 
-      if (gapIsLargerThanSelection && Math.abs(centerOffset) <= minOffset.x) {
+      if (
+        gapIsLargerThanSelection &&
+        isWithinSnapOffset(centerOffset, minOffset.x)
+      ) {
         if (Math.abs(centerOffset) < minOffset.x) {
           nearestSnapsX.length = 0;
         }
@@ -586,7 +624,7 @@ const getGapSnaps = (
       const distanceToEndElementX = minX - endMaxX;
       const sideOffsetRight = round(gap.length - distanceToEndElementX);
 
-      if (Math.abs(sideOffsetRight) <= minOffset.x) {
+      if (isWithinSnapOffset(sideOffsetRight, minOffset.x)) {
         if (Math.abs(sideOffsetRight) < minOffset.x) {
           nearestSnapsX.length = 0;
         }
@@ -607,7 +645,7 @@ const getGapSnaps = (
       const distanceToStartElementX = startMinX - maxX;
       const sideOffsetLeft = round(distanceToStartElementX - gap.length);
 
-      if (Math.abs(sideOffsetLeft) <= minOffset.x) {
+      if (isWithinSnapOffset(sideOffsetLeft, minOffset.x)) {
         if (Math.abs(sideOffsetLeft) < minOffset.x) {
           nearestSnapsX.length = 0;
         }
@@ -633,7 +671,10 @@ const getGapSnaps = (
       const centerOffset = round(gapMidY - centerY);
       const gapIsLargerThanSelection = gap.length > maxY - minY;
 
-      if (gapIsLargerThanSelection && Math.abs(centerOffset) <= minOffset.y) {
+      if (
+        gapIsLargerThanSelection &&
+        isWithinSnapOffset(centerOffset, minOffset.y)
+      ) {
         if (Math.abs(centerOffset) < minOffset.y) {
           nearestSnapsY.length = 0;
         }
@@ -655,7 +696,7 @@ const getGapSnaps = (
       const distanceToStartElementY = startMinY - maxY;
       const sideOffsetTop = round(distanceToStartElementY - gap.length);
 
-      if (Math.abs(sideOffsetTop) <= minOffset.y) {
+      if (isWithinSnapOffset(sideOffsetTop, minOffset.y)) {
         if (Math.abs(sideOffsetTop) < minOffset.y) {
           nearestSnapsY.length = 0;
         }
@@ -676,7 +717,7 @@ const getGapSnaps = (
       const distanceToEndElementY = round(minY - endMaxY);
       const sideOffsetBottom = gap.length - distanceToEndElementY;
 
-      if (Math.abs(sideOffsetBottom) <= minOffset.y) {
+      if (isWithinSnapOffset(sideOffsetBottom, minOffset.y)) {
         if (Math.abs(sideOffsetBottom) < minOffset.y) {
           nearestSnapsY.length = 0;
         }
@@ -757,14 +798,22 @@ const filterPointSnapsToNearestCluster = (
   const minOffset = Math.min(
     ...nearestOffsetGroups.map(({ offset }) => Math.abs(offset)),
   );
-  const selectedOffsets = new Set(
-    nearestOffsetGroups
-      .filter(({ offset }) => Math.abs(offset) === minOffset)
-      .map(({ offset }) => offset),
-  );
+  const selectedOffsets = nearestOffsetGroups
+    .filter(({ offset }) =>
+      areRoughlyEqual(Math.abs(offset), minOffset, SNAP_OFFSET_TOLERANCE),
+    )
+    .map(({ offset }) => offset);
 
   for (const offsetSnaps of snapsByOffset.values()) {
-    if (!selectedOffsets.has(round(offsetSnaps[0].offset))) {
+    if (
+      !selectedOffsets.some((offset) =>
+        areRoughlyEqual(
+          round(offsetSnaps[0].offset),
+          offset,
+          SNAP_OFFSET_TOLERANCE,
+        ),
+      )
+    ) {
       continue;
     }
 
@@ -830,7 +879,7 @@ export const getReferenceSnapPoints = (
         elementGroup,
         elementsMap,
         {},
-        getSnapPointSourceId(elementGroup),
+        getSnapSourceId(elementGroup),
       ),
     );
 };
@@ -864,12 +913,15 @@ const getPointSnaps = (
         const offsetX = otherSnapPoint.point[0] - thisSnapPoint.point[0];
         const offsetY = otherSnapPoint.point[1] - thisSnapPoint.point[1];
 
-        if (Math.abs(offsetX) <= minOffset.x) {
+        if (isWithinSnapOffset(offsetX, minOffset.x)) {
           nearestSnapsX.push({
             type: "point",
             points: [thisSnapPoint.point, otherSnapPoint.point],
             pointTypes: [thisSnapPoint.type, otherSnapPoint.type],
-            sourceIds: [thisSnapPoint.sourceId, otherSnapPoint.sourceId],
+            snapSourceIds: [
+              thisSnapPoint.snapSourceId,
+              otherSnapPoint.snapSourceId,
+            ],
             visualDistance: Math.abs(
               otherSnapPoint.point[1] - thisSnapPoint.point[1],
             ),
@@ -877,12 +929,15 @@ const getPointSnaps = (
           });
         }
 
-        if (Math.abs(offsetY) <= minOffset.y) {
+        if (isWithinSnapOffset(offsetY, minOffset.y)) {
           nearestSnapsY.push({
             type: "point",
             points: [thisSnapPoint.point, otherSnapPoint.point],
             pointTypes: [thisSnapPoint.type, otherSnapPoint.type],
-            sourceIds: [thisSnapPoint.sourceId, otherSnapPoint.sourceId],
+            snapSourceIds: [
+              thisSnapPoint.snapSourceId,
+              otherSnapPoint.snapSourceId,
+            ],
             visualDistance: Math.abs(
               otherSnapPoint.point[0] - thisSnapPoint.point[0],
             ),
@@ -1049,130 +1104,183 @@ const dedupePoints = (points: GlobalPoint[]): GlobalPoint[] => {
   return Array.from(map.values());
 };
 
-type PointSnapLineMatch = {
-  sourceKey: string;
+// Point snaplines are collected from every winning point snap first. Multiple
+// snap source pairs can collapse to the same rendered line, so candidates keep
+// source-pair metadata until redundant center and inner outer lines are removed.
+type PointSnapLineSourcePair = {
+  snapSourcePairKey: string;
   pointType: SnapPointType;
 };
 
 type PointSnapLineCandidate = PointSnapLine & {
-  matches: PointSnapLineMatch[];
+  sourcePairs: PointSnapLineSourcePair[];
 };
 
 type PointSnapLineBucket = {
   points: GlobalPoint[];
-  matches: PointSnapLineMatch[];
+  sourcePairs: PointSnapLineSourcePair[];
+};
+
+type OuterSnapLineCoordinateRange = {
+  count: number;
+  min: number;
+  max: number;
 };
 
 /**
- * Describes which source pair produced a rendered point snapline, so later
+ * Only center-to-center snaps count as center snaplines for redundancy. A
+ * center-to-outer snap still explains an outer edge or midpoint alignment.
+ */
+const isCenterToCenterSnap = (snap: PointSnap) => {
+  return snap.pointTypes.every((pointType) => pointType === "center");
+};
+
+/**
+ * Describes which snap source pair produced a rendered point snapline, so later
  * filtering can reason about redundancy without mixing unrelated references.
  */
-const getPointSnapLineMatch = (snap: PointSnap): PointSnapLineMatch => {
+const getPointSnapLineSourcePair = (
+  snap: PointSnap,
+): PointSnapLineSourcePair => {
   return {
-    sourceKey: snap.sourceIds.join("->"),
-    pointType: snap.pointTypes.every((pointType) => pointType === "center")
-      ? "center"
-      : "outer",
+    snapSourcePairKey: snap.snapSourceIds.join("->"),
+    pointType: isCenterToCenterSnap(snap) ? "center" : "outer",
   };
 };
 
 /**
- * Builds the outer snapline coordinates by source pair. Center snaplines use
- * this map to decide whether the surrounding outer lines already explain them.
+ * Builds each snap source pair's outer coordinate range. Center snaplines use
+ * this range to decide whether the surrounding outer lines already explain
+ * them, and outer snaplines use it to keep only the two extremes.
  */
-const getOuterCoordinatesBySourceKey = (
+const getOuterCoordinateRangesBySnapSourcePairKey = (
   snapLines: PointSnapLineCandidate[],
   getCoordinate: (snapLine: PointSnapLine) => number,
 ) => {
-  const outerCoordinates = new Map<string, number[]>();
+  const ranges = new Map<string, OuterSnapLineCoordinateRange>();
 
   for (const snapLine of snapLines) {
     const coordinate = getCoordinate(snapLine);
 
-    for (const match of snapLine.matches) {
-      if (match.pointType === "center") {
+    for (const sourcePair of snapLine.sourcePairs) {
+      if (sourcePair.pointType === "center") {
         continue;
       }
 
-      const sourceCoordinates = outerCoordinates.get(match.sourceKey) ?? [];
-      sourceCoordinates.push(coordinate);
-      outerCoordinates.set(match.sourceKey, sourceCoordinates);
+      const range = ranges.get(sourcePair.snapSourcePairKey);
+
+      ranges.set(sourcePair.snapSourcePairKey, {
+        count: (range?.count ?? 0) + 1,
+        min: range ? Math.min(range.min, coordinate) : coordinate,
+        max: range ? Math.max(range.max, coordinate) : coordinate,
+      });
     }
   }
 
-  return outerCoordinates;
+  return ranges;
 };
 
-// A center snapline is redundant when outer snaplines from the same source pair
-// exist on both sides, because the outer lines already imply center alignment.
+/**
+ * A center snapline is redundant when outer snaplines from the same snap source
+ * pair exist on both sides, because the outer lines already imply center
+ * alignment.
+ */
 const isRedundantCenterSnapLine = (
   coordinate: number,
-  sourceOuterCoordinates: number[],
+  outerCoordinateRange?: OuterSnapLineCoordinateRange,
 ) => {
-  const hasOuterBefore = sourceOuterCoordinates.some(
-    (outerCoordinate) => outerCoordinate < coordinate,
-  );
-  const hasOuterAfter = sourceOuterCoordinates.some(
-    (outerCoordinate) => outerCoordinate > coordinate,
-  );
-
-  return hasOuterBefore && hasOuterAfter;
-};
-
-// When more than two outer snaplines come from the same source pair, the inner
-// ones are redundant; the two extremes communicate the same shape alignment.
-const isRedundantOuterSnapLine = (
-  coordinate: number,
-  sourceOuterCoordinates: number[],
-) => {
-  if (sourceOuterCoordinates.length <= 2) {
+  if (!outerCoordinateRange) {
     return false;
   }
 
-  const minCoordinate = Math.min(...sourceOuterCoordinates);
-  const maxCoordinate = Math.max(...sourceOuterCoordinates);
+  return (
+    outerCoordinateRange.min < coordinate &&
+    outerCoordinateRange.max > coordinate
+  );
+};
 
-  return coordinate !== minCoordinate && coordinate !== maxCoordinate;
+/**
+ * When more than two outer snaplines come from the same snap source pair, the
+ * inner ones are redundant; the two extremes communicate the same shape
+ * alignment.
+ */
+const isRedundantOuterSnapLine = (
+  coordinate: number,
+  outerCoordinateRange?: OuterSnapLineCoordinateRange,
+) => {
+  if (!outerCoordinateRange || outerCoordinateRange.count <= 2) {
+    return false;
+  }
+
+  return (
+    coordinate !== outerCoordinateRange.min &&
+    coordinate !== outerCoordinateRange.max
+  );
+};
+
+/**
+ * Keeps a visual snapline if at least one snap source pair represented by the
+ * line still needs it. This matters when multiple snap source pairs collapse to
+ * the same rendered coordinate.
+ */
+const isPointSnapLineNeededBySourcePair = (
+  sourcePair: PointSnapLineSourcePair,
+  coordinate: number,
+  outerCoordinateRangesBySnapSourcePairKey: Map<
+    string,
+    OuterSnapLineCoordinateRange
+  >,
+) => {
+  const outerCoordinateRange = outerCoordinateRangesBySnapSourcePairKey.get(
+    sourcePair.snapSourcePairKey,
+  );
+
+  if (sourcePair.pointType === "center") {
+    return !isRedundantCenterSnapLine(coordinate, outerCoordinateRange);
+  }
+
+  return !isRedundantOuterSnapLine(coordinate, outerCoordinateRange);
 };
 
 /**
  * Removes point snaplines that are visually redundant, while preserving any line
- * that is still needed by at least one source pair represented on that line.
+ * that is still needed by at least one snap source pair represented on that
+ * line.
  */
 const filterRedundantPointSnapLines = (
   snapLines: PointSnapLineCandidate[],
   getCoordinate: (snapLine: PointSnapLine) => number,
 ): PointSnapLine[] => {
   if (snapLines.length < 3) {
-    return snapLines.map(({ matches, ...snapLine }) => snapLine);
+    return snapLines.map(({ sourcePairs, ...snapLine }) => snapLine);
   }
 
-  // Track outer-line coordinates per source pair. The same visual snapline can
-  // be produced by multiple source pairs, so a line is removed only when every
-  // pair represented by that line considers it redundant.
-  const outerCoordinatesBySourceKey = getOuterCoordinatesBySourceKey(
-    snapLines,
-    getCoordinate,
-  );
+  // Track outer-line ranges per snap source pair. The same visual snapline can
+  // be produced by multiple snap source pairs, so a line is removed only when
+  // every pair represented by that line considers it redundant.
+  const outerCoordinateRangesBySnapSourcePairKey =
+    getOuterCoordinateRangesBySnapSourcePairKey(snapLines, getCoordinate);
 
   return snapLines
     .filter((snapLine) => {
       const coordinate = getCoordinate(snapLine);
 
-      return snapLine.matches.some((match) => {
-        const sourceOuterCoordinates =
-          outerCoordinatesBySourceKey.get(match.sourceKey) ?? [];
-
-        if (match.pointType === "center") {
-          return !isRedundantCenterSnapLine(coordinate, sourceOuterCoordinates);
-        }
-
-        return !isRedundantOuterSnapLine(coordinate, sourceOuterCoordinates);
-      });
+      return snapLine.sourcePairs.some((sourcePair) =>
+        isPointSnapLineNeededBySourcePair(
+          sourcePair,
+          coordinate,
+          outerCoordinateRangesBySnapSourcePairKey,
+        ),
+      );
     })
-    .map(({ matches, ...snapLine }) => snapLine);
+    .map(({ sourcePairs, ...snapLine }) => snapLine);
 };
 
+/**
+ * Merges point snaps that render on the same x/y coordinate, attaches their
+ * snap source pair metadata, then removes redundant center and inner outer
+ * lines.
+ */
 const createPointSnapLines = (
   nearestSnapsX: Snaps,
   nearestSnapsY: Snaps,
@@ -1186,14 +1294,14 @@ const createPointSnapLines = (
         // key = thisPoint.x
         const key = round(snap.points[0][0]);
         if (!snapsX[key]) {
-          snapsX[key] = { points: [], matches: [] };
+          snapsX[key] = { points: [], sourcePairs: [] };
         }
         snapsX[key].points.push(
           ...snap.points.map((p) =>
             pointFrom<GlobalPoint>(round(p[0]), round(p[1])),
           ),
         );
-        snapsX[key].matches.push(getPointSnapLineMatch(snap));
+        snapsX[key].sourcePairs.push(getPointSnapLineSourcePair(snap));
       }
     }
   }
@@ -1204,14 +1312,14 @@ const createPointSnapLines = (
         // key = thisPoint.y
         const key = round(snap.points[0][1]);
         if (!snapsY[key]) {
-          snapsY[key] = { points: [], matches: [] };
+          snapsY[key] = { points: [], sourcePairs: [] };
         }
         snapsY[key].points.push(
           ...snap.points.map((p) =>
             pointFrom<GlobalPoint>(round(p[0]), round(p[1])),
           ),
         );
-        snapsY[key].matches.push(getPointSnapLineMatch(snap));
+        snapsY[key].sourcePairs.push(getPointSnapLineSourcePair(snap));
       }
     }
   }
@@ -1226,7 +1334,7 @@ const createPointSnapLines = (
           })
           .sort((a, b) => a[1] - b[1]),
       ),
-      matches: snap.matches,
+      sourcePairs: snap.sourcePairs,
     } as PointSnapLineCandidate;
   });
 
@@ -1240,7 +1348,7 @@ const createPointSnapLines = (
           })
           .sort((a, b) => a[0] - b[0]),
       ),
-      matches: snap.matches,
+      sourcePairs: snap.sourcePairs,
     } as PointSnapLineCandidate;
   });
 
@@ -1277,10 +1385,13 @@ const createGapSnapLines = (
   dragOffset: Vector2D,
   gapSnaps: GapSnap[],
 ): GapSnapLine[] => {
+  // Use the same rounded bounds as getGapSnaps(). Otherwise a gap snap can be
+  // accepted during snapping but skipped here because the raw bounds miss the
+  // reference gap overlap by a tiny floating-point delta.
   const [minX, minY, maxX, maxY] = getDraggedElementsBounds(
     selectedElements,
     dragOffset,
-  );
+  ).map((bound) => round(bound));
 
   const gapSnapLines: GapSnapLine[] = [];
 

--- a/packages/excalidraw/snapping.ts
+++ b/packages/excalidraw/snapping.ts
@@ -39,6 +39,10 @@ import type {
 } from "./types";
 
 const SNAP_DISTANCE = 8;
+// Point snaps can come from both nearby and distant references within snap
+// distance. If their visual distances have a large break, prefer the nearest
+// cluster before comparing offsets.
+const SNAP_REFERENCE_CLUSTER_BREAK_DISTANCE = 200;
 
 // do not comput more gaps per axis than this limit
 // TODO increase or remove once we optimize
@@ -47,6 +51,13 @@ const VISIBLE_GAPS_LIMIT_PER_AXIS = 99999;
 // snap distance with zoom value taken into consideration
 export const getSnapDistance = (zoomValue: number) => {
   return SNAP_DISTANCE / zoomValue;
+};
+
+/**
+ * Keeps the cluster threshold visually stable across zoom levels.
+ */
+const getSnapReferenceClusterBreakDistance = (zoomValue: number) => {
+  return SNAP_REFERENCE_CLUSTER_BREAK_DISTANCE / zoomValue;
 };
 
 type Vector2D = {
@@ -84,6 +95,9 @@ export type PointSnap = {
   points: PointPair;
   pointTypes: [SnapPointType, SnapPointType];
   sourceIds: [SnapPointSourceId, SnapPointSourceId];
+  // Distance along the rendered snapline, used to group visually nearby
+  // references before choosing which point snaps should win.
+  visualDistance: number;
   offset: number;
 };
 
@@ -361,18 +375,37 @@ const getSnapPointSourceId = (elements: ExcalidrawElement[]) => {
     .join(",");
 };
 
+const getSelectedFrameIdsForSnapping = (
+  selectedElements: readonly ExcalidrawElement[],
+) => {
+  const selectedFrameIds = new Set<ExcalidrawElement["id"]>();
+
+  for (const element of selectedElements) {
+    if (element.frameId) {
+      selectedFrameIds.add(element.frameId);
+    }
+  }
+
+  return selectedFrameIds;
+};
+
 const getReferenceElements = (
   elements: readonly NonDeletedExcalidrawElement[],
   selectedElements: NonDeletedExcalidrawElement[],
   appState: AppState,
   elementsMap: ElementsMap,
-) =>
-  getVisibleAndNonSelectedElements(
+) => {
+  const selectedFrameIds = getSelectedFrameIdsForSnapping(selectedElements);
+
+  return getVisibleAndNonSelectedElements(
     elements,
     selectedElements,
     appState,
     elementsMap,
-  );
+  ).filter((element) => {
+    return !element.frameId || selectedFrameIds.has(element.frameId);
+  });
+};
 
 export const getVisibleGaps = (
   elements: readonly NonDeletedExcalidrawElement[],
@@ -662,6 +695,119 @@ const getGapSnaps = (
   }
 };
 
+/**
+ * Narrows point snaps to the nearest visual cluster, then keeps the best offset
+ * inside that cluster. If all references look continuous, this preserves the
+ * old smallest-offset behavior.
+ */
+const filterPointSnapsToNearestCluster = (
+  snaps: Snaps,
+  clusterBreakDistance: number,
+) => {
+  const pointSnaps = snaps.filter(
+    (snap): snap is PointSnap => snap.type === "point",
+  );
+
+  if (pointSnaps.length < 2) {
+    return;
+  }
+
+  const snapsByOffset = new Map<number, PointSnap[]>();
+
+  for (const snap of pointSnaps) {
+    const offset = round(snap.offset);
+    const offsetSnaps = snapsByOffset.get(offset) ?? [];
+    offsetSnaps.push(snap);
+    snapsByOffset.set(offset, offsetSnaps);
+  }
+
+  const keptPointSnaps = new Set<PointSnap>();
+  const offsetGroups = Array.from(snapsByOffset.entries()).map(
+    ([offset, offsetSnaps]) => ({
+      offset,
+      snaps: offsetSnaps,
+      visualDistance: Math.min(
+        ...offsetSnaps.map((snap) => snap.visualDistance),
+      ),
+    }),
+  );
+  const sortedOffsetGroups = offsetGroups
+    .slice()
+    .sort((a, b) => a.visualDistance - b.visualDistance);
+  let keepOffsetGroupsUntil = sortedOffsetGroups.length;
+
+  // Prefer a nearby reference cluster before comparing offset. If there is no
+  // clear distance break, this keeps all offsets and falls back to the old
+  // smallest-offset behavior.
+  for (let i = 1; i < sortedOffsetGroups.length; i++) {
+    const distanceGap =
+      sortedOffsetGroups[i].visualDistance -
+      sortedOffsetGroups[i - 1].visualDistance;
+
+    if (distanceGap > clusterBreakDistance) {
+      keepOffsetGroupsUntil = i;
+      break;
+    }
+  }
+
+  const nearestOffsetGroups = sortedOffsetGroups.slice(
+    0,
+    keepOffsetGroupsUntil,
+  );
+  const minOffset = Math.min(
+    ...nearestOffsetGroups.map(({ offset }) => Math.abs(offset)),
+  );
+  const selectedOffsets = new Set(
+    nearestOffsetGroups
+      .filter(({ offset }) => Math.abs(offset) === minOffset)
+      .map(({ offset }) => offset),
+  );
+
+  for (const offsetSnaps of snapsByOffset.values()) {
+    if (!selectedOffsets.has(round(offsetSnaps[0].offset))) {
+      continue;
+    }
+
+    if (offsetSnaps.length < 2) {
+      offsetSnaps.forEach((snap) => keptPointSnaps.add(snap));
+      continue;
+    }
+
+    const sortedSnaps = offsetSnaps
+      .slice()
+      .sort((a, b) => a.visualDistance - b.visualDistance);
+
+    let keepUntil = sortedSnaps.length;
+
+    // This runs after the winning snap offset is known. A big visual-distance
+    // gap means references after it belong to a separate, farther cluster.
+    for (let i = 1; i < sortedSnaps.length; i++) {
+      const distanceGap =
+        sortedSnaps[i].visualDistance - sortedSnaps[i - 1].visualDistance;
+
+      if (distanceGap > clusterBreakDistance) {
+        keepUntil = i;
+        break;
+      }
+    }
+
+    for (let i = 0; i < keepUntil; i++) {
+      keptPointSnaps.add(sortedSnaps[i]);
+    }
+  }
+
+  let writeIndex = 0;
+
+  for (const snap of snaps) {
+    if (snap.type !== "point" || keptPointSnaps.has(snap)) {
+      snaps[writeIndex] = snap;
+      writeIndex++;
+    }
+  }
+
+  snaps.length = writeIndex;
+};
+
 export const getReferenceSnapPoints = (
   elements: readonly NonDeletedExcalidrawElement[],
   selectedElements: ExcalidrawElement[],
@@ -689,6 +835,11 @@ export const getReferenceSnapPoints = (
     );
 };
 
+/**
+ * Collects point snaps within snap distance. Unlike gap snaps, point snaps first
+ * go through visual-cluster filtering so a nearby reference can beat a slightly
+ * better offset from a far-away reference.
+ */
 const getPointSnaps = (
   selectedElements: ExcalidrawElement[],
   selectionSnapPoints: SnapPoint[],
@@ -714,38 +865,51 @@ const getPointSnaps = (
         const offsetY = otherSnapPoint.point[1] - thisSnapPoint.point[1];
 
         if (Math.abs(offsetX) <= minOffset.x) {
-          if (Math.abs(offsetX) < minOffset.x) {
-            nearestSnapsX.length = 0;
-          }
-
           nearestSnapsX.push({
             type: "point",
             points: [thisSnapPoint.point, otherSnapPoint.point],
             pointTypes: [thisSnapPoint.type, otherSnapPoint.type],
             sourceIds: [thisSnapPoint.sourceId, otherSnapPoint.sourceId],
+            visualDistance: Math.abs(
+              otherSnapPoint.point[1] - thisSnapPoint.point[1],
+            ),
             offset: offsetX,
           });
-
-          minOffset.x = Math.abs(offsetX);
         }
 
         if (Math.abs(offsetY) <= minOffset.y) {
-          if (Math.abs(offsetY) < minOffset.y) {
-            nearestSnapsY.length = 0;
-          }
-
           nearestSnapsY.push({
             type: "point",
             points: [thisSnapPoint.point, otherSnapPoint.point],
             pointTypes: [thisSnapPoint.type, otherSnapPoint.type],
             sourceIds: [thisSnapPoint.sourceId, otherSnapPoint.sourceId],
+            visualDistance: Math.abs(
+              otherSnapPoint.point[0] - thisSnapPoint.point[0],
+            ),
             offset: offsetY,
           });
-
-          minOffset.y = Math.abs(offsetY);
         }
       }
     }
+  }
+
+  const clusterBreakDistance = getSnapReferenceClusterBreakDistance(
+    app.state.zoom.value,
+  );
+
+  filterPointSnapsToNearestCluster(nearestSnapsX, clusterBreakDistance);
+  filterPointSnapsToNearestCluster(nearestSnapsY, clusterBreakDistance);
+
+  if (nearestSnapsX.length > 0) {
+    minOffset.x = Math.min(
+      ...nearestSnapsX.map((snap) => Math.abs(snap.offset)),
+    );
+  }
+
+  if (nearestSnapsY.length > 0) {
+    minOffset.y = Math.min(
+      ...nearestSnapsY.map((snap) => Math.abs(snap.offset)),
+    );
   }
 };
 
@@ -899,6 +1063,10 @@ type PointSnapLineBucket = {
   matches: PointSnapLineMatch[];
 };
 
+/**
+ * Describes which source pair produced a rendered point snapline, so later
+ * filtering can reason about redundancy without mixing unrelated references.
+ */
 const getPointSnapLineMatch = (snap: PointSnap): PointSnapLineMatch => {
   return {
     sourceKey: snap.sourceIds.join("->"),
@@ -908,6 +1076,10 @@ const getPointSnapLineMatch = (snap: PointSnap): PointSnapLineMatch => {
   };
 };
 
+/**
+ * Builds the outer snapline coordinates by source pair. Center snaplines use
+ * this map to decide whether the surrounding outer lines already explain them.
+ */
 const getOuterCoordinatesBySourceKey = (
   snapLines: PointSnapLineCandidate[],
   getCoordinate: (snapLine: PointSnapLine) => number,
@@ -963,6 +1135,10 @@ const isRedundantOuterSnapLine = (
   return coordinate !== minCoordinate && coordinate !== maxCoordinate;
 };
 
+/**
+ * Removes point snaplines that are visually redundant, while preserving any line
+ * that is still needed by at least one source pair represented on that line.
+ */
 const filterRedundantPointSnapLines = (
   snapLines: PointSnapLineCandidate[],
   getCoordinate: (snapLine: PointSnapLine) => number,

--- a/packages/excalidraw/tests/snapping.test.ts
+++ b/packages/excalidraw/tests/snapping.test.ts
@@ -1,11 +1,17 @@
 import { arrayToMap } from "@excalidraw/common";
-import { pointFrom, type GlobalPoint, type Radians } from "@excalidraw/math";
+import {
+  pointFrom,
+  rangeInclusive,
+  type GlobalPoint,
+  type Radians,
+} from "@excalidraw/math";
 
 import type { ExcalidrawElement } from "@excalidraw/element/types";
 
 import { getDefaultAppState } from "../appState";
 import {
   getElementsCorners,
+  getVisibleGaps,
   getReferenceSnapPoints,
   SnapCache,
   snapDraggedElements,
@@ -56,6 +62,22 @@ const getHorizontalPointSnapLineCoordinates = (
     .sort((a, b) => a - b);
 };
 
+const getVerticalPointSnapLineCoordinates = (
+  snapLines: ReturnType<typeof snapDraggedElements>["snapLines"],
+) => {
+  return snapLines
+    .filter((snapLine) => snapLine.type === "points")
+    .filter((snapLine) => {
+      const [firstPoint, lastPoint] = snapLine.points;
+
+      return firstPoint[0] === lastPoint[0];
+    })
+    .map((snapLine) => {
+      return snapLine.points[0][0];
+    })
+    .sort((a, b) => a - b);
+};
+
 const getHorizontalPointSnapLineMaxX = (
   snapLines: ReturnType<typeof snapDraggedElements>["snapLines"],
 ) => {
@@ -72,6 +94,23 @@ const getHorizontalPointSnapLineMaxX = (
   }
 
   return horizontalSnapLine.points[horizontalSnapLine.points.length - 1][0];
+};
+
+const getHorizontalGapSnapLines = (
+  snapLines: ReturnType<typeof snapDraggedElements>["snapLines"],
+) => {
+  return snapLines.filter(
+    (snapLine) =>
+      snapLine.type === "gap" && snapLine.direction === "horizontal",
+  );
+};
+
+const getVerticalGapSnapLines = (
+  snapLines: ReturnType<typeof snapDraggedElements>["snapLines"],
+) => {
+  return snapLines.filter(
+    (snapLine) => snapLine.type === "gap" && snapLine.direction === "vertical",
+  );
 };
 
 const getPointKeys = (points: ReturnType<typeof getElementsCorners>) => {
@@ -111,7 +150,7 @@ const primeReferenceSnapPoints = (
         return corners.map((point, index) => ({
           point,
           type: index === corners.length - 1 ? "center" : "outer",
-          sourceId: element.id,
+          snapSourceId: element.id,
         }));
       }) as Parameters<typeof SnapCache.setReferenceSnapPoints>[0],
   );
@@ -254,6 +293,57 @@ describe("snapping", () => {
     ).toBe(false);
   });
 
+  it("does not use frame children as visible gap references when snapping outside elements", () => {
+    const frame = API.createElement({
+      type: "frame",
+      id: "frame",
+      x: 0,
+      y: 0,
+      width: 500,
+      height: 300,
+    });
+    const frameChildA = API.createElement({
+      type: "rectangle",
+      id: "frameChildA",
+      x: 50,
+      y: 50,
+      width: 100,
+      height: 100,
+      frameId: frame.id,
+    });
+    const frameChildB = API.createElement({
+      type: "rectangle",
+      id: "frameChildB",
+      x: 250,
+      y: 50,
+      width: 100,
+      height: 100,
+      frameId: frame.id,
+    });
+    const selected = API.createElement({
+      type: "rectangle",
+      id: "selected",
+      x: 700,
+      y: 50,
+      width: 100,
+      height: 100,
+    });
+    const elements = [frame, frameChildA, frameChildB, selected];
+    const app = createSnappingApp({
+      selectedElementIds: { [selected.id]: true },
+    });
+
+    const visibleGaps = getVisibleGaps(
+      elements,
+      [selected],
+      app.state,
+      arrayToMap(elements),
+    );
+
+    expect(visibleGaps.horizontalGaps).toHaveLength(0);
+    expect(visibleGaps.verticalGaps).toHaveLength(0);
+  });
+
   it("filters center and inner outer point snaplines for the same reference", () => {
     const angle = 0.68 as Radians;
     const reference = API.createElement({
@@ -319,7 +409,7 @@ describe("snapping", () => {
       ...outerSnapPoints.map((point) => ({
         point: pointFrom<GlobalPoint>(point[0] - 200, point[1]),
         type: "outer" as const,
-        sourceId: "referenceA",
+        snapSourceId: "referenceA",
       })),
       {
         point: pointFrom<GlobalPoint>(
@@ -327,7 +417,7 @@ describe("snapping", () => {
           centerSnapPoint[1],
         ),
         type: "center" as const,
-        sourceId: "referenceA",
+        snapSourceId: "referenceA",
       },
       {
         point: pointFrom<GlobalPoint>(
@@ -335,7 +425,7 @@ describe("snapping", () => {
           innerOuterSnapPoint[1],
         ),
         type: "outer" as const,
-        sourceId: "referenceB",
+        snapSourceId: "referenceB",
       },
     ];
 
@@ -387,6 +477,90 @@ describe("snapping", () => {
     expect(getHorizontalPointSnapLineCoordinates(snapLines)).toEqual([50]);
   });
 
+  it("filters center snaplines when matching outer offsets differ by rounding precision", () => {
+    const selected = API.createElement({
+      type: "rectangle",
+      id: "selected",
+      x: 2532.227563984471,
+      y: -1553.9657067952232,
+      width: 140.1015625,
+      height: 140.1015625,
+    });
+    const reference = API.createElement({
+      type: "rectangle",
+      id: "reference",
+      x: 2532.2275640966914,
+      y: -1299.4323092037737,
+      width: 140.1015625,
+      height: 140.1015625,
+    });
+    const elements = [reference, selected];
+    const app = createSnappingApp({
+      selectedElementIds: { [selected.id]: true },
+    });
+
+    primeReferenceSnapPoints(elements, [selected]);
+
+    const { snapLines } = snapDraggedElements(
+      elements,
+      { x: 0, y: 0 },
+      app,
+      NO_MODIFIER_KEYS,
+      arrayToMap(elements),
+    );
+
+    expect(getVerticalPointSnapLineCoordinates(snapLines)).toEqual([
+      2532.227564, 2672.329126,
+    ]);
+  });
+
+  it("keeps outer snaplines stable while dragging a snapped element through rounding-equivalent offsets", () => {
+    const referenceMiddle = API.createElement({
+      type: "rectangle",
+      id: "referenceMiddle",
+      x: 2532.22756398447,
+      y: -1553.9657067952237,
+      width: 140.1015625,
+      height: 140.1015625,
+    });
+    const referenceAbove = API.createElement({
+      type: "rectangle",
+      id: "referenceAbove",
+      x: 2532.2275637826165,
+      y: -1779.7363232531268,
+      width: 140.1015625,
+      height: 140.1015625,
+    });
+    const selected = API.createElement({
+      type: "rectangle",
+      id: "selected",
+      x: 2532.227563096691,
+      y: -1328.1950902037736,
+      width: 140.1015625,
+      height: 140.1015625,
+    });
+    const elements = [referenceAbove, referenceMiddle, selected];
+    const app = createSnappingApp({
+      selectedElementIds: { [selected.id]: true },
+    });
+
+    primeReferenceSnapPoints(elements, [selected]);
+
+    for (const dragOffsetX of [-4, -1, -0.1, 0, 0.1, 1, 4]) {
+      const { snapLines } = snapDraggedElements(
+        elements,
+        { x: dragOffsetX, y: 0 },
+        app,
+        NO_MODIFIER_KEYS,
+        arrayToMap(elements),
+      );
+      const coordinates = getVerticalPointSnapLineCoordinates(snapLines);
+
+      expect(coordinates).toHaveLength(2);
+      expect(coordinates[1] - coordinates[0]).toBeCloseTo(selected.width, 5);
+    }
+  });
+
   it("prefers the nearest visual cluster for same-offset point snaps", () => {
     const selected = API.createElement({
       type: "rectangle",
@@ -405,12 +579,12 @@ describe("snapping", () => {
       {
         point: pointFrom<GlobalPoint>(220, 50),
         type: "center",
-        sourceId: "near",
+        snapSourceId: "near",
       },
       {
         point: pointFrom<GlobalPoint>(900, 50),
         type: "center",
-        sourceId: "far",
+        snapSourceId: "far",
       },
     ]);
 
@@ -443,12 +617,12 @@ describe("snapping", () => {
       {
         point: pointFrom<GlobalPoint>(220, 54),
         type: "center",
-        sourceId: "near",
+        snapSourceId: "near",
       },
       {
         point: pointFrom<GlobalPoint>(900, 50),
         type: "center",
-        sourceId: "far",
+        snapSourceId: "far",
       },
     ]);
 
@@ -482,17 +656,17 @@ describe("snapping", () => {
       {
         point: pointFrom<GlobalPoint>(200, 50),
         type: "center",
-        sourceId: "referenceA",
+        snapSourceId: "referenceA",
       },
       {
         point: pointFrom<GlobalPoint>(350, 50),
         type: "center",
-        sourceId: "referenceB",
+        snapSourceId: "referenceB",
       },
       {
         point: pointFrom<GlobalPoint>(500, 50),
         type: "center",
-        sourceId: "referenceC",
+        snapSourceId: "referenceC",
       },
     ]);
 
@@ -505,5 +679,90 @@ describe("snapping", () => {
     );
 
     expect(getHorizontalPointSnapLineMaxX(snapLines)).toBe(500);
+  });
+
+  it("renders gap snaplines when rounded bounds touch the reference gap overlap", () => {
+    const selected = API.createElement({
+      type: "rectangle",
+      id: "selected",
+      x: 0,
+      y: 0.0000004,
+      width: 100,
+      height: 100,
+    });
+    const elements = [selected];
+    const app = createSnappingApp({
+      selectedElementIds: { [selected.id]: true },
+    });
+
+    SnapCache.setVisibleGaps({
+      horizontalGaps: [
+        {
+          startBounds: [200, -100, 300, 0],
+          endBounds: [400, -100, 500, 0],
+          startSide: [pointFrom(300, -100), pointFrom(300, 0)],
+          endSide: [pointFrom(400, -100), pointFrom(400, 0)],
+          overlap: rangeInclusive(-100, 0),
+          length: 100,
+        },
+      ],
+      verticalGaps: [],
+    });
+
+    const { snapLines } = snapDraggedElements(
+      elements,
+      { x: 0, y: 0 },
+      app,
+      NO_MODIFIER_KEYS,
+      arrayToMap(elements),
+    );
+
+    expect(getHorizontalGapSnapLines(snapLines)).toHaveLength(2);
+  });
+
+  it("renders gap snaplines when the winning gap offset only differs by rounding precision", () => {
+    const selected = API.createElement({
+      type: "rectangle",
+      id: "selected",
+      x: 0,
+      y: 399.999999,
+      width: 100,
+      height: 100,
+    });
+    const elements = [selected];
+    const app = createSnappingApp({
+      selectedElementIds: { [selected.id]: true },
+    });
+
+    SnapCache.setReferenceSnapPoints([
+      {
+        point: pointFrom<GlobalPoint>(0, 399.999999),
+        type: "outer",
+        snapSourceId: "reference",
+      },
+    ]);
+    SnapCache.setVisibleGaps({
+      horizontalGaps: [],
+      verticalGaps: [
+        {
+          startBounds: [0, 100, 100, 200],
+          endBounds: [0, 250, 100, 350],
+          startSide: [pointFrom(0, 200), pointFrom(100, 200)],
+          endSide: [pointFrom(0, 250), pointFrom(100, 250)],
+          overlap: rangeInclusive(0, 100),
+          length: 50,
+        },
+      ],
+    });
+
+    const { snapLines } = snapDraggedElements(
+      elements,
+      { x: 0, y: 0 },
+      app,
+      NO_MODIFIER_KEYS,
+      arrayToMap(elements),
+    );
+
+    expect(getVerticalGapSnapLines(snapLines)).toHaveLength(2);
   });
 });

--- a/packages/excalidraw/tests/snapping.test.ts
+++ b/packages/excalidraw/tests/snapping.test.ts
@@ -1,0 +1,509 @@
+import { arrayToMap } from "@excalidraw/common";
+import { pointFrom, type GlobalPoint, type Radians } from "@excalidraw/math";
+
+import type { ExcalidrawElement } from "@excalidraw/element/types";
+
+import { getDefaultAppState } from "../appState";
+import {
+  getElementsCorners,
+  getReferenceSnapPoints,
+  SnapCache,
+  snapDraggedElements,
+} from "../snapping";
+
+import { API } from "./helpers/api";
+
+import type { AppClassProperties, AppState } from "../types";
+
+type ReferenceSnapPoints = NonNullable<
+  ReturnType<typeof SnapCache.getReferenceSnapPoints>
+>;
+
+const NO_MODIFIER_KEYS = {
+  altKey: false,
+  ctrlKey: false,
+  metaKey: false,
+  shiftKey: false,
+};
+
+const createSnappingApp = (appState: Partial<AppState> = {}) =>
+  ({
+    props: {},
+    state: {
+      ...getDefaultAppState(),
+      objectsSnapModeEnabled: true,
+      width: 1000,
+      height: 1000,
+      offsetLeft: 0,
+      offsetTop: 0,
+      ...appState,
+    },
+  } as AppClassProperties);
+
+const getHorizontalPointSnapLineCoordinates = (
+  snapLines: ReturnType<typeof snapDraggedElements>["snapLines"],
+) => {
+  return snapLines
+    .filter((snapLine) => snapLine.type === "points")
+    .filter((snapLine) => {
+      const [firstPoint, lastPoint] = snapLine.points;
+
+      return firstPoint[1] === lastPoint[1];
+    })
+    .map((snapLine) => {
+      return snapLine.points[0][1];
+    })
+    .sort((a, b) => a - b);
+};
+
+const getHorizontalPointSnapLineMaxX = (
+  snapLines: ReturnType<typeof snapDraggedElements>["snapLines"],
+) => {
+  const horizontalSnapLine = snapLines
+    .filter((snapLine) => snapLine.type === "points")
+    .find((snapLine) => {
+      const [firstPoint, lastPoint] = snapLine.points;
+
+      return firstPoint[1] === lastPoint[1];
+    });
+
+  if (!horizontalSnapLine) {
+    return null;
+  }
+
+  return horizontalSnapLine.points[horizontalSnapLine.points.length - 1][0];
+};
+
+const getPointKeys = (points: ReturnType<typeof getElementsCorners>) => {
+  return points.map((point) => point.join(","));
+};
+
+const getReferenceSnapPointKeys = (
+  elements: ExcalidrawElement[],
+  selectedElements: ExcalidrawElement[],
+  app: AppClassProperties,
+) => {
+  return new Set(
+    getReferenceSnapPoints(
+      elements,
+      selectedElements,
+      app.state,
+      arrayToMap(elements),
+    ).map((snapPoint) => snapPoint.point.join(",")),
+  );
+};
+
+const primeReferenceSnapPoints = (
+  elements: ExcalidrawElement[],
+  selectedElements: ExcalidrawElement[],
+) => {
+  const selectedElementIds = new Set(
+    selectedElements.map((element) => element.id),
+  );
+  const elementsMap = arrayToMap(elements);
+
+  SnapCache.setReferenceSnapPoints(
+    elements
+      .filter((element) => !selectedElementIds.has(element.id))
+      .flatMap((element) => {
+        const corners = getElementsCorners([element], elementsMap);
+
+        return corners.map((point, index) => ({
+          point,
+          type: index === corners.length - 1 ? "center" : "outer",
+          sourceId: element.id,
+        }));
+      }) as Parameters<typeof SnapCache.setReferenceSnapPoints>[0],
+  );
+};
+
+describe("snapping", () => {
+  afterEach(() => {
+    SnapCache.destroy();
+  });
+
+  it("does not use frame children as references when snapping outside elements", () => {
+    const frame = API.createElement({
+      type: "frame",
+      id: "frame",
+      x: 0,
+      y: 0,
+      width: 300,
+      height: 300,
+    });
+    const frameChild = API.createElement({
+      type: "rectangle",
+      id: "frameChild",
+      x: 37,
+      y: 53,
+      width: 71,
+      height: 83,
+      frameId: frame.id,
+    });
+    const selected = API.createElement({
+      type: "rectangle",
+      id: "selected",
+      x: 400,
+      y: 50,
+      width: 100,
+      height: 100,
+    });
+    const elements = [frame, frameChild, selected];
+    const app = createSnappingApp({
+      selectedElementIds: { [selected.id]: true },
+    });
+
+    const referenceSnapPointKeys = getReferenceSnapPointKeys(
+      elements,
+      [selected],
+      app,
+    );
+    const frameChildPointKeys = getPointKeys(
+      getElementsCorners([frameChild], arrayToMap(elements)),
+    );
+
+    expect(
+      frameChildPointKeys.some((pointKey) =>
+        referenceSnapPointKeys.has(pointKey),
+      ),
+    ).toBe(false);
+  });
+
+  it("uses frame siblings as references when snapping elements in the same frame", () => {
+    const frame = API.createElement({
+      type: "frame",
+      id: "frame",
+      x: 0,
+      y: 0,
+      width: 300,
+      height: 300,
+    });
+    const sibling = API.createElement({
+      type: "rectangle",
+      id: "sibling",
+      x: 37,
+      y: 53,
+      width: 71,
+      height: 83,
+      frameId: frame.id,
+    });
+    const selected = API.createElement({
+      type: "rectangle",
+      id: "selected",
+      x: 150,
+      y: 50,
+      width: 100,
+      height: 100,
+      frameId: frame.id,
+    });
+    const elements = [frame, sibling, selected];
+    const app = createSnappingApp({
+      selectedElementIds: { [selected.id]: true },
+    });
+
+    const referenceSnapPointKeys = getReferenceSnapPointKeys(
+      elements,
+      [selected],
+      app,
+    );
+    const siblingPointKeys = getPointKeys(
+      getElementsCorners([sibling], arrayToMap(elements)),
+    );
+
+    expect(
+      siblingPointKeys.some((pointKey) => referenceSnapPointKeys.has(pointKey)),
+    ).toBe(true);
+  });
+
+  it("does not use frame children as references when snapping the frame itself", () => {
+    const frame = API.createElement({
+      type: "frame",
+      id: "frame",
+      x: 0,
+      y: 0,
+      width: 300,
+      height: 300,
+    });
+    const frameChild = API.createElement({
+      type: "rectangle",
+      id: "frameChild",
+      x: 37,
+      y: 53,
+      width: 71,
+      height: 83,
+      frameId: frame.id,
+    });
+    const elements = [frame, frameChild];
+    const app = createSnappingApp({
+      selectedElementIds: { [frame.id]: true },
+    });
+
+    const referenceSnapPointKeys = getReferenceSnapPointKeys(
+      elements,
+      [frame],
+      app,
+    );
+    const frameChildPointKeys = getPointKeys(
+      getElementsCorners([frameChild], arrayToMap(elements)),
+    );
+
+    expect(
+      frameChildPointKeys.some((pointKey) =>
+        referenceSnapPointKeys.has(pointKey),
+      ),
+    ).toBe(false);
+  });
+
+  it("filters center and inner outer point snaplines for the same reference", () => {
+    const angle = 0.68 as Radians;
+    const reference = API.createElement({
+      type: "rectangle",
+      id: "reference",
+      x: 0,
+      y: 0,
+      width: 140,
+      height: 140,
+      angle,
+    });
+    const selected = API.createElement({
+      type: "rectangle",
+      id: "selected",
+      x: 200,
+      y: 0,
+      width: 140,
+      height: 140,
+      angle,
+    });
+    const elements = [reference, selected];
+    const app = createSnappingApp({
+      selectedElementIds: { [selected.id]: true },
+    });
+
+    primeReferenceSnapPoints(elements, [selected]);
+
+    const { snapLines } = snapDraggedElements(
+      elements,
+      { x: 0, y: 0 },
+      app,
+      NO_MODIFIER_KEYS,
+      arrayToMap(elements),
+    );
+
+    expect(getHorizontalPointSnapLineCoordinates(snapLines)).toHaveLength(2);
+  });
+
+  it("keeps a snapline that is redundant for one reference but needed for another", () => {
+    const angle = 0.68 as Radians;
+    const selected = API.createElement({
+      type: "rectangle",
+      id: "selected",
+      x: 200,
+      y: 0,
+      width: 140,
+      height: 140,
+      angle,
+    });
+    const elements = [selected];
+    const elementsMap = arrayToMap(elements);
+    const selectedSnapPoints = getElementsCorners([selected], elementsMap);
+    const outerSnapPoints = selectedSnapPoints.slice(0, -1);
+    const centerSnapPoint = selectedSnapPoints[selectedSnapPoints.length - 1];
+    const innerOuterSnapPoint = [...outerSnapPoints].sort(
+      (a, b) => a[1] - b[1],
+    )[1];
+    const app = createSnappingApp({
+      selectedElementIds: { [selected.id]: true },
+    });
+
+    const referenceSnapPoints: ReferenceSnapPoints = [
+      ...outerSnapPoints.map((point) => ({
+        point: pointFrom<GlobalPoint>(point[0] - 200, point[1]),
+        type: "outer" as const,
+        sourceId: "referenceA",
+      })),
+      {
+        point: pointFrom<GlobalPoint>(
+          centerSnapPoint[0] - 200,
+          centerSnapPoint[1],
+        ),
+        type: "center" as const,
+        sourceId: "referenceA",
+      },
+      {
+        point: pointFrom<GlobalPoint>(
+          innerOuterSnapPoint[0] - 300,
+          innerOuterSnapPoint[1],
+        ),
+        type: "outer" as const,
+        sourceId: "referenceB",
+      },
+    ];
+
+    SnapCache.setReferenceSnapPoints(referenceSnapPoints);
+
+    const { snapLines } = snapDraggedElements(
+      elements,
+      { x: 0, y: 0 },
+      app,
+      NO_MODIFIER_KEYS,
+      elementsMap,
+    );
+
+    expect(getHorizontalPointSnapLineCoordinates(snapLines)).toHaveLength(3);
+  });
+
+  it("keeps a center snapline when no outer snaplines imply it", () => {
+    const reference = API.createElement({
+      type: "rectangle",
+      id: "reference",
+      x: 0,
+      y: 0,
+      width: 100,
+      height: 100,
+    });
+    const selected = API.createElement({
+      type: "rectangle",
+      id: "selected",
+      x: 200,
+      y: 25,
+      width: 50,
+      height: 50,
+    });
+    const elements = [reference, selected];
+    const app = createSnappingApp({
+      selectedElementIds: { [selected.id]: true },
+    });
+
+    primeReferenceSnapPoints(elements, [selected]);
+
+    const { snapLines } = snapDraggedElements(
+      elements,
+      { x: 0, y: 0 },
+      app,
+      NO_MODIFIER_KEYS,
+      arrayToMap(elements),
+    );
+
+    expect(getHorizontalPointSnapLineCoordinates(snapLines)).toEqual([50]);
+  });
+
+  it("prefers the nearest visual cluster for same-offset point snaps", () => {
+    const selected = API.createElement({
+      type: "rectangle",
+      id: "selected",
+      x: 0,
+      y: 0,
+      width: 100,
+      height: 100,
+    });
+    const elements = [selected];
+    const app = createSnappingApp({
+      selectedElementIds: { [selected.id]: true },
+    });
+
+    SnapCache.setReferenceSnapPoints([
+      {
+        point: pointFrom<GlobalPoint>(220, 50),
+        type: "center",
+        sourceId: "near",
+      },
+      {
+        point: pointFrom<GlobalPoint>(900, 50),
+        type: "center",
+        sourceId: "far",
+      },
+    ]);
+
+    const { snapLines } = snapDraggedElements(
+      elements,
+      { x: 0, y: 0 },
+      app,
+      NO_MODIFIER_KEYS,
+      arrayToMap(elements),
+    );
+
+    expect(getHorizontalPointSnapLineMaxX(snapLines)).toBe(220);
+  });
+
+  it("prefers a nearby point snap over a slightly better far offset", () => {
+    const selected = API.createElement({
+      type: "rectangle",
+      id: "selected",
+      x: 0,
+      y: 0,
+      width: 100,
+      height: 100,
+    });
+    const elements = [selected];
+    const app = createSnappingApp({
+      selectedElementIds: { [selected.id]: true },
+    });
+
+    SnapCache.setReferenceSnapPoints([
+      {
+        point: pointFrom<GlobalPoint>(220, 54),
+        type: "center",
+        sourceId: "near",
+      },
+      {
+        point: pointFrom<GlobalPoint>(900, 50),
+        type: "center",
+        sourceId: "far",
+      },
+    ]);
+
+    const { snapOffset, snapLines } = snapDraggedElements(
+      elements,
+      { x: 0, y: 0 },
+      app,
+      NO_MODIFIER_KEYS,
+      arrayToMap(elements),
+    );
+
+    expect(snapOffset.y).toBe(4);
+    expect(getHorizontalPointSnapLineMaxX(snapLines)).toBe(220);
+  });
+
+  it("keeps same-offset point snaps when references form a continuous cluster", () => {
+    const selected = API.createElement({
+      type: "rectangle",
+      id: "selected",
+      x: 0,
+      y: 0,
+      width: 100,
+      height: 100,
+    });
+    const elements = [selected];
+    const app = createSnappingApp({
+      selectedElementIds: { [selected.id]: true },
+    });
+
+    SnapCache.setReferenceSnapPoints([
+      {
+        point: pointFrom<GlobalPoint>(200, 50),
+        type: "center",
+        sourceId: "referenceA",
+      },
+      {
+        point: pointFrom<GlobalPoint>(350, 50),
+        type: "center",
+        sourceId: "referenceB",
+      },
+      {
+        point: pointFrom<GlobalPoint>(500, 50),
+        type: "center",
+        sourceId: "referenceC",
+      },
+    ]);
+
+    const { snapLines } = snapDraggedElements(
+      elements,
+      { x: 0, y: 0 },
+      app,
+      NO_MODIFIER_KEYS,
+      arrayToMap(elements),
+    );
+
+    expect(getHorizontalPointSnapLineMaxX(snapLines)).toBe(500);
+  });
+});

--- a/packages/excalidraw/tests/snapping.test.ts
+++ b/packages/excalidraw/tests/snapping.test.ts
@@ -19,7 +19,11 @@ import {
 
 import { API } from "./helpers/api";
 
-import type { AppClassProperties, AppState } from "../types";
+import type {
+  AppClassProperties,
+  AppState,
+  NormalizedZoomValue,
+} from "../types";
 
 type ReferenceSnapPoints = NonNullable<
   ReturnType<typeof SnapCache.getReferenceSnapPoints>
@@ -94,6 +98,27 @@ const getHorizontalPointSnapLineMaxX = (
   }
 
   return horizontalSnapLine.points[horizontalSnapLine.points.length - 1][0];
+};
+
+const getHorizontalPointSnapLineXRange = (
+  snapLines: ReturnType<typeof snapDraggedElements>["snapLines"],
+) => {
+  const horizontalSnapLine = snapLines
+    .filter((snapLine) => snapLine.type === "points")
+    .find((snapLine) => {
+      const [firstPoint, lastPoint] = snapLine.points;
+
+      return firstPoint[1] === lastPoint[1];
+    });
+
+  if (!horizontalSnapLine) {
+    return null;
+  }
+
+  return [
+    horizontalSnapLine.points[0][0],
+    horizontalSnapLine.points[horizontalSnapLine.points.length - 1][0],
+  ] as const;
 };
 
 const getHorizontalGapSnapLines = (
@@ -561,7 +586,7 @@ describe("snapping", () => {
     }
   });
 
-  it("prefers the nearest visual cluster for same-offset point snaps", () => {
+  it("keeps same-offset point snaps even across distant references", () => {
     const selected = API.createElement({
       type: "rectangle",
       id: "selected",
@@ -596,7 +621,7 @@ describe("snapping", () => {
       arrayToMap(elements),
     );
 
-    expect(getHorizontalPointSnapLineMaxX(snapLines)).toBe(220);
+    expect(getHorizontalPointSnapLineMaxX(snapLines)).toBe(900);
   });
 
   it("prefers a nearby point snap over a slightly better far offset", () => {
@@ -679,6 +704,46 @@ describe("snapping", () => {
     );
 
     expect(getHorizontalPointSnapLineMaxX(snapLines)).toBe(500);
+  });
+
+  it("keeps same-source same-offset point snaps across zoom-scaled cluster breaks", () => {
+    const reference = API.createElement({
+      type: "rectangle",
+      id: "reference",
+      x: 0,
+      y: 0,
+      width: 140.1015625,
+      height: 140.1015625,
+    });
+    const selected = API.createElement({
+      type: "rectangle",
+      id: "selected",
+      x: 338.608871112217,
+      y: 0,
+      width: 140.1015625,
+      height: 140.1015625,
+    });
+    const elements = [reference, selected];
+    const app = createSnappingApp({
+      selectedElementIds: { [selected.id]: true },
+      zoom: { value: 1.5 as NormalizedZoomValue },
+    });
+
+    primeReferenceSnapPoints(elements, [selected]);
+
+    const { snapLines } = snapDraggedElements(
+      elements,
+      { x: 0, y: 0 },
+      app,
+      NO_MODIFIER_KEYS,
+      arrayToMap(elements),
+    );
+
+    const range = getHorizontalPointSnapLineXRange(snapLines);
+
+    expect(range).not.toBe(null);
+    expect(range![0]).toBeCloseTo(reference.x, 6);
+    expect(range![1]).toBeCloseTo(selected.x + selected.width, 6);
   });
 
   it("renders gap snaplines when rounded bounds touch the reference gap overlap", () => {


### PR DESCRIPTION
- removed point marker x indicator
- filters redundant point snaplines:
  - hides center snaplines when surrounding outer snaplines already communicate the alignment
  - keeps only the outermost lines when multiple outer snaplines come from the same snap source pair
- prioritizes nearby point snap references before comparing snap offsets (to reduce interference from distant elements)
- avoids snapping external elements to children inside unrelated frames
- stabilizes gap/equal-distance snapline rendering around floating-point precision edge cases