### PR TITLE
i18n: add missing progressDialog translation for zh-CN

### DIFF
--- a/packages/excalidraw/locales/zh-CN.json
+++ b/packages/excalidraw/locales/zh-CN.json
@@ -711,5 +711,9 @@
     "spacebar": "空格",
     "delete": "Delete",
     "mmb": "鼠标滚轮"
+  },
+  "progressDialog": {
+    "title": "正在保存",
+    "defaultMessage": "准备保存中…"
   }
 }


### PR DESCRIPTION
## Summary
- Added the missing `progressDialog` translation key to the Chinese (zh-CN) locale
- The key was present in English but absent from zh-CN, causing a fallback to English text when the save progress dialog is shown

## What changed
Added Chinese translation for `progressDialog`:
- `title`: "正在保存" (Saving)
- `defaultMessage`: "准备保存中…" (Preparing to save...)

## Test plan
- [ ] Verify `progressDialog` renders in Chinese when locale is set to zh-CN