### PR TITLE
fix(editor): avoid rendering null in toolbar shortcut hover tooltip

### DIFF
--- a/packages/excalidraw/components/Actions.tsx
+++ b/packages/excalidraw/components/Actions.tsx
@@ -1097,9 +1097,10 @@ export const ShapesSwitcher = ({
           const label = t(`toolBar.${value}`);
           const letter =
             key && capitalizeString(typeof key === "string" ? key : key[0]);
-          const shortcut = letter
-            ? `${letter} ${t("helpDialog.or")} ${numericKey}`
-            : `${numericKey}`;
+          const shortcut =
+            [letter, numericKey]
+              .filter(Boolean)
+              .join(` ${t("helpDialog.or")} `) || undefined;
           const keybindingLabel =
             value === "hand" ? undefined : numericKey || letter;
 
@@ -1146,7 +1147,11 @@ export const ShapesSwitcher = ({
               icon={icon}
               checked={activeTool.type === value}
               name="editor-current-shape"
-              title={`${capitalizeString(label)} — ${shortcut}`}
+              title={
+                shortcut
+                  ? `${capitalizeString(label)} — ${shortcut}`
+                  : capitalizeString(label)
+              }
               keyBindingLabel={keybindingLabel}
               aria-label={capitalizeString(label)}
               aria-keyshortcuts={shortcut}


### PR DESCRIPTION
The toolbar tool buttons build their hover tooltip and `aria-keyshortcuts` by interpolating both the letter key and the numeric key into a `"<letter> or <number>"` template. The **Hand** tool has `numericKey: null`, so the tooltip rendered `Hand (panning tool) — H or null` and `aria-keyshortcuts="H or null"`.

<img width="625" height="107" alt="Screenshot From 2026-05-27 15-14-16" src="https://github.com/user-attachments/assets/00513072-30b6-4497-9a62-b3e590a9150d" /> 

This PR filters out falsy parts before joining, and omits the `— shortcut` suffix and the aria attribute entirely when neither key is available.