### PR TITLE
fix(editor): keep canvas search results order stable (#9503)

### DIFF
--- a/packages/excalidraw/components/SearchMenu.tsx
+++ b/packages/excalidraw/components/SearchMenu.tsx
@@ -94,6 +94,11 @@ export const SearchMenu = () => {
   });
   const searchedQueryRef = useRef<SearchQuery | null>(null);
   const lastSceneNonceRef = useRef<number | undefined>(undefined);
+  // Tracks the visual order of matches from the last completed search run,
+  // keyed by `${element.id}:${match.index}`. Used to keep results stable
+  // across re-runs of the same query (e.g. when scene changes during drag).
+  // See https://github.com/excalidraw/excalidraw/issues/9503
+  const prevMatchOrderRef = useRef<Map<string, number>>(new Map());
 
   const [focusIndex, setFocusIndex] = useAtom(searchItemInFocusAtom);
   const elementsMap = app.scene.getNonDeletedElementsMap();
@@ -102,31 +107,41 @@ export const SearchMenu = () => {
     if (isSearching) {
       return;
     }
+    const isQueryChanged = searchQuery !== searchedQueryRef.current;
     if (
-      searchQuery !== searchedQueryRef.current ||
+      isQueryChanged ||
       app.scene.getSceneNonce() !== lastSceneNonceRef.current
     ) {
+      if (isQueryChanged) {
+        prevMatchOrderRef.current = new Map();
+      }
       searchedQueryRef.current = null;
-      handleSearch(searchQuery, app, (matchItems, index) => {
-        setSearchMatches({
-          nonce: randomInteger(),
-          items: matchItems,
-        });
-        searchedQueryRef.current = searchQuery;
-        lastSceneNonceRef.current = app.scene.getSceneNonce();
-        setAppState({
-          searchMatches: matchItems.length
-            ? {
-                focusedId: null,
-                matches: matchItems.map((searchMatch) => ({
-                  id: searchMatch.element.id,
-                  focus: false,
-                  matchedLines: searchMatch.matchedLines,
-                })),
-              }
-            : null,
-        });
-      });
+      handleSearch(
+        searchQuery,
+        app,
+        (matchItems, index) => {
+          setSearchMatches({
+            nonce: randomInteger(),
+            items: matchItems,
+          });
+          searchedQueryRef.current = searchQuery;
+          lastSceneNonceRef.current = app.scene.getSceneNonce();
+          prevMatchOrderRef.current = buildMatchOrder(matchItems);
+          setAppState({
+            searchMatches: matchItems.length
+              ? {
+                  focusedId: null,
+                  matches: matchItems.map((searchMatch) => ({
+                    id: searchMatch.element.id,
+                    focus: false,
+                    matchedLines: searchMatch.matchedLines,
+                  })),
+                }
+              : null,
+          });
+        },
+        isQueryChanged ? null : prevMatchOrderRef.current,
+      );
     }
   }, [
     isSearching,
@@ -265,6 +280,7 @@ export const SearchMenu = () => {
       setFocusIndex(null);
       searchedQueryRef.current = null;
       lastSceneNonceRef.current = undefined;
+      prevMatchOrderRef.current = new Map();
       setAppState({
         searchMatches: null,
       });
@@ -360,29 +376,37 @@ export const SearchMenu = () => {
             setInputValue(value);
             setIsSearching(true);
             const searchQuery = value.trim() as SearchQuery;
-            handleSearch(searchQuery, app, (matchItems, index) => {
-              setSearchMatches({
-                nonce: randomInteger(),
-                items: matchItems,
-              });
-              setFocusIndex(index);
-              searchedQueryRef.current = searchQuery;
-              lastSceneNonceRef.current = app.scene.getSceneNonce();
-              setAppState({
-                searchMatches: matchItems.length
-                  ? {
-                      focusedId: null,
-                      matches: matchItems.map((searchMatch) => ({
-                        id: searchMatch.element.id,
-                        focus: false,
-                        matchedLines: searchMatch.matchedLines,
-                      })),
-                    }
-                  : null,
-              });
+            // user-driven query change -> drop previous order so we resort by y
+            prevMatchOrderRef.current = new Map();
+            handleSearch(
+              searchQuery,
+              app,
+              (matchItems, index) => {
+                setSearchMatches({
+                  nonce: randomInteger(),
+                  items: matchItems,
+                });
+                setFocusIndex(index);
+                searchedQueryRef.current = searchQuery;
+                lastSceneNonceRef.current = app.scene.getSceneNonce();
+                prevMatchOrderRef.current = buildMatchOrder(matchItems);
+                setAppState({
+                  searchMatches: matchItems.length
+                    ? {
+                        focusedId: null,
+                        matches: matchItems.map((searchMatch) => ({
+                          id: searchMatch.element.id,
+                          focus: false,
+                          matchedLines: searchMatch.matchedLines,
+                        })),
+                      }
+                    : null,
+                });
 
-              setIsSearching(false);
-            });
+                setIsSearching(false);
+              },
+              null,
+            );
           }}
           selectOnRender
         />
@@ -784,11 +808,48 @@ const escapeSpecialCharacters = (string: string) => {
   return string.replace(/[.*+?^${}()|[\]\\-]/g, "\\$&");
 };
 
+const getMatchKey = (item: SearchMatchItem) =>
+  `${item.element.id}:${item.index}`;
+
+const buildMatchOrder = (
+  items: readonly SearchMatchItem[],
+): Map<string, number> => {
+  const order = new Map<string, number>();
+  for (let i = 0; i < items.length; i++) {
+    order.set(getMatchKey(items[i]), i);
+  }
+  return order;
+};
+
+// Sorts in place. On first run for a query (previousOrder is null), sorts
+// matches top-to-bottom by `y` for an intuitive initial presentation. On
+// re-runs of the same query, preserves the previous visual order so dragging
+// or editing elements doesn't reshuffle the list (#9503). New matches that
+// weren't in the previous run go to the end, ordered by `y` among themselves.
+const sortMatchesPreservingOrder = (
+  items: SearchMatchItem[],
+  previousOrder: Map<string, number> | null,
+) => {
+  if (!previousOrder || previousOrder.size === 0) {
+    items.sort((a, b) => a.element.y - b.element.y);
+    return;
+  }
+  items.sort((a, b) => {
+    const ka = previousOrder.get(getMatchKey(a)) ?? Infinity;
+    const kb = previousOrder.get(getMatchKey(b)) ?? Infinity;
+    if (ka !== kb) {
+      return ka - kb;
+    }
+    return a.element.y - b.element.y;
+  });
+};
+
 const handleSearch = debounce(
   (
     searchQuery: SearchQuery,
     app: AppClassProperties,
     cb: (matchItems: SearchMatchItem[], focusIndex: number | null) => void,
+    previousOrder: Map<string, number> | null,
   ) => {
     if (!searchQuery || searchQuery === "") {
       cb([], null);
@@ -803,9 +864,6 @@ const handleSearch = debounce(
     const frames = elements.filter((el) =>
       isFrameLikeElement(el),
     ) as ExcalidrawFrameLikeElement[];
-
-    texts.sort((a, b) => a.y - b.y);
-    frames.sort((a, b) => a.y - b.y);
 
     const textMatches: SearchMatchItem[] = [];
 
@@ -857,6 +915,9 @@ const handleSearch = debounce(
         }
       }
     }
+
+    sortMatchesPreservingOrder(frameMatches, previousOrder);
+    sortMatchesPreservingOrder(textMatches, previousOrder);
 
     const visibleIds = new Set(
       app.visibleElements.map((visibleElement) => visibleElement.id),

--- a/packages/excalidraw/tests/search.test.tsx
+++ b/packages/excalidraw/tests/search.test.tsx
@@ -161,6 +161,106 @@ describe("search", () => {
     });
   });
 
+  it("should keep search results order stable when an element is moved (#9503)", async () => {
+    const scrollIntoViewMock = jest.fn();
+    window.HTMLElement.prototype.scrollIntoView = scrollIntoViewMock;
+
+    const elementA = API.createElement({
+      type: "text",
+      text: "test alpha",
+      y: 100,
+    });
+    const elementB = API.createElement({
+      type: "text",
+      text: "test bravo",
+      y: 500,
+    });
+    API.setElements([elementA, elementB]);
+
+    Keyboard.withModifierKeys({ ctrl: true }, () => {
+      Keyboard.keyPress(KEYS.F);
+    });
+
+    const searchInput = await querySearchInput();
+    updateTextEditor(searchInput, "test");
+
+    // first render: top-to-bottom by y -> A then B
+    await waitFor(() => {
+      expect(h.app.state.searchMatches?.matches.length).toBe(2);
+      expect(h.app.state.searchMatches?.matches[0].id).toBe(elementA.id);
+      expect(h.app.state.searchMatches?.matches[1].id).toBe(elementB.id);
+    });
+
+    const initialMatches = h.app.state.searchMatches!.matches;
+
+    // move A to below B and commit via a full scene update (mimics drag-end
+    // `replaceAllElements`, which is what triggers SearchMenu's re-search).
+    // A y-based re-sort would now put B first.
+    const movedA = {
+      ...(h.elements[0] as ExcalidrawTextElement),
+      y: 1000,
+    };
+    API.setElements([movedA, h.elements[1]]);
+
+    // wait for search to re-run (new matches array reference)
+    await waitFor(() => {
+      expect(h.app.state.searchMatches?.matches).not.toBe(initialMatches);
+    });
+
+    // order must stay stable: A still first even though it has higher y now
+    expect(h.app.state.searchMatches?.matches[0].id).toBe(elementA.id);
+    expect(h.app.state.searchMatches?.matches[1].id).toBe(elementB.id);
+  });
+
+  it("should append newly matching elements at the end of the search results (#9503)", async () => {
+    const scrollIntoViewMock = jest.fn();
+    window.HTMLElement.prototype.scrollIntoView = scrollIntoViewMock;
+
+    const elementA = API.createElement({
+      type: "text",
+      text: "test alpha",
+      y: 100,
+    });
+    const elementB = API.createElement({
+      type: "text",
+      text: "test bravo",
+      y: 500,
+    });
+    API.setElements([elementA, elementB]);
+
+    Keyboard.withModifierKeys({ ctrl: true }, () => {
+      Keyboard.keyPress(KEYS.F);
+    });
+
+    const searchInput = await querySearchInput();
+    updateTextEditor(searchInput, "test");
+
+    await waitFor(() => {
+      expect(h.app.state.searchMatches?.matches.length).toBe(2);
+    });
+
+    const initialMatches = h.app.state.searchMatches!.matches;
+
+    // add a new matching element with `y` between A and B; a y-based sort
+    // would slot it between them, but we want stable order with the new
+    // match appended at the end.
+    const elementC = API.createElement({
+      type: "text",
+      text: "test charlie",
+      y: 300,
+    });
+    API.setElements([...h.elements, elementC]);
+
+    await waitFor(() => {
+      expect(h.app.state.searchMatches?.matches.length).toBe(3);
+      expect(h.app.state.searchMatches?.matches).not.toBe(initialMatches);
+    });
+
+    expect(h.app.state.searchMatches?.matches[0].id).toBe(elementA.id);
+    expect(h.app.state.searchMatches?.matches[1].id).toBe(elementB.id);
+    expect(h.app.state.searchMatches?.matches[2].id).toBe(elementC.id);
+  });
+
   it("should match frame names", async () => {
     const scrollIntoViewMock = jest.fn();
     window.HTMLElement.prototype.scrollIntoView = scrollIntoViewMock;


### PR DESCRIPTION
Fixes #9503.

## Problem

Canvas search results re-sort by element `y` on every search re-run. The re-run is triggered when `sceneNonce` changes (e.g. after dragging an element commits via `replaceAllElements`), so the list visibly reshuffles under the user's cursor.

## Approach

Preserves visual order across re-runs of the same query (keyed by `${element.id}:${matchIndex}`), while keeping top-to-bottom `y` sort on the first run. Resets on query change or unmount.

## Tests

Two regression tests in `packages/excalidraw/tests/search.test.tsx`, verified red/green against pre-fix code.

Made with [Cursor](https://cursor.com)