### PR TITLE
Fix Ctrl+F behavior inside help menu

### DIFF
--- a/packages/excalidraw/actions/actionToggleSearchMenu.ts
+++ b/packages/excalidraw/actions/actionToggleSearchMenu.ts
@@ -56,5 +56,6 @@ export const actionToggleSearchMenu = register({
   predicate: (element, appState, props) => {
     return props.gridModeEnabled === undefined;
   },
-  keyTest: (event) => event[KEYS.CTRL_OR_CMD] && event.key === KEYS.F,
+  keyTest: (event, appState) =>
+    !appState.openDialog && event[KEYS.CTRL_OR_CMD] && event.key === KEYS.F,
 });

--- a/packages/excalidraw/tests/search.test.tsx
+++ b/packages/excalidraw/tests/search.test.tsx
@@ -17,7 +17,7 @@ import { Excalidraw } from "../index";
 import { API } from "./helpers/api";
 import { Keyboard } from "./helpers/ui";
 import { updateTextEditor } from "./queries/dom";
-import { act, render, waitFor } from "./test-utils";
+import { act, fireEvent, render, waitFor } from "./test-utils";
 
 const { h } = window;
 
@@ -73,6 +73,21 @@ describe("search", () => {
       Keyboard.keyPress(KEYS.F);
     });
     expect(searchInput?.matches(":focus")).toBe(true);
+  });
+
+  it("should let browser handle cmd+f when help dialog is open", () => {
+    API.setAppState({
+      openDialog: { name: "help" },
+    });
+
+    const wasNotPrevented = fireEvent.keyDown(document, {
+      key: KEYS.F,
+      [KEYS.CTRL_OR_CMD]: true,
+    });
+
+    expect(wasNotPrevented).toBe(true);
+    expect(h.app.state.openDialog?.name).toBe("help");
+    expect(h.app.state.openSidebar).toBeNull();
   });
 
   it("should match text and cycle through matches on Enter", async () => {


### PR DESCRIPTION
## Summary
Fixes the issue where Ctrl + F does not function correctly inside the Excalidraw help menu.

## Changes
- Updated keyboard shortcut handling for the help modal
- Preserved existing app shortcuts and behaviors
- Kept the fix minimal and isolated

## Verification
- Tested Ctrl + F behavior inside the help menu
- Verified app shortcuts still work
- Ran project checks/build/tests successfully