### PR TITLE
fix(app,packages/excalidraw): bump @excalidraw/random-username to 1.2.0

### DIFF
--- a/excalidraw-app/package.json
+++ b/excalidraw-app/package.json
@@ -26,7 +26,7 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
-    "@excalidraw/random-username": "1.0.0",
+    "@excalidraw/random-username": "1.2.0",
     "@sentry/browser": "9.0.1",
     "callsites": "4.2.0",
     "firebase": "11.3.1",

--- a/packages/excalidraw/package.json
+++ b/packages/excalidraw/package.json
@@ -89,7 +89,6 @@
     "@excalidraw/laser-pointer": "1.3.1",
     "@excalidraw/math": "0.18.0",
     "@excalidraw/mermaid-to-excalidraw": "2.2.2",
-    "@excalidraw/random-username": "1.1.0",
     "browser-fs-access": "0.38.0",
     "canvas-roundrect-polyfill": "0.0.1",
     "clsx": "1.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1546,15 +1546,10 @@
   resolved "https://registry.yarnpkg.com/@excalidraw/prettier-config/-/prettier-config-1.0.2.tgz#b7c061c99cee2f78b9ca470ea1fbd602683bba65"
   integrity sha512-rFIq8+A8WvkEzBsF++Rw6gzxE+hU3ZNkdg8foI+Upz2y/rOC/gUpWJaggPbCkoH3nlREVU59axQjZ1+F6ePRGg==
 
-"@excalidraw/random-username@1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@excalidraw/random-username/-/random-username-1.0.0.tgz#6d5293148aee6cd08dcdfcadc0c91276572f4499"
-  integrity sha512-pd4VapWahQ7PIyThGq32+C+JUS73mf3RSdC7BmQiXzhQsCTU4RHc8y9jBi+pb1CFV0iJXvjJRXnVdLCbTj3+HA==
-
-"@excalidraw/random-username@1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@excalidraw/random-username/-/random-username-1.1.0.tgz#6f388d6a9708cf655b8c9c6aa3fa569ee71ecf0f"
-  integrity sha512-nULYsQxkWHnbmHvcs+efMkJ4/9TtvNyFeLyHdeGxW0zHs6P+jYVqcRff9A6Vq9w9JXeDRnRh2VKvTtS19GW2qA==
+"@excalidraw/random-username@1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@excalidraw/random-username/-/random-username-1.2.0.tgz#82fae5689dc7f35340ed5e2bb501e18786fcbebd"
+  integrity sha512-05lXTrPCJV30YDm7LRDtdXdGKTNfH2/zc+hq5uVltlyKo5Z1rKDgjXKLcCdS4ROPDohrFhqZplhaTZaHL7peVQ==
 
 "@firebase/analytics-compat@0.2.17":
   version "0.2.17"


### PR DESCRIPTION
Fixes #11478 (recurrence of #7262)

## Problem

excalidraw.com still generates collab usernames like "Cheerful Ape", even though these were removed for #7262 via `@excalidraw/random-username@1.1.0`.

The fix regressed when app dependencies were moved into `excalidraw-app/package.json` (#7021), which re-pinned the old `1.0.0`. Additionally, `packages/excalidraw` declares `@excalidraw/random-username@1.1.0` as a dependency (since #7415), but nothing in the package imports it — the only usage in the entire repo is the dynamic import in `excalidraw-app/collab/Collab.tsx`.

## Changes

- `excalidraw-app`: bump `@excalidraw/random-username` from `1.0.0` to `1.2.0` (latest — includes the 1.1.0 name-list cleanup, plus removal of `gorilla` in 1.2.0)
- `@excalidraw/excalidraw`: remove the unused `@excalidraw/random-username` dependency
- `yarn.lock`: the two stale entries (1.0.0 / 1.1.0) collapse into a single 1.2.0 entry

No code changes needed — the `getRandomUsername()` API is unchanged.

## Verification

- Confirmed the installed 1.2.0 name list contains none of the words removed for #7262 (`ape`, `baboon`, `monkey`, `dog`, `gorilla`, etc.)
- Ran `getRandomUsername()` against 1.2.0 — works as expected (e.g. "Thoughtful Barracuda", "Cheery Swan")
- Grepped the repo to confirm `excalidraw-app/collab/Collab.tsx` is the only consumer, so dropping the dependency from `@excalidraw/excalidraw` is safe
- `yarn test:typecheck` passes, and `excalidraw-app/tests/collab.test.tsx` passes (2/2)