### PR TITLE
Fix canceling multi-point arrows

### DIFF
--- a/packages/excalidraw/actions/actionFinalize.tsx
+++ b/packages/excalidraw/actions/actionFinalize.tsx
@@ -44,10 +44,19 @@ import { register } from "./register";
 
 import type { AppState } from "../types";
 
-type FormData = {
-  event: PointerEvent;
-  sceneCoords: { x: number; y: number };
-};
+type FormData =
+  | {
+      event: PointerEvent;
+      sceneCoords: { x: number; y: number };
+    }
+  | Pick<KeyboardEvent, "key">;
+
+const isKeyboardFormData = (
+  data: FormData | undefined,
+): data is Pick<KeyboardEvent, "key"> => !!data && "key" in data;
+
+const isEscapeKey = (data: FormData | undefined) =>
+  isKeyboardFormData(data) && data.key === KEYS.ESCAPE;
 
 export const actionFinalize = register<FormData>({
   name: "finalize",
@@ -58,7 +67,7 @@ export const actionFinalize = register<FormData>({
     const { interactiveCanvas, focusContainer, scene } = app;
     const elementsMap = scene.getNonDeletedElementsMap();
 
-    if (data && appState.selectedLinearElement) {
+    if (data && !isKeyboardFormData(data) && appState.selectedLinearElement) {
       const { event, sceneCoords } = data;
       const element = LinearElementEditor.getElement(
         appState.selectedLinearElement.elementId,
@@ -209,6 +218,37 @@ export const actionFinalize = register<FormData>({
     }
 
     if (element) {
+      if (
+        isEscapeKey(data) &&
+        appState.newElement &&
+        appState.multiElement?.id === appState.newElement.id
+      ) {
+        return {
+          elements: newElements.map((el) => {
+            if (el.id === appState.newElement?.id) {
+              return newElementWith(el, { isDeleted: true });
+            }
+            return el;
+          }),
+          appState: {
+            ...appState,
+            cursorButton: "up",
+            activeTool: appState.activeTool.locked
+              ? appState.activeTool
+              : updateActiveTool(appState, {
+                  type: app.state.preferredSelectionTool.type,
+                }),
+            selectedElementIds: {},
+            selectedLinearElement: null,
+            newElement: null,
+            multiElement: null,
+            selectionElement: null,
+            suggestedBinding: null,
+          },
+          captureUpdate: CaptureUpdateAction.IMMEDIATELY,
+        };
+      }
+
       // pen and mouse have hover
       if (
         appState.selectedLinearElement &&

--- a/packages/excalidraw/actions/manager.tsx
+++ b/packages/excalidraw/actions/manager.tsx
@@ -119,13 +119,13 @@ export class ActionManager {
 
     const elements = this.getElementsIncludingDeleted();
     const appState = this.getAppState();
-    const value = null;
+    const value = action.name === "finalize" ? event : null;
 
-    trackAction(action, "keyboard", appState, elements, this.app, null);
+    trackAction(action, "keyboard", appState, elements, this.app, value);
 
     event.preventDefault();
     event.stopPropagation();
-    this.updater(data[0].perform(elements, appState, value, this.app));
+    this.updater(action.perform(elements, appState, value, this.app));
     return true;
   }
 

--- a/packages/excalidraw/tests/multiPointCreate.test.tsx
+++ b/packages/excalidraw/tests/multiPointCreate.test.tsx
@@ -138,6 +138,35 @@ describe("multi point mode in linear elements", () => {
     h.elements.forEach((element) => expect(element).toMatchSnapshot());
   });
 
+  it("bumps arrow version when canceling with Escape", async () => {
+    const { getByToolName, container } = await render(
+      <Excalidraw handleKeyboardGlobally={true} />,
+    );
+    // select tool
+    const tool = getByToolName("arrow");
+    fireEvent.click(tool);
+
+    const canvas = container.querySelector("canvas.interactive")!;
+    // first point is added on pointer down
+    fireEvent.pointerDown(canvas, { clientX: 30, clientY: 30 });
+    fireEvent.pointerUp(canvas, { clientX: 30, clientY: 30 });
+    fireEvent.pointerMove(canvas, { clientX: 50, clientY: 60 });
+
+    const versionBeforeCancel = h.elements[0].version;
+
+    fireEvent.keyDown(document, {
+      key: KEYS.ESCAPE,
+    });
+
+    expect(h.elements).toEqual([
+      expect.objectContaining({
+        type: "arrow",
+        isDeleted: true,
+        version: versionBeforeCancel + 1,
+      }),
+    ]);
+  });
+
   it("line", async () => {
     const { getByToolName, container } = await render(<Excalidraw />);
     // select tool


### PR DESCRIPTION
## Summary
- pass the keyboard event to the finalize action so Escape can be distinguished from Enter
- delete newly-created multi-point arrows when canceled with Escape, bumping the element version for collaboration sync
- add a regression test for canceling an in-progress multi-point arrow

Fixes #9467.

## Tests
- npx vitest run packages/excalidraw/tests/multiPointCreate.test.tsx
- npx vitest run packages/excalidraw/tests/dragCreate.test.tsx packages/excalidraw/tests/multiPointCreate.test.tsx
- npx eslint --max-warnings=0 packages/excalidraw/actions/actionFinalize.tsx packages/excalidraw/actions/manager.tsx packages/excalidraw/tests/multiPointCreate.test.tsx
- npx tsc --noEmit