### PR TITLE
Fix Ctrl+S in WYSIWYG editor opening browser Save dialog on Firefox

### DIFF
--- a/packages/excalidraw/wysiwyg/textWysiwyg.tsx
+++ b/packages/excalidraw/wysiwyg/textWysiwyg.tsx
@@ -53,7 +53,7 @@ import type {
   ExcalidrawTextElement,
 } from "@excalidraw/element/types";
 
-import { actionSaveToActiveFile } from "../actions";
+import { actionSaveFileToDisk, actionSaveToActiveFile } from "../actions";
 
 import {
   parseClipboard,
@@ -626,6 +626,28 @@ export const textWysiwyg = ({
     };
   }
 
+  const onWysiwygSave = (event: KeyboardEvent) => {
+    event.preventDefault();
+    handleSubmit();
+    if (app.state.fileHandle) {
+      app.actionManager.executeAction(actionSaveToActiveFile);
+    } else {
+      app.actionManager.executeAction(actionSaveFileToDisk);
+    }
+  };
+
+  const onCaptureKeyDown = (event: KeyboardEvent) => {
+    if (
+      event.key === KEYS.S &&
+      event[KEYS.CTRL_OR_CMD] &&
+      !event.shiftKey
+    ) {
+      event.preventDefault();
+      event.stopPropagation();
+    }
+  };
+  document.addEventListener("keydown", onCaptureKeyDown, { capture: true });
+
   editable.onkeydown = (event) => {
     if (!event.shiftKey && actionZoomIn.keyTest(event)) {
       event.preventDefault();
@@ -648,9 +670,7 @@ export const textWysiwyg = ({
       submittedViaKeyboard = true;
       handleSubmit();
     } else if (actionSaveToActiveFile.keyTest(event)) {
-      event.preventDefault();
-      handleSubmit();
-      app.actionManager.executeAction(actionSaveToActiveFile);
+      onWysiwygSave(event);
     } else if (event.key === KEYS.ENTER && event[KEYS.CTRL_OR_CMD]) {
       event.preventDefault();
       if (event.isComposing || event.keyCode === 229) {
@@ -848,6 +868,7 @@ export const textWysiwyg = ({
       observer.disconnect();
     }
 
+    document.removeEventListener("keydown", onCaptureKeyDown, { capture: true });
     window.removeEventListener("resize", updateWysiwygStyle);
     window.removeEventListener("wheel", stopEvent, true);
     window.removeEventListener("pointerdown", onPointerDown);

--- a/packages/excalidraw/wysiwyg/textWysiwyg.tsx
+++ b/packages/excalidraw/wysiwyg/textWysiwyg.tsx
@@ -642,7 +642,7 @@ export const textWysiwyg = ({
       event[KEYS.CTRL_OR_CMD] &&
       !event.shiftKey
     ) {
-      event.preventDefault();
+      onWysiwygSave(event);
       event.stopPropagation();
     }
   };


### PR DESCRIPTION
## Description

Fixes #9281

On Firefox, when editing text in the WYSIWYG textarea, pressing Ctrl+S triggers the browser's native "Save Page" dialog instead of saving the Excalidraw drawing.

### Root Cause

The existing `onkeydown` handler on the `<textarea>` called `event.preventDefault()` for Ctrl+S, but Firefox intercepts this shortcut at a higher level for form elements, preventing the JavaScript handler from stopping the browser default action.

### Changes

1. **Added a capture-phase keydown listener on `document`** — intercepts Ctrl+S during the capture phase before the browser handles it natively. Calls `event.preventDefault()` and `event.stopPropagation()`.

2. **Fall back to `actionSaveFileToDisk` when no `fileHandle` exists** — Previously, Ctrl+S with no active file handle called `actionSaveToActiveFile` whose predicate returned false (no file handle), resulting in a no-op despite `preventDefault()` being called. Now it saves to disk, so Ctrl+S always saves the drawing as expected.
