### PR TITLE
fix: keep search results stable when elements move

### DIFF
--- a/packages/excalidraw/components/SearchMenu.tsx
+++ b/packages/excalidraw/components/SearchMenu.tsx
@@ -804,9 +804,6 @@ const handleSearch = debounce(
       isFrameLikeElement(el),
     ) as ExcalidrawFrameLikeElement[];
 
-    texts.sort((a, b) => a.y - b.y);
-    frames.sort((a, b) => a.y - b.y);
-
     const textMatches: SearchMatchItem[] = [];
 
     const regex = new RegExp(escapeSpecialCharacters(searchQuery), "gi");

--- a/packages/excalidraw/tests/search.test.tsx
+++ b/packages/excalidraw/tests/search.test.tsx
@@ -113,6 +113,41 @@ describe("search", () => {
     expect(h.app.state.searchMatches?.matches[1].focus).toBe(false);
   });
 
+  it("should keep search results stable when matching text elements move", async () => {
+    API.setElements([
+      API.createElement({ type: "text", text: "test one", y: 0 }),
+      API.createElement({ type: "text", text: "test two", y: 100 }),
+    ]);
+
+    Keyboard.withModifierKeys({ ctrl: true }, () => {
+      Keyboard.keyPress(KEYS.F);
+    });
+
+    const searchInput = await querySearchInput();
+
+    updateTextEditor(searchInput, "test");
+
+    await waitFor(() => {
+      expect(h.app.state.searchMatches?.matches.length).toBe(2);
+    });
+
+    const initialMatchIds = h.app.state.searchMatches?.matches.map(
+      (match) => match.id,
+    );
+
+    API.updateElement(h.elements[0] as ExcalidrawTextElement, {
+      y: 200,
+    });
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 400));
+    });
+
+    expect(h.app.state.searchMatches?.matches.map((match) => match.id)).toEqual(
+      initialMatchIds,
+    );
+  });
+
   it("should match text split across multiple lines", async () => {
     const scrollIntoViewMock = jest.fn();
     window.HTMLElement.prototype.scrollIntoView = scrollIntoViewMock;


### PR DESCRIPTION
## Summary

Fixes #9503.

Keeps canvas search results in scene element order instead of sorting text and frame matches by their y-coordinate. This prevents the results list from reordering when a matched element is moved vertically.

## Testing

- yarn test:app packages/excalidraw/tests/search.test.tsx --run
- yarn eslint --max-warnings=0 packages/excalidraw/components/SearchMenu.tsx packages/excalidraw/tests/search.test.tsx