### PR TITLE
feat(editor): add whyp.it to embeddable URL whitelist

### DIFF
--- a/packages/element/src/embeddable.ts
+++ b/packages/element/src/embeddable.ts
@@ -147,6 +147,7 @@ const ALLOWED_DOMAINS = new Set([
   "giphy.com",
   "reddit.com",
   "forms.microsoft.com",
+  "whyp.it",
 ]);
 
 const ALLOW_SAME_ORIGIN = new Set([
@@ -162,6 +163,7 @@ const ALLOW_SAME_ORIGIN = new Set([
   "stackblitz.com",
   "reddit.com",
   "forms.microsoft.com",
+  "whyp.it",
 ]);
 
 export const createSrcDoc = (body: string) => {

--- a/packages/element/tests/embeddable.test.ts
+++ b/packages/element/tests/embeddable.test.ts
@@ -231,3 +231,11 @@ describe("Google Drive video embedding", () => {
     ).toBe(true);
   });
 });
+
+describe("whyp.it audio embedding", () => {
+  it("should validate whyp.it domain by default", () => {
+    expect(
+      embeddableURLValidator("https://whyp.it/tracks/293120/example", undefined),
+    ).toBe(true);
+  });
+});

--- a/packages/element/tests/embeddable.test.ts
+++ b/packages/element/tests/embeddable.test.ts
@@ -231,3 +231,14 @@ describe("Google Drive video embedding", () => {
     ).toBe(true);
   });
 });
+
+describe("whyp.it audio embedding", () => {
+  it("should validate whyp.it domain by default", () => {
+    expect(
+      embeddableURLValidator(
+        "https://whyp.it/tracks/293120/example",
+        undefined,
+      ),
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
whyp.it is an audio hosting platform for creative/professional collaboration. Adding it to the embed whitelist lets users embed playable audio snippets into Excalidraw documents.

Closes #11493