### PR TITLE
fix: update app title from scene name

### DIFF
--- a/excalidraw-app/App.tsx
+++ b/excalidraw-app/App.tsx
@@ -94,6 +94,7 @@ import {
   STORAGE_KEYS,
   SYNC_BROWSER_TABS_TIMEOUT,
 } from "./app_constants";
+import { updateDocumentTitle } from "./appTitle";
 import Collab, {
   collabAPIAtom,
   isCollaboratingAtom,
@@ -651,6 +652,12 @@ const ExcalidrawWrapper = () => {
   }, [isCollabDisabled, collabAPI, excalidrawAPI, setLangCode, loadImages]);
 
   useEffect(() => {
+    if (excalidrawAPI) {
+      updateDocumentTitle(excalidrawAPI.getName());
+    }
+  }, [excalidrawAPI]);
+
+  useEffect(() => {
     const unloadHandler = (event: BeforeUnloadEvent) => {
       LocalData.flushSave();
 
@@ -680,6 +687,8 @@ const ExcalidrawWrapper = () => {
     appState: AppState,
     files: BinaryFiles,
   ) => {
+    updateDocumentTitle(appState.name);
+
     if (collabAPI?.isCollaborating()) {
       collabAPI.syncElements(elements);
     }

--- a/excalidraw-app/appTitle.ts
+++ b/excalidraw-app/appTitle.ts
@@ -1,0 +1,15 @@
+import { APP_NAME } from "@excalidraw/common";
+
+export const getDocumentTitle = (name: string | null | undefined) => {
+  const trimmedName = name?.trim();
+
+  return trimmedName ? `${trimmedName} - ${APP_NAME}` : APP_NAME;
+};
+
+export const updateDocumentTitle = (name: string | null | undefined) => {
+  const title = getDocumentTitle(name);
+
+  if (document.title !== title) {
+    document.title = title;
+  }
+};

--- a/excalidraw-app/tests/appTitle.test.ts
+++ b/excalidraw-app/tests/appTitle.test.ts
@@ -1,0 +1,13 @@
+import { APP_NAME } from "@excalidraw/common";
+
+import { getDocumentTitle } from "../appTitle";
+
+describe("app title", () => {
+  it("uses the scene name in the document title", () => {
+    expect(getDocumentTitle("Project plan")).toBe(`Project plan - ${APP_NAME}`);
+  });
+
+  it("falls back to the app name for blank scene names", () => {
+    expect(getDocumentTitle(" ")).toBe(APP_NAME);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #4344.

Updates the browser/PWA document title from the current Excalidraw scene name so multiple app windows can be distinguished more easily.

## Testing

- yarn test:app excalidraw-app/tests/appTitle.test.ts --run
- yarn eslint --max-warnings=0 excalidraw-app/App.tsx excalidraw-app/appTitle.ts excalidraw-app/tests/appTitle.test.ts