### PR TITLE
fix: show feedback for invalid color input

### DIFF
--- a/packages/excalidraw/actions/actionProperties.test.tsx
+++ b/packages/excalidraw/actions/actionProperties.test.tsx
@@ -10,7 +10,7 @@ import {
 import { Excalidraw } from "../index";
 import { API } from "../tests/helpers/api";
 import { UI } from "../tests/helpers/ui";
-import { render } from "../tests/test-utils";
+import { fireEvent, render, togglePopover } from "../tests/test-utils";
 
 describe("element locking", () => {
   beforeEach(async () => {
@@ -79,6 +79,20 @@ describe("element locking", () => {
 
       const centerTextAlign = queryByTestId(document.body, `align-right`);
       expect(centerTextAlign).toBeChecked();
+    });
+
+    it("should show feedback for invalid color input", () => {
+      UI.clickTool("rectangle");
+      togglePopover("Stroke");
+
+      const colorInput = document.querySelector<HTMLInputElement>(
+        ".color-picker-input",
+      )!;
+
+      fireEvent.change(colorInput, { target: { value: "gggggg" } });
+
+      expect(colorInput).toHaveAttribute("aria-invalid", "true");
+      expect(document.body).toHaveTextContent("Enter a valid color.");
     });
   });
 

--- a/packages/excalidraw/components/ColorPicker/ColorInput.tsx
+++ b/packages/excalidraw/components/ColorPicker/ColorInput.tsx
@@ -1,5 +1,5 @@
 import clsx from "clsx";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useId, useRef, useState } from "react";
 
 import { KEYS, normalizeInputColor } from "@excalidraw/common";
 
@@ -29,22 +29,27 @@ export const ColorInput = ({
 }) => {
   const editorInterface = useEditorInterface();
   const [innerValue, setInnerValue] = useState(color);
+  const [isInvalid, setIsInvalid] = useState(false);
+  const errorId = useId();
   const [activeSection, setActiveColorPickerSection] = useAtom(
     activeColorPickerSectionAtom,
   );
 
   useEffect(() => {
     setInnerValue(color);
+    setIsInvalid(false);
   }, [color]);
 
   const changeColor = useCallback(
     (inputValue: string) => {
       const value = inputValue.toLowerCase();
       const color = normalizeInputColor(value);
+      const isInvalidColor = !!value.trim() && !color;
 
       if (color) {
         onChange(color);
       }
+      setIsInvalid(isInvalidColor);
       setInnerValue(value);
     },
     [onChange],
@@ -68,7 +73,11 @@ export const ColorInput = ({
   }, [setEyeDropperState]);
 
   return (
-    <div className="color-picker__input-label">
+    <div
+      className={clsx("color-picker__input-label", {
+        "color-picker__input-label--invalid": isInvalid,
+      })}
+    >
       <div className="color-picker__input-hash">#</div>
       <input
         ref={activeSection === "hex" ? inputRef : undefined}
@@ -76,12 +85,15 @@ export const ColorInput = ({
         spellCheck={false}
         className="color-picker-input"
         aria-label={label}
+        aria-invalid={isInvalid || undefined}
+        aria-describedby={isInvalid ? errorId : undefined}
         onChange={(event) => {
           changeColor(event.target.value);
         }}
         value={(innerValue || "").replace(/^#/, "")}
         onBlur={() => {
           setInnerValue(color);
+          setIsInvalid(false);
         }}
         tabIndex={-1}
         onFocus={() => setActiveColorPickerSection("hex")}
@@ -128,6 +140,11 @@ export const ColorInput = ({
             {eyeDropperIcon}
           </div>
         </>
+      )}
+      {isInvalid && (
+        <div id={errorId} role="alert" className="color-picker__input-error">
+          {t("colorPicker.invalidColor")}
+        </div>
       )}
     </div>
   );

--- a/packages/excalidraw/components/ColorPicker/ColorPicker.scss
+++ b/packages/excalidraw/components/ColorPicker/ColorPicker.scss
@@ -383,10 +383,27 @@
       box-shadow: 0 0 0 1px var(--color-primary-darkest);
       border-radius: var(--border-radius-lg);
     }
+
+    &--invalid {
+      border-color: var(--color-danger);
+
+      &:focus-within {
+        box-shadow: 0 0 0 1px var(--color-danger);
+      }
+    }
   }
 
   .color-picker__input-hash {
     padding: 0 0.25rem;
+  }
+
+  .color-picker__input-error {
+    grid-column: 1 / -1;
+    color: var(--color-danger);
+    font-size: 0.75rem;
+    line-height: 1.25;
+    margin-top: -0.25rem;
+    padding-bottom: 0.5rem;
   }
 
   .color-picker-input {

--- a/packages/excalidraw/locales/en.json
+++ b/packages/excalidraw/locales/en.json
@@ -598,6 +598,7 @@
     "colors": "Colors",
     "shades": "Shades",
     "hexCode": "Hex code",
+    "invalidColor": "Enter a valid color.",
     "noShades": "No shades available for this color"
   },
   "overwriteConfirm": {


### PR DESCRIPTION
## Summary
- show feedback when the color picker input contains a non-empty invalid color
- mark the input with `aria-invalid` and connect it to the error message
- add coverage for invalid color input feedback

Fixes #9527

## Testing
- `yarn test:app packages/excalidraw/actions/actionProperties.test.tsx --watch=false`
- `yarn test:typecheck`
- `yarn eslint --max-warnings=0 packages/excalidraw/components/ColorPicker/ColorInput.tsx packages/excalidraw/actions/actionProperties.test.tsx`
- `yarn prettier --list-different packages/excalidraw/components/ColorPicker/ColorPicker.scss packages/excalidraw/locales/en.json`