### PR TITLE
perf(renderer): add uniform-grid viewport culling to avoid O(N) scene…

### DIFF
--- a/packages/excalidraw/scene/Renderer.ts
+++ b/packages/excalidraw/scene/Renderer.ts
@@ -1,10 +1,16 @@
 import {
   getCommonFrameId,
+  getElementBounds,
   getFrameChildrenInsertionIndex,
   isElementInViewport,
 } from "@excalidraw/element";
 
-import { arrayToMap, memoize, toBrandedType } from "@excalidraw/common";
+import {
+  arrayToMap,
+  memoize,
+  toBrandedType,
+  viewportCoordsToSceneCoords,
+} from "@excalidraw/common";
 
 import type {
   ExcalidrawElement,
@@ -37,15 +43,70 @@ type GetRenderableElementsOpts = {
   frameToHighlight: AppState["frameToHighlight"];
 };
 
+// size (in scene coordinates) of a single uniform-grid cell used to index
+// elements for viewport culling. Scene-space (zoom-independent) so the index
+// survives pan/zoom without rebuilding.
+const GRID_CELL_SIZE = 1000;
+
 export class Renderer {
   private scene: Scene;
+
+  // uniform spatial grid used to avoid an O(N) scan over every element on each
+  // viewport update. Cached and only rebuilt when the underlying set of
+  // renderable elements changes (tracked via `key`), not on pan/zoom.
+  private gridCache: {
+    key: string;
+    grid: Map<string, Set<string>>;
+    order: Map<string, number>;
+  } | null = null;
 
   constructor(scene: Scene) {
     this.scene = scene;
   }
 
+  // builds (or returns a cached) uniform spatial grid indexing every element by
+  // the grid cells its bounding box overlaps. `order` records each element's
+  // index in the original (z-ordered) iteration so we can restore stacking
+  // order after a grid query. Rebuilds are O(N) but only happen when `key`
+  // changes (i.e. the scene/renderable set changed), so pan/zoom reuses it.
+  private getSpatialGrid(elementsMap: NonDeletedElementsMap, key: string) {
+    if (this.gridCache && this.gridCache.key === key) {
+      return this.gridCache;
+    }
+
+    const grid = new Map<string, Set<string>>();
+    const order = new Map<string, number>();
+
+    let index = 0;
+    for (const element of elementsMap.values()) {
+      order.set(element.id, index++);
+
+      const [x1, y1, x2, y2] = getElementBounds(element, elementsMap);
+      const minCol = Math.floor(x1 / GRID_CELL_SIZE);
+      const maxCol = Math.floor(x2 / GRID_CELL_SIZE);
+      const minRow = Math.floor(y1 / GRID_CELL_SIZE);
+      const maxRow = Math.floor(y2 / GRID_CELL_SIZE);
+
+      for (let col = minCol; col <= maxCol; col++) {
+        for (let row = minRow; row <= maxRow; row++) {
+          const cellKey = `${col}:${row}`;
+          let bucket = grid.get(cellKey);
+          if (!bucket) {
+            bucket = new Set();
+            grid.set(cellKey, bucket);
+          }
+          bucket.add(element.id);
+        }
+      }
+    }
+
+    this.gridCache = { key, grid, order };
+    return this.gridCache;
+  }
+
   private getVisibleCanvasElements({
     elementsMap,
+    gridCacheKey,
     zoom,
     offsetLeft,
     offsetTop,
@@ -55,6 +116,7 @@ export class Renderer {
     width,
   }: {
     elementsMap: NonDeletedElementsMap;
+    gridCacheKey: string;
     zoom: AppState["zoom"];
     offsetLeft: AppState["offsetLeft"];
     offsetTop: AppState["offsetTop"];
@@ -63,26 +125,72 @@ export class Renderer {
     height: AppState["height"];
     width: AppState["width"];
   }): readonly NonDeletedExcalidrawElement[] {
+    const { grid, order } = this.getSpatialGrid(elementsMap, gridCacheKey);
+
+    const viewTransformations = {
+      zoom,
+      offsetLeft,
+      offsetTop,
+      scrollX,
+      scrollY,
+    };
+
+    // viewport rect in scene coordinates — computed once per frame instead of
+    // (previously) once per element.
+    const topLeft = viewportCoordsToSceneCoords(
+      { clientX: offsetLeft, clientY: offsetTop },
+      viewTransformations,
+    );
+    const bottomRight = viewportCoordsToSceneCoords(
+      { clientX: offsetLeft + width, clientY: offsetTop + height },
+      viewTransformations,
+    );
+
+    // collect candidate ids from the grid cells the viewport overlaps. Because
+    // elements are bucketed by the same bounds `isElementInViewport` tests,
+    // every truly-visible element is guaranteed to be among the candidates (no
+    // false negatives); the precise check below removes false positives.
+    const candidateIds = new Set<string>();
+    const minCol = Math.floor(topLeft.x / GRID_CELL_SIZE);
+    const maxCol = Math.floor(bottomRight.x / GRID_CELL_SIZE);
+    const minRow = Math.floor(topLeft.y / GRID_CELL_SIZE);
+    const maxRow = Math.floor(bottomRight.y / GRID_CELL_SIZE);
+
+    for (let col = minCol; col <= maxCol; col++) {
+      for (let row = minRow; row <= maxRow; row++) {
+        const bucket = grid.get(`${col}:${row}`);
+        if (bucket) {
+          for (const id of bucket) {
+            candidateIds.add(id);
+          }
+        }
+      }
+    }
+
+    // run the authoritative viewport check only on candidates
     const visibleElements: NonDeletedExcalidrawElement[] = [];
-    for (const element of elementsMap.values()) {
+    for (const id of candidateIds) {
+      const element = elementsMap.get(id);
       if (
+        element &&
         isElementInViewport(
           element,
           width,
           height,
-          {
-            zoom,
-            offsetLeft,
-            offsetTop,
-            scrollX,
-            scrollY,
-          },
+          viewTransformations,
           elementsMap,
         )
       ) {
         visibleElements.push(element);
       }
     }
+
+    // CRITICAL: restore original z-order (a grid query yields no inherent
+    // ordering, but render order must follow the scene element order).
+    visibleElements.sort(
+      (a, b) => (order.get(a.id) ?? 0) - (order.get(b.id) ?? 0),
+    );
+
     return visibleElements;
   }
 
@@ -185,8 +293,17 @@ export class Renderer {
           newElement,
         });
 
+      // the renderable set is determined by the scene contents plus which
+      // element (if any) is being edited / freshly drawn (those are filtered
+      // out above). Keying the spatial grid on these lets pan/zoom reuse it
+      // while still rebuilding when the set actually changes.
+      const gridCacheKey = `${this.scene.getSceneNonce()}:${
+        editingTextElement?.id ?? ""
+      }:${newElement?.id ?? ""}`;
+
       const visibleElements = this.getVisibleCanvasElements({
         elementsMap,
+        gridCacheKey,
         zoom,
         offsetLeft,
         offsetTop,
@@ -258,5 +375,6 @@ export class Renderer {
   public destroy() {
     renderStaticSceneThrottled.cancel();
     this._getRenderableElements.clear();
+    this.gridCache = null;
   }
 }


### PR DESCRIPTION
Addresses the O(N) bottleneck described in #10512.

### The Problem
Currently, `getVisibleCanvasElements` iterates over all non-deleted elements on every viewport update (pan/zoom), creating an O(N) bottleneck that degrades performance on large scenes.

### The Solution
Implemented a lightweight uniform-grid spatial hash to act as a candidate pre-filter. 
1. Elements are bucketed into a spatial grid based on their bounding box.
2. On viewport updates, the renderer only queries the grid cells that intersect the current viewport.
3. These candidates are passed through the authoritative `isElementInViewport` check for exact accuracy.
4. Z-order is strictly preserved by sorting the final candidates using a cached order map.

### Notes for Reviewers
* I am aware of the open PR #10514 tackling the same issue. I wanted to offer this uniform-grid approach as an alternative, lightweight architecture (avoiding heavier tree structures) to see if it aligns well with the project's performance goals.
* **Note:** I am currently resolving local environment issues and couldn't run `yarn test:typecheck` locally prior to pushing, though I manually verified the imported signatures. I will monitor the CI pipeline and immediately address any type errors that Vercel catches.