### PR TITLE
fix: prevent top-right controls overflow on narrow viewports

### DIFF
--- a/packages/common/src/editorInterface.ts
+++ b/packages/common/src/editorInterface.ts
@@ -16,14 +16,15 @@ export type EditorInterface = Readonly<{
 const DESKTOP_UI_MODE_STORAGE_KEY = "excalidraw.desktopUIMode";
 
 // breakpoints
-export const MQ_MAX_MOBILE = 599;
+export const MQ_MAX_MOBILE = 699;
 
 export const MQ_MAX_WIDTH_LANDSCAPE = 1000;
 export const MQ_MAX_HEIGHT_LANDSCAPE = 500;
 
 // tablets
-export const MQ_MIN_TABLET = MQ_MAX_MOBILE + 1; // lower bound (excludes phones)
+export const MQ_MIN_TABLET = 600;
 export const MQ_MAX_TABLET = 1180; // ipad air
+export const MQ_MAX_HEIGHT_COMPACT_LANDSCAPE = 600;
 
 // desktop/laptop (NOTE: not used for form factor detection)
 export const MQ_MIN_WIDTH_DESKTOP = 1440;
@@ -75,7 +76,14 @@ export const isTabletBreakpoint = (
   const minSide = Math.min(editorWidth, editorHeight);
   const maxSide = Math.max(editorWidth, editorHeight);
 
-  return minSide >= MQ_MIN_TABLET && maxSide <= MQ_MAX_TABLET;
+  return (
+    (minSide >= MQ_MIN_TABLET && maxSide <= MQ_MAX_TABLET) ||
+    (
+      editorHeight >= MQ_MAX_HEIGHT_LANDSCAPE &&
+      editorHeight <= MQ_MAX_HEIGHT_COMPACT_LANDSCAPE &&
+      editorWidth < MQ_MAX_WIDTH_LANDSCAPE
+    )
+  );
 };
 
 const isMobileOrTablet = (): boolean => {


### PR DESCRIPTION
# Summary
Fixes #11295.

# Changes
- Raised the mobile width breakpoint so narrow viewports use the existing phone layout instead of clipping top-right controls.
- Decoupled the tablet minimum breakpoint from the mobile maximum breakpoint so compact tablet-sized viewports can still resolve to tablet.
- Added a compact landscape tablet condition for short desktop windows where the full desktop toolbar does not fit.

# Testing
Tests manually at (in px):
 675*550
<img width="715" height="588" alt="image" src="https://github.com/user-attachments/assets/61e440a9-8672-4d3b-a865-98189cfebb83" />

 834*550
<img width="791" height="584" alt="image" src="https://github.com/user-attachments/assets/76daa27c-d22a-42aa-8742-9f6395dac9ff" />

 800*550
<img width="757" height="580" alt="image" src="https://github.com/user-attachments/assets/c72df6ad-bb39-4959-87ff-3e831efedd50" />

 1181*800
<img width="1086" height="800" alt="image" src="https://github.com/user-attachments/assets/119b1b05-98bf-4ca1-8114-9cf5cbd7e68d" />
