### PR TITLE
Fixes: #10952: replaced the br tags which were visible in the diagram with new line

### DIFF
--- a/packages/element/src/textMeasurements.ts
+++ b/packages/element/src/textMeasurements.ts
@@ -66,6 +66,8 @@ export const normalizeText = (text: string) => {
     normalizeEOL(text)
       // replace tabs with spaces so they render and measure correctly
       .replace(/\t/g, "        ")
+      //replaced <br> to sanitize it making the tag not visible in the final diagram
+      .replace(/<br\s*\/?>/gi, "\n")
   );
 };
 


### PR DESCRIPTION
Fixes: #10952
Summary:
Replace literal <br> tags with newline characters during text normalization so Mermaid-generated text renders correctly in Excalidraw diagrams.
Changes:
Added <br> to newline conversion in normalizeText()
Preserved existing tab normalization behavior