### PR TITLE
fix: allow round arrows inside start container

### DIFF
--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -7112,16 +7112,32 @@ class App extends React.Component<AppProps, AppState> {
       setCursorForShape(this.interactiveCanvas, this.state);
 
       if (lastPoint === lastCommittedPoint) {
+        const globalPoint = pointFrom<GlobalPoint>(
+          scenePointerX,
+          scenePointerY,
+        );
+        const elementsMap = this.scene.getNonDeletedElementsMap();
         const hoveredElement =
           isArrowElement(this.state.newElement) &&
           isBindingEnabled(this.state) &&
           getHoveredElementForBinding(
-            pointFrom<GlobalPoint>(scenePointerX, scenePointerY),
+            globalPoint,
             this.scene.getNonDeletedElements(),
-            this.scene.getNonDeletedElementsMap(),
+            elementsMap,
             maxBindingDistance_simple(this.state.zoom),
           );
-        if (hoveredElement) {
+        const isInsideStartBoundElement =
+          hoveredElement &&
+          isArrowElement(multiElement) &&
+          hoveredElement.id === multiElement.startBinding?.elementId &&
+          hitElementItself({
+            point: globalPoint,
+            element: hoveredElement,
+            threshold: 0,
+            elementsMap,
+            overrideShouldTestInside: true,
+          });
+        if (hoveredElement && !isInsideStartBoundElement) {
           this.actionManager.executeAction(actionFinalize, "ui", {
             event: event.nativeEvent,
             sceneCoords: {
@@ -9265,22 +9281,37 @@ class App extends React.Component<AppProps, AppState> {
       const { x: rx, y: ry } = multiElement;
       const { lastCommittedPoint } = selectedLinearElement;
 
+      const elementsMap = this.scene.getNonDeletedElementsMap();
+      const bindingPoint = pointFrom<GlobalPoint>(
+        this.lastPointerMoveCoords?.x ??
+          rx + multiElement.points[multiElement.points.length - 1][0],
+        this.lastPointerMoveCoords?.y ??
+          ry + multiElement.points[multiElement.points.length - 1][1],
+      );
       const hoveredElementForBinding =
         isBindingEnabled(this.state) &&
         getHoveredElementForBinding(
-          pointFrom<GlobalPoint>(
-            this.lastPointerMoveCoords?.x ??
-              rx + multiElement.points[multiElement.points.length - 1][0],
-            this.lastPointerMoveCoords?.y ??
-              ry + multiElement.points[multiElement.points.length - 1][1],
-          ),
+          bindingPoint,
           this.scene.getNonDeletedElements(),
-          this.scene.getNonDeletedElementsMap(),
+          elementsMap,
         );
+      const isInsideStartBoundElement =
+        hoveredElementForBinding &&
+        isArrowElement(multiElement) &&
+        hoveredElementForBinding.id === multiElement.startBinding?.elementId &&
+        hitElementItself({
+          point: bindingPoint,
+          element: hoveredElementForBinding,
+          threshold: 0,
+          elementsMap,
+          overrideShouldTestInside: true,
+        });
 
       // clicking inside commit zone → finalize arrow
       if (
-        (isBindingElement(multiElement) && hoveredElementForBinding) ||
+        (isBindingElement(multiElement) &&
+          hoveredElementForBinding &&
+          !isInsideStartBoundElement) ||
         (multiElement.points.length > 1 &&
           lastCommittedPoint &&
           pointDistance(

--- a/packages/excalidraw/tests/multiPointCreate.test.tsx
+++ b/packages/excalidraw/tests/multiPointCreate.test.tsx
@@ -3,7 +3,10 @@ import { vi } from "vitest";
 
 import { KEYS, reseed } from "@excalidraw/common";
 
-import type { ExcalidrawLinearElement } from "@excalidraw/element/types";
+import type {
+  ExcalidrawArrowElement,
+  ExcalidrawLinearElement,
+} from "@excalidraw/element/types";
 
 import { Excalidraw } from "../index";
 
@@ -17,6 +20,7 @@ import {
   restoreOriginalGetBoundingClientRect,
   unmountComponent,
 } from "./test-utils";
+import { API } from "./helpers/api";
 
 unmountComponent();
 
@@ -92,6 +96,85 @@ describe("remove shape in non linear elements", () => {
 });
 
 describe("multi point mode in linear elements", () => {
+  it("round arrow can add an intermediate point inside its start rectangle", async () => {
+    const { getByToolName, container } = await render(<Excalidraw />);
+    API.setElements([
+      API.createElement({
+        type: "rectangle",
+        id: "startRect",
+        x: 100,
+        y: 100,
+        width: 300,
+        height: 200,
+      }),
+    ]);
+
+    fireEvent.click(getByToolName("arrow"));
+
+    const canvas = container.querySelector("canvas.interactive")!;
+    fireEvent.pointerDown(canvas, { clientX: 150, clientY: 150 });
+    fireEvent.pointerUp(canvas, { clientX: 150, clientY: 150 });
+
+    fireEvent.pointerMove(canvas, { clientX: 220, clientY: 180 });
+    fireEvent.pointerDown(canvas, { clientX: 220, clientY: 180 });
+    fireEvent.pointerUp(canvas, { clientX: 220, clientY: 180 });
+    fireEvent.pointerMove(canvas, { clientX: 300, clientY: 250 });
+
+    fireEvent.pointerDown(canvas, { clientX: 300, clientY: 250 });
+    fireEvent.pointerUp(canvas, { clientX: 300, clientY: 250 });
+    fireEvent.keyDown(document, {
+      key: KEYS.ENTER,
+    });
+
+    const element = h.elements.find(
+      (element): element is ExcalidrawLinearElement => element.type === "arrow",
+    );
+
+    expect(element).toBeDefined();
+    expect(element!.roundness).not.toBeNull();
+    expect(element!.points).toEqual([
+      [0, 0],
+      [70, 30],
+      [150, 100],
+    ]);
+  });
+
+  it("arrow still auto-finalizes when reaching a different rectangle", async () => {
+    const { getByToolName, container } = await render(<Excalidraw />);
+    API.setElements([
+      API.createElement({
+        type: "rectangle",
+        id: "startRect",
+        x: 100,
+        y: 100,
+        width: 100,
+        height: 100,
+      }),
+      API.createElement({
+        type: "rectangle",
+        id: "endRect",
+        x: 300,
+        y: 100,
+        width: 100,
+        height: 100,
+      }),
+    ]);
+
+    fireEvent.click(getByToolName("arrow"));
+
+    const canvas = container.querySelector("canvas.interactive")!;
+    fireEvent.pointerDown(canvas, { clientX: 150, clientY: 150 });
+    fireEvent.pointerUp(canvas, { clientX: 150, clientY: 150 });
+    fireEvent.pointerMove(canvas, { clientX: 350, clientY: 150 });
+
+    const element = h.elements.find(
+      (element): element is ExcalidrawArrowElement => element.type === "arrow",
+    );
+
+    expect(element).toBeDefined();
+    expect(element!.endBinding?.elementId).toBe("endRect");
+  });
+
   it("arrow", async () => {
     const { getByToolName, container } = await render(<Excalidraw />);
     // select tool


### PR DESCRIPTION
Fixes https://github.com/excalidraw/excalidraw/issues/10661

## Summary
- avoid prematurely auto-finalizing a multi-point arrow when the hovered bindable element is the arrow's own start container and the pointer is still inside it
- preserve auto-finalization/binding when the arrow reaches a different target shape
- add regression coverage for creating a round arrow with an intermediate point inside its start rectangle

## Validation
- yarn test:app packages/excalidraw/tests/multiPointCreate.test.tsx --watch=false
- yarn test:app packages/excalidraw/tests/arrowBinding.test.tsx --watch=false
- yarn test:typecheck
- ./node_modules/.bin/prettier --check packages/excalidraw/components/App.tsx packages/excalidraw/tests/multiPointCreate.test.tsx
- yarn eslint --max-warnings=0 packages/excalidraw/components/App.tsx packages/excalidraw/tests/multiPointCreate.test.tsx
