### PR TITLE
fix(packages/excalidraw): harvest coalesced pointer events for stylus input

### DIFF
--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -10366,24 +10366,55 @@ class App extends React.Component<AppProps, AppState> {
         }
 
         if (newElement.type === "freedraw") {
-          const points = newElement.points;
-          const dx = pointerCoords.x - newElement.x;
-          const dy = pointerCoords.y - newElement.y;
+          let currentPoints = newElement.points;
+          let currentPressures = newElement.pressures;
 
-          const lastPoint = points.length > 0 && points[points.length - 1];
-          const discardPoint =
-            lastPoint && lastPoint[0] === dx && lastPoint[1] === dy;
+          const addFreedrawPoint = (
+            coords: { x: number; y: number },
+            pressure: number,
+          ) => {
+            const dx = coords.x - newElement.x;
+            const dy = coords.y - newElement.y;
+            const lastPoint =
+              currentPoints.length > 0 &&
+              currentPoints[currentPoints.length - 1];
+            if (!(lastPoint && lastPoint[0] === dx && lastPoint[1] === dy)) {
+              currentPoints = [...currentPoints, pointFrom<LocalPoint>(dx, dy)];
+              if (!newElement.simulatePressure) {
+                currentPressures = [...currentPressures, pressure];
+              }
+              return true;
+            }
+            return false;
+          };
 
-          if (!discardPoint) {
-            const pressures = newElement.simulatePressure
-              ? newElement.pressures
-              : [...newElement.pressures, event.pressure];
+          const isStylus = event.pointerType === "pen";
+          const coalescedEvents =
+            isStylus && typeof event.getCoalescedEvents === "function"
+              ? event.getCoalescedEvents()
+              : null;
+          let pointsChanged = false;
 
+          if (coalescedEvents && coalescedEvents.length > 0) {
+            for (const ce of coalescedEvents) {
+              const cp = viewportCoordsToSceneCoords(ce, this.state);
+              if (addFreedrawPoint(cp, ce.pressure ?? 0.5)) {
+                pointsChanged = true;
+              }
+            }
+            if (addFreedrawPoint(pointerCoords, event.pressure ?? 0.5)) {
+              pointsChanged = true;
+            }
+          } else if (addFreedrawPoint(pointerCoords, event.pressure)) {
+            pointsChanged = true;
+          }
+
+          if (pointsChanged) {
             this.scene.mutateElement(
               newElement,
               {
-                points: [...points, pointFrom<LocalPoint>(dx, dy)],
-                pressures,
+                points: currentPoints,
+                pressures: currentPressures,
               },
               {
                 informMutation: false,


### PR DESCRIPTION
On iPadOS, WKWebView fires pointer events at 60 Hz, but Apple Pencil samples at 240 Hz. This means 3 out of 4 stylus positions are dropped between frames, causing visible stroke lag and reduced drawing fidelity.

This PR harvests coalesced pointer events via `PointerEvent.getCoalescedEvents()` in the freedraw pointer-move handler when `pointerType === "pen"`. Each coalesced event is transformed to scene coordinates and added as a point, recovering the missing high-frequency samples.

The change is minimal:
- The inline freedraw point logic is extracted into an `addFreedrawPoint()` helper to avoid code duplication when iterating coalesced events.
- When `pointerType === "pen"` and `getCoalescedEvents()` is available, all coalesced samples plus the current event are processed.
- Mouse and touch input (`pointerType !== "pen"`) are completely unaffected — the difference from a non-pen user's perspective is zero.
- The same fix benefits S Pen and other high-sample-rate stylus users on platforms that coalesce pointer events, not just Apple Pencil on iOS.

**One file changed:** `packages/excalidraw/components/App.tsx`, +47/-13 lines.