### PR TITLE
fix: show error message for invalid hex color input

### DIFF
--- a/packages/excalidraw/components/ColorPicker/ColorInput.tsx
+++ b/packages/excalidraw/components/ColorPicker/ColorInput.tsx
@@ -29,21 +29,28 @@ export const ColorInput = ({
 }) => {
   const editorInterface = useEditorInterface();
   const [innerValue, setInnerValue] = useState(color);
+  const [error, setError] = useState<string | null>(null);
   const [activeSection, setActiveColorPickerSection] = useAtom(
     activeColorPickerSectionAtom,
   );
 
   useEffect(() => {
     setInnerValue(color);
+    setError(null);
   }, [color]);
 
   const changeColor = useCallback(
     (inputValue: string) => {
       const value = inputValue.toLowerCase();
-      const color = normalizeInputColor(value);
+      const normalizedColor = normalizeInputColor(value);
 
-      if (color) {
-        onChange(color);
+      if (normalizedColor) {
+        onChange(normalizedColor);
+        setError(null);
+      } else if (value.length > 0) {
+        setError("Invalid color");
+      } else {
+        setError(null);
       }
       setInnerValue(value);
     },
@@ -74,8 +81,11 @@ export const ColorInput = ({
         ref={activeSection === "hex" ? inputRef : undefined}
         style={{ border: 0, padding: 0 }}
         spellCheck={false}
-        className="color-picker-input"
+        className={clsx("color-picker-input", {
+          "color-picker-input--error": error,
+        })}
         aria-label={label}
+        aria-invalid={error ? "true" : undefined}
         onChange={(event) => {
           changeColor(event.target.value);
         }}
@@ -95,6 +105,11 @@ export const ColorInput = ({
         }}
         placeholder={placeholder}
       />
+      {error && (
+        <div className="color-picker-input__error" role="alert">
+          {error}
+        </div>
+      )}
       {/* TODO reenable on mobile with a better UX */}
       {editorInterface.formFactor !== "phone" && (
         <>

--- a/packages/excalidraw/components/ColorPicker/ColorPicker.scss
+++ b/packages/excalidraw/components/ColorPicker/ColorPicker.scss
@@ -421,6 +421,17 @@
     &:focus-visible {
       box-shadow: none;
     }
+
+    &--error {
+      border-color: var(--color-danger) !important;
+    }
+  }
+
+  .color-picker-input__error {
+    grid-column: 2 / span 2;
+    font-size: 0.75rem;
+    color: var(--color-danger);
+    margin-top: -4px;
   }
 
   .color-picker-label-swatch-container {


### PR DESCRIPTION
Fixes #9527.

Display an error message when users enter invalid hexadecimal color values in the color picker input field. Previously, invalid input was silently ignored with no feedback.

## Changes

- **`ColorInput.tsx`**: Added error state tracking and validation feedback when `normalizeInputColor` returns null for non-empty input
- **`ColorPicker.scss`**: Added `.color-picker-input--error` class for red border styling and `.color-picker-input__error` class for the error message display

## Testing

- `yarn test:typecheck` passes
- `yarn vitest run packages/excalidraw/tests/colorInput.test.ts` passes (17 tests)