### PR TITLE
fix: improve dark mode selection contrast and eraser for bound text

### DIFF
--- a/packages/excalidraw/css/theme.scss
+++ b/packages/excalidraw/css/theme.scss
@@ -226,7 +226,7 @@
     --color-slider-track: hsl(244, 23%, 39%);
 
     // will be inverted to a lighter color.
-    --color-selection: #3530c4;
+    --color-selection: #1d1a99;
 
     --color-icon-white: var(--color-gray-90);
 

--- a/packages/excalidraw/eraser/index.ts
+++ b/packages/excalidraw/eraser/index.ts
@@ -13,6 +13,7 @@ import {
   isFreeDrawElement,
   isLineElement,
   isPointInElement,
+  isTextElement,
 } from "@excalidraw/element";
 import {
   lineSegment,
@@ -201,6 +202,20 @@ const eraserTest = (
   elementsMap: ElementsMap,
   zoom: number,
 ): boolean => {
+  if (isTextElement(element) && isBoundToContainer(element)) {
+    const container = elementsMap.get(element.containerId);
+    if (container) {
+      element = {
+        ...element,
+        ...computeBoundTextPosition(
+          container,
+          element as ExcalidrawTextElementWithContainer,
+          elementsMap,
+        ),
+      };
+    }
+  }
+
   const lastPoint = pathSegment[1];
 
   // PERF: Do a quick bounds intersection test first because it's cheap

--- a/packages/excalidraw/eraser/index.ts
+++ b/packages/excalidraw/eraser/index.ts
@@ -32,7 +32,11 @@ import { getBoundTextElementId } from "@excalidraw/element";
 import type { Bounds } from "@excalidraw/common";
 
 import type { GlobalPoint, LineSegment } from "@excalidraw/math/types";
-import type { ElementsMap, ExcalidrawElement } from "@excalidraw/element/types";
+import type {
+  ElementsMap,
+  ExcalidrawElement,
+  ExcalidrawTextElementWithContainer,
+} from "@excalidraw/element/types";
 
 import { AnimatedTrail } from "../animated-trail";
 
@@ -202,14 +206,16 @@ const eraserTest = (
   elementsMap: ElementsMap,
   zoom: number,
 ): boolean => {
-  if (isTextElement(element) && isBoundToContainer(element)) {
-    const container = elementsMap.get(element.containerId);
+  let targetElement = element;
+
+  if (isTextElement(targetElement) && isBoundToContainer(targetElement)) {
+    const container = elementsMap.get(targetElement.containerId);
     if (container) {
-      element = {
-        ...element,
+      targetElement = {
+        ...targetElement,
         ...computeBoundTextPosition(
           container,
-          element as ExcalidrawTextElementWithContainer,
+          targetElement as ExcalidrawTextElementWithContainer,
           elementsMap,
         ),
       };
@@ -219,14 +225,14 @@ const eraserTest = (
   const lastPoint = pathSegment[1];
 
   // PERF: Do a quick bounds intersection test first because it's cheap
-  const threshold = isFreeDrawElement(element) ? 15 : element.strokeWidth / 2;
+  const threshold = isFreeDrawElement(targetElement) ? 15 : targetElement.strokeWidth / 2;
   const segmentBounds = [
     Math.min(pathSegment[0][0], pathSegment[1][0]) - threshold,
     Math.min(pathSegment[0][1], pathSegment[1][1]) - threshold,
     Math.max(pathSegment[0][0], pathSegment[1][0]) + threshold,
     Math.max(pathSegment[0][1], pathSegment[1][1]) + threshold,
   ] as Bounds;
-  const origElementBounds = getElementBounds(element, elementsMap);
+  const origElementBounds = getElementBounds(targetElement, elementsMap);
   const elementBounds: Bounds = [
     origElementBounds[0] - threshold,
     origElementBounds[1] - threshold,
@@ -242,8 +248,8 @@ const eraserTest = (
   // even though the eraser path segment doesn't intersect with or
   // get close to the shape's stroke
   if (
-    shouldTestInside(element) &&
-    isPointInElement(lastPoint, element, elementsMap)
+    shouldTestInside(targetElement) &&
+    isPointInElement(lastPoint, targetElement, elementsMap)
   ) {
     return true;
   }
@@ -251,10 +257,10 @@ const eraserTest = (
   // Freedraw elements are tested for erasure by measuring the distance
   // of the eraser path and the freedraw shape outline lines to a tolerance
   // which offers a good visual precision at various zoom levels
-  if (isFreeDrawElement(element)) {
-    const outlinePoints = getFreedrawOutlinePoints(element);
+  if (isFreeDrawElement(targetElement)) {
+    const outlinePoints = getFreedrawOutlinePoints(targetElement);
     const strokeSegments = getFreedrawOutlineAsSegments(
-      element,
+      targetElement,
       outlinePoints,
       elementsMap,
     );
@@ -268,7 +274,7 @@ const eraserTest = (
 
     const poly = polygon(
       ...(outlinePoints.map(([x, y]) =>
-        pointFrom<GlobalPoint>(element.x + x, element.y + y),
+        pointFrom<GlobalPoint>(targetElement.x + x, targetElement.y + y),
       ) as GlobalPoint[]),
     );
 
@@ -282,18 +288,18 @@ const eraserTest = (
     return false;
   }
 
-  const boundTextElement = getBoundTextElement(element, elementsMap);
+  const boundTextElement = getBoundTextElement(targetElement, elementsMap);
 
-  if (isArrowElement(element) || (isLineElement(element) && !element.polygon)) {
+  if (isArrowElement(targetElement) || (isLineElement(targetElement) && !targetElement.polygon)) {
     const tolerance = Math.max(
-      element.strokeWidth,
-      (element.strokeWidth * 2) / zoom,
+      targetElement.strokeWidth,
+      (targetElement.strokeWidth * 2) / zoom,
     );
 
     // If the eraser movement is so fast that a large distance is covered
     // between the last two points, the distanceToElement miss, so we test
     // agaist each segment of the linear element
-    const segments = getElementLineSegments(element, elementsMap);
+    const segments = getElementLineSegments(targetElement, elementsMap);
     for (const seg of segments) {
       if (lineSegmentsDistance(seg, pathSegment) <= tolerance) {
         return true;
@@ -304,13 +310,13 @@ const eraserTest = (
   }
 
   return (
-    intersectElementWithLineSegment(element, elementsMap, pathSegment, 0, true)
+    intersectElementWithLineSegment(targetElement, elementsMap, pathSegment, 0, true)
       .length > 0 ||
     (!!boundTextElement &&
       intersectElementWithLineSegment(
         {
           ...boundTextElement,
-          ...computeBoundTextPosition(element, boundTextElement, elementsMap),
+          ...computeBoundTextPosition(targetElement, boundTextElement, elementsMap),
         },
         elementsMap,
         pathSegment,


### PR DESCRIPTION
## Fixes & Improvements

- **Selection Accessibility Fix**  
  Adjusted `--color-selection` in dark mode to improve visibility and ensure compliance with WCAG 3:1 contrast requirements.

- **Eraser Bound Text Fix**  
  Updated `eraserTest` to calculate absolute positions for bound text, resolving an issue where labels attached to arrows could not be erased correctly.