### PR TITLE
fix: duplicated words in element/{groups,collision,duplicate} comments

### DIFF
--- a/packages/element/src/collision.ts
+++ b/packages/element/src/collision.ts
@@ -309,7 +309,7 @@ export const getAllHoveredElementAtPoint = (
   tolerance?: number,
 ): NonDeleted<ExcalidrawBindableElement>[] => {
   const candidateElements: NonDeleted<ExcalidrawBindableElement>[] = [];
-  // We need to to hit testing from front (end of the array) to back (beginning of the array)
+  // We need to hit testing from front (end of the array) to back (beginning of the array)
   // because array is ordered from lower z-index to highest and we want element z-index
   // with higher z-index
   for (let index = elements.length - 1; index >= 0; --index) {
@@ -375,7 +375,7 @@ export const getHoveredElementForFocusPoint = (
   tolerance?: number,
 ): ExcalidrawBindableElement | null => {
   const candidateElements: NonDeleted<ExcalidrawBindableElement>[] = [];
-  // We need to to hit testing from front (end of the array) to back (beginning of the array)
+  // We need to hit testing from front (end of the array) to back (beginning of the array)
   // because array is ordered from lower z-index to highest and we want element z-index
   // with higher z-index
   for (let index = elements.length - 1; index >= 0; --index) {

--- a/packages/element/src/duplicate.ts
+++ b/packages/element/src/duplicate.ts
@@ -485,7 +485,7 @@ const _deepCopyElement = (val: any, depth: number = 0) => {
 
 /**
  * Clones ExcalidrawElement data structure. Does not regenerate id, nonce, or
- * any value. The purpose is to to break object references for immutability
+ * any value. The purpose is to break object references for immutability
  * reasons, whenever we want to keep the original element, but ensure it's not
  * mutated.
  *

--- a/packages/element/src/groups.ts
+++ b/packages/element/src/groups.ts
@@ -234,7 +234,7 @@ export const getSelectedGroupIds = (
     .filter(([groupId, isSelected]) => isSelected)
     .map(([groupId, isSelected]) => groupId);
 
-// given a list of elements, return the the actual group ids that should be selected
+// given a list of elements, return the actual group ids that should be selected
 // or used to update the elements
 export const selectGroupsFromGivenElements = (
   elements: readonly NonDeleted<ExcalidrawElement>[],


### PR DESCRIPTION
Three one-line typo fixes for duplicated words in source comments inside `packages/element/src/`:
- `groups.ts` — "return the the actual group ids" → "return the actual group ids"
- `collision.ts` (two identical comments) — "We need to to hit testing from front" → "We need to hit testing from front"
- `duplicate.ts` — "The purpose is to to break object references" → "The purpose is to break object references"

No code/behavior change.