### PR TITLE
fix(editor): allow Tab arrow-type switching for bound and labeled arrows

### DIFF
--- a/packages/element/src/newElement.ts
+++ b/packages/element/src/newElement.ts
@@ -48,6 +48,7 @@ import type {
   ExcalidrawArrowElement,
   ExcalidrawElbowArrowElement,
   ExcalidrawLineElement,
+  FixedPointBinding,
 } from "./types";
 
 export type ElementConstructorOpts = MarkOptional<
@@ -492,6 +493,8 @@ export const newArrowElement = <T extends boolean>(
     points?: ExcalidrawArrowElement["points"];
     elbowed?: T;
     fixedSegments?: ExcalidrawElbowArrowElement["fixedSegments"] | null;
+    startBinding?: FixedPointBinding | null;
+    endBinding?: FixedPointBinding | null;
   } & ElementConstructorOpts,
 ): T extends true
   ? NonDeleted<ExcalidrawElbowArrowElement>
@@ -500,8 +503,8 @@ export const newArrowElement = <T extends boolean>(
     return {
       ..._newElementBase<ExcalidrawElbowArrowElement>(opts.type, opts),
       points: opts.points || [],
-      startBinding: null,
-      endBinding: null,
+      startBinding: opts.startBinding ?? null,
+      endBinding: opts.endBinding ?? null,
       startArrowhead: opts.startArrowhead || null,
       endArrowhead: opts.endArrowhead || null,
       elbowed: true,
@@ -514,8 +517,8 @@ export const newArrowElement = <T extends boolean>(
   return {
     ..._newElementBase<ExcalidrawArrowElement>(opts.type, opts),
     points: opts.points || [],
-    startBinding: null,
-    endBinding: null,
+    startBinding: opts.startBinding ?? null,
+    endBinding: opts.endBinding ?? null,
     startArrowhead: opts.startArrowhead || null,
     endArrowhead: opts.endArrowhead || null,
     elbowed: false,

--- a/packages/excalidraw/components/ConvertElementTypePopup.tsx
+++ b/packages/excalidraw/components/ConvertElementTypePopup.tsx
@@ -113,6 +113,12 @@ const LINEAR_TYPES = [
   "elbowArrow",
 ] as const;
 
+const BOUND_ARROW_LINEAR_TYPES = [
+  "sharpArrow",
+  "curvedArrow",
+  "elbowArrow",
+] as const;
+
 const CONVERTIBLE_GENERIC_TYPES: ReadonlySet<ConvertibleGenericTypes> = new Set(
   GENERIC_TYPES,
 );
@@ -292,12 +298,18 @@ const Panel = ({
 
   const SHAPES: [string, ReactNode][] =
     conversionType === "linear"
-      ? [
-          ["line", LineIcon],
-          ["sharpArrow", sharpArrowIcon],
-          ["curvedArrow", roundArrowIcon],
-          ["elbowArrow", elbowArrowIcon],
-        ]
+      ? shouldExcludeLineConversion(elements)
+        ? [
+            ["sharpArrow", sharpArrowIcon],
+            ["curvedArrow", roundArrowIcon],
+            ["elbowArrow", elbowArrowIcon],
+          ]
+        : [
+            ["line", LineIcon],
+            ["sharpArrow", sharpArrowIcon],
+            ["curvedArrow", roundArrowIcon],
+            ["elbowArrow", elbowArrowIcon],
+          ]
       : conversionType === "generic"
       ? [
           ["rectangle", RectangleIcon],
@@ -515,10 +527,14 @@ export const convertElementTypes = (
         getLinearElementSubType,
       );
 
-      const index = commonSubType ? LINEAR_TYPES.indexOf(commonSubType) : -1;
+      const availableLinearTypes = getAvailableLinearTypes(selectedElements);
+      const index = commonSubType
+        ? availableLinearTypes.findIndex((type) => type === commonSubType)
+        : -1;
       nextType =
-        LINEAR_TYPES[
-          (index + LINEAR_TYPES.length + advancement) % LINEAR_TYPES.length
+        availableLinearTypes[
+          (index + availableLinearTypes.length + advancement) %
+            availableLinearTypes.length
         ];
     }
 
@@ -653,12 +669,28 @@ export const getConversionTypeFromElements = (
 };
 
 const isEligibleLinearElement = (element: ExcalidrawElement) => {
-  return (
-    isLinearElement(element) &&
-    (!isArrowElement(element) ||
-      (!isArrowBoundToElement(element) && !hasBoundTextElement(element)))
-  );
+  return isLinearElement(element);
 };
+
+/** Lines cannot preserve shape bindings or arrow labels — hide line option. */
+const shouldExcludeLineConversion = (elements: ExcalidrawElement[]) => {
+  for (const element of elements) {
+    if (
+      isArrowElement(element) &&
+      (isArrowBoundToElement(element) || hasBoundTextElement(element))
+    ) {
+      return true;
+    }
+  }
+  return false;
+};
+
+const getAvailableLinearTypes = (
+  elements: ExcalidrawElement[],
+): readonly (typeof LINEAR_TYPES)[number][] =>
+  shouldExcludeLineConversion(elements)
+    ? BOUND_ARROW_LINEAR_TYPES
+    : LINEAR_TYPES;
 
 const toCacheKey = (
   elementId: ExcalidrawElement["id"],
@@ -866,6 +898,8 @@ const convertElementType = <
             roundness: null,
             startArrowhead: app.state.currentItemStartArrowhead,
             endArrowhead: app.state.currentItemEndArrowhead,
+            startBinding: isArrowElement(element) ? element.startBinding : null,
+            endBinding: isArrowElement(element) ? element.endBinding : null,
           }),
         );
       }
@@ -880,6 +914,8 @@ const convertElementType = <
             },
             startArrowhead: app.state.currentItemStartArrowhead,
             endArrowhead: app.state.currentItemEndArrowhead,
+            startBinding: isArrowElement(element) ? element.startBinding : null,
+            endBinding: isArrowElement(element) ? element.endBinding : null,
           }),
         );
       }
