### PR TITLE
fix: prevent browser default save dialog when Ctrl+S pressed in text editor

### DIFF
--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -4989,6 +4989,14 @@ class App extends React.Component<AppProps, AppState> {
         // or unless using arrows (to move between buttons)
         (isArrowKey(event.key) && isInputLike(event.target))
       ) {
+        // Fix #9281: Prevent browser's default save dialog when Ctrl+S is pressed in text editor
+        if (
+          isWritableElement(event.target) &&
+          event[KEYS.CTRL_OR_CMD] &&
+          event.key.toLowerCase() === KEYS.S
+        ) {
+          event.preventDefault();
+        }
         return;
       }
 

--- a/packages/excalidraw/tests/shortcuts.test.tsx
+++ b/packages/excalidraw/tests/shortcuts.test.tsx
@@ -31,4 +31,37 @@ describe("shortcuts", () => {
       expect(window.h.elements[0].isDeleted).toBe(true);
     });
   });
+
+  // Regression test for https://github.com/excalidraw/excalidraw/issues/9281
+  it("Ctrl+S in text editor should prevent default browser save dialog", async () => {
+    const preventDefaultMock = jest.fn();
+    await render(
+      <Excalidraw
+        initialData={{
+          elements: [API.createElement({ type: "text" })],
+        }}
+        handleKeyboardGlobally
+      />,
+    );
+
+    // Focus on the text element to enter text editing mode
+    const textElement = document.querySelector(".excalidraw-textEditable");
+    expect(textElement).not.toBe(null);
+
+    // Simulate Ctrl+S keydown event while in text editing mode
+    const keyboardEvent = new KeyboardEvent("keydown", {
+      key: "s",
+      code: "KeyS",
+      ctrlKey: true,
+      metaKey: false,
+      bubbles: true,
+    });
+    keyboardEvent.preventDefault = preventDefaultMock;
+
+    // Dispatch the event
+    document.dispatchEvent(keyboardEvent);
+
+    // The event should be prevented (browser default save dialog should not appear)
+    expect(preventDefaultMock).toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
Fixes #9281

When the user is editing text in Excalidraw and presses Ctrl+S, the browser's default 'Save As' dialog appears instead of being prevented. This PR fixes this behavior by adding a check to call event.preventDefault() when Ctrl+S is pressed in a writable element.

Added a regression test to verify this behavior.