### PR TITLE
feat: add search to help dialog shortcuts

### DIFF
--- a/packages/excalidraw/components/HelpDialog.scss
+++ b/packages/excalidraw/components/HelpDialog.scss
@@ -16,6 +16,13 @@
       display: flex;
       flex-wrap: wrap;
       gap: 0.75rem;
+      margin-bottom: 1rem;
+    }
+
+    &__searchBar {
+      display: flex;
+      padding: 4px;
+      width: 100%;
     }
 
     &__btn {
@@ -78,6 +85,20 @@
       &__island--editor {
         grid-area: 1 / 2 / 3 / 3;
       }
+    }
+
+    &__islands-container--filtered {
+      .HelpDialog__island--tools,
+      .HelpDialog__island--view,
+      .HelpDialog__island--editor {
+        grid-area: auto;
+      }
+    }
+
+    &__no-results {
+      margin: 0;
+      color: var(--text-secondary-color);
+      font-size: 0.875rem;
     }
 
     &__island {

--- a/packages/excalidraw/components/HelpDialog.tsx
+++ b/packages/excalidraw/components/HelpDialog.tsx
@@ -1,4 +1,5 @@
-import React from "react";
+import clsx from "clsx";
+import React, { useMemo, useState } from "react";
 
 import { isDarwin, isFirefox, isWindows } from "@excalidraw/common";
 
@@ -15,6 +16,322 @@ import { ExternalLinkIcon, GithubIcon, youtubeIcon } from "./icons";
 import "./HelpDialog.scss";
 
 import type { JSX } from "react";
+
+const shortcutSections = [
+  {
+    title: t("helpDialog.tools"),
+    className: "HelpDialog__island--tools",
+    active: true,
+    items: [
+      { label: t("toolBar.hand"), shortcuts: [KEYS.H] },
+      { label: t("toolBar.selection"), shortcuts: [KEYS.V, KEYS["1"]] },
+      { label: t("toolBar.rectangle"), shortcuts: [KEYS.R, KEYS["2"]] },
+      { label: t("toolBar.diamond"), shortcuts: [KEYS.D, KEYS["3"]] },
+      { label: t("toolBar.ellipse"), shortcuts: [KEYS.O, KEYS["4"]] },
+      { label: t("toolBar.arrow"), shortcuts: [KEYS.A, KEYS["5"]] },
+      { label: t("toolBar.line"), shortcuts: [KEYS.L, KEYS["6"]] },
+      { label: t("toolBar.freedraw"), shortcuts: [KEYS.P, KEYS["7"]] },
+      { label: t("toolBar.text"), shortcuts: [KEYS.T, KEYS["8"]] },
+      { label: t("toolBar.image"), shortcuts: [KEYS["9"]] },
+      { label: t("toolBar.eraser"), shortcuts: [KEYS.E, KEYS["0"]] },
+      { label: t("toolBar.frame"), shortcuts: [KEYS.F] },
+      { label: t("toolBar.laser"), shortcuts: [KEYS.K] },
+      {
+        label: t("labels.eyeDropper"),
+        shortcuts: [KEYS.I, "Shift+S", "Shift+G"],
+      },
+      {
+        label: t("helpDialog.editLineArrowPoints"),
+        shortcuts: [getShortcutKey("CtrlOrCmd+Enter")],
+      },
+      {
+        label: t("helpDialog.editText"),
+        shortcuts: [getShortcutKey("Enter")],
+      },
+      {
+        label: t("helpDialog.textNewLine"),
+        shortcuts: [getShortcutKey("Enter"), getShortcutKey("Shift+Enter")],
+      },
+      {
+        label: t("helpDialog.textFinish"),
+        shortcuts: [getShortcutKey("Esc"), getShortcutKey("CtrlOrCmd+Enter")],
+      },
+      {
+        label: t("helpDialog.curvedArrow"),
+        shortcuts: [
+          "A",
+          t("helpDialog.click"),
+          t("helpDialog.click"),
+          t("helpDialog.click"),
+        ],
+        isOr: false,
+      },
+      {
+        label: t("helpDialog.curvedLine"),
+        shortcuts: [
+          "L",
+          t("helpDialog.click"),
+          t("helpDialog.click"),
+          t("helpDialog.click"),
+        ],
+        isOr: false,
+      },
+      {
+        label: t("helpDialog.cropStart"),
+        shortcuts: [t("helpDialog.doubleClick"), getShortcutKey("Enter")],
+      },
+      {
+        label: t("helpDialog.cropFinish"),
+        shortcuts: [getShortcutKey("Enter"), getShortcutKey("Escape")],
+      },
+      { label: t("toolBar.lock"), shortcuts: [KEYS.Q] },
+      {
+        label: t("helpDialog.preventBinding"),
+        shortcuts: [getShortcutKey("CtrlOrCmd")],
+      },
+      {
+        label: t("toolBar.link"),
+        shortcuts: [getShortcutKey("CtrlOrCmd+K")],
+      },
+      {
+        label: t("toolBar.convertElementType"),
+        shortcuts: ["Tab", "Shift+Tab"],
+      },
+    ],
+  },
+  {
+    title: t("helpDialog.view"),
+    className: "HelpDialog__island--view",
+    active: true,
+    items: [
+      {
+        label: t("buttons.zoomIn"),
+        shortcuts: [getShortcutKey("CtrlOrCmd++")],
+      },
+      {
+        label: t("buttons.zoomOut"),
+        shortcuts: [getShortcutKey("CtrlOrCmd+-")],
+      },
+      {
+        label: t("buttons.resetZoom"),
+        shortcuts: [getShortcutKey("CtrlOrCmd+0")],
+      },
+      { label: t("helpDialog.zoomToFit"), shortcuts: ["Shift+1"] },
+      { label: t("helpDialog.zoomToSelection"), shortcuts: ["Shift+2"] },
+      { label: t("helpDialog.movePageUpDown"), shortcuts: ["PgUp/PgDn"] },
+      {
+        label: t("helpDialog.movePageLeftRight"),
+        shortcuts: ["Shift+PgUp/PgDn"],
+      },
+      { label: t("buttons.zenMode"), shortcuts: [getShortcutKey("Alt+Z")] },
+      {
+        label: t("buttons.objectsSnapMode"),
+        shortcuts: [getShortcutKey("Alt+S")],
+      },
+      {
+        label: t("labels.toggleGrid"),
+        shortcuts: [getShortcutKey("CtrlOrCmd+'")],
+      },
+      { label: t("labels.viewMode"), shortcuts: [getShortcutKey("Alt+R")] },
+      {
+        label: t("labels.toggleTheme"),
+        shortcuts: [getShortcutKey("Alt+Shift+D")],
+      },
+      { label: t("stats.fullTitle"), shortcuts: [getShortcutKey("Alt+/")] },
+      {
+        label: t("search.title"),
+        shortcuts: [getShortcutFromShortcutName("searchMenu")],
+      },
+      {
+        label: t("commandPalette.title"),
+        shortcuts: isFirefox
+          ? [getShortcutFromShortcutName("commandPalette")]
+          : [
+              getShortcutFromShortcutName("commandPalette"),
+              getShortcutFromShortcutName("commandPalette", 1),
+            ],
+      },
+    ],
+  },
+  {
+    title: t("helpDialog.editor"),
+    className: "HelpDialog__island--editor",
+    active: true,
+    items: [
+      {
+        label: t("helpDialog.createFlowchart"),
+        shortcuts: [getShortcutKey(`CtrlOrCmd+Arrow Key`)],
+        isOr: true,
+      },
+      {
+        label: t("helpDialog.navigateFlowchart"),
+        shortcuts: [getShortcutKey(`Alt+Arrow Key`)],
+        isOr: true,
+      },
+      {
+        label: t("labels.moveCanvas"),
+        shortcuts: [
+          getShortcutKey(`Space+${t("helpDialog.drag")}`),
+          getShortcutKey(`Wheel+${t("helpDialog.drag")}`),
+        ],
+        isOr: true,
+      },
+      {
+        label: t("buttons.clearReset"),
+        shortcuts: [getShortcutKey("CtrlOrCmd+Delete")],
+      },
+      {
+        label: t("labels.delete"),
+        shortcuts: [getShortcutKey("Delete")],
+      },
+      {
+        label: t("labels.cut"),
+        shortcuts: [getShortcutKey("CtrlOrCmd+X")],
+      },
+      {
+        label: t("labels.copy"),
+        shortcuts: [getShortcutKey("CtrlOrCmd+C")],
+      },
+      {
+        label: t("labels.paste"),
+        shortcuts: [getShortcutKey("CtrlOrCmd+V")],
+      },
+      {
+        label: t("labels.pasteAsPlaintext"),
+        shortcuts: [getShortcutKey("CtrlOrCmd+Shift+V")],
+      },
+      {
+        label: t("labels.selectAll"),
+        shortcuts: [getShortcutKey("CtrlOrCmd+A")],
+      },
+      {
+        label: t("labels.multiSelect"),
+        shortcuts: [getShortcutKey(`Shift+${t("helpDialog.click")}`)],
+      },
+      {
+        label: t("helpDialog.deepSelect"),
+        shortcuts: [getShortcutKey(`CtrlOrCmd+${t("helpDialog.click")}`)],
+      },
+      {
+        label: t("helpDialog.deepBoxSelect"),
+        shortcuts: [getShortcutKey(`CtrlOrCmd+${t("helpDialog.drag")}`)],
+      },
+      ...(probablySupportsClipboardBlob || isFirefox
+        ? [
+            {
+              label: t("labels.copyAsPng"),
+              shortcuts: [getShortcutKey("Shift+Alt+C")],
+            },
+          ]
+        : []),
+      {
+        label: t("labels.copyStyles"),
+        shortcuts: [getShortcutKey("CtrlOrCmd+Alt+C")],
+      },
+      {
+        label: t("labels.pasteStyles"),
+        shortcuts: [getShortcutKey("CtrlOrCmd+Alt+V")],
+      },
+      {
+        label: t("labels.sendToBack"),
+        shortcuts: [
+          isDarwin
+            ? getShortcutKey("CtrlOrCmd+Alt+[")
+            : getShortcutKey("CtrlOrCmd+Shift+["),
+        ],
+      },
+      {
+        label: t("labels.bringToFront"),
+        shortcuts: [
+          isDarwin
+            ? getShortcutKey("CtrlOrCmd+Alt+]")
+            : getShortcutKey("CtrlOrCmd+Shift+]"),
+        ],
+      },
+      {
+        label: t("labels.sendBackward"),
+        shortcuts: [getShortcutKey("CtrlOrCmd+[")],
+      },
+      {
+        label: t("labels.bringForward"),
+        shortcuts: [getShortcutKey("CtrlOrCmd+]")],
+      },
+      {
+        label: t("labels.alignTop"),
+        shortcuts: [getShortcutKey("CtrlOrCmd+Shift+Up")],
+      },
+      {
+        label: t("labels.alignBottom"),
+        shortcuts: [getShortcutKey("CtrlOrCmd+Shift+Down")],
+      },
+      {
+        label: t("labels.alignLeft"),
+        shortcuts: [getShortcutKey("CtrlOrCmd+Shift+Left")],
+      },
+      {
+        label: t("labels.alignRight"),
+        shortcuts: [getShortcutKey("CtrlOrCmd+Shift+Right")],
+      },
+      {
+        label: t("labels.duplicateSelection"),
+        shortcuts: [
+          getShortcutKey("CtrlOrCmd+D"),
+          getShortcutKey(`Alt+${t("helpDialog.drag")}`),
+        ],
+      },
+      {
+        label: t("helpDialog.toggleElementLock"),
+        shortcuts: [getShortcutKey("CtrlOrCmd+Shift+L")],
+      },
+      {
+        label: t("buttons.undo"),
+        shortcuts: [getShortcutKey("CtrlOrCmd+Z")],
+      },
+      {
+        label: t("buttons.redo"),
+        shortcuts: isWindows
+          ? [getShortcutKey("CtrlOrCmd+Y"), getShortcutKey("CtrlOrCmd+Shift+Z")]
+          : [getShortcutKey("CtrlOrCmd+Shift+Z")],
+      },
+      {
+        label: t("labels.group"),
+        shortcuts: [getShortcutKey("CtrlOrCmd+G")],
+      },
+      {
+        label: t("labels.ungroup"),
+        shortcuts: [getShortcutKey("CtrlOrCmd+Shift+G")],
+      },
+      {
+        label: t("labels.flipHorizontal"),
+        shortcuts: [getShortcutKey("Shift+H")],
+      },
+      {
+        label: t("labels.flipVertical"),
+        shortcuts: [getShortcutKey("Shift+V")],
+      },
+      {
+        label: t("labels.showStroke"),
+        shortcuts: [getShortcutKey("S")],
+      },
+      {
+        label: t("labels.showBackground"),
+        shortcuts: [getShortcutKey("G")],
+      },
+      {
+        label: t("labels.showFonts"),
+        shortcuts: [getShortcutKey("Shift+F")],
+      },
+      {
+        label: t("labels.decreaseFontSize"),
+        shortcuts: [getShortcutKey("CtrlOrCmd+Shift+<")],
+      },
+      {
+        label: t("labels.increaseFontSize"),
+        shortcuts: [getShortcutKey("CtrlOrCmd+Shift+>")],
+      },
+    ],
+  },
+];
 
 const Header = () => (
   <div className="HelpDialog__header">
@@ -57,10 +374,20 @@ const Header = () => (
   </div>
 );
 
-const Section = (props: { title: string; children: React.ReactNode }) => (
+const Section = (props: {
+  title: string;
+  children: React.ReactNode;
+  isFiltering?: boolean;
+}) => (
   <>
     <h3>{props.title}</h3>
-    <div className="HelpDialog__islands-container">{props.children}</div>
+    <div
+      className={clsx("HelpDialog__islands-container", {
+        "HelpDialog__islands-container--filtered": props.isFiltering,
+      })}
+    >
+      {props.children}
+    </div>
   </>
 );
 
@@ -124,6 +451,38 @@ const ShortcutKey = (props: { children: React.ReactNode }) => (
 );
 
 export const HelpDialog = ({ onClose }: { onClose?: () => void }) => {
+  const [query, setQuery] = useState<string>("");
+
+  // Find the filtered shortcuts which match the query
+  const filteredShortcutSections = useMemo(() => {
+    const normalizedQuery = query.trim().toLowerCase();
+
+    if (!normalizedQuery) {
+      return shortcutSections;
+    }
+
+    return shortcutSections.map((shortcutSection) => {
+      const filteredItems = shortcutSection.items.filter((item) => {
+        return (
+          item.label.toLowerCase().includes(normalizedQuery) ||
+          item.shortcuts.find((shortcut) =>
+            shortcut.toLowerCase().includes(normalizedQuery),
+          )
+        );
+      });
+
+      return {
+        ...shortcutSection,
+        items: filteredItems,
+        active: filteredItems.length > 0,
+      };
+    });
+  }, [query]);
+
+  const hasResults = filteredShortcutSections.some(
+    (shortcutSection) => shortcutSection.active,
+  );
+
   const handleClose = React.useCallback(() => {
     if (onClose) {
       onClose();
@@ -138,375 +497,44 @@ export const HelpDialog = ({ onClose }: { onClose?: () => void }) => {
         className={"HelpDialog"}
       >
         <Header />
-        <Section title={t("helpDialog.shortcuts")}>
-          <ShortcutIsland
-            className="HelpDialog__island--tools"
-            caption={t("helpDialog.tools")}
-          >
-            <Shortcut label={t("toolBar.hand")} shortcuts={[KEYS.H]} />
-            <Shortcut
-              label={t("toolBar.selection")}
-              shortcuts={[KEYS.V, KEYS["1"]]}
-            />
-            <Shortcut
-              label={t("toolBar.rectangle")}
-              shortcuts={[KEYS.R, KEYS["2"]]}
-            />
-            <Shortcut
-              label={t("toolBar.diamond")}
-              shortcuts={[KEYS.D, KEYS["3"]]}
-            />
-            <Shortcut
-              label={t("toolBar.ellipse")}
-              shortcuts={[KEYS.O, KEYS["4"]]}
-            />
-            <Shortcut
-              label={t("toolBar.arrow")}
-              shortcuts={[KEYS.A, KEYS["5"]]}
-            />
-            <Shortcut
-              label={t("toolBar.line")}
-              shortcuts={[KEYS.L, KEYS["6"]]}
-            />
-            <Shortcut
-              label={t("toolBar.freedraw")}
-              shortcuts={[KEYS.P, KEYS["7"]]}
-            />
-            <Shortcut
-              label={t("toolBar.text")}
-              shortcuts={[KEYS.T, KEYS["8"]]}
-            />
-            <Shortcut label={t("toolBar.image")} shortcuts={[KEYS["9"]]} />
-            <Shortcut
-              label={t("toolBar.eraser")}
-              shortcuts={[KEYS.E, KEYS["0"]]}
-            />
-            <Shortcut label={t("toolBar.frame")} shortcuts={[KEYS.F]} />
-            <Shortcut label={t("toolBar.laser")} shortcuts={[KEYS.K]} />
-            <Shortcut
-              label={t("labels.eyeDropper")}
-              shortcuts={[KEYS.I, "Shift+S", "Shift+G"]}
-            />
-            <Shortcut
-              label={t("helpDialog.editLineArrowPoints")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+Enter")]}
-            />
-            <Shortcut
-              label={t("helpDialog.editText")}
-              shortcuts={[getShortcutKey("Enter")]}
-            />
-            <Shortcut
-              label={t("helpDialog.textNewLine")}
-              shortcuts={[
-                getShortcutKey("Enter"),
-                getShortcutKey("Shift+Enter"),
-              ]}
-            />
-            <Shortcut
-              label={t("helpDialog.textFinish")}
-              shortcuts={[
-                getShortcutKey("Esc"),
-                getShortcutKey("CtrlOrCmd+Enter"),
-              ]}
-            />
-            <Shortcut
-              label={t("helpDialog.curvedArrow")}
-              shortcuts={[
-                "A",
-                t("helpDialog.click"),
-                t("helpDialog.click"),
-                t("helpDialog.click"),
-              ]}
-              isOr={false}
-            />
-            <Shortcut
-              label={t("helpDialog.curvedLine")}
-              shortcuts={[
-                "L",
-                t("helpDialog.click"),
-                t("helpDialog.click"),
-                t("helpDialog.click"),
-              ]}
-              isOr={false}
-            />
-            <Shortcut
-              label={t("helpDialog.cropStart")}
-              shortcuts={[t("helpDialog.doubleClick"), getShortcutKey("Enter")]}
-              isOr={true}
-            />
-            <Shortcut
-              label={t("helpDialog.cropFinish")}
-              shortcuts={[getShortcutKey("Enter"), getShortcutKey("Escape")]}
-              isOr={true}
-            />
-            <Shortcut label={t("toolBar.lock")} shortcuts={[KEYS.Q]} />
-            <Shortcut
-              label={t("helpDialog.preventBinding")}
-              shortcuts={[getShortcutKey("CtrlOrCmd")]}
-            />
-            <Shortcut
-              label={t("toolBar.link")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+K")]}
-            />
-            <Shortcut
-              label={t("toolBar.convertElementType")}
-              shortcuts={["Tab", "Shift+Tab"]}
-              isOr={true}
-            />
-          </ShortcutIsland>
-          <ShortcutIsland
-            className="HelpDialog__island--view"
-            caption={t("helpDialog.view")}
-          >
-            <Shortcut
-              label={t("buttons.zoomIn")}
-              shortcuts={[getShortcutKey("CtrlOrCmd++")]}
-            />
-            <Shortcut
-              label={t("buttons.zoomOut")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+-")]}
-            />
-            <Shortcut
-              label={t("buttons.resetZoom")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+0")]}
-            />
-            <Shortcut
-              label={t("helpDialog.zoomToFit")}
-              shortcuts={["Shift+1"]}
-            />
-            <Shortcut
-              label={t("helpDialog.zoomToSelection")}
-              shortcuts={["Shift+2"]}
-            />
-            <Shortcut
-              label={t("helpDialog.movePageUpDown")}
-              shortcuts={["PgUp/PgDn"]}
-            />
-            <Shortcut
-              label={t("helpDialog.movePageLeftRight")}
-              shortcuts={["Shift+PgUp/PgDn"]}
-            />
-            <Shortcut
-              label={t("buttons.zenMode")}
-              shortcuts={[getShortcutKey("Alt+Z")]}
-            />
-            <Shortcut
-              label={t("buttons.objectsSnapMode")}
-              shortcuts={[getShortcutKey("Alt+S")]}
-            />
-            <Shortcut
-              label={t("labels.toggleGrid")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+'")]}
-            />
-            <Shortcut
-              label={t("labels.viewMode")}
-              shortcuts={[getShortcutKey("Alt+R")]}
-            />
-            <Shortcut
-              label={t("labels.toggleTheme")}
-              shortcuts={[getShortcutKey("Alt+Shift+D")]}
-            />
-            <Shortcut
-              label={t("stats.fullTitle")}
-              shortcuts={[getShortcutKey("Alt+/")]}
-            />
-            <Shortcut
-              label={t("search.title")}
-              shortcuts={[getShortcutFromShortcutName("searchMenu")]}
-            />
-            <Shortcut
-              label={t("commandPalette.title")}
-              shortcuts={
-                isFirefox
-                  ? [getShortcutFromShortcutName("commandPalette")]
-                  : [
-                      getShortcutFromShortcutName("commandPalette"),
-                      getShortcutFromShortcutName("commandPalette", 1),
-                    ]
-              }
-            />
-          </ShortcutIsland>
-          <ShortcutIsland
-            className="HelpDialog__island--editor"
-            caption={t("helpDialog.editor")}
-          >
-            <Shortcut
-              label={t("helpDialog.createFlowchart")}
-              shortcuts={[getShortcutKey(`CtrlOrCmd+Arrow Key`)]}
-              isOr={true}
-            />
-            <Shortcut
-              label={t("helpDialog.navigateFlowchart")}
-              shortcuts={[getShortcutKey(`Alt+Arrow Key`)]}
-              isOr={true}
-            />
-            <Shortcut
-              label={t("labels.moveCanvas")}
-              shortcuts={[
-                getShortcutKey(`Space+${t("helpDialog.drag")}`),
-                getShortcutKey(`Wheel+${t("helpDialog.drag")}`),
-              ]}
-              isOr={true}
-            />
-            <Shortcut
-              label={t("buttons.clearReset")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+Delete")]}
-            />
-            <Shortcut
-              label={t("labels.delete")}
-              shortcuts={[getShortcutKey("Delete")]}
-            />
-            <Shortcut
-              label={t("labels.cut")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+X")]}
-            />
-            <Shortcut
-              label={t("labels.copy")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+C")]}
-            />
-            <Shortcut
-              label={t("labels.paste")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+V")]}
-            />
-            <Shortcut
-              label={t("labels.pasteAsPlaintext")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+Shift+V")]}
-            />
-            <Shortcut
-              label={t("labels.selectAll")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+A")]}
-            />
-            <Shortcut
-              label={t("labels.multiSelect")}
-              shortcuts={[getShortcutKey(`Shift+${t("helpDialog.click")}`)]}
-            />
-            <Shortcut
-              label={t("helpDialog.deepSelect")}
-              shortcuts={[getShortcutKey(`CtrlOrCmd+${t("helpDialog.click")}`)]}
-            />
-            <Shortcut
-              label={t("helpDialog.deepBoxSelect")}
-              shortcuts={[getShortcutKey(`CtrlOrCmd+${t("helpDialog.drag")}`)]}
-            />
-            {/* firefox supports clipboard API under a flag, so we'll
-                show users what they can do in the error message */}
-            {(probablySupportsClipboardBlob || isFirefox) && (
-              <Shortcut
-                label={t("labels.copyAsPng")}
-                shortcuts={[getShortcutKey("Shift+Alt+C")]}
-              />
-            )}
-            <Shortcut
-              label={t("labels.copyStyles")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+Alt+C")]}
-            />
-            <Shortcut
-              label={t("labels.pasteStyles")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+Alt+V")]}
-            />
-            <Shortcut
-              label={t("labels.sendToBack")}
-              shortcuts={[
-                isDarwin
-                  ? getShortcutKey("CtrlOrCmd+Alt+[")
-                  : getShortcutKey("CtrlOrCmd+Shift+["),
-              ]}
-            />
-            <Shortcut
-              label={t("labels.bringToFront")}
-              shortcuts={[
-                isDarwin
-                  ? getShortcutKey("CtrlOrCmd+Alt+]")
-                  : getShortcutKey("CtrlOrCmd+Shift+]"),
-              ]}
-            />
-            <Shortcut
-              label={t("labels.sendBackward")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+[")]}
-            />
-            <Shortcut
-              label={t("labels.bringForward")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+]")]}
-            />
-            <Shortcut
-              label={t("labels.alignTop")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+Shift+Up")]}
-            />
-            <Shortcut
-              label={t("labels.alignBottom")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+Shift+Down")]}
-            />
-            <Shortcut
-              label={t("labels.alignLeft")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+Shift+Left")]}
-            />
-            <Shortcut
-              label={t("labels.alignRight")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+Shift+Right")]}
-            />
-            <Shortcut
-              label={t("labels.duplicateSelection")}
-              shortcuts={[
-                getShortcutKey("CtrlOrCmd+D"),
-                getShortcutKey(`Alt+${t("helpDialog.drag")}`),
-              ]}
-            />
-            <Shortcut
-              label={t("helpDialog.toggleElementLock")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+Shift+L")]}
-            />
-            <Shortcut
-              label={t("buttons.undo")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+Z")]}
-            />
-            <Shortcut
-              label={t("buttons.redo")}
-              shortcuts={
-                isWindows
-                  ? [
-                      getShortcutKey("CtrlOrCmd+Y"),
-                      getShortcutKey("CtrlOrCmd+Shift+Z"),
-                    ]
-                  : [getShortcutKey("CtrlOrCmd+Shift+Z")]
-              }
-            />
-            <Shortcut
-              label={t("labels.group")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+G")]}
-            />
-            <Shortcut
-              label={t("labels.ungroup")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+Shift+G")]}
-            />
-            <Shortcut
-              label={t("labels.flipHorizontal")}
-              shortcuts={[getShortcutKey("Shift+H")]}
-            />
-            <Shortcut
-              label={t("labels.flipVertical")}
-              shortcuts={[getShortcutKey("Shift+V")]}
-            />
-            <Shortcut
-              label={t("labels.showStroke")}
-              shortcuts={[getShortcutKey("S")]}
-            />
-            <Shortcut
-              label={t("labels.showBackground")}
-              shortcuts={[getShortcutKey("G")]}
-            />
-            <Shortcut
-              label={t("labels.showFonts")}
-              shortcuts={[getShortcutKey("Shift+F")]}
-            />
-            <Shortcut
-              label={t("labels.decreaseFontSize")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+Shift+<")]}
-            />
-            <Shortcut
-              label={t("labels.increaseFontSize")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+Shift+>")]}
-            />
-          </ShortcutIsland>
+        <input
+          placeholder="Search"
+          aria-label={t("search.title")}
+          onChange={(event) => {
+            setQuery(event.target.value);
+          }}
+          value={query}
+          className="HelpDialog__searchBar"
+        />
+        <Section
+          title={t("helpDialog.shortcuts")}
+          isFiltering={query.trim().length > 0}
+        >
+          {filteredShortcutSections.map((shortcutSection) => {
+            if (shortcutSection.active) {
+              return (
+                <ShortcutIsland
+                  key={shortcutSection.title}
+                  className={`${shortcutSection.className}`}
+                  caption={`${shortcutSection.title}`}
+                >
+                  {shortcutSection.items.map((item) => (
+                    <Shortcut
+                      key={`${item.label}-${item.shortcuts.join("-")}`}
+                      label={`${item.label}`}
+                      shortcuts={item.shortcuts}
+                      isOr={item.isOr}
+                    ></Shortcut>
+                  ))}
+                </ShortcutIsland>
+              );
+            } else {
+              return null;
+            }
+          })}
+          {!hasResults && (
+            <p className="HelpDialog__no-results">{t("search.noMatch")}</p>
+          )}
         </Section>
       </Dialog>
     </>


### PR DESCRIPTION
## Summary
- add a search input to filter Help dialog shortcut sections
- search across shortcut labels and displayed shortcut keys
- let filtered results flow naturally instead of keeping the fixed desktop layout

## Testing
- yarn test:typecheck
- git diff --check

Fixes #9276