### PR TITLE
fix: show error message for invalid hex color codes

### DIFF
--- a/packages/excalidraw/components/ColorPicker/ColorInput.tsx
+++ b/packages/excalidraw/components/ColorPicker/ColorInput.tsx
@@ -29,6 +29,7 @@ export const ColorInput = ({
 }) => {
   const editorInterface = useEditorInterface();
   const [innerValue, setInnerValue] = useState(color);
+  const [error, setError] = useState<string | null>(null);
   const [activeSection, setActiveColorPickerSection] = useAtom(
     activeColorPickerSectionAtom,
   );
@@ -44,6 +45,11 @@ export const ColorInput = ({
 
       if (color) {
         onChange(color);
+        setError(null);
+      } else if (value.trim() !== "") {
+        setError(t("errors.invalidHexColor"));
+      } else {
+        setError(null);
       }
       setInnerValue(value);
     },
@@ -74,7 +80,9 @@ export const ColorInput = ({
         ref={activeSection === "hex" ? inputRef : undefined}
         style={{ border: 0, padding: 0 }}
         spellCheck={false}
-        className="color-picker-input"
+        className={clsx("color-picker-input", {
+          "color-picker-input--invalid": error,
+        })}
         aria-label={label}
         onChange={(event) => {
           changeColor(event.target.value);
@@ -82,6 +90,7 @@ export const ColorInput = ({
         value={(innerValue || "").replace(/^#/, "")}
         onBlur={() => {
           setInnerValue(color);
+          setError(null);
         }}
         tabIndex={-1}
         onFocus={() => setActiveColorPickerSection("hex")}
@@ -95,6 +104,9 @@ export const ColorInput = ({
         }}
         placeholder={placeholder}
       />
+      {error && (
+        <div className="color-picker__input-error">{error}</div>
+      )}
       {/* TODO reenable on mobile with a better UX */}
       {editorInterface.formFactor !== "phone" && (
         <>

--- a/packages/excalidraw/components/ColorPicker/ColorPicker.scss
+++ b/packages/excalidraw/components/ColorPicker/ColorPicker.scss
@@ -421,6 +421,23 @@
     &:focus-visible {
       box-shadow: none;
     }
+
+    &--invalid {
+      border-color: #e03131;
+      background-color: rgba(224, 49, 49, 0.05);
+
+      &:focus-visible {
+        box-shadow: 0 0 0 2px rgba(224, 49, 49, 0.2);
+      }
+    }
+  }
+
+  .color-picker__input-error {
+    grid-column: 1 / -1;
+    font-size: 0.75rem;
+    color: #e03131;
+    margin-top: -0.25rem;
+    padding-left: 0.25rem;
   }
 
   .color-picker-label-swatch-container {

--- a/packages/excalidraw/locales/en.json
+++ b/packages/excalidraw/locales/en.json
@@ -286,6 +286,7 @@
     "imageInsertError": "Couldn't insert image. Try again later...",
     "fileTooBig": "File is too big. Maximum allowed size is {{maxSize}}.",
     "svgImageInsertError": "Couldn't insert SVG image. The SVG markup looks invalid.",
+    "invalidHexColor": "Invalid hex color code.",
     "failedToFetchImage": "Failed to fetch image.",
     "cannotResolveCollabServer": "Couldn't connect to the collab server. Please reload the page and try again.",
     "importLibraryError": "Couldn't load library",


### PR DESCRIPTION
When users enter invalid hexadecimal color codes in the color picker
input, the input was silently ignored with no visual feedback.

Changes:
- Add isInvalid state to ColorInput component
- Show red border and error text when invalid hex is entered
- Add invalidHexColor i18n key to en.json
- Add CSS classes for error state: red border, red focus ring, error text
- Clear error on blur (reset to last valid color)
- Don't show error for empty input

Fixes #9527
