### PR TITLE
fix(editor): don't treat pen pointer events as touchscreen

### DIFF
--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -7813,7 +7813,7 @@ class App extends React.Component<AppProps, AppState> {
 
     if (
       !this.editorInterface.isTouchScreen &&
-      ["pen", "touch"].includes(event.pointerType)
+      ["touch"].includes(event.pointerType)
     ) {
       this.editorInterface = updateObject(this.editorInterface, {
         isTouchScreen: true,

--- a/packages/excalidraw/tests/multiPointCreate.test.tsx
+++ b/packages/excalidraw/tests/multiPointCreate.test.tsx
@@ -182,4 +182,79 @@ describe("multi point mode in linear elements", () => {
 
     h.elements.forEach((element) => expect(element).toMatchSnapshot());
   });
+
+  // Regression: pen taps were previously treated as touch taps and finalized
+  // as a fixed-width 2-point line instead of entering multipoint mode.
+  it("line with pen enters multi point mode", async () => {
+    const { getByToolName, container } = await render(<Excalidraw />);
+    const tool = getByToolName("line");
+    fireEvent.click(tool);
+
+    const canvas = container.querySelector("canvas.interactive")!;
+
+    // pen tap should start a multipoint line, not finalize it
+    fireEvent.pointerDown(canvas, {
+      clientX: 30,
+      clientY: 30,
+      pointerType: "pen",
+    });
+    fireEvent.pointerUp(canvas, {
+      clientX: 30,
+      clientY: 30,
+      pointerType: "pen",
+    });
+
+    expect(h.state.multiElement).not.toBeNull();
+
+    fireEvent.pointerMove(canvas, {
+      clientX: 50,
+      clientY: 60,
+      pointerType: "pen",
+    });
+    fireEvent.pointerDown(canvas, {
+      clientX: 50,
+      clientY: 60,
+      pointerType: "pen",
+    });
+    fireEvent.pointerUp(canvas, {
+      clientX: 50,
+      clientY: 60,
+      pointerType: "pen",
+    });
+    fireEvent.keyDown(document, { key: KEYS.ENTER });
+
+    expect(h.elements.length).toEqual(1);
+    const element = h.elements[0] as ExcalidrawLinearElement;
+    expect(element.type).toEqual("line");
+    expect(element.points.length).toBeGreaterThanOrEqual(2);
+  });
+
+  // Regression: after a pen interaction, switching back to mouse used to
+  // remain stuck in touchscreen mode and finalize mouse clicks as 2-point lines.
+  it("mouse multi point works after pen interaction", async () => {
+    const { getByToolName, container } = await render(<Excalidraw />);
+    const tool = getByToolName("line");
+    fireEvent.click(tool);
+
+    const canvas = container.querySelector("canvas.interactive")!;
+
+    // pen interaction first
+    fireEvent.pointerDown(canvas, {
+      clientX: 30,
+      clientY: 30,
+      pointerType: "pen",
+    });
+    fireEvent.pointerUp(canvas, {
+      clientX: 30,
+      clientY: 30,
+      pointerType: "pen",
+    });
+    fireEvent.keyDown(document, { key: KEYS.ESCAPE });
+
+    // mouse multipoint must still work
+    fireEvent.pointerDown(canvas, { clientX: 100, clientY: 100 });
+    fireEvent.pointerUp(canvas, { clientX: 100, clientY: 100 });
+
+    expect(h.state.multiElement).not.toBeNull();
+  });
 });


### PR DESCRIPTION
## Summary
Pen input was being lumped together with touch in `handleCanvasPointerDown`, setting `editorInterface.isTouchScreen = true`. This caused two related bugs:

1. A pen tap with the line/arrow tool drew a fixed-width horizontal stub and finalized immediately, instead of entering multipoint mode.
2. Since the flag was never reset, subsequent mouse clicks also finalized as 2-point lines until the page was reloaded.

The touchscreen-finalize behavior was intentionally designed for fingers, which can't precisely click multipoint. Pens are precise pointing devices and should behave like a mouse for this purpose.

## Fix
Remove `"pen"` from the condition at `App.tsx:7814-7821` that sets `isTouchScreen = true`. Touch (finger) input still gets the existing fixed-width finalize behavior.

## Related
- Fixes #9929
- Related to zsviczian/obsidian-excalidraw-plugin#2606
- Related to #11296 (that PR fixes the mouse-after-pen tail; this fixes the root cause, so the mouse-after-pen problem doesn't occur in the first place)

## Test plan
- [x] Added two regression tests in `multiPointCreate.test.tsx`:
  - Pen tap enters multipoint mode
  - Mouse multipoint still works after a pen interaction
- [x] Verified both tests fail without the fix and pass with it
- [x] Manually verified by a human on macOS Safari via Sidecar with an iPad + stylus (both pen-tap multipoint and pen→mouse handoff work as expected)
- [x] `yarn test:typecheck`, `yarn test:code`, `yarn test:other` all pass

---
Bug reported and manually tested by @pbhopeful. Diagnosis, code change, and regression tests authored with assistance from Claude Code.