### PR TITLE
feat(editor): inline ghost-text autocomplete while typing text

### DIFF
--- a/packages/excalidraw/wysiwyg/textAutocomplete.test.ts
+++ b/packages/excalidraw/wysiwyg/textAutocomplete.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+
+import { createSuggestionEngine } from "./textAutocomplete";
+
+import type App from "../components/App";
+
+// Minimal stub — the engine only ever touches app.scene.getNonDeletedElements
+// to build its corpus, so we only need to stub that.
+const makeStubApp = (sceneTexts: string[] = []): App => {
+  const elements = sceneTexts.map((text, i) => ({
+    id: `t${i}`,
+    type: "text",
+    text,
+    isDeleted: false,
+  }));
+  return {
+    scene: {
+      getNonDeletedElements: () => elements,
+    },
+  } as unknown as App;
+};
+
+describe("createSuggestionEngine", () => {
+  it("suggests a built-in diagramming term from a 3-char prefix", () => {
+    const engine = createSuggestionEngine(makeStubApp());
+    expect(engine.getSuggestion("Dec", 3, "id")).toBe("ision");
+  });
+
+  it("preserves user-typed case and only appends the suffix", () => {
+    const engine = createSuggestionEngine(makeStubApp());
+    // user typed lowercase — completion should still be the missing
+    // characters using the corpus word's spelling
+    expect(engine.getSuggestion("dec", 3, "id")).toBe("ision");
+  });
+
+  it("returns null when the caret is not at the end of the text", () => {
+    const engine = createSuggestionEngine(makeStubApp());
+    // caret at offset 2 ("De|c") — mid-word caret never suggests
+    expect(engine.getSuggestion("Dec", 2, "id")).toBeNull();
+  });
+
+  it("requires at least 2 characters before suggesting", () => {
+    const engine = createSuggestionEngine(makeStubApp());
+    expect(engine.getSuggestion("D", 1, "id")).toBeNull();
+    expect(engine.getSuggestion("De", 2, "id")).not.toBeNull();
+  });
+
+  it("only suggests the current word, not the whole text", () => {
+    const engine = createSuggestionEngine(makeStubApp());
+    // After a space the prefix is just "Logi", not the whole "User Logi" —
+    // proves we split on whitespace before matching.
+    expect(engine.getSuggestion("User Logi", 9, "id")).toBe("n");
+  });
+
+  it("returns null when no corpus word matches the prefix", () => {
+    const engine = createSuggestionEngine(makeStubApp());
+    expect(engine.getSuggestion("xyz", 3, "id")).toBeNull();
+  });
+
+  it("returns null when prefix already equals the corpus word", () => {
+    const engine = createSuggestionEngine(makeStubApp());
+    expect(engine.getSuggestion("Decision", 8, "id")).toBeNull();
+  });
+
+  it("does not suggest while the prefix ends in punctuation", () => {
+    const engine = createSuggestionEngine(makeStubApp());
+    expect(engine.getSuggestion("Dec.", 4, "id")).toBeNull();
+  });
+
+  it("picks up words from text elements already on the canvas", () => {
+    const engine = createSuggestionEngine(
+      makeStubApp(["Onboarding flow", "Quickstart guide"]),
+    );
+    // "Onboarding" wasn't in the built-in corpus
+    expect(engine.getSuggestion("Onb", 3, "id")).toBe("oarding");
+    expect(engine.getSuggestion("Qui", 3, "id")).toBe("ckstart");
+  });
+
+  it("refreshes the corpus when called", () => {
+    const elements: {
+      id: string;
+      type: string;
+      text: string;
+      isDeleted: boolean;
+    }[] = [];
+    const stubApp = {
+      scene: { getNonDeletedElements: () => elements },
+    } as unknown as App;
+    const engine = createSuggestionEngine(stubApp);
+    expect(engine.getSuggestion("Zoo", 3, "id")).toBeNull();
+    elements.push({
+      id: "x",
+      type: "text",
+      text: "Zookeeper",
+      isDeleted: false,
+    });
+    engine.refreshCorpus();
+    expect(engine.getSuggestion("Zoo", 3, "id")).toBe("keeper");
+  });
+});

