### PR TITLE
fix(editor): keep multi-line bound text and container centered during alt resize

### DIFF
--- a/packages/element/src/resizeElements.ts
+++ b/packages/element/src/resizeElements.ts
@@ -919,6 +919,7 @@ export const resizeSingleElement = (
       scene,
       handleDirection,
       shouldMaintainAspectRatio,
+      shouldResizeFromCenter,
     );
 
     updateBoundElements(latestElement, scene);
@@ -1491,7 +1492,13 @@ export const resizeMultipleElements = (
           fontSize: boundTextFontSize,
           angle: isLinearElement(element) ? undefined : angle,
         });
-        handleBindTextResize(element, scene, handleDirection, true);
+        handleBindTextResize(
+          element,
+          scene,
+          handleDirection,
+          true,
+          shouldResizeFromCenter,
+        );
       }
     }
 

--- a/packages/element/src/textElement.ts
+++ b/packages/element/src/textElement.ts
@@ -144,6 +144,7 @@ export const handleBindTextResize = (
   scene: Scene,
   transformHandleType: MaybeTransformHandleType,
   shouldMaintainAspectRatio = false,
+  shouldResizeFromCenter = false,
 ) => {
   const elementsMap = scene.getNonDeletedElementsMap();
   const boundTextElementId = getBoundTextElementId(container);
@@ -191,16 +192,22 @@ export const handleBindTextResize = (
 
       const diff = containerHeight - container.height;
       // fix the y coord when resizing from ne/nw/n
-      const updatedY =
-        !isArrowElement(container) &&
-        (transformHandleType === "ne" ||
-          transformHandleType === "nw" ||
-          transformHandleType === "n")
-          ? container.y - diff
-          : container.y;
+      const shouldResizeFromTop =
+        transformHandleType === "n" ||
+        transformHandleType === "ne" ||
+        transformHandleType === "nw";
+
+      let offsetY = 0;
+      if (!isArrowElement(container)) {
+        if (shouldResizeFromCenter) {
+          offsetY = diff / 2;
+        } else if (shouldResizeFromTop) {
+          offsetY = diff;
+        }
+      }
       scene.mutateElement(container, {
         height: containerHeight,
-        y: updatedY,
+        y: container.y - offsetY,
       });
     }
 

--- a/packages/element/tests/linearElementEditor.test.tsx
+++ b/packages/element/tests/linearElementEditor.test.tsx
@@ -1344,6 +1344,7 @@ describe("Test Linear Elements", () => {
         h.app.scene,
         "nw",
         false,
+        false,
       );
       expect(
         wrapText(

--- a/packages/element/tests/resize.test.tsx
+++ b/packages/element/tests/resize.test.tsx
@@ -22,13 +22,14 @@ import { isLinearElement } from "../src/typeChecks";
 import { resizeSingleElement } from "../src/resizeElements";
 import { LinearElementEditor } from "../src/linearElementEditor";
 import { getElementPointsCoords } from "../src/bounds";
+import { computeContainerDimensionForBoundText } from "../src/textElement";
 
 import type {
   ExcalidrawElbowArrowElement,
   ExcalidrawFreeDrawElement,
   ExcalidrawLinearElement,
 } from "../src/types";
-
+import type { TransformHandleDirection } from "../src/transformHandles";
 unmountComponent();
 
 const { h } = window;
@@ -226,6 +227,36 @@ describe("generic element", () => {
     expect(label.angle).toBeCloseTo(rectangle.angle);
     expect(label.fontSize).toEqual(20);
   });
+
+  it.each<{ handle: TransformHandleDirection; move: [number, number] }>([
+    { handle: "n", move: [0, 100] },
+    { handle: "s", move: [0, -100] },
+  ])(
+    "resizes from center with multi-line label from $handle handle, with respect to min height",
+    async ({ handle, move }) => {
+      const rectangle = UI.createElement("rectangle", {
+        width: 200,
+        height: 100, // height not enough for label fit, so it will be resized
+      });
+
+      const label = await UI.editText(
+        rectangle,
+        "hello\nhello\nhello\nhello\nhello",
+      );
+      const initCenterY = rectangle.y + rectangle.height / 2;
+      const minContainerHeight = computeContainerDimensionForBoundText(
+        label.height,
+        rectangle.type,
+      );
+
+      UI.resize(rectangle, handle, move, {
+        alt: true,
+      });
+      const newCenterY = rectangle.y + rectangle.height / 2;
+      expect(newCenterY).toBeCloseTo(initCenterY);
+      expect(rectangle.height).toBeCloseTo(minContainerHeight);
+    },
+  );
 });
 
 describe.each(["line", "freedraw"] as const)("%s element", (type) => {

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,4 @@
 {
-  "public": true,
   "headers": [
     {
       "source": "/(.*)",


### PR DESCRIPTION
# Summary
This PR addresses the case where when alt keypress + transform is applied to containers with multi-line bound text in vertical space, the element stays constrained to the respective center axis.

https://github.com/user-attachments/assets/db5d8655-855b-4d6e-a689-29ff16d4555e

## Fix
The fix involved carrying over the parameter `shouldResizeFromCenter` to `handleBindTextResize` and using it as a condition to determine the updated y position.

## Additional Task
- [x] create tests to cover this resizing edge case

## Feedback Welcome
Open to any suggestions, and if there's a better approach, I'm more than willing to change and/or collaborate! @dwelle @mtolmacs 

Fixes #11479 