### PR TITLE
fix: show invalid state for malformed hex color input

### DIFF
--- a/packages/excalidraw/components/ColorPicker/ColorInput.tsx
+++ b/packages/excalidraw/components/ColorPicker/ColorInput.tsx
@@ -37,6 +37,10 @@ export const ColorInput = ({
     setInnerValue(color);
   }, [color]);
 
+  // Show invalid state when user has typed a non-empty value that isn't a
+  // recognized color (hex, named color, transparent, etc.)
+  const isInvalid = innerValue !== "" && !normalizeInputColor(innerValue);
+
   const changeColor = useCallback(
     (inputValue: string) => {
       const value = inputValue.toLowerCase();
@@ -68,7 +72,11 @@ export const ColorInput = ({
   }, [setEyeDropperState]);
 
   return (
-    <div className="color-picker__input-label">
+    <div
+      className={clsx("color-picker__input-label", {
+        "color-picker__input-label--invalid": isInvalid,
+      })}
+    >
       <div className="color-picker__input-hash">#</div>
       <input
         ref={activeSection === "hex" ? inputRef : undefined}
@@ -76,6 +84,7 @@ export const ColorInput = ({
         spellCheck={false}
         className="color-picker-input"
         aria-label={label}
+        aria-invalid={isInvalid || undefined}
         onChange={(event) => {
           changeColor(event.target.value);
         }}

--- a/packages/excalidraw/components/ColorPicker/ColorPicker.scss
+++ b/packages/excalidraw/components/ColorPicker/ColorPicker.scss
@@ -383,6 +383,19 @@
       box-shadow: 0 0 0 1px var(--color-primary-darkest);
       border-radius: var(--border-radius-lg);
     }
+
+    // Invalid hex value: red border + matching focus ring
+    &.color-picker__input-label--invalid {
+      border-color: #e03131;
+
+      .color-picker__input-hash {
+        color: #e03131;
+      }
+
+      &:focus-within {
+        box-shadow: 0 0 0 1px #e03131;
+      }
+    }
   }
 
   .color-picker__input-hash {


### PR DESCRIPTION
## Summary

Fixes #9527

When a user types an invalid hex value into the color picker input (e.g. `zzzzzz`, `123456789`, `12345`), the color silently stays unchanged with no visual feedback. This PR adds a red border and red `#` prefix to indicate the error, following standard UX patterns.

## Changes

**`packages/excalidraw/components/ColorPicker/ColorInput.tsx`** (+10 lines)

Derive `isInvalid` from the already-present `normalizeInputColor()\ call and apply a CSS modifier class + `aria-invalid` on the input:

```tsx
// new: one derived boolean, zero new imports
const isInvalid = innerValue !== "" && !normalizeInputColor(innerValue);
```

**`packages/excalidraw/components/ColorPicker/ColorPicker.scss`** (+13 lines)

Add a `&.color-picker__input-label--invalid` modifier inside the existing `.color-picker__input-label` block:

```scss
&.color-picker__input-label--invalid {
  border-color: #e03131;           // COLOR_PALETTE.red[4]
  .color-picker__input-hash { color: #e03131; }
  &:focus-within { box-shadow: 0 0 0 1px #e03131; }
}
```

## Behaviour

| Scenario | Before | After |
|---|---|---|
| User types `zzzzzz` | Silent, no feedback | Red border + red `#` |
| User types `123456789` | Silent | Red border + red `#` |
| User types `ff0000` (valid) | Color applied | Color applied, no error |
| User blurs invalid input | Resets to last valid color | Same — error disappears |

## Design decisions

- **No new imports** — reuses `normalizeInputColor` and `clsx`, both already imported
- **`#e03131`** — `COLOR_PALETTE.red[4]` already in the codebase
- **Border-only indicator** — matches the compact UI with no room for text
- **`aria-invalid`** — free accessibility win
- **Clears on blur** — consistent with existing reset-on-blur behaviour

## Test matrix (verified locally)

| Input | `normalizeInputColor` | `isInvalid` |
|---|---|---|
| `ff0000` | `#ff0000` | false |
| `#ff0000` | `#ff0000` | false |
| `red` | `red` | false |
| `transparent` | `transparent` | false |
| `` (empty) | guarded | false |
| `zzzzzz` | null | **true** |
| `123456789` | null | **true** |
| `12345` | null | **true** |