--- a/packages/excalidraw/wysiwyg/textAutocomplete.ts
+++ b/packages/excalidraw/wysiwyg/textAutocomplete.ts
@@ -1,0 +1,214 @@
+import { isTextElement } from "@excalidraw/element";
+
+import type App from "../components/App";
+
+// Common diagramming / flowchart terms that show up over and over in
+// real-world excalidraw boards. Used as the seed corpus so suggestions
+// work even on an empty canvas.
+const COMMON_TERMS = [
+  // Flow control
+  "Start",
+  "Begin",
+  "End",
+  "Stop",
+  "Finish",
+  "Done",
+  "Cancel",
+  "Submit",
+  "Continue",
+  "Retry",
+  // Yes/no
+  "Yes",
+  "No",
+  "True",
+  "False",
+  "Maybe",
+  // Process steps
+  "Decision",
+  "Process",
+  "Action",
+  "Step",
+  "Input",
+  "Output",
+  "Check",
+  "Validate",
+  "Review",
+  "Approve",
+  "Reject",
+  // Roles & actors
+  "User",
+  "Admin",
+  "Customer",
+  "Client",
+  "Server",
+  "Worker",
+  "System",
+  // Services
+  "Database",
+  "Cache",
+  "Queue",
+  "Service",
+  "API",
+  "Frontend",
+  "Backend",
+  "Mobile",
+  "Web",
+  "Browser",
+  // CRUD
+  "Create",
+  "Read",
+  "Update",
+  "Delete",
+  "Fetch",
+  "Save",
+  "Load",
+  "Send",
+  "Receive",
+  // Auth
+  "Login",
+  "Logout",
+  "Signup",
+  "Signin",
+  "Authenticate",
+  "Authorize",
+  "Token",
+  "Session",
+  // Outcomes
+  "Success",
+  "Failure",
+  "Error",
+  "Warning",
+  "Info",
+  "Loading",
+  "Pending",
+  "Active",
+  "Inactive",
+  "Archived",
+  "Draft",
+  "Published",
+  // Project / planning
+  "Project",
+  "Team",
+  "Sprint",
+  "Milestone",
+  "Goal",
+  "Plan",
+  "Task",
+  "Issue",
+  "Feature",
+  "Bug",
+  "Question",
+  "Answer",
+  "Idea",
+  "Note",
+  // Environments
+  "Production",
+  "Staging",
+  "Development",
+  "Testing",
+];
+
+const WORD_SPLIT_RE = /[\s,.\-:;!?()/\\[\]{}'"`]+/;
+
+/**
+ * Pull every distinct ≥3-char "word" off any text element currently on the
+ * canvas. We use this to bias suggestions toward terminology the user is
+ * already using on this particular board.
+ */
+export const buildCorpusFromScene = (app: App): string[] => {
+  const elements = app.scene.getNonDeletedElements();
+  const words = new Set<string>();
+  for (const el of elements) {
+    if (isTextElement(el) && el.text) {
+      for (const raw of el.text.split(WORD_SPLIT_RE)) {
+        // Strip leading/trailing residual punctuation, keep internal hyphens
+        const word = raw.trim();
+        if (word.length >= 3) {
+          words.add(word);
+        }
+      }
+    }
+  }
+  return Array.from(words);
+};
+
+export type SuggestionEngine = {
+  getSuggestion: (
+    value: string,
+    cursorOffset: number,
+    currentElementId: string,
+  ) => string | null;
+  refreshCorpus: () => void;
+};
+
+/**
+ * Builds a suggestion engine for a given app. The engine merges a built-in
+ * corpus of common diagramming words with words harvested from text elements
+ * already on the canvas. Call refreshCorpus() if the canvas changes.
+ */
+export const createSuggestionEngine = (app: App): SuggestionEngine => {
+  let corpus: string[] = [...COMMON_TERMS];
+
+  const refreshCorpus = () => {
+    const sceneWords = buildCorpusFromScene(app);
+    // de-dupe while preserving order (canvas words first so they win on ties)
+    const merged = new Set<string>(sceneWords);
+    for (const word of COMMON_TERMS) {
+      merged.add(word);
+    }
+    corpus = Array.from(merged);
+  };
+
+  refreshCorpus();
+
+  const getSuggestion = (
+    value: string,
+    cursorOffset: number,
+    currentElementId: string,
+  ): string | null => {
+    // Only suggest when the caret is at the very end of the text — anywhere
+    // else, inserting a completion at the cursor would look like teleportation.
+    if (cursorOffset !== value.length) {
+      return null;
+    }
+
+    // Find the start of the word the user is currently typing.
+    const lastBreak = Math.max(
+      value.lastIndexOf(" ", cursorOffset - 1),
+      value.lastIndexOf("\n", cursorOffset - 1),
+      value.lastIndexOf("\t", cursorOffset - 1),
+    );
+    const wordStart = lastBreak + 1;
+    const prefix = value.slice(wordStart, cursorOffset);
+
+    // Need at least 2 chars before we attempt to suggest, to avoid being
+    // noisy on the first keystroke.
+    if (prefix.length < 2) {
+      return null;
+    }
+
+    // Skip if the prefix already ends in non-letter chars (e.g. punctuation).
+    if (!/[A-Za-z]$/.test(prefix)) {
+      return null;
+    }
+
+    const prefixLower = prefix.toLowerCase();
+
+    for (const word of corpus) {
+      const wordLower = word.toLowerCase();
+      if (
+        wordLower.startsWith(prefixLower) &&
+        wordLower !== prefixLower &&
+        // Don't suggest the exact string the user has currently typed
+        word !== value
+      ) {
+        // Return just the completion suffix — keep the case the user already
+        // typed and append the remainder using the corpus word's case.
+        return word.slice(prefix.length);
+      }
+    }
+    return null;
+  };
+
+  return { getSuggestion, refreshCorpus };
+};

--- a/packages/excalidraw/wysiwyg/textWysiwyg.tsx
+++ b/packages/excalidraw/wysiwyg/textWysiwyg.tsx
@@ -70,6 +70,8 @@ import {
   actionZoomOut,
 } from "../actions/actionCanvas";
 
+import { createSuggestionEngine } from "./textAutocomplete";
+
 import type { ParsedDataTranferList } from "../clipboard";
 
 import type App from "../components/App";
@@ -420,8 +422,14 @@ export const textWysiwyg = ({
       }
 
       app.scene.mutateElement(updatedTextElement, { x: coordX, y: coordY });
+
+      // Keep the ghost overlay aligned with the textarea on zoom/scroll/etc.
+      // `syncGhostStyle` is defined after this function but invoked via the
+      // lazy ref so the lookup is safe.
+      syncGhostStyleRef?.();
     }
   };
