### PR TITLE
fix: don't setPointerCapture for right-clicks, fixing context menu on macOS touchpad tap

### DIFF
--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -7706,7 +7706,18 @@ class App extends React.Component<AppProps, AppState> {
     const target = event.target as HTMLElement;
     // capture subsequent pointer events to the canvas
     // this makes other elements non-interactive until pointer up
-    if (target.setPointerCapture) {
+    //
+    // Don't capture for right-clicks (SECONDARY button).
+    // Root cause of https://github.com/excalidraw/excalidraw/issues/11401:
+    // For SECONDARY button we always return early below (not a drag-initiating
+    // event), so the capture serves no purpose. On macOS with "Tap to Click"
+    // enabled, a two-finger touchpad tap that opens the context menu fires
+    // `pointerdown` (button=SECONDARY) + `contextmenu` but NOT `pointerup`
+    // (the OS intercepts it for the native menu). This left the canvas holding
+    // pointer-capture indefinitely, routing all subsequent pointer events
+    // (hover / click) away from the Excalidraw context menu items so they
+    // appeared unresponsive.
+    if (target.setPointerCapture && event.button !== POINTER_BUTTON.SECONDARY) {
       target.setPointerCapture(event.pointerId);
     }
 


### PR DESCRIPTION
## Summary

Fixes #11401 — _Can't use Excalidraw context menu after native context menu using touchpad tap_.

### Root cause

`handleCanvasPointerDown` called `target.setPointerCapture(event.pointerId)` **unconditionally** — before the early-return guard that discards non-left-click events:

```ts
// button check (returns early for right-click / SECONDARY)
if (
  event.button !== POINTER_BUTTON.MAIN &&
  event.button !== POINTER_BUTTON.TOUCH &&
  event.button !== POINTER_BUTTON.ERASER
) {
  return;
}
```

On macOS with _Tap to Click_ enabled, a two-finger touchpad **tap** that opens the context menu generates:

1. `pointerdown` (button = `SECONDARY`) → `setPointerCapture` called ✅
2. `contextmenu` → Excalidraw context menu opens ✅
3. `pointerup` → **never fires** (the OS intercepts the tap for the native/context-menu gesture)

Because `pointerup` never fires, the browser never automatically releases pointer capture. The canvas element held capture indefinitely, so all subsequent pointer events (hover/click on the Excalidraw context menu items) were routed to the captured canvas instead of the menu — making the menu appear frozen and unresponsive.

A firm two-finger **click** (as opposed to a tap) reliably fires `pointerup`, which releases capture and explains why the firm-click path worked fine.

### Fix

Skip `setPointerCapture` when `event.button === POINTER_BUTTON.SECONDARY`.

Right-click events return early anyway (they never initiate a drag interaction), so pointer capture was never useful for them. Skipping it eliminates the lingering capture entirely.

```ts
// Before
if (target.setPointerCapture) {
  target.setPointerCapture(event.pointerId);
}

// After
if (target.setPointerCapture && event.button !== POINTER_BUTTON.SECONDARY) {
  target.setPointerCapture(event.pointerId);
}
```

### Testing

- Manually verified: two-finger touchpad tap (Tap to Click, macOS) → native context menu → close → two-finger tap again → Excalidraw context menu items now highlight on hover and respond to clicks.
- No regression to left-click drag, pan, or other pointer interactions (pointer capture is unchanged for all non-secondary button events).