### PR TITLE
fix: show error feedback for invalid hex color input

### DIFF
--- a/packages/excalidraw/components/ColorPicker/ColorInput.tsx
+++ b/packages/excalidraw/components/ColorPicker/ColorInput.tsx
@@ -29,12 +29,14 @@ export const ColorInput = ({
 }) => {
   const editorInterface = useEditorInterface();
   const [innerValue, setInnerValue] = useState(color);
+  const [isInvalidColor, setIsInvalidColor] = useState(false);
   const [activeSection, setActiveColorPickerSection] = useAtom(
     activeColorPickerSectionAtom,
   );
 
   useEffect(() => {
     setInnerValue(color);
+    setIsInvalidColor(false);
   }, [color]);
 
   const changeColor = useCallback(
@@ -44,6 +46,9 @@ export const ColorInput = ({
 
       if (color) {
         onChange(color);
+        setIsInvalidColor(false);
+      } else {
+        setIsInvalidColor(value.length > 0);
       }
       setInnerValue(value);
     },
@@ -68,7 +73,11 @@ export const ColorInput = ({
   }, [setEyeDropperState]);
 
   return (
-    <div className="color-picker__input-label">
+    <div
+      className={clsx("color-picker__input-label", {
+        "color-picker__input-label--error": isInvalidColor,
+      })}
+    >
       <div className="color-picker__input-hash">#</div>
       <input
         ref={activeSection === "hex" ? inputRef : undefined}
@@ -76,12 +85,15 @@ export const ColorInput = ({
         spellCheck={false}
         className="color-picker-input"
         aria-label={label}
+        aria-invalid={isInvalidColor}
+        title={isInvalidColor ? t("errors.invalidHexColor") : undefined}
         onChange={(event) => {
           changeColor(event.target.value);
         }}
         value={(innerValue || "").replace(/^#/, "")}
         onBlur={() => {
           setInnerValue(color);
+          setIsInvalidColor(false);
         }}
         tabIndex={-1}
         onFocus={() => setActiveColorPickerSection("hex")}

--- a/packages/excalidraw/components/ColorPicker/ColorPicker.scss
+++ b/packages/excalidraw/components/ColorPicker/ColorPicker.scss
@@ -383,6 +383,14 @@
       box-shadow: 0 0 0 1px var(--color-primary-darkest);
       border-radius: var(--border-radius-lg);
     }
+
+    &--error {
+      border-color: var(--color-danger);
+
+      &:focus-within {
+        box-shadow: 0 0 0 1px var(--color-danger);
+      }
+    }
   }
 
   .color-picker__input-hash {

--- a/packages/excalidraw/locales/en.json
+++ b/packages/excalidraw/locales/en.json
@@ -282,6 +282,7 @@
     "localStorageQuotaExceeded": "Browser storage quota exceeded. Changes will not be saved."
   },
   "errors": {
+    "invalidHexColor": "Invalid hex color",
     "unsupportedFileType": "Unsupported file type.",
     "imageInsertError": "Couldn't insert image. Try again later...",
     "fileTooBig": "File is too big. Maximum allowed size is {{maxSize}}.",


### PR DESCRIPTION
Fixes #9527

When a user types an invalid hex value in the color picker (e.g. 'zzzzzz', '123456789', or 'blue'), the input previously rejected it silently with no visual feedback.

This commit adds:
- A red border on the input container via a BEM modifier class
- aria-invalid attribute for screen readers
- A tooltip on the input showing 'Invalid hex color' when the value is invalid
- Error clears on blur or when a valid value is typed

Files changed: ColorInput.tsx, ColorPicker.scss, locales/en.json