### PR TITLE
fix: drop between frames bug

### DIFF
--- a/packages/element/src/frame.ts
+++ b/packages/element/src/frame.ts
@@ -569,7 +569,8 @@ export const addElementsToFrame = <T extends ElementsMapOrArray>(
       continue;
     }
 
-    if (element.frameId && element.frameId !== frame.id) {
+    // skip elements already in target frame
+    if (element.frameId && element.frameId === frame.id) {
       continue;
     }
 


### PR DESCRIPTION
This fixes moving an element from a frame into another, currently the frameID remains as the previous frame and so the element can no longer be clicked (due to clipped outside the bounds of the frame) etc 

Feel free to review the PR I opened because it seems like a logical fix but I dont have enough knowledge about the codebase.

You can read a full write-up here https://github.com/zsviczian/obsidian-excalidraw-plugin/issues/2799

Thanks a lot.
Best regards.