### PR TITLE
fix: secure tab sync against unsafe localStorage parsing

### DIFF
--- a/excalidraw-app/data/tabSync.ts
+++ b/excalidraw-app/data/tabSync.ts
@@ -9,31 +9,66 @@ const LOCAL_STATE_VERSIONS = {
 
 type BrowserStateTypes = keyof typeof LOCAL_STATE_VERSIONS;
 
+const getStorageTimestamp = (type: BrowserStateTypes): number => {
+  try {
+    const value = localStorage.getItem(type);
+    if (value === null) {
+      return -1;
+    }
+
+    const parsed = JSON.parse(value);
+
+    if (typeof parsed !== "number" || !Number.isFinite(parsed)) {
+      console.warn(`Invalid timestamp in localStorage for key: ${type}`);
+      return -1;
+    }
+
+    return parsed;
+  } catch (error) {
+    console.error(`Error reading localStorage for key ${type}:`, error);
+    try {
+      localStorage.removeItem(type);
+    } catch (e) {
+      // ignore
+    }
+    return -1;
+  }
+};
+
+const setStorageTimestamp = (
+  type: BrowserStateTypes,
+  timestamp: number,
+): boolean => {
+  if (!Number.isFinite(timestamp)) {
+    console.error(`Attempted to save invalid timestamp: ${timestamp}`);
+    return false;
+  }
+  try {
+    localStorage.setItem(type, JSON.stringify(timestamp));
+    return true;
+  } catch (error) {
+    console.error("error while writing to localStorage", error);
+    return false;
+  }
+};
+
 export const isBrowserStorageStateNewer = (type: BrowserStateTypes) => {
-  const storageTimestamp = JSON.parse(localStorage.getItem(type) || "-1");
+  const storageTimestamp = getStorageTimestamp(type);
   return storageTimestamp > LOCAL_STATE_VERSIONS[type];
 };
 
 export const updateBrowserStateVersion = (type: BrowserStateTypes) => {
   const timestamp = Date.now();
-  try {
-    localStorage.setItem(type, JSON.stringify(timestamp));
+  if (setStorageTimestamp(type, timestamp)) {
     LOCAL_STATE_VERSIONS[type] = timestamp;
-  } catch (error) {
-    console.error("error while updating browser state verison", error);
   }
 };
 
 export const resetBrowserStateVersions = () => {
-  try {
-    for (const key of Object.keys(
-      LOCAL_STATE_VERSIONS,
-    ) as BrowserStateTypes[]) {
-      const timestamp = -1;
-      localStorage.setItem(key, JSON.stringify(timestamp));
+  for (const key of Object.keys(LOCAL_STATE_VERSIONS) as BrowserStateTypes[]) {
+    const timestamp = -1;
+    if (setStorageTimestamp(key, timestamp)) {
       LOCAL_STATE_VERSIONS[key] = timestamp;
     }
-  } catch (error) {
-    console.error("error while resetting browser state verison", error);
   }
 };

--- a/excalidraw-app/tests/tabSync.test.ts
+++ b/excalidraw-app/tests/tabSync.test.ts
@@ -1,0 +1,95 @@
+import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
+
+import { STORAGE_KEYS } from "../app_constants";
+import {
+  isBrowserStorageStateNewer,
+  updateBrowserStateVersion,
+  resetBrowserStateVersions,
+} from "../data/tabSync";
+
+describe("tabSync", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it("should update storage and detect newer state correctly", () => {
+    const now = Date.now();
+    localStorage.setItem(STORAGE_KEYS.VERSION_DATA_STATE, JSON.stringify(now));
+
+    expect(isBrowserStorageStateNewer(STORAGE_KEYS.VERSION_DATA_STATE)).toBe(
+      true,
+    );
+
+    updateBrowserStateVersion(STORAGE_KEYS.VERSION_DATA_STATE);
+    expect(isBrowserStorageStateNewer(STORAGE_KEYS.VERSION_DATA_STATE)).toBe(
+      false,
+    );
+  });
+
+  it("should handle missing keys (null/empty) in localStorage safely", () => {
+    expect(isBrowserStorageStateNewer(STORAGE_KEYS.VERSION_DATA_STATE)).toBe(
+      false,
+    );
+  });
+
+  it("should handle and clean up malformed JSON in localStorage", () => {
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    localStorage.setItem(STORAGE_KEYS.VERSION_DATA_STATE, "{broken json");
+
+    expect(isBrowserStorageStateNewer(STORAGE_KEYS.VERSION_DATA_STATE)).toBe(
+      false,
+    );
+    expect(localStorage.getItem(STORAGE_KEYS.VERSION_DATA_STATE)).toBeNull();
+    expect(consoleErrorSpy).toHaveBeenCalled();
+  });
+
+  it("should handle incorrect/invalid types in localStorage", () => {
+    const consoleWarnSpy = vi
+      .spyOn(console, "warn")
+      .mockImplementation(() => {});
+
+    localStorage.setItem(
+      STORAGE_KEYS.VERSION_DATA_STATE,
+      JSON.stringify("not-a-number"),
+    );
+    expect(isBrowserStorageStateNewer(STORAGE_KEYS.VERSION_DATA_STATE)).toBe(
+      false,
+    );
+    expect(consoleWarnSpy).toHaveBeenCalled();
+
+    localStorage.setItem(
+      STORAGE_KEYS.VERSION_DATA_STATE,
+      JSON.stringify({ version: 123 }),
+    );
+    expect(isBrowserStorageStateNewer(STORAGE_KEYS.VERSION_DATA_STATE)).toBe(
+      false,
+    );
+
+    localStorage.setItem(
+      STORAGE_KEYS.VERSION_DATA_STATE,
+      JSON.stringify(Infinity),
+    );
+    expect(isBrowserStorageStateNewer(STORAGE_KEYS.VERSION_DATA_STATE)).toBe(
+      false,
+    );
+
+    localStorage.setItem(STORAGE_KEYS.VERSION_DATA_STATE, JSON.stringify(NaN));
+    expect(isBrowserStorageStateNewer(STORAGE_KEYS.VERSION_DATA_STATE)).toBe(
+      false,
+    );
+  });
+
+  it("should handle write operations successfully", () => {
+    resetBrowserStateVersions();
+    expect(localStorage.getItem(STORAGE_KEYS.VERSION_DATA_STATE)).toBe("-1");
+    expect(localStorage.getItem(STORAGE_KEYS.VERSION_FILES)).toBe("-1");
+  });
+});


### PR DESCRIPTION
## Description

This PR implements robust error handling and type/bounds validation for `localStorage` read and write operations within the tab synchronization module (`excalidraw-app/data/tabSync.ts`).

Previously, the tab synchronization feature performed direct `JSON.parse` operations on storage values without validation. This could cause uncaught exceptions on malformed input (resulting in application crashes/denial of service) or logic errors due to type confusion (such as strings or non-finite numbers).

### Changes
- Implemented `getStorageTimestamp` which safely retrieves, parses, and validates that values are finite numbers.
- Handles parsing corruption by automatically clearing the corrupt entry from localStorage.
- Implemented `setStorageTimestamp` which prevents saving non-finite values and gracefully catches errors if storage is blocked/restricted.
- Replaced direct localStorage reads/writes in `isBrowserStorageStateNewer`, `updateBrowserStateVersion`, and `resetBrowserStateVersions` with these safe helper methods.
- Added comprehensive unit tests in `excalidraw-app/tests/tabSync.test.ts` covering missing keys, malformed JSON, invalid types, and write behaviors.

Fixes #11389
