### PR TITLE
feat: add shape templates sidebar with drag-and-drop

### DIFF
--- a/packages/common/src/constants.ts
+++ b/packages/common/src/constants.ts
@@ -257,6 +257,8 @@ export const STRING_MIME_TYPES = {
   excalidrawlib: "application/vnd.excalidrawlib+json",
   // list of excalidraw library item ids
   excalidrawlibIds: "application/vnd.excalidrawlib.ids+json",
+  // list of excalidraw shape template ids
+  excalidrawTemplateIds: "application/vnd.excalidraw-template.ids+json",
 } as const;
 
 export const MIME_TYPES = {
@@ -286,6 +288,7 @@ export const EXPORT_DATA_TYPES = {
   excalidraw: "excalidraw",
   excalidrawClipboard: "excalidraw/clipboard",
   excalidrawLibrary: "excalidrawlib",
+  excalidrawTemplates: "excalidraw-templates",
   excalidrawClipboardWithAPI: "excalidraw-api/clipboard",
 } as const;
 
@@ -352,6 +355,7 @@ export const ENCRYPTION_KEY_BITS = 128;
 export const VERSIONS = {
   excalidraw: 2,
   excalidrawLibrary: 2,
+  excalidrawTemplates: 1,
 } as const;
 
 export const BOUND_TEXT_PADDING = 5;
@@ -432,6 +436,7 @@ export const DEFAULT_ELEMENT_PROPS: {
 
 export const LIBRARY_SIDEBAR_TAB = "library";
 export const CANVAS_SEARCH_TAB = "search";
+export const TEMPLATES_SIDEBAR_TAB = "templates";
 
 export const DEFAULT_SIDEBAR = {
   name: "default",
@@ -469,6 +474,7 @@ export const EDITOR_LS_KEYS = {
   // legacy naming (non)scheme
   MERMAID_TO_EXCALIDRAW: "mermaid-to-excalidraw",
   PUBLISH_LIBRARY: "publish-library-data",
+  SHAPE_TEMPLATES: "excalidraw-shape-templates",
 } as const;
 
 /**

--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -357,6 +357,7 @@ import {
 
 import { exportCanvas, loadFromBlob } from "../data";
 import Library, { distributeLibraryItemsOnSquareGrid } from "../data/library";
+import { getShapeTemplatesByIds } from "../data/shapeTemplates";
 import { restoreAppState, restoreElements } from "../data/restore";
 import { getCenter, getDistance } from "../gesture";
 import { History } from "../history";
@@ -458,7 +459,10 @@ import { findShapeByKey } from "./shapes";
 
 import UnlockPopup from "./UnlockPopup";
 
-import type { ExcalidrawLibraryIds } from "../data/types";
+import type {
+  ExcalidrawLibraryIds,
+  ExcalidrawTemplateIds,
+} from "../data/types";
 
 import type {
   RenderInteractiveSceneCallback,
@@ -12150,6 +12154,41 @@ class App extends React.Component<AppProps, AppState> {
               randomizeSeed: true,
               preserveFrameChildrenOrder: true,
             }).duplicatedElements,
+          }));
+
+          this.addElementsFromPasteOrLibrary({
+            elements: distributeLibraryItemsOnSquareGrid(libraryItems),
+            position: event,
+            files: null,
+          });
+        }
+      } catch (error: any) {
+        this.setState({ errorMessage: error.message });
+      }
+      return;
+    }
+
+    const excalidrawTemplate_ids = dataTransferList.getData(
+      MIME_TYPES.excalidrawTemplateIds,
+    );
+    if (excalidrawTemplate_ids) {
+      try {
+        const { templateIds } = JSON.parse(
+          excalidrawTemplate_ids,
+        ) as ExcalidrawTemplateIds;
+        const shapeTemplates = getShapeTemplatesByIds(templateIds);
+        if (shapeTemplates.length) {
+          const libraryItems = shapeTemplates.map((template) => ({
+            id: template.id,
+            status: "unpublished" as const,
+            elements: duplicateElements({
+              type: "everything",
+              elements: template.elements,
+              randomizeSeed: true,
+              preserveFrameChildrenOrder: true,
+            }).duplicatedElements,
+            created: 0,
+            name: template.name,
           }));
 
           this.addElementsFromPasteOrLibrary({

--- a/packages/excalidraw/components/DefaultSidebar.tsx
+++ b/packages/excalidraw/components/DefaultSidebar.tsx
@@ -4,6 +4,7 @@ import {
   CANVAS_SEARCH_TAB,
   DEFAULT_SIDEBAR,
   LIBRARY_SIDEBAR_TAB,
+  TEMPLATES_SIDEBAR_TAB,
   composeEventHandlers,
 } from "@excalidraw/common";
 
@@ -17,9 +18,10 @@ import "../components/dropdownMenu/DropdownMenu.scss";
 import { useExcalidrawSetAppState } from "./App";
 import { LibraryMenu } from "./LibraryMenu";
 import { SearchMenu } from "./SearchMenu";
+import { ShapeTemplatesMenu } from "./ShapeTemplatesMenu";
 import { Sidebar } from "./Sidebar/Sidebar";
 import { withInternalFallback } from "./hoc/withInternalFallback";
-import { LibraryIcon, searchIcon } from "./icons";
+import { LibraryIcon, ShapeTemplatesIcon, searchIcon } from "./icons";
 
 import type { SidebarProps, SidebarTriggerProps } from "./Sidebar/common";
 
@@ -105,11 +107,17 @@ export const DefaultSidebar = Object.assign(
                 <Sidebar.TabTrigger tab={LIBRARY_SIDEBAR_TAB}>
                   {LibraryIcon}
                 </Sidebar.TabTrigger>
+                <Sidebar.TabTrigger tab={TEMPLATES_SIDEBAR_TAB}>
+                  {ShapeTemplatesIcon}
+                </Sidebar.TabTrigger>
                 <DefaultSidebarTabTriggersTunnel.Out />
               </Sidebar.TabTriggers>
             </Sidebar.Header>
             <Sidebar.Tab tab={LIBRARY_SIDEBAR_TAB}>
               <LibraryMenu />
+            </Sidebar.Tab>
+            <Sidebar.Tab tab={TEMPLATES_SIDEBAR_TAB}>
+              <ShapeTemplatesMenu />
             </Sidebar.Tab>
             <Sidebar.Tab tab={CANVAS_SEARCH_TAB}>
               <SearchMenu />

--- a/packages/excalidraw/components/LibraryMenuSection.tsx
+++ b/packages/excalidraw/components/LibraryMenuSection.tsx
@@ -26,6 +26,7 @@ interface Props {
   isItemSelected: (id: LibraryItem["id"] | null) => boolean;
   svgCache: SvgCache;
   itemsRenderedPerBatch: number;
+  renderItemOverlay?: (id: LibraryItem["id"]) => ReactNode;
 }
 
 export const LibraryMenuSectionGrid = ({
@@ -45,6 +46,7 @@ export const LibraryMenuSection = memo(
     onClick,
     svgCache,
     itemsRenderedPerBatch,
+    renderItemOverlay,
   }: Props) => {
     const [, startTransition] = useTransition();
     const [index, setIndex] = useState(0);
@@ -61,17 +63,22 @@ export const LibraryMenuSection = memo(
       <>
         {items.map((item, i) => {
           return i < index ? (
-            <LibraryUnit
-              elements={item?.elements}
-              isPending={!item?.id && !!item?.elements}
-              onClick={onClick}
-              svgCache={svgCache}
-              id={item?.id}
-              selected={isItemSelected(item.id)}
-              onToggle={onItemSelectToggle}
-              onDrag={onItemDrag}
+            <div
+              className="library-menu-items-container__cell"
               key={item?.id ?? i}
-            />
+            >
+              <LibraryUnit
+                elements={item?.elements}
+                isPending={!item?.id && !!item?.elements}
+                onClick={onClick}
+                svgCache={svgCache}
+                id={item?.id}
+                selected={isItemSelected(item.id)}
+                onToggle={onItemSelectToggle}
+                onDrag={onItemDrag}
+              />
+              {item?.id && renderItemOverlay?.(item.id)}
+            </div>
           ) : (
             <EmptyLibraryUnit key={i} />
           );

--- a/packages/excalidraw/components/ShapeTemplatesMenu.scss
+++ b/packages/excalidraw/components/ShapeTemplatesMenu.scss
@@ -1,0 +1,91 @@
+@use "../css/variables.module" as *;
+
+.excalidraw {
+  .layer-ui__shape-templates {
+    display: flex;
+    flex-direction: column;
+    flex: 1 1 auto;
+    overflow: hidden;
+  }
+
+  .shape-templates-menu__search {
+    display: flex;
+    align-items: center;
+    gap: 0.375rem;
+    margin: 0.5rem 0.5rem 0;
+    padding: 0.25rem 0.375rem;
+    border: 1px solid var(--adobe-neutral-200, var(--color-surface-high));
+    border-radius: var(--adobe-radius, 0.25rem);
+    background: var(--adobe-neutral-50, var(--island-bg-color-alt));
+
+    svg {
+      width: 0.875rem;
+      height: 0.875rem;
+      flex-shrink: 0;
+      color: var(--adobe-neutral-500, var(--color-gray-60));
+    }
+
+    input {
+      flex: 1;
+      min-width: 0;
+      border: none;
+      background: transparent;
+      font-size: 0.75rem;
+      line-height: 1.25;
+      color: var(--text-primary-color);
+      font-family: inherit;
+
+      &::placeholder {
+        color: var(--adobe-neutral-500, var(--color-gray-60));
+      }
+
+      &:focus {
+        outline: none;
+      }
+    }
+  }
+
+  .shape-templates-menu__tabs {
+    display: flex;
+    gap: 0.25rem;
+    margin: 0.5rem 0.5rem 0;
+  }
+
+  .shape-templates-menu__tab {
+    flex: 1;
+    padding: 0.25rem 0.375rem;
+    border: none;
+    border-radius: var(--adobe-radius, 0.25rem);
+    background: transparent;
+    color: var(--adobe-neutral-700, var(--color-gray-60));
+    font-family: inherit;
+    font-size: 0.625rem;
+    font-weight: 600;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    cursor: pointer;
+
+    &:hover {
+      background: var(--adobe-neutral-50, var(--button-hover-bg));
+      color: var(--text-primary-color);
+    }
+
+    &--active {
+      background: var(--adobe-neutral-50, var(--button-hover-bg));
+      color: var(--text-primary-color);
+      box-shadow: inset 0 0 0 1px var(--adobe-neutral-200, var(--default-border-color));
+    }
+  }
+
+  .shape-templates-menu__hint {
+    padding: 0.75rem 1rem;
+    margin: 0;
+    font-size: 0.75rem;
+    color: var(--color-gray-60);
+    border-top: 1px solid var(--color-surface-high);
+  }
+
+  .library-menu-items-container__cell {
+    position: relative;
+  }
+}

--- a/packages/excalidraw/components/ShapeTemplatesMenu.tsx
+++ b/packages/excalidraw/components/ShapeTemplatesMenu.tsx
@@ -1,0 +1,172 @@
+import clsx from "clsx";
+import { memo, useCallback, useEffect, useMemo, useState } from "react";
+
+import { duplicateElements } from "@excalidraw/element";
+
+import { distributeLibraryItemsOnSquareGrid } from "../data/library";
+import {
+  getAllShapeTemplates,
+  loadUserShapeTemplates,
+} from "../data/shapeTemplates";
+import {
+  getFavoriteTemplateIds,
+  getRecentTemplateIds,
+  pushRecentTemplateId,
+} from "../data/shapeTemplatesStorage";
+import { t } from "../i18n";
+
+import { useApp } from "./App";
+import ShapeTemplatesMenuItems from "./ShapeTemplatesMenuItems";
+import { searchIcon } from "./icons";
+
+import "./ShapeTemplatesMenu.scss";
+
+import type { LibraryItem, ShapeTemplate, ShapeTemplates } from "../types";
+
+type TemplatesTab = "recent" | "favorites";
+
+const toLibraryItems = (templates: ShapeTemplates): LibraryItem[] =>
+  templates.map((template) => ({
+    id: template.id,
+    status: "unpublished" as const,
+    elements: template.elements,
+    created: 0,
+    name: template.name,
+  }));
+
+export const ShapeTemplatesMenu = memo(() => {
+  const { onInsertElements } = useApp();
+  const [templates, setTemplates] = useState<ShapeTemplates>(() =>
+    getAllShapeTemplates(),
+  );
+  const [searchQuery, setSearchQuery] = useState("");
+  const [activeTab, setActiveTab] = useState<TemplatesTab>("recent");
+  const [favoritesRevision, setFavoritesRevision] = useState(0);
+
+  useEffect(() => {
+    loadUserShapeTemplates();
+    setTemplates(getAllShapeTemplates());
+  }, []);
+
+  const libraryItems = useMemo(() => toLibraryItems(templates), [templates]);
+
+  const displayedTemplates = useMemo(() => {
+    void favoritesRevision;
+    const query = searchQuery.trim().toLowerCase();
+
+    let list: ShapeTemplate[];
+    if (activeTab === "favorites") {
+      const favoriteIds = new Set(getFavoriteTemplateIds());
+      list = templates.filter((template) => favoriteIds.has(template.id));
+    } else {
+      const recentIds = getRecentTemplateIds();
+      const byId = new Map(templates.map((template) => [template.id, template]));
+      list = recentIds
+        .map((id) => byId.get(id))
+        .filter((template): template is ShapeTemplate => template != null);
+      if (list.length === 0) {
+        list = [...templates];
+      }
+    }
+
+    if (!query) {
+      return list;
+    }
+
+    return list.filter((template) => {
+      const name = template.name.toLowerCase();
+      const category = (template.category || "").toLowerCase();
+      return name.includes(query) || category.includes(query);
+    });
+  }, [activeTab, favoritesRevision, searchQuery, templates]);
+
+  const onInsertTemplates = useCallback(
+    (items: LibraryItem[]) => {
+      const duplicated = items.map((item) => ({
+        ...item,
+        elements: duplicateElements({
+          type: "everything",
+          elements: item.elements,
+          randomizeSeed: true,
+          preserveFrameChildrenOrder: true,
+        }).duplicatedElements,
+      }));
+      onInsertElements(distributeLibraryItemsOnSquareGrid(duplicated));
+    },
+    [onInsertElements],
+  );
+
+  const onInsertTemplate = useCallback(
+    (template: ShapeTemplate) => {
+      pushRecentTemplateId(template.id);
+      const item = libraryItems.find((i) => i.id === template.id);
+      if (item) {
+        onInsertTemplates([item]);
+      }
+    },
+    [libraryItems, onInsertTemplates],
+  );
+
+  return (
+    <div className="layer-ui__shape-templates">
+      <label className="shape-templates-menu__search">
+        {searchIcon}
+        <input
+          type="search"
+          value={searchQuery}
+          onChange={(event) => setSearchQuery(event.target.value)}
+          placeholder={t("shapeTemplates.searchPlaceholder")}
+          aria-label={t("shapeTemplates.searchPlaceholder")}
+          data-testid="shape-templates-search"
+        />
+      </label>
+
+      <div
+        className="shape-templates-menu__tabs"
+        role="tablist"
+        aria-label={t("shapeTemplates.tabsLabel")}
+      >
+        <button
+          type="button"
+          role="tab"
+          aria-selected={activeTab === "recent"}
+          className={clsx("shape-templates-menu__tab", {
+            "shape-templates-menu__tab--active": activeTab === "recent",
+          })}
+          onClick={() => setActiveTab("recent")}
+          data-testid="shape-templates-tab-recent"
+        >
+          {t("shapeTemplates.recent")}
+        </button>
+        <button
+          type="button"
+          role="tab"
+          aria-selected={activeTab === "favorites"}
+          className={clsx("shape-templates-menu__tab", {
+            "shape-templates-menu__tab--active": activeTab === "favorites",
+          })}
+          onClick={() => setActiveTab("favorites")}
+          data-testid="shape-templates-tab-favorites"
+        >
+          {t("shapeTemplates.favorites")}
+        </button>
+      </div>
+
+      <ShapeTemplatesMenuItems
+        templates={displayedTemplates}
+        onInsertTemplate={onInsertTemplate}
+        emptyMessage={
+          activeTab === "favorites"
+            ? t("shapeTemplates.emptyFavorites")
+            : searchQuery.trim()
+              ? t("shapeTemplates.emptySearch")
+              : t("shapeTemplates.empty")
+        }
+        onFavoritesChange={() => setFavoritesRevision((n) => n + 1)}
+      />
+      <p className="shape-templates-menu__hint">{t("shapeTemplates.hint")}</p>
+    </div>
+  );
+});
+
+ShapeTemplatesMenu.displayName = "ShapeTemplatesMenu";

--- a/packages/excalidraw/components/ShapeTemplatesMenuItems.scss
+++ b/packages/excalidraw/components/ShapeTemplatesMenuItems.scss
@@ -1,0 +1,42 @@
+.excalidraw {
+  .shape-templates-menu-items {
+    flex: 1 1 auto;
+    overflow-y: auto;
+    padding: 0.5rem;
+  }
+
+  .shape-templates-menu-items__empty {
+    padding: 2rem 1rem;
+    text-align: center;
+    color: var(--color-gray-60);
+    font-size: 0.875rem;
+  }
+
+  .shape-templates-menu-items__favorite {
+    position: absolute;
+    top: 0.125rem;
+    right: 0.125rem;
+    z-index: 1;
+    width: 1rem;
+    height: 1rem;
+    padding: 0;
+    border: none;
+    border-radius: 2px;
+    background: transparent;
+    color: var(--adobe-neutral-500, var(--color-gray-60));
+    font-size: 0.625rem;
+    line-height: 1;
+    cursor: pointer;
+    opacity: 0;
+
+    .library-menu-items-container__cell:hover &,
+    .library-menu-items-container__cell:focus-within &,
+    &--active {
+      opacity: 1;
+    }
+
+    &--active {
+      color: var(--adobe-red, var(--color-primary));
+    }
+  }
+}

--- a/packages/excalidraw/components/ShapeTemplatesMenuItems.tsx
+++ b/packages/excalidraw/components/ShapeTemplatesMenuItems.tsx
@@ -1,0 +1,121 @@
+import { useCallback } from "react";
+
+import { MIME_TYPES } from "@excalidraw/common";
+
+import { useLibraryCache } from "../hooks/useLibraryItemSvg";
+import { t } from "../i18n";
+import {
+  isFavoriteTemplateId,
+  toggleFavoriteTemplateId,
+} from "../data/shapeTemplatesStorage";
+
+import {
+  LibraryMenuSection,
+  LibraryMenuSectionGrid,
+} from "./LibraryMenuSection";
+
+import "./ShapeTemplatesMenuItems.scss";
+
+import type { ExcalidrawTemplateIds } from "../data/types";
+import type { LibraryItem, ShapeTemplate, ShapeTemplates } from "../types";
+
+const ITEMS_RENDERED_PER_BATCH = 17;
+
+export default function ShapeTemplatesMenuItems({
+  templates,
+  onInsertTemplate,
+  emptyMessage,
+  onFavoritesChange,
+}: {
+  templates: ShapeTemplates;
+  onInsertTemplate: (template: ShapeTemplate) => void;
+  emptyMessage: string;
+  onFavoritesChange: () => void;
+}) {
+  const { svgCache } = useLibraryCache();
+
+  const onItemDrag = useCallback(
+    (id: LibraryItem["id"], event: React.DragEvent) => {
+      const data: ExcalidrawTemplateIds = {
+        templateIds: [id],
+      };
+      event.dataTransfer.setData(
+        MIME_TYPES.excalidrawTemplateIds,
+        JSON.stringify(data),
+      );
+    },
+    [],
+  );
+
+  const onItemClick = useCallback(
+    (id: LibraryItem["id"] | null) => {
+      if (!id) {
+        return;
+      }
+      const template = templates.find((t) => t.id === id);
+      if (template) {
+        onInsertTemplate(template);
+      }
+    },
+    [templates, onInsertTemplate],
+  );
+
+  const onItemSelectToggle = useCallback(() => {}, []);
+
+  const isItemSelected = useCallback(() => false, []);
+
+  const onToggleFavorite = useCallback(
+    (event: React.MouseEvent, templateId: string) => {
+      event.stopPropagation();
+      toggleFavoriteTemplateId(templateId);
+      onFavoritesChange();
+    },
+    [onFavoritesChange],
+  );
+
+  return (
+    <div className="shape-templates-menu-items" role="tabpanel">
+      {templates.length === 0 ? (
+        <div className="shape-templates-menu-items__empty">{emptyMessage}</div>
+      ) : (
+        <LibraryMenuSectionGrid>
+          <LibraryMenuSection
+            items={templates.map((template) => ({
+              id: template.id,
+              status: "unpublished" as const,
+              elements: template.elements,
+              created: 0,
+            }))}
+            onClick={onItemClick}
+            onItemDrag={onItemDrag}
+            onItemSelectToggle={onItemSelectToggle}
+            isItemSelected={isItemSelected}
+            svgCache={svgCache}
+            itemsRenderedPerBatch={ITEMS_RENDERED_PER_BATCH}
+            renderItemOverlay={(id) => {
+              const favorited = isFavoriteTemplateId(id);
+              return (
+                <button
+                  type="button"
+                  className={`shape-templates-menu-items__favorite${
+                    favorited
+                      ? " shape-templates-menu-items__favorite--active"
+                      : ""
+                  }`}
+                  aria-label={
+                    favorited
+                      ? t("shapeTemplates.removeFavorite")
+                      : t("shapeTemplates.addFavorite")
+                  }
+                  onClick={(event) => onToggleFavorite(event, id)}
+                >
+                  ★
+                </button>
+              );
+            }}
+          />
+        </LibraryMenuSectionGrid>
+      )}
+    </div>
+  );
+}

--- a/packages/excalidraw/components/icons.tsx
+++ b/packages/excalidraw/components/icons.tsx
@@ -88,6 +88,18 @@ export const PlusPromoIcon = createIcon(
   tablerIconProps,
 );
 
+// tabler-icons: layout-grid
+export const ShapeTemplatesIcon = createIcon(
+  <g strokeWidth="1.25">
+    <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+    <rect x="4" y="4" width="6" height="6" rx="1" />
+    <rect x="14" y="4" width="6" height="6" rx="1" />
+    <rect x="4" y="14" width="6" height="6" rx="1" />
+    <rect x="14" y="14" width="6" height="6" rx="1" />
+  </g>,
+  tablerIconProps,
+);
+
 // tabler-icons: book
 export const LibraryIcon = createIcon(
   <g strokeWidth="1.25">

--- a/packages/excalidraw/data/shapeTemplates.ts
+++ b/packages/excalidraw/data/shapeTemplates.ts
@@ -1,0 +1,245 @@
+import {
+  ADOBE_BRAND_RED,
+  EDITOR_LS_KEYS,
+  EXPORT_DATA_TYPES,
+  VERSIONS,
+  getExportSource,
+  randomId,
+} from "@excalidraw/common";
+
+import {
+  getNonDeletedElements,
+  newElement,
+  newTextElement,
+} from "@excalidraw/element";
+
+import { EditorLocalStorage } from "./EditorLocalStorage";
+import { restoreElements } from "./restore";
+
+import type {
+  ExportedShapeTemplatesData,
+  ImportedShapeTemplatesData,
+} from "./types";
+import type { ShapeTemplate, ShapeTemplates } from "../types";
+
+export type ShapeTemplatesPersistedData = {
+  templates: ShapeTemplates;
+};
+
+const BUILTIN_TEMPLATE_IDS = {
+  LABEL_BOX: "builtin-label-box",
+  STICKY_NOTE: "builtin-sticky-note",
+  FLOWCHART_NODE: "builtin-flowchart-node",
+} as const;
+
+const createLabelBoxTemplate = (): ShapeTemplate => {
+  const rectangle = newElement({
+    type: "rectangle",
+    x: 0,
+    y: 0,
+    width: 160,
+    height: 60,
+    strokeColor: ADOBE_BRAND_RED,
+    roundness: { type: 3 },
+  });
+  const text = newTextElement({
+    x: 80,
+    y: 30,
+    text: "Label",
+    fontSize: 20,
+    containerId: rectangle.id,
+    textAlign: "center",
+    verticalAlign: "middle",
+  });
+  const rectangleWithBinding = {
+    ...rectangle,
+    boundElements: [{ type: "text" as const, id: text.id }],
+  };
+  return {
+    id: BUILTIN_TEMPLATE_IDS.LABEL_BOX,
+    name: "Label box",
+    category: "Basic",
+    builtin: true,
+    elements: [rectangleWithBinding, text],
+  };
+};
+
+const createStickyNoteTemplate = (): ShapeTemplate => {
+  const rectangle = newElement({
+    type: "rectangle",
+    x: 0,
+    y: 0,
+    width: 140,
+    height: 140,
+    backgroundColor: "#fff9b1",
+    strokeColor: "#8e8e8e",
+    roundness: { type: 3 },
+  });
+  const text = newTextElement({
+    x: 70,
+    y: 70,
+    text: "Note",
+    fontSize: 16,
+    containerId: rectangle.id,
+    textAlign: "center",
+    verticalAlign: "middle",
+  });
+  const rectangleWithBinding = {
+    ...rectangle,
+    boundElements: [{ type: "text" as const, id: text.id }],
+  };
+  return {
+    id: BUILTIN_TEMPLATE_IDS.STICKY_NOTE,
+    name: "Sticky note",
+    category: "Basic",
+    builtin: true,
+    elements: [rectangleWithBinding, text],
+  };
+};
+
+const createFlowchartNodeTemplate = (): ShapeTemplate => {
+  const diamond = newElement({
+    type: "diamond",
+    x: 0,
+    y: 0,
+    width: 120,
+    height: 80,
+    strokeColor: ADOBE_BRAND_RED,
+  });
+  const text = newTextElement({
+    x: 60,
+    y: 40,
+    text: "Step",
+    fontSize: 16,
+    containerId: diamond.id,
+    textAlign: "center",
+    verticalAlign: "middle",
+  });
+  const diamondWithBinding = {
+    ...diamond,
+    boundElements: [{ type: "text" as const, id: text.id }],
+  };
+  return {
+    id: BUILTIN_TEMPLATE_IDS.FLOWCHART_NODE,
+    name: "Flowchart step",
+    category: "Flowchart",
+    builtin: true,
+    elements: [diamondWithBinding, text],
+  };
+};
+
+export const BUILTIN_SHAPE_TEMPLATES: ShapeTemplates = [
+  createLabelBoxTemplate(),
+  createStickyNoteTemplate(),
+  createFlowchartNodeTemplate(),
+];
+
+const restoreShapeTemplate = (
+  template: ShapeTemplate,
+): ShapeTemplate | null => {
+  const elements = restoreElements(
+    getNonDeletedElements(template.elements),
+    null,
+  );
+  return elements.length
+    ? { ...template, elements: elements as ShapeTemplate["elements"] }
+    : null;
+};
+
+export const restoreShapeTemplates = (
+  templates: ShapeTemplates = [],
+): ShapeTemplates => {
+  const restored: ShapeTemplate[] = [];
+  for (const template of templates) {
+    const restoredTemplate = restoreShapeTemplate({
+      ...template,
+      id: template.id || randomId(),
+    });
+    if (restoredTemplate) {
+      restored.push(restoredTemplate);
+    }
+  }
+  return restored;
+};
+
+export const isValidShapeTemplates = (
+  json: unknown,
+): json is ImportedShapeTemplatesData => {
+  return (
+    typeof json === "object" &&
+    json != null &&
+    "type" in json &&
+    (json as ImportedShapeTemplatesData).type ===
+      EXPORT_DATA_TYPES.excalidrawTemplates &&
+    "templates" in json &&
+    Array.isArray((json as ImportedShapeTemplatesData).templates)
+  );
+};
+
+export const serializeShapeTemplatesAsJSON = (templates: ShapeTemplates) => {
+  const data: ExportedShapeTemplatesData = {
+    type: EXPORT_DATA_TYPES.excalidrawTemplates,
+    version: VERSIONS.excalidrawTemplates,
+    source: getExportSource(),
+    templates,
+  };
+  return JSON.stringify(data, null, 2);
+};
+
+export const parseShapeTemplatesJSON = (
+  json: string,
+): ShapeTemplates | null => {
+  try {
+    const data: unknown = JSON.parse(json);
+    if (!isValidShapeTemplates(data)) {
+      return null;
+    }
+    return restoreShapeTemplates(data.templates);
+  } catch {
+    return null;
+  }
+};
+
+export const loadUserShapeTemplates = (): ShapeTemplates => {
+  const data = EditorLocalStorage.get<ShapeTemplatesPersistedData>(
+    EDITOR_LS_KEYS.SHAPE_TEMPLATES,
+  );
+  if (!data?.templates?.length) {
+    return [];
+  }
+  return restoreShapeTemplates(data.templates);
+};
+
+export const saveUserShapeTemplates = (templates: ShapeTemplates): boolean => {
+  const userTemplates = templates.filter((t) => !t.builtin);
+  return EditorLocalStorage.set(EDITOR_LS_KEYS.SHAPE_TEMPLATES, {
+    templates: userTemplates,
+  });
+};
+
+export const getAllShapeTemplates = (): ShapeTemplates => {
+  const userTemplates = loadUserShapeTemplates();
+  const builtinIds = new Set(BUILTIN_SHAPE_TEMPLATES.map((t) => t.id));
+  const filteredUser = userTemplates.filter((t) => !builtinIds.has(t.id));
+  return [...BUILTIN_SHAPE_TEMPLATES, ...filteredUser];
+};
+
+export const getShapeTemplatesByIds = (
+  ids: ShapeTemplate["id"][],
+): ShapeTemplates => {
+  const all = getAllShapeTemplates();
+  return all.filter((t) => ids.includes(t.id));
+};
+
+export const getShapeTemplatesGroupedByCategory = (
+  templates: ShapeTemplates,
+): Map<string, ShapeTemplates> => {
+  const grouped = new Map<string, ShapeTemplate[]>();
+  for (const template of templates) {
+    const category = template.category || "Other";
+    const list = grouped.get(category) || [];
+    list.push(template);
+    grouped.set(category, list);
+  }
+  return grouped;
+};

--- a/packages/excalidraw/data/shapeTemplatesStorage.test.ts
+++ b/packages/excalidraw/data/shapeTemplatesStorage.test.ts
@@ -1,0 +1,33 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  getFavoriteTemplateIds,
+  getRecentTemplateIds,
+  isFavoriteTemplateId,
+  pushRecentTemplateId,
+  toggleFavoriteTemplateId,
+} from "./shapeTemplatesStorage";
+
+describe("shapeTemplatesStorage", () => {
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it("tracks recent template ids in order", () => {
+    pushRecentTemplateId("a");
+    pushRecentTemplateId("b");
+    pushRecentTemplateId("a");
+
+    expect(getRecentTemplateIds()).toEqual(["a", "b"]);
+  });
+
+  it("toggles template favorites", () => {
+    expect(toggleFavoriteTemplateId("tpl-1")).toBe(true);
+    expect(isFavoriteTemplateId("tpl-1")).toBe(true);
+    expect(getFavoriteTemplateIds()).toEqual(["tpl-1"]);
+
+    expect(toggleFavoriteTemplateId("tpl-1")).toBe(false);
+    expect(isFavoriteTemplateId("tpl-1")).toBe(false);
+    expect(getFavoriteTemplateIds()).toEqual([]);
+  });
+});

--- a/packages/excalidraw/data/shapeTemplatesStorage.ts
+++ b/packages/excalidraw/data/shapeTemplatesStorage.ts
@@ -1,0 +1,52 @@
+const RECENT_KEY = "excalidraw-shape-templates-recent";
+const FAVORITES_KEY = "excalidraw-shape-templates-favorites";
+const MAX_RECENT = 12;
+
+const readList = (key: string): string[] => {
+  try {
+    const raw = localStorage.getItem(key);
+    if (!raw) {
+      return [];
+    }
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed)
+      ? parsed.filter((item): item is string => typeof item === "string")
+      : [];
+  } catch {
+    return [];
+  }
+};
+
+const writeList = (key: string, values: string[]) => {
+  try {
+    localStorage.setItem(key, JSON.stringify(values));
+  } catch {
+    // ignore quota / private mode errors
+  }
+};
+
+export const getRecentTemplateIds = () => readList(RECENT_KEY);
+
+export const getFavoriteTemplateIds = () => readList(FAVORITES_KEY);
+
+export const pushRecentTemplateId = (templateId: string) => {
+  const recent = readList(RECENT_KEY).filter((id) => id !== templateId);
+  recent.unshift(templateId);
+  writeList(RECENT_KEY, recent.slice(0, MAX_RECENT));
+};
+
+export const toggleFavoriteTemplateId = (templateId: string): boolean => {
+  const favorites = readList(FAVORITES_KEY);
+  const index = favorites.indexOf(templateId);
+  if (index >= 0) {
+    favorites.splice(index, 1);
+    writeList(FAVORITES_KEY, favorites);
+    return false;
+  }
+  favorites.push(templateId);
+  writeList(FAVORITES_KEY, favorites);
+  return true;
+};
+
+export const isFavoriteTemplateId = (templateId: string) =>
+  readList(FAVORITES_KEY).includes(templateId);

--- a/packages/excalidraw/data/types.ts
+++ b/packages/excalidraw/data/types.ts
@@ -64,3 +64,17 @@ export interface ImportedLibraryData extends Partial<ExportedLibraryData> {
 export type ExcalidrawLibraryIds = {
   itemIds: LibraryItem["id"][];
 };
+
+export interface ExportedShapeTemplatesData {
+  type: string;
+  version: number;
+  source: string;
+  templates: import("../types").ShapeTemplates;
+}
+
+export interface ImportedShapeTemplatesData
+  extends Partial<ExportedShapeTemplatesData> {}
+
+export type ExcalidrawTemplateIds = {
+  templateIds: import("../types").ShapeTemplate["id"][];
+};

--- a/packages/excalidraw/locales/en.json
+++ b/packages/excalidraw/locales/en.json
@@ -196,6 +196,28 @@
     "desc": "Click on a shape on canvas or paste a link.",
     "notFound": "Linked object wasn't found on canvas."
   },
+  "shapeTemplates": {
+    "hint": "Drag a template onto the canvas or click to insert at center.",
+    "empty": "No shape templates available.",
+    "searchPlaceholder": "Search templates",
+    "tabsLabel": "Shape templates sections",
+    "recent": "Recent",
+    "favorites": "Favorites",
+    "emptyFavorites": "Star templates to add favorites.",
+    "emptySearch": "No templates match your search.",
+    "addFavorite": "Add to favorites",
+    "removeFavorite": "Remove from favorites"
+  },
+  "shapePanel": {
+    "searchPlaceholder": "Search tools",
+    "tabsLabel": "Shape panel sections",
+    "recent": "Recent",
+    "favorites": "Favorites",
+    "addFavorite": "Add to favorites",
+    "removeFavorite": "Remove from favorites",
+    "emptyFavorites": "Star tools to add favorites.",
+    "emptySearch": "No tools match your search."
+  },
   "library": {
     "noItems": "No items added yet...",
     "hint_emptyLibrary": "Select an item on canvas to add it here, or install a library from the public repository, below.",

--- a/packages/excalidraw/tests/shapeTemplates.test.tsx
+++ b/packages/excalidraw/tests/shapeTemplates.test.tsx
@@ -1,0 +1,133 @@
+import { act } from "@testing-library/react";
+import React from "react";
+
+import {
+  EDITOR_LS_KEYS,
+  MIME_TYPES,
+  TEMPLATES_SIDEBAR_TAB,
+} from "@excalidraw/common";
+
+import { duplicateElements } from "@excalidraw/element";
+
+import { EditorLocalStorage } from "../data/EditorLocalStorage";
+import {
+  BUILTIN_SHAPE_TEMPLATES,
+  getAllShapeTemplates,
+  getShapeTemplatesByIds,
+  loadUserShapeTemplates,
+  parseShapeTemplatesJSON,
+  saveUserShapeTemplates,
+  serializeShapeTemplatesAsJSON,
+} from "../data/shapeTemplates";
+import { Excalidraw } from "../index";
+
+import { API } from "./helpers/api";
+import { fireEvent, render, waitFor } from "./test-utils";
+
+const { h } = window;
+
+describe("shape templates data", () => {
+  beforeEach(() => {
+    EditorLocalStorage.delete(EDITOR_LS_KEYS.SHAPE_TEMPLATES);
+  });
+
+  it("includes built-in templates", () => {
+    const templates = getAllShapeTemplates();
+    expect(templates.length).toBeGreaterThanOrEqual(
+      BUILTIN_SHAPE_TEMPLATES.length,
+    );
+    expect(templates.some((t) => t.id === BUILTIN_SHAPE_TEMPLATES[0].id)).toBe(
+      true,
+    );
+  });
+
+  it("serializes and parses template JSON", () => {
+    const templates = getAllShapeTemplates().slice(0, 1);
+    const json = serializeShapeTemplatesAsJSON(templates);
+    const parsed = parseShapeTemplatesJSON(json);
+    expect(parsed).toHaveLength(1);
+    expect(parsed![0].name).toBe(templates[0].name);
+  });
+
+  it("persists user templates to localStorage", () => {
+    const userTemplate = {
+      id: "user-template-1",
+      name: "Custom",
+      category: "Custom",
+      elements: BUILTIN_SHAPE_TEMPLATES[0].elements,
+    };
+    saveUserShapeTemplates([userTemplate]);
+    const loaded = loadUserShapeTemplates();
+    expect(loaded).toHaveLength(1);
+    expect(loaded[0].id).toBe("user-template-1");
+    expect(getAllShapeTemplates().some((t) => t.id === "user-template-1")).toBe(
+      true,
+    );
+  });
+
+  it("resolves templates by id", () => {
+    const id = BUILTIN_SHAPE_TEMPLATES[0].id;
+    const found = getShapeTemplatesByIds([id]);
+    expect(found).toHaveLength(1);
+    expect(found[0].id).toBe(id);
+  });
+});
+
+describe("shape templates UI", () => {
+  beforeEach(async () => {
+    await render(<Excalidraw />);
+    await act(() => {
+      h.app.setState({
+        openSidebar: { name: "default", tab: TEMPLATES_SIDEBAR_TAB },
+      });
+    });
+  });
+
+  it("renders search and tab controls", () => {
+    expect(
+      document.querySelector('[data-testid="shape-templates-search"]'),
+    ).toBeTruthy();
+    expect(
+      document.querySelector('[data-testid="shape-templates-tab-recent"]'),
+    ).toBeTruthy();
+    expect(
+      document.querySelector('[data-testid="shape-templates-tab-favorites"]'),
+    ).toBeTruthy();
+  });
+
+  it("inserts template on click", async () => {
+    const templateUnit = document.querySelector(".library-unit__dragger");
+    expect(templateUnit).toBeTruthy();
+
+    fireEvent.click(templateUnit!);
+
+    await waitFor(() => {
+      expect(h.elements.length).toBeGreaterThan(0);
+    });
+  });
+
+  it("inserts template via drag and drop", async () => {
+    const templateId = BUILTIN_SHAPE_TEMPLATES[0].id;
+
+    await API.drop([
+      {
+        kind: "string",
+        value: JSON.stringify({ templateIds: [templateId] }),
+        type: MIME_TYPES.excalidrawTemplateIds,
+      },
+    ]);
+
+    await waitFor(() => {
+      const elements = h.elements;
+      expect(elements.length).toBeGreaterThan(0);
+      const template = getShapeTemplatesByIds([templateId])[0];
+      const duplicated = duplicateElements({
+        type: "everything",
+        elements: template.elements,
+        randomizeSeed: true,
+        preserveFrameChildrenOrder: true,
+      }).duplicatedElements;
+      expect(elements.length).toBe(duplicated.length);
+    });
+  });
+});

--- a/packages/excalidraw/types.ts
+++ b/packages/excalidraw/types.ts
@@ -546,6 +546,17 @@ export type LibraryItemsSource =
       currentLibraryItems: LibraryItems,
     ) => MaybePromise<LibraryItems_anyVersion | Blob>)
   | MaybePromise<LibraryItems_anyVersion | Blob>;
+
+export type ShapeTemplate = {
+  id: string;
+  name: string;
+  category?: string;
+  elements: readonly NonDeleted<ExcalidrawElement>[];
+  /** built-in templates are not persisted to localStorage */
+  builtin?: boolean;
+};
+export type ShapeTemplates = readonly ShapeTemplate[];
+
 // -----------------------------------------------------------------------------
 
 export type ExcalidrawInitialDataState = Merge<


### PR DESCRIPTION
Introduce pre-made shape combinations in a new sidebar tab, with JSON template format, localStorage persistence, favorites/recent, and tests.