### PR TITLE
feat: allow viewing shared drawings without overwriting local canvas

### DIFF
--- a/excalidraw-app/App.tsx
+++ b/excalidraw-app/App.tsx
@@ -34,7 +34,7 @@ import {
   isDevEnv,
 } from "@excalidraw/common";
 import polyfill from "@excalidraw/excalidraw/polyfill";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { loadFromBlob } from "@excalidraw/excalidraw/data/blob";
 import { t } from "@excalidraw/excalidraw/i18n";
 
@@ -211,13 +211,14 @@ const shareableLinkConfirmDialog = {
   ),
   actionLabel: t("overwriteConfirm.modal.shareableLink.button"),
   color: "danger",
+  viewOnlyLabel: t("overwriteConfirm.modal.shareableLink.viewOnly"),
 } as const;
 
 const initializeScene = async (opts: {
   collabAPI: CollabAPI | null;
   excalidrawAPI: ExcalidrawImperativeAPI;
 }): Promise<
-  { scene: ExcalidrawInitialDataState | null } & (
+  { scene: ExcalidrawInitialDataState | null; viewOnly?: boolean } & (
     | { isExternalScene: true; id: string; key: string }
     | { isExternalScene: false; id?: null; key?: null }
   )
@@ -248,15 +249,23 @@ const initializeScene = async (opts: {
 
   let roomLinkData = getCollaborationLinkData(window.location.href);
   const isExternalScene = !!(id || jsonBackendMatch || roomLinkData);
+  let viewOnly = false;
   if (isExternalScene) {
+    // Determine whether to load, view-only, or cancel
+    let action: "confirm" | "viewOnly" | "cancel" = "confirm";
     if (
       // don't prompt if scene is empty
       !scene.elements.length ||
       // don't prompt for collab scenes because we don't override local storage
-      roomLinkData ||
-      // otherwise, prompt whether user wants to override current scene
-      (await openConfirmModal(shareableLinkConfirmDialog))
+      roomLinkData
     ) {
+      action = "confirm";
+    } else {
+      // prompt whether user wants to override current scene or view only
+      action = await openConfirmModal(shareableLinkConfirmDialog);
+    }
+
+    if (action === "confirm" || action === "viewOnly") {
       if (jsonBackendMatch) {
         const imported = await importFromBackend(
           jsonBackendMatch[1],
@@ -280,6 +289,7 @@ const initializeScene = async (opts: {
         };
       }
       scene.scrollToContent = true;
+      viewOnly = action === "viewOnly";
       if (!roomLinkData) {
         window.history.replaceState({}, APP_NAME, window.location.origin);
       }
@@ -307,11 +317,28 @@ const initializeScene = async (opts: {
     try {
       const request = await fetch(window.decodeURIComponent(url));
       const data = await loadFromBlob(await request.blob(), null, null);
-      if (
-        !scene.elements.length ||
-        (await openConfirmModal(shareableLinkConfirmDialog))
-      ) {
-        return { scene: data, isExternalScene };
+      let extAction: "confirm" | "viewOnly" | "cancel" = "confirm";
+      if (scene.elements.length) {
+        extAction = await openConfirmModal({
+          title: t("overwriteConfirm.modal.shareableLink.title"),
+          description: (
+            <Trans
+              i18nKey="overwriteConfirm.modal.shareableLink.description"
+              bold={(text) => <strong>{text}</strong>}
+              br={() => <br />}
+            />
+          ),
+          actionLabel: t("overwriteConfirm.modal.shareableLink.button"),
+          color: "danger" as const,
+          viewOnlyLabel: t("overwriteConfirm.modal.shareableLink.viewOnly"),
+        });
+      }
+      if (extAction === "confirm" || extAction === "viewOnly") {
+        return {
+          scene: data,
+          isExternalScene,
+          viewOnly: extAction === "viewOnly",
+        };
       }
     } catch (error: any) {
       return {
@@ -365,8 +392,9 @@ const initializeScene = async (opts: {
           isExternalScene,
           id: jsonBackendMatch[1],
           key: jsonBackendMatch[2],
+          viewOnly,
         }
-      : { scene, isExternalScene: false };
+      : { scene, isExternalScene: false, viewOnly };
   }
   return { scene: null, isExternalScene: false };
 };
@@ -419,6 +447,10 @@ const ExcalidrawWrapper = () => {
   });
 
   const [, forceRefresh] = useState(false);
+  const [isViewOnlyMode, setIsViewOnlyMode] = useState(false);
+
+  // Pre-load local state so it's ready for view-only exit
+  const localDataForRestore = importFromLocalStorage();
 
   useEffect(() => {
     if (isDevEnv()) {
@@ -527,6 +559,20 @@ const ExcalidrawWrapper = () => {
 
     initializeScene({ collabAPI, excalidrawAPI }).then(async (data) => {
       loadImages(data, /* isInitialLoad */ true);
+
+      if (data.viewOnly && data.scene) {
+        // Enter view-only mode: pause saving and enable viewMode
+        LocalData.pauseSave("viewOnly");
+        setIsViewOnlyMode(true);
+        data.scene = {
+          ...data.scene,
+          appState: {
+            ...data.scene.appState,
+            viewModeEnabled: true,
+          },
+        };
+      }
+
       initialStatePromiseRef.current.promise.resolve(data.scene);
     });
 
@@ -545,11 +591,18 @@ const ExcalidrawWrapper = () => {
         initializeScene({ collabAPI, excalidrawAPI }).then((data) => {
           loadImages(data);
           if (data.scene) {
+            if (data.viewOnly) {
+              LocalData.pauseSave("viewOnly");
+              setIsViewOnlyMode(true);
+            }
             excalidrawAPI.updateScene({
               elements: restoreElements(data.scene.elements, null, {
                 repairBindings: true,
               }),
-              appState: restoreAppState(data.scene.appState, null),
+              appState: {
+                ...restoreAppState(data.scene.appState, null),
+                ...(data.viewOnly ? { viewModeEnabled: true } : {}),
+              },
               captureUpdate: CaptureUpdateAction.IMMEDIATELY,
             });
           }
@@ -843,6 +896,29 @@ const ExcalidrawWrapper = () => {
   //   // console.log("onExport");
   // };
 
+  // ---------------------------------------------------------------------------
+  // View-only mode: exit and restore local drawing
+  // ---------------------------------------------------------------------------
+  const exitViewOnlyMode = useCallback(() => {
+    if (!excalidrawAPI) {
+      return;
+    }
+    // Resume saving and restore the local scene
+    LocalData.resumeSave("viewOnly");
+    setIsViewOnlyMode(false);
+
+    const raw = localStorage.getItem("excalidraw");
+    const localDataState = raw ? JSON.parse(raw) : {} as any;
+    excalidrawAPI.updateScene({
+      elements: localDataState?.elements || [],
+      appState: {
+        ...localDataState?.appState,
+        viewModeEnabled: false,
+      },
+      captureUpdate: CaptureUpdateAction.NEVER,
+    });
+  }, [excalidrawAPI]);
+
   // browsers generally prevent infinite self-embedding, there are
   // cases where it still happens, and while we disallow self-embedding
   // by not whitelisting our own origin, this serves as an additional guard
@@ -1028,6 +1104,27 @@ const ExcalidrawWrapper = () => {
           <div className="alert alert--danger">
             {t("alerts.localStorageQuotaExceeded")}
           </div>
+        )}
+        {isViewOnlyMode && (
+          <div
+            className="view-only-banner"
+            onClick={exitViewOnlyMode}
+            style={{
+              cursor: "pointer",
+              position: "absolute",
+              top: "104px",
+              left: "50%",
+              transform: "translateX(-50%)",
+              padding: "8px 16px",
+              backgroundColor: "#e08a09",
+              color: "#000000",
+              borderRadius: "4px",
+              fontSize: "14px",
+              zIndex: 9999,
+              textAlign: "center",
+            }}
+            dangerouslySetInnerHTML={{ __html: t("alerts.viewOnlyBanner") }}
+          />
         )}
         {latestShareableLink && (
           <ShareableLinkDialog

--- a/excalidraw-app/data/LocalData.ts
+++ b/excalidraw-app/data/LocalData.ts
@@ -112,7 +112,7 @@ const isQuotaExceededError = (error: any) => {
   return error instanceof DOMException && error.name === "QuotaExceededError";
 };
 
-type SavingLockTypes = "collaboration";
+type SavingLockTypes = "collaboration" | "viewOnly";
 
 export class LocalData {
   private static _save = debounce(

--- a/excalidraw-app/index.scss
+++ b/excalidraw-app/index.scss
@@ -77,6 +77,16 @@
       background-color: var(--color-danger-dark);
       color: var(--color-danger-text);
     }
+
+    &.view-only-banner {
+      pointer-events: auto;
+      cursor: pointer;
+      transition: opacity 0.15s ease;
+
+      &:hover {
+        opacity: 0.85;
+      }
+    }
   }
 }
 

--- a/packages/excalidraw/components/OverwriteConfirm/OverwriteConfirm.scss
+++ b/packages/excalidraw/components/OverwriteConfirm/OverwriteConfirm.scss
@@ -50,6 +50,16 @@
         flex-grow: 1;
       }
 
+      &__buttons {
+        display: flex;
+        flex-direction: row;
+        gap: 8px;
+        flex-shrink: 0;
+        border: 1px solid #cccccc;
+        padding: 4px;
+        border-radius: 4px;
+      }
+
       &__icon {
         box-sizing: border-box;
         display: flex;

--- a/packages/excalidraw/components/OverwriteConfirm/OverwriteConfirm.tsx
+++ b/packages/excalidraw/components/OverwriteConfirm/OverwriteConfirm.tsx
@@ -39,11 +39,18 @@ const OverwriteConfirmDialog = Object.assign(
         setState((state) => ({ ...state, active: false }));
       };
 
+      const handleViewOnly = () => {
+        overwriteConfirmState.onViewOnly?.();
+        setState((state) => ({ ...state, active: false }));
+      };
+
+      const dialogTitle = (overwriteConfirmState as any).title;
+
       return (
         <OverwriteConfirmDialogTunnel.In>
           <Dialog onCloseRequest={handleClose} title={false} size={916}>
             <div className="OverwriteConfirm">
-              <h3>{overwriteConfirmState.title}</h3>
+              <h3>{dialogTitle}</h3>
               <div
                 className={`OverwriteConfirm__Description OverwriteConfirm__Description--color-${overwriteConfirmState.color}`}
               >
@@ -52,12 +59,24 @@ const OverwriteConfirmDialog = Object.assign(
                 </div>
                 <div>{overwriteConfirmState.description}</div>
                 <div className="OverwriteConfirm__Description__spacer"></div>
-                <FilledButton
-                  color={overwriteConfirmState.color}
-                  size="large"
-                  label={overwriteConfirmState.actionLabel}
-                  onClick={handleConfirm}
-                />
+                <div className="OverwriteConfirm__Description__buttons">
+                  {overwriteConfirmState.viewOnlyLabel &&
+                    overwriteConfirmState.onViewOnly && (
+                      <FilledButton
+                        variant="outlined"
+                        color="muted"
+                        size="large"
+                        label={overwriteConfirmState.viewOnlyLabel}
+                        onClick={handleViewOnly}
+                      />
+                    )}
+                  <FilledButton
+                    color={overwriteConfirmState.color}
+                    size="large"
+                    label={overwriteConfirmState.actionLabel}
+                    onClick={handleConfirm}
+                  />
+                </div>
               </div>
               <Actions>{children}</Actions>
             </div>

--- a/packages/excalidraw/components/OverwriteConfirm/OverwriteConfirmState.ts
+++ b/packages/excalidraw/components/OverwriteConfirm/OverwriteConfirmState.ts
@@ -9,10 +9,12 @@ export type OverwriteConfirmState =
       description: React.ReactNode;
       actionLabel: string;
       color: "danger" | "warning";
+      viewOnlyLabel?: string;
 
       onClose: () => void;
       onConfirm: () => void;
       onReject: () => void;
+      onViewOnly?: () => void;
     }
   | { active: false };
 
@@ -20,27 +22,34 @@ export const overwriteConfirmStateAtom = atom<OverwriteConfirmState>({
   active: false,
 });
 
+export type OverwriteConfirmResult = "confirm" | "viewOnly" | "cancel";
+
 export async function openConfirmModal({
   title,
   description,
   actionLabel,
   color,
+  viewOnlyLabel,
 }: {
   title: string;
   description: React.ReactNode;
   actionLabel: string;
   color: "danger" | "warning";
-}) {
-  return new Promise<boolean>((resolve) => {
+  viewOnlyLabel?: string;
+}): Promise<OverwriteConfirmResult> {
+  return new Promise<OverwriteConfirmResult>((resolve) => {
     editorJotaiStore.set(overwriteConfirmStateAtom, {
       active: true,
-      onConfirm: () => resolve(true),
-      onClose: () => resolve(false),
-      onReject: () => resolve(false),
+      onConfirm: () => resolve("confirm"),
+      onClose: () => resolve("cancel"),
+      onReject: () => resolve("cancel"),
+      onViewOnly: viewOnlyLabel ? () => resolve("viewOnly") : undefined,
       title,
       description,
       actionLabel,
       color,
+      viewOnlyLabel,
     });
   });
 }
+

--- a/packages/excalidraw/components/main-menu/DefaultItems.tsx
+++ b/packages/excalidraw/components/main-menu/DefaultItems.tsx
@@ -86,7 +86,7 @@ export const LoadScene = () => {
             br={() => <br />}
           />
         ),
-      }))
+      })) === "confirm"
     ) {
       actionManager.executeAction(actionLoadScene);
     }

--- a/packages/excalidraw/locales/en.json
+++ b/packages/excalidraw/locales/en.json
@@ -279,7 +279,8 @@
     "removeItemsFromsLibrary": "Delete {{count}} item(s) from library?",
     "invalidEncryptionKey": "Encryption key must be of 22 characters. Live collaboration is disabled.",
     "collabOfflineWarning": "No internet connection available.\nYour changes will not be saved!",
-    "localStorageQuotaExceeded": "Browser storage quota exceeded. Changes will not be saved."
+    "localStorageQuotaExceeded": "Browser storage quota exceeded. Changes will not be saved.",
+    "viewOnlyBanner": "Viewing a shared drawing (read-only). Click to return to your drawing."
   },
   "errors": {
     "unsupportedFileType": "Unsupported file type.",
@@ -627,7 +628,8 @@
       "shareableLink": {
         "title": "Load from link",
         "button": "Replace my content",
-        "description": "Loading external drawing will <bold>replace your existing content</bold>.<br></br>You can back up your drawing first by using one of the options below."
+        "description": "Loading external drawing will <bold>replace your existing content</bold>.<br></br>You can back up your drawing first by using one of the options below.",
+        "viewOnly": "View only"
       }
     }
   },


### PR DESCRIPTION
## Description

Currently, opening a shareable link (e.g., `#json=...`) or an external URL (`#url=...`) forces users to either replace their existing local canvas or cancel the operation entirely. There is no supported way to simply "peek" at a shared file while preserving current work, which is a common workflow limitation.

This PR introduces a first-class **"View only"** option to the overwrite confirmation dialog. When selected, the shared drawing loads in read-only mode while the user's local canvas is preserved. 

## Changes Made
- **OverwriteConfirmDialog**: Added a secondary "View only" button when opening external links.
- **LocalData State**: Added a `viewOnly` lock to `LocalData` to pause saving to localStorage while the user is previewing a shared drawing.
- **App.tsx Logic**: 
  - Updated `initializeScene` to handle the new 3-way modal result.
  - Added a floating `view-only-banner` that allows the user to easily exit the view-only mode and restore their original local canvas.
- **i18n & Styling**: Added necessary localized strings and layout updates for the new dialog structure and banner.

## How to Test
1. Have some existing drawings on your local canvas.
2. Open an Excalidraw shareable link (e.g., `/#json=...`).
3. You should see a new "View only" option next to "Replace my content".
4. Click "View only" — the shared drawing will load, and a warning banner will appear.
5. Verify that making changes to the canvas does not overwrite your local storage.
6. Click the banner to exit view-only mode and verify your original drawing is restored.
