### PR TITLE
Fix invalid hex color feedback

### DIFF
--- a/packages/excalidraw/components/ColorPicker/ColorInput.tsx
+++ b/packages/excalidraw/components/ColorPicker/ColorInput.tsx
@@ -1,7 +1,7 @@
 import clsx from "clsx";
 import { useCallback, useEffect, useRef, useState } from "react";
 
-import { KEYS, normalizeInputColor } from "@excalidraw/common";
+import { KEYS } from "@excalidraw/common";
 
 import { getShortcutKey } from "../..//shortcut";
 import { useAtom } from "../../editor-jotai";
@@ -10,7 +10,10 @@ import { useEditorInterface } from "../App";
 import { activeEyeDropperAtom } from "../EyeDropper";
 import { eyeDropperIcon } from "../icons";
 
-import { activeColorPickerSectionAtom } from "./colorPickerUtils";
+import {
+  activeColorPickerSectionAtom,
+  normalizeHexColorInput,
+} from "./colorPickerUtils";
 
 import type { ColorPickerType } from "./colorPickerUtils";
 
@@ -29,21 +32,26 @@ export const ColorInput = ({
 }) => {
   const editorInterface = useEditorInterface();
   const [innerValue, setInnerValue] = useState(color);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [activeSection, setActiveColorPickerSection] = useAtom(
     activeColorPickerSectionAtom,
   );
 
   useEffect(() => {
     setInnerValue(color);
+    setErrorMessage(null);
   }, [color]);
 
   const changeColor = useCallback(
     (inputValue: string) => {
       const value = inputValue.toLowerCase();
-      const color = normalizeInputColor(value);
+      const color = normalizeHexColorInput(value);
 
       if (color) {
+        setErrorMessage(null);
         onChange(color);
+      } else {
+        setErrorMessage(t("colorPicker.invalidHexColor"));
       }
       setInnerValue(value);
     },
@@ -68,67 +76,83 @@ export const ColorInput = ({
   }, [setEyeDropperState]);
 
   return (
-    <div className="color-picker__input-label">
-      <div className="color-picker__input-hash">#</div>
-      <input
-        ref={activeSection === "hex" ? inputRef : undefined}
-        style={{ border: 0, padding: 0 }}
-        spellCheck={false}
-        className="color-picker-input"
-        aria-label={label}
-        onChange={(event) => {
-          changeColor(event.target.value);
-        }}
-        value={(innerValue || "").replace(/^#/, "")}
-        onBlur={() => {
-          setInnerValue(color);
-        }}
-        tabIndex={-1}
-        onFocus={() => setActiveColorPickerSection("hex")}
-        onKeyDown={(event) => {
-          if (event.key === KEYS.TAB) {
-            return;
-          } else if (event.key === KEYS.ESCAPE) {
-            eyeDropperTriggerRef.current?.focus();
+    <>
+      <div className="color-picker__input-label">
+        <div className="color-picker__input-hash">#</div>
+        <input
+          ref={activeSection === "hex" ? inputRef : undefined}
+          style={{ border: 0, padding: 0 }}
+          spellCheck={false}
+          className="color-picker-input"
+          aria-label={label}
+          aria-invalid={!!errorMessage}
+          aria-describedby={
+            errorMessage ? "color-picker-input-error" : undefined
           }
-          event.stopPropagation();
-        }}
-        placeholder={placeholder}
-      />
-      {/* TODO reenable on mobile with a better UX */}
-      {editorInterface.formFactor !== "phone" && (
-        <>
-          <div
-            style={{
-              width: "1px",
-              height: "1.25rem",
-              backgroundColor: "var(--default-border-color)",
-            }}
-          />
-          <div
-            ref={eyeDropperTriggerRef}
-            className={clsx("excalidraw-eye-dropper-trigger", {
-              selected: eyeDropperState,
-            })}
-            onClick={() =>
-              setEyeDropperState((s) =>
-                s
-                  ? null
-                  : {
-                      keepOpenOnAlt: false,
-                      onSelect: (color) => onChange(color),
-                      colorPickerType,
-                    },
-              )
+          onChange={(event) => {
+            changeColor(event.target.value);
+          }}
+          value={(innerValue || "").replace(/^#/, "")}
+          onBlur={() => {
+            setInnerValue(color);
+            setErrorMessage(null);
+          }}
+          tabIndex={-1}
+          onFocus={() => setActiveColorPickerSection("hex")}
+          onKeyDown={(event) => {
+            if (event.key === KEYS.TAB) {
+              return;
+            } else if (event.key === KEYS.ESCAPE) {
+              eyeDropperTriggerRef.current?.focus();
             }
-            title={`${t(
-              "labels.eyeDropper",
-            )} — ${KEYS.I.toLocaleUpperCase()} or ${getShortcutKey("Alt")} `}
-          >
-            {eyeDropperIcon}
-          </div>
-        </>
+            event.stopPropagation();
+          }}
+          placeholder={placeholder}
+        />
+        {/* TODO reenable on mobile with a better UX */}
+        {editorInterface.formFactor !== "phone" && (
+          <>
+            <div
+              style={{
+                width: "1px",
+                height: "1.25rem",
+                backgroundColor: "var(--default-border-color)",
+              }}
+            />
+            <div
+              ref={eyeDropperTriggerRef}
+              className={clsx("excalidraw-eye-dropper-trigger", {
+                selected: eyeDropperState,
+              })}
+              onClick={() =>
+                setEyeDropperState((s) =>
+                  s
+                    ? null
+                    : {
+                        keepOpenOnAlt: false,
+                        onSelect: (color) => onChange(color),
+                        colorPickerType,
+                      },
+                )
+              }
+              title={`${t(
+                "labels.eyeDropper",
+              )} — ${KEYS.I.toLocaleUpperCase()} or ${getShortcutKey("Alt")} `}
+            >
+              {eyeDropperIcon}
+            </div>
+          </>
+        )}
+      </div>
+      {errorMessage && (
+        <div
+          id="color-picker-input-error"
+          className="color-picker__input-error"
+          role="alert"
+        >
+          {errorMessage}
+        </div>
       )}
-    </div>
+    </>
   );
 };

--- a/packages/excalidraw/components/ColorPicker/ColorPicker.scss
+++ b/packages/excalidraw/components/ColorPicker/ColorPicker.scss
@@ -389,6 +389,13 @@
     padding: 0 0.25rem;
   }
 
+  .color-picker__input-error {
+    margin: 0 8px 8px;
+    font-size: 0.6875rem;
+    line-height: 1.3;
+    color: var(--color-danger);
+  }
+
   .color-picker-input {
     box-sizing: border-box;
     width: 100%;

--- a/packages/excalidraw/components/ColorPicker/colorPickerUtils.ts
+++ b/packages/excalidraw/components/ColorPicker/colorPickerUtils.ts
@@ -38,6 +38,18 @@ export const colorPickerHotkeyBindings = [
   ["z", "x", "c", "v", "b"],
 ].flat();
 
+const HEX_COLOR_INPUT_REGEX =
+  /^#?(?:[0-9a-f]{3}|[0-9a-f]{4}|[0-9a-f]{6}|[0-9a-f]{8})$/i;
+
+export const normalizeHexColorInput = (input: string): string | null => {
+  const value = input.trim();
+  if (!HEX_COLOR_INPUT_REGEX.test(value)) {
+    return null;
+  }
+
+  return value.startsWith("#") ? value : `#${value}`;
+};
+
 export const isCustomColor = ({
   color,
   palette,

--- a/packages/excalidraw/locales/en.json
+++ b/packages/excalidraw/locales/en.json
@@ -598,7 +598,8 @@
     "colors": "Colors",
     "shades": "Shades",
     "hexCode": "Hex code",
-    "noShades": "No shades available for this color"
+    "noShades": "No shades available for this color",
+    "invalidHexColor": "Enter a valid hex color with 3, 4, 6, or 8 characters."
   },
   "overwriteConfirm": {
     "action": {

--- a/packages/excalidraw/tests/actionStyles.test.tsx
+++ b/packages/excalidraw/tests/actionStyles.test.tsx
@@ -83,4 +83,35 @@ describe("actionStyles", () => {
     expect(firstRect.roughness).toBe(2); // Cartoonist: 2
     expect(firstRect.opacity).toBe(60);
   });
+
+  it("shows feedback for invalid custom hex colors", async () => {
+    UI.clickTool("rectangle");
+    mouse.down(10, 10);
+    mouse.up(20, 20);
+
+    togglePopover("Stroke");
+    const colorInput = screen.getByRole("textbox", { name: "Stroke" });
+
+    fireEvent.change(colorInput, {
+      target: { value: "12345" },
+    });
+
+    expect(
+      screen.getByText(
+        "Enter a valid hex color with 3, 4, 6, or 8 characters.",
+      ),
+    ).toBeInTheDocument();
+    expect(API.getSelectedElement().strokeColor).not.toBe("#12345");
+
+    fireEvent.change(colorInput, {
+      target: { value: "123456" },
+    });
+
+    expect(
+      screen.queryByText(
+        "Enter a valid hex color with 3, 4, 6, or 8 characters.",
+      ),
+    ).toBeNull();
+    expect(API.getSelectedElement().strokeColor).toBe("#123456");
+  });
 });

--- a/packages/excalidraw/tests/colorInput.test.ts
+++ b/packages/excalidraw/tests/colorInput.test.ts
@@ -1,5 +1,7 @@
 import { normalizeInputColor } from "@excalidraw/common";
 
+import { normalizeHexColorInput } from "../components/ColorPicker/colorPickerUtils";
+
 describe("normalizeInputColor", () => {
   describe("hex colors", () => {
     it("returns hex color with hash as-is", () => {
@@ -110,5 +112,28 @@ describe("normalizeInputColor", () => {
       expect(normalizeInputColor("#ff")).toBe(null);
       expect(normalizeInputColor("rgb(")).toBe(null);
     });
+  });
+});
+
+describe("normalizeHexColorInput", () => {
+  it("accepts optional hash and valid hex lengths only", () => {
+    expect(normalizeHexColorInput("abc")).toBe("#abc");
+    expect(normalizeHexColorInput("#abcd")).toBe("#abcd");
+    expect(normalizeHexColorInput("123456")).toBe("#123456");
+    expect(normalizeHexColorInput("#12345678")).toBe("#12345678");
+  });
+
+  it("rejects invalid hex strings and non-hex colors", () => {
+    for (const value of [
+      "1",
+      "12",
+      "12345",
+      "1234567",
+      "123456789",
+      "zzzzzz",
+      "blue",
+    ]) {
+      expect(normalizeHexColorInput(value)).toBe(null);
+    }
   });
 });


### PR DESCRIPTION
## Summary
Add visible inline feedback when the custom hex color input receives an invalid value. Valid hex values still behave as before, and the error clears once the input becomes valid again.

## Changes
- Add minimal hex-only validation for the custom color input
- Show an inline error message with accessibility wiring
- Keep existing blur/reset behavior intact
- Add focused regression tests for validation and UI feedback

## Verification
- `yarn test:app --run packages/excalidraw/tests/colorInput.test.ts packages/excalidraw/tests/actionStyles.test.tsx`
- `./node_modules/.bin/eslint --max-warnings=0 packages/excalidraw/components/ColorPicker/ColorInput.tsx packages/excalidraw/components/ColorPicker/colorPickerUtils.ts packages/excalidraw/tests/colorInput.test.ts packages/excalidraw/tests/actionStyles.test.tsx`
- `git diff --check`

Fixes #9527