### PR TITLE
feat: add emoji fallback font for consistent rendering

### DIFF
--- a/packages/element/src/textWrapping.ts
+++ b/packages/element/src/textWrapping.ts
@@ -34,6 +34,12 @@ export const containsCJK = (text: string) => {
 
   return cachedCjkRegex.test(text);
 };
+/**
+ * Test if a given text contains any emoji characters.
+ */
+export const containsEmoji = (text: string) => {
+  return getEmojiRegex().test(text);
+};
 
 const getLineBreakRegex = () => {
   if (!cachedLineBreakRegex) {

--- a/packages/excalidraw/fonts/Fonts.ts
+++ b/packages/excalidraw/fonts/Fonts.ts
@@ -8,7 +8,7 @@ import {
 } from "@excalidraw/common";
 import { getContainerElement } from "@excalidraw/element";
 import { charWidth } from "@excalidraw/element";
-import { containsCJK } from "@excalidraw/element";
+import { containsCJK, containsEmoji } from "@excalidraw/element";
 
 import {
   FONT_METADATA,
@@ -195,6 +195,24 @@ export class Fonts {
         // the order between the families and fallbacks is important, as fallbacks need to be defined first and in the reversed order
         // so that they get overriden with the later defined font faces, i.e. in case they share some codepoints
         families.unshift(FONT_FAMILY_FALLBACKS[CJK_HAND_DRAWN_FALLBACK_FONT]);
+      }
+    }
+    // Check for Emoji fallback
+    const familyWithEmoji = families.find((x) =>
+      getFontFamilyFallbacks(x).includes(WINDOWS_EMOJI_FALLBACK_FONT),
+    );
+
+    if (familyWithEmoji) {
+      const characters = Fonts.getCharacters(charsPerFamily, familyWithEmoji);
+
+      if (containsEmoji(characters)) {
+        const family = FONT_FAMILY_FALLBACKS[WINDOWS_EMOJI_FALLBACK_FONT];
+
+        // Adding the characters to the Emoji fallback family
+        charsPerFamily[family] = new Set(characters);
+
+        // Put the Emoji font at the front of the list
+        families.unshift(FONT_FAMILY_FALLBACKS[WINDOWS_EMOJI_FALLBACK_FONT]);
       }
     }
 


### PR DESCRIPTION
This PR adds the emoji fallback font to the font-face generation logic to ensure consistent emoji rendering across different platforms and during export.

Tested locally by exporting an SVG containing emojis and verifying the font-family inclusion in the SVG source.

Closes #9442