### PR TITLE
feat (packages/excalidraw): add custom stroke width input

### DIFF
--- a/packages/excalidraw/actions/actionProperties.test.tsx
+++ b/packages/excalidraw/actions/actionProperties.test.tsx
@@ -1,4 +1,4 @@
-import { queryByTestId } from "@testing-library/react";
+import { fireEvent, queryByTestId } from "@testing-library/react";
 
 import {
   COLOR_PALETTE,
@@ -11,6 +11,8 @@ import { Excalidraw } from "../index";
 import { API } from "../tests/helpers/api";
 import { UI } from "../tests/helpers/ui";
 import { render } from "../tests/test-utils";
+
+const { h } = window;
 
 describe("element locking", () => {
   beforeEach(async () => {
@@ -150,6 +152,67 @@ describe("element locking", () => {
       expect(
         queryByTestId(document.body, `strokeWidth-extraBold`),
       ).not.toBeChecked();
+    });
+
+    it("should commit a custom stroke width through the numeric input", () => {
+      const rect = API.createElement({
+        type: "rectangle",
+        strokeWidth: STROKE_WIDTH.thin,
+      });
+      API.setElements([rect]);
+      API.setSelectedElements([rect]);
+
+      const input = queryByTestId(
+        document.body,
+        "strokeWidth-custom",
+      ) as HTMLInputElement;
+      expect(input).not.toBe(null);
+
+      fireEvent.change(input, { target: { value: "3.5" } });
+      fireEvent.blur(input);
+
+      expect(h.elements[0].strokeWidth).toBe(3.5);
+      expect(h.state.currentItemStrokeWidth).toBe(3.5);
+    });
+
+    it("should clamp out-of-range stroke width values", () => {
+      const rect = API.createElement({
+        type: "rectangle",
+        strokeWidth: STROKE_WIDTH.thin,
+      });
+      API.setElements([rect]);
+      API.setSelectedElements([rect]);
+
+      const input = queryByTestId(
+        document.body,
+        "strokeWidth-custom",
+      ) as HTMLInputElement;
+
+      fireEvent.change(input, { target: { value: "999" } });
+      fireEvent.blur(input);
+      expect(h.elements[0].strokeWidth).toBe(32);
+
+      fireEvent.change(input, { target: { value: "0" } });
+      fireEvent.blur(input);
+      expect(h.elements[0].strokeWidth).toBe(0.5);
+    });
+
+    it("should ignore non-numeric input and restore prior value", () => {
+      const rect = API.createElement({
+        type: "rectangle",
+        strokeWidth: STROKE_WIDTH.bold,
+      });
+      API.setElements([rect]);
+      API.setSelectedElements([rect]);
+
+      const input = queryByTestId(
+        document.body,
+        "strokeWidth-custom",
+      ) as HTMLInputElement;
+
+      fireEvent.change(input, { target: { value: "abc" } });
+      fireEvent.blur(input);
+      expect(h.elements[0].strokeWidth).toBe(STROKE_WIDTH.bold);
     });
 
     it("should show properties of different element types when selected", () => {

--- a/packages/excalidraw/actions/actionProperties.tsx
+++ b/packages/excalidraw/actions/actionProperties.tsx
@@ -544,6 +544,62 @@ export const actionChangeFillStyle = register<ExcalidrawElement["fillStyle"]>({
   },
 });
 
+const STROKE_WIDTH_MIN = 0.5;
+const STROKE_WIDTH_MAX = 32;
+const STROKE_WIDTH_STEP = 0.5;
+
+const clampStrokeWidth = (value: number) =>
+  Math.min(STROKE_WIDTH_MAX, Math.max(STROKE_WIDTH_MIN, value));
+
+const StrokeWidthCustomInput = ({
+  value,
+  onChange,
+}: {
+  value: number | null;
+  onChange: (value: number) => void;
+}) => {
+  const [draft, setDraft] = useState<string>(value == null ? "" : String(value));
+
+  useEffect(() => {
+    setDraft(value == null ? "" : String(value));
+  }, [value]);
+
+  const commit = (raw: string) => {
+    const trimmed = raw.trim();
+    const parsed = Number(trimmed);
+    if (trimmed === "" || !Number.isFinite(parsed)) {
+      setDraft(value == null ? "" : String(value));
+      return;
+    }
+    const clamped = clampStrokeWidth(parsed);
+    setDraft(String(clamped));
+    if (clamped !== value) {
+      onChange(clamped);
+    }
+  };
+
+  return (
+    <input
+      type="number"
+      className="strokeWidth-customInput"
+      min={STROKE_WIDTH_MIN}
+      max={STROKE_WIDTH_MAX}
+      step={STROKE_WIDTH_STEP}
+      value={draft}
+      onChange={(event) => setDraft(event.target.value)}
+      onBlur={(event) => commit(event.target.value)}
+      onKeyDown={(event) => {
+        if (event.key === KEYS.ENTER) {
+          event.currentTarget.blur();
+        }
+      }}
+      aria-label={t("labels.strokeWidthCustom")}
+      title={t("labels.strokeWidthCustom")}
+      data-testid="strokeWidth-custom"
+    />
+  );
+};
+
 export const actionChangeStrokeWidth = register<
   ExcalidrawElement["strokeWidth"]
 >({
@@ -561,45 +617,53 @@ export const actionChangeStrokeWidth = register<
       captureUpdate: CaptureUpdateAction.IMMEDIATELY,
     };
   },
-  PanelComponent: ({ elements, appState, updateData, app, data }) => (
-    <fieldset>
-      <legend>{t("labels.strokeWidth")}</legend>
-      <div className="buttonList">
-        <RadioSelection
-          group="stroke-width"
-          options={[
-            {
-              value: STROKE_WIDTH.thin,
-              text: t("labels.thin"),
-              icon: StrokeWidthBaseIcon,
-              testId: "strokeWidth-thin",
-            },
-            {
-              value: STROKE_WIDTH.bold,
-              text: t("labels.bold"),
-              icon: StrokeWidthBoldIcon,
-              testId: "strokeWidth-bold",
-            },
-            {
-              value: STROKE_WIDTH.extraBold,
-              text: t("labels.extraBold"),
-              icon: StrokeWidthExtraBoldIcon,
-              testId: "strokeWidth-extraBold",
-            },
-          ]}
-          value={getFormValue(
-            elements,
-            app,
-            (element) => element.strokeWidth,
-            (element) => element.hasOwnProperty("strokeWidth"),
-            (hasSelection) =>
-              hasSelection ? null : appState.currentItemStrokeWidth,
-          )}
-          onChange={(value) => updateData(value)}
-        />
-      </div>
-    </fieldset>
-  ),
+  PanelComponent: ({ elements, appState, updateData, app, data }) => {
+    const currentValue = getFormValue(
+      elements,
+      app,
+      (element) => element.strokeWidth,
+      (element) => element.hasOwnProperty("strokeWidth"),
+      (hasSelection) =>
+        hasSelection ? null : appState.currentItemStrokeWidth,
+    );
+
+    return (
+      <fieldset>
+        <legend>{t("labels.strokeWidth")}</legend>
+        <div className="buttonList strokeWidth-buttonList">
+          <RadioSelection
+            group="stroke-width"
+            options={[
+              {
+                value: STROKE_WIDTH.thin,
+                text: t("labels.thin"),
+                icon: StrokeWidthBaseIcon,
+                testId: "strokeWidth-thin",
+              },
+              {
+                value: STROKE_WIDTH.bold,
+                text: t("labels.bold"),
+                icon: StrokeWidthBoldIcon,
+                testId: "strokeWidth-bold",
+              },
+              {
+                value: STROKE_WIDTH.extraBold,
+                text: t("labels.extraBold"),
+                icon: StrokeWidthExtraBoldIcon,
+                testId: "strokeWidth-extraBold",
+              },
+            ]}
+            value={currentValue}
+            onChange={(value) => updateData(value)}
+          />
+          <StrokeWidthCustomInput
+            value={currentValue}
+            onChange={(value) => updateData(value)}
+          />
+        </div>
+      </fieldset>
+    );
+  },
 });
 
 export const actionChangeSloppiness = register<ExcalidrawElement["roughness"]>({

--- a/packages/excalidraw/css/styles.scss
+++ b/packages/excalidraw/css/styles.scss
@@ -202,6 +202,28 @@ body.excalidraw-cursor-resize * {
       }
     }
 
+    .strokeWidth-customInput {
+      width: 3.5rem;
+      height: 2rem;
+      padding: 0 0.375rem;
+      border-radius: var(--border-radius-md, 0.5rem);
+      border: 1px solid var(--input-border-color, var(--default-border-color));
+      background-color: var(--input-bg-color, var(--island-bg-color));
+      color: var(--text-primary-color);
+      font-size: 0.75rem;
+      font-family: inherit;
+      text-align: center;
+      box-sizing: border-box;
+      appearance: textfield;
+      -moz-appearance: textfield;
+
+      &::-webkit-outer-spin-button,
+      &::-webkit-inner-spin-button {
+        -webkit-appearance: none;
+        margin: 0;
+      }
+    }
+
     fieldset {
       margin: 0;
       padding: 0;

--- a/packages/excalidraw/locales/en.json
+++ b/packages/excalidraw/locales/en.json
@@ -30,6 +30,7 @@
     "changeBackground": "Change background color",
     "fill": "Fill",
     "strokeWidth": "Stroke width",
+    "strokeWidthCustom": "Custom stroke width",
     "strokeStyle": "Stroke style",
     "strokeStyle_solid": "Solid",
     "strokeStyle_dashed": "Dashed",


### PR DESCRIPTION
Adds a numeric input next to the thin/bold/extraBold radio buttons so users can type an exact stroke width. Values are clamped to [0.5, 32].