### PR TITLE
refactor: rename cleanAppStateForExport to clearAppStateForExport

### DIFF
--- a/packages/excalidraw/appState.ts
+++ b/packages/excalidraw/appState.ts
@@ -284,7 +284,7 @@ export const clearAppStateForLocalStorage = (appState: Partial<AppState>) => {
   return _clearAppStateForStorage(appState, "browser");
 };
 
-export const cleanAppStateForExport = (appState: Partial<AppState>) => {
+export const clearAppStateForExport = (appState: Partial<AppState>) => {
   return _clearAppStateForStorage(appState, "export");
 };
 

--- a/packages/excalidraw/data/blob.ts
+++ b/packages/excalidraw/data/blob.ts
@@ -10,7 +10,7 @@ import {
 import type { ValueOf } from "@excalidraw/common/utility-types";
 import type { ExcalidrawElement, FileId } from "@excalidraw/element/types";
 
-import { cleanAppStateForExport } from "../appState";
+import { clearAppStateForExport } from "../appState";
 
 import { CanvasError, ImageSceneDataError } from "../errors";
 import { calculateScrollCenter } from "../scene";
@@ -169,7 +169,7 @@ export const loadSceneOrLibraryFromBlob = async (
             {
               theme: localAppState?.theme,
               fileHandle: fileHandle || blob.handle || null,
-              ...cleanAppStateForExport(data.appState || {}),
+              ...clearAppStateForExport(data.appState || {}),
               ...(localAppState
                 ? calculateScrollCenter(data.elements || [], localAppState)
                 : {}),

--- a/packages/excalidraw/data/json.ts
+++ b/packages/excalidraw/data/json.ts
@@ -9,7 +9,7 @@ import type { ExcalidrawElement, NonDeleted } from "@excalidraw/element/types";
 
 import type { MaybePromise } from "@excalidraw/common/utility-types";
 
-import { cleanAppStateForExport, clearAppStateForDatabase } from "../appState";
+import { clearAppStateForExport, clearAppStateForDatabase } from "../appState";
 
 import { isImageFileHandle, loadFromBlob } from "./blob";
 import { fileOpen, fileSave } from "./filesystem";
@@ -62,7 +62,7 @@ export const serializeAsJSON = (
     elements,
     appState:
       type === "local"
-        ? cleanAppStateForExport(appState)
+        ? clearAppStateForExport(appState)
         : clearAppStateForDatabase(appState),
     files:
       type === "local"

--- a/packages/excalidraw/data/types.ts
+++ b/packages/excalidraw/data/types.ts
@@ -2,7 +2,7 @@ import type { VERSIONS } from "@excalidraw/common";
 
 import type { ExcalidrawElement } from "@excalidraw/element/types";
 
-import type { cleanAppStateForExport } from "../appState";
+import type { clearAppStateForExport } from "../appState";
 import type {
   AppState,
   BinaryFiles,
@@ -16,7 +16,7 @@ export interface ExportedDataState {
   version: number;
   source: string;
   elements: readonly ExcalidrawElement[];
-  appState: ReturnType<typeof cleanAppStateForExport>;
+  appState: ReturnType<typeof clearAppStateForExport>;
   files: BinaryFiles | undefined;
 }
 


### PR DESCRIPTION
Fixes #11333

Renames cleanAppStateForExport to clearAppStateForExport for naming consistency. The three sibling functions clearAppStateForLocalStorage, cleanAppStateForExport, and clearAppStateForDatabase all wrap the same internal helper _clearAppStateForStorage but two use clear and one uses clean. This updates all references across the codebase to use the consistent clear prefix.

Changes:
- packages/excalidraw/appState.ts
- packages/excalidraw/data/blob.ts
- packages/excalidraw/data/json.ts
- packages/excalidraw/data/types.ts