### PR TITLE
fix(editor): label redaction toggle in text fields

### DIFF
--- a/packages/excalidraw/components/TextField.test.tsx
+++ b/packages/excalidraw/components/TextField.test.tsx
@@ -1,0 +1,33 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import { t } from "../i18n";
+
+import { TextField } from "./TextField";
+
+describe("TextField", () => {
+  it("should expose a localized accessible label for the redaction toggle", () => {
+    render(<TextField value="super-secret" isRedacted />);
+
+    const input = screen.getByDisplayValue("super-secret");
+    const revealButton = screen.getByRole("button", {
+      name: t("buttons.showRedactedValue"),
+    });
+
+    expect(input).toHaveClass("is-redacted");
+    expect(revealButton).toHaveAttribute("aria-pressed", "false");
+    expect(revealButton).toHaveAttribute(
+      "title",
+      t("buttons.showRedactedValue"),
+    );
+
+    fireEvent.click(revealButton);
+
+    const hideButton = screen.getByRole("button", {
+      name: t("buttons.hideRedactedValue"),
+    });
+
+    expect(input).not.toHaveClass("is-redacted");
+    expect(hideButton).toHaveAttribute("aria-pressed", "true");
+    expect(hideButton).toHaveAttribute("title", t("buttons.hideRedactedValue"));
+  });
+});

--- a/packages/excalidraw/components/TextField.tsx
+++ b/packages/excalidraw/components/TextField.tsx
@@ -7,6 +7,8 @@ import {
   useState,
 } from "react";
 
+import { t } from "../i18n";
+
 import { Button } from "./Button";
 import { eyeIcon, eyeClosedIcon } from "./icons";
 
@@ -63,6 +65,9 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
 
     const [isTemporarilyUnredacted, setIsTemporarilyUnredacted] =
       useState<boolean>(false);
+    const redactionToggleLabel = isTemporarilyUnredacted
+      ? t("buttons.hideRedactedValue")
+      : t("buttons.showRedactedValue");
 
     return (
       <div
@@ -106,6 +111,9 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
                 setIsTemporarilyUnredacted(!isTemporarilyUnredacted)
               }
               style={{ border: 0, userSelect: "none" }}
+              aria-label={redactionToggleLabel}
+              aria-pressed={isTemporarilyUnredacted}
+              title={redactionToggleLabel}
             >
               {isTemporarilyUnredacted ? eyeClosedIcon : eyeIcon}
             </Button>

--- a/packages/excalidraw/locales/en.json
+++ b/packages/excalidraw/locales/en.json
@@ -250,6 +250,8 @@
     "cancel": "Cancel",
     "saveLibNames": "Save name(s) and exit",
     "clear": "Clear",
+    "showRedactedValue": "Show hidden value",
+    "hideRedactedValue": "Hide value",
     "remove": "Remove",
     "embed": "Toggle embedding",
     "publishLibrary": "Rename or publish",


### PR DESCRIPTION
## Summary
- add an accessible label to the icon-only redaction toggle in `TextField`
- add the matching English locale string
- add a focused component test covering the labeled toggle

## Why
The redaction toggle is currently an icon-only action inside the text field controls. Adding an explicit accessible label makes the control clearer for assistive technology users and improves keyboard/screen-reader discoverability without changing editor behavior.

## Testing
- covered with a focused `TextField` component test
- existing redaction toggle behavior remains unchanged

## Manual verification
1. Open a text element in the editor
2. Focus the redaction toggle inside the text field controls
3. Confirm the control exposes a readable accessible label
4. Confirm toggling redaction still works as before