### PR TITLE
fix: validate custom color hex input

### DIFF
--- a/packages/excalidraw/components/ColorPicker/ColorInput.tsx
+++ b/packages/excalidraw/components/ColorPicker/ColorInput.tsx
@@ -14,6 +14,28 @@ import { activeColorPickerSectionAtom } from "./colorPickerUtils";
 
 import type { ColorPickerType } from "./colorPickerUtils";
 
+let colorInputErrorId = 0;
+
+const VALID_HEX_COLOR_LENGTHS = new Set([3, 4, 6, 8]);
+
+const getHexColorInputError = (value: string) => {
+  const color = value.trim().replace(/^#/, "");
+
+  if (!color) {
+    return null;
+  }
+
+  if (!/^[0-9a-f]+$/i.test(color)) {
+    return t("colorPicker.invalidHexCharacters");
+  }
+
+  if (!VALID_HEX_COLOR_LENGTHS.has(color.length)) {
+    return t("colorPicker.invalidHexLength");
+  }
+
+  return null;
+};
+
 export const ColorInput = ({
   color,
   onChange,
@@ -32,6 +54,10 @@ export const ColorInput = ({
   const [activeSection, setActiveColorPickerSection] = useAtom(
     activeColorPickerSectionAtom,
   );
+  const errorIdRef = useRef<string | null>(null);
+  if (!errorIdRef.current) {
+    errorIdRef.current = `color-picker-input-error-${colorInputErrorId++}`;
+  }
 
   useEffect(() => {
     setInnerValue(color);
@@ -40,7 +66,8 @@ export const ColorInput = ({
   const changeColor = useCallback(
     (inputValue: string) => {
       const value = inputValue.toLowerCase();
-      const color = normalizeInputColor(value);
+      const inputError = getHexColorInputError(value);
+      const color = !inputError ? normalizeInputColor(value) : null;
 
       if (color) {
         onChange(color);
@@ -60,6 +87,8 @@ export const ColorInput = ({
   }, [activeSection]);
 
   const [eyeDropperState, setEyeDropperState] = useAtom(activeEyeDropperAtom);
+  const colorInputError = getHexColorInputError(innerValue);
+  const hasColorInputError = !!colorInputError;
 
   useEffect(() => {
     return () => {
@@ -68,66 +97,85 @@ export const ColorInput = ({
   }, [setEyeDropperState]);
 
   return (
-    <div className="color-picker__input-label">
-      <div className="color-picker__input-hash">#</div>
-      <input
-        ref={activeSection === "hex" ? inputRef : undefined}
-        style={{ border: 0, padding: 0 }}
-        spellCheck={false}
-        className="color-picker-input"
-        aria-label={label}
-        onChange={(event) => {
-          changeColor(event.target.value);
-        }}
-        value={(innerValue || "").replace(/^#/, "")}
-        onBlur={() => {
-          setInnerValue(color);
-        }}
-        tabIndex={-1}
-        onFocus={() => setActiveColorPickerSection("hex")}
-        onKeyDown={(event) => {
-          if (event.key === KEYS.TAB) {
-            return;
-          } else if (event.key === KEYS.ESCAPE) {
-            eyeDropperTriggerRef.current?.focus();
+    <div className="color-picker__input-container">
+      <div
+        className={clsx("color-picker__input-label", {
+          "color-picker__input-label--invalid": hasColorInputError,
+        })}
+      >
+        <div className="color-picker__input-hash">#</div>
+        <input
+          ref={activeSection === "hex" ? inputRef : undefined}
+          style={{ border: 0, padding: 0 }}
+          spellCheck={false}
+          className="color-picker-input"
+          aria-label={label}
+          aria-invalid={hasColorInputError}
+          aria-describedby={
+            hasColorInputError ? errorIdRef.current ?? undefined : undefined
           }
-          event.stopPropagation();
-        }}
-        placeholder={placeholder}
-      />
-      {/* TODO reenable on mobile with a better UX */}
-      {editorInterface.formFactor !== "phone" && (
-        <>
-          <div
-            style={{
-              width: "1px",
-              height: "1.25rem",
-              backgroundColor: "var(--default-border-color)",
-            }}
-          />
-          <div
-            ref={eyeDropperTriggerRef}
-            className={clsx("excalidraw-eye-dropper-trigger", {
-              selected: eyeDropperState,
-            })}
-            onClick={() =>
-              setEyeDropperState((s) =>
-                s
-                  ? null
-                  : {
-                      keepOpenOnAlt: false,
-                      onSelect: (color) => onChange(color),
-                      colorPickerType,
-                    },
-              )
+          onChange={(event) => {
+            changeColor(event.target.value);
+          }}
+          value={(innerValue || "").replace(/^#/, "")}
+          onBlur={() => {
+            setInnerValue(color);
+          }}
+          tabIndex={-1}
+          onFocus={() => setActiveColorPickerSection("hex")}
+          onKeyDown={(event) => {
+            if (event.key === KEYS.TAB) {
+              return;
+            } else if (event.key === KEYS.ESCAPE) {
+              eyeDropperTriggerRef.current?.focus();
             }
-            title={`${t(
-              "labels.eyeDropper",
-            )} — ${KEYS.I.toLocaleUpperCase()} or ${getShortcutKey("Alt")} `}
-          >
-            {eyeDropperIcon}
-          </div>
-        </>
+            event.stopPropagation();
+          }}
+          placeholder={placeholder}
+        />
+        {/* TODO reenable on mobile with a better UX */}
+        {editorInterface.formFactor !== "phone" && (
+          <>
+            <div
+              style={{
+                width: "1px",
+                height: "1.25rem",
+                backgroundColor: "var(--default-border-color)",
+              }}
+            />
+            <div
+              ref={eyeDropperTriggerRef}
+              className={clsx("excalidraw-eye-dropper-trigger", {
+                selected: eyeDropperState,
+              })}
+              onClick={() =>
+                setEyeDropperState((s) =>
+                  s
+                    ? null
+                    : {
+                        keepOpenOnAlt: false,
+                        onSelect: (color) => onChange(color),
+                        colorPickerType,
+                      },
+                )
+              }
+              title={`${t(
+                "labels.eyeDropper",
+              )} — ${KEYS.I.toLocaleUpperCase()} or ${getShortcutKey("Alt")} `}
+            >
+              {eyeDropperIcon}
+            </div>
+          </>
+        )}
+      </div>
+      {hasColorInputError && (
+        <div
+          className="color-picker__input-error"
+          id={errorIdRef.current ?? undefined}
+          role="alert"
+        >
+          {colorInputError}
+        </div>
       )}
     </div>
   );

--- a/packages/excalidraw/components/ColorPicker/ColorPicker.scss
+++ b/packages/excalidraw/components/ColorPicker/ColorPicker.scss
@@ -368,6 +368,10 @@
     }
   }
 
+  .color-picker__input-container {
+    margin: 8px;
+  }
+
   .color-picker__input-label {
     display: grid;
     grid-template-columns: auto 1fr auto auto;
@@ -376,16 +380,27 @@
     border: 1px solid var(--default-border-color);
     border-radius: 8px;
     padding: 0 12px;
-    margin: 8px;
     box-sizing: border-box;
 
     &:focus-within {
       box-shadow: 0 0 0 1px var(--color-primary-darkest);
       border-radius: var(--border-radius-lg);
     }
+
+    &--invalid {
+      border-color: var(--color-danger);
+    }
   }
 
   .color-picker__input-hash {
+    padding: 0 0.25rem;
+  }
+
+  .color-picker__input-error {
+    color: var(--color-danger);
+    font-size: 0.75rem;
+    line-height: 1rem;
+    margin-top: 0.25rem;
     padding: 0 0.25rem;
   }
 

--- a/packages/excalidraw/locales/en.json
+++ b/packages/excalidraw/locales/en.json
@@ -598,6 +598,8 @@
     "colors": "Colors",
     "shades": "Shades",
     "hexCode": "Hex code",
+    "invalidHexCharacters": "Only hexadecimal characters are allowed.",
+    "invalidHexLength": "Hex code must be 3, 4, 6, or 8 characters.",
     "noShades": "No shades available for this color"
   },
   "overwriteConfirm": {

--- a/packages/excalidraw/tests/colorInputComponent.test.tsx
+++ b/packages/excalidraw/tests/colorInputComponent.test.tsx
@@ -1,0 +1,79 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { vi } from "vitest";
+
+import { ColorInput } from "../components/ColorPicker/ColorInput";
+import { EditorJotaiProvider } from "../editor-jotai";
+
+describe("ColorInput", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  const renderColorInput = (onChange = vi.fn()) => {
+    render(
+      <EditorJotaiProvider>
+        <ColorInput
+          color="#000000"
+          label="Stroke color"
+          onChange={onChange}
+          colorPickerType="elementStroke"
+        />
+      </EditorJotaiProvider>,
+    );
+
+    return {
+      input: screen.getByLabelText("Stroke color"),
+      onChange,
+    };
+  };
+
+  it("shows an error message for invalid color input", () => {
+    const { input, onChange } = renderColorInput();
+
+    fireEvent.change(input, { target: { value: "gggggg" } });
+
+    expect(input.getAttribute("aria-invalid")).toBe("true");
+    expect(input.getAttribute("aria-describedby")).toBe(
+      screen.getByRole("alert").id,
+    );
+    expect(screen.getByRole("alert").textContent).toBe(
+      "Only hexadecimal characters are allowed.",
+    );
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("shows an error message for invalid hex length", () => {
+    const { input, onChange } = renderColorInput();
+
+    fireEvent.change(input, { target: { value: "fffff" } });
+
+    expect(input.getAttribute("aria-invalid")).toBe("true");
+    expect(screen.getByRole("alert").textContent).toBe(
+      "Hex code must be 3, 4, 6, or 8 characters.",
+    );
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("shows an error message for named colors", () => {
+    const { input, onChange } = renderColorInput();
+
+    fireEvent.change(input, { target: { value: "blue" } });
+
+    expect(input.getAttribute("aria-invalid")).toBe("true");
+    expect(screen.getByRole("alert").textContent).toBe(
+      "Only hexadecimal characters are allowed.",
+    );
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("clears the error message when input becomes valid", () => {
+    const { input, onChange } = renderColorInput();
+
+    fireEvent.change(input, { target: { value: "gggggg" } });
+    fireEvent.change(input, { target: { value: "ff0000" } });
+
+    expect(input.getAttribute("aria-invalid")).toBe("false");
+    expect(screen.queryByRole("alert")).toBeNull();
+    expect(onChange).toHaveBeenCalledWith("#ff0000");
+  });
+});


### PR DESCRIPTION
## Summary
- add inline validation for the color picker hex input
- show specific errors for invalid hex characters and invalid hex lengths
- cover invalid and recovered input states with component tests

Fixes #9527

## Tests
- .\\node_modules\\.bin\\vitest.cmd run packages/excalidraw/tests/colorInput.test.ts packages/excalidraw/tests/colorInputComponent.test.tsx
- .\\node_modules\\.bin\\prettier.cmd --check packages/excalidraw/components/ColorPicker/ColorInput.tsx packages/excalidraw/components/ColorPicker/ColorPicker.scss packages/excalidraw/locales/en.json packages/excalidraw/tests/colorInputComponent.test.tsx
- git diff --check