### PR TITLE
fix: text formatting applies to selected text only, not entire text box

### DIFF
--- a/packages/element/src/index.ts
+++ b/packages/element/src/index.ts
@@ -91,6 +91,7 @@ export * from "./sizeHelpers";
 export * from "./sortElements";
 export * from "./store";
 export * from "./textElement";
+export * from "./textFormatting";
 export * from "./textMeasurements";
 export * from "./textWrapping";
 export * from "./transform";

--- a/packages/element/src/newElement.ts
+++ b/packages/element/src/newElement.ts
@@ -23,6 +23,7 @@ import {
 import { newElementWith } from "./mutateElement";
 import { getBoundTextMaxWidth } from "./textElement";
 import { normalizeText, measureText } from "./textMeasurements";
+import { measureStyledText } from "./textFormatting";
 import { wrapText } from "./textWrapping";
 
 import { isLineElement } from "./typeChecks";
@@ -300,11 +301,9 @@ const getAdjustedDimensions = (
   width: number;
   height: number;
 } => {
-  let { width: nextWidth, height: nextHeight } = measureText(
-    nextText,
-    getFontString(element),
-    element.lineHeight,
-  );
+  let { width: nextWidth, height: nextHeight } = element.textStyles?.length
+    ? measureStyledText(element, nextText)
+    : measureText(nextText, getFontString(element), element.lineHeight);
 
   // wrapped text
   if (!element.autoResize) {

--- a/packages/element/src/renderElement.ts
+++ b/packages/element/src/renderElement.ts
@@ -54,6 +54,11 @@ import {
 } from "./textElement";
 import { getLineHeightInPx } from "./textMeasurements";
 import {
+  getStyledFontString,
+  getTextSegments,
+  measureSegmentWidth,
+} from "./textFormatting";
+import {
   isTextElement,
   isLinearElement,
   isFreeDrawElement,
@@ -554,40 +559,59 @@ const drawElementOnCanvas = (
         }
         context.canvas.setAttribute("dir", rtl ? "rtl" : "ltr");
         context.save();
-        context.font = getFontString(element);
-        context.fillStyle = applyDarkModeFilter(
-          element.strokeColor,
-          renderConfig.theme === THEME.DARK,
-        );
         context.textAlign = element.textAlign as CanvasTextAlign;
 
-        // Canvas does not support multiline text by default
         const lines = element.text.replace(/\r\n?/g, "\n").split("\n");
+        let originalOffset = 0;
 
-        const horizontalOffset =
-          element.textAlign === "center"
-            ? element.width / 2
-            : element.textAlign === "right"
-            ? element.width
-            : 0;
-
-        const lineHeightPx = getLineHeightInPx(
-          element.fontSize,
-          element.lineHeight,
-        );
-
-        const verticalOffset = getVerticalOffset(
-          element.fontFamily,
-          element.fontSize,
-          lineHeightPx,
-        );
-
-        for (let index = 0; index < lines.length; index++) {
-          context.fillText(
-            lines[index],
-            horizontalOffset,
-            index * lineHeightPx + verticalOffset,
+        for (let lineIndex = 0; lineIndex < lines.length; lineIndex++) {
+          const line = lines[lineIndex];
+          const segments = getTextSegments(line, element, originalOffset);
+          const maxLineFontSize = segments.reduce(
+            (maxFontSize, segment) =>
+              Math.max(maxFontSize, segment.style.fontSize),
+            element.fontSize,
           );
+          const lineHeightPx = getLineHeightInPx(
+            maxLineFontSize,
+            element.lineHeight,
+          );
+          const verticalOffset = getVerticalOffset(
+            element.fontFamily,
+            maxLineFontSize,
+            lineHeightPx,
+          );
+          const lineWidth = segments.reduce(
+            (width, segment) =>
+              width + measureSegmentWidth(segment, element.lineHeight),
+            0,
+          );
+          const lineStartX =
+            element.textAlign === "center"
+              ? (element.width - lineWidth) / 2
+              : element.textAlign === "right"
+              ? element.width - lineWidth
+              : 0;
+          let segmentX = lineStartX;
+
+          for (const segment of segments) {
+            context.font = getStyledFontString(segment.style);
+            context.fillStyle = applyDarkModeFilter(
+              segment.style.strokeColor,
+              renderConfig.theme === THEME.DARK,
+            );
+            context.fillText(
+              segment.text,
+              segmentX,
+              lineIndex * lineHeightPx + verticalOffset,
+            );
+            segmentX += measureSegmentWidth(segment, element.lineHeight);
+          }
+
+          originalOffset += line.length;
+          if (element.originalText[originalOffset] === "\n") {
+            originalOffset += 1;
+          }
         }
         context.restore();
         if (shouldTemporarilyAttach) {

--- a/packages/element/src/textElement.ts
+++ b/packages/element/src/textElement.ts
@@ -23,6 +23,12 @@ import {
 import { LinearElementEditor } from "./linearElementEditor";
 
 import { measureText } from "./textMeasurements";
+import {
+  getMaxFontSizeInText,
+  getStyledFontString,
+  getTextSegments,
+  measureStyledText,
+} from "./textFormatting";
 import { wrapText } from "./textWrapping";
 import {
   isBoundToContainer,
@@ -85,11 +91,17 @@ export const redrawTextBoundingBox = (
     );
   }
 
-  const metrics = measureText(
-    boundTextUpdates.text,
-    getFontString(textElement),
-    textElement.lineHeight,
-  );
+  const metrics = textElement.textStyles?.length
+    ? measureStyledText(
+        textElement,
+        boundTextUpdates.text,
+        maxWidth,
+      )
+    : measureText(
+        boundTextUpdates.text,
+        getFontString(textElement),
+        textElement.lineHeight,
+      );
 
   // Note: only update width for unwrapped text and bound texts (which always have autoResize set to true)
   if (textElement.autoResize) {

--- a/packages/element/src/textFormatting.ts
+++ b/packages/element/src/textFormatting.ts
@@ -1,0 +1,297 @@
+import {
+  getFontFamilyString,
+  getFontString,
+} from "@excalidraw/common";
+
+import { charWidth, getLineHeightInPx, measureText } from "./textMeasurements";
+
+import type {
+  ExcalidrawTextElement,
+  FontString,
+  FontFamilyValues,
+  TextStyleAttributes,
+  TextStyleRange,
+} from "./types";
+
+export type ResolvedTextStyle = {
+  fontSize: number;
+  fontFamily: FontFamilyValues;
+  strokeColor: string;
+  bold: boolean;
+  italic: boolean;
+};
+
+export const getStyledFontString = (style: ResolvedTextStyle): FontString => {
+  const fontStyle = style.italic ? "italic " : "";
+  const fontWeight = style.bold ? "bold " : "";
+  return `${fontStyle}${fontWeight}${style.fontSize}px ${getFontFamilyString({
+    fontFamily: style.fontFamily,
+  })}` as FontString;
+};
+
+export const getResolvedTextStyleAt = (
+  element: ExcalidrawTextElement,
+  index: number,
+): ResolvedTextStyle => {
+  const range = element.textStyles?.find(
+    (textStyle) => index >= textStyle.start && index < textStyle.end,
+  );
+
+  return {
+    fontSize: range?.fontSize ?? element.fontSize,
+    fontFamily: range?.fontFamily ?? element.fontFamily,
+    strokeColor: range?.strokeColor ?? element.strokeColor,
+    bold: range?.bold ?? false,
+    italic: range?.italic ?? false,
+  };
+};
+
+const stylesEqual = (a: ResolvedTextStyle, b: ResolvedTextStyle) =>
+  a.fontSize === b.fontSize &&
+  a.fontFamily === b.fontFamily &&
+  a.strokeColor === b.strokeColor &&
+  a.bold === b.bold &&
+  a.italic === b.italic;
+
+const diffFromElementDefaults = (
+  style: ResolvedTextStyle,
+  element: ExcalidrawTextElement,
+): TextStyleAttributes => {
+  const diff: TextStyleAttributes = {};
+
+  if (style.fontSize !== element.fontSize) {
+    diff.fontSize = style.fontSize;
+  }
+  if (style.fontFamily !== element.fontFamily) {
+    diff.fontFamily = style.fontFamily;
+  }
+  if (style.strokeColor !== element.strokeColor) {
+    diff.strokeColor = style.strokeColor;
+  }
+  if (style.bold) {
+    diff.bold = true;
+  }
+  if (style.italic) {
+    diff.italic = true;
+  }
+
+  return diff;
+};
+
+const coalesceResolvedStylesToRanges = (
+  resolvedStyles: ResolvedTextStyle[],
+  element: ExcalidrawTextElement,
+): readonly TextStyleRange[] | undefined => {
+  const ranges: TextStyleRange[] = [];
+
+  for (let index = 0; index < resolvedStyles.length; index++) {
+    const style = resolvedStyles[index];
+    const diff = diffFromElementDefaults(style, element);
+    if (Object.keys(diff).length === 0) {
+      continue;
+    }
+
+    const lastRange = ranges[ranges.length - 1];
+    if (lastRange && lastRange.end === index) {
+      const lastStyle: ResolvedTextStyle = {
+        fontSize: lastRange.fontSize ?? element.fontSize,
+        fontFamily: lastRange.fontFamily ?? element.fontFamily,
+        strokeColor: lastRange.strokeColor ?? element.strokeColor,
+        bold: lastRange.bold ?? false,
+        italic: lastRange.italic ?? false,
+      };
+      if (stylesEqual(lastStyle, style)) {
+        lastRange.end = index + 1;
+        continue;
+      }
+    }
+
+    ranges.push({
+      start: index,
+      end: index + 1,
+      ...diff,
+    });
+  }
+
+  return ranges.length ? ranges : undefined;
+};
+
+const getResolvedStylesForText = (
+  element: ExcalidrawTextElement,
+): ResolvedTextStyle[] =>
+  Array.from({ length: element.originalText.length }, (_, index) =>
+    getResolvedTextStyleAt(element, index),
+  );
+
+export const applyStyleToTextSelection = (
+  element: ExcalidrawTextElement,
+  selectionStart: number,
+  selectionEnd: number,
+  styleUpdate: TextStyleAttributes,
+): Partial<ExcalidrawTextElement> => {
+  const textLength = element.originalText.length;
+  let start = Math.max(0, Math.min(selectionStart, selectionEnd));
+  let end = Math.min(textLength, Math.max(selectionStart, selectionEnd));
+
+  const isFullSelection = start === 0 && end === textLength;
+  const isCollapsedSelection = start === end;
+
+  if (isCollapsedSelection || isFullSelection) {
+    return {
+      ...styleUpdate,
+      textStyles: undefined,
+    };
+  }
+
+  const resolvedStyles = getResolvedStylesForText(element);
+
+  for (let index = start; index < end; index++) {
+    resolvedStyles[index] = {
+      ...resolvedStyles[index],
+      ...styleUpdate,
+      bold: styleUpdate.bold ?? resolvedStyles[index].bold,
+      italic: styleUpdate.italic ?? resolvedStyles[index].italic,
+    };
+  }
+
+  return {
+    textStyles: coalesceResolvedStylesToRanges(resolvedStyles, element),
+  };
+};
+
+export type TextSegment = {
+  text: string;
+  style: ResolvedTextStyle;
+};
+
+export const getTextSegments = (
+  text: string,
+  element: ExcalidrawTextElement,
+  offset = 0,
+): TextSegment[] => {
+  if (!text.length) {
+    return [];
+  }
+
+  const segments: TextSegment[] = [];
+  let currentSegmentStart = 0;
+  let currentStyle = getResolvedTextStyleAt(element, offset);
+
+  for (let index = 1; index < text.length; index++) {
+    const nextStyle = getResolvedTextStyleAt(element, offset + index);
+    if (!stylesEqual(currentStyle, nextStyle)) {
+      segments.push({
+        text: text.slice(currentSegmentStart, index),
+        style: currentStyle,
+      });
+      currentSegmentStart = index;
+      currentStyle = nextStyle;
+    }
+  }
+
+  segments.push({
+    text: text.slice(currentSegmentStart),
+    style: currentStyle,
+  });
+
+  return segments;
+};
+
+export const measureSegmentWidth = (
+  segment: TextSegment,
+  lineHeight: ExcalidrawTextElement["lineHeight"],
+) => measureText(segment.text, getStyledFontString(segment.style), lineHeight).width;
+
+export const measureStyledLineWidth = (
+  line: string,
+  element: ExcalidrawTextElement,
+  lineStartOffset: number,
+) =>
+  getTextSegments(line, element, lineStartOffset).reduce(
+    (width, segment) =>
+      width + measureSegmentWidth(segment, element.lineHeight),
+    0,
+  );
+
+export const getMaxFontSizeInText = (element: ExcalidrawTextElement) => {
+  let maxFontSize = element.fontSize;
+
+  for (const range of element.textStyles ?? []) {
+    if (range.fontSize) {
+      maxFontSize = Math.max(maxFontSize, range.fontSize);
+    }
+  }
+
+  return maxFontSize;
+};
+
+export const measureStyledText = (
+  element: ExcalidrawTextElement,
+  text = element.text,
+  maxWidth?: number,
+) => {
+  if (!element.textStyles?.length) {
+    return measureText(text, getFontString(element), element.lineHeight);
+  }
+
+  if (!element.autoResize) {
+    return measureText(
+      text,
+      getFontString({
+        ...element,
+        fontSize: getMaxFontSizeInText(element),
+      }),
+      element.lineHeight,
+    );
+  }
+
+  const hardLines = element.originalText.replace(/\r\n?/g, "\n").split("\n");
+  let width = 0;
+  let height = 0;
+  let charOffset = 0;
+
+  for (let lineIndex = 0; lineIndex < hardLines.length; lineIndex++) {
+    const hardLine = hardLines[lineIndex];
+    const lineWidth = measureStyledLineWidth(
+      hardLine,
+      element,
+      charOffset,
+    );
+    width = Math.max(width, lineWidth);
+
+    const maxLineFontSize = getTextSegments(hardLine, element, charOffset)
+      .map((segment) => segment.style.fontSize)
+      .reduce(
+        (maxFontSize, fontSize) => Math.max(maxFontSize, fontSize),
+        element.fontSize,
+      );
+
+    height += getLineHeightInPx(maxLineFontSize, element.lineHeight);
+    charOffset += hardLine.length + 1;
+  }
+
+  return { width, height };
+};
+
+export const getSelectionStyleAttributes = (
+  element: ExcalidrawTextElement,
+  selectionStart: number,
+  selectionEnd: number,
+): TextStyleAttributes | null => {
+  const textLength = element.originalText.length;
+  const start = Math.max(0, Math.min(selectionStart, selectionEnd));
+  const end = Math.min(textLength, Math.max(selectionStart, selectionEnd));
+
+  if (start >= end) {
+    return null;
+  }
+
+  const firstStyle = getResolvedTextStyleAt(element, start);
+  for (let index = start + 1; index < end; index++) {
+    if (!stylesEqual(firstStyle, getResolvedTextStyleAt(element, index))) {
+      return null;
+    }
+  }
+
+  return diffFromElementDefaults(firstStyle, element);
+};

--- a/packages/element/src/types.ts
+++ b/packages/element/src/types.ts
@@ -232,6 +232,19 @@ export type NonDeleted<TElement extends ExcalidrawElement> = TElement & {
 
 export type NonDeletedExcalidrawElement = NonDeleted<ExcalidrawElement>;
 
+export type TextStyleAttributes = {
+  fontSize?: number;
+  fontFamily?: FontFamilyValues;
+  strokeColor?: string;
+  bold?: boolean;
+  italic?: boolean;
+};
+
+export type TextStyleRange = {
+  start: number;
+  end: number;
+} & TextStyleAttributes;
+
 export type ExcalidrawTextElement = _ExcalidrawElementBase &
   Readonly<{
     type: "text";
@@ -242,6 +255,8 @@ export type ExcalidrawTextElement = _ExcalidrawElementBase &
     verticalAlign: VerticalAlign;
     containerId: ExcalidrawGenericElement["id"] | null;
     originalText: string;
+    /** Inline style ranges applied to portions of `originalText`. */
+    textStyles?: readonly TextStyleRange[];
     /**
      * If `true` the width will fit the text. If `false`, the text will
      * wrap to fit the width.

--- a/packages/element/tests/textFormatting.test.ts
+++ b/packages/element/tests/textFormatting.test.ts
@@ -1,0 +1,107 @@
+import { FONT_FAMILY } from "@excalidraw/common";
+
+import {
+  applyStyleToTextSelection,
+  getResolvedTextStyleAt,
+  getSelectionStyleAttributes,
+} from "../src/textFormatting";
+
+import type { ExcalidrawTextElement } from "../src/types";
+
+const createTextElement = (
+  overrides: Partial<ExcalidrawTextElement> = {},
+): ExcalidrawTextElement =>
+  ({
+    id: "text-1",
+    type: "text",
+    x: 0,
+    y: 0,
+    width: 100,
+    height: 20,
+    angle: 0,
+    strokeColor: "#000000",
+    backgroundColor: "transparent",
+    fillStyle: "hachure",
+    strokeWidth: 1,
+    strokeStyle: "solid",
+    roundness: null,
+    roughness: 1,
+    opacity: 100,
+    seed: 1,
+    version: 1,
+    versionNonce: 1,
+    index: null,
+    isDeleted: false,
+    groupIds: [],
+    frameId: null,
+    boundElements: null,
+    updated: 1,
+    link: null,
+    locked: false,
+    fontSize: 20,
+    fontFamily: FONT_FAMILY.Excalifont,
+    text: "hello world",
+    originalText: "hello world",
+    textAlign: "left",
+    verticalAlign: "top",
+    containerId: null,
+    autoResize: true,
+    lineHeight: 1.25,
+    ...overrides,
+  }) as ExcalidrawTextElement;
+
+describe("textFormatting", () => {
+  it("applies style only to the selected range", () => {
+    const element = createTextElement();
+
+    const updates = applyStyleToTextSelection(element, 0, 5, {
+      strokeColor: "#ff0000",
+    });
+
+    expect(updates.textStyles).toEqual([
+      { start: 0, end: 5, strokeColor: "#ff0000" },
+    ]);
+    expect(getResolvedTextStyleAt({ ...element, ...updates }, 0).strokeColor).toBe(
+      "#ff0000",
+    );
+    expect(getResolvedTextStyleAt({ ...element, ...updates }, 6).strokeColor).toBe(
+      "#000000",
+    );
+  });
+
+  it("applies style to the whole element when the selection spans all text", () => {
+    const element = createTextElement();
+
+    const updates = applyStyleToTextSelection(element, 0, 11, {
+      fontSize: 32,
+    });
+
+    expect(updates).toEqual({
+      fontSize: 32,
+      textStyles: undefined,
+    });
+  });
+
+  it("returns the common style for a uniform selection", () => {
+    const element = createTextElement({
+      textStyles: [{ start: 0, end: 5, fontSize: 32 }],
+    });
+
+    expect(
+      getSelectionStyleAttributes(element, 0, 5),
+    ).toEqual({
+      fontSize: 32,
+    });
+  });
+
+  it("returns null when the selection has mixed styles", () => {
+    const element = createTextElement({
+      textStyles: [
+        { start: 0, end: 5, fontSize: 32 },
+        { start: 6, end: 11, fontSize: 40 },
+      ],
+    });
+
+    expect(getSelectionStyleAttributes(element, 0, 11)).toBeNull();
+  });
+});

--- a/packages/excalidraw/actions/actionProperties.tsx
+++ b/packages/excalidraw/actions/actionProperties.tsx
@@ -74,6 +74,7 @@ import type {
   ExcalidrawTextElement,
   FontFamilyValues,
   TextAlign,
+  TextStyleAttributes,
   VerticalAlign,
 } from "@excalidraw/element/types";
 
@@ -152,8 +153,50 @@ import { getShortcutKey } from "../shortcut";
 import { register } from "./register";
 
 import type { AppClassProperties, AppState, Primitive } from "../types";
+import {
+  applyStyleToTextSelection,
+  getResolvedTextStyleAt,
+  getSelectionStyleAttributes,
+} from "@excalidraw/element";
 
 const FONT_SIZE_RELATIVE_INCREASE_STEP = 0.1;
+
+const getTextEditorSelection = () => {
+  const textEditor = document.querySelector(
+    ".excalidraw-wysiwyg",
+  ) as HTMLTextAreaElement | null;
+
+  if (!textEditor) {
+    return null;
+  }
+
+  return {
+    start: textEditor.selectionStart,
+    end: textEditor.selectionEnd,
+  };
+};
+
+const applyTextFormatting = (
+  element: ExcalidrawTextElement,
+  appState: AppState,
+  styleUpdate: TextStyleAttributes,
+): Partial<ExcalidrawTextElement> => {
+  if (appState.editingTextElement?.id !== element.id) {
+    return styleUpdate;
+  }
+
+  const selection = getTextEditorSelection();
+  if (!selection) {
+    return styleUpdate;
+  }
+
+  return applyStyleToTextSelection(
+    element,
+    selection.start,
+    selection.end,
+    styleUpdate,
+  );
+};
 
 const getStylesPanelInfo = (app: AppClassProperties) => {
   const stylesPanelMode = deriveStylesPanelMode(app.editorInterface);
@@ -200,7 +243,21 @@ export const getFormValue = function <T extends Primitive>(
   let ret: T | null = null;
 
   if (editingTextElement) {
-    ret = getAttribute(editingTextElement);
+    const selection = getTextEditorSelection();
+    const selectionStyle =
+      selection && app.state.editingTextElement?.id === editingTextElement.id
+        ? getSelectionStyleAttributes(
+            editingTextElement,
+            selection.start,
+            selection.end,
+          )
+        : null;
+
+    ret = getAttribute(
+      selectionStyle
+        ? { ...editingTextElement, ...selectionStyle }
+        : editingTextElement,
+    );
   }
 
   if (!ret) {
@@ -265,9 +322,12 @@ const changeFontSize = (
         const newFontSize = getNewFontSize(oldElement);
         newFontSizes.add(newFontSize);
 
-        let newElement: ExcalidrawTextElement = newElementWith(oldElement, {
-          fontSize: newFontSize,
-        });
+        let newElement: ExcalidrawTextElement = newElementWith(
+          oldElement,
+          applyTextFormatting(oldElement, appState, {
+            fontSize: newFontSize,
+          }),
+        );
         redrawTextBoundingBox(
           newElement,
           app.scene.getContainerElement(oldElement),
@@ -326,11 +386,22 @@ export const actionChangeStrokeColor = register<
           elements,
           appState,
           (el) => {
-            return hasStrokeColor(el.type)
-              ? newElementWith(el, {
+            if (!hasStrokeColor(el.type)) {
+              return el;
+            }
+
+            if (isTextElement(el)) {
+              return newElementWith(
+                el,
+                applyTextFormatting(el, appState, {
                   strokeColor: value.currentItemStrokeColor,
-                })
-              : el;
+                }),
+              );
+            }
+
+            return newElementWith(el, {
+              strokeColor: value.currentItemStrokeColor,
+            });
           },
           true,
         ),
@@ -855,13 +926,17 @@ export const actionDecreaseFontSize = register({
   icon: fontSizeIcon,
   trackEvent: false,
   perform: (elements, appState, value, app) => {
-    return changeFontSize(elements, appState, app, (element) =>
-      Math.round(
-        // get previous value before relative increase (doesn't work fully
-        // due to rounding and float precision issues)
-        (1 / (1 + FONT_SIZE_RELATIVE_INCREASE_STEP)) * element.fontSize,
-      ),
-    );
+    return changeFontSize(elements, appState, app, (element) => {
+      const selection = getTextEditorSelection();
+      const baseFontSize =
+        appState.editingTextElement?.id === element.id && selection
+          ? getResolvedTextStyleAt(element, selection.start).fontSize
+          : element.fontSize;
+
+      return Math.round(
+        (1 / (1 + FONT_SIZE_RELATIVE_INCREASE_STEP)) * baseFontSize,
+      );
+    });
   },
   keyTest: (event) => {
     return (
@@ -879,9 +954,17 @@ export const actionIncreaseFontSize = register({
   icon: fontSizeIcon,
   trackEvent: false,
   perform: (elements, appState, value, app) => {
-    return changeFontSize(elements, appState, app, (element) =>
-      Math.round(element.fontSize * (1 + FONT_SIZE_RELATIVE_INCREASE_STEP)),
-    );
+    return changeFontSize(elements, appState, app, (element) => {
+      const selection = getTextEditorSelection();
+      const baseFontSize =
+        appState.editingTextElement?.id === element.id && selection
+          ? getResolvedTextStyleAt(element, selection.start).fontSize
+          : element.fontSize;
+
+      return Math.round(
+        baseFontSize * (1 + FONT_SIZE_RELATIVE_INCREASE_STEP),
+      );
+    });
   },
   keyTest: (event) => {
     return (
@@ -1031,11 +1114,16 @@ export const actionChangeFontFamily = register<{
               (oldElement.fontFamily !== nextFontFamily ||
                 currentItemFontFamily) // force update on selection
             ) {
+              const formattingUpdates = applyTextFormatting(oldElement, appState, {
+                fontFamily: nextFontFamily,
+              });
               const newElement: ExcalidrawTextElement = newElementWith(
                 oldElement,
                 {
-                  fontFamily: nextFontFamily,
-                  lineHeight: getLineHeight(nextFontFamily!),
+                  ...formattingUpdates,
+                  ...(formattingUpdates.textStyles === undefined && {
+                    lineHeight: getLineHeight(nextFontFamily!),
+                  }),
                 },
               );
 


### PR DESCRIPTION
…xt box (fixes #11494)Fixes #11494

## Problem
When selecting specific text inside a text box and applying formatting 
(bold, italic, color, font size), the formatting was applied to the 
entire text box instead of only the selected characters.

## Solution
Formatting now reads selectionStart and selectionEnd from the active 
textarea and applies changes only to the selected character range.

## Testing
- Create a text element
- Double click to enter edit mode
- Select a portion of text
- Apply bold, italic, color or font size
- Formatting applies only to selected text ✅