### PR TITLE
fix: resolve z-index shortcut conflicts on macOS

### DIFF
--- a/packages/excalidraw/actions/actionZindex.tsx
+++ b/packages/excalidraw/actions/actionZindex.tsx
@@ -35,15 +35,23 @@ export const actionSendBackward = register({
   },
   keyPriority: 40,
   keyTest: (event) =>
-    event[KEYS.CTRL_OR_CMD] &&
-    !event.shiftKey &&
-    event.code === CODES.BRACKET_LEFT,
+    isDarwin
+      ? event[KEYS.CTRL_OR_CMD] &&
+        event.shiftKey &&
+        event.code === CODES.BRACKET_LEFT
+      : event[KEYS.CTRL_OR_CMD] &&
+        !event.shiftKey &&
+        event.code === CODES.BRACKET_LEFT,
   PanelComponent: ({ updateData, appState }) => (
     <button
       type="button"
       className="zIndexButton"
       onClick={() => updateData(null)}
-      title={`${t("labels.sendBackward")} — ${getShortcutKey("CtrlOrCmd+[")}`}
+      title={`${t("labels.sendBackward")} — ${
+        isDarwin
+          ? getShortcutKey("CtrlOrCmd+Shift+[")
+          : getShortcutKey("CtrlOrCmd+[")
+      }`}
     >
       {SendBackwardIcon}
     </button>
@@ -65,15 +73,23 @@ export const actionBringForward = register({
   },
   keyPriority: 40,
   keyTest: (event) =>
-    event[KEYS.CTRL_OR_CMD] &&
-    !event.shiftKey &&
-    event.code === CODES.BRACKET_RIGHT,
+    isDarwin
+      ? event[KEYS.CTRL_OR_CMD] &&
+        event.shiftKey &&
+        event.code === CODES.BRACKET_RIGHT
+      : event[KEYS.CTRL_OR_CMD] &&
+        !event.shiftKey &&
+        event.code === CODES.BRACKET_RIGHT,
   PanelComponent: ({ updateData, appState }) => (
     <button
       type="button"
       className="zIndexButton"
       onClick={() => updateData(null)}
-      title={`${t("labels.bringForward")} — ${getShortcutKey("CtrlOrCmd+]")}`}
+      title={`${t("labels.bringForward")} — ${
+        isDarwin
+          ? getShortcutKey("CtrlOrCmd+Shift+]")
+          : getShortcutKey("CtrlOrCmd+]")
+      }`}
     >
       {BringForwardIcon}
     </button>

--- a/packages/excalidraw/actions/shortcuts.ts
+++ b/packages/excalidraw/actions/shortcuts.ts
@@ -79,8 +79,16 @@ const shortcutMap: Record<ShortcutName, string[]> = {
     getShortcutKey("CtrlOrCmd+D"),
     getShortcutKey(`Alt+${t("helpDialog.drag")}`),
   ],
-  sendBackward: [getShortcutKey("CtrlOrCmd+[")],
-  bringForward: [getShortcutKey("CtrlOrCmd+]")],
+  sendBackward: [
+    isDarwin
+      ? getShortcutKey("CtrlOrCmd+Shift+[")
+      : getShortcutKey("CtrlOrCmd+["),
+  ],
+  bringForward: [
+    isDarwin
+      ? getShortcutKey("CtrlOrCmd+Shift+]")
+      : getShortcutKey("CtrlOrCmd+]"),
+  ],
   sendToBack: [
     isDarwin
       ? getShortcutKey("CtrlOrCmd+Alt+[")

--- a/packages/excalidraw/components/HelpDialog.tsx
+++ b/packages/excalidraw/components/HelpDialog.tsx
@@ -422,11 +422,19 @@ export const HelpDialog = ({ onClose }: { onClose?: () => void }) => {
             />
             <Shortcut
               label={t("labels.sendBackward")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+[")]}
+              shortcuts={[
+                isDarwin
+                  ? getShortcutKey("CtrlOrCmd+Shift+[")
+                  : getShortcutKey("CtrlOrCmd+["),
+              ]}
             />
             <Shortcut
               label={t("labels.bringForward")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+]")]}
+              shortcuts={[
+                isDarwin
+                  ? getShortcutKey("CtrlOrCmd+Shift+]")
+                  : getShortcutKey("CtrlOrCmd+]"),
+              ]}
             />
             <Shortcut
               label={t("labels.alignTop")}


### PR DESCRIPTION
## Summary

The `Ctrl/Cmd + [` and `Ctrl/Cmd + ]` shortcuts for **sendBackward** and **bringForward** did not work on macOS because they conflicted with macOS system shortcuts (`Cmd+[` = back, `Cmd+]` = forward). Additionally, multiple actions could match these keys in the action manager, causing silent cancellation.

## Root Cause Analysis

1. **macOS system interception**: `Cmd+[` and `Cmd+]` are macOS system-level shortcuts for navigating back/forward in many apps (Finder, browser), preventing the keyboard event from reaching Excalidraw.

2. **Action manager multi-match**: In the action manager (`manager.tsx`), when `keyTest()` returns true for multiple actions on the same event, the action manager logs "Canceling as multiple actions match this shortcut" and silently cancels all matching actions — no visual feedback for the user.

## Changes

### `actionZindex.tsx`
- **actionSendBackward**: Changed keyTest on macOS from `Cmd+[` to `Cmd+Shift+[` (Windows keeps `Ctrl+[`)
- **actionBringForward**: Changed keyTest on macOS from `Cmd+]` to `Cmd+Shift+]` (Windows keeps `Ctrl+]`)
- Updated PanelComponent tooltips to reflect the platform-specific shortcuts

### `shortcuts.ts`
- Updated `sendBackward` and `bringForward` shortcut display names for macOS (`CtrlOrCmd+Shift+[` / `CtrlOrCmd+Shift+]`)

### `HelpDialog.tsx`
- Updated the help dialog to show the correct platform-specific shortcuts for sendBackward and bringForward

## Final macOS mapping (no conflicts):
| Action | macOS | Windows/Linux |
|--------|-------|--------------|
| sendBackward | `⌘⇧[` | `Ctrl+[` |
| bringForward | `⌘⇧]` | `Ctrl+]` |
| sendToBack | `⌘⌥[` | `Ctrl+⇧[` |
| bringToFront | `⌘⌥]` | `Ctrl+⇧]` |

## Related Issue

Closes https://github.com/excalidraw/excalidraw/issues/9535