### PR TITLE
fix: harden tab synchronization localStorage parsing

### DIFF
--- a/excalidraw-app/data/tabSync.ts
+++ b/excalidraw-app/data/tabSync.ts
@@ -9,13 +9,45 @@ const LOCAL_STATE_VERSIONS = {
 
 type BrowserStateTypes = keyof typeof LOCAL_STATE_VERSIONS;
 
+const getStorageTimestamp = (type: BrowserStateTypes): number => {
+  try {
+    const value = localStorage.getItem(type);
+    if (value === null) {
+      return -1;
+    }
+
+    const parsed = JSON.parse(value);
+
+    // Validate it's a finite number
+    if (typeof parsed !== "number" || !Number.isFinite(parsed)) {
+      console.warn(`Invalid timestamp in localStorage for key: ${type}`);
+      return -1;
+    }
+
+    return parsed;
+  } catch (error) {
+    console.error(`Error reading localStorage for key ${type}:`, error);
+    // Clear corrupted data
+    try {
+      localStorage.removeItem(type);
+    } catch (e) {
+      console.error(e);
+    }
+    return -1;
+  }
+};
+
 export const isBrowserStorageStateNewer = (type: BrowserStateTypes) => {
-  const storageTimestamp = JSON.parse(localStorage.getItem(type) || "-1");
+  const storageTimestamp = getStorageTimestamp(type);
   return storageTimestamp > LOCAL_STATE_VERSIONS[type];
 };
 
 export const updateBrowserStateVersion = (type: BrowserStateTypes) => {
   const timestamp = Date.now();
+  if (typeof timestamp !== "number" || !Number.isFinite(timestamp)) {
+    console.error("Attempted to save invalid timestamp");
+    return;
+  }
   try {
     localStorage.setItem(type, JSON.stringify(timestamp));
     LOCAL_STATE_VERSIONS[type] = timestamp;

--- a/excalidraw-app/tests/tabSync.test.ts
+++ b/excalidraw-app/tests/tabSync.test.ts
@@ -1,0 +1,138 @@
+import { STORAGE_KEYS } from "../app_constants";
+import {
+  isBrowserStorageStateNewer,
+  updateBrowserStateVersion,
+  resetBrowserStateVersions,
+} from "../data/tabSync";
+
+describe("tabSync", () => {
+  let consoleErrorSpy: any;
+  let consoleWarnSpy: any;
+
+  beforeEach(() => {
+    localStorage.clear();
+    consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+    consoleWarnSpy.mockRestore();
+  });
+
+  it("should initialize and return false when storage is empty", () => {
+    expect(isBrowserStorageStateNewer(STORAGE_KEYS.VERSION_DATA_STATE)).toBe(
+      false,
+    );
+  });
+
+  it("should update state version and store timestamp in localStorage", () => {
+    updateBrowserStateVersion(STORAGE_KEYS.VERSION_DATA_STATE);
+
+    const storedValue = localStorage.getItem(STORAGE_KEYS.VERSION_DATA_STATE);
+    expect(storedValue).not.toBeNull();
+
+    const timestamp = JSON.parse(storedValue!);
+    expect(typeof timestamp).toBe("number");
+    expect(Number.isFinite(timestamp)).toBe(true);
+
+    // After updating, local state is same as storage, so it shouldn't be newer
+    expect(isBrowserStorageStateNewer(STORAGE_KEYS.VERSION_DATA_STATE)).toBe(
+      false,
+    );
+  });
+
+  it("should detect if storage state is newer", () => {
+    // Set a baseline local version
+    updateBrowserStateVersion(STORAGE_KEYS.VERSION_DATA_STATE);
+
+    // Simulate another tab updating the timestamp
+    const futureTimestamp = Date.now() + 10000;
+    localStorage.setItem(
+      STORAGE_KEYS.VERSION_DATA_STATE,
+      JSON.stringify(futureTimestamp),
+    );
+
+    expect(isBrowserStorageStateNewer(STORAGE_KEYS.VERSION_DATA_STATE)).toBe(
+      true,
+    );
+  });
+
+  it("should handle malformed JSON gracefully, delete item, and log error", () => {
+    localStorage.setItem(STORAGE_KEYS.VERSION_DATA_STATE, "{invalid json");
+
+    expect(isBrowserStorageStateNewer(STORAGE_KEYS.VERSION_DATA_STATE)).toBe(
+      false,
+    );
+    expect(localStorage.getItem(STORAGE_KEYS.VERSION_DATA_STATE)).toBeNull();
+    expect(consoleErrorSpy).toHaveBeenCalled();
+  });
+
+  it("should handle non-number types in localStorage gracefully and log warning", () => {
+    // String in localStorage
+    localStorage.setItem(
+      STORAGE_KEYS.VERSION_DATA_STATE,
+      JSON.stringify("not-a-number"),
+    );
+    expect(isBrowserStorageStateNewer(STORAGE_KEYS.VERSION_DATA_STATE)).toBe(
+      false,
+    );
+    expect(consoleWarnSpy).toHaveBeenCalled();
+
+    // Object in localStorage
+    localStorage.setItem(
+      STORAGE_KEYS.VERSION_DATA_STATE,
+      JSON.stringify({ time: 12345 }),
+    );
+    expect(isBrowserStorageStateNewer(STORAGE_KEYS.VERSION_DATA_STATE)).toBe(
+      false,
+    );
+
+    // Array in localStorage
+    localStorage.setItem(STORAGE_KEYS.VERSION_DATA_STATE, JSON.stringify([1]));
+    expect(isBrowserStorageStateNewer(STORAGE_KEYS.VERSION_DATA_STATE)).toBe(
+      false,
+    );
+
+    // Boolean in localStorage
+    localStorage.setItem(STORAGE_KEYS.VERSION_DATA_STATE, JSON.stringify(true));
+    expect(isBrowserStorageStateNewer(STORAGE_KEYS.VERSION_DATA_STATE)).toBe(
+      false,
+    );
+  });
+
+  it("should handle invalid numbers (NaN, Infinity) gracefully and log warning", () => {
+    const jsonParseSpy = vi.spyOn(JSON, "parse").mockReturnValueOnce(NaN);
+    localStorage.setItem(STORAGE_KEYS.VERSION_DATA_STATE, "123");
+
+    expect(isBrowserStorageStateNewer(STORAGE_KEYS.VERSION_DATA_STATE)).toBe(
+      false,
+    );
+    expect(consoleWarnSpy).toHaveBeenCalled();
+    jsonParseSpy.mockRestore();
+
+    const jsonParseSpy2 = vi.spyOn(JSON, "parse").mockReturnValueOnce(Infinity);
+    localStorage.setItem(STORAGE_KEYS.VERSION_DATA_STATE, "123");
+
+    expect(isBrowserStorageStateNewer(STORAGE_KEYS.VERSION_DATA_STATE)).toBe(
+      false,
+    );
+    expect(consoleWarnSpy).toHaveBeenCalledTimes(2);
+    jsonParseSpy2.mockRestore();
+  });
+
+  it("should reset browser state versions properly", () => {
+    updateBrowserStateVersion(STORAGE_KEYS.VERSION_DATA_STATE);
+    updateBrowserStateVersion(STORAGE_KEYS.VERSION_FILES);
+
+    resetBrowserStateVersions();
+
+    expect(localStorage.getItem(STORAGE_KEYS.VERSION_DATA_STATE)).toBe("-1");
+    expect(localStorage.getItem(STORAGE_KEYS.VERSION_FILES)).toBe("-1");
+
+    expect(isBrowserStorageStateNewer(STORAGE_KEYS.VERSION_DATA_STATE)).toBe(
+      false,
+    );
+    expect(isBrowserStorageStateNewer(STORAGE_KEYS.VERSION_FILES)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
This PR hardens the tab synchronization feature in `excalidraw-app/data/tabSync.ts` against security vulnerabilities (such as prototype pollution, type confusion, application crashes, and denial of service) arising from malformed or untrusted `localStorage` data.

## Changes
- **Safe JSON Parsing**: Wrapped `localStorage.getItem` and `JSON.parse` in a `try-catch` block inside a new helper function `getStorageTimestamp` to catch exceptions from malformed inputs.
- **Type Validation**: Validated that the parsed output is a finite number using `typeof parsed === "number" && Number.isFinite(parsed)`.
- **Corrupted Data Eviction**: If parsing fails (throws an error), the corrupted key is deleted from `localStorage` using `localStorage.removeItem` within a safe try-catch.
- **Validation on Save**: Added input validation to `updateBrowserStateVersion` to guarantee only finite numbers are written to `localStorage`.
- **Comprehensive Testing**: Added detailed unit tests in `excalidraw-app/tests/tabSync.test.ts` to test all scenarios including valid numbers, malformed JSON, strings, objects, arrays, booleans, NaN, and Infinity.

## References
Closes #11389