### PR TITLE
fix: allow save shortcut (Ctrl/Cmd+S) when editing text elements

### DIFF
--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -4985,7 +4985,8 @@ class App extends React.Component<AppProps, AppState> {
         // inside an input
         (isWritableElement(event.target) &&
           // unless pressing escape (finalize action)
-          event.key !== KEYS.ESCAPE) ||
+          event.key !== KEYS.ESCAPE &&
+          !(event[KEYS.CTRL_OR_CMD] && event.key === KEYS.S)) ||
         // or unless using arrows (to move between buttons)
         (isArrowKey(event.key) && isInputLike(event.target))
       ) {


### PR DESCRIPTION
This is an independent contribution made in a personal capacity and is not affiliated with or sponsored by any organization.

## Summary

Fixes #9281: When editing text in Excalidraw, pressing Ctrl/Cmd+S triggers the browser's native "Save page as HTML" dialog instead of saving the drawing as a .excalidraw file. This occurs because the keyboard handler's "bail if" block returns early for writable elements without allowing the save shortcut to pass through to the action manager.

## Root Cause

In `App.tsx`, the `onKeyDown` handler has a guard clause that bails out when the event target is a writable element (like a text input being edited), unless the key is Escape. This prevents `actionManager.handleKeyDown()` from ever seeing the Ctrl+S shortcut, so `event.preventDefault()` is never called, and the browser's default save behavior takes over.

## Fix

Added an exception in the bail condition to allow the save shortcut (Ctrl/Cmd+S) to pass through. When the user presses Ctrl+S while editing text, the event now reaches the action manager, which calls `preventDefault()` and triggers the normal save flow.

## Testing

- Open an Excalidraw drawing
- Create and select a text element so the cursor is active inside it
- Press Ctrl+S (or Cmd+S on macOS)
- The drawing should save as .excalidraw instead of opening the browser's "Save page" dialog