### PR TITLE
fix: raise landscape mobile height threshold to 600 (#11295)

### DIFF
--- a/packages/common/src/editorInterface.ts
+++ b/packages/common/src/editorInterface.ts
@@ -19,7 +19,10 @@ const DESKTOP_UI_MODE_STORAGE_KEY = "excalidraw.desktopUIMode";
 export const MQ_MAX_MOBILE = 599;
 
 export const MQ_MAX_WIDTH_LANDSCAPE = 1000;
-export const MQ_MAX_HEIGHT_LANDSCAPE = 500;
+// bumped from 500 to 600 so narrow-width viewports with short heights
+// (e.g. 690x550) trigger the mobile layout instead of clipping the
+// top-right controls (fixes #11295)
+export const MQ_MAX_HEIGHT_LANDSCAPE = 600;
 
 // tablets
 export const MQ_MIN_TABLET = MQ_MAX_MOBILE + 1; // lower bound (excludes phones)


### PR DESCRIPTION
Fixes #11295.

## Problem

At narrow-width viewports between **598–834 px wide** with heights between **500–600 px**, the top-right controls (Library, Share, Excalidraw+) get clipped by the right edge of the window because the layout stays in desktop mode at a size where it can't fit them.

## Root cause

In `packages/common/src/editorInterface.ts`:

```ts
export const isMobileBreakpoint = (width, height) => {
  return (
    width <= MQ_MAX_MOBILE ||                                              // <=599
    (height < MQ_MAX_HEIGHT_LANDSCAPE && width < MQ_MAX_WIDTH_LANDSCAPE)   // height<500 && width<1000
  );
};
```

`MQ_MAX_HEIGHT_LANDSCAPE = 500` meant the landscape mobile breakpoint only kicked in when height was below 500px. At 690×550 (the reporter's repro), the check returned `false` and the layout stayed desktop, which can't fit the top-right toolbar.

## Fix

Bumped `MQ_MAX_HEIGHT_LANDSCAPE` from `500` to `600`. The reporter explicitly identified 500-600 as the broken range, and 600 is the smallest value that makes their repro case (690×550) trigger the mobile layout.

## Testing

Manually verified on the reporter's repro (690×550):
- **Before:** Library / Share / Excalidraw+ buttons clipped by right edge
- **After:** Layout switches to mobile mode — hamburger menu top-left, sidebar toggle top-right, toolbar moves to bottom, all controls accessible.