### PR TITLE
feat: add customizable workspace layout mode

### DIFF
--- a/packages/excalidraw/actions/actionWorkspaceLayout.tsx
+++ b/packages/excalidraw/actions/actionWorkspaceLayout.tsx
@@ -1,0 +1,53 @@
+import { CaptureUpdateAction } from "@excalidraw/element";
+
+import { frameToolIcon } from "../components/icons";
+import { getDefaultWorkspaceLayout } from "../workspaceLayout";
+
+import { register } from "./register";
+
+export const actionToggleWorkspaceLayoutEdit = register({
+  name: "toggleWorkspaceLayoutEdit",
+  label: "labels.workspaceLayoutEdit",
+  icon: frameToolIcon,
+  viewMode: true,
+  trackEvent: { category: "menu" },
+  perform(elements, appState) {
+    return {
+      appState: {
+        ...appState,
+        workspaceLayout: {
+          ...appState.workspaceLayout,
+          editing: !this.checked!(appState),
+        },
+      },
+      captureUpdate: CaptureUpdateAction.EVENTUALLY,
+    };
+  },
+  checked: (appState) => appState.workspaceLayout.editing,
+  predicate: (elements, appState, appProps, app) => {
+    return app.editorInterface.formFactor !== "phone";
+  },
+});
+
+export const actionResetWorkspaceLayout = register({
+  name: "resetWorkspaceLayout",
+  label: "labels.workspaceLayoutReset",
+  icon: frameToolIcon,
+  viewMode: true,
+  trackEvent: { category: "menu" },
+  perform(elements, appState) {
+    return {
+      appState: {
+        ...appState,
+        workspaceLayout: {
+          ...getDefaultWorkspaceLayout(),
+          editing: appState.workspaceLayout.editing,
+        },
+      },
+      captureUpdate: CaptureUpdateAction.EVENTUALLY,
+    };
+  },
+  predicate: (elements, appState, appProps, app) => {
+    return app.editorInterface.formFactor !== "phone";
+  },
+});

--- a/packages/excalidraw/actions/index.ts
+++ b/packages/excalidraw/actions/index.ts
@@ -84,6 +84,10 @@ export { actionToggleArrowBinding } from "./actionToggleArrowBinding";
 export { actionToggleMidpointSnapping } from "./actionToggleMidpointSnapping";
 
 export { actionToggleStats } from "./actionToggleStats";
+export {
+  actionToggleWorkspaceLayoutEdit,
+  actionResetWorkspaceLayout,
+} from "./actionWorkspaceLayout";
 export { actionUnbindText, actionBindText } from "./actionBoundText";
 export { actionLink } from "./actionLink";
 export { actionToggleElementLock } from "./actionElementLock";

--- a/packages/excalidraw/actions/types.ts
+++ b/packages/excalidraw/actions/types.ts
@@ -58,6 +58,8 @@ export type ActionName =
   | "pasteStyles"
   | "gridMode"
   | "zenMode"
+  | "toggleWorkspaceLayoutEdit"
+  | "resetWorkspaceLayout"
   | "objectsSnapMode"
   | "arrowBinding"
   | "midpointSnapping"

--- a/packages/excalidraw/appState.ts
+++ b/packages/excalidraw/appState.ts
@@ -13,6 +13,8 @@ import {
   isTestEnv,
 } from "@excalidraw/common";
 
+import { getDefaultWorkspaceLayout } from "./workspaceLayout";
+
 import type { AppState, NormalizedZoomValue } from "./types";
 
 const defaultExportScale = EXPORT_SCALES.includes(devicePixelRatio)
@@ -128,6 +130,7 @@ export const getDefaultAppState = (): Omit<
     activeLockedId: null,
     bindMode: "orbit",
     boxSelectionMode: "contain",
+    workspaceLayout: getDefaultWorkspaceLayout(),
   };
 };
 
@@ -254,6 +257,7 @@ const APP_STATE_STORAGE_CONF = (<
   lockedMultiSelections: { browser: true, export: true, server: true },
   activeLockedId: { browser: false, export: false, server: false },
   bindMode: { browser: true, export: false, server: false },
+  workspaceLayout: { browser: true, export: false, server: false },
 });
 
 const _clearAppStateForStorage = <