@@ -889,8 +925,10 @@ const convertElementType = <
             ...element,
             type: "arrow",
             elbowed: true,
-            fixedSegments: null,
+            fixedSegments: [],
             roundness: null,
+            startBinding: isArrowElement(element) ? element.startBinding : null,
+            endBinding: isArrowElement(element) ? element.endBinding : null,
           }),
         );
       }

--- a/packages/excalidraw/tests/convertElementType.test.tsx
+++ b/packages/excalidraw/tests/convertElementType.test.tsx
@@ -1,0 +1,119 @@
+/**
+ * Regression tests for #9656 — bound arrows should be eligible for Tab
+ * arrow-type switching (but not conversion to line).
+ */
+import {
+  convertElementTypes,
+  getConversionTypeFromElements,
+} from "../components/ConvertElementTypePopup";
+import { getLinearElementSubType } from "@excalidraw/element";
+
+import { Excalidraw } from "../index";
+
+import { API } from "./helpers/api";
+import { render } from "./test-utils";
+
+const { h } = window;
+
+describe("issue #9656 — bound arrow Tab shape switching", () => {
+  it("bound arrow is eligible for Tab shape switching", () => {
+    const boundArrow = API.createElement({
+      type: "arrow",
+      id: "arrow-1",
+      startBinding: {
+        elementId: "rect-1",
+        mode: "orbit",
+        fixedPoint: [0.5, 0.5],
+      },
+      endBinding: null,
+    });
+
+    expect(getConversionTypeFromElements([boundArrow])).toBe("linear");
+  });
+
+  it("labeled arrow is eligible for Tab shape switching", () => {
+    const labeledArrow = API.createElement({
+      type: "arrow",
+      id: "arrow-labeled",
+      boundElements: [{ type: "text", id: "text-1" }],
+    });
+
+    expect(getConversionTypeFromElements([labeledArrow])).toBe("linear");
+  });
+
+  it("converting labeled arrow preserves bound text reference", async () => {
+    await render(<Excalidraw handleKeyboardGlobally />);
+
+    const text = API.createElement({
+      type: "text",
+      id: "text-1",
+      text: "label",
+      containerId: "arrow-labeled",
+    });
+
+    const labeledArrow = API.createElement({
+      type: "arrow",
+      id: "arrow-labeled",
+      boundElements: [{ type: "text", id: "text-1" }],
+    });
+
+    API.setElements([labeledArrow, text]);
+    API.setSelectedElements([labeledArrow]);
+
+    convertElementTypes(h.app, {
+      conversionType: "linear",
+      nextType: "curvedArrow",
+    });
+
+    const converted = h.elements.find((el) => el.id === "arrow-labeled")!;
+    expect(getLinearElementSubType(converted as any)).toBe("curvedArrow");
+    expect((converted as any).boundElements).toEqual([
+      { type: "text", id: "text-1" },
+    ]);
+  });
+
+  it("unbound arrow is eligible (control case)", () => {
+    const arrow = API.createElement({ type: "arrow", id: "arrow-2" });
+    expect(getConversionTypeFromElements([arrow])).toBe("linear");
+  });
+
+  it("converting bound arrow preserves bindings and skips line", async () => {
+    await render(<Excalidraw handleKeyboardGlobally />);
+
+    const rect = API.createElement({
+      type: "rectangle",
+      id: "rect-1",
+      x: 0,
+      y: 0,
+      width: 100,
+      height: 100,
+      boundElements: [{ type: "arrow", id: "arrow-1" }],
+    });
+
+    const boundArrow = API.createElement({
+      type: "arrow",
+      id: "arrow-1",
+      x: 50,
+      y: 50,
+      startBinding: {
+        elementId: "rect-1",
+        mode: "orbit",
+        fixedPoint: [0.5, 0.5],
+      },
+      endBinding: null,
+    });
+
+    API.setElements([rect, boundArrow]);
+    API.setSelectedElements([boundArrow]);
+
+    convertElementTypes(h.app, {
+      conversionType: "linear",
+      nextType: "curvedArrow",
+    });
+
+    const converted = h.elements.find((el) => el.id === "arrow-1")!;
+    expect(getLinearElementSubType(converted as any)).toBe("curvedArrow");
+    expect((converted as any).startBinding?.elementId).toBe("rect-1");
+    expect((converted as any).type).toBe("arrow");
+  });
+});


### PR DESCRIPTION
## Summary
- Enable Tab-based arrow type cycling (sharp / curved / elbow) for arrows bound to shapes and arrows with text labels
- Hide the "line" option when switching would drop shape bindings or arrow labels, per maintainer guidance on #9656
- Preserve `startBinding` / `endBinding` when converting between arrow subtypes via `newArrowElement`
- Add regression tests in `convertElementType.test.tsx`

Fixes #9656

## Test plan
- [x] `yarn test:app --run packages/excalidraw/tests/convertElementType.test.tsx` (5 tests pass)
- [x] `yarn test:typecheck`
- [ ] Manual: bind arrow to rectangle → select arrow → Tab cycles arrow types, stays attached
- [ ] Manual: add label to arrow → Tab cycles arrow types, label preserved; line option not shown
- [ ] Manual: unbound arrow without label → Tab still cycles all four types including line


Made with [Cursor](https://cursor.com)