### PR TITLE
fix: allow Ctrl+F to open search when help dialog is open

### DIFF
--- a/packages/excalidraw/actions/actionToggleSearchMenu.ts
+++ b/packages/excalidraw/actions/actionToggleSearchMenu.ts
@@ -26,7 +26,14 @@ export const actionToggleSearchMenu = register({
   },
   perform(elements, appState, _, app) {
     if (appState.openDialog) {
-      return false;
+      return {
+        appState: {
+          ...appState,
+          openSidebar: { name: DEFAULT_SIDEBAR.name, tab: CANVAS_SEARCH_TAB },
+          openDialog: null,
+        },
+        captureUpdate: CaptureUpdateAction.EVENTUALLY,
+      };
     }
 
     if (


### PR DESCRIPTION
## Summary

When the help dialog is open, pressing Ctrl+F currently does nothing helpful — the `actionToggleSearchMenu` returns `false` when any dialog is open, causing the event to bubble up to the browser and trigger the browser native "find in page" dialog.

## Changes

Modified `actionToggleSearchMenu.ts` so that when a dialog is open and Ctrl+F is pressed, the dialog is closed and the search sidebar is opened instead — matching user expectations.

## Related Issue

Closes https://github.com/excalidraw/excalidraw/issues/9276