### PR TITLE
fix(canvas-offset): re-measure canvas offsets on every pointerdown

### DIFF
--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -7686,6 +7686,11 @@ class App extends React.Component<AppProps, AppState> {
   private handleCanvasPointerDown = (
     event: React.PointerEvent<HTMLElement>,
   ) => {
+    // Re-measure position on every interaction so that coordinate transforms
+    // stay correct if the container moved since mount (e.g. elements inserted
+    // above in a notebook/dashboard without triggering a resize event).
+    this.refresh();
+
     const selectedElements = this.scene.getSelectedElements(this.state);
 
     // If Ctrl is not held, ensure isBindingEnabled reflects the user preference.

--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -7689,7 +7689,7 @@ class App extends React.Component<AppProps, AppState> {
     // Re-measure position on every interaction so that coordinate transforms
     // stay correct if the container moved since mount (e.g. elements inserted
     // above in a notebook/dashboard without triggering a resize event).
-    this.refresh();
+    flushSync(() => this.refresh());
 
     const selectedElements = this.scene.getSelectedElements(this.state);
 


### PR DESCRIPTION
# Motivation
When Excalidraw is embedded in a dynamic layout, its container can shift vertically after mount without triggering a ResizeObserver or scroll event. The cached offsetTop/offsetLeft then disagrees with the real position and all pointer→scene coordinate transforms are wrong by the delta.

I have a MRE for this:

```html
<!doctype html>
<html>
<head>
  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@excalidraw/excalidraw@0.18.1/dist/prod/index.min.css">
  <style>
    #app { height: 500px; }
  </style>
</head>
<body>
  <button id="btn">Insert banner above (reproduces offset bug)</button>
  <div id="banner" style="display:none;height:100px;background:#d4edda">
    Banner inserted after mount — canvas moved down, size unchanged
  </div>
  <div id="app"></div>

  <script type="module">
    const React = await import("https://esm.sh/react@18.2.0");
    const { createRoot } = await import("https://esm.sh/react-dom@18.2.0/client?deps=react@18.2.0");
    const { Excalidraw } = await import("https://esm.sh/@excalidraw/excalidraact-dom@18.2.0");

    createRoot(document.getElementById("app")).render(React.createElement(Exc

    document.getElementById("btn").onclick = () => {
      document.getElementById("banner").style.display = "block";
      document.getElementById("btn").disabled = true;
    };
  </script>
</body>
</html>
```

# Changes

Calling refresh() at the top of handleCanvasPointerDown fixes this with a single getBoundingClientRect() per interaction 

I'm not an expert on the subject, but I think it's near zero-cost.

# Related issues

Closes: #3410

(also #4917 ? and maybe #6026 ?)