+  let syncGhostStyleRef: (() => void) | null = null;
 
   const editable = document.createElement("textarea");
 
@@ -461,6 +469,131 @@ export const textWysiwyg = ({
   });
   editable.value = element.originalText;
   updateWysiwygStyle();
+
+  // ──────────────────────────────────────────────────────────────────────
+  // Inline ghost-text autocomplete
+  //
+  // The overlay is a non-interactive <div> sitting in the same place as the
+  // textarea, with the same font/size/wrap/transform. It renders the text
+  // the user has already typed as a transparent span (taking up the same
+  // layout space), followed by a faded span containing the suggested
+  // completion — so the ghost text lines up perfectly with the cursor
+  // regardless of wrapping, RTL, or alignment.
+  // ──────────────────────────────────────────────────────────────────────
+  const suggestionEngine = createSuggestionEngine(app);
+  let currentSuggestion: string | null = null;
+  // When the user dismisses a suggestion (via Esc), we remember the textarea
+  // value at that moment so we don't immediately re-show the same suggestion
+  // from the keyup handler. The dismissal clears as soon as the value
+  // changes (a new keystroke → potentially a new suggestion).
+  let dismissedForValue: string | null = null;
+
+  const ghostOverlay = document.createElement("div");
+  ghostOverlay.classList.add("excalidraw-wysiwyg-ghost");
+  ghostOverlay.setAttribute("aria-hidden", "true");
+  Object.assign(ghostOverlay.style, {
+    position: "absolute",
+    pointerEvents: "none",
+    margin: 0,
+    padding: 0,
+    border: 0,
+    boxSizing: "content-box",
+    display: "none",
+    zIndex: "var(--zIndex-wysiwyg)",
+  });
+
+  // Transparent span holds the already-typed text (takes layout space but
+  // is visually invisible) so the ghost span lands at the right position.
+  const ghostTypedSpan = document.createElement("span");
+  ghostTypedSpan.style.color = "transparent";
+  ghostTypedSpan.style.whiteSpace = "inherit";
+  const ghostSuggestionSpan = document.createElement("span");
+  ghostSuggestionSpan.style.opacity = "0.4";
+  ghostSuggestionSpan.style.whiteSpace = "inherit";
+  ghostOverlay.appendChild(ghostTypedSpan);
+  ghostOverlay.appendChild(ghostSuggestionSpan);
+
+  const syncGhostStyle = () => {
+    // Copy every style that influences text layout from the textarea so
+    // the ghost div lays out identically.
+    Object.assign(ghostOverlay.style, {
+      font: editable.style.font,
+      lineHeight: editable.style.lineHeight,
+      width: editable.style.width,
+      height: editable.style.height,
+      left: editable.style.left,
+      top: editable.style.top,
+      transform: editable.style.transform,
+      transformOrigin: editable.style.transformOrigin || "",
+      textAlign: editable.style.textAlign,
+      verticalAlign: editable.style.verticalAlign,
+      color: editable.style.color,
+      opacity: editable.style.opacity,
+      whiteSpace: editable.style.whiteSpace || "pre",
+      wordBreak: editable.style.wordBreak || "normal",
+      overflowWrap: editable.style.overflowWrap || "",
+      maxHeight: editable.style.maxHeight,
+      // For unbounded text the textarea is only as wide as the typed text,
+      // and `overflow: hidden` would clip our trailing ghost. We let the
+      // ghost extend visibly past the textarea's width.
+      overflow: "visible",
+    });
+    // For bounded text (wrapping), keep width strict so the ghost wraps
+    // identically. For unbounded text (single-line, no wrap) let the ghost
+    // extend past the box.
+    if (whiteSpace === "pre") {
+      ghostOverlay.style.width = "max-content";
+    }
+  };
+  syncGhostStyleRef = syncGhostStyle;
+
+  const updateGhostSuggestion = () => {
+    // Respect an explicit Esc dismissal until the user types something new.
+    if (dismissedForValue !== null && dismissedForValue === editable.value) {
+      return;
+    }
+    dismissedForValue = null;
+
+    const suggestion = suggestionEngine.getSuggestion(
+      editable.value,
+      editable.selectionStart,
+      element.id,
+    );
+    currentSuggestion = suggestion;
+    if (!suggestion) {
+      ghostOverlay.style.display = "none";
+      return;
+    }
+    syncGhostStyle();
+    ghostTypedSpan.textContent = editable.value;
+    ghostSuggestionSpan.textContent = suggestion;
+    ghostOverlay.style.display = "block";
+  };
+
+  const dismissGhostSuggestion = () => {
+    currentSuggestion = null;
+    ghostOverlay.style.display = "none";
+    dismissedForValue = editable.value;
+  };
+
+  const acceptGhostSuggestion = (): boolean => {
+    if (!currentSuggestion) {
+      return false;
+    }
+    const completion = currentSuggestion;
+    const insertAt = editable.selectionStart;
+    editable.value =
+      editable.value.slice(0, insertAt) +
+      completion +
+      editable.value.slice(insertAt);
+    const nextCaret = insertAt + completion.length;
+    editable.selectionStart = nextCaret;
+    editable.selectionEnd = nextCaret;
+    dismissGhostSuggestion();
+    // Fire input so the wysiwyg refreshes layout/onChange downstream.
+    editable.dispatchEvent(new Event("input"));
+    return true;
+  };
 
   const getCaretIndexFromInitialSceneCoords = () => {
     if (!initialCaretSceneCoords || !currentTextLayout) {
@@ -623,10 +756,38 @@ export const textWysiwyg = ({
         editable.selectionEnd = selectionStart;
       }
       onChange(editable.value);
+      updateGhostSuggestion();
     };
+
+    // Caret moves via arrow keys, mouse clicks, etc. don't fire `input`, so
+    // we listen on selection changes too — otherwise the ghost stays put
+    // when the user moves their cursor away from the end of the text.
+    editable.addEventListener("keyup", updateGhostSuggestion);
+    editable.addEventListener("mouseup", updateGhostSuggestion);
   }
 
   editable.onkeydown = (event) => {
+    // Accept an active ghost suggestion via Tab. We intercept this *before*
+    // the existing Tab→indent branch below so the indent only fires when
+    // there's no suggestion to accept.
+    if (
+      event.key === KEYS.TAB &&
+      !event.shiftKey &&
+      !event[KEYS.CTRL_OR_CMD] &&
+      !event.isComposing &&
+      currentSuggestion
+    ) {
+      event.preventDefault();
+      acceptGhostSuggestion();
+      return;
+    }
+    // Esc dismisses the suggestion if one is showing; only when no
+    // suggestion is visible does it fall through to the existing submit.
+    if (event.key === KEYS.ESCAPE && currentSuggestion) {
+      event.preventDefault();
+      dismissGhostSuggestion();
+      return;
+    }
     if (!event.shiftKey && actionZoomIn.keyTest(event)) {
       event.preventDefault();
       app.actionManager.executeAction(actionZoomIn);
@@ -859,6 +1020,7 @@ export const textWysiwyg = ({
     unbindOnScroll();
 
     editable.remove();
+    ghostOverlay.remove();
   };
 
   const bindBlurEvent = (event?: MouseEvent) => {
@@ -1014,9 +1176,13 @@ export const textWysiwyg = ({
     window.addEventListener("pointerdown", onPointerDown, { capture: true });
   });
   window.addEventListener("beforeunload", handleSubmit);
-  excalidrawContainer
-    ?.querySelector(".excalidraw-textEditorContainer")!
-    .appendChild(editable);
+  const editorContainer = excalidrawContainer?.querySelector(
+    ".excalidraw-textEditorContainer",
+  );
+  editorContainer?.appendChild(editable);
+  // Append the ghost overlay AFTER the textarea so the textarea retains
+  // pointer interaction; the overlay has `pointer-events: none` regardless.
+  editorContainer?.appendChild(ghostOverlay);
 
   return handleSubmit;
 };


### PR DESCRIPTION
## What

Adds **inline ghost-text autocomplete** while typing in any text element on the canvas — Gmail-style suggestions that complete the word you're typing. Press **Tab** to accept, **Esc** to dismiss, or just keep typing to ignore.

## Demo

> Drag-drop GIF here: `/tmp/excalidraw-autocomplete.gif`

The interaction in one line: **type `Dec` → see `ision` appear in faded grey after the cursor → hit Tab → `Decision`**.

## Why this design

Before building, I prototyped 5 different autocomplete UIs to compare them against excalidraw's existing patterns:

| Variant | Form factor | Verdict |
|---|---|---|
| 1. **Inline ghost text** | Faded suffix after cursor | ✅ chosen |
| 2. Dropdown list below | IDE-style multi-suggestion popover | Adds chrome that fights the editor's minimalism |
| 3. Floating pill above | Linear/Notion-AI style tooltip | Bright, but pops in distractingly |
| 4. Sketchy popover | Hand-drawn style menu matching canvas | Novel pattern, harder to discover |
| 5. Side rail chips | Right-side property-panel chips | Eyes leave the cursor; mouse-only |

The wysiwyg text editor in excalidraw is intentionally chromeless — it's literally a transparent `<textarea>` overlaid on the canvas (`textWysiwyg.tsx`). Every other variant adds UI chrome that fights that. Ghost text is the canonical "invisible until needed" autocomplete pattern (Gmail Smart Compose, GitHub Copilot, iOS, VS Code), and excalidraw's text elements are usually short labels (`Start`, `User`, `Decision`) where one good completion is plenty.

## How it works

- **`packages/excalidraw/wysiwyg/textAutocomplete.ts`** — a small suggestion engine. Merges a built-in corpus of ~80 common diagramming terms (Start / End / Decision / User / API / Service / Login / …) with every ≥3-character word currently on the canvas, so suggestions get smarter as a board fills up.
- **`packages/excalidraw/wysiwyg/textWysiwyg.tsx`** — the ghost overlay is a non-interactive `<div>` mirroring the textarea's position / transform / font / wrap / alignment. Inside it: a `color: transparent` span containing the typed text (occupying real layout space) followed by an `opacity: 0.4` span with the completion. The transparent span pushes the visible ghost to exactly the right caret position — wraps naturally in bounded text, follows the canvas zoom/rotation transform, works with RTL via the textarea's `dir="auto"`.
- **Tab** accepts the suggestion; the existing Tab→indent behavior still fires when there's no suggestion to accept.
- **Esc** dismisses the suggestion and only submits the text element on a second press (or if no suggestion is showing). A "dismissed for this exact value" guard prevents the keyup handler from immediately re-showing the suggestion.

## Behaviors covered

- ✅ Suggestion appears after typing ≥2 letters of a recognised word
- ✅ Updates as you keep typing
- ✅ Hidden if caret moves away from end of text (via arrow keys / clicks)
- ✅ Hidden if prefix ends in punctuation
- ✅ Works inside container-bound text (wraps with the textarea)
- ✅ Works under canvas zoom and rotation (inherits textarea's transform)
- ✅ Cleaned up on text-element submit / blur / unmount

## Tests

- 10 new unit tests for `createSuggestionEngine` covering prefix matching, end-of-text guarding, the 2-char minimum, word-boundary splitting, canvas-corpus harvesting, and the refresh API.
- All 1,384 existing tests still pass.
- TypeScript clean.

## Known v1 limitations (follow-ups, not blockers)

- No discoverability hint for the Tab shortcut (followed Gmail / Copilot conventions). Could add a one-line entry in the shortcuts dialog if desired.
- Suggestion is "first corpus match" rather than ranked — could weight by recency or frequency later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
