### PR TITLE
feat: add invert colors button in top-left toolbar

### DIFF
--- a/packages/excalidraw/actions/actionCanvas.tsx
+++ b/packages/excalidraw/actions/actionCanvas.tsx
@@ -10,10 +10,13 @@ import {
   updateActiveTool,
   CODES,
   KEYS,
+  applyDarkModeFilter,
+  isTransparent,
 } from "@excalidraw/common";
 
 import { getNonDeletedElements } from "@excalidraw/element";
 import { newElementWith } from "@excalidraw/element";
+import { hasBackground, hasStrokeColor } from "@excalidraw/element";
 import { getCommonBounds, type SceneBounds } from "@excalidraw/element";
 
 import { CaptureUpdateAction } from "@excalidraw/element";
@@ -85,6 +88,44 @@ export const actionChangeViewBackgroundColor = register<Partial<AppState>>({
         updateData={updateData}
       />
     );
+  },
+});
+
+export const actionInvertColors = register({
+  name: "invertColors",
+  label: "labels.invertColors",
+  trackEvent: { category: "canvas" },
+  predicate: (_, appState) => !appState.viewModeEnabled,
+  perform: (elements, appState) => {
+    const invert = (color: string) =>
+      !color || isTransparent(color) ? color : applyDarkModeFilter(color);
+
+    const nextElements = elements.map((el) => {
+      if (el.isDeleted) {
+        return el;
+      }
+      const updates: Partial<typeof el> = {};
+      if (hasStrokeColor(el.type)) {
+        updates.strokeColor = invert(el.strokeColor);
+      }
+      if (hasBackground(el.type)) {
+        updates.backgroundColor = invert(el.backgroundColor);
+      }
+      return Object.keys(updates).length ? newElementWith(el, updates) : el;
+    });
+
+    return {
+      elements: nextElements,
+      appState: {
+        ...appState,
+        viewBackgroundColor: invert(appState.viewBackgroundColor),
+        currentItemStrokeColor: invert(appState.currentItemStrokeColor),
+        currentItemBackgroundColor: invert(
+          appState.currentItemBackgroundColor,
+        ),
+      },
+      captureUpdate: CaptureUpdateAction.IMMEDIATELY,
+    };
   },
 });
 

--- a/packages/excalidraw/components/LayerUI.tsx
+++ b/packages/excalidraw/components/LayerUI.tsx
@@ -19,6 +19,7 @@ import { ShapeCache } from "@excalidraw/element";
 import type { NonDeletedExcalidrawElement } from "@excalidraw/element/types";
 
 import { actionToggleStats } from "../actions";
+import { actionInvertColors } from "../actions/actionCanvas";
 import { trackEvent } from "../analytics";
 import { TunnelsContext, useInitializeTunnels } from "../context/tunnels";
 import { UIAppStateContext } from "../context/ui-appState";
@@ -46,7 +47,8 @@ import MainMenu from "./main-menu/MainMenu";
 import { ActiveConfirmDialog } from "./ActiveConfirmDialog";
 import { useEditorInterface, useStylesPanelMode } from "./App";
 import { OverwriteConfirmDialog } from "./OverwriteConfirm/OverwriteConfirm";
-import { sidebarRightIcon } from "./icons";
+import { InvertColorsIcon, sidebarRightIcon } from "./icons";
+import { ToolButton } from "./ToolButton";
 import { DefaultSidebar } from "./DefaultSidebar";
 import { TTDDialog } from "./TTDDialog/TTDDialog";
 import { Stats } from "./Stats";
@@ -226,10 +228,27 @@ const LayerUI = ({
   };
 
   const renderCanvasActions = () => (
-    <div style={{ position: "relative" }}>
+    <div
+      style={{
+        position: "relative",
+        display: "flex",
+        gap: "0.5rem",
+        alignItems: "center",
+      }}
+    >
       {/* wrapping to Fragment stops React from occasionally complaining
                 about identical Keys */}
       <tunnels.MainMenuTunnel.Out />
+      {!appState.viewModeEnabled && (
+        <ToolButton
+          type="button"
+          icon={InvertColorsIcon}
+          title={t("labels.invertColors")}
+          aria-label={t("labels.invertColors")}
+          onClick={() => actionManager.executeAction(actionInvertColors)}
+          data-testid="invert-colors-button"
+        />
+      )}
       {renderWelcomeScreen && <tunnels.WelcomeScreenMenuHintTunnel.Out />}
     </div>
   );

--- a/packages/excalidraw/components/icons.tsx
+++ b/packages/excalidraw/components/icons.tsx
@@ -508,6 +508,14 @@ export const SunIcon = createIcon(
   { ...modifiedTablerIconProps, strokeWidth: 1.5 },
 );
 
+export const InvertColorsIcon = createIcon(
+  <g stroke="currentColor" strokeWidth="1.5">
+    <circle cx="10" cy="10" r="7.5" fill="none" />
+    <path d="M10 2.5a7.5 7.5 0 0 1 0 15V2.5Z" fill="currentColor" stroke="none" />
+  </g>,
+  modifiedTablerIconProps,
+);
+
 export const HamburgerMenuIcon = createIcon(
   <g strokeWidth="1.5">
     <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>

--- a/packages/excalidraw/locales/en.json
+++ b/packages/excalidraw/locales/en.json
@@ -94,6 +94,7 @@
     "canvasBackground": "Canvas background",
     "drawingCanvas": "Drawing canvas",
     "clearCanvas": "Clear canvas",
+    "invertColors": "Invert colors",
     "layers": "Layers",
     "actions": "Actions",
     "language": "Language",


### PR DESCRIPTION
## Summary

Adds an **Invert colors** button in the top-left of the desktop editor (next to the hamburger menu). Clicking it inverts:

- Stroke and background colors of all non-deleted elements
- Canvas background color
- Current drawing defaults (`currentItemStrokeColor`, `currentItemBackgroundColor`)

Uses the existing `applyDarkModeFilter` transform (same as dark-mode rendering). Transparent fills are left unchanged. The change is undoable in a single Cmd+Z.

## Test plan

- [ ] Draw rectangles with different stroke/fill colors, including one with transparent fill
- [ ] Click the invert button → colors and canvas background update; transparent fill unchanged
- [ ] Draw a new shape → uses inverted defaults
- [ ] Cmd+Z restores everything in one step
- [ ] View mode → button is hidden

Made with [Cursor](https://cursor.com)