### PR TITLE
feat: add help dialog search

### DIFF
--- a/packages/excalidraw/components/CommandPalette/CommandPalette.tsx
+++ b/packages/excalidraw/components/CommandPalette/CommandPalette.tsx
@@ -1,5 +1,4 @@
 import clsx from "clsx";
-import fuzzy from "fuzzy";
 import { useEffect, useRef, useMemo, useState } from "react";
 
 import {
@@ -27,7 +26,6 @@ import {
 import { getShortcutFromShortcutName } from "../../actions/shortcuts";
 import { trackEvent } from "../../analytics";
 import { useUIAppState } from "../../context/ui-appState";
-import { deburr } from "../../deburr";
 import { atom, useAtom, editorJotaiStore } from "../../editor-jotai";
 import { t } from "../../i18n";
 import {
@@ -72,6 +70,7 @@ import {
 } from "../../hooks/useLibraryItemSvg";
 
 import * as defaultItems from "./defaultCommandPaletteItems";
+import { buildSearchHaystack, filterItemsBySearch } from "./search";
 import "./CommandPalette.scss";
 
 import type { CommandPaletteItem } from "./types";
@@ -235,7 +234,7 @@ function CommandPaletteInner({
           ),
           category: "Library",
           order: getCategoryOrder("Library"),
-          haystack: deburr(libraryItem.name),
+          haystack: buildSearchHaystack(libraryItem.name),
           perform: () => {
             app.onInsertElements(
               distributeLibraryItemsOnSquareGrid([libraryItem]),
@@ -616,9 +615,7 @@ function CommandPaletteInner({
           ...command,
           icon: command.icon || boltIcon,
           order: command.order ?? getCategoryOrder(command.category),
-          haystack: `${deburr(command.label.toLocaleLowerCase())} ${
-            command.keywords?.join(" ") || ""
-          }`,
+          haystack: buildSearchHaystack(command.label, command.keywords),
         };
       });
 
@@ -863,15 +860,7 @@ function CommandPaletteInner({
       return;
     }
 
-    const _query = deburr(
-      commandSearch.toLocaleLowerCase().replace(/[<>_| -]/g, ""),
-    );
-    matchingCommands = fuzzy
-      .filter(_query, matchingCommands, {
-        extract: (command) => command.haystack ?? "",
-      })
-      .sort((a, b) => b.score - a.score)
-      .map((item) => item.original);
+    matchingCommands = filterItemsBySearch(commandSearch, matchingCommands);
 
     setCommandsByCategory(getNextCommandsByCategory(matchingCommands));
     setCurrentCommand(matchingCommands[0] ?? null);

--- a/packages/excalidraw/components/CommandPalette/search.ts
+++ b/packages/excalidraw/components/CommandPalette/search.ts
@@ -1,0 +1,39 @@
+import fuzzy from "fuzzy";
+
+import { deburr } from "../../deburr";
+
+const SEARCH_QUERY_CHARS_TO_IGNORE = /[<>_| -]/g;
+
+export type SearchableItem = {
+  haystack?: string;
+};
+
+export const normalizeSearchQuery = (query: string) => {
+  return deburr(
+    query.toLocaleLowerCase().replace(SEARCH_QUERY_CHARS_TO_IGNORE, ""),
+  );
+};
+
+export const buildSearchHaystack = (
+  ...parts: Array<string | string[] | null | undefined>
+) => {
+  return deburr(parts.flat().filter(Boolean).join(" ").toLocaleLowerCase());
+};
+
+export const filterItemsBySearch = <T extends SearchableItem>(
+  query: string,
+  items: T[],
+) => {
+  const normalizedQuery = normalizeSearchQuery(query);
+
+  if (!normalizedQuery) {
+    return items;
+  }
+
+  return fuzzy
+    .filter(normalizedQuery, items, {
+      extract: (item) => item.haystack ?? "",
+    })
+    .sort((a, b) => b.score - a.score)
+    .map((item) => item.original);
+};

--- a/packages/excalidraw/components/HelpDialog.scss
+++ b/packages/excalidraw/components/HelpDialog.scss
@@ -18,6 +18,10 @@
       gap: 0.75rem;
     }
 
+    &__search {
+      margin-top: 1rem;
+    }
+
     &__btn {
       --background: var(--color-surface-mid);
 
@@ -106,6 +110,14 @@
       &:last-child {
         border-bottom: none;
       }
+    }
+
+    &__no-results {
+      grid-column: 1 / -1;
+      padding: 1rem;
+      color: var(--color-gray-50);
+      text-align: center;
+      font-size: 0.875rem;
     }
 
     &__key-container {

--- a/packages/excalidraw/components/HelpDialog.tsx
+++ b/packages/excalidraw/components/HelpDialog.tsx
@@ -1,20 +1,78 @@
 import React from "react";
 
-import { isDarwin, isFirefox, isWindows } from "@excalidraw/common";
-
-import { KEYS } from "@excalidraw/common";
+import {
+  EVENT,
+  KEYS,
+  addEventListener,
+  isDarwin,
+  isFirefox,
+  isWindows,
+} from "@excalidraw/common";
 
 import { getShortcutFromShortcutName } from "../actions/shortcuts";
 import { probablySupportsClipboardBlob } from "../clipboard";
 import { t } from "../i18n";
 import { getShortcutKey } from "../shortcut";
 
+import {
+  buildSearchHaystack,
+  normalizeSearchQuery,
+} from "./CommandPalette/search";
 import { Dialog } from "./Dialog";
-import { ExternalLinkIcon, GithubIcon, youtubeIcon } from "./icons";
+import { TextField } from "./TextField";
+import { ExternalLinkIcon, GithubIcon, searchIcon, youtubeIcon } from "./icons";
 
 import "./HelpDialog.scss";
 
 import type { JSX } from "react";
+
+type ShortcutData = {
+  id: string;
+  label: string;
+  shortcuts: string[];
+  isOr?: boolean;
+  keywords?: string[];
+  haystack: string;
+};
+
+type ShortcutIslandData = {
+  id: string;
+  caption: string;
+  className?: string;
+  shortcuts: ShortcutData[];
+};
+
+const shortcut = ({
+  id,
+  label,
+  shortcuts,
+  isOr,
+  keywords,
+}: Omit<ShortcutData, "haystack">): ShortcutData => ({
+  id,
+  label,
+  shortcuts,
+  isOr,
+  keywords,
+  haystack: buildSearchHaystack(label, shortcuts, keywords),
+});
+
+const shortcutMatchesSearch = (shortcut: ShortcutData, query: string) => {
+  const normalizedQuery = normalizeSearchQuery(query);
+
+  if (!normalizedQuery) {
+    return true;
+  }
+
+  const normalizedHaystack = normalizeSearchQuery(shortcut.haystack);
+
+  return (
+    normalizedHaystack.includes(normalizedQuery) ||
+    normalizedHaystack
+      .replace(/\+/g, "")
+      .includes(normalizedQuery.replace(/\+/g, ""))
+  );
+};
 
 const Header = () => (
   <div className="HelpDialog__header">
@@ -69,7 +127,11 @@ const ShortcutIsland = (props: {
   children: React.ReactNode;
   className?: string;
 }) => (
-  <div className={`HelpDialog__island ${props.className}`}>
+  <div
+    className={["HelpDialog__island", props.className]
+      .filter(Boolean)
+      .join(" ")}
+  >
     <h4 className="HelpDialog__island-title">{props.caption}</h4>
     <div className="HelpDialog__island-content">{props.children}</div>
   </div>
@@ -104,8 +166,10 @@ const Shortcut = ({
       ? [...shortcut.slice(0, -2).split("+"), "+"]
       : shortcut.split("+");
 
-    return keys.map((key) => (
-      <ShortcutKey key={key}>{upperCaseSingleChars(key)}</ShortcutKey>
+    return keys.map((key, index) => (
+      <ShortcutKey key={`${key}-${index}`}>
+        {upperCaseSingleChars(key)}
+      </ShortcutKey>
     ));
   });
 
@@ -123,12 +187,499 @@ const ShortcutKey = (props: { children: React.ReactNode }) => (
   <kbd className="HelpDialog__key" {...props} />
 );
 
+const getShortcutIslands = (): ShortcutIslandData[] => [
+  {
+    id: "tools",
+    caption: t("helpDialog.tools"),
+    className: "HelpDialog__island--tools",
+    shortcuts: [
+      shortcut({ id: "hand", label: t("toolBar.hand"), shortcuts: [KEYS.H] }),
+      shortcut({
+        id: "selection",
+        label: t("toolBar.selection"),
+        shortcuts: [KEYS.V, KEYS["1"]],
+      }),
+      shortcut({
+        id: "rectangle",
+        label: t("toolBar.rectangle"),
+        shortcuts: [KEYS.R, KEYS["2"]],
+      }),
+      shortcut({
+        id: "diamond",
+        label: t("toolBar.diamond"),
+        shortcuts: [KEYS.D, KEYS["3"]],
+      }),
+      shortcut({
+        id: "ellipse",
+        label: t("toolBar.ellipse"),
+        shortcuts: [KEYS.O, KEYS["4"]],
+      }),
+      shortcut({
+        id: "arrow",
+        label: t("toolBar.arrow"),
+        shortcuts: [KEYS.A, KEYS["5"]],
+      }),
+      shortcut({
+        id: "line",
+        label: t("toolBar.line"),
+        shortcuts: [KEYS.L, KEYS["6"]],
+      }),
+      shortcut({
+        id: "freedraw",
+        label: t("toolBar.freedraw"),
+        shortcuts: [KEYS.P, KEYS["7"]],
+      }),
+      shortcut({
+        id: "text",
+        label: t("toolBar.text"),
+        shortcuts: [KEYS.T, KEYS["8"]],
+      }),
+      shortcut({
+        id: "image",
+        label: t("toolBar.image"),
+        shortcuts: [KEYS["9"]],
+      }),
+      shortcut({
+        id: "eraser",
+        label: t("toolBar.eraser"),
+        shortcuts: [KEYS.E, KEYS["0"]],
+      }),
+      shortcut({ id: "frame", label: t("toolBar.frame"), shortcuts: [KEYS.F] }),
+      shortcut({ id: "laser", label: t("toolBar.laser"), shortcuts: [KEYS.K] }),
+      shortcut({
+        id: "eyeDropper",
+        label: t("labels.eyeDropper"),
+        shortcuts: [KEYS.I, "Shift+S", "Shift+G"],
+        keywords: ["color", "picker"],
+      }),
+      shortcut({
+        id: "editLineArrowPoints",
+        label: t("helpDialog.editLineArrowPoints"),
+        shortcuts: [getShortcutKey("CtrlOrCmd+Enter")],
+        keywords: ["line", "arrow", "points"],
+      }),
+      shortcut({
+        id: "editText",
+        label: t("helpDialog.editText"),
+        shortcuts: [getShortcutKey("Enter")],
+        keywords: ["label"],
+      }),
+      shortcut({
+        id: "textNewLine",
+        label: t("helpDialog.textNewLine"),
+        shortcuts: [getShortcutKey("Enter"), getShortcutKey("Shift+Enter")],
+      }),
+      shortcut({
+        id: "textFinish",
+        label: t("helpDialog.textFinish"),
+        shortcuts: [getShortcutKey("Esc"), getShortcutKey("CtrlOrCmd+Enter")],
+      }),
+      shortcut({
+        id: "curvedArrow",
+        label: t("helpDialog.curvedArrow"),
+        shortcuts: [
+          "A",
+          t("helpDialog.click"),
+          t("helpDialog.click"),
+          t("helpDialog.click"),
+        ],
+        isOr: false,
+      }),
+      shortcut({
+        id: "curvedLine",
+        label: t("helpDialog.curvedLine"),
+        shortcuts: [
+          "L",
+          t("helpDialog.click"),
+          t("helpDialog.click"),
+          t("helpDialog.click"),
+        ],
+        isOr: false,
+      }),
+      shortcut({
+        id: "cropStart",
+        label: t("helpDialog.cropStart"),
+        shortcuts: [t("helpDialog.doubleClick"), getShortcutKey("Enter")],
+      }),
+      shortcut({
+        id: "cropFinish",
+        label: t("helpDialog.cropFinish"),
+        shortcuts: [getShortcutKey("Enter"), getShortcutKey("Escape")],
+      }),
+      shortcut({ id: "lock", label: t("toolBar.lock"), shortcuts: [KEYS.Q] }),
+      shortcut({
+        id: "preventBinding",
+        label: t("helpDialog.preventBinding"),
+        shortcuts: [getShortcutKey("CtrlOrCmd")],
+        keywords: ["arrow"],
+      }),
+      shortcut({
+        id: "link",
+        label: t("toolBar.link"),
+        shortcuts: [getShortcutKey("CtrlOrCmd+K")],
+      }),
+      shortcut({
+        id: "convertElementType",
+        label: t("toolBar.convertElementType"),
+        shortcuts: ["Tab", "Shift+Tab"],
+      }),
+    ],
+  },
+  {
+    id: "view",
+    caption: t("helpDialog.view"),
+    className: "HelpDialog__island--view",
+    shortcuts: [
+      shortcut({
+        id: "zoomIn",
+        label: t("buttons.zoomIn"),
+        shortcuts: [getShortcutKey("CtrlOrCmd++")],
+      }),
+      shortcut({
+        id: "zoomOut",
+        label: t("buttons.zoomOut"),
+        shortcuts: [getShortcutKey("CtrlOrCmd+-")],
+      }),
+      shortcut({
+        id: "resetZoom",
+        label: t("buttons.resetZoom"),
+        shortcuts: [getShortcutKey("CtrlOrCmd+0")],
+      }),
+      shortcut({
+        id: "zoomToFit",
+        label: t("helpDialog.zoomToFit"),
+        shortcuts: ["Shift+1"],
+      }),
+      shortcut({
+        id: "zoomToSelection",
+        label: t("helpDialog.zoomToSelection"),
+        shortcuts: ["Shift+2"],
+      }),
+      shortcut({
+        id: "movePageUpDown",
+        label: t("helpDialog.movePageUpDown"),
+        shortcuts: ["PgUp/PgDn"],
+        keywords: ["page"],
+      }),
+      shortcut({
+        id: "movePageLeftRight",
+        label: t("helpDialog.movePageLeftRight"),
+        shortcuts: ["Shift+PgUp/PgDn"],
+        keywords: ["page"],
+      }),
+      shortcut({
+        id: "zenMode",
+        label: t("buttons.zenMode"),
+        shortcuts: [getShortcutKey("Alt+Z")],
+      }),
+      shortcut({
+        id: "objectsSnapMode",
+        label: t("buttons.objectsSnapMode"),
+        shortcuts: [getShortcutKey("Alt+S")],
+      }),
+      shortcut({
+        id: "toggleGrid",
+        label: t("labels.toggleGrid"),
+        shortcuts: [getShortcutKey("CtrlOrCmd+'")],
+      }),
+      shortcut({
+        id: "viewMode",
+        label: t("labels.viewMode"),
+        shortcuts: [getShortcutKey("Alt+R")],
+      }),
+      shortcut({
+        id: "toggleTheme",
+        label: t("labels.toggleTheme"),
+        shortcuts: [getShortcutKey("Alt+Shift+D")],
+        keywords: ["dark", "light", "mode"],
+      }),
+      shortcut({
+        id: "stats",
+        label: t("stats.fullTitle"),
+        shortcuts: [getShortcutKey("Alt+/")],
+      }),
+      shortcut({
+        id: "search",
+        label: t("search.title"),
+        shortcuts: [getShortcutFromShortcutName("searchMenu")],
+        keywords: ["find"],
+      }),
+      shortcut({
+        id: "commandPalette",
+        label: t("commandPalette.title"),
+        shortcuts: isFirefox
+          ? [getShortcutFromShortcutName("commandPalette")]
+          : [
+              getShortcutFromShortcutName("commandPalette"),
+              getShortcutFromShortcutName("commandPalette", 1),
+            ],
+        keywords: ["commands", "menu"],
+      }),
+    ],
+  },
+  {
+    id: "editor",
+    caption: t("helpDialog.editor"),
+    className: "HelpDialog__island--editor",
+    shortcuts: [
+      shortcut({
+        id: "createFlowchart",
+        label: t("helpDialog.createFlowchart"),
+        shortcuts: [getShortcutKey(`CtrlOrCmd+Arrow Key`)],
+        keywords: ["flowchart"],
+      }),
+      shortcut({
+        id: "navigateFlowchart",
+        label: t("helpDialog.navigateFlowchart"),
+        shortcuts: [getShortcutKey(`Alt+Arrow Key`)],
+        keywords: ["flowchart"],
+      }),
+      shortcut({
+        id: "moveCanvas",
+        label: t("labels.moveCanvas"),
+        shortcuts: [
+          getShortcutKey(`Space+${t("helpDialog.drag")}`),
+          getShortcutKey(`Wheel+${t("helpDialog.drag")}`),
+        ],
+        keywords: ["pan"],
+      }),
+      shortcut({
+        id: "clearCanvas",
+        label: t("buttons.clearReset"),
+        shortcuts: [getShortcutKey("CtrlOrCmd+Delete")],
+      }),
+      shortcut({
+        id: "delete",
+        label: t("labels.delete"),
+        shortcuts: [getShortcutKey("Delete")],
+      }),
+      shortcut({
+        id: "cut",
+        label: t("labels.cut"),
+        shortcuts: [getShortcutKey("CtrlOrCmd+X")],
+      }),
+      shortcut({
+        id: "copy",
+        label: t("labels.copy"),
+        shortcuts: [getShortcutKey("CtrlOrCmd+C")],
+      }),
+      shortcut({
+        id: "paste",
+        label: t("labels.paste"),
+        shortcuts: [getShortcutKey("CtrlOrCmd+V")],
+      }),
+      shortcut({
+        id: "pasteAsPlaintext",
+        label: t("labels.pasteAsPlaintext"),
+        shortcuts: [getShortcutKey("CtrlOrCmd+Shift+V")],
+      }),
+      shortcut({
+        id: "selectAll",
+        label: t("labels.selectAll"),
+        shortcuts: [getShortcutKey("CtrlOrCmd+A")],
+      }),
+      shortcut({
+        id: "multiSelect",
+        label: t("labels.multiSelect"),
+        shortcuts: [getShortcutKey(`Shift+${t("helpDialog.click")}`)],
+      }),
+      shortcut({
+        id: "deepSelect",
+        label: t("helpDialog.deepSelect"),
+        shortcuts: [getShortcutKey(`CtrlOrCmd+${t("helpDialog.click")}`)],
+      }),
+      shortcut({
+        id: "deepBoxSelect",
+        label: t("helpDialog.deepBoxSelect"),
+        shortcuts: [getShortcutKey(`CtrlOrCmd+${t("helpDialog.drag")}`)],
+      }),
+      ...(probablySupportsClipboardBlob || isFirefox
+        ? [
+            shortcut({
+              id: "copyAsPng",
+              label: t("labels.copyAsPng"),
+              shortcuts: [getShortcutKey("Shift+Alt+C")],
+              keywords: ["clipboard", "image"],
+            }),
+          ]
+        : []),
+      shortcut({
+        id: "copyStyles",
+        label: t("labels.copyStyles"),
+        shortcuts: [getShortcutKey("CtrlOrCmd+Alt+C")],
+      }),
+      shortcut({
+        id: "pasteStyles",
+        label: t("labels.pasteStyles"),
+        shortcuts: [getShortcutKey("CtrlOrCmd+Alt+V")],
+      }),
+      shortcut({
+        id: "sendToBack",
+        label: t("labels.sendToBack"),
+        shortcuts: [
+          isDarwin
+            ? getShortcutKey("CtrlOrCmd+Alt+[")
+            : getShortcutKey("CtrlOrCmd+Shift+["),
+        ],
+        keywords: ["zindex", "layer"],
+      }),
+      shortcut({
+        id: "bringToFront",
+        label: t("labels.bringToFront"),
+        shortcuts: [
+          isDarwin
+            ? getShortcutKey("CtrlOrCmd+Alt+]")
+            : getShortcutKey("CtrlOrCmd+Shift+]"),
+        ],
+        keywords: ["zindex", "layer"],
+      }),
+      shortcut({
+        id: "sendBackward",
+        label: t("labels.sendBackward"),
+        shortcuts: [getShortcutKey("CtrlOrCmd+[")],
+        keywords: ["zindex", "layer"],
+      }),
+      shortcut({
+        id: "bringForward",
+        label: t("labels.bringForward"),
+        shortcuts: [getShortcutKey("CtrlOrCmd+]")],
+        keywords: ["zindex", "layer"],
+      }),
+      shortcut({
+        id: "alignTop",
+        label: t("labels.alignTop"),
+        shortcuts: [getShortcutKey("CtrlOrCmd+Shift+Up")],
+      }),
+      shortcut({
+        id: "alignBottom",
+        label: t("labels.alignBottom"),
+        shortcuts: [getShortcutKey("CtrlOrCmd+Shift+Down")],
+      }),
+      shortcut({
+        id: "alignLeft",
+        label: t("labels.alignLeft"),
+        shortcuts: [getShortcutKey("CtrlOrCmd+Shift+Left")],
+      }),
+      shortcut({
+        id: "alignRight",
+        label: t("labels.alignRight"),
+        shortcuts: [getShortcutKey("CtrlOrCmd+Shift+Right")],
+      }),
+      shortcut({
+        id: "duplicateSelection",
+        label: t("labels.duplicateSelection"),
+        shortcuts: [
+          getShortcutKey("CtrlOrCmd+D"),
+          getShortcutKey(`Alt+${t("helpDialog.drag")}`),
+        ],
+      }),
+      shortcut({
+        id: "toggleElementLock",
+        label: t("helpDialog.toggleElementLock"),
+        shortcuts: [getShortcutKey("CtrlOrCmd+Shift+L")],
+      }),
+      shortcut({
+        id: "undo",
+        label: t("buttons.undo"),
+        shortcuts: [getShortcutKey("CtrlOrCmd+Z")],
+      }),
+      shortcut({
+        id: "redo",
+        label: t("buttons.redo"),
+        shortcuts: isWindows
+          ? [getShortcutKey("CtrlOrCmd+Y"), getShortcutKey("CtrlOrCmd+Shift+Z")]
+          : [getShortcutKey("CtrlOrCmd+Shift+Z")],
+      }),
+      shortcut({
+        id: "group",
+        label: t("labels.group"),
+        shortcuts: [getShortcutKey("CtrlOrCmd+G")],
+      }),
+      shortcut({
+        id: "ungroup",
+        label: t("labels.ungroup"),
+        shortcuts: [getShortcutKey("CtrlOrCmd+Shift+G")],
+      }),
+      shortcut({
+        id: "flipHorizontal",
+        label: t("labels.flipHorizontal"),
+        shortcuts: [getShortcutKey("Shift+H")],
+      }),
+      shortcut({
+        id: "flipVertical",
+        label: t("labels.flipVertical"),
+        shortcuts: [getShortcutKey("Shift+V")],
+      }),
+      shortcut({
+        id: "showStroke",
+        label: t("labels.showStroke"),
+        shortcuts: [getShortcutKey("S")],
+      }),
+      shortcut({
+        id: "showBackground",
+        label: t("labels.showBackground"),
+        shortcuts: [getShortcutKey("G")],
+      }),
+      shortcut({
+        id: "showFonts",
+        label: t("labels.showFonts"),
+        shortcuts: [getShortcutKey("Shift+F")],
+        keywords: ["font", "family", "picker"],
+      }),
+      shortcut({
+        id: "decreaseFontSize",
+        label: t("labels.decreaseFontSize"),
+        shortcuts: [getShortcutKey("CtrlOrCmd+Shift+<")],
+        keywords: ["font"],
+      }),
+      shortcut({
+        id: "increaseFontSize",
+        label: t("labels.increaseFontSize"),
+        shortcuts: [getShortcutKey("CtrlOrCmd+Shift+>")],
+        keywords: ["font"],
+      }),
+    ],
+  },
+];
+
 export const HelpDialog = ({ onClose }: { onClose?: () => void }) => {
+  const [searchQuery, setSearchQuery] = React.useState("");
+  const searchInputRef = React.useRef<HTMLInputElement>(null);
+
   const handleClose = React.useCallback(() => {
     if (onClose) {
       onClose();
     }
   }, [onClose]);
+
+  React.useEffect(() => {
+    const eventHandler = (event: KeyboardEvent) => {
+      if (event[KEYS.CTRL_OR_CMD] && event.key.toLocaleLowerCase() === KEYS.F) {
+        event.preventDefault();
+        event.stopPropagation();
+        searchInputRef.current?.focus();
+        searchInputRef.current?.select();
+      }
+    };
+
+    return addEventListener(window, EVENT.KEYDOWN, eventHandler, {
+      capture: true,
+      passive: false,
+    });
+  }, []);
+
+  const shortcutIslands = getShortcutIslands();
+  const trimmedSearchQuery = searchQuery.trim();
+  const filteredShortcutIslands = trimmedSearchQuery
+    ? shortcutIslands
+        .map((island) => ({
+          ...island,
+          shortcuts: island.shortcuts.filter((shortcut) =>
+            shortcutMatchesSearch(shortcut, trimmedSearchQuery),
+          ),
+        }))
+        .filter((island) => island.shortcuts.length > 0)
+    : shortcutIslands;
 
   return (
     <>
@@ -138,375 +689,32 @@ export const HelpDialog = ({ onClose }: { onClose?: () => void }) => {
         className={"HelpDialog"}
       >
         <Header />
+        <TextField
+          className="HelpDialog__search"
+          value={searchQuery}
+          ref={searchInputRef}
+          placeholder={t("commandPalette.search.placeholder")}
+          icon={searchIcon}
+          type="search"
+          fullWidth
+          onChange={setSearchQuery}
+        />
         <Section title={t("helpDialog.shortcuts")}>
-          <ShortcutIsland
-            className="HelpDialog__island--tools"
-            caption={t("helpDialog.tools")}
-          >
-            <Shortcut label={t("toolBar.hand")} shortcuts={[KEYS.H]} />
-            <Shortcut
-              label={t("toolBar.selection")}
-              shortcuts={[KEYS.V, KEYS["1"]]}
-            />
-            <Shortcut
-              label={t("toolBar.rectangle")}
-              shortcuts={[KEYS.R, KEYS["2"]]}
-            />
-            <Shortcut
-              label={t("toolBar.diamond")}
-              shortcuts={[KEYS.D, KEYS["3"]]}
-            />
-            <Shortcut
-              label={t("toolBar.ellipse")}
-              shortcuts={[KEYS.O, KEYS["4"]]}
-            />
-            <Shortcut
-              label={t("toolBar.arrow")}
-              shortcuts={[KEYS.A, KEYS["5"]]}
-            />
-            <Shortcut
-              label={t("toolBar.line")}
-              shortcuts={[KEYS.L, KEYS["6"]]}
-            />
-            <Shortcut
-              label={t("toolBar.freedraw")}
-              shortcuts={[KEYS.P, KEYS["7"]]}
-            />
-            <Shortcut
-              label={t("toolBar.text")}
-              shortcuts={[KEYS.T, KEYS["8"]]}
-            />
-            <Shortcut label={t("toolBar.image")} shortcuts={[KEYS["9"]]} />
-            <Shortcut
-              label={t("toolBar.eraser")}
-              shortcuts={[KEYS.E, KEYS["0"]]}
-            />
-            <Shortcut label={t("toolBar.frame")} shortcuts={[KEYS.F]} />
-            <Shortcut label={t("toolBar.laser")} shortcuts={[KEYS.K]} />
-            <Shortcut
-              label={t("labels.eyeDropper")}
-              shortcuts={[KEYS.I, "Shift+S", "Shift+G"]}
-            />
-            <Shortcut
-              label={t("helpDialog.editLineArrowPoints")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+Enter")]}
-            />
-            <Shortcut
-              label={t("helpDialog.editText")}
-              shortcuts={[getShortcutKey("Enter")]}
-            />
-            <Shortcut
-              label={t("helpDialog.textNewLine")}
-              shortcuts={[
-                getShortcutKey("Enter"),
-                getShortcutKey("Shift+Enter"),
-              ]}
-            />
-            <Shortcut
-              label={t("helpDialog.textFinish")}
-              shortcuts={[
-                getShortcutKey("Esc"),
-                getShortcutKey("CtrlOrCmd+Enter"),
-              ]}
-            />
-            <Shortcut
-              label={t("helpDialog.curvedArrow")}
-              shortcuts={[
-                "A",
-                t("helpDialog.click"),
-                t("helpDialog.click"),
-                t("helpDialog.click"),
-              ]}
-              isOr={false}
-            />
-            <Shortcut
-              label={t("helpDialog.curvedLine")}
-              shortcuts={[
-                "L",
-                t("helpDialog.click"),
-                t("helpDialog.click"),
-                t("helpDialog.click"),
-              ]}
-              isOr={false}
-            />
-            <Shortcut
-              label={t("helpDialog.cropStart")}
-              shortcuts={[t("helpDialog.doubleClick"), getShortcutKey("Enter")]}
-              isOr={true}
-            />
-            <Shortcut
-              label={t("helpDialog.cropFinish")}
-              shortcuts={[getShortcutKey("Enter"), getShortcutKey("Escape")]}
-              isOr={true}
-            />
-            <Shortcut label={t("toolBar.lock")} shortcuts={[KEYS.Q]} />
-            <Shortcut
-              label={t("helpDialog.preventBinding")}
-              shortcuts={[getShortcutKey("CtrlOrCmd")]}
-            />
-            <Shortcut
-              label={t("toolBar.link")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+K")]}
-            />
-            <Shortcut
-              label={t("toolBar.convertElementType")}
-              shortcuts={["Tab", "Shift+Tab"]}
-              isOr={true}
-            />
-          </ShortcutIsland>
-          <ShortcutIsland
-            className="HelpDialog__island--view"
-            caption={t("helpDialog.view")}
-          >
-            <Shortcut
-              label={t("buttons.zoomIn")}
-              shortcuts={[getShortcutKey("CtrlOrCmd++")]}
-            />
-            <Shortcut
-              label={t("buttons.zoomOut")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+-")]}
-            />
-            <Shortcut
-              label={t("buttons.resetZoom")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+0")]}
-            />
-            <Shortcut
-              label={t("helpDialog.zoomToFit")}
-              shortcuts={["Shift+1"]}
-            />
-            <Shortcut
-              label={t("helpDialog.zoomToSelection")}
-              shortcuts={["Shift+2"]}
-            />
-            <Shortcut
-              label={t("helpDialog.movePageUpDown")}
-              shortcuts={["PgUp/PgDn"]}
-            />
-            <Shortcut
-              label={t("helpDialog.movePageLeftRight")}
-              shortcuts={["Shift+PgUp/PgDn"]}
-            />
-            <Shortcut
-              label={t("buttons.zenMode")}
-              shortcuts={[getShortcutKey("Alt+Z")]}
-            />
-            <Shortcut
-              label={t("buttons.objectsSnapMode")}
-              shortcuts={[getShortcutKey("Alt+S")]}
-            />
-            <Shortcut
-              label={t("labels.toggleGrid")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+'")]}
-            />
-            <Shortcut
-              label={t("labels.viewMode")}
-              shortcuts={[getShortcutKey("Alt+R")]}
-            />
-            <Shortcut
-              label={t("labels.toggleTheme")}
-              shortcuts={[getShortcutKey("Alt+Shift+D")]}
-            />
-            <Shortcut
-              label={t("stats.fullTitle")}
-              shortcuts={[getShortcutKey("Alt+/")]}
-            />
-            <Shortcut
-              label={t("search.title")}
-              shortcuts={[getShortcutFromShortcutName("searchMenu")]}
-            />
-            <Shortcut
-              label={t("commandPalette.title")}
-              shortcuts={
-                isFirefox
-                  ? [getShortcutFromShortcutName("commandPalette")]
-                  : [
-                      getShortcutFromShortcutName("commandPalette"),
-                      getShortcutFromShortcutName("commandPalette", 1),
-                    ]
-              }
-            />
-          </ShortcutIsland>
-          <ShortcutIsland
-            className="HelpDialog__island--editor"
-            caption={t("helpDialog.editor")}
-          >
-            <Shortcut
-              label={t("helpDialog.createFlowchart")}
-              shortcuts={[getShortcutKey(`CtrlOrCmd+Arrow Key`)]}
-              isOr={true}
-            />
-            <Shortcut
-              label={t("helpDialog.navigateFlowchart")}
-              shortcuts={[getShortcutKey(`Alt+Arrow Key`)]}
-              isOr={true}
-            />
-            <Shortcut
-              label={t("labels.moveCanvas")}
-              shortcuts={[
-                getShortcutKey(`Space+${t("helpDialog.drag")}`),
-                getShortcutKey(`Wheel+${t("helpDialog.drag")}`),
-              ]}
-              isOr={true}
-            />
-            <Shortcut
-              label={t("buttons.clearReset")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+Delete")]}
-            />
-            <Shortcut
-              label={t("labels.delete")}
-              shortcuts={[getShortcutKey("Delete")]}
-            />
-            <Shortcut
-              label={t("labels.cut")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+X")]}
-            />
-            <Shortcut
-              label={t("labels.copy")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+C")]}
-            />
-            <Shortcut
-              label={t("labels.paste")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+V")]}
-            />
-            <Shortcut
-              label={t("labels.pasteAsPlaintext")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+Shift+V")]}
-            />
-            <Shortcut
-              label={t("labels.selectAll")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+A")]}
-            />
-            <Shortcut
-              label={t("labels.multiSelect")}
-              shortcuts={[getShortcutKey(`Shift+${t("helpDialog.click")}`)]}
-            />
-            <Shortcut
-              label={t("helpDialog.deepSelect")}
-              shortcuts={[getShortcutKey(`CtrlOrCmd+${t("helpDialog.click")}`)]}
-            />
-            <Shortcut
-              label={t("helpDialog.deepBoxSelect")}
-              shortcuts={[getShortcutKey(`CtrlOrCmd+${t("helpDialog.drag")}`)]}
-            />
-            {/* firefox supports clipboard API under a flag, so we'll
-                show users what they can do in the error message */}
-            {(probablySupportsClipboardBlob || isFirefox) && (
-              <Shortcut
-                label={t("labels.copyAsPng")}
-                shortcuts={[getShortcutKey("Shift+Alt+C")]}
-              />
-            )}
-            <Shortcut
-              label={t("labels.copyStyles")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+Alt+C")]}
-            />
-            <Shortcut
-              label={t("labels.pasteStyles")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+Alt+V")]}
-            />
-            <Shortcut
-              label={t("labels.sendToBack")}
-              shortcuts={[
-                isDarwin
-                  ? getShortcutKey("CtrlOrCmd+Alt+[")
-                  : getShortcutKey("CtrlOrCmd+Shift+["),
-              ]}
-            />
-            <Shortcut
-              label={t("labels.bringToFront")}
-              shortcuts={[
-                isDarwin
-                  ? getShortcutKey("CtrlOrCmd+Alt+]")
-                  : getShortcutKey("CtrlOrCmd+Shift+]"),
-              ]}
-            />
-            <Shortcut
-              label={t("labels.sendBackward")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+[")]}
-            />
-            <Shortcut
-              label={t("labels.bringForward")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+]")]}
-            />
-            <Shortcut
-              label={t("labels.alignTop")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+Shift+Up")]}
-            />
-            <Shortcut
-              label={t("labels.alignBottom")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+Shift+Down")]}
-            />
-            <Shortcut
-              label={t("labels.alignLeft")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+Shift+Left")]}
-            />
-            <Shortcut
-              label={t("labels.alignRight")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+Shift+Right")]}
-            />
-            <Shortcut
-              label={t("labels.duplicateSelection")}
-              shortcuts={[
-                getShortcutKey("CtrlOrCmd+D"),
-                getShortcutKey(`Alt+${t("helpDialog.drag")}`),
-              ]}
-            />
-            <Shortcut
-              label={t("helpDialog.toggleElementLock")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+Shift+L")]}
-            />
-            <Shortcut
-              label={t("buttons.undo")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+Z")]}
-            />
-            <Shortcut
-              label={t("buttons.redo")}
-              shortcuts={
-                isWindows
-                  ? [
-                      getShortcutKey("CtrlOrCmd+Y"),
-                      getShortcutKey("CtrlOrCmd+Shift+Z"),
-                    ]
-                  : [getShortcutKey("CtrlOrCmd+Shift+Z")]
-              }
-            />
-            <Shortcut
-              label={t("labels.group")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+G")]}
-            />
-            <Shortcut
-              label={t("labels.ungroup")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+Shift+G")]}
-            />
-            <Shortcut
-              label={t("labels.flipHorizontal")}
-              shortcuts={[getShortcutKey("Shift+H")]}
-            />
-            <Shortcut
-              label={t("labels.flipVertical")}
-              shortcuts={[getShortcutKey("Shift+V")]}
-            />
-            <Shortcut
-              label={t("labels.showStroke")}
-              shortcuts={[getShortcutKey("S")]}
-            />
-            <Shortcut
-              label={t("labels.showBackground")}
-              shortcuts={[getShortcutKey("G")]}
-            />
-            <Shortcut
-              label={t("labels.showFonts")}
-              shortcuts={[getShortcutKey("Shift+F")]}
-            />
-            <Shortcut
-              label={t("labels.decreaseFontSize")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+Shift+<")]}
-            />
-            <Shortcut
-              label={t("labels.increaseFontSize")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+Shift+>")]}
-            />
-          </ShortcutIsland>
+          {filteredShortcutIslands.length > 0 ? (
+            filteredShortcutIslands.map((island) => (
+              <ShortcutIsland
+                key={island.id}
+                className={island.className}
+                caption={island.caption}
+              >
+                {island.shortcuts.map((shortcut) => (
+                  <Shortcut key={shortcut.id} {...shortcut} />
+                ))}
+              </ShortcutIsland>
+            ))
+          ) : (
+            <div className="HelpDialog__no-results">{t("search.noMatch")}</div>
+          )}
         </Section>
       </Dialog>
     </>

--- a/packages/excalidraw/tests/search.test.tsx
+++ b/packages/excalidraw/tests/search.test.tsx
@@ -17,7 +17,7 @@ import { Excalidraw } from "../index";
 import { API } from "./helpers/api";
 import { Keyboard } from "./helpers/ui";
 import { updateTextEditor } from "./queries/dom";
-import { act, render, waitFor } from "./test-utils";
+import { act, render, screen, waitFor } from "./test-utils";
 
 const { h } = window;
 
@@ -27,6 +27,18 @@ const querySearchInput = async () => {
       `.${CLASSES.SEARCH_MENU_INPUT_WRAPPER} input`,
     )!;
   await waitFor(() => expect(input).not.toBeNull());
+  return input;
+};
+
+const queryHelpSearchInput = async () => {
+  await waitFor(() => {
+    expect(document.querySelector(".HelpDialog")).not.toBeNull();
+  });
+
+  const input = document.querySelector<HTMLInputElement>(
+    ".HelpDialog__search input",
+  )!;
+  expect(input).not.toBeNull();
   return input;
 };
 
@@ -73,6 +85,50 @@ describe("search", () => {
       Keyboard.keyPress(KEYS.F);
     });
     expect(searchInput?.matches(":focus")).toBe(true);
+  });
+
+  it("should focus help dialog search on cmd+f without opening canvas search", async () => {
+    API.setAppState({
+      openDialog: { name: "help" },
+      openSidebar: null,
+    });
+
+    const helpSearchInput = await queryHelpSearchInput();
+
+    Keyboard.withModifierKeys({ ctrl: true }, () => {
+      Keyboard.keyPress(KEYS.F);
+    });
+
+    expect(h.app.state.openDialog?.name).toBe("help");
+    expect(h.app.state.openSidebar).toBeNull();
+    expect(helpSearchInput.matches(":focus")).toBe(true);
+  });
+
+  it("should filter help dialog shortcuts", async () => {
+    API.setAppState({
+      openDialog: { name: "help" },
+      openSidebar: null,
+    });
+
+    const helpSearchInput = await queryHelpSearchInput();
+
+    updateTextEditor(helpSearchInput, "font");
+
+    await waitFor(() => {
+      expect(screen.getByText("Show font picker")).toBeInTheDocument();
+      expect(screen.getByText("Decrease font size")).toBeInTheDocument();
+      expect(screen.queryByText("Find on canvas")).not.toBeInTheDocument();
+      expect(
+        screen.queryByText("Finish editing (text editor)"),
+      ).not.toBeInTheDocument();
+      expect(screen.queryByText("Zoom in")).not.toBeInTheDocument();
+    });
+
+    updateTextEditor(helpSearchInput, "zzzzzz");
+
+    await waitFor(() => {
+      expect(screen.getByText("No matches found...")).toBeInTheDocument();
+    });
   });
 
   it("should match text and cycle through matches on Enter", async () => {


### PR DESCRIPTION
﻿Fixes #9276.

## Summary
- Add search inside the Help dialog.
- Focus the Help search field with Ctrl/Cmd+F while Help is open.
- Reuse the command palette fuzzy search helper.

## Testing
- `corepack yarn test:app packages/excalidraw/tests/search.test.tsx --watch=false`
- `corepack yarn test:typecheck`
- `corepack yarn eslint --max-warnings=0 packages/excalidraw/components/CommandPalette/CommandPalette.tsx packages/excalidraw/components/CommandPalette/search.ts packages/excalidraw/components/HelpDialog.tsx packages/excalidraw/tests/search.test.tsx`
