### PR TITLE
feat: show hint on empty canvas when no drawing tool is selected

### DIFF
--- a/packages/excalidraw/components/HintViewer.tsx
+++ b/packages/excalidraw/components/HintViewer.tsx
@@ -176,6 +176,9 @@ const getHints = ({
     }
 
     if (!selectedElements.length && !isMobile) {
+      if (app.scene.getNonDeletedElements().length === 0) {
+        return t("hints.selectToolOnEmptyCanvas");
+      }
       return t("hints.canvasPanning", {
         shortcut_1: getTaggedShortcutKey(t("keys.mmb")),
         shortcut_2: getTaggedShortcutKey("Space"),

--- a/packages/excalidraw/locales/en.json
+++ b/packages/excalidraw/locales/en.json
@@ -357,6 +357,7 @@
   "hints": {
     "dismissSearch": "{{shortcut}} to dismiss search",
     "canvasPanning": "To move canvas, hold {{shortcut_1}} or {{shortcut_2}} while dragging, or use the hand tool",
+    "selectToolOnEmptyCanvas": "Select a shape or drawing tool from the toolbar to start creating",
     "linearElement": "Click to start multiple points, drag for single line",
     "arrowTool": "Click to start multiple points, drag for single line. Press {{shortcut}} again to change arrow type.",
     "arrowBindModifiers": "Hold {{shortcut_1}} to disable binding, or {{shortcut_2}} to bind at a fixed point",


### PR DESCRIPTION
Fixes #9541  - 'Enhancement: Show tooltip or hint when no drawing tool is selected'
Related to #11272

Shows a subtle hint at the bottom of the canvas when the user is on 
the selection tool and the canvas is empty, guiding new users to pick 
a drawing tool.

Changes made:
`HintViewer.tsx`: added hint condition for empty canvas + selection tool
`en.json`: added `hints.selectToolOnEmptyCanvas` string

Mobile excluded intentionally — the bottom toolbar is already 
  visually discoverable on small screens. I am happy to add if needed.