### PR TITLE
fix: show error for invalid hex color input

### DIFF
--- a/packages/excalidraw/components/ColorPicker/ColorInput.tsx
+++ b/packages/excalidraw/components/ColorPicker/ColorInput.tsx
@@ -1,7 +1,7 @@
 import clsx from "clsx";
 import { useCallback, useEffect, useRef, useState } from "react";
 
-import { KEYS, normalizeInputColor } from "@excalidraw/common";
+import { KEYS } from "@excalidraw/common";
 
 import { getShortcutKey } from "../..//shortcut";
 import { useAtom } from "../../editor-jotai";
@@ -10,9 +10,26 @@ import { useEditorInterface } from "../App";
 import { activeEyeDropperAtom } from "../EyeDropper";
 import { eyeDropperIcon } from "../icons";
 
-import { activeColorPickerSectionAtom } from "./colorPickerUtils";
+import {
+  activeColorPickerSectionAtom,
+  normalizeHexInputColor,
+} from "./colorPickerUtils";
 
-import type { ColorPickerType } from "./colorPickerUtils";
+import type {
+  ColorPickerType,
+  HexInputValidationError,
+} from "./colorPickerUtils";
+
+let colorInputErrorCounter = 0;
+
+const getHexInputErrorMessage = (error: HexInputValidationError) => {
+  switch (error) {
+    case "invalidHexLength":
+      return t("colorPicker.invalidHexLength");
+    case "invalidHexCharacters":
+      return t("colorPicker.invalidHexCharacters");
+  }
+};
 
 export const ColorInput = ({
   color,
@@ -29,21 +46,32 @@ export const ColorInput = ({
 }) => {
   const editorInterface = useEditorInterface();
   const [innerValue, setInnerValue] = useState(color);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [errorId] = useState(() => {
+    colorInputErrorCounter += 1;
+    return `color-picker-input-error-${colorInputErrorCounter}`;
+  });
   const [activeSection, setActiveColorPickerSection] = useAtom(
     activeColorPickerSectionAtom,
   );
 
   useEffect(() => {
     setInnerValue(color);
+    setErrorMessage(null);
   }, [color]);
 
   const changeColor = useCallback(
     (inputValue: string) => {
       const value = inputValue.toLowerCase();
-      const color = normalizeInputColor(value);
+      const result = normalizeHexInputColor(value);
 
-      if (color) {
-        onChange(color);
+      if (result.color) {
+        onChange(result.color);
+        setErrorMessage(null);
+      } else if (result.error) {
+        setErrorMessage(getHexInputErrorMessage(result.error));
+      } else {
+        setErrorMessage(null);
       }
       setInnerValue(value);
     },
@@ -68,7 +96,11 @@ export const ColorInput = ({
   }, [setEyeDropperState]);
 
   return (
-    <div className="color-picker__input-label">
+    <div
+      className={clsx("color-picker__input-label", {
+        "color-picker__input-label--invalid": errorMessage,
+      })}
+    >
       <div className="color-picker__input-hash">#</div>
       <input
         ref={activeSection === "hex" ? inputRef : undefined}
@@ -76,12 +108,15 @@ export const ColorInput = ({
         spellCheck={false}
         className="color-picker-input"
         aria-label={label}
+        aria-invalid={!!errorMessage}
+        aria-describedby={errorMessage ? errorId : undefined}
         onChange={(event) => {
           changeColor(event.target.value);
         }}
         value={(innerValue || "").replace(/^#/, "")}
         onBlur={() => {
           setInnerValue(color);
+          setErrorMessage(null);
         }}
         tabIndex={-1}
         onFocus={() => setActiveColorPickerSection("hex")}
@@ -128,6 +163,11 @@ export const ColorInput = ({
             {eyeDropperIcon}
           </div>
         </>
+      )}
+      {errorMessage && (
+        <div id={errorId} className="color-picker__input-error" role="alert">
+          {errorMessage}
+        </div>
       )}
     </div>
   );

--- a/packages/excalidraw/components/ColorPicker/ColorPicker.scss
+++ b/packages/excalidraw/components/ColorPicker/ColorPicker.scss
@@ -383,10 +383,26 @@
       box-shadow: 0 0 0 1px var(--color-primary-darkest);
       border-radius: var(--border-radius-lg);
     }
+
+    &--invalid {
+      border-color: var(--color-danger);
+
+      &:focus-within {
+        box-shadow: 0 0 0 1px var(--color-danger);
+      }
+    }
   }
 
   .color-picker__input-hash {
     padding: 0 0.25rem;
+  }
+
+  .color-picker__input-error {
+    grid-column: 1 / -1;
+    color: var(--color-danger);
+    font-size: 0.75rem;
+    line-height: 1.2;
+    padding-bottom: 0.5rem;
   }
 
   .color-picker-input {

--- a/packages/excalidraw/components/ColorPicker/colorPickerUtils.ts
+++ b/packages/excalidraw/components/ColorPicker/colorPickerUtils.ts
@@ -96,6 +96,32 @@ export type ActiveColorPickerSectionAtomType =
 export const activeColorPickerSectionAtom =
   atom<ActiveColorPickerSectionAtomType>(null);
 
+export type HexInputValidationError =
+  | "invalidHexLength"
+  | "invalidHexCharacters";
+
+const VALID_HEX_LENGTHS = new Set([3, 4, 6, 8]);
+
+export const normalizeHexInputColor = (
+  color: string,
+): { color: string | null; error: HexInputValidationError | null } => {
+  const hex = color.trim().replace(/^#/, "");
+
+  if (!hex) {
+    return { color: null, error: null };
+  }
+
+  if (!/^[\da-f]+$/i.test(hex)) {
+    return { color: null, error: "invalidHexCharacters" };
+  }
+
+  if (!VALID_HEX_LENGTHS.has(hex.length)) {
+    return { color: null, error: "invalidHexLength" };
+  }
+
+  return { color: `#${hex.toLowerCase()}`, error: null };
+};
+
 export type ColorPickerType =
   | "canvasBackground"
   | "elementBackground"

--- a/packages/excalidraw/locales/en.json
+++ b/packages/excalidraw/locales/en.json
@@ -598,6 +598,8 @@
     "colors": "Colors",
     "shades": "Shades",
     "hexCode": "Hex code",
+    "invalidHexLength": "Hex code must be 3, 4, 6, or 8 characters (excluding #)",
+    "invalidHexCharacters": "Hex code can only contain characters 0-9 and A-F",
     "noShades": "No shades available for this color"
   },
   "overwriteConfirm": {

--- a/packages/excalidraw/locales/zh-CN.json
+++ b/packages/excalidraw/locales/zh-CN.json
@@ -576,6 +576,8 @@
     "colors": "颜色",
     "shades": "色调明暗",
     "hexCode": "十六进制值",
+    "invalidHexLength": "十六进制颜色值必须是 3、4、6 或 8 位字符（不含 #）",
+    "invalidHexCharacters": "十六进制颜色值只能包含 0-9 和 A-F",
     "noShades": "此颜色没有可用的明暗变化"
   },
   "overwriteConfirm": {

--- a/packages/excalidraw/tests/colorInput.test.ts
+++ b/packages/excalidraw/tests/colorInput.test.ts
@@ -1,5 +1,7 @@
 import { normalizeInputColor } from "@excalidraw/common";
 
+import { normalizeHexInputColor } from "../components/ColorPicker/colorPickerUtils";
+
 describe("normalizeInputColor", () => {
   describe("hex colors", () => {
     it("returns hex color with hash as-is", () => {
@@ -109,6 +111,68 @@ describe("normalizeInputColor", () => {
     it("returns null for partial/malformed colors", () => {
       expect(normalizeInputColor("#ff")).toBe(null);
       expect(normalizeInputColor("rgb(")).toBe(null);
+    });
+  });
+});
+
+describe("normalizeHexInputColor", () => {
+  it("returns normalized hex colors for valid lengths", () => {
+    expect(normalizeHexInputColor("abc")).toEqual({
+      color: "#abc",
+      error: null,
+    });
+    expect(normalizeHexInputColor("#abcd")).toEqual({
+      color: "#abcd",
+      error: null,
+    });
+    expect(normalizeHexInputColor("ff0000")).toEqual({
+      color: "#ff0000",
+      error: null,
+    });
+    expect(normalizeHexInputColor("#ff000080")).toEqual({
+      color: "#ff000080",
+      error: null,
+    });
+  });
+
+  it("returns a length error for malformed hex lengths", () => {
+    expect(normalizeHexInputColor("1")).toEqual({
+      color: null,
+      error: "invalidHexLength",
+    });
+    expect(normalizeHexInputColor("12")).toEqual({
+      color: null,
+      error: "invalidHexLength",
+    });
+    expect(normalizeHexInputColor("12345")).toEqual({
+      color: null,
+      error: "invalidHexLength",
+    });
+    expect(normalizeHexInputColor("1234567")).toEqual({
+      color: null,
+      error: "invalidHexLength",
+    });
+    expect(normalizeHexInputColor("123456789")).toEqual({
+      color: null,
+      error: "invalidHexLength",
+    });
+  });
+
+  it("returns a character error for non-hex input", () => {
+    expect(normalizeHexInputColor("zzzzzz")).toEqual({
+      color: null,
+      error: "invalidHexCharacters",
+    });
+    expect(normalizeHexInputColor("blue")).toEqual({
+      color: null,
+      error: "invalidHexCharacters",
+    });
+  });
+
+  it("does not show an error for empty input", () => {
+    expect(normalizeHexInputColor("")).toEqual({
+      color: null,
+      error: null,
     });
   });
 });


### PR DESCRIPTION
Fixes #9527

### Summary
- validates the color picker hex input against 3, 4, 6, or 8 hex characters
- shows an inline error for invalid length or invalid characters
- keeps existing generic color normalization behavior unchanged

### Tests
- yarn test:app packages/excalidraw/tests/colorInput.test.ts --watch=false
- yarn eslint --max-warnings=0 packages/excalidraw/components/ColorPicker/ColorInput.tsx packages/excalidraw/components/ColorPicker/colorPickerUtils.ts packages/excalidraw/tests/colorInput.test.ts
- yarn test:typecheck