### PR TITLE
fix: enable touchpad navigation (zoom/pan) when hovering over frame name

### DIFF
--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -2068,7 +2068,6 @@ class App extends React.Component<AppProps, AppState> {
               : POINTER_EVENTS.enabled,
           }}
           onPointerDown={(event) => this.handleCanvasPointerDown(event)}
-          onWheel={(event) => this.handleWheel(event)}
           onContextMenu={this.handleCanvasContextMenu}
           onDoubleClick={() => {
             this.setState({
@@ -12801,7 +12800,7 @@ class App extends React.Component<AppProps, AppState> {
           event.target instanceof HTMLTextAreaElement ||
           event.target instanceof HTMLIFrameElement ||
           (event.target instanceof HTMLElement &&
-            event.target.classList.contains(CLASSES.FRAME_NAME))
+            event.target.closest(`.${CLASSES.FRAME_NAME}`))
         )
       ) {
         // prevent zooming the browser (but allow scrolling DOM)

--- a/packages/excalidraw/tests/helpers/api.ts
+++ b/packages/excalidraw/tests/helpers/api.ts
@@ -219,6 +219,7 @@ export class API {
       : never;
     elbowed?: boolean;
     fixedSegments?: FixedSegment[] | null;
+    name?: string;
   }): T extends "arrow" | "line"
     ? ExcalidrawLinearElement
     : T extends "freedraw"
@@ -358,10 +359,10 @@ export class API {
         });
         break;
       case "frame":
-        element = newFrameElement({ ...base, width, height });
+        element = newFrameElement({ ...base, width, height, name: rest.name });
         break;
       case "magicframe":
-        element = newMagicFrameElement({ ...base, width, height });
+        element = newMagicFrameElement({ ...base, width, height, name: rest.name });
         break;
       default:
         assertNever(

--- a/packages/excalidraw/tests/scroll.test.tsx
+++ b/packages/excalidraw/tests/scroll.test.tsx
@@ -11,6 +11,7 @@ import {
   render,
   restoreOriginalGetBoundingClientRect,
   waitFor,
+  fireEvent,
 } from "./test-utils";
 
 const { h } = window;
@@ -110,6 +111,51 @@ describe("appState", () => {
     // Assert we scroll properly with normal zoom
     API.setAppState({ zoom: { value: zoom } });
     scrollTest();
+    restoreOriginalGetBoundingClientRect();
+  });
+
+  it("wheel zoom / pan works when hovering over frame name", async () => {
+    mockBoundingClientRect();
+    const frame = API.createElement({
+      type: "frame",
+      id: "frame-1",
+      name: "My Awesome Frame",
+      x: 0,
+      y: 0,
+      width: 200,
+      height: 200,
+    });
+
+    await render(
+      <Excalidraw
+        initialData={{
+          elements: [frame],
+        }}
+      />
+    );
+
+    const frameNameElement = document.querySelector(".frame-name");
+    expect(frameNameElement).not.toBeNull();
+
+    const initialScrollX = h.state.scrollX;
+    const initialScrollY = h.state.scrollY;
+
+    fireEvent.wheel(frameNameElement!, {
+      deltaX: 50,
+      deltaY: 100,
+    });
+
+    expect(h.state.scrollX).toBe(initialScrollX - 50);
+    expect(h.state.scrollY).toBe(initialScrollY - 100);
+
+    const initialZoom = h.state.zoom.value;
+
+    fireEvent.wheel(frameNameElement!, {
+      deltaY: -100,
+      ctrlKey: true,
+    });
+
+    expect(h.state.zoom.value).toBeGreaterThan(initialZoom);
     restoreOriginalGetBoundingClientRect();
   });
 });


### PR DESCRIPTION
### Description
This PR resolves the issue where touchpad/wheel navigation (scroll, pan, zoom) does not work when hovering the cursor on top of the frame name element.

### Root Cause
1. The global `handleWheel` listener was filtering out the wheel event when `event.target` was a descendant of `.frame-name` (such as the text node or the inner `<input>` when editing), because it only checked exact class match with `event.target.classList.contains(CLASSES.FRAME_NAME)`.
2. An inline `onWheel` listener was additionally registered on the frame name element itself, which bubbled up and caused double executions once matched.

### Fix
1. Updated the target check in `handleWheel` to use `event.target.closest("." + CLASSES.FRAME_NAME)` instead of `classList.contains(CLASSES.FRAME_NAME)`, so it correctly allows zooming/panning when hovering over the frame name or any of its descendants (like the text or edit input).
2. Removed the duplicate, redundant inline `onWheel` listener on the frame name `div`, allowing the wheel event to bubble naturally and be handled exactly once by the global handler.
3. Added a comprehensive regression unit test in `scroll.test.tsx` to verify that both panning and zooming function perfectly when the cursor is positioned over the frame name element.
