### PR TITLE
fix: add support for the browser type in serializeAsJSON to save the full visible app state

### DIFF
--- a/packages/excalidraw/data/json.ts
+++ b/packages/excalidraw/data/json.ts
@@ -9,7 +9,11 @@ import type { ExcalidrawElement, NonDeleted } from "@excalidraw/element/types";
 
 import type { MaybePromise } from "@excalidraw/common/utility-types";
 
-import { cleanAppStateForExport, clearAppStateForDatabase } from "../appState";
+import {
+  cleanAppStateForExport,
+  clearAppStateForDatabase,
+  clearAppStateForLocalStorage,
+} from "../appState";
 
 import { isImageFileHandle, loadFromBlob } from "./blob";
 import { fileOpen, fileSave } from "./filesystem";
@@ -53,7 +57,7 @@ export const serializeAsJSON = (
   elements: readonly ExcalidrawElement[],
   appState: Partial<AppState>,
   files: BinaryFiles,
-  type: "local" | "database",
+  type: "local" | "database" | "browser",
 ): string => {
   const data: ExportedDataState = {
     type: EXPORT_DATA_TYPES.excalidraw,
@@ -63,9 +67,11 @@ export const serializeAsJSON = (
     appState:
       type === "local"
         ? cleanAppStateForExport(appState)
-        : clearAppStateForDatabase(appState),
+        : type === "browser"
+          ? clearAppStateForLocalStorage(appState)
+          : clearAppStateForDatabase(appState),
     files:
-      type === "local"
+      type === "local" || type === "browser"
         ? filterOutDeletedFiles(elements, files)
         : // will be stripped from JSON
           undefined,


### PR DESCRIPTION
Hi! 👋 

I'm integrating Excalidraw into an application, and while trying to customize how the full _visible_ app state is serialized and saved locally, I noticed it's not possible through the [`serializeAsJSON()` function](https://github.com/excalidraw/excalidraw/blob/f6d85bc80fe328e8f472636eb0d541f7bb891aa0/packages/excalidraw/data/json.ts#L52-L75). 

Since there is an [appropriate handler for this](https://github.com/excalidraw/excalidraw/blob/f6d85bc80fe328e8f472636eb0d541f7bb891aa0/packages/excalidraw/appState.ts#L134-L293), `clearAppStateForLocalStorage()`, I believe the `serializeAsJSON()` function should also support it, covering the three current ways of processing the `appState`. This PR serves to introduce this possibility.

Let me know your feedback, please. Thanks!

---

Related to #7707 