### PR TITLE
fix: show visual error feedback for invalid hex color input

### DIFF
--- a/packages/excalidraw/components/ColorPicker/ColorInput.tsx
+++ b/packages/excalidraw/components/ColorPicker/ColorInput.tsx
@@ -29,21 +29,27 @@ export const ColorInput = ({
 }) => {
   const editorInterface = useEditorInterface();
   const [innerValue, setInnerValue] = useState(color);
+  const [isInvalid, setIsInvalid] = useState(false);
   const [activeSection, setActiveColorPickerSection] = useAtom(
     activeColorPickerSectionAtom,
   );
 
   useEffect(() => {
     setInnerValue(color);
+    setIsInvalid(false);
   }, [color]);
 
   const changeColor = useCallback(
     (inputValue: string) => {
       const value = inputValue.toLowerCase();
-      const color = normalizeInputColor(value);
+      const normalizedColor = normalizeInputColor(value);
 
-      if (color) {
-        onChange(color);
+      if (normalizedColor) {
+        onChange(normalizedColor);
+        setIsInvalid(false);
+      } else {
+        // Only show error if there's actual input (not empty)
+        setIsInvalid(value.length > 0);
       }
       setInnerValue(value);
     },
@@ -74,14 +80,19 @@ export const ColorInput = ({
         ref={activeSection === "hex" ? inputRef : undefined}
         style={{ border: 0, padding: 0 }}
         spellCheck={false}
-        className="color-picker-input"
+        className={clsx("color-picker-input", {
+          "color-picker-input--invalid": isInvalid,
+        })}
         aria-label={label}
+        aria-invalid={isInvalid}
+        title={isInvalid ? t("colorPicker.invalidColor") : undefined}
         onChange={(event) => {
           changeColor(event.target.value);
         }}
         value={(innerValue || "").replace(/^#/, "")}
         onBlur={() => {
           setInnerValue(color);
+          setIsInvalid(false);
         }}
         tabIndex={-1}
         onFocus={() => setActiveColorPickerSection("hex")}
@@ -95,6 +106,15 @@ export const ColorInput = ({
         }}
         placeholder={placeholder}
       />
+      {isInvalid && (
+        <span
+          className="color-picker-input__error-indicator"
+          title={t("colorPicker.invalidColor")}
+          aria-label={t("colorPicker.invalidColor")}
+        >
+          !
+        </span>
+      )}
       {/* TODO reenable on mobile with a better UX */}
       {editorInterface.formFactor !== "phone" && (
         <>

--- a/packages/excalidraw/components/ColorPicker/ColorPicker.scss
+++ b/packages/excalidraw/components/ColorPicker/ColorPicker.scss
@@ -421,6 +421,29 @@
     &:focus-visible {
       box-shadow: none;
     }
+
+    &--invalid {
+      color: var(--color-danger, #e03131);
+    }
+  }
+
+  .color-picker-input__error-indicator {
+    color: var(--color-danger, #e03131);
+    font-weight: 700;
+    font-size: 0.875rem;
+    line-height: 1;
+    cursor: default;
+    user-select: none;
+  }
+
+  .color-picker__input-label {
+    &:focus-within:has(.color-picker-input--invalid) {
+      box-shadow: 0 0 0 1px var(--color-danger, #e03131);
+    }
+
+    &:has(.color-picker-input--invalid) {
+      border-color: var(--color-danger, #e03131);
+    }
   }
 
   .color-picker-label-swatch-container {

--- a/packages/excalidraw/locales/en.json
+++ b/packages/excalidraw/locales/en.json
@@ -598,6 +598,7 @@
     "colors": "Colors",
     "shades": "Shades",
     "hexCode": "Hex code",
+    "invalidColor": "Invalid color",
     "noShades": "No shades available for this color"
   },
   "overwriteConfirm": {


### PR DESCRIPTION
## Summary

Closes #9527.

Currently, when a user types an invalid hex color (e.g. `zzzzzz`, `12345`, `blue`) into the color picker input, the input is silently ignored with no feedback. This is confusing — users don't know why their color didn't apply.

## Changes

### `ColorInput.tsx`
- Added a local `isInvalid` state that tracks whether the current input value is invalid
- `isInvalid` is set to `true` when `normalizeInputColor` returns `null` for a non-empty input
- Reset to `false` on blur (restores original color) and when the parent color prop changes
- Added `aria-invalid` attribute for accessibility
- Added a small `!` error indicator span next to the input when invalid, with a tooltip

### `ColorPicker.scss`
- `.color-picker-input--invalid`: turns the input text red
- `.color-picker-input__error-indicator`: styles the red `!` badge
- `.color-picker__input-label:has(.color-picker-input--invalid)`: turns the border red when invalid

### `locales/en.json`
- Added `colorPicker.invalidColor` key: `"Invalid color"`

## Before / After
| Before | After |
|--------|-------|
| Silent no-op on invalid input | Input text turns red, border turns red, `!` indicator appears with tooltip |