### PR TITLE
fix(editor): make element transparency option bar RTL-compatible

### DIFF
--- a/packages/excalidraw/components/Range.scss
+++ b/packages/excalidraw/components/Range.scss
@@ -44,12 +44,16 @@
     transform: translateX(-50%);
     font-size: 12px;
     color: var(--text-primary-color);
+
+    :root[dir="rtl"] & {
+      transform: translateX(50%);
+    }
   }
 
   .zero-label {
     position: absolute;
     bottom: 0;
-    left: 4px;
+    inset-inline-start: 4px;
     font-size: 12px;
     color: var(--text-primary-color);
   }

--- a/packages/excalidraw/components/Range.tsx
+++ b/packages/excalidraw/components/Range.tsx
@@ -33,17 +33,22 @@ export const Range = ({
       const rangeElement = rangeRef.current;
       const valueElement = valueRef.current;
       const inputWidth = rangeElement.offsetWidth;
+      const computed = getComputedStyle(rangeElement);
       const thumbWidth =
-        parseFloat(
-          getComputedStyle(rangeElement).getPropertyValue(
-            "--slider-thumb-size",
-          ),
-        ) || 16;
+        parseFloat(computed.getPropertyValue("--slider-thumb-size")) || 16;
       const progress = ((value - min) / (max - min || 1)) * 100;
       const position =
         (progress / 100) * (inputWidth - thumbWidth) + thumbWidth / 2;
-      valueElement.style.left = `${position}px`;
-      rangeElement.style.background = `linear-gradient(to right, var(--color-slider-track) 0%, var(--color-slider-track) ${progress}%, var(--button-bg) ${progress}%, var(--button-bg) 100%)`;
+      // `inset-inline-start` anchors the bubble to the slider's logical start,
+      // so the position stays aligned with the thumb whether `dir` is `ltr` or
+      // `rtl`. The gradient direction is in physical CSS keywords and has to
+      // be flipped explicitly when the document is RTL — browsers don't flip
+      // `to right` automatically.
+      const isRTL = computed.direction === "rtl";
+      valueElement.style.insetInlineStart = `${position}px`;
+      rangeElement.style.background = `linear-gradient(${
+        isRTL ? "to left" : "to right"
+      }, var(--color-slider-track) 0%, var(--color-slider-track) ${progress}%, var(--button-bg) ${progress}%, var(--button-bg) 100%)`;
     }
   }, [max, min, value]);
 


### PR DESCRIPTION
Closes #9710.

## What was broken

In RTL layouts, the opacity slider in the element properties panel looked off in three ways at once:

- The **value bubble** ("100" by default) sat on the physical-right of the track even though the slider's thumb moves to the physical-left when value is high (browsers auto-flip `<input type="range">` in RTL).
- The **zero label** stayed pinned to the physical-left, i.e. the logical *end* of the slider, while it should sit at the logical start.
- The **filled portion of the track** ran left-to-right regardless of `dir`, so the filled side and the thumb side never matched.

Each is a physical-vs-logical CSS mismatch.

## What changed

Two files in `packages/excalidraw/components/`:

**`Range.tsx`** — the bubble position and the gradient direction are written from JS each time the value changes. The bubble now uses `insetInlineStart` (which resolves to `left` in LTR and `right` in RTL), and the gradient flips to `to left` when `getComputedStyle(rangeElement).direction === "rtl"`:

```ts
const isRTL = computed.direction === "rtl";
valueElement.style.insetInlineStart = `${position}px`;
rangeElement.style.background = `linear-gradient(${
  isRTL ? "to left" : "to right"
}, var(--color-slider-track) 0%, var(--color-slider-track) ${progress}%, var(--button-bg) ${progress}%, var(--button-bg) 100%)`;
```

**`Range.scss`** — `.zero-label` switches from `left: 4px` to `inset-inline-start: 4px` (auto-flips). `.value-bubble` keeps its physical `translateX(-50%)` centering but adds the existing project convention `:root[dir="rtl"] &` override to flip the sign:

```scss
.value-bubble {
  /* … */
  transform: translateX(-50%);

  :root[dir="rtl"] & {
    transform: translateX(50%);
  }
}
```

## How to verify

1. `yarn start`
2. Open the language picker → pick **test language (rtl)** (or any of `ar-SA`, `fa-IR`, `he-IL`)
3. Draw a rectangle, keep it selected
4. Look at the **opacity** row in the right-side properties panel

**Before**

- Value bubble pinned to the physical-right, thumb on the physical-left
- "0" label sat on the physical-left
- Track filled left-to-right regardless of where the thumb was

(Original repro screenshot is on the issue: <https://github.com/excalidraw/excalidraw/issues/9710>)

**After**

- Value bubble follows the thumb at all values
- "0" label sits at the logical start (physical-right in RTL)
- Track fills from the thumb side outward

DOM check at `value=100` with `dir="rtl"` confirms the bubble's `insetInlineStart` matches the thumb's projected position and `rangeElement.style.background` starts with `linear-gradient(to left, …)`. In LTR, behaviour is unchanged (`left` → `insetInlineStart` resolves to `left`, gradient stays `to right`, `:root[dir="rtl"]` override doesn't fire).

## Scope

2 files, 17 / 8 lines. No public API change. No new tests in this PR — `Range` doesn't have a dedicated test file today and `dir`-conditional layout is hard to assert under JSDOM (no real layout). Happy to add a Playwright snapshot in a follow-up if the team prefers; landing this incrementally first keeps the diff reviewable.

## Out of scope

The reporter's second screenshot on #9710 ("also the user name") looks like a separate RTL layout issue in the username/avatar area — different component, different file. Left alone here to keep the diff focused.