### PR TITLE
fix(shadow-dom): load css into shadow-root

### DIFF
--- a/packages/excalidraw/css/styles.scss
+++ b/packages/excalidraw/css/styles.scss
@@ -1,7 +1,8 @@
 @use "./variables.module" as *;
 @use "./theme";
 
-:root {
+:root,
+:host {
   --zIndex-canvas: 1;
   --zIndex-interactiveCanvas: 2;
   --zIndex-svgLayer: 3;

--- a/packages/excalidraw/hooks/useCreatePortalContainer.ts
+++ b/packages/excalidraw/hooks/useCreatePortalContainer.ts
@@ -29,9 +29,18 @@ export const useCreatePortalContainer = (opts?: {
   }, [div, theme, editorInterface.formFactor, opts?.className]);
 
   useLayoutEffect(() => {
-    const container = opts?.parentSelector
-      ? excalidrawContainer?.querySelector(opts.parentSelector)
-      : document.body;
+    let container: Element | ShadowRoot | null | undefined;
+
+    if (opts?.parentSelector) {
+      container = excalidrawContainer?.querySelector(opts.parentSelector);
+    } else {
+      // If Excalidraw is rendered inside a shadow root (e.g. a web component or
+      // anywidget/marimo), portal into that shadow root so modals stay within
+      // the same styling scope. In a regular document, fall back to document.body.
+      const rootNode = excalidrawContainer?.getRootNode();
+      container =
+        rootNode instanceof ShadowRoot ? rootNode : document.body;
+    }
 
     if (!container) {
       return;
@@ -44,7 +53,7 @@ export const useCreatePortalContainer = (opts?: {
     setDiv(div);
 
     return () => {
-      container.removeChild(div);
+      container!.removeChild(div);
     };
   }, [excalidrawContainer, opts?.parentSelector]);
 


### PR DESCRIPTION
# Changes

This PR change the useCreatePortalContainer hook. Before it always fall back to the head element of the page but for a shadow root we want to fall back to the root node instead. It's a step for shadow root support.


I hope you will be happy with my changes. Of course, there might be other shadow roots problems in other places, but I tried it and for now my integration does not seem to break.

Closes: #7322 