### PR TITLE
fix(editor): keep canvas search results order stable (#9503)

### DIFF
--- a/packages/excalidraw/components/SearchMenu.tsx
+++ b/packages/excalidraw/components/SearchMenu.tsx
@@ -804,8 +804,8 @@ const handleSearch = debounce(
       isFrameLikeElement(el),
     ) as ExcalidrawFrameLikeElement[];
 
-    texts.sort((a, b) => a.y - b.y);
-    frames.sort((a, b) => a.y - b.y);
+    texts.sort((a, b) => a.id.localeCompare(b.id));
+    frames.sort((a, b) => a.id.localeCompare(b.id));
 
     const textMatches: SearchMatchItem[] = [];
 

--- a/packages/excalidraw/tests/search.test.tsx
+++ b/packages/excalidraw/tests/search.test.tsx
@@ -194,4 +194,51 @@ describe("search", () => {
       expect(h.app.state.searchMatches?.matches.length).toBe(3);
     });
   });
+
+  it("should maintain stable search results order when dragging elements", async () => {
+    const scrollIntoViewMock = jest.fn();
+    window.HTMLElement.prototype.scrollIntoView = scrollIntoViewMock;
+
+    const text1 = API.createElement({
+      type: "text",
+      text: "test 1",
+      x: 0,
+      y: 100,
+    });
+    const text2 = API.createElement({
+      type: "text",
+      text: "test 2",
+      x: 0,
+      y: 0,
+    });
+
+    API.setElements([text1, text2]);
+
+    Keyboard.withModifierKeys({ ctrl: true }, () => {
+      Keyboard.keyPress(KEYS.F);
+    });
+
+    const searchInput = await querySearchInput();
+    updateTextEditor(searchInput, "test");
+
+    await waitFor(() => {
+      expect(h.app.state.searchMatches?.matches.length).toBe(2);
+    });
+
+    const initialOrder = h.app.state.searchMatches!.matches.map(
+      (match) => match.id,
+    );
+
+    API.updateElement(text2, {
+      y: 200,
+    });
+
+    await waitFor(() => {
+      expect(h.app.state.searchMatches?.matches.length).toBe(2);
+      const newOrder = h.app.state.searchMatches!.matches.map(
+        (match) => match.id,
+      );
+      expect(newOrder).toEqual(initialOrder);
+    });
+  });
 });


### PR DESCRIPTION
Fixes #9503

## Problem
When searching on the canvas, results were sorted by the element's y-position. Dragging an element changed that position and caused the results list to reorder — making it hard to track which matches you'd already reviewed.

## Solution
Sort search matches by element `id` instead of `y` position. Element IDs are stable, so the results list no longer shifts when elements are moved on the canvas.

## Changes
- Update sorting logic in `SearchMenu` for text and frame matches
- Add regression test to verify order stays stable when an element is dragged

## Test plan
- [x] `yarn test packages/excalidraw/tests/search.test.tsx --watch=false`
- [x] Manual: create "test 1" and "test 2", search "test", drag one element → list order unchanged