### PR TITLE
feat(collections): multi-collection disk save for excalidraw-app

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,3 +122,13 @@ If you like the project, you can become a sponsor at [Open Collective](https://o
 Last but not least, we're thankful to these companies for offering their services for free:
 
 [![Vercel](./.github/assets/vercel.svg)](https://vercel.com) [![Sentry](./.github/assets/sentry.svg)](https://sentry.io) [![Crowdin](./.github/assets/crowdin.svg)](https://crowdin.com)
+
+## Collections fork (this branch)
+
+This fork adds **multiple collections**, **save to disk**, autosave recovery, and export ZIP in the web app layer only (`excalidraw-app/`).
+
+- Usage guide: [excalidraw-app/COLLECTIONS.md](excalidraw-app/COLLECTIONS.md)
+- Roadmap: [excalidraw-app/FUTURE_IMPROVEMENTS.md](excalidraw-app/FUTURE_IMPROVEMENTS.md)
+- Windows helpers: [scripts/windows/](scripts/windows/)
+
+Not part of the official Excalidraw release unless merged upstream.

--- a/excalidraw-app/App.tsx
+++ b/excalidraw-app/App.tsx
@@ -102,6 +102,9 @@ import Collab, {
 import { AppFooter } from "./components/AppFooter";
 import { AppMainMenu } from "./components/AppMainMenu";
 import { AppWelcomeScreen } from "./components/AppWelcomeScreen";
+import { CollectionsDialog } from "./components/CollectionsDialog";
+import { collectionsDialogOpenAtom } from "./components/collectionsDialogAtom";
+import { SaveStatusIndicator } from "./components/SaveStatusIndicator";
 import {
   ExportToExcalidrawPlus,
   exportToExcalidrawPlus,
@@ -121,6 +124,8 @@ import {
   importFromLocalStorage,
   importUsernameFromLocalStorage,
 } from "./data/localStorage";
+import { applyActiveCollectionToInitialScene } from "./collections/initializeCollectionScene";
+import { useCollectionsAppIntegration } from "./collections/useCollectionsAppIntegration";
 
 import { loadFilesFromFirebase } from "./data/firebase";
 import {
@@ -238,6 +243,7 @@ const initializeScene = async (opts: {
     "files"
   > & {
     scrollToContent?: boolean;
+    files?: BinaryFiles;
   } = {
     elements: restoreElements(localDataState?.elements, null, {
       repairBindings: true,
@@ -248,6 +254,14 @@ const initializeScene = async (opts: {
 
   let roomLinkData = getCollaborationLinkData(window.location.href);
   const isExternalScene = !!(id || jsonBackendMatch || roomLinkData);
+
+  if (!isExternalScene) {
+    scene = await applyActiveCollectionToInitialScene(
+      scene,
+      localDataState?.elements ?? null,
+      localDataState?.appState ?? null,
+    );
+  }
   if (isExternalScene) {
     if (
       // don't prompt if scene is empty
@@ -411,6 +425,12 @@ const ExcalidrawWrapper = () => {
   });
   const collabError = useAtomValue(collabErrorIndicatorAtom);
 
+  const collections = useCollectionsAppIntegration({
+    excalidrawAPI,
+    collabAPI,
+    setErrorMessage,
+  });
+
   useHandleLibrary({
     excalidrawAPI,
     adapter: LibraryIndexedDBAdapter,
@@ -495,6 +515,9 @@ const ExcalidrawWrapper = () => {
             ]);
           });
         } else if (isInitialLoad) {
+          if (data.scene.files && Object.keys(data.scene.files).length > 0) {
+            excalidrawAPI.addFiles(Object.values(data.scene.files));
+          }
           if (fileIds.length) {
             LocalData.fileStorage
               .getFiles(fileIds)
@@ -654,6 +677,8 @@ const ExcalidrawWrapper = () => {
     const unloadHandler = (event: BeforeUnloadEvent) => {
       LocalData.flushSave();
 
+      collections.flushActiveCollectionOnUnload();
+
       if (
         excalidrawAPI &&
         LocalData.fileStorage.shouldPreventUnload(
@@ -673,7 +698,7 @@ const ExcalidrawWrapper = () => {
     return () => {
       window.removeEventListener(EVENT.BEFORE_UNLOAD, unloadHandler);
     };
-  }, [excalidrawAPI]);
+  }, [excalidrawAPI, collabAPI, collections]);
 
   const onChange = (
     elements: readonly OrderedExcalidrawElement[],
@@ -713,7 +738,11 @@ const ExcalidrawWrapper = () => {
             });
           }
         }
+
+        collections.afterLocalSave();
       });
+    } else {
+      collections.updateDirtyState();
     }
 
     // Render the debug scene if the debug canvas is available
@@ -985,6 +1014,9 @@ const ExcalidrawWrapper = () => {
       >
         <AppMainMenu
           onCollabDialogOpen={onCollabDialogOpen}
+          onCollectionsOpen={() =>
+            appJotaiStore.set(collectionsDialogOpenAtom, true)
+          }
           isCollaborating={isCollaborating}
           isCollabEnabled={!isCollabDisabled}
           theme={appTheme}
@@ -994,6 +1026,7 @@ const ExcalidrawWrapper = () => {
         <AppWelcomeScreen
           onCollabDialogOpen={onCollabDialogOpen}
           isCollabEnabled={!isCollabDisabled}
+          onOpenCollection={collections.openCollectionById}
         />
         <OverwriteConfirmDialog>
           <OverwriteConfirmDialog.Actions.ExportToImage />
@@ -1039,6 +1072,16 @@ const ExcalidrawWrapper = () => {
         {excalidrawAPI && !isCollabDisabled && (
           <Collab excalidrawAPI={excalidrawAPI} />
         )}
+
+        <CollectionsDialog
+          excalidrawAPI={excalidrawAPI}
+          onSwitchCollection={collections.switchCollection}
+          onSaveCollection={collections.saveCollectionToDisk}
+          onSaveCollectionAs={collections.saveCollectionAs}
+          onDownloadCollection={collections.downloadCollection}
+          isDirty={collections.isCollectionDirty}
+        />
+        <SaveStatusIndicator onSaveActive={collections.saveActiveCollection} />
 
         <ShareDialog
           collabAPI={collabAPI}

--- a/excalidraw-app/COLLECTIONS.md
+++ b/excalidraw-app/COLLECTIONS.md
@@ -1,0 +1,124 @@
+# Collections and disk save
+
+This fork extends the Excalidraw web app (`excalidraw-app`) with **multiple named collections**, optional **save to disk** via the File System Access API, crash **autosave** files, and backup **export**.
+
+All feature code lives under:
+
+- `excalidraw-app/data/collections/` — storage and I/O
+- `excalidraw-app/components/` — Collections dialog, save indicator, unsaved-changes dialog
+- `excalidraw-app/collections/` — app integration bridge (`useCollectionsAppIntegration`)
+
+The core library `packages/excalidraw` is unchanged.
+
+## Quick start
+
+1. Start the app: from the repo root, `yarn start` (or `scripts/windows/run-excalidraw.bat` on Windows).
+2. Open **Menu → Collections**.
+3. Enter a name and click **Create**.
+4. Click **Save** on that collection and choose a folder (Chrome or Edge).
+5. Edits auto-save to disk for that collection after the first successful Save.
+
+## Save status indicator
+
+A chip at the bottom-left shows:
+
+- **Saving…** / **Saved · time ago**
+- **Unsaved changes** when the canvas differs from the last persisted snapshot
+- The active save location (folder name + file name when available)
+
+Click the chip to run **Save** for the active collection (same as the row Save action).
+
+## Collections dialog
+
+| Action | Description |
+|--------|-------------|
+| **Create** | New collection (stored in browser until first Save to folder) |
+| **Save** | Write `.excalidraw` to the session folder (requires supported browser) |
+| **Save As** | Pick a file path for this collection only |
+| **Download** | Download one `.excalidraw` file (all browsers) |
+| **Duplicate** | Copy collection as `Name (copy)` |
+| **Import file** | Register an existing `.excalidraw` from disk |
+| **Rename** / **Delete** | Update metadata; delete removes disk file when possible |
+| **Export all** | ZIP of every collection’s JSON |
+| **Choose / Change folder** | Session folder for new saves |
+| **Open save folder** | Folder name, file list, copy helpers |
+| **Search / Sort** | Filter and sort the list |
+
+### Unsaved changes
+
+Switching to another collection while the active one has unsaved edits opens a prompt:
+
+- **Save & continue** — saves then switches  
+- **Discard** — switches without saving outgoing IDB/disk flush from switch handler  
+- **Cancel**
+
+## Welcome screen
+
+Up to **five recent collections** appear under the main menu for one-click open.
+
+## Autosave and recovery
+
+When saving to a session folder, each write also updates `YourFile.autosave.excalidraw` beside the main file.
+
+On load, if the autosave file is newer than the main file, the app loads autosave and shows:
+
+> Recovered from autosave backup. Save to confirm this version on disk.
+
+Use **Save** to write the recovered scene to the main file.
+
+## Browser support
+
+| Browser | Save to folder | Auto-save to disk | Download / Export ZIP |
+|---------|----------------|-------------------|------------------------|
+| Chrome, Edge | Yes | After first Save | Yes |
+| Firefox, Safari | No (IDB only) | IDB only | Yes |
+
+Firefox and Safari show a banner in the Collections dialog explaining limited folder support.
+
+## Optional Windows folder path
+
+For opening a folder in Explorer outside the browser:
+
+1. In Collections, set **Collections folder path** and click **Save path**.
+2. Create `.excalidraw-collections-path.txt` in the repo root with that path (one line), **or** use the path saved in the app.
+3. Run `scripts/windows/open-collections-folder.bat`.
+
+Browsers cannot expose the full OS path from the folder picker for security reasons.
+
+## Data storage
+
+| Data | Location |
+|------|----------|
+| Collection index | `localStorage` key `excalidraw-collections-index` |
+| Active collection id | `localStorage` key `excalidraw-active-collection-id` |
+| Scene fallback | IndexedDB `excalidraw-collections` store |
+| Directory / file handles | IndexedDB (persisted) + session memory |
+| Thumbnails | IndexedDB per collection |
+
+Legacy single-scene `localStorage` is migrated when you choose a folder and have no collections yet.
+
+## Development
+
+```bash
+cd excalidraw
+yarn install
+yarn start
+```
+
+Checks:
+
+```bash
+yarn test:code
+yarn test:typecheck
+```
+
+## Troubleshooting
+
+| Problem | What to try |
+|---------|-------------|
+| Save does nothing | Use Chrome/Edge; click Save inside the dialog (user gesture); allow folder permission |
+| Permission denied | Choose folder again via **Change folder** |
+| Collection empty after reload | Use **Import** or check autosave file in your save folder |
+| Chip stuck on Unsaved | Click chip to Save, or switch away and use Save & continue |
+
+See [FUTURE_IMPROVEMENTS.md](./FUTURE_IMPROVEMENTS.md) for planned work and upstream contribution notes.

--- a/excalidraw-app/FUTURE_IMPROVEMENTS.md
+++ b/excalidraw-app/FUTURE_IMPROVEMENTS.md
@@ -1,0 +1,43 @@
+# Future improvements
+
+Roadmap for the collections and disk-save feature. Items are grouped by theme.
+
+## Storage and platform
+
+- **Reveal in Explorer / Finder** via a thin desktop wrapper (Electron or Tauri) instead of manual path + `.bat`
+- **Sync optional OS path** to `open-collections-folder.bat` automatically when the user saves path in settings
+- **Cloud folder** support (OneDrive/Dropbox paths) with clear conflict rules
+- **Per-collection sync** metadata (last synced, remote etag)
+
+## User experience
+
+- **Unsaved warning** when closing the Collections dialog or the tab (beyond collection switch)
+- **Drag-and-drop** reorder collections; pin favorites
+- **Bulk actions** — delete or export selected collections
+- **Empty collection** template picker on create
+- **i18n** — move UI strings into Excalidraw’s translation files for upstream merge
+
+## Thumbnails and performance
+
+- Generate thumbnails for IDB-only saves, not only disk Save
+- Lazy-load thumbnails for long lists; revoke object URLs on dialog close consistently
+- Virtualized list for 50+ collections
+
+## Collaboration
+
+- Define behavior when **live collaboration** is active (disable auto disk save or branch per room)
+- Export collection snapshot for collab room handoff
+
+## Testing and upstream
+
+- Unit tests for `CollectionStore` (create, duplicate, index, autosave preference)
+- Integration test with mocked File System Access API
+- **Upstream PR** to [excalidraw/excalidraw](https://github.com/excalidraw/excalidraw): app-layer only, feature flag, design review, changelog entry
+
+Upstream may require product alignment before merge; this fork remains the reference implementation.
+
+## Architecture (done in this fork)
+
+- [x] Isolate storage in `data/collections/`
+- [x] UI in dedicated components
+- [x] Bridge hook `collections/useCollectionsAppIntegration.ts` to keep `App.tsx` thin

--- a/excalidraw-app/app_constants.ts
+++ b/excalidraw-app/app_constants.ts
@@ -48,6 +48,12 @@ export const STORAGE_KEYS = {
   IDB_LIBRARY: "excalidraw-library",
   IDB_TTD_CHATS: "excalidraw-ttd-chats",
 
+  LOCAL_STORAGE_COLLECTIONS_INDEX: "excalidraw-collections-index",
+  LOCAL_STORAGE_ACTIVE_COLLECTION_ID: "excalidraw-active-collection-id",
+  LOCAL_STORAGE_COLLECTIONS_OS_PATH: "excalidraw-collections-os-path",
+  LOCAL_STORAGE_COLLECTIONS_SORT: "excalidraw-collections-sort",
+  IDB_COLLECTIONS: "excalidraw-collections",
+
   // do not use apart from migrations
   __LEGACY_LOCAL_STORAGE_LIBRARY: "excalidraw-library",
 } as const;

--- a/excalidraw-app/collections/initializeCollectionScene.ts
+++ b/excalidraw-app/collections/initializeCollectionScene.ts
@@ -1,0 +1,65 @@
+import {
+  restoreAppState,
+  restoreElements,
+} from "@excalidraw/excalidraw/data/restore";
+
+import type { ExcalidrawElement } from "@excalidraw/element/types";
+import type { RestoredDataState } from "@excalidraw/excalidraw/data/restore";
+import type { AppState, BinaryFiles } from "@excalidraw/excalidraw/types";
+
+import { CollectionStore } from "../data/collections/CollectionStore";
+
+export const RECOVERED_FROM_AUTOSAVE_SESSION_KEY =
+  "excalidraw-recovered-from-autosave";
+
+export type CollectionSceneInput = Omit<RestoredDataState, "files"> & {
+  scrollToContent?: boolean;
+  files?: BinaryFiles;
+};
+
+export const applyActiveCollectionToInitialScene = async (
+  scene: CollectionSceneInput,
+  localElements: readonly ExcalidrawElement[] | null | undefined,
+  localAppState: Partial<AppState> | null | undefined,
+): Promise<CollectionSceneInput> => {
+  CollectionStore.ensureActiveCollectionOnStartup();
+  const activeCollection = CollectionStore.getActiveCollection();
+  if (!activeCollection) {
+    return scene;
+  }
+
+  try {
+    const collectionScene = await CollectionStore.loadActiveCollectionScene(
+      null,
+      localElements ?? null,
+    );
+    if (!collectionScene?.elements) {
+      return scene;
+    }
+
+    const next: CollectionSceneInput = {
+      elements: restoreElements(collectionScene.elements, null, {
+        repairBindings: true,
+        deleteInvisibleElements: true,
+      }),
+      appState: restoreAppState(
+        collectionScene.appState,
+        localAppState ?? null,
+      ),
+      files: collectionScene.files,
+    };
+
+    if (collectionScene.recoveredFromAutosave) {
+      try {
+        sessionStorage.setItem(RECOVERED_FROM_AUTOSAVE_SESSION_KEY, "1");
+      } catch {
+        /* ignore */
+      }
+    }
+
+    return next;
+  } catch (error) {
+    console.error(error);
+    return scene;
+  }
+};

--- a/excalidraw-app/collections/useCollectionsAppIntegration.ts
+++ b/excalidraw-app/collections/useCollectionsAppIntegration.ts
@@ -1,0 +1,401 @@
+import { CaptureUpdateAction } from "@excalidraw/excalidraw";
+import {
+  restoreAppState,
+  restoreElements,
+} from "@excalidraw/excalidraw/data/restore";
+import { useCallback, useEffect, useRef } from "react";
+
+import type { ExcalidrawImperativeAPI } from "@excalidraw/excalidraw/types";
+import type { AppState } from "@excalidraw/excalidraw/types";
+
+import { useAtomValue, useSetAtom } from "../app-jotai";
+
+import {
+  activeCollectionDirtyAtom,
+  activeSaveLocationAtom,
+  recoveredFromAutosaveAtom,
+} from "../data/collectionUiAtoms";
+import { CollectionStore } from "../data/collections/CollectionStore";
+import { computeSceneSnapshot } from "../data/collections/sceneSnapshot";
+import { LocalData } from "../data/LocalData";
+import {
+  lastSavedAtAtom,
+  saveErrorMessageAtom,
+  saveStatusAtom,
+} from "../data/saveStatusAtoms";
+
+import { RECOVERED_FROM_AUTOSAVE_SESSION_KEY } from "./initializeCollectionScene";
+
+import type { CollabAPI } from "../collab/Collab";
+
+export type UseCollectionsAppIntegrationArgs = {
+  excalidrawAPI: ExcalidrawImperativeAPI | null;
+  collabAPI: CollabAPI | null;
+  setErrorMessage: (message: string) => void;
+};
+
+export const useCollectionsAppIntegration = ({
+  excalidrawAPI,
+  collabAPI,
+  setErrorMessage,
+}: UseCollectionsAppIntegrationArgs) => {
+  const setSaveStatus = useSetAtom(saveStatusAtom);
+  const setLastSavedAt = useSetAtom(lastSavedAtAtom);
+  const setSaveErrorMessage = useSetAtom(saveErrorMessageAtom);
+  const setActiveCollectionDirty = useSetAtom(activeCollectionDirtyAtom);
+  const setActiveSaveLocation = useSetAtom(activeSaveLocationAtom);
+  const setRecoveredFromAutosave = useSetAtom(recoveredFromAutosaveAtom);
+  const isCollectionDirty = useAtomValue(activeCollectionDirtyAtom);
+
+  const lastPersistedSnapshotRef = useRef<string | null>(null);
+
+  const syncPersistedSnapshot = useCallback(() => {
+    if (!excalidrawAPI) {
+      return;
+    }
+    const snapshot = computeSceneSnapshot(
+      excalidrawAPI.getSceneElementsIncludingDeleted(),
+      excalidrawAPI.getFiles(),
+    );
+    lastPersistedSnapshotRef.current = snapshot;
+    setActiveCollectionDirty(false);
+  }, [excalidrawAPI, setActiveCollectionDirty]);
+
+  const updateDirtyState = useCallback(() => {
+    if (!excalidrawAPI || collabAPI?.isCollaborating()) {
+      return;
+    }
+    if (!CollectionStore.getActiveCollection()) {
+      setActiveCollectionDirty(false);
+      return;
+    }
+    const snapshot = computeSceneSnapshot(
+      excalidrawAPI.getSceneElementsIncludingDeleted(),
+      excalidrawAPI.getFiles(),
+    );
+    const baseline = lastPersistedSnapshotRef.current;
+    setActiveCollectionDirty(!!baseline && snapshot !== baseline);
+  }, [excalidrawAPI, collabAPI, setActiveCollectionDirty]);
+
+  useEffect(() => {
+    if (!excalidrawAPI) {
+      return;
+    }
+    const active = CollectionStore.getActiveCollection();
+    if (active) {
+      setActiveSaveLocation(active.saveLocationLabel ?? null);
+      syncPersistedSnapshot();
+    }
+    try {
+      if (sessionStorage.getItem(RECOVERED_FROM_AUTOSAVE_SESSION_KEY)) {
+        sessionStorage.removeItem(RECOVERED_FROM_AUTOSAVE_SESSION_KEY);
+        setRecoveredFromAutosave(true);
+        setErrorMessage(
+          "Recovered from autosave backup. Save to confirm this version on disk.",
+        );
+      }
+    } catch {
+      /* ignore */
+    }
+  }, [
+    excalidrawAPI,
+    setActiveSaveLocation,
+    syncPersistedSnapshot,
+    setRecoveredFromAutosave,
+    setErrorMessage,
+  ]);
+
+  useEffect(() => {
+    LocalData.onSaveStart = () => {
+      setSaveErrorMessage(null);
+      setSaveStatus("saving");
+    };
+    LocalData.onSaveComplete = () => {
+      setSaveStatus("saved");
+      setLastSavedAt(Date.now());
+    };
+    return () => {
+      LocalData.onSaveStart = null;
+      LocalData.onSaveComplete = null;
+    };
+  }, [setSaveStatus, setLastSavedAt, setSaveErrorMessage]);
+
+  const persistActiveCollection = useCallback(async () => {
+    if (!excalidrawAPI || collabAPI?.isCollaborating()) {
+      return;
+    }
+    if (!CollectionStore.getActiveCollection()) {
+      return;
+    }
+    try {
+      await CollectionStore.saveActiveToFile(
+        excalidrawAPI.getSceneElementsIncludingDeleted(),
+        excalidrawAPI.getAppState(),
+        excalidrawAPI.getFiles(),
+      );
+      syncPersistedSnapshot();
+    } catch (error: any) {
+      setSaveStatus("error");
+      setSaveErrorMessage(error?.message ?? "Could not save collection file.");
+    }
+  }, [
+    excalidrawAPI,
+    collabAPI,
+    setSaveStatus,
+    setSaveErrorMessage,
+    syncPersistedSnapshot,
+  ]);
+
+  const getSceneForCollection = useCallback(
+    async (collectionId: string) => {
+      if (!excalidrawAPI) {
+        throw new Error("Canvas is still loading. Try again in a moment.");
+      }
+      const active = CollectionStore.getActiveCollection();
+      if (active?.id === collectionId) {
+        return {
+          elements: excalidrawAPI.getSceneElementsIncludingDeleted(),
+          appState: excalidrawAPI.getAppState(),
+          files: excalidrawAPI.getFiles(),
+        };
+      }
+      const scene = await CollectionStore.loadCollectionScene(
+        collectionId,
+        null,
+        null,
+      );
+      if (!scene) {
+        throw new Error("Collection has no data.");
+      }
+      return {
+        elements: scene.elements ?? [],
+        appState: {
+          ...excalidrawAPI.getAppState(),
+          ...(scene.appState ?? {}),
+        } as AppState,
+        files: scene.files ?? {},
+      };
+    },
+    [excalidrawAPI],
+  );
+
+  const saveCollectionToDisk = useCallback(
+    async (collectionId: string) => {
+      setSaveErrorMessage(null);
+
+      try {
+        if (CollectionStore.isFileSystemSupported()) {
+          await CollectionStore.ensureSessionDirectory();
+        }
+
+        LocalData.flushSave();
+
+        const { elements, appState, files } = await getSceneForCollection(
+          collectionId,
+        );
+        const active = CollectionStore.getActiveCollection();
+
+        await CollectionStore.saveCollectionToDisk(
+          collectionId,
+          elements,
+          appState,
+          files,
+        );
+
+        const saved = CollectionStore.getCollections().find(
+          (c) => c.id === collectionId,
+        );
+        if (saved?.saveLocationLabel) {
+          setActiveSaveLocation(saved.saveLocationLabel);
+        }
+        if (active?.id === collectionId) {
+          syncPersistedSnapshot();
+        }
+        setRecoveredFromAutosave(false);
+        setSaveStatus("saved");
+        setLastSavedAt(Date.now());
+      } catch (error: any) {
+        setSaveStatus("error");
+        setSaveErrorMessage(
+          error?.message ?? "Could not save collection file.",
+        );
+        throw error;
+      }
+    },
+    [
+      getSceneForCollection,
+      setSaveStatus,
+      setLastSavedAt,
+      setSaveErrorMessage,
+      setActiveSaveLocation,
+      syncPersistedSnapshot,
+      setRecoveredFromAutosave,
+    ],
+  );
+
+  const saveCollectionAs = useCallback(
+    async (collectionId: string) => {
+      setSaveErrorMessage(null);
+      LocalData.flushSave();
+
+      const { elements, appState, files } = await getSceneForCollection(
+        collectionId,
+      );
+      const active = CollectionStore.getActiveCollection();
+
+      await CollectionStore.saveCollectionAs(
+        collectionId,
+        elements,
+        appState,
+        files,
+      );
+
+      const saved = CollectionStore.getCollections().find(
+        (c) => c.id === collectionId,
+      );
+      if (saved?.saveLocationLabel) {
+        setActiveSaveLocation(saved.saveLocationLabel);
+      }
+      if (active?.id === collectionId) {
+        syncPersistedSnapshot();
+      }
+      setSaveStatus("saved");
+      setLastSavedAt(Date.now());
+    },
+    [
+      getSceneForCollection,
+      setSaveStatus,
+      setLastSavedAt,
+      setSaveErrorMessage,
+      setActiveSaveLocation,
+      syncPersistedSnapshot,
+    ],
+  );
+
+  const downloadCollection = useCallback(
+    async (collectionId: string) => {
+      if (!excalidrawAPI) {
+        return;
+      }
+      const { elements, appState, files } = await getSceneForCollection(
+        collectionId,
+      );
+      CollectionStore.downloadCollection(
+        collectionId,
+        elements,
+        appState,
+        files,
+      );
+    },
+    [excalidrawAPI, getSceneForCollection],
+  );
+
+  const saveActiveCollection = useCallback(async () => {
+    const active = CollectionStore.getActiveCollection();
+    if (!active) {
+      return;
+    }
+    await saveCollectionToDisk(active.id);
+  }, [saveCollectionToDisk]);
+
+  const switchCollection = useCallback(
+    async (collectionId: string) => {
+      if (!excalidrawAPI) {
+        return;
+      }
+
+      LocalData.flushSave();
+
+      const active = CollectionStore.getActiveCollection();
+      if (active && active.id !== collectionId) {
+        await CollectionStore.saveCollectionToStorage(
+          active.id,
+          excalidrawAPI.getSceneElementsIncludingDeleted(),
+          excalidrawAPI.getAppState(),
+          excalidrawAPI.getFiles(),
+        );
+      }
+
+      CollectionStore.setActiveCollection(collectionId);
+
+      const collectionScene = await CollectionStore.loadCollectionScene(
+        collectionId,
+        excalidrawAPI.getAppState(),
+        excalidrawAPI.getSceneElementsIncludingDeleted(),
+      );
+
+      if (collectionScene) {
+        excalidrawAPI.updateScene({
+          elements: restoreElements(collectionScene.elements ?? [], null, {
+            repairBindings: true,
+            deleteInvisibleElements: true,
+          }),
+          appState: restoreAppState(
+            collectionScene.appState,
+            excalidrawAPI.getAppState(),
+          ),
+          captureUpdate: CaptureUpdateAction.IMMEDIATELY,
+        });
+        if (collectionScene.files) {
+          excalidrawAPI.addFiles(Object.values(collectionScene.files));
+        }
+      } else {
+        excalidrawAPI.resetScene();
+      }
+
+      const switched = CollectionStore.getActiveCollection();
+      setActiveSaveLocation(switched?.saveLocationLabel ?? null);
+      syncPersistedSnapshot();
+      setRecoveredFromAutosave(false);
+    },
+    [
+      excalidrawAPI,
+      setActiveSaveLocation,
+      syncPersistedSnapshot,
+      setRecoveredFromAutosave,
+    ],
+  );
+
+  const openCollectionById = useCallback(
+    async (collectionId: string) => {
+      await switchCollection(collectionId);
+    },
+    [switchCollection],
+  );
+
+  const afterLocalSave = useCallback(() => {
+    const activeCollection = CollectionStore.getActiveCollection();
+    if (activeCollection?.savedToDisk) {
+      void persistActiveCollection();
+    }
+    updateDirtyState();
+  }, [persistActiveCollection, updateDirtyState]);
+
+  const flushActiveCollectionOnUnload = useCallback(() => {
+    if (
+      !excalidrawAPI ||
+      collabAPI?.isCollaborating() ||
+      !CollectionStore.getActiveCollection()?.savedToDisk
+    ) {
+      return;
+    }
+    void CollectionStore.saveActiveToFile(
+      excalidrawAPI.getSceneElementsIncludingDeleted(),
+      excalidrawAPI.getAppState(),
+      excalidrawAPI.getFiles(),
+    );
+  }, [excalidrawAPI, collabAPI]);
+
+  return {
+    isCollectionDirty,
+    saveCollectionToDisk,
+    saveCollectionAs,
+    downloadCollection,
+    saveActiveCollection,
+    switchCollection,
+    openCollectionById,
+    afterLocalSave,
+    updateDirtyState,
+    flushActiveCollectionOnUnload,
+  };
+};

--- a/excalidraw-app/components/AppMainMenu.tsx
+++ b/excalidraw-app/components/AppMainMenu.tsx
@@ -17,6 +17,7 @@ import { saveDebugState } from "./DebugCanvas";
 
 export const AppMainMenu: React.FC<{
   onCollabDialogOpen: () => any;
+  onCollectionsOpen: () => void;
   isCollaborating: boolean;
   isCollabEnabled: boolean;
   theme: Theme | "system";
@@ -26,6 +27,9 @@ export const AppMainMenu: React.FC<{
   return (
     <MainMenu>
       <MainMenu.DefaultItems.LoadScene />
+      <MainMenu.Item onSelect={props.onCollectionsOpen}>
+        Collections
+      </MainMenu.Item>
       <MainMenu.DefaultItems.SaveToActiveFile />
       <MainMenu.DefaultItems.Export />
       <MainMenu.DefaultItems.SaveAsImage />

--- a/excalidraw-app/components/AppWelcomeScreen.scss
+++ b/excalidraw-app/components/AppWelcomeScreen.scss
@@ -1,0 +1,34 @@
+.welcome-screen-recent {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  width: 100%;
+  margin-top: 0.5rem;
+  padding-top: 0.5rem;
+  border-top: 1px solid var(--default-border-color);
+}
+
+.welcome-screen-recent__label {
+  margin: 0;
+  font-size: 0.75rem;
+  opacity: 0.75;
+  text-align: left;
+}
+
+.welcome-screen-recent__item {
+  display: block;
+  width: 100%;
+  text-align: left;
+  padding: 0.5rem 0.75rem;
+  min-height: 2.75rem;
+  font-size: 0.875rem;
+  background: transparent;
+  border: 1px solid var(--default-border-color);
+  border-radius: 0.375rem;
+  color: var(--text-primary-color);
+  cursor: pointer;
+
+  &:hover {
+    background: var(--color-surface-high);
+  }
+}

--- a/excalidraw-app/components/AppWelcomeScreen.tsx
+++ b/excalidraw-app/components/AppWelcomeScreen.tsx
@@ -2,15 +2,25 @@ import { loginIcon } from "@excalidraw/excalidraw/components/icons";
 import { POINTER_EVENTS } from "@excalidraw/common";
 import { useI18n } from "@excalidraw/excalidraw/i18n";
 import { WelcomeScreen } from "@excalidraw/excalidraw/index";
-import React from "react";
+import React, { useMemo } from "react";
 
 import { isExcalidrawPlusSignedUser } from "../app_constants";
+import { CollectionStore } from "../data/collections/CollectionStore";
+
+import "./AppWelcomeScreen.scss";
 
 export const AppWelcomeScreen: React.FC<{
   onCollabDialogOpen: () => any;
   isCollabEnabled: boolean;
+  onOpenCollection?: (collectionId: string) => void;
 }> = React.memo((props) => {
   const { t } = useI18n();
+
+  const recentCollections = useMemo(
+    () => CollectionStore.getRecentCollections(),
+    [],
+  );
+
   let headingContent;
 
   if (isExcalidrawPlusSignedUser) {
@@ -63,6 +73,21 @@ export const AppWelcomeScreen: React.FC<{
             <WelcomeScreen.Center.MenuItemLiveCollaborationTrigger
               onSelect={() => props.onCollabDialogOpen()}
             />
+          )}
+          {recentCollections.length > 0 && props.onOpenCollection && (
+            <div className="welcome-screen-recent">
+              <p className="welcome-screen-recent__label">Recent collections</p>
+              {recentCollections.map((c) => (
+                <button
+                  key={c.id}
+                  type="button"
+                  className="welcome-screen-recent__item"
+                  onClick={() => props.onOpenCollection?.(c.id)}
+                >
+                  {c.name}
+                </button>
+              ))}
+            </div>
           )}
           {!isExcalidrawPlusSignedUser && (
             <WelcomeScreen.Center.MenuItemLink

--- a/excalidraw-app/components/CollectionsDialog.scss
+++ b/excalidraw-app/components/CollectionsDialog.scss
@@ -1,0 +1,229 @@
+.collections-dialog {
+  .collections-dialog__content {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  .collections-dialog__hint {
+    margin: 0;
+    font-size: 0.875rem;
+    line-height: 1.4;
+    color: var(--text-primary-color);
+    opacity: 0.85;
+  }
+
+  .collections-dialog__hint--warn {
+    color: var(--color-danger);
+    opacity: 1;
+  }
+
+  .collections-dialog__location {
+    margin: 0;
+    font-size: 0.8125rem;
+    word-break: break-all;
+  }
+
+  .collections-dialog__toolbar {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    align-items: center;
+  }
+
+  .collections-dialog__toolbar-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    align-items: center;
+  }
+
+  .collections-dialog__select {
+    padding: 0.5rem 0.75rem;
+    border: 1px solid var(--default-border-color);
+    border-radius: 0.375rem;
+    font-size: 0.875rem;
+    background: var(--island-bg-color);
+    color: var(--text-primary-color);
+    min-height: 2.75rem;
+  }
+
+  .collections-dialog__file-input {
+    display: none;
+  }
+
+  .collections-dialog__os-path {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    font-size: 0.8125rem;
+
+    label {
+      opacity: 0.85;
+    }
+  }
+
+  .collections-dialog__os-path-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    align-items: center;
+  }
+
+  .collections-dialog__create {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    align-items: center;
+  }
+
+  .collections-dialog__input {
+    flex: 1 1 12rem;
+    min-width: 0;
+    padding: 0.5rem 0.75rem;
+    border: 1px solid var(--default-border-color);
+    border-radius: 0.375rem;
+    font-size: 0.875rem;
+    background: var(--island-bg-color);
+    color: var(--text-primary-color);
+    min-height: 2.75rem;
+  }
+
+  .collections-dialog__progress {
+    margin: 0;
+    font-size: 0.8125rem;
+    opacity: 0.85;
+  }
+
+  .collections-dialog__list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    max-height: 20rem;
+    overflow-y: auto;
+    border: 1px solid var(--default-border-color);
+    border-radius: 0.375rem;
+  }
+
+  .collections-dialog__file-list {
+    margin: 0;
+    padding-left: 1.25rem;
+    font-size: 0.8125rem;
+    max-height: 8rem;
+    overflow-y: auto;
+  }
+
+  .collections-dialog__empty {
+    padding: 1rem;
+    text-align: center;
+    opacity: 0.7;
+    font-size: 0.875rem;
+  }
+
+  .collections-dialog__item {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+    padding: 0.5rem 0.75rem;
+    border-bottom: 1px solid var(--default-border-color);
+
+    &:last-child {
+      border-bottom: none;
+    }
+  }
+
+  .collections-dialog__item--active {
+    background: var(--color-surface-high);
+  }
+
+  .collections-dialog__name {
+    flex: 1 1 auto;
+    min-width: 0;
+    text-align: left;
+    background: none;
+    border: none;
+    cursor: pointer;
+    padding: 0.25rem 0;
+    color: var(--text-primary-color);
+    font-size: 0.9375rem;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 0.5rem;
+
+    &:disabled {
+      cursor: default;
+      opacity: 0.6;
+    }
+  }
+
+  .collections-dialog__thumb {
+    width: 3rem;
+    height: 3rem;
+    object-fit: contain;
+    border-radius: 0.25rem;
+    border: 1px solid var(--default-border-color);
+    flex-shrink: 0;
+    background: var(--default-bg-color);
+  }
+
+  .collections-dialog__name-text {
+    display: flex;
+    flex-direction: column;
+    gap: 0.125rem;
+    min-width: 0;
+  }
+
+  .collections-dialog__file {
+    font-size: 0.75rem;
+    opacity: 0.65;
+  }
+
+  .collections-dialog__path {
+    opacity: 0.8;
+  }
+
+  .collections-dialog__unsaved {
+    font-style: italic;
+    opacity: 0.8;
+  }
+
+  .collections-dialog__actions,
+  .collections-dialog__rename {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.35rem;
+    align-items: center;
+
+    button {
+      font-size: 0.8125rem;
+      padding: 0.25rem 0.5rem;
+      min-height: 2.75rem;
+      cursor: pointer;
+      background: var(--island-bg-color);
+      border: 1px solid var(--default-border-color);
+      border-radius: 0.25rem;
+      color: var(--text-primary-color);
+
+      &:disabled {
+        opacity: 0.5;
+        cursor: not-allowed;
+      }
+    }
+  }
+
+  .collections-dialog__error {
+    margin: 0;
+    color: var(--color-danger);
+    font-size: 0.875rem;
+  }
+
+  @media (max-width: 480px) {
+    .collections-dialog__actions {
+      width: 100%;
+      justify-content: flex-start;
+    }
+  }
+}

--- a/excalidraw-app/components/CollectionsDialog.tsx
+++ b/excalidraw-app/components/CollectionsDialog.tsx
@@ -1,0 +1,747 @@
+import { Dialog } from "@excalidraw/excalidraw/components/Dialog";
+import { FilledButton } from "@excalidraw/excalidraw/components/FilledButton";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import type { ExcalidrawImperativeAPI } from "@excalidraw/excalidraw/types";
+
+import { useAtom, useAtomValue } from "../app-jotai";
+import { STORAGE_KEYS } from "../app_constants";
+import { CollectionStore } from "../data/collections/CollectionStore";
+import { exportAllCollectionsToZip } from "../data/collections/exportCollections";
+import { getCollectionThumbnail } from "../data/collections/collectionThumbnails";
+import { activeCollectionDirtyAtom } from "../data/collectionUiAtoms";
+
+import { collectionsDialogOpenAtom } from "./collectionsDialogAtom";
+import { UnsavedChangesDialog } from "./UnsavedChangesDialog";
+
+import "./CollectionsDialog.scss";
+
+import type { Collection } from "../data/collections/types";
+
+export type CollectionsDialogProps = {
+  excalidrawAPI: ExcalidrawImperativeAPI | null;
+  onSwitchCollection: (collectionId: string) => Promise<void>;
+  onSaveCollection: (collectionId: string) => Promise<void>;
+  onSaveCollectionAs: (collectionId: string) => Promise<void>;
+  onDownloadCollection: (collectionId: string) => Promise<void>;
+  isDirty: boolean;
+};
+
+type SortMode = "name-asc" | "name-desc" | "modified";
+
+const readSortMode = (): SortMode => {
+  try {
+    const v = localStorage.getItem(STORAGE_KEYS.LOCAL_STORAGE_COLLECTIONS_SORT);
+    if (v === "name-asc" || v === "name-desc" || v === "modified") {
+      return v;
+    }
+  } catch {
+    /* ignore */
+  }
+  return "modified";
+};
+
+export const CollectionsDialog = ({
+  excalidrawAPI,
+  onSwitchCollection,
+  onSaveCollection,
+  onSaveCollectionAs,
+  onDownloadCollection,
+  isDirty,
+}: CollectionsDialogProps) => {
+  const [isOpen, setIsOpen] = useAtom(collectionsDialogOpenAtom);
+  const activeDirty = useAtomValue(activeCollectionDirtyAtom);
+  const dirty = isDirty || activeDirty;
+
+  const [collections, setCollections] = useState<Collection[]>([]);
+  const [activeId, setActiveId] = useState<string | null>(null);
+  const [newName, setNewName] = useState("");
+  const [renameId, setRenameId] = useState<string | null>(null);
+  const [renameValue, setRenameValue] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [hasSessionFolder, setHasSessionFolder] = useState(false);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [sortMode, setSortMode] = useState<SortMode>(readSortMode);
+  const [osPath, setOsPath] = useState(CollectionStore.getOsFolderPath());
+  const [folderInfoOpen, setFolderInfoOpen] = useState(false);
+  const [folderInfo, setFolderInfo] = useState<{
+    folderName: string | null;
+    fileNames: string[];
+    osPath: string;
+  } | null>(null);
+  const [exportProgress, setExportProgress] = useState<string | null>(null);
+  const [thumbnails, setThumbnails] = useState<Record<string, string>>({});
+  const [pendingSwitchId, setPendingSwitchId] = useState<string | null>(null);
+  const [unsavedOpen, setUnsavedOpen] = useState(false);
+
+  const importInputRef = useRef<HTMLInputElement>(null);
+  const fsSupported = CollectionStore.isFileSystemSupported();
+
+  const refresh = useCallback(async () => {
+    const index = CollectionStore.getIndex();
+    setCollections([...index.collections]);
+    setActiveId(CollectionStore.getActiveCollection()?.id ?? null);
+    setHasSessionFolder(
+      CollectionStore.hasSessionDirectory() || index.hasDirectory,
+    );
+    setOsPath(CollectionStore.getOsFolderPath());
+
+    const urls: Record<string, string> = {};
+    await Promise.all(
+      index.collections.map(async (c) => {
+        const blob = await getCollectionThumbnail(c.id);
+        if (blob) {
+          urls[c.id] = URL.createObjectURL(blob);
+        }
+      }),
+    );
+    setThumbnails((prev) => {
+      Object.values(prev).forEach((u) => URL.revokeObjectURL(u));
+      return urls;
+    });
+  }, []);
+
+  useEffect(() => {
+    if (isOpen) {
+      void refresh();
+      setError(null);
+      setSearchQuery("");
+    }
+    return () => {
+      setThumbnails((prev) => {
+        Object.values(prev).forEach((u) => URL.revokeObjectURL(u));
+        return {};
+      });
+    };
+  }, [isOpen, refresh]);
+
+  const handleClose = () => setIsOpen(false);
+
+  const filteredCollections = useMemo(() => {
+    const q = searchQuery.trim().toLowerCase();
+    let list = [...collections];
+    if (q) {
+      list = list.filter(
+        (c) =>
+          c.name.toLowerCase().includes(q) ||
+          c.fileName.toLowerCase().includes(q),
+      );
+    }
+    list.sort((a, b) => {
+      if (sortMode === "name-asc") {
+        return a.name.localeCompare(b.name);
+      }
+      if (sortMode === "name-desc") {
+        return b.name.localeCompare(a.name);
+      }
+      return (b.lastSavedAt ?? b.updatedAt) - (a.lastSavedAt ?? a.updatedAt);
+    });
+    return list;
+  }, [collections, searchQuery, sortMode]);
+
+  const handleSortChange = (mode: SortMode) => {
+    setSortMode(mode);
+    localStorage.setItem(STORAGE_KEYS.LOCAL_STORAGE_COLLECTIONS_SORT, mode);
+  };
+
+  const handlePickFolder = async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      await CollectionStore.pickDirectory();
+      await CollectionStore.migrateLegacySceneToDefaultCollection();
+      await refresh();
+    } catch (e: any) {
+      setError(e?.message ?? "Could not open folder picker.");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleCreate = async () => {
+    const name = newName.trim();
+    if (!name) {
+      return;
+    }
+    setBusy(true);
+    setError(null);
+    try {
+      const created = await CollectionStore.createCollection(name);
+      setNewName("");
+      CollectionStore.setActiveCollection(created.id);
+      await onSwitchCollection(created.id);
+      await refresh();
+    } catch (e: any) {
+      setError(e?.message ?? "Could not create collection.");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleSave = async (id: string) => {
+    setBusy(true);
+    setError(null);
+    try {
+      await onSaveCollection(id);
+      await refresh();
+    } catch (e: any) {
+      setError(e?.message ?? "Could not save collection.");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const performSwitch = async (id: string) => {
+    setBusy(true);
+    setError(null);
+    try {
+      await onSwitchCollection(id);
+      await refresh();
+    } catch (e: any) {
+      setError(e?.message ?? "Could not switch collection.");
+    } finally {
+      setBusy(false);
+      setPendingSwitchId(null);
+      setUnsavedOpen(false);
+    }
+  };
+
+  const handleSwitch = async (id: string) => {
+    if (id === activeId) {
+      return;
+    }
+    if (dirty && activeId) {
+      setPendingSwitchId(id);
+      setUnsavedOpen(true);
+      return;
+    }
+    await performSwitch(id);
+  };
+
+  const handleUnsavedSaveAndContinue = async () => {
+    if (!activeId || !pendingSwitchId) {
+      return;
+    }
+    setBusy(true);
+    try {
+      await onSaveCollection(activeId);
+      await performSwitch(pendingSwitchId);
+    } catch (e: any) {
+      setError(e?.message ?? "Could not save before switching.");
+      setBusy(false);
+    }
+  };
+
+  const handleUnsavedDiscard = async () => {
+    if (!pendingSwitchId) {
+      return;
+    }
+    await performSwitch(pendingSwitchId);
+  };
+
+  const handleRename = async (id: string) => {
+    const name = renameValue.trim();
+    if (!name) {
+      return;
+    }
+    setBusy(true);
+    setError(null);
+    try {
+      await CollectionStore.renameCollection(id, name);
+      setRenameId(null);
+      setRenameValue("");
+      await refresh();
+    } catch (e: any) {
+      setError(e?.message ?? "Could not rename collection.");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleDelete = async (id: string) => {
+    if (
+      !window.confirm(
+        "Delete this collection? The file on disk will be removed if possible.",
+      )
+    ) {
+      return;
+    }
+    setBusy(true);
+    setError(null);
+    try {
+      const wasActive = activeId === id;
+      await CollectionStore.deleteCollection(id);
+      await refresh();
+      if (wasActive && excalidrawAPI) {
+        const next = CollectionStore.getActiveCollection();
+        if (next) {
+          await onSwitchCollection(next.id);
+        } else {
+          excalidrawAPI.resetScene();
+        }
+      }
+    } catch (e: any) {
+      setError(e?.message ?? "Could not delete collection.");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleDuplicate = async (id: string) => {
+    setBusy(true);
+    setError(null);
+    try {
+      const created = await CollectionStore.duplicateCollection(id);
+      CollectionStore.setActiveCollection(created.id);
+      await onSwitchCollection(created.id);
+      await refresh();
+    } catch (e: any) {
+      setError(e?.message ?? "Could not duplicate collection.");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleImport = async (file: File) => {
+    setBusy(true);
+    setError(null);
+    try {
+      const created = await CollectionStore.importFromFile(file);
+      await onSwitchCollection(created.id);
+      await refresh();
+    } catch (e: any) {
+      setError(e?.message ?? "Could not import file.");
+    } finally {
+      setBusy(false);
+      if (importInputRef.current) {
+        importInputRef.current.value = "";
+      }
+    }
+  };
+
+  const handleExportAll = async () => {
+    if (!excalidrawAPI) {
+      return;
+    }
+    setBusy(true);
+    setError(null);
+    setExportProgress(null);
+    try {
+      const { failed } = await exportAllCollectionsToZip(
+        excalidrawAPI.getAppState(),
+        (current, total, name) => {
+          setExportProgress(`Exporting ${current}/${total}: ${name}`);
+        },
+      );
+      if (failed.length > 0) {
+        setError(`Some collections failed to export: ${failed.join(", ")}`);
+      }
+    } catch (e: any) {
+      setError(e?.message ?? "Could not export collections.");
+    } finally {
+      setBusy(false);
+      setExportProgress(null);
+    }
+  };
+
+  const handleOpenFolderInfo = async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      if (fsSupported) {
+        try {
+          await CollectionStore.ensureSessionDirectory();
+        } catch {
+          /* may not have picked yet */
+        }
+      }
+      setFolderInfo(CollectionStore.getFolderInfo());
+      setFolderInfoOpen(true);
+    } catch (e: any) {
+      setError(e?.message ?? "Could not read folder info.");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleSaveOsPath = () => {
+    CollectionStore.setOsFolderPath(osPath);
+    setError(null);
+  };
+
+  const activeCollection = collections.find((c) => c.id === activeId);
+
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <>
+      <Dialog
+        onCloseRequest={handleClose}
+        title="Collections"
+        size="regular"
+        className="collections-dialog"
+      >
+        <div className="collections-dialog__content">
+          {!fsSupported && (
+            <p className="collections-dialog__hint collections-dialog__hint--warn">
+              This browser cannot write files directly. Collections are stored
+              in browser storage. Use <strong>Download</strong> or{" "}
+              <strong>Export all</strong> to back up your drawings.
+            </p>
+          )}
+          {fsSupported && (
+            <p className="collections-dialog__hint">
+              {hasSessionFolder
+                ? "New collections in this session will save to the same folder when you click Save."
+                : "Click Save on a collection to choose where it is stored on disk."}
+            </p>
+          )}
+
+          {activeCollection?.saveLocationLabel && (
+            <p className="collections-dialog__location">
+              Active save location:{" "}
+              <code>{activeCollection.saveLocationLabel}</code>
+            </p>
+          )}
+
+          <div className="collections-dialog__toolbar">
+            <input
+              type="search"
+              className="collections-dialog__input"
+              placeholder="Search collections…"
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              disabled={busy}
+              aria-label="Search collections"
+            />
+            <select
+              className="collections-dialog__select"
+              value={sortMode}
+              onChange={(e) => handleSortChange(e.target.value as SortMode)}
+              disabled={busy}
+              aria-label="Sort collections"
+            >
+              <option value="modified">Last modified</option>
+              <option value="name-asc">Name A–Z</option>
+              <option value="name-desc">Name Z–A</option>
+            </select>
+          </div>
+
+          <div className="collections-dialog__toolbar-actions">
+            {fsSupported && (
+              <FilledButton
+                label={hasSessionFolder ? "Change folder" : "Choose folder"}
+                onClick={handlePickFolder}
+                disabled={busy}
+              />
+            )}
+            <FilledButton
+              label="Open save folder"
+              onClick={handleOpenFolderInfo}
+              disabled={busy}
+            />
+            <FilledButton
+              label="Import file"
+              onClick={() => importInputRef.current?.click()}
+              disabled={busy}
+            />
+            <input
+              ref={importInputRef}
+              type="file"
+              accept=".excalidraw,.json,application/json"
+              className="collections-dialog__file-input"
+              onChange={(e) => {
+                const file = e.target.files?.[0];
+                if (file) {
+                  void handleImport(file);
+                }
+              }}
+            />
+            <FilledButton
+              label="Export all"
+              onClick={handleExportAll}
+              disabled={busy || collections.length === 0}
+            />
+          </div>
+
+          <div className="collections-dialog__os-path">
+            <label htmlFor="collections-os-path">
+              Collections folder path (optional, for Explorer / .bat)
+            </label>
+            <div className="collections-dialog__os-path-row">
+              <input
+                id="collections-os-path"
+                type="text"
+                className="collections-dialog__input"
+                placeholder="C:\Users\you\Documents\my-drawings"
+                value={osPath}
+                onChange={(e) => setOsPath(e.target.value)}
+                disabled={busy}
+              />
+              <button type="button" onClick={handleSaveOsPath} disabled={busy}>
+                Save path
+              </button>
+            </div>
+          </div>
+
+          <div className="collections-dialog__create">
+            <input
+              type="text"
+              className="collections-dialog__input"
+              placeholder="New collection name"
+              value={newName}
+              onChange={(e) => setNewName(e.target.value)}
+              onKeyDown={(e) => e.key === "Enter" && handleCreate()}
+              disabled={busy}
+            />
+            <FilledButton
+              label="Create"
+              onClick={handleCreate}
+              disabled={busy || !newName.trim()}
+            />
+          </div>
+
+          {exportProgress && (
+            <p className="collections-dialog__progress">{exportProgress}</p>
+          )}
+
+          <ul className="collections-dialog__list">
+            {filteredCollections.length === 0 && (
+              <li className="collections-dialog__empty">
+                {collections.length === 0
+                  ? "No collections yet."
+                  : "No collections match your search."}
+              </li>
+            )}
+            {filteredCollections.map((c) => (
+              <li
+                key={c.id}
+                className={
+                  c.id === activeId
+                    ? "collections-dialog__item collections-dialog__item--active"
+                    : "collections-dialog__item"
+                }
+              >
+                {renameId === c.id ? (
+                  <div className="collections-dialog__rename">
+                    <input
+                      type="text"
+                      className="collections-dialog__input"
+                      value={renameValue}
+                      onChange={(e) => setRenameValue(e.target.value)}
+                      onKeyDown={(e) => e.key === "Enter" && handleRename(c.id)}
+                      disabled={busy}
+                    />
+                    <button
+                      type="button"
+                      onClick={() => handleRename(c.id)}
+                      disabled={busy}
+                    >
+                      Apply
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setRenameId(null);
+                        setRenameValue("");
+                      }}
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                ) : (
+                  <>
+                    <button
+                      type="button"
+                      className="collections-dialog__name"
+                      onClick={() => handleSwitch(c.id)}
+                      disabled={busy}
+                    >
+                      {thumbnails[c.id] && (
+                        <img
+                          src={thumbnails[c.id]}
+                          alt=""
+                          className="collections-dialog__thumb"
+                        />
+                      )}
+                      <span className="collections-dialog__name-text">
+                        {c.name}
+                        <span className="collections-dialog__file">
+                          {c.fileName}
+                          {c.saveLocationLabel && (
+                            <span className="collections-dialog__path">
+                              {" "}
+                              · {c.saveLocationLabel}
+                            </span>
+                          )}
+                          {fsSupported && !c.savedToDisk && (
+                            <span className="collections-dialog__unsaved">
+                              {" "}
+                              · not saved to folder
+                            </span>
+                          )}
+                        </span>
+                      </span>
+                    </button>
+                    <div className="collections-dialog__actions">
+                      {fsSupported && (
+                        <button
+                          type="button"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            void handleSave(c.id);
+                          }}
+                          disabled={busy}
+                        >
+                          Save
+                        </button>
+                      )}
+                      {fsSupported && (
+                        <button
+                          type="button"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            setBusy(true);
+                            setError(null);
+                            onSaveCollectionAs(c.id)
+                              .then(() => refresh())
+                              .catch((err: any) =>
+                                setError(err?.message ?? "Save As failed."),
+                              )
+                              .finally(() => setBusy(false));
+                          }}
+                          disabled={busy}
+                        >
+                          Save As
+                        </button>
+                      )}
+                      <button
+                        type="button"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          void onDownloadCollection(c.id);
+                        }}
+                        disabled={busy}
+                      >
+                        Download
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => handleDuplicate(c.id)}
+                        disabled={busy}
+                      >
+                        Duplicate
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => {
+                          setRenameId(c.id);
+                          setRenameValue(c.name);
+                        }}
+                        disabled={busy}
+                      >
+                        Rename
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => handleDelete(c.id)}
+                        disabled={busy}
+                      >
+                        Delete
+                      </button>
+                    </div>
+                  </>
+                )}
+              </li>
+            ))}
+          </ul>
+
+          {error && <p className="collections-dialog__error">{error}</p>}
+        </div>
+      </Dialog>
+
+      {folderInfoOpen && folderInfo && (
+        <Dialog
+          onCloseRequest={() => setFolderInfoOpen(false)}
+          title="Save folder"
+          size="small"
+          className="collections-dialog"
+        >
+          <div className="collections-dialog__content">
+            {folderInfo.folderName ? (
+              <p>
+                Session folder: <strong>{folderInfo.folderName}</strong>
+              </p>
+            ) : (
+              <p>No session folder selected yet. Save a collection first.</p>
+            )}
+            {folderInfo.fileNames.length > 0 && (
+              <>
+                <p>Files in this session:</p>
+                <ul className="collections-dialog__file-list">
+                  {folderInfo.fileNames.map((f) => (
+                    <li key={f}>
+                      <code>{f}</code>
+                    </li>
+                  ))}
+                </ul>
+              </>
+            )}
+            {folderInfo.osPath && (
+              <p>
+                Configured OS path: <code>{folderInfo.osPath}</code>
+              </p>
+            )}
+            <p className="collections-dialog__hint">
+              Browsers cannot reveal the full folder path automatically. Set the
+              optional path above and use{" "}
+              <code>open-collections-folder.bat</code> in the project root to
+              open it in Explorer.
+            </p>
+            <div className="collections-dialog__toolbar-actions">
+              {folderInfo.folderName && (
+                <button
+                  type="button"
+                  onClick={() => {
+                    void navigator.clipboard?.writeText(folderInfo.folderName!);
+                  }}
+                >
+                  Copy folder name
+                </button>
+              )}
+              {folderInfo.osPath && (
+                <button
+                  type="button"
+                  onClick={() => {
+                    void navigator.clipboard?.writeText(folderInfo.osPath);
+                  }}
+                >
+                  Copy OS path
+                </button>
+              )}
+              <FilledButton
+                label="Close"
+                onClick={() => setFolderInfoOpen(false)}
+              />
+            </div>
+          </div>
+        </Dialog>
+      )}
+
+      <UnsavedChangesDialog
+        isOpen={unsavedOpen}
+        collectionName={activeCollection?.name ?? "Collection"}
+        onSaveAndContinue={handleUnsavedSaveAndContinue}
+        onDiscard={handleUnsavedDiscard}
+        onCancel={() => {
+          setUnsavedOpen(false);
+          setPendingSwitchId(null);
+        }}
+        busy={busy}
+      />
+    </>
+  );
+};

--- a/excalidraw-app/components/SaveStatusIndicator.scss
+++ b/excalidraw-app/components/SaveStatusIndicator.scss
@@ -1,0 +1,61 @@
+.excalidraw-app {
+  .save-status-indicator {
+    position: fixed;
+    bottom: 1rem;
+    left: 1rem;
+    z-index: 4;
+    padding: 0.35rem 0.75rem;
+    border-radius: 0.375rem;
+    font-size: 0.8125rem;
+    line-height: 1.25;
+    pointer-events: none;
+    background: var(--island-bg-color);
+    border: 1px solid var(--default-border-color);
+    color: var(--text-primary-color);
+    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.08);
+    display: flex;
+    flex-direction: column;
+    gap: 0.125rem;
+    max-width: min(20rem, calc(100vw - 2rem));
+  }
+
+  .save-status-indicator--clickable,
+  .save-status-indicator--saved,
+  .save-status-indicator--dirty,
+  .save-status-indicator--error {
+    pointer-events: auto;
+    cursor: pointer;
+  }
+
+  .save-status-indicator--saving {
+    opacity: 0.85;
+  }
+
+  .save-status-indicator--saved {
+    opacity: 0.9;
+  }
+
+  .save-status-indicator--dirty {
+    border-color: var(--color-warning);
+  }
+
+  .save-status-indicator--error {
+    color: var(--color-danger);
+  }
+
+  .save-status-indicator__path {
+    font-size: 0.6875rem;
+    opacity: 0.7;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  @media (max-width: 480px) {
+    .save-status-indicator {
+      bottom: 4.5rem;
+      left: 0.5rem;
+      max-width: calc(100vw - 1rem);
+    }
+  }
+}

--- a/excalidraw-app/components/SaveStatusIndicator.tsx
+++ b/excalidraw-app/components/SaveStatusIndicator.tsx
@@ -1,0 +1,138 @@
+import React, { useEffect, useState } from "react";
+
+import { useAtomValue } from "../app-jotai";
+import {
+  activeCollectionDirtyAtom,
+  activeSaveLocationAtom,
+} from "../data/collectionUiAtoms";
+import {
+  lastSavedAtAtom,
+  saveErrorMessageAtom,
+  saveStatusAtom,
+} from "../data/saveStatusAtoms";
+import { CollectionStore } from "../data/collections/CollectionStore";
+
+import "./SaveStatusIndicator.scss";
+
+const formatRelativeTime = (timestamp: number): string => {
+  const seconds = Math.floor((Date.now() - timestamp) / 1000);
+  if (seconds < 10) {
+    return "just now";
+  }
+  if (seconds < 60) {
+    return `${seconds}s ago`;
+  }
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) {
+    return `${minutes}m ago`;
+  }
+  return new Date(timestamp).toLocaleTimeString();
+};
+
+export type SaveStatusIndicatorProps = {
+  onSaveActive?: () => void;
+};
+
+export const SaveStatusIndicator = ({
+  onSaveActive,
+}: SaveStatusIndicatorProps) => {
+  const status = useAtomValue(saveStatusAtom);
+  const lastSavedAt = useAtomValue(lastSavedAtAtom);
+  const errorMessage = useAtomValue(saveErrorMessageAtom);
+  const isDirty = useAtomValue(activeCollectionDirtyAtom);
+  const saveLocation = useAtomValue(activeSaveLocationAtom);
+  const fsSupported = CollectionStore.isFileSystemSupported();
+  const [, tick] = useState(0);
+
+  useEffect(() => {
+    if (status !== "saved" || !lastSavedAt) {
+      return;
+    }
+    const id = window.setInterval(() => tick((n) => n + 1), 15000);
+    return () => window.clearInterval(id);
+  }, [status, lastSavedAt]);
+
+  const canClickSave =
+    !!onSaveActive &&
+    (status === "saved" || status === "error" || isDirty) &&
+    status !== "saving";
+
+  if (status === "idle" && !isDirty) {
+    return null;
+  }
+
+  let label = "";
+  let className = "save-status-indicator";
+
+  switch (status) {
+    case "saving":
+      label = "Saving…";
+      className += " save-status-indicator--saving";
+      break;
+    case "saved":
+      if (isDirty) {
+        label = "Unsaved changes";
+        className += " save-status-indicator--dirty";
+      } else {
+        label = lastSavedAt
+          ? `Saved · ${formatRelativeTime(lastSavedAt)}`
+          : "Saved";
+        className += " save-status-indicator--saved";
+      }
+      break;
+    case "error":
+      label = "Save failed";
+      className += " save-status-indicator--error";
+      break;
+    default:
+      if (isDirty) {
+        label = "Unsaved changes";
+        className += " save-status-indicator--dirty";
+      }
+      break;
+  }
+
+  const locationHint = saveLocation
+    ? fsSupported
+      ? saveLocation
+      : `Browser · ${saveLocation}`
+    : undefined;
+
+  const title = [
+    errorMessage,
+    locationHint,
+    canClickSave ? "Click to save" : null,
+  ]
+    .filter(Boolean)
+    .join("\n");
+
+  const handleClick = () => {
+    if (canClickSave) {
+      onSaveActive?.();
+    }
+  };
+
+  const handleKeyDown = (event: React.KeyboardEvent) => {
+    if (canClickSave && (event.key === "Enter" || event.key === " ")) {
+      event.preventDefault();
+      onSaveActive?.();
+    }
+  };
+
+  return (
+    <span
+      className={className}
+      title={title || undefined}
+      aria-live="polite"
+      role={canClickSave ? "button" : undefined}
+      tabIndex={canClickSave ? 0 : undefined}
+      onClick={canClickSave ? handleClick : undefined}
+      onKeyDown={canClickSave ? handleKeyDown : undefined}
+    >
+      {label}
+      {locationHint && !isDirty && status === "saved" && (
+        <span className="save-status-indicator__path">{locationHint}</span>
+      )}
+    </span>
+  );
+};

--- a/excalidraw-app/components/UnsavedChangesDialog.scss
+++ b/excalidraw-app/components/UnsavedChangesDialog.scss
@@ -1,0 +1,36 @@
+.unsaved-changes-dialog {
+  .unsaved-changes-dialog__content {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+
+    p {
+      margin: 0;
+      font-size: 0.875rem;
+      line-height: 1.4;
+    }
+  }
+
+  .unsaved-changes-dialog__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    align-items: center;
+  }
+
+  .unsaved-changes-dialog__secondary {
+    font-size: 0.8125rem;
+    padding: 0.35rem 0.75rem;
+    min-height: 2.75rem;
+    cursor: pointer;
+    background: var(--island-bg-color);
+    border: 1px solid var(--default-border-color);
+    border-radius: 0.25rem;
+    color: var(--text-primary-color);
+
+    &:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+  }
+}

--- a/excalidraw-app/components/UnsavedChangesDialog.tsx
+++ b/excalidraw-app/components/UnsavedChangesDialog.tsx
@@ -1,0 +1,65 @@
+import { Dialog } from "@excalidraw/excalidraw/components/Dialog";
+import { FilledButton } from "@excalidraw/excalidraw/components/FilledButton";
+
+import "./UnsavedChangesDialog.scss";
+
+export type UnsavedChangesDialogProps = {
+  isOpen: boolean;
+  collectionName: string;
+  onSaveAndContinue: () => void;
+  onDiscard: () => void;
+  onCancel: () => void;
+  busy?: boolean;
+};
+
+export const UnsavedChangesDialog = ({
+  isOpen,
+  collectionName,
+  onSaveAndContinue,
+  onDiscard,
+  onCancel,
+  busy = false,
+}: UnsavedChangesDialogProps) => {
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <Dialog
+      onCloseRequest={onCancel}
+      title="Unsaved changes"
+      size="small"
+      className="unsaved-changes-dialog"
+    >
+      <div className="unsaved-changes-dialog__content">
+        <p>
+          <strong>{collectionName}</strong> has unsaved changes. What would you
+          like to do?
+        </p>
+        <div className="unsaved-changes-dialog__actions">
+          <FilledButton
+            label="Save & continue"
+            onClick={onSaveAndContinue}
+            disabled={busy}
+          />
+          <button
+            type="button"
+            className="unsaved-changes-dialog__secondary"
+            onClick={onDiscard}
+            disabled={busy}
+          >
+            Discard
+          </button>
+          <button
+            type="button"
+            className="unsaved-changes-dialog__secondary"
+            onClick={onCancel}
+            disabled={busy}
+          >
+            Cancel
+          </button>
+        </div>
+      </div>
+    </Dialog>
+  );
+};

--- a/excalidraw-app/components/collectionsDialogAtom.ts
+++ b/excalidraw-app/components/collectionsDialogAtom.ts
@@ -1,0 +1,3 @@
+import { atom } from "../app-jotai";
+
+export const collectionsDialogOpenAtom = atom(false);

--- a/excalidraw-app/data/LocalData.ts
+++ b/excalidraw-app/data/LocalData.ts
@@ -115,6 +115,9 @@ const isQuotaExceededError = (error: any) => {
 type SavingLockTypes = "collaboration";
 
 export class LocalData {
+  static onSaveStart: (() => void) | null = null;
+  static onSaveComplete: (() => void) | null = null;
+
   private static _save = debounce(
     async (
       elements: readonly ExcalidrawElement[],
@@ -129,6 +132,7 @@ export class LocalData {
         files,
       });
       onFilesSaved();
+      LocalData.onSaveComplete?.();
     },
     SAVE_TO_LOCAL_STORAGE_TIMEOUT,
   );
@@ -142,6 +146,7 @@ export class LocalData {
   ) => {
     // we need to make the `isSavePaused` check synchronously (undebounced)
     if (!this.isSavePaused()) {
+      LocalData.onSaveStart?.();
       this._save(elements, appState, files, onFilesSaved);
     }
   };

--- a/excalidraw-app/data/collectionUiAtoms.ts
+++ b/excalidraw-app/data/collectionUiAtoms.ts
@@ -1,0 +1,5 @@
+import { atom } from "../app-jotai";
+
+export const activeCollectionDirtyAtom = atom(false);
+export const activeSaveLocationAtom = atom<string | null>(null);
+export const recoveredFromAutosaveAtom = atom(false);

--- a/excalidraw-app/data/collections/CollectionStore.ts
+++ b/excalidraw-app/data/collections/CollectionStore.ts
@@ -1,0 +1,870 @@
+import { getDefaultAppState } from "@excalidraw/excalidraw/appState";
+
+import { createStore, del, get, set } from "idb-keyval";
+
+import { nanoid } from "nanoid";
+
+import type { ExcalidrawElement } from "@excalidraw/element/types";
+import type { ImportedDataState } from "@excalidraw/excalidraw/data/types";
+import type { AppState, BinaryFiles } from "@excalidraw/excalidraw/types";
+
+import { STORAGE_KEYS } from "../../app_constants";
+import { importFromLocalStorage } from "../localStorage";
+
+import {
+  downloadSceneAsFile,
+  getAutosaveFileName,
+  getOrCreateFileHandle,
+  isCollectionsFileSystemSupported,
+  readSceneFromFileHandle,
+  requestDirectoryHandle,
+  requestSaveFileHandle,
+  sanitizeCollectionFileName,
+  serializeScene,
+  tryReadSceneFromDirectoryFile,
+  verifyHandlePermission,
+  writeAutosaveBackup,
+  writeSceneToFileHandle,
+} from "./collectionFiles";
+import { saveCollectionThumbnail } from "./collectionThumbnails";
+
+import type {
+  Collection,
+  CollectionsIndex,
+  CollectionSceneData,
+} from "./types";
+
+const IDB_KEYS = {
+  DIRECTORY_HANDLE: "directory-handle",
+  fileHandle: (collectionId: string) => `file-handle-${collectionId}`,
+  sceneFallback: (collectionId: string) => `scene-fallback-${collectionId}`,
+} as const;
+
+const collectionsStore = createStore(
+  `${STORAGE_KEYS.IDB_COLLECTIONS}-db`,
+  `${STORAGE_KEYS.IDB_COLLECTIONS}-store`,
+);
+
+const MAX_RECENT = 5;
+
+/** Cleared when the page is reloaded (browser session scope). */
+let sessionDirectoryHandle: FileSystemDirectoryHandle | null = null;
+
+const readIndex = (): CollectionsIndex => {
+  try {
+    const raw = localStorage.getItem(
+      STORAGE_KEYS.LOCAL_STORAGE_COLLECTIONS_INDEX,
+    );
+    if (raw) {
+      const parsed = JSON.parse(raw) as CollectionsIndex;
+      if (parsed?.collections && Array.isArray(parsed.collections)) {
+        return parsed;
+      }
+    }
+  } catch (error) {
+    console.error(error);
+  }
+  return { collections: [], hasDirectory: false, recentCollectionIds: [] };
+};
+
+const writeIndex = (index: CollectionsIndex) => {
+  localStorage.setItem(
+    STORAGE_KEYS.LOCAL_STORAGE_COLLECTIONS_INDEX,
+    JSON.stringify(index),
+  );
+};
+
+const getActiveCollectionId = (): string | null => {
+  try {
+    return localStorage.getItem(
+      STORAGE_KEYS.LOCAL_STORAGE_ACTIVE_COLLECTION_ID,
+    );
+  } catch {
+    return null;
+  }
+};
+
+const setActiveCollectionId = (id: string) => {
+  localStorage.setItem(STORAGE_KEYS.LOCAL_STORAGE_ACTIVE_COLLECTION_ID, id);
+};
+
+const updateCollectionInIndex = (
+  id: string,
+  patch: Partial<
+    Pick<
+      Collection,
+      | "name"
+      | "fileName"
+      | "updatedAt"
+      | "savedToDisk"
+      | "lastSavedAt"
+      | "saveLocationLabel"
+      | "customFileHandle"
+      | "thumbnailUpdatedAt"
+    >
+  >,
+) => {
+  const index = readIndex();
+  const collection = index.collections.find((c) => c.id === id);
+  if (collection) {
+    Object.assign(collection, patch, { updatedAt: Date.now() });
+    writeIndex(index);
+  }
+};
+
+const buildSaveLocationLabel = (
+  directoryHandle: FileSystemDirectoryHandle | null,
+  fileName: string,
+  customFileHandle?: boolean,
+): string => {
+  if (customFileHandle) {
+    return fileName;
+  }
+  if (directoryHandle) {
+    return `${directoryHandle.name}/${fileName}`;
+  }
+  return fileName;
+};
+
+const touchRecentCollection = (id: string) => {
+  const index = readIndex();
+  const recent = index.recentCollectionIds ?? [];
+  const next = [id, ...recent.filter((rid) => rid !== id)].slice(0, MAX_RECENT);
+  index.recentCollectionIds = next;
+  writeIndex(index);
+};
+
+const markCollectionSavedToDisk = (id: string, saveLocationLabel: string) => {
+  updateCollectionInIndex(id, {
+    savedToDisk: true,
+    lastSavedAt: Date.now(),
+    saveLocationLabel,
+  });
+  touchRecentCollection(id);
+};
+
+export class CollectionStore {
+  static isFileSystemSupported = isCollectionsFileSystemSupported;
+
+  static getSessionDirectory(): FileSystemDirectoryHandle | null {
+    return sessionDirectoryHandle;
+  }
+
+  static hasSessionDirectory(): boolean {
+    return sessionDirectoryHandle != null;
+  }
+
+  static getSessionDirectoryName(): string | null {
+    return sessionDirectoryHandle?.name ?? null;
+  }
+
+  static async getDirectoryHandle(): Promise<FileSystemDirectoryHandle | null> {
+    if (sessionDirectoryHandle) {
+      return sessionDirectoryHandle;
+    }
+    const handle = await get<FileSystemDirectoryHandle>(
+      IDB_KEYS.DIRECTORY_HANDLE,
+      collectionsStore,
+    );
+    return handle ?? null;
+  }
+
+  private static async saveDirectoryHandle(
+    handle: FileSystemDirectoryHandle,
+  ): Promise<void> {
+    sessionDirectoryHandle = handle;
+    await set(IDB_KEYS.DIRECTORY_HANDLE, handle, collectionsStore);
+    const index = readIndex();
+    index.hasDirectory = true;
+    writeIndex(index);
+  }
+
+  private static async tryUseDirectoryHandle(
+    handle: FileSystemDirectoryHandle,
+  ): Promise<FileSystemDirectoryHandle | null> {
+    const hasPermission = await verifyHandlePermission(handle, "readwrite");
+    if (hasPermission) {
+      sessionDirectoryHandle = handle;
+      return handle;
+    }
+    return null;
+  }
+
+  /** Prompts for a folder only when none is set for this session or in IDB. */
+  static async ensureSessionDirectory(): Promise<FileSystemDirectoryHandle> {
+    if (sessionDirectoryHandle) {
+      const usable = await this.tryUseDirectoryHandle(sessionDirectoryHandle);
+      if (usable) {
+        return usable;
+      }
+      sessionDirectoryHandle = null;
+    }
+
+    const persisted = await get<FileSystemDirectoryHandle>(
+      IDB_KEYS.DIRECTORY_HANDLE,
+      collectionsStore,
+    );
+    if (persisted) {
+      const usable = await this.tryUseDirectoryHandle(persisted);
+      if (usable) {
+        return usable;
+      }
+    }
+
+    if (!this.isFileSystemSupported()) {
+      throw new Error("Folder picker is not supported in this browser.");
+    }
+
+    const handle = await requestDirectoryHandle();
+    await this.saveDirectoryHandle(handle);
+    return handle;
+  }
+
+  static getIndex(): CollectionsIndex {
+    return readIndex();
+  }
+
+  static getCollections(): Collection[] {
+    return readIndex().collections;
+  }
+
+  static getRecentCollections(): Collection[] {
+    const index = readIndex();
+    const ids = index.recentCollectionIds ?? [];
+    const byId = new Map(index.collections.map((c) => [c.id, c]));
+    const recent: Collection[] = [];
+    for (const id of ids) {
+      const c = byId.get(id);
+      if (c) {
+        recent.push(c);
+      }
+    }
+    if (recent.length < MAX_RECENT) {
+      const sorted = [...index.collections].sort(
+        (a, b) =>
+          (b.lastSavedAt ?? b.updatedAt) - (a.lastSavedAt ?? a.updatedAt),
+      );
+      for (const c of sorted) {
+        if (!recent.some((r) => r.id === c.id)) {
+          recent.push(c);
+        }
+        if (recent.length >= MAX_RECENT) {
+          break;
+        }
+      }
+    }
+    return recent.slice(0, MAX_RECENT);
+  }
+
+  static getActiveCollection(): Collection | null {
+    const id = getActiveCollectionId();
+    if (!id) {
+      return null;
+    }
+    return readIndex().collections.find((c) => c.id === id) ?? null;
+  }
+
+  static hasConfiguredStorage(): boolean {
+    const index = readIndex();
+    return index.collections.length > 0 || index.hasDirectory;
+  }
+
+  static ensureActiveCollectionOnStartup(): string | null {
+    const index = readIndex();
+    if (index.collections.length === 0) {
+      return null;
+    }
+
+    const activeId = getActiveCollectionId();
+    if (activeId && index.collections.some((c) => c.id === activeId)) {
+      return activeId;
+    }
+
+    const sorted = [...index.collections].sort(
+      (a, b) => (b.lastSavedAt ?? b.updatedAt) - (a.lastSavedAt ?? a.updatedAt),
+    );
+    const fallback = sorted[0];
+    if (fallback) {
+      setActiveCollectionId(fallback.id);
+      return fallback.id;
+    }
+    return null;
+  }
+
+  static getOsFolderPath(): string {
+    try {
+      return (
+        localStorage.getItem(STORAGE_KEYS.LOCAL_STORAGE_COLLECTIONS_OS_PATH) ??
+        ""
+      );
+    } catch {
+      return "";
+    }
+  }
+
+  static setOsFolderPath(path: string): void {
+    localStorage.setItem(
+      STORAGE_KEYS.LOCAL_STORAGE_COLLECTIONS_OS_PATH,
+      path.trim(),
+    );
+  }
+
+  /** Set session folder without migrating or saving a collection. */
+  static async pickDirectory(): Promise<void> {
+    const handle = await requestDirectoryHandle();
+    await this.saveDirectoryHandle(handle);
+  }
+
+  static async createCollection(
+    name: string,
+    initialScene?: CollectionSceneData,
+  ): Promise<Collection> {
+    const fileName = `${sanitizeCollectionFileName(name)}.excalidraw`;
+    const collection: Collection = {
+      id: nanoid(),
+      name: name.trim() || "Untitled",
+      fileName,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      savedToDisk: false,
+    };
+
+    const index = readIndex();
+    index.collections.push(collection);
+    writeIndex(index);
+
+    const emptyScene: CollectionSceneData = {
+      elements: [],
+      appState: { ...getDefaultAppState() } as AppState,
+      files: {},
+    };
+
+    await set(
+      IDB_KEYS.sceneFallback(collection.id),
+      initialScene ?? emptyScene,
+      collectionsStore,
+    );
+
+    if (!getActiveCollectionId()) {
+      setActiveCollectionId(collection.id);
+    }
+
+    return collection;
+  }
+
+  private static async writeToDiskWithBackup(
+    collectionId: string,
+    collection: Collection,
+    dir: FileSystemDirectoryHandle,
+    elements: readonly ExcalidrawElement[],
+    appState: AppState,
+    files: BinaryFiles,
+    fileHandle?: FileSystemFileHandle,
+  ): Promise<string> {
+    const handle =
+      fileHandle ?? (await getOrCreateFileHandle(dir, collection.fileName));
+    const serialized = await writeSceneToFileHandle(
+      handle,
+      elements,
+      appState,
+      files,
+    );
+    await set(IDB_KEYS.fileHandle(collectionId), handle, collectionsStore);
+    if (!collection.customFileHandle) {
+      await writeAutosaveBackup(dir, collection.fileName, serialized);
+    }
+    return serialized;
+  }
+
+  static async saveCollectionToDisk(
+    collectionId: string,
+    elements: readonly ExcalidrawElement[],
+    appState: AppState,
+    files: BinaryFiles,
+    options?: { skipThumbnail?: boolean },
+  ): Promise<void> {
+    const index = readIndex();
+    const collection = index.collections.find((c) => c.id === collectionId);
+    if (!collection) {
+      return;
+    }
+
+    if (this.isFileSystemSupported()) {
+      let dir: FileSystemDirectoryHandle | null = null;
+      let fileHandle: FileSystemFileHandle | null = null;
+
+      if (collection.customFileHandle) {
+        fileHandle =
+          (await get<FileSystemFileHandle>(
+            IDB_KEYS.fileHandle(collectionId),
+            collectionsStore,
+          )) ?? null;
+        if (!fileHandle) {
+          throw new Error("Save As file handle was lost. Use Save As again.");
+        }
+      } else {
+        dir = sessionDirectoryHandle ?? (await this.ensureSessionDirectory());
+      }
+
+      if (fileHandle) {
+        await writeSceneToFileHandle(fileHandle, elements, appState, files);
+      } else if (dir) {
+        await this.writeToDiskWithBackup(
+          collectionId,
+          collection,
+          dir,
+          elements,
+          appState,
+          files,
+        );
+      }
+
+      const label = buildSaveLocationLabel(
+        dir ?? sessionDirectoryHandle,
+        collection.fileName,
+        collection.customFileHandle,
+      );
+      markCollectionSavedToDisk(collectionId, label);
+
+      if (!options?.skipThumbnail) {
+        await saveCollectionThumbnail(collectionId, elements, appState, files);
+        updateCollectionInIndex(collectionId, {
+          thumbnailUpdatedAt: Date.now(),
+        });
+      }
+      return;
+    }
+
+    await set(
+      IDB_KEYS.sceneFallback(collectionId),
+      { elements, appState, files },
+      collectionsStore,
+    );
+    markCollectionSavedToDisk(collectionId, "Browser storage");
+    if (!options?.skipThumbnail) {
+      await saveCollectionThumbnail(collectionId, elements, appState, files);
+      updateCollectionInIndex(collectionId, {
+        thumbnailUpdatedAt: Date.now(),
+      });
+    }
+  }
+
+  static async saveCollectionAs(
+    collectionId: string,
+    elements: readonly ExcalidrawElement[],
+    appState: AppState,
+    files: BinaryFiles,
+  ): Promise<void> {
+    const collection = readIndex().collections.find(
+      (c) => c.id === collectionId,
+    );
+    if (!collection) {
+      return;
+    }
+
+    const fileHandle = await requestSaveFileHandle(collection.fileName);
+    const serialized = await writeSceneToFileHandle(
+      fileHandle,
+      elements,
+      appState,
+      files,
+    );
+    await set(IDB_KEYS.fileHandle(collectionId), fileHandle, collectionsStore);
+
+    const newFileName = fileHandle.name;
+    updateCollectionInIndex(collectionId, {
+      fileName: newFileName,
+      customFileHandle: true,
+      savedToDisk: true,
+      lastSavedAt: Date.now(),
+      saveLocationLabel: newFileName,
+    });
+
+    const dir = await this.getDirectoryHandle();
+    if (dir && !collection.customFileHandle) {
+      await writeAutosaveBackup(dir, collection.fileName, serialized);
+    }
+
+    await saveCollectionThumbnail(collectionId, elements, appState, files);
+    updateCollectionInIndex(collectionId, { thumbnailUpdatedAt: Date.now() });
+  }
+
+  static async saveCollectionToStorage(
+    collectionId: string,
+    elements: readonly ExcalidrawElement[],
+    appState: AppState,
+    files: BinaryFiles,
+  ): Promise<void> {
+    const collection = readIndex().collections.find(
+      (c) => c.id === collectionId,
+    );
+    if (!collection) {
+      return;
+    }
+
+    if (collection.savedToDisk && this.isFileSystemSupported()) {
+      await this.saveCollectionToDisk(collectionId, elements, appState, files, {
+        skipThumbnail: true,
+      });
+      return;
+    }
+
+    await set(
+      IDB_KEYS.sceneFallback(collectionId),
+      { elements, appState, files },
+      collectionsStore,
+    );
+    updateCollectionInIndex(collectionId, {});
+  }
+
+  static async saveActiveToFile(
+    elements: readonly ExcalidrawElement[],
+    appState: AppState,
+    files: BinaryFiles,
+  ): Promise<void> {
+    const active = this.getActiveCollection();
+    if (!active?.savedToDisk) {
+      return;
+    }
+    await this.saveCollectionToStorage(active.id, elements, appState, files);
+  }
+
+  static downloadCollection(
+    collectionId: string,
+    elements: readonly ExcalidrawElement[],
+    appState: AppState,
+    files: BinaryFiles,
+  ): void {
+    const collection = readIndex().collections.find(
+      (c) => c.id === collectionId,
+    );
+    if (!collection) {
+      return;
+    }
+    downloadSceneAsFile(collection.fileName, elements, appState, files);
+  }
+
+  static async duplicateCollection(id: string): Promise<Collection> {
+    const source = readIndex().collections.find((c) => c.id === id);
+    if (!source) {
+      throw new Error("Collection not found.");
+    }
+
+    const scene = await this.loadCollectionScene(id, null, null);
+    const copyName = `${source.name} (copy)`;
+    const created = await this.createCollection(
+      copyName,
+      scene
+        ? {
+            elements: scene.elements ?? [],
+            appState: (scene.appState ?? {}) as Partial<AppState>,
+            files: scene.files ?? {},
+          }
+        : undefined,
+    );
+
+    return created;
+  }
+
+  static async importFromFile(file: File): Promise<Collection> {
+    const { loadFromBlob } = await import("@excalidraw/excalidraw/data/blob");
+    const data = await loadFromBlob(file, null, null);
+    const baseName =
+      file.name.replace(/\.(excalidraw|json)$/i, "") || "Imported";
+    const created = await this.createCollection(baseName, {
+      elements: data.elements ?? [],
+      appState: (data.appState ?? {}) as Partial<AppState>,
+      files: data.files ?? {},
+    });
+    setActiveCollectionId(created.id);
+    touchRecentCollection(created.id);
+    return created;
+  }
+
+  static async renameCollection(id: string, newName: string): Promise<void> {
+    const index = readIndex();
+    const collection = index.collections.find((c) => c.id === id);
+    if (!collection) {
+      return;
+    }
+
+    const trimmed = newName.trim() || "Untitled";
+    const newFileName = `${sanitizeCollectionFileName(trimmed)}.excalidraw`;
+    const oldFileName = collection.fileName;
+
+    collection.name = trimmed;
+    collection.fileName = newFileName;
+    collection.updatedAt = Date.now();
+    if (collection.saveLocationLabel && !collection.customFileHandle) {
+      const dir = sessionDirectoryHandle ?? (await this.getDirectoryHandle());
+      collection.saveLocationLabel = buildSaveLocationLabel(
+        dir,
+        newFileName,
+        false,
+      );
+    }
+    writeIndex(index);
+
+    if (!collection.savedToDisk || oldFileName === newFileName) {
+      return;
+    }
+
+    if (collection.customFileHandle) {
+      return;
+    }
+
+    const dir = await this.getDirectoryHandle();
+    if (dir && this.isFileSystemSupported()) {
+      try {
+        const oldHandle = await get<FileSystemFileHandle>(
+          IDB_KEYS.fileHandle(id),
+          collectionsStore,
+        );
+        if (oldHandle) {
+          const file = await oldHandle.getFile();
+          const newHandle = await getOrCreateFileHandle(dir, newFileName);
+          const writable = await newHandle.createWritable();
+          await writable.write(file);
+          await writable.close();
+          await set(IDB_KEYS.fileHandle(id), newHandle, collectionsStore);
+          await dir.removeEntry(oldFileName).catch(() => {
+            /* old file may not exist */
+          });
+          const autosaveOld = getAutosaveFileName(oldFileName);
+          await dir.removeEntry(autosaveOld).catch(() => {});
+        }
+      } catch (error) {
+        console.error(error);
+      }
+    }
+  }
+
+  static async deleteCollection(id: string): Promise<void> {
+    const index = readIndex();
+    const collection = index.collections.find((c) => c.id === id);
+    index.collections = index.collections.filter((c) => c.id !== id);
+    if (index.recentCollectionIds) {
+      index.recentCollectionIds = index.recentCollectionIds.filter(
+        (rid) => rid !== id,
+      );
+    }
+    writeIndex(index);
+
+    await del(IDB_KEYS.fileHandle(id), collectionsStore);
+    await del(IDB_KEYS.sceneFallback(id), collectionsStore);
+    await del(`thumbnail-${id}`, collectionsStore);
+
+    if (
+      collection?.savedToDisk &&
+      index.hasDirectory &&
+      !collection.customFileHandle
+    ) {
+      const dir = await this.getDirectoryHandle();
+      if (dir) {
+        await dir.removeEntry(collection.fileName).catch(() => {});
+        await dir
+          .removeEntry(getAutosaveFileName(collection.fileName))
+          .catch(() => {});
+      }
+    }
+
+    const activeId = getActiveCollectionId();
+    if (activeId === id) {
+      const next = index.collections[0];
+      if (next) {
+        setActiveCollectionId(next.id);
+      } else {
+        localStorage.removeItem(
+          STORAGE_KEYS.LOCAL_STORAGE_ACTIVE_COLLECTION_ID,
+        );
+      }
+    }
+  }
+
+  static async loadCollectionScene(
+    collectionId: string,
+    localAppState: AppState | null,
+    localElements: readonly ExcalidrawElement[] | null,
+  ): Promise<(ImportedDataState & { recoveredFromAutosave?: boolean }) | null> {
+    const collection = readIndex().collections.find(
+      (c) => c.id === collectionId,
+    );
+
+    if (collection?.savedToDisk && this.isFileSystemSupported()) {
+      const fileHandle = await get<FileSystemFileHandle>(
+        IDB_KEYS.fileHandle(collectionId),
+        collectionsStore,
+      );
+
+      if (fileHandle) {
+        try {
+          return await readSceneFromFileHandle(
+            fileHandle,
+            localAppState,
+            localElements,
+          );
+        } catch (error) {
+          console.error(error);
+        }
+      }
+
+      if (!collection.customFileHandle) {
+        const dir = await this.getDirectoryHandle();
+        if (dir) {
+          let mainScene: ImportedDataState | null = null;
+          try {
+            mainScene = await tryReadSceneFromDirectoryFile(
+              dir,
+              collection.fileName,
+              localAppState,
+              localElements,
+            );
+          } catch {
+            mainScene = null;
+          }
+
+          const autosaveName = getAutosaveFileName(collection.fileName);
+          let autosaveScene: ImportedDataState | null = null;
+          try {
+            autosaveScene = await tryReadSceneFromDirectoryFile(
+              dir,
+              autosaveName,
+              localAppState,
+              localElements,
+            );
+          } catch {
+            autosaveScene = null;
+          }
+
+          if (autosaveScene && !mainScene) {
+            return { ...autosaveScene, recoveredFromAutosave: true };
+          }
+
+          if (autosaveScene && mainScene) {
+            try {
+              const mainHandle = await dir.getFileHandle(collection.fileName);
+              const autoHandle = await dir.getFileHandle(autosaveName);
+              const mainFile = await mainHandle.getFile();
+              const autoFile = await autoHandle.getFile();
+              if (autoFile.lastModified > mainFile.lastModified) {
+                return { ...autosaveScene, recoveredFromAutosave: true };
+              }
+            } catch {
+              return { ...autosaveScene, recoveredFromAutosave: true };
+            }
+            return mainScene;
+          }
+
+          if (mainScene) {
+            return mainScene;
+          }
+        }
+      }
+    }
+
+    const fallback = await get<CollectionSceneData>(
+      IDB_KEYS.sceneFallback(collectionId),
+      collectionsStore,
+    );
+
+    if (fallback) {
+      return {
+        elements: fallback.elements,
+        appState: fallback.appState,
+        files: fallback.files,
+      };
+    }
+
+    return null;
+  }
+
+  static async loadActiveCollectionScene(
+    localAppState: AppState | null,
+    localElements: readonly ExcalidrawElement[] | null,
+  ): Promise<(ImportedDataState & { recoveredFromAutosave?: boolean }) | null> {
+    const active = this.getActiveCollection();
+    if (!active) {
+      return null;
+    }
+    return this.loadCollectionScene(active.id, localAppState, localElements);
+  }
+
+  static setActiveCollection(id: string): void {
+    const exists = readIndex().collections.some((c) => c.id === id);
+    if (exists) {
+      setActiveCollectionId(id);
+      touchRecentCollection(id);
+    }
+  }
+
+  static getFolderInfo(): {
+    folderName: string | null;
+    fileNames: string[];
+    osPath: string;
+  } {
+    const index = readIndex();
+    return {
+      folderName: sessionDirectoryHandle?.name ?? null,
+      fileNames: index.collections.map((c) => c.fileName),
+      osPath: this.getOsFolderPath(),
+    };
+  }
+
+  static serializeCollectionForExport(
+    collectionId: string,
+    fallbackAppState: AppState,
+  ): Promise<string | null> {
+    return this.loadCollectionScene(collectionId, fallbackAppState, null).then(
+      (scene) => {
+        if (!scene?.elements) {
+          return null;
+        }
+        const appState = {
+          ...fallbackAppState,
+          ...(scene.appState ?? {}),
+        } as AppState;
+        return serializeScene(scene.elements, appState, scene.files ?? {});
+      },
+    );
+  }
+
+  /** One-time migration when user picks a folder and has legacy localStorage scene. */
+  static async migrateLegacySceneToDefaultCollection(): Promise<void> {
+    const index = readIndex();
+    if (index.collections.length > 0) {
+      return;
+    }
+
+    const legacy = importFromLocalStorage();
+    const hasLegacyContent =
+      (legacy.elements?.length ?? 0) > 0 || legacy.appState != null;
+
+    const collection = await this.createCollection(
+      "Default",
+      hasLegacyContent
+        ? {
+            elements: legacy.elements ?? [],
+            appState: {
+              ...getDefaultAppState(),
+              ...(legacy.appState ?? {}),
+            } as AppState,
+            files: {},
+          }
+        : undefined,
+    );
+
+    setActiveCollectionId(collection.id);
+
+    if (hasLegacyContent && sessionDirectoryHandle) {
+      await this.saveCollectionToDisk(
+        collection.id,
+        legacy.elements ?? [],
+        {
+          ...getDefaultAppState(),
+          ...(legacy.appState ?? {}),
+        } as AppState,
+        {},
+      );
+    }
+  }
+}

--- a/excalidraw-app/data/collections/collectionFiles.ts
+++ b/excalidraw-app/data/collections/collectionFiles.ts
@@ -1,0 +1,190 @@
+import { MIME_TYPES } from "@excalidraw/common";
+import { serializeAsJSON } from "@excalidraw/excalidraw/data/json";
+import { loadFromBlob } from "@excalidraw/excalidraw/data/blob";
+import { nativeFileSystemSupported } from "@excalidraw/excalidraw/data/filesystem";
+
+import type { ExcalidrawElement } from "@excalidraw/element/types";
+import type { AppState, BinaryFiles } from "@excalidraw/excalidraw/types";
+import type { ImportedDataState } from "@excalidraw/excalidraw/data/types";
+
+export const isCollectionsFileSystemSupported = (): boolean => {
+  return (
+    nativeFileSystemSupported &&
+    typeof window.showDirectoryPicker === "function"
+  );
+};
+
+export const getAutosaveFileName = (fileName: string): string => {
+  if (fileName.endsWith(".excalidraw")) {
+    return fileName.replace(/\.excalidraw$/, ".autosave.excalidraw");
+  }
+  return `${fileName}.autosave.excalidraw`;
+};
+
+export const sanitizeCollectionFileName = (name: string): string => {
+  const withoutInvalidChars = name
+    .split("")
+    .map((char) => (char.charCodeAt(0) < 32 ? "_" : char))
+    .join("")
+    .replace(/[<>:"/\\|?*]/g, "_")
+    .trim();
+  return withoutInvalidChars || "Untitled";
+};
+
+export const verifyHandlePermission = async (
+  handle: FileSystemHandle,
+  mode: FileSystemHandlePermissionDescriptor["mode"] = "readwrite",
+): Promise<boolean> => {
+  if (!handle.queryPermission) {
+    return true;
+  }
+  const options: FileSystemHandlePermissionDescriptor = { mode };
+  if ((await handle.queryPermission(options)) === "granted") {
+    return true;
+  }
+  if (handle.requestPermission) {
+    return (await handle.requestPermission(options)) === "granted";
+  }
+  return false;
+};
+
+export const requestDirectoryHandle =
+  async (): Promise<FileSystemDirectoryHandle> => {
+    if (!isCollectionsFileSystemSupported()) {
+      throw new Error("Folder picker is not supported in this browser.");
+    }
+    try {
+      return await window.showDirectoryPicker!({ mode: "readwrite" });
+    } catch (error: any) {
+      if (error?.name === "AbortError") {
+        throw new Error("Folder selection was cancelled.");
+      }
+      throw error;
+    }
+  };
+
+export const requestSaveFileHandle = async (
+  suggestedName: string,
+): Promise<FileSystemFileHandle> => {
+  if (!isCollectionsFileSystemSupported()) {
+    throw new Error("Save As is not supported in this browser.");
+  }
+  try {
+    return await window.showSaveFilePicker!({
+      suggestedName,
+      types: [
+        {
+          description: "Excalidraw file",
+          accept: { [MIME_TYPES.excalidraw]: [".excalidraw"] },
+        },
+      ],
+    });
+  } catch (error: any) {
+    if (error?.name === "AbortError") {
+      throw new Error("Save was cancelled.");
+    }
+    throw error;
+  }
+};
+
+export const getOrCreateFileHandle = async (
+  directoryHandle: FileSystemDirectoryHandle,
+  fileName: string,
+): Promise<FileSystemFileHandle> => {
+  try {
+    return await directoryHandle.getFileHandle(fileName, { create: true });
+  } catch {
+    return directoryHandle.getFileHandle(fileName);
+  }
+};
+
+export const writeSerializedToFileHandle = async (
+  fileHandle: FileSystemFileHandle,
+  serialized: string,
+): Promise<void> => {
+  const hasPermission = await verifyHandlePermission(fileHandle, "readwrite");
+  if (!hasPermission) {
+    throw new Error("Permission denied to save collection file.");
+  }
+
+  const writable = await fileHandle.createWritable();
+  await writable.write(new Blob([serialized], { type: MIME_TYPES.excalidraw }));
+  await writable.close();
+};
+
+export const writeSceneToFileHandle = async (
+  fileHandle: FileSystemFileHandle,
+  elements: readonly ExcalidrawElement[],
+  appState: AppState,
+  files: BinaryFiles,
+): Promise<string> => {
+  const serialized = serializeAsJSON(elements, appState, files, "local");
+  await writeSerializedToFileHandle(fileHandle, serialized);
+  return serialized;
+};
+
+export const writeAutosaveBackup = async (
+  directoryHandle: FileSystemDirectoryHandle,
+  fileName: string,
+  serialized: string,
+): Promise<void> => {
+  const autosaveName = getAutosaveFileName(fileName);
+  try {
+    const handle = await getOrCreateFileHandle(directoryHandle, autosaveName);
+    await writeSerializedToFileHandle(handle, serialized);
+  } catch (error) {
+    console.error("Autosave backup failed", error);
+  }
+};
+
+export const readSceneFromFileHandle = async (
+  fileHandle: FileSystemFileHandle,
+  localAppState: AppState | null,
+  localElements: readonly ExcalidrawElement[] | null,
+): Promise<ImportedDataState> => {
+  const hasPermission = await verifyHandlePermission(fileHandle, "read");
+  if (!hasPermission) {
+    throw new Error("Permission denied to read collection file.");
+  }
+
+  const file = await fileHandle.getFile();
+  return loadFromBlob(file, localAppState, localElements, fileHandle);
+};
+
+export const tryReadSceneFromDirectoryFile = async (
+  directoryHandle: FileSystemDirectoryHandle,
+  fileName: string,
+  localAppState: AppState | null,
+  localElements: readonly ExcalidrawElement[] | null,
+): Promise<ImportedDataState | null> => {
+  try {
+    const handle = await directoryHandle.getFileHandle(fileName);
+    return await readSceneFromFileHandle(handle, localAppState, localElements);
+  } catch {
+    return null;
+  }
+};
+
+export const downloadSceneAsFile = (
+  fileName: string,
+  elements: readonly ExcalidrawElement[],
+  appState: AppState,
+  files: BinaryFiles,
+): void => {
+  const serialized = serializeAsJSON(elements, appState, files, "local");
+  const blob = new Blob([serialized], { type: MIME_TYPES.excalidraw });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = fileName.endsWith(".excalidraw")
+    ? fileName
+    : `${fileName}.excalidraw`;
+  anchor.click();
+  URL.revokeObjectURL(url);
+};
+
+export const serializeScene = (
+  elements: readonly ExcalidrawElement[],
+  appState: AppState,
+  files: BinaryFiles,
+): string => serializeAsJSON(elements, appState, files, "local");

--- a/excalidraw-app/data/collections/collectionThumbnails.ts
+++ b/excalidraw-app/data/collections/collectionThumbnails.ts
@@ -1,0 +1,51 @@
+import { exportToBlob, MIME_TYPES } from "@excalidraw/excalidraw";
+
+import { createStore, get, set } from "idb-keyval";
+
+import type { ExcalidrawElement } from "@excalidraw/element/types";
+import type { AppState, BinaryFiles } from "@excalidraw/excalidraw/types";
+
+import { STORAGE_KEYS } from "../../app_constants";
+
+const collectionsStore = createStore(
+  `${STORAGE_KEYS.IDB_COLLECTIONS}-db`,
+  `${STORAGE_KEYS.IDB_COLLECTIONS}-store`,
+);
+
+const thumbnailKey = (collectionId: string) => `thumbnail-${collectionId}`;
+
+export const saveCollectionThumbnail = async (
+  collectionId: string,
+  elements: readonly ExcalidrawElement[],
+  appState: AppState,
+  files: BinaryFiles,
+): Promise<void> => {
+  const visible = elements.filter((el) => !el.isDeleted);
+  if (visible.length === 0) {
+    return;
+  }
+
+  try {
+    const blob = await exportToBlob({
+      elements: visible,
+      appState: {
+        ...appState,
+        exportBackground: true,
+        viewBackgroundColor: appState.viewBackgroundColor,
+      },
+      files,
+      mimeType: MIME_TYPES.png,
+      exportPadding: 10,
+      maxWidthOrHeight: 200,
+    });
+    await set(thumbnailKey(collectionId), blob, collectionsStore);
+  } catch (error) {
+    console.error("Thumbnail generation failed", error);
+  }
+};
+
+export const getCollectionThumbnail = async (
+  collectionId: string,
+): Promise<Blob | undefined> => {
+  return get<Blob>(thumbnailKey(collectionId), collectionsStore);
+};

--- a/excalidraw-app/data/collections/exportCollections.ts
+++ b/excalidraw-app/data/collections/exportCollections.ts
@@ -1,0 +1,55 @@
+import JSZip from "jszip";
+
+import type { AppState } from "@excalidraw/excalidraw/types";
+
+import { CollectionStore } from "./CollectionStore";
+import { serializeScene } from "./collectionFiles";
+
+const downloadBlob = (blob: Blob, fileName: string) => {
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = fileName;
+  anchor.click();
+  URL.revokeObjectURL(url);
+};
+
+export const exportAllCollectionsToZip = async (
+  fallbackAppState: AppState,
+  onProgress?: (current: number, total: number, name: string) => void,
+): Promise<{ failed: string[] }> => {
+  const collections = CollectionStore.getCollections();
+  const zip = new JSZip();
+  const failed: string[] = [];
+
+  for (let i = 0; i < collections.length; i++) {
+    const collection = collections[i];
+    onProgress?.(i + 1, collections.length, collection.name);
+
+    try {
+      const scene = await CollectionStore.loadCollectionScene(
+        collection.id,
+        fallbackAppState,
+        null,
+      );
+      if (!scene?.elements) {
+        failed.push(collection.name);
+        continue;
+      }
+      const appState = {
+        ...fallbackAppState,
+        ...(scene.appState ?? {}),
+      } as AppState;
+      const json = serializeScene(scene.elements, appState, scene.files ?? {});
+      zip.file(collection.fileName, json);
+    } catch {
+      failed.push(collection.name);
+    }
+  }
+
+  const blob = await zip.generateAsync({ type: "blob" });
+  const date = new Date().toISOString().slice(0, 10);
+  downloadBlob(blob, `excalidraw-collections-${date}.zip`);
+
+  return { failed };
+};

--- a/excalidraw-app/data/collections/sceneSnapshot.ts
+++ b/excalidraw-app/data/collections/sceneSnapshot.ts
@@ -1,0 +1,13 @@
+import type { ExcalidrawElement } from "@excalidraw/element/types";
+import type { BinaryFiles } from "@excalidraw/excalidraw/types";
+
+export const computeSceneSnapshot = (
+  elements: readonly ExcalidrawElement[],
+  files: BinaryFiles,
+): string => {
+  const elementPart = elements
+    .map((el) => `${el.id}:${el.version}:${el.versionNonce}`)
+    .join("|");
+  const filePart = Object.keys(files).sort().join(",");
+  return `${elementPart}::${filePart}`;
+};

--- a/excalidraw-app/data/collections/types.ts
+++ b/excalidraw-app/data/collections/types.ts
@@ -1,0 +1,28 @@
+import type { ExcalidrawElement } from "@excalidraw/element/types";
+import type { AppState, BinaryFiles } from "@excalidraw/excalidraw/types";
+
+export type Collection = {
+  id: string;
+  name: string;
+  fileName: string;
+  createdAt: number;
+  updatedAt: number;
+  /** Set after the collection is written to a folder on disk */
+  savedToDisk?: boolean;
+  lastSavedAt?: number;
+  saveLocationLabel?: string;
+  customFileHandle?: boolean;
+  thumbnailUpdatedAt?: number;
+};
+
+export type CollectionsIndex = {
+  collections: Collection[];
+  hasDirectory: boolean;
+  recentCollectionIds?: string[];
+};
+
+export type CollectionSceneData = {
+  elements: readonly ExcalidrawElement[];
+  appState: Partial<AppState>;
+  files: BinaryFiles;
+};

--- a/excalidraw-app/data/saveStatusAtoms.ts
+++ b/excalidraw-app/data/saveStatusAtoms.ts
@@ -1,0 +1,7 @@
+import { atom } from "../app-jotai";
+
+export type SaveStatus = "idle" | "saving" | "saved" | "error";
+
+export const saveStatusAtom = atom<SaveStatus>("idle");
+export const lastSavedAtAtom = atom<number | null>(null);
+export const saveErrorMessageAtom = atom<string | null>(null);

--- a/excalidraw-app/global.d.ts
+++ b/excalidraw-app/global.d.ts
@@ -1,6 +1,41 @@
-import "@excalidraw/excalidraw/global";
-import "@excalidraw/excalidraw/css";
-
 interface Window {
-  __EXCALIDRAW_SHA__: string | undefined;
+  showSaveFilePicker?: (options?: {
+    suggestedName?: string;
+    types?: Array<{
+      description?: string;
+      accept: Record<string, string[]>;
+    }>;
+  }) => Promise<FileSystemFileHandle>;
+  showDirectoryPicker?: (options?: {
+    id?: string;
+    mode?: "read" | "readwrite";
+    startIn?:
+      | "desktop"
+      | "documents"
+      | "downloads"
+      | "music"
+      | "pictures"
+      | "videos";
+  }) => Promise<FileSystemDirectoryHandle>;
+}
+
+interface FileSystemHandlePermissionDescriptor {
+  mode?: "read" | "readwrite";
+}
+
+interface FileSystemHandle {
+  queryPermission?(
+    descriptor?: FileSystemHandlePermissionDescriptor,
+  ): Promise<PermissionState>;
+  requestPermission?(
+    descriptor?: FileSystemHandlePermissionDescriptor,
+  ): Promise<PermissionState>;
+}
+
+interface FileSystemDirectoryHandle extends FileSystemHandle {
+  getFileHandle(
+    name: string,
+    options?: { create?: boolean },
+  ): Promise<FileSystemFileHandle>;
+  removeEntry(name: string, options?: { recursive?: boolean }): Promise<void>;
 }

--- a/excalidraw-app/package.json
+++ b/excalidraw-app/package.json
@@ -32,6 +32,7 @@
     "firebase": "11.3.1",
     "i18next-browser-languagedetector": "6.1.4",
     "idb-keyval": "6.0.3",
+    "jszip": "3.10.1",
     "jotai": "2.11.0",
     "react": "19.0.0",
     "react-dom": "19.0.0",

--- a/scripts/windows/install-excalidraw.bat
+++ b/scripts/windows/install-excalidraw.bat
@@ -1,0 +1,48 @@
+@echo off
+setlocal EnableExtensions
+cd /d "%~dp0..\.."
+
+echo ========================================
+echo  Excalidraw - First-time installation
+echo ========================================
+echo.
+
+echo [1/3] Checking Node.js...
+where node >nul 2>&1
+if errorlevel 1 (
+    echo ERROR: Node.js is not installed.
+    echo Install Node.js 18 or newer from https://nodejs.org/
+    goto :failed
+)
+for /f "delims=" %%v in ('node -v') do echo       Found %%v
+
+echo.
+echo [2/3] Checking Yarn...
+where yarn >nul 2>&1
+if errorlevel 1 (
+    echo       Yarn not found. Installing globally via npm...
+    call npm install -g yarn
+    if errorlevel 1 goto :failed
+)
+for /f "delims=" %%v in ('yarn -v') do echo       Found Yarn %%v
+
+echo.
+echo [3/3] Installing dependencies (may take several minutes)...
+call yarn
+if errorlevel 1 goto :failed
+
+echo.
+echo ========================================
+echo  Installation complete!
+echo  Run scripts\windows\run-excalidraw.bat to start.
+echo ========================================
+goto :end
+
+:failed
+echo.
+echo Installation did not finish successfully.
+exit /b 1
+
+:end
+pause
+exit /b 0

--- a/scripts/windows/open-collections-folder.bat
+++ b/scripts/windows/open-collections-folder.bat
@@ -1,0 +1,28 @@
+@echo off
+REM Opens the collections folder in Windows Explorer.
+REM Set path in app: Collections - Collections folder path - Save path
+REM Or create .excalidraw-collections-path.txt in repo root (one line = full path).
+setlocal
+cd /d "%~dp0..\.."
+set "CONFIG_FILE=%CD%\.excalidraw-collections-path.txt"
+set "FOLDER="
+
+if exist "%CONFIG_FILE%" (
+  set /p FOLDER=<"%CONFIG_FILE%"
+)
+
+if "%FOLDER%"=="" (
+  echo No folder path configured.
+  echo In Excalidraw: Menu - Collections - set path - Save path.
+  echo Or create %CONFIG_FILE% with one line: your folder path.
+  pause
+  exit /b 1
+)
+
+if not exist "%FOLDER%" (
+  echo Folder does not exist: %FOLDER%
+  pause
+  exit /b 1
+)
+
+start "" explorer "%FOLDER%"

--- a/scripts/windows/run-excalidraw.bat
+++ b/scripts/windows/run-excalidraw.bat
@@ -1,0 +1,44 @@
+@echo off
+setlocal EnableExtensions
+cd /d "%~dp0..\.."
+
+echo ========================================
+echo  Excalidraw - Dev server
+echo ========================================
+echo.
+
+if not exist "package.json" (
+    echo ERROR: Run from excalidraw repo root. package.json not found.
+    goto :failed
+)
+
+if not exist "node_modules" (
+    echo ERROR: Dependencies are not installed.
+    echo Run scripts\windows\install-excalidraw.bat first.
+    goto :failed
+)
+
+where yarn >nul 2>&1
+if errorlevel 1 (
+    echo ERROR: Yarn is not installed.
+    goto :failed
+)
+
+echo Starting Vite dev server...
+echo   Default URL: http://localhost:3000
+echo   Press Ctrl+C to stop.
+echo.
+
+call yarn start
+if errorlevel 1 goto :failed
+goto :end
+
+:failed
+echo.
+echo Server exited with an error.
+pause
+exit /b 1
+
+:end
+pause
+exit /b 0


### PR DESCRIPTION
## Summary

Adds **multi-collection** support to `excalidraw-app` with optional **save to disk** (File System Access API), autosave recovery files, export-all ZIP, Collections dialog, save status chip, and welcome-screen recents.

- **App-layer only** — no changes to `packages/excalidraw`
- Integration refactored into `excalidraw-app/collections/useCollectionsAppIntegration.ts` to keep `App.tsx` wiring thin
- User docs: [excalidraw-app/COLLECTIONS.md](https://github.com/Rengoku30/excalidraw/blob/feature/collections-and-save/excalidraw-app/COLLECTIONS.md)

## Test plan

- [x] `yarn test:code` and `yarn test:typecheck` pass locally
- [ ] Chrome/Edge: create collection → Save → pick folder → edit → reload → scene persists
- [ ] Switch collection with unsaved changes → Save & continue / Discard / Cancel
- [ ] Export all → ZIP contains `.excalidraw` files
- [ ] Firefox: Download + Export all work; Save to folder hidden with fallback banner

## Upstream follow-ups (if considered for merge)

- i18n for new UI strings (currently English in fork)
- Unit tests for `CollectionStore`
- Product/design review vs existing Open / library flows
- Feature flag or gradual rollout discussion

## Notes

This is a substantial app-only feature; happy to split commits or reduce scope per maintainer feedback.
