### PR TITLE
fix: Request persistent storage in order to prevent images from getting deleted from projects (fixes #11348)

### DIFF
--- a/excalidraw-app/App.tsx
+++ b/excalidraw-app/App.tsx
@@ -127,6 +127,7 @@ import {
   LibraryLocalStorageMigrationAdapter,
   LocalData,
   localStorageQuotaExceededAtom,
+  requestPersistentStorage,
 } from "./data/LocalData";
 import { isBrowserStorageStateNewer } from "./data/tabSync";
 import { ShareDialog, shareDialogStateAtom } from "./share/ShareDialog";
@@ -506,6 +507,14 @@ const ExcalidrawWrapper = () => {
                   erroredFiles,
                   elements: excalidrawAPI.getSceneElementsIncludingDeleted(),
                 });
+
+                if (erroredFiles.size > 0) {
+                  excalidrawAPI.updateScene({
+                    appState: {
+                      errorMessage: t("alerts.localImagesLost"),
+                    },
+                  });
+                }
               });
           }
           // on fresh load, clear unused files from IDB (from previous
@@ -523,6 +532,8 @@ const ExcalidrawWrapper = () => {
     if (!excalidrawAPI || (!isCollabDisabled && !collabAPI)) {
       return;
     }
+
+    requestPersistentStorage();
 
     initializeScene({ collabAPI, excalidrawAPI }).then(async (data) => {
       loadImages(data, /* isInitialLoad */ true);

--- a/excalidraw-app/data/LocalData.ts
+++ b/excalidraw-app/data/LocalData.ts
@@ -48,6 +48,23 @@ import { updateBrowserStateVersion } from "./tabSync";
 
 const filesStore = createStore("files-db", "files-store");
 
+/**
+ * Request persistent storage so the browser won't evict IndexedDB data
+ * (where images are stored) under storage pressure.
+ */
+export const requestPersistentStorage = async () => {
+  if (navigator.storage?.persist) {
+    try {
+      const isPersisted = await navigator.storage.persisted();
+      if (!isPersisted) {
+        await navigator.storage.persist();
+      }
+    } catch (error) {
+      console.warn("Failed to request persistent storage:", error);
+    }
+  }
+};
+
 export const localStorageQuotaExceededAtom = atom(false);
 
 class LocalFileManager extends FileManager {

--- a/packages/excalidraw/locales/en.json
+++ b/packages/excalidraw/locales/en.json
@@ -279,7 +279,8 @@
     "removeItemsFromsLibrary": "Delete {{count}} item(s) from library?",
     "invalidEncryptionKey": "Encryption key must be of 22 characters. Live collaboration is disabled.",
     "collabOfflineWarning": "No internet connection available.\nYour changes will not be saved!",
-    "localStorageQuotaExceeded": "Browser storage quota exceeded. Changes will not be saved."
+    "localStorageQuotaExceeded": "Browser storage quota exceeded. Changes will not be saved.",
+    "localImagesLost": "Some images could not be loaded from browser storage. Your browser may have cleared locally stored data. To avoid future data loss, consider exporting your drawings as .excalidraw files."
   },
   "errors": {
     "unsupportedFileType": "Unsupported file type.",


### PR DESCRIPTION
Added a request for persistent storage and a warning when the image is not found