--- a/packages/excalidraw/components/CommandPalette/CommandPalette.tsx
+++ b/packages/excalidraw/components/CommandPalette/CommandPalette.tsx
@@ -371,6 +371,8 @@ function CommandPaletteInner({
         actionManager.actions.zenMode,
         actionManager.actions.viewMode,
         actionManager.actions.gridMode,
+        actionManager.actions.toggleWorkspaceLayoutEdit,
+        actionManager.actions.resetWorkspaceLayout,
         actionManager.actions.objectsSnapMode,
         actionManager.actions.toggleShortcuts,
         actionManager.actions.selectAll,

--- a/packages/excalidraw/components/LayerUI.tsx
+++ b/packages/excalidraw/components/LayerUI.tsx
@@ -61,6 +61,7 @@ import { Island } from "./Island";
 import { JSONExportDialog } from "./JSONExportDialog";
 import { LaserPointerButton } from "./LaserPointerButton";
 import { Toast } from "./Toast";
+import { WorkspaceZone } from "./WorkspaceZone/WorkspaceZone";
 
 import "./LayerUI.scss";
 import "./Toolbar.scss";
@@ -226,12 +227,14 @@ const LayerUI = ({
   };
 
   const renderCanvasActions = () => (
-    <div style={{ position: "relative" }}>
-      {/* wrapping to Fragment stops React from occasionally complaining
+    <WorkspaceZone zoneId="mainMenu" controlsPlacement="right" hideable={false}>
+      <div style={{ position: "relative" }}>
+        {/* wrapping to Fragment stops React from occasionally complaining
                 about identical Keys */}
-      <tunnels.MainMenuTunnel.Out />
-      {renderWelcomeScreen && <tunnels.WelcomeScreenMenuHintTunnel.Out />}
-    </div>
+        <tunnels.MainMenuTunnel.Out />
+        {renderWelcomeScreen && <tunnels.WelcomeScreenMenuHintTunnel.Out />}
+      </div>
+    </WorkspaceZone>
   );
 
   const renderSelectedShapeActions = () => {
@@ -310,85 +313,102 @@ const LayerUI = ({
                   isCompactStylesPanel,
               })}
             >
-              {shouldRenderSelectedShapeActions && renderSelectedShapeActions()}
+              {(shouldRenderSelectedShapeActions ||
+                appState.workspaceLayout.editing) && (
+                <WorkspaceZone
+                  zoneId="propertiesPanel"
+                  resizableHeight
+                  controlsPlacement="below"
+                >
+                  {shouldRenderSelectedShapeActions ? (
+                    renderSelectedShapeActions()
+                  ) : (
+                    <Island padding={2} className="workspace-zone__placeholder">
+                      {t("workspaceLayout.propertiesPanelPlaceholder")}
+                    </Island>
+                  )}
+                </WorkspaceZone>
+              )}
             </div>
           </Stack.Col>
           {!appState.viewModeEnabled &&
             appState.openDialog?.name !== "elementLinkSelector" && (
               <Section heading="shapes" className="shapes-section">
                 {(heading: React.ReactNode) => (
-                  <div style={{ position: "relative" }}>
-                    {renderWelcomeScreen && (
-                      <tunnels.WelcomeScreenToolbarHintTunnel.Out />
-                    )}
-                    <Stack.Col gap={spacing.toolbarColGap} align="start">
-                      <Stack.Row
-                        gap={spacing.toolbarRowGap}
-                        className={clsx("App-toolbar-container", {
-                          "zen-mode": appState.zenModeEnabled,
-                        })}
-                      >
-                        <Island
-                          padding={spacing.islandPadding}
-                          className={clsx("App-toolbar", {
+                  <WorkspaceZone zoneId="toolbar" controlsPlacement="below">
+                    <div style={{ position: "relative" }}>
+                      {renderWelcomeScreen && (
+                        <tunnels.WelcomeScreenToolbarHintTunnel.Out />
+                      )}
+                      <Stack.Col gap={spacing.toolbarColGap} align="start">
+                        <Stack.Row
+                          gap={spacing.toolbarRowGap}
+                          className={clsx("App-toolbar-container", {
                             "zen-mode": appState.zenModeEnabled,
-                            "App-toolbar--compact": isCompactStylesPanel,
                           })}
                         >
-                          <HintViewer
-                            appState={appState}
-                            isMobile={editorInterface.formFactor === "phone"}
-                            editorInterface={editorInterface}
-                            app={app}
-                          />
-                          {heading}
-                          <Stack.Row gap={spacing.toolbarInnerRowGap}>
-                            <PenModeButton
-                              zenModeEnabled={appState.zenModeEnabled}
-                              checked={appState.penMode}
-                              onChange={() => onPenModeToggle(null)}
-                              title={t("toolBar.penMode")}
-                              penDetected={appState.penDetected}
-                            />
-                            <LockButton
-                              checked={appState.activeTool.locked}
-                              onChange={onLockToggle}
-                              title={t("toolBar.lock")}
-                            />
-
-                            <div className="App-toolbar__divider" />
-
-                            <ShapesSwitcher
-                              setAppState={setAppState}
-                              activeTool={appState.activeTool}
-                              UIOptions={UIOptions}
+                          <Island
+                            padding={spacing.islandPadding}
+                            className={clsx("App-toolbar", {
+                              "zen-mode": appState.zenModeEnabled,
+                              "App-toolbar--compact": isCompactStylesPanel,
+                            })}
+                          >
+                            <HintViewer
+                              appState={appState}
+                              isMobile={editorInterface.formFactor === "phone"}
+                              editorInterface={editorInterface}
                               app={app}
                             />
-                          </Stack.Row>
-                        </Island>
-                        {isCollaborating && (
-                          <Island
-                            style={{
-                              marginLeft: spacing.collabMarginLeft,
-                              alignSelf: "center",
-                              height: "fit-content",
-                            }}
-                          >
-                            <LaserPointerButton
-                              title={t("toolBar.laser")}
-                              checked={
-                                appState.activeTool.type === TOOL_TYPE.laser
-                              }
-                              onChange={() =>
-                                app.setActiveTool({ type: TOOL_TYPE.laser })
-                              }
-                              isMobile
-                            />
+                            {heading}
+                            <Stack.Row gap={spacing.toolbarInnerRowGap}>
+                              <PenModeButton
+                                zenModeEnabled={appState.zenModeEnabled}
+                                checked={appState.penMode}
+                                onChange={() => onPenModeToggle(null)}
+                                title={t("toolBar.penMode")}
+                                penDetected={appState.penDetected}
+                              />
+                              <LockButton
+                                checked={appState.activeTool.locked}
+                                onChange={onLockToggle}
+                                title={t("toolBar.lock")}
+                              />
+
+                              <div className="App-toolbar__divider" />
+
+                              <ShapesSwitcher
+                                setAppState={setAppState}
+                                activeTool={appState.activeTool}
+                                UIOptions={UIOptions}
+                                app={app}
+                              />
+                            </Stack.Row>
                           </Island>
-                        )}
-                      </Stack.Row>
-                    </Stack.Col>
-                  </div>
+                          {isCollaborating && (
+                            <Island
+                              style={{
+                                marginLeft: spacing.collabMarginLeft,
+                                alignSelf: "center",
+                                height: "fit-content",
+                              }}
+                            >
+                              <LaserPointerButton
+                                title={t("toolBar.laser")}
+                                checked={
+                                  appState.activeTool.type === TOOL_TYPE.laser
+                                }
+                                onChange={() =>
+                                  app.setActiveTool({ type: TOOL_TYPE.laser })
+                                }
+                                isMobile
+                              />
+                            </Island>
+                          )}
+                        </Stack.Row>
+                      </Stack.Col>
+                    </div>
+                  </WorkspaceZone>
                 )}
               </Section>
             )}
@@ -416,7 +436,13 @@ const LayerUI = ({
               // hide button when sidebar docked
               (!isSidebarDocked ||
                 appState.openSidebar?.name !== DEFAULT_SIDEBAR.name) && (
-                <tunnels.DefaultSidebarTriggerTunnel.Out />
+                <WorkspaceZone
+                  zoneId="libraryButton"
+                  controlsPlacement="below"
+                  controlsAlign="end"
+                >
+                  <tunnels.DefaultSidebarTriggerTunnel.Out />
+                </WorkspaceZone>
               )}
             {shouldShowStats && (
               <Stats

--- a/packages/excalidraw/components/WorkspaceZone/WorkspaceZone.scss
+++ b/packages/excalidraw/components/WorkspaceZone/WorkspaceZone.scss
@@ -1,0 +1,166 @@
+.excalidraw {
+  .workspace-zone {
+    position: relative;
+    display: flex;
+
+    &--editing {
+      outline: 1px dashed var(--color-primary);
+      outline-offset: 3px;
+      border-radius: var(--border-radius-lg);
+    }
+
+    &--editing.workspace-zone--locked {
+      outline-style: solid;
+      outline-color: var(--default-border-color);
+    }
+
+    // outside edit mode, unlocked zones are dragged by grabbing any
+    // non-interactive area; interactive children keep their own cursor
+    &--quick-draggable {
+      cursor: grab;
+    }
+
+    &--dragging {
+      cursor: grabbing;
+      user-select: none;
+    }
+
+    &--ghost
+      > *:not(.workspace-zone__controls):not(.workspace-zone__resize-handle) {
+      opacity: 0.4;
+      pointer-events: none !important;
+    }
+
+    // let the wrapper hug the (normally absolutely-positioned) properties
+    // panel island so the outline/handles match its bounds in every mode
+    &--zone-propertiesPanel {
+      .App-menu__left,
+      .compact-shape-actions-island {
+        position: static;
+      }
+    }
+
+    &--has-height {
+      .App-menu__left,
+      .compact-shape-actions-island {
+        max-height: var(--workspace-zone-height) !important;
+      }
+    }
+
+    &__controls {
+      position: absolute;
+      display: flex;
+      gap: 2px;
+      padding: 2px;
+      background-color: var(--island-bg-color);
+      border: 1px solid var(--default-border-color);
+      border-radius: var(--border-radius-md);
+      box-shadow: var(--shadow-island);
+      z-index: 10;
+      pointer-events: var(--ui-pointerEvents);
+
+      &--above {
+        bottom: calc(100% + 6px);
+      }
+
+      &--below {
+        top: calc(100% + 6px);
+      }
+
+      &--align-start {
+        left: 0;
+      }
+
+      &--align-end {
+        right: 0;
+      }
+
+      &--right {
+        top: 0;
+        bottom: auto;
+        left: calc(100% + 6px);
+        right: auto;
+      }
+    }
+
+    &__control {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 1.75rem;
+      height: 1.75rem;
+      padding: 0.25rem;
+      border: none;
+      border-radius: var(--border-radius-md);
+      background-color: transparent;
+      color: var(--text-primary-color);
+      cursor: pointer;
+
+      svg {
+        width: 1rem;
+        height: 1rem;
+      }
+
+      &:hover:not(:disabled) {
+        background-color: var(--button-hover-bg);
+      }
+
+      &:active:not(:disabled) {
+        background-color: var(--button-hover-bg);
+      }
+
+      &:disabled {
+        opacity: 0.4;
+        cursor: default;
+      }
+
+      &--drag {
+        cursor: grab;
+        touch-action: none;
+
+        &:active:not(:disabled) {
+          cursor: grabbing;
+        }
+      }
+    }
+
+    &__resize-handle {
+      position: absolute;
+      left: 15%;
+      right: 15%;
+      bottom: -4px;
+      height: 7px;
+      border-radius: 4px;
+      background-color: var(--color-primary);
+      opacity: 0.5;
+      cursor: ns-resize;
+      touch-action: none;
+      z-index: 10;
+      pointer-events: var(--ui-pointerEvents);
+
+      &:hover {
+        opacity: 1;
+      }
+
+      &--quick {
+        opacity: 0.2;
+        transition: opacity 0.15s ease-in-out;
+
+        &:hover {
+          opacity: 0.9;
+        }
+      }
+    }
+
+    &__placeholder {
+      width: 12.5rem;
+      box-sizing: border-box;
+      color: var(--color-gray-50);
+      font-size: 0.875rem;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      min-height: 4rem;
+    }
+  }
+}

--- a/packages/excalidraw/components/WorkspaceZone/WorkspaceZone.tsx
+++ b/packages/excalidraw/components/WorkspaceZone/WorkspaceZone.tsx
@@ -1,0 +1,340 @@
+import clsx from "clsx";
+import { useRef, useState } from "react";
+
+import { useUIAppState } from "../../context/ui-appState";
+import { t } from "../../i18n";
+import {
+  getWorkspaceZoneConfig,
+  getDefaultWorkspaceZoneConfig,
+} from "../../workspaceLayout";
+import { useExcalidrawSetAppState } from "../App";
+import {
+  DotsHorizontalIcon,
+  LockedIcon,
+  UnlockedIcon,
+  UndoIcon,
+  eyeClosedIcon,
+  eyeIcon,
+} from "../icons";
+
+import "./WorkspaceZone.scss";
+
+import type {
+  WorkspaceZoneConfig,
+  WorkspaceZoneId,
+} from "../../workspaceLayout";
+
+const MIN_ZONE_HEIGHT = 120;
+
+interface WorkspaceZoneProps {
+  zoneId: WorkspaceZoneId;
+  children: React.ReactNode;
+  resizableHeight?: boolean;
+  /** zones that are the only entry point to preferences (main menu) must not
+      be hideable, otherwise there'd be no pointer-only way to bring them back */
+  hideable?: boolean;
+  controlsPlacement?: "above" | "below" | "right";
+  controlsAlign?: "start" | "end";
+}
+
+export const WorkspaceZone = ({
+  zoneId,
+  children,
+  resizableHeight = false,
+  hideable = true,
+  controlsPlacement = "above",
+  controlsAlign = "start",
+}: WorkspaceZoneProps) => {
+  const appState = useUIAppState();
+  const setAppState = useExcalidrawSetAppState();
+
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const [dragDelta, setDragDelta] = useState<{ x: number; y: number } | null>(
+    null,
+  );
+  const [resizeHeight, setResizeHeight] = useState<number | null>(null);
+  const dragStartRef = useRef<{ x: number; y: number } | null>(null);
+  const resizeStartRef = useRef<{ y: number; height: number } | null>(null);
+
+  const { workspaceLayout } = appState;
+  const config = getWorkspaceZoneConfig(workspaceLayout, zoneId);
+  const isEditing = workspaceLayout.editing;
+
+  const updateZone = (patch: Partial<WorkspaceZoneConfig>) => {
+    setAppState((state) => ({
+      workspaceLayout: {
+        ...state.workspaceLayout,
+        zones: {
+          ...state.workspaceLayout.zones,
+          [zoneId]: {
+            ...getWorkspaceZoneConfig(state.workspaceLayout, zoneId),
+            ...patch,
+          },
+        },
+      },
+    }));
+  };
+
+  const resetZone = () => {
+    setAppState((state) => {
+      const zones = { ...state.workspaceLayout.zones };
+      delete zones[zoneId];
+      return {
+        workspaceLayout: {
+          ...state.workspaceLayout,
+          zones,
+        },
+      };
+    });
+  };
+
+  if (!config.visible && !isEditing) {
+    return null;
+  }
+
+  const offsetX = config.offsetX + (dragDelta?.x ?? 0);
+  const offsetY = config.offsetY + (dragDelta?.y ?? 0);
+  const height = resizeHeight ?? config.height;
+
+  const startDrag = (event: React.PointerEvent<HTMLElement>) => {
+    event.currentTarget.setPointerCapture?.(event.pointerId);
+    dragStartRef.current = { x: event.clientX, y: event.clientY };
+    setDragDelta({ x: 0, y: 0 });
+  };
+
+  const onDragPointerDown = (event: React.PointerEvent<HTMLElement>) => {
+    if (config.locked || event.button !== 0) {
+      return;
+    }
+    event.preventDefault();
+    event.stopPropagation();
+    startDrag(event);
+  };
+
+  // outside edit mode the zone itself is the drag surface: grabbing any
+  // non-interactive area moves it, while clicks on its actual controls
+  // (buttons, inputs, menu content, ...) behave as usual
+  const onZonePointerDown = (event: React.PointerEvent<HTMLElement>) => {
+    if (config.locked || event.button !== 0) {
+      return;
+    }
+    const target = event.target as HTMLElement;
+    if (
+      target.closest(
+        'button, a, input, textarea, select, label, [role="button"], [contenteditable="true"], .dropdown-menu, .workspace-zone__resize-handle',
+      )
+    ) {
+      return;
+    }
+    event.preventDefault();
+    startDrag(event);
+  };
+
+  const onDragPointerMove = (event: React.PointerEvent<HTMLElement>) => {
+    if (!dragStartRef.current) {
+      return;
+    }
+    setDragDelta({
+      x: event.clientX - dragStartRef.current.x,
+      y: event.clientY - dragStartRef.current.y,
+    });
+  };
+
+  const onDragPointerUp = (event: React.PointerEvent<HTMLElement>) => {
+    if (!dragStartRef.current) {
+      return;
+    }
+    const delta = {
+      x: event.clientX - dragStartRef.current.x,
+      y: event.clientY - dragStartRef.current.y,
+    };
+    dragStartRef.current = null;
+    setDragDelta(null);
+    if (event.currentTarget.hasPointerCapture?.(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId);
+    }
+    if (delta.x !== 0 || delta.y !== 0) {
+      updateZone({
+        offsetX: config.offsetX + delta.x,
+        offsetY: config.offsetY + delta.y,
+      });
+    }
+  };
+
+  const onResizePointerDown = (event: React.PointerEvent<HTMLElement>) => {
+    if (config.locked || event.button !== 0) {
+      return;
+    }
+    event.preventDefault();
+    event.stopPropagation();
+    event.currentTarget.setPointerCapture?.(event.pointerId);
+    const currentHeight =
+      config.height ??
+      (wrapperRef.current?.getBoundingClientRect().height || MIN_ZONE_HEIGHT);
+    resizeStartRef.current = { y: event.clientY, height: currentHeight };
+    setResizeHeight(currentHeight);
+  };
+
+  const onResizePointerMove = (event: React.PointerEvent<HTMLElement>) => {
+    if (!resizeStartRef.current) {
+      return;
+    }
+    setResizeHeight(
+      Math.max(
+        MIN_ZONE_HEIGHT,
+        resizeStartRef.current.height +
+          (event.clientY - resizeStartRef.current.y),
+      ),
+    );
+  };
+
+  const onResizePointerUp = (event: React.PointerEvent<HTMLElement>) => {
+    if (!resizeStartRef.current) {
+      return;
+    }
+    const nextHeight = Math.max(
+      MIN_ZONE_HEIGHT,
+      resizeStartRef.current.height +
+        (event.clientY - resizeStartRef.current.y),
+    );
+    resizeStartRef.current = null;
+    setResizeHeight(null);
+    if (event.currentTarget.hasPointerCapture?.(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId);
+    }
+    updateZone({ height: nextHeight });
+  };
+
+  const defaults = getDefaultWorkspaceZoneConfig();
+  const isModified =
+    config.offsetX !== defaults.offsetX ||
+    config.offsetY !== defaults.offsetY ||
+    config.visible !== defaults.visible ||
+    config.locked !== defaults.locked ||
+    config.height !== undefined;
+
+  // outside edit mode, unlocked zones are draggable by grabbing any
+  // non-interactive area (grab cursor) and, where supported, keep their
+  // resize handle; locked zones stay fixed
+  const isQuickDraggable = !isEditing && config.visible && !config.locked;
+  const showResizeHandle = resizableHeight && (isEditing || isQuickDraggable);
+
+  return (
+    <div
+      ref={wrapperRef}
+      className={clsx("workspace-zone", `workspace-zone--zone-${zoneId}`, {
+        "workspace-zone--editing": isEditing,
+        "workspace-zone--ghost": isEditing && !config.visible,
+        "workspace-zone--locked": config.locked,
+        "workspace-zone--has-height": height !== undefined,
+        "workspace-zone--quick-draggable": isQuickDraggable,
+        "workspace-zone--dragging": dragDelta !== null,
+      })}
+      style={
+        {
+          transform:
+            offsetX !== 0 || offsetY !== 0
+              ? `translate(${offsetX}px, ${offsetY}px)`
+              : undefined,
+          "--workspace-zone-height":
+            height !== undefined ? `${height}px` : undefined,
+        } as React.CSSProperties
+      }
+      data-testid={`workspace-zone-${zoneId}`}
+      onPointerDown={isQuickDraggable ? onZonePointerDown : undefined}
+      onPointerMove={isQuickDraggable ? onDragPointerMove : undefined}
+      onPointerUp={isQuickDraggable ? onDragPointerUp : undefined}
+      onPointerCancel={isQuickDraggable ? onDragPointerUp : undefined}
+    >
+      {children}
+      {isEditing && (
+        <div
+          className={clsx(
+            "workspace-zone__controls",
+            `workspace-zone__controls--${controlsPlacement}`,
+            `workspace-zone__controls--align-${controlsAlign}`,
+          )}
+        >
+          <button
+            type="button"
+            className="workspace-zone__control workspace-zone__control--drag"
+            title={t("workspaceLayout.drag")}
+            aria-label={t("workspaceLayout.drag")}
+            disabled={config.locked}
+            data-testid={`workspace-zone-drag-${zoneId}`}
+            onPointerDown={onDragPointerDown}
+            onPointerMove={onDragPointerMove}
+            onPointerUp={onDragPointerUp}
+            onPointerCancel={onDragPointerUp}
+          >
+            {DotsHorizontalIcon}
+          </button>
+          <button
+            type="button"
+            className="workspace-zone__control"
+            title={
+              config.locked
+                ? t("workspaceLayout.unlock")
+                : t("workspaceLayout.lock")
+            }
+            aria-label={
+              config.locked
+                ? t("workspaceLayout.unlock")
+                : t("workspaceLayout.lock")
+            }
+            data-testid={`workspace-zone-lock-${zoneId}`}
+            onClick={() => updateZone({ locked: !config.locked })}
+          >
+            {config.locked ? LockedIcon : UnlockedIcon}
+          </button>
+          {hideable && (
+            <button
+              type="button"
+              className="workspace-zone__control"
+              title={
+                config.visible
+                  ? t("workspaceLayout.hide")
+                  : t("workspaceLayout.show")
+              }
+              aria-label={
+                config.visible
+                  ? t("workspaceLayout.hide")
+                  : t("workspaceLayout.show")
+              }
+              data-testid={`workspace-zone-visibility-${zoneId}`}
+              onClick={() => updateZone({ visible: !config.visible })}
+            >
+              {config.visible ? eyeIcon : eyeClosedIcon}
+            </button>
+          )}
+          <button
+            type="button"
+            className="workspace-zone__control"
+            title={t("workspaceLayout.reset")}
+            aria-label={t("workspaceLayout.reset")}
+            disabled={!isModified}
+            data-testid={`workspace-zone-reset-${zoneId}`}
+            onClick={resetZone}
+          >
+            {UndoIcon}
+          </button>
+        </div>
+      )}
+      {showResizeHandle && (
+        <div
+          className={clsx("workspace-zone__resize-handle", {
+            "workspace-zone__resize-handle--quick": !isEditing,
+          })}
+          title={t("workspaceLayout.resize")}
+          data-testid={`workspace-zone-resize-${zoneId}`}
+          onPointerDown={onResizePointerDown}
+          onPointerMove={onResizePointerMove}
+          onPointerUp={onResizePointerUp}
+          onPointerCancel={onResizePointerUp}
+        />
+      )}
+    </div>
+  );
+};
+
+WorkspaceZone.displayName = "WorkspaceZone";

--- a/packages/excalidraw/components/footer/Footer.tsx
+++ b/packages/excalidraw/components/footer/Footer.tsx
@@ -6,6 +6,7 @@ import { ExitZenModeButton, UndoRedoActions, ZoomActions } from "../Actions";
 import { HelpButton } from "../HelpButton";
 import { Section } from "../Section";
 import Stack from "../Stack";
+import { WorkspaceZone } from "../WorkspaceZone/WorkspaceZone";
 
 import type { ActionManager } from "../../actions/manager";
 import type { UIAppState } from "../../types";
@@ -36,19 +37,23 @@ const Footer = ({
       >
         <Stack.Col gap={2}>
           <Section heading="canvasActions">
-            <ZoomActions
-              renderAction={actionManager.renderAction}
-              zoom={appState.zoom}
-            />
+            <WorkspaceZone zoneId="zoom" controlsPlacement="above">
+              <ZoomActions
+                renderAction={actionManager.renderAction}
+                zoom={appState.zoom}
+              />
+            </WorkspaceZone>
 
             {!appState.viewModeEnabled && (
-              <UndoRedoActions
-                renderAction={actionManager.renderAction}
-                className={clsx("zen-mode-transition", {
-                  "layer-ui__wrapper__footer-left--transition-bottom":
-                    appState.zenModeEnabled,
-                })}
-              />
+              <WorkspaceZone zoneId="undoRedo" controlsPlacement="above">
+                <UndoRedoActions
+                  renderAction={actionManager.renderAction}
+                  className={clsx("zen-mode-transition", {
+                    "layer-ui__wrapper__footer-left--transition-bottom":
+                      appState.zenModeEnabled,
+                  })}
+                />
+              </WorkspaceZone>
             )}
           </Section>
         </Stack.Col>

--- a/packages/excalidraw/components/main-menu/DefaultItems.tsx
+++ b/packages/excalidraw/components/main-menu/DefaultItems.tsx
@@ -7,6 +7,7 @@ import type { Theme } from "@excalidraw/element/types";
 import {
   actionClearCanvas,
   actionLoadScene,
+  actionResetWorkspaceLayout,
   actionSaveToActiveFile,
   actionShortcuts,
   actionToggleArrowBinding,
@@ -16,6 +17,7 @@ import {
   actionToggleSearchMenu,
   actionToggleStats,
   actionToggleTheme,
+  actionToggleWorkspaceLayoutEdit,
   actionToggleZenMode,
 } from "../../actions";
 import { actionToggleViewMode } from "../../actions/actionToggleViewMode";
@@ -591,6 +593,51 @@ const PreferencesToggleElementPropertiesItem = () => {
   );
 };
 
+export const PreferencesToggleWorkspaceLayoutEditItem = () => {
+  const { t } = useI18n();
+  const actionManager = useExcalidrawActionManager();
+  const appState = useUIAppState();
+
+  if (!actionManager.isActionEnabled(actionToggleWorkspaceLayoutEdit)) {
+    return null;
+  }
+
+  return (
+    <DropdownMenuItemCheckbox
+      checked={appState.workspaceLayout.editing}
+      data-testid="toggle-workspace-layout-edit"
+      onSelect={(event) => {
+        actionManager.executeAction(actionToggleWorkspaceLayoutEdit);
+        event.preventDefault();
+      }}
+    >
+      {t("labels.workspaceLayoutEdit")}
+    </DropdownMenuItemCheckbox>
+  );
+};
+
+export const PreferencesResetWorkspaceLayoutItem = () => {
+  const { t } = useI18n();
+  const actionManager = useExcalidrawActionManager();
+
+  if (!actionManager.isActionEnabled(actionResetWorkspaceLayout)) {
+    return null;
+  }
+
+  return (
+    <DropdownMenuItem
+      icon={emptyIcon}
+      data-testid="reset-workspace-layout"
+      onSelect={() => {
+        actionManager.executeAction(actionResetWorkspaceLayout);
+      }}
+      aria-label={t("labels.workspaceLayoutReset")}
+    >
+      {t("labels.workspaceLayoutReset")}
+    </DropdownMenuItem>
+  );
+};
+
 export const Preferences = ({
   children,
   additionalItems,
@@ -616,6 +663,8 @@ export const Preferences = ({
             <PreferencesToggleElementPropertiesItem />
             <PreferencesToggleArrowBindingItem />
             <PreferencesToggleMidpointSnappingItem />
+            <PreferencesToggleWorkspaceLayoutEditItem />
+            <PreferencesResetWorkspaceLayoutItem />
           </>
         )}
         {additionalItems}
@@ -633,5 +682,8 @@ Preferences.ToggleGridMode = PreferencesToggleGridModeItem;
 Preferences.ToggleZenMode = PreferencesToggleZenModeItem;
 Preferences.ToggleViewMode = PreferencesToggleViewModeItem;
 Preferences.ToggleElementProperties = PreferencesToggleElementPropertiesItem;
+Preferences.ToggleWorkspaceLayoutEdit =
+  PreferencesToggleWorkspaceLayoutEditItem;
+Preferences.ResetWorkspaceLayout = PreferencesResetWorkspaceLayoutItem;
 
 Preferences.displayName = "Preferences";

--- a/packages/excalidraw/data/restore.ts
+++ b/packages/excalidraw/data/restore.ts
@@ -83,6 +83,11 @@ import {
   getNormalizedZoom,
 } from "../scene";
 
+import {
+  getDefaultWorkspaceLayout,
+  isWorkspaceLayoutValid,
+} from "../workspaceLayout";
+
 import type {
   AppState,
   BinaryFiles,
@@ -1094,6 +1099,13 @@ export const restoreAppState = (
       isFiniteNumber(appState.gridStep) ? appState.gridStep : DEFAULT_GRID_STEP,
     ),
     editingFrame: null,
+    workspaceLayout: {
+      ...(isWorkspaceLayoutValid(nextAppState.workspaceLayout)
+        ? nextAppState.workspaceLayout
+        : getDefaultWorkspaceLayout()),
+      // edit mode is transient and shouldn't survive a reload
+      editing: false,
+    },
   };
 };
 

--- a/packages/excalidraw/locales/en.json
+++ b/packages/excalidraw/locales/en.json
@@ -189,7 +189,19 @@
     "boxSelectionContain": "Wrap",
     "boxSelectionOverlap": "Overlap",
     "arrowBinding": "Arrow binding",
-    "midpointSnapping": "Snap to midpoints"
+    "midpointSnapping": "Snap to midpoints",
+    "workspaceLayoutEdit": "Edit workspace layout",
+    "workspaceLayoutReset": "Reset workspace layout"
+  },
+  "workspaceLayout": {
+    "drag": "Drag to move",
+    "lock": "Lock position",
+    "unlock": "Unlock position",
+    "hide": "Hide",
+    "show": "Show",
+    "reset": "Reset this zone",
+    "resize": "Drag to resize",
+    "propertiesPanelPlaceholder": "Properties panel"
   },
   "elementLink": {
     "title": "Link to object",

--- a/packages/excalidraw/tests/workspaceLayout.test.tsx
+++ b/packages/excalidraw/tests/workspaceLayout.test.tsx
@@ -1,0 +1,447 @@
+import React from "react";
+
+import {
+  actionResetWorkspaceLayout,
+  actionToggleWorkspaceLayoutEdit,
+} from "../actions";
+import { clearAppStateForLocalStorage } from "../appState";
+import { Excalidraw } from "../index";
+
+import { API } from "./helpers/api";
+import { Keyboard, Pointer, UI } from "./helpers/ui";
+import { fireEvent, render, unmountComponent } from "./test-utils";
+
+const { h } = window;
+
+const mouse = new Pointer("mouse");
+
+const queryZone = (zoneId: string) =>
+  document.querySelector<HTMLElement>(
+    `[data-testid="workspace-zone-${zoneId}"]`,
+  );
+
+const queryZoneControl = (control: string, zoneId: string) =>
+  document.querySelector<HTMLElement>(
+    `[data-testid="workspace-zone-${control}-${zoneId}"]`,
+  );
+
+const isQuickDraggable = (zoneId: string) =>
+  queryZone(zoneId)!.classList.contains("workspace-zone--quick-draggable");
+
+const dragElement = (element: HTMLElement, dx: number, dy: number) => {
+  fireEvent.pointerDown(element, {
+    clientX: 200,
+    clientY: 200,
+    pointerId: 1,
+    button: 0,
+  });
+  fireEvent.pointerMove(element, {
+    clientX: 200 + dx,
+    clientY: 200 + dy,
+    pointerId: 1,
+  });
+  fireEvent.pointerUp(element, {
+    clientX: 200 + dx,
+    clientY: 200 + dy,
+    pointerId: 1,
+  });
+};
+
+// drags via the explicit drag handle shown in edit mode
+const dragZoneByHandle = (zoneId: string, dx: number, dy: number) => {
+  const handle = queryZoneControl("drag", zoneId);
+  expect(handle).not.toBe(null);
+  dragElement(handle!, dx, dy);
+};
+
+// drags by grabbing the zone surface (normal mode, no handle shown)
+const dragZoneBySurface = (zoneId: string, dx: number, dy: number) => {
+  const zone = queryZone(zoneId);
+  expect(zone).not.toBe(null);
+  dragElement(zone!, dx, dy);
+};
+
+const resizeZone = (zoneId: string, dy: number) => {
+  const handle = queryZoneControl("resize", zoneId);
+  expect(handle).not.toBe(null);
+  fireEvent.pointerDown(handle!, {
+    clientX: 0,
+    clientY: 300,
+    pointerId: 1,
+    button: 0,
+  });
+  fireEvent.pointerMove(handle!, {
+    clientX: 0,
+    clientY: 300 + dy,
+    pointerId: 1,
+  });
+  fireEvent.pointerUp(handle!, { clientX: 0, clientY: 300 + dy, pointerId: 1 });
+};
+
+describe("workspace layout", () => {
+  beforeEach(async () => {
+    mouse.reset();
+    await render(<Excalidraw handleKeyboardGlobally={true} />);
+  });
+
+  describe("edit mode", () => {
+    it("should toggle edit mode and show/hide zone controls", () => {
+      expect(h.state.workspaceLayout.editing).toBe(false);
+      // outside edit mode there are no controls, only the grab-draggable zone
+      expect(queryZoneControl("drag", "toolbar")).toBe(null);
+      expect(queryZoneControl("lock", "toolbar")).toBe(null);
+      expect(queryZoneControl("visibility", "toolbar")).toBe(null);
+      expect(queryZoneControl("reset", "toolbar")).toBe(null);
+      expect(isQuickDraggable("toolbar")).toBe(true);
+
+      API.executeAction(actionToggleWorkspaceLayoutEdit);
+      expect(h.state.workspaceLayout.editing).toBe(true);
+
+      for (const zoneId of ["toolbar", "zoom", "undoRedo", "libraryButton"]) {
+        expect(queryZone(zoneId)).not.toBe(null);
+        expect(queryZoneControl("drag", zoneId)).not.toBe(null);
+        expect(queryZoneControl("lock", zoneId)).not.toBe(null);
+        expect(queryZoneControl("visibility", zoneId)).not.toBe(null);
+        expect(queryZoneControl("reset", zoneId)).not.toBe(null);
+      }
+      expect(isQuickDraggable("toolbar")).toBe(false);
+
+      // the hamburger / main menu zone is editable, but cannot be hidden
+      // since it is the entry point to the Preferences menu
+      expect(queryZone("mainMenu")).not.toBe(null);
+      expect(queryZoneControl("drag", "mainMenu")).not.toBe(null);
+      expect(queryZoneControl("lock", "mainMenu")).not.toBe(null);
+      expect(queryZoneControl("reset", "mainMenu")).not.toBe(null);
+      expect(queryZoneControl("visibility", "mainMenu")).toBe(null);
+
+      API.executeAction(actionToggleWorkspaceLayoutEdit);
+      expect(h.state.workspaceLayout.editing).toBe(false);
+      expect(queryZoneControl("drag", "toolbar")).toBe(null);
+      expect(queryZoneControl("lock", "toolbar")).toBe(null);
+      expect(isQuickDraggable("toolbar")).toBe(true);
+    });
+
+    it("should render the properties panel placeholder while editing", () => {
+      expect(queryZone("propertiesPanel")).toBe(null);
+
+      API.executeAction(actionToggleWorkspaceLayoutEdit);
+      expect(queryZone("propertiesPanel")).not.toBe(null);
+      expect(queryZoneControl("resize", "propertiesPanel")).not.toBe(null);
+    });
+  });
+
+  describe("dragging in edit mode", () => {
+    it("should move an unlocked zone and persist its offset", () => {
+      API.executeAction(actionToggleWorkspaceLayoutEdit);
+
+      dragZoneByHandle("zoom", 40, -25);
+
+      expect(h.state.workspaceLayout.zones.zoom).toEqual(
+        expect.objectContaining({ offsetX: 40, offsetY: -25 }),
+      );
+      expect(queryZone("zoom")!.style.transform).toBe("translate(40px, -25px)");
+
+      // dragging again accumulates from the stored offset
+      dragZoneByHandle("zoom", -10, 5);
+      expect(h.state.workspaceLayout.zones.zoom).toEqual(
+        expect.objectContaining({ offsetX: 30, offsetY: -20 }),
+      );
+    });
+
+    it("should not move a locked zone", () => {
+      API.executeAction(actionToggleWorkspaceLayoutEdit);
+
+      fireEvent.click(queryZoneControl("lock", "zoom")!);
+      expect(h.state.workspaceLayout.zones.zoom?.locked).toBe(true);
+
+      dragZoneByHandle("zoom", 40, 40);
+
+      expect(h.state.workspaceLayout.zones.zoom?.offsetX ?? 0).toBe(0);
+      expect(h.state.workspaceLayout.zones.zoom?.offsetY ?? 0).toBe(0);
+      expect(queryZone("zoom")!.style.transform).toBe("");
+
+      // unlocking re-enables dragging
+      fireEvent.click(queryZoneControl("lock", "zoom")!);
+      dragZoneByHandle("zoom", 40, 40);
+      expect(h.state.workspaceLayout.zones.zoom).toEqual(
+        expect.objectContaining({ offsetX: 40, offsetY: 40 }),
+      );
+    });
+  });
+
+  describe("dragging outside edit mode", () => {
+    it("should drag the main menu zone by grabbing it and persist the offset", () => {
+      expect(h.state.workspaceLayout.editing).toBe(false);
+      // no drag handle is rendered outside edit mode
+      expect(queryZoneControl("drag", "mainMenu")).toBe(null);
+      expect(isQuickDraggable("mainMenu")).toBe(true);
+
+      dragZoneBySurface("mainMenu", 30, 60);
+
+      expect(h.state.workspaceLayout.zones.mainMenu).toEqual(
+        expect.objectContaining({ offsetX: 30, offsetY: 60 }),
+      );
+      expect(queryZone("mainMenu")!.style.transform).toBe(
+        "translate(30px, 60px)",
+      );
+
+      const persisted = clearAppStateForLocalStorage(h.state);
+      expect(persisted.workspaceLayout?.zones.mainMenu).toEqual(
+        expect.objectContaining({ offsetX: 30, offsetY: 60 }),
+      );
+    });
+
+    it("should drag any unlocked zone by grabbing it outside edit mode", () => {
+      dragZoneBySurface("undoRedo", -15, -30);
+
+      expect(h.state.workspaceLayout.editing).toBe(false);
+      expect(h.state.workspaceLayout.zones.undoRedo).toEqual(
+        expect.objectContaining({ offsetX: -15, offsetY: -30 }),
+      );
+    });
+
+    it("should not start dragging from interactive elements inside a zone", () => {
+      const undoButton = document.querySelector<HTMLElement>(
+        '[data-testid="button-undo"]',
+      );
+      expect(undoButton).not.toBe(null);
+
+      dragElement(undoButton!, 50, 50);
+
+      expect(h.state.workspaceLayout.zones.undoRedo).toBeUndefined();
+      expect(queryZone("undoRedo")!.style.transform).toBe("");
+    });
+
+    it("should keep locked zones fixed outside edit mode", () => {
+      API.executeAction(actionToggleWorkspaceLayoutEdit);
+      fireEvent.click(queryZoneControl("lock", "zoom")!);
+      API.executeAction(actionToggleWorkspaceLayoutEdit);
+
+      // locked zones aren't grab-draggable in normal mode
+      expect(queryZone("zoom")).not.toBe(null);
+      expect(isQuickDraggable("zoom")).toBe(false);
+      dragZoneBySurface("zoom", 40, 40);
+      expect(h.state.workspaceLayout.zones.zoom?.offsetX ?? 0).toBe(0);
+      expect(queryZone("zoom")!.style.transform).toBe("");
+
+      // unlocked zones still are
+      expect(isQuickDraggable("undoRedo")).toBe(true);
+    });
+  });
+
+  describe("resizing", () => {
+    it("should resize the properties panel and persist its height", () => {
+      API.executeAction(actionToggleWorkspaceLayoutEdit);
+
+      // jsdom reports no measurable height, so resizing starts from the
+      // minimum zone height (120)
+      resizeZone("propertiesPanel", 80);
+      expect(h.state.workspaceLayout.zones.propertiesPanel?.height).toBe(200);
+      expect(
+        queryZone("propertiesPanel")!.style.getPropertyValue(
+          "--workspace-zone-height",
+        ),
+      ).toBe("200px");
+
+      // shrinking below the minimum clamps to it
+      resizeZone("propertiesPanel", -200);
+      expect(h.state.workspaceLayout.zones.propertiesPanel?.height).toBe(120);
+
+      const persisted = clearAppStateForLocalStorage(h.state);
+      expect(persisted.workspaceLayout?.zones.propertiesPanel?.height).toBe(
+        120,
+      );
+    });
+
+    it("should keep grab-dragging and resizing available outside edit mode for the unlocked properties panel", () => {
+      // the panel only renders in normal mode once an element is selected
+      UI.createElement("rectangle", { x: 100, y: 100, size: 50 });
+
+      expect(h.state.workspaceLayout.editing).toBe(false);
+      expect(queryZone("propertiesPanel")).not.toBe(null);
+      expect(isQuickDraggable("propertiesPanel")).toBe(true);
+      expect(queryZoneControl("resize", "propertiesPanel")).not.toBe(null);
+      // no edit-only controls in normal mode
+      expect(queryZoneControl("drag", "propertiesPanel")).toBe(null);
+      expect(queryZoneControl("lock", "propertiesPanel")).toBe(null);
+      expect(queryZoneControl("visibility", "propertiesPanel")).toBe(null);
+
+      dragZoneBySurface("propertiesPanel", 25, 35);
+      expect(h.state.workspaceLayout.zones.propertiesPanel).toEqual(
+        expect.objectContaining({ offsetX: 25, offsetY: 35 }),
+      );
+
+      resizeZone("propertiesPanel", 100);
+      expect(h.state.workspaceLayout.zones.propertiesPanel?.height).toBe(220);
+    });
+
+    it("should not show a resize handle on zones that don't support resizing", () => {
+      API.executeAction(actionToggleWorkspaceLayoutEdit);
+
+      for (const zoneId of [
+        "mainMenu",
+        "toolbar",
+        "zoom",
+        "undoRedo",
+        "libraryButton",
+      ]) {
+        expect(queryZoneControl("resize", zoneId)).toBe(null);
+      }
+    });
+  });
+
+  describe("hide and show", () => {
+    it("should hide a zone in normal mode and show it as ghost while editing", () => {
+      API.executeAction(actionToggleWorkspaceLayoutEdit);
+
+      fireEvent.click(queryZoneControl("visibility", "undoRedo")!);
+      expect(h.state.workspaceLayout.zones.undoRedo?.visible).toBe(false);
+
+      // still rendered as a ghost while editing
+      expect(queryZone("undoRedo")).not.toBe(null);
+      expect(
+        queryZone("undoRedo")!.classList.contains("workspace-zone--ghost"),
+      ).toBe(true);
+
+      // gone in normal mode
+      API.executeAction(actionToggleWorkspaceLayoutEdit);
+      expect(queryZone("undoRedo")).toBe(null);
+
+      // can be shown again from edit mode
+      API.executeAction(actionToggleWorkspaceLayoutEdit);
+      fireEvent.click(queryZoneControl("visibility", "undoRedo")!);
+      expect(h.state.workspaceLayout.zones.undoRedo?.visible).toBe(true);
+      API.executeAction(actionToggleWorkspaceLayoutEdit);
+      expect(queryZone("undoRedo")).not.toBe(null);
+    });
+
+    it("should persist the workspace layout to browser storage", () => {
+      API.executeAction(actionToggleWorkspaceLayoutEdit);
+      fireEvent.click(queryZoneControl("visibility", "zoom")!);
+      dragZoneByHandle("undoRedo", 12, 34);
+
+      const persisted = clearAppStateForLocalStorage(h.state);
+      expect(persisted.workspaceLayout).toEqual({
+        editing: true,
+        zones: {
+          zoom: expect.objectContaining({ visible: false }),
+          undoRedo: expect.objectContaining({ offsetX: 12, offsetY: 34 }),
+        },
+      });
+    });
+
+    it("should restore persisted layout on load with edit mode disabled", async () => {
+      // drop the app rendered in beforeEach so DOM queries only see the
+      // freshly-loaded instance
+      unmountComponent();
+      await render(
+        <Excalidraw
+          initialData={{
+            appState: {
+              workspaceLayout: {
+                editing: true,
+                zones: {
+                  zoom: {
+                    offsetX: 0,
+                    offsetY: 0,
+                    visible: false,
+                    locked: false,
+                  },
+                  toolbar: {
+                    offsetX: 50,
+                    offsetY: 10,
+                    visible: true,
+                    locked: true,
+                  },
+                  propertiesPanel: {
+                    offsetX: 0,
+                    offsetY: 0,
+                    visible: true,
+                    locked: false,
+                    height: 240,
+                  },
+                },
+              },
+            },
+          }}
+        />,
+      );
+
+      // edit mode is transient and must not survive a reload
+      expect(h.state.workspaceLayout.editing).toBe(false);
+      expect(h.state.workspaceLayout.zones.zoom?.visible).toBe(false);
+      expect(h.state.workspaceLayout.zones.toolbar).toEqual(
+        expect.objectContaining({ offsetX: 50, offsetY: 10, locked: true }),
+      );
+      expect(h.state.workspaceLayout.zones.propertiesPanel?.height).toBe(240);
+
+      expect(queryZone("zoom")).toBe(null);
+      expect(queryZone("toolbar")!.style.transform).toBe(
+        "translate(50px, 10px)",
+      );
+      // the locked toolbar isn't grab-draggable after reload, unlocked zones are
+      expect(isQuickDraggable("toolbar")).toBe(false);
+      expect(isQuickDraggable("undoRedo")).toBe(true);
+    });
+  });
+
+  describe("reset", () => {
+    it("should reset a single zone via its control", () => {
+      API.executeAction(actionToggleWorkspaceLayoutEdit);
+      dragZoneByHandle("zoom", 40, 40);
+      expect(h.state.workspaceLayout.zones.zoom).toBeDefined();
+
+      fireEvent.click(queryZoneControl("reset", "zoom")!);
+      expect(h.state.workspaceLayout.zones.zoom).toBeUndefined();
+      expect(queryZone("zoom")!.style.transform).toBe("");
+    });
+
+    it("should restore the default layout via the global reset action", () => {
+      API.executeAction(actionToggleWorkspaceLayoutEdit);
+      dragZoneByHandle("toolbar", 100, 20);
+      dragZoneByHandle("mainMenu", 10, 10);
+      fireEvent.click(queryZoneControl("visibility", "undoRedo")!);
+      fireEvent.click(queryZoneControl("lock", "zoom")!);
+      expect(Object.keys(h.state.workspaceLayout.zones)).not.toHaveLength(0);
+
+      API.executeAction(actionResetWorkspaceLayout);
+
+      expect(h.state.workspaceLayout.zones).toEqual({});
+      // edit mode itself is not affected by the reset
+      expect(h.state.workspaceLayout.editing).toBe(true);
+
+      API.executeAction(actionToggleWorkspaceLayoutEdit);
+      expect(queryZone("toolbar")!.style.transform).toBe("");
+      expect(queryZone("mainMenu")!.style.transform).toBe("");
+      expect(queryZone("undoRedo")).not.toBe(null);
+    });
+  });
+
+  describe("regressions", () => {
+    it("should not break drawing, undo or redo after layout changes", () => {
+      API.executeAction(actionToggleWorkspaceLayoutEdit);
+      dragZoneByHandle("toolbar", 60, 30);
+      dragZoneByHandle("zoom", -20, -40);
+      API.executeAction(actionToggleWorkspaceLayoutEdit);
+      dragZoneBySurface("mainMenu", 15, 0);
+
+      const rect = UI.createElement("rectangle", {
+        x: 100,
+        y: 100,
+        size: 50,
+      });
+      expect(h.elements.length).toBe(1);
+      expect(rect.isDeleted).toBe(false);
+
+      Keyboard.undo();
+      expect(h.elements[0].isDeleted).toBe(true);
+
+      Keyboard.redo();
+      expect(h.elements[0].isDeleted).toBe(false);
+
+      // selecting the element shows the (relocated) properties panel zone
+      mouse.clickOn(rect);
+      expect(queryZone("propertiesPanel")).not.toBe(null);
+    });
+  });
+});

--- a/packages/excalidraw/types.ts
+++ b/packages/excalidraw/types.ts
@@ -56,6 +56,7 @@ import type App from "./components/App";
 import type Library from "./data/library";
 import type { ContextMenuItems } from "./components/ContextMenu";
 import type { SnapLine } from "./snapping";
+import type { WorkspaceLayout } from "./workspaceLayout";
 import type { ImportedDataState } from "./data/types";
 
 import type { Language } from "./i18n";
@@ -482,6 +483,8 @@ export interface AppState {
   // a drag operation (like pointer position vs bindable element) but needed
   // globally for calculating the binding strategy
   bindMode: BindMode;
+  /** customizable workspace layout (position/visibility/lock of UI zones) */
+  workspaceLayout: WorkspaceLayout;
 }
 
 export type SearchMatch = {

--- a/packages/excalidraw/workspaceLayout.ts
+++ b/packages/excalidraw/workspaceLayout.ts
@@ -1,0 +1,63 @@
+export type WorkspaceZoneId =
+  | "mainMenu"
+  | "toolbar"
+  | "propertiesPanel"
+  | "undoRedo"
+  | "zoom"
+  | "libraryButton";
+
+export type WorkspaceZoneConfig = {
+  offsetX: number;
+  offsetY: number;
+  visible: boolean;
+  locked: boolean;
+  /** only honored by zones that support resizing (propertiesPanel) */
+  height?: number;
+};
+
+export type WorkspaceLayout = {
+  /** whether the "Edit workspace layout" mode is active. Not persisted. */
+  editing: boolean;
+  /** sparse map of zone overrides; missing zones use defaults */
+  zones: Partial<Record<WorkspaceZoneId, WorkspaceZoneConfig>>;
+};
+
+export const WORKSPACE_ZONE_IDS: readonly WorkspaceZoneId[] = [
+  "mainMenu",
+  "toolbar",
+  "propertiesPanel",
+  "undoRedo",
+  "zoom",
+  "libraryButton",
+];
+
+export const getDefaultWorkspaceZoneConfig = (): WorkspaceZoneConfig => ({
+  offsetX: 0,
+  offsetY: 0,
+  visible: true,
+  locked: false,
+});
+
+export const getDefaultWorkspaceLayout = (): WorkspaceLayout => ({
+  editing: false,
+  zones: {},
+});
+
+export const getWorkspaceZoneConfig = (
+  workspaceLayout: WorkspaceLayout,
+  zoneId: WorkspaceZoneId,
+): WorkspaceZoneConfig => ({
+  ...getDefaultWorkspaceZoneConfig(),
+  ...workspaceLayout.zones[zoneId],
+});
+
+export const isWorkspaceLayoutValid = (
+  workspaceLayout: unknown,
+): workspaceLayout is WorkspaceLayout => {
+  return (
+    typeof workspaceLayout === "object" &&
+    workspaceLayout !== null &&
+    typeof (workspaceLayout as WorkspaceLayout).zones === "object" &&
+    (workspaceLayout as WorkspaceLayout).zones !== null
+  );
+};


### PR DESCRIPTION
## Summary

Adds a new customizable workspace layout mode for Excalidraw.

This introduces an “Edit Workspace Layout” option that allows selected UI zones to be moved, locked, hidden, and reset. Layout state is persisted locally, so customized positions remain after refresh.

## What changed

- Added workspace layout state and defaults
- Added editable workspace zones
- Added controls for drag, lock, hide, and reset
- Added global “Reset workspace layout” action
- Added workspace layout entry in preferences / menu flow
- Persisted layout state through app state restore
- Added tests for layout editing behavior

## Testing

- Added workspace layout tests
- Verified normal app usage still works locally
- Verified the app runs on localhost