### PR TITLE
fix(editor): z-order shortcuts conflict with Alt modifier on macOS

### DIFF
--- a/packages/excalidraw/actions/actionZindex.test.tsx
+++ b/packages/excalidraw/actions/actionZindex.test.tsx
@@ -1,0 +1,67 @@
+import React from "react";
+
+import { CODES } from "@excalidraw/common";
+
+import { Excalidraw } from "../index";
+import { API } from "../tests/helpers/api";
+import { Keyboard } from "../tests/helpers/ui";
+import { render } from "../tests/test-utils";
+
+const { h } = window;
+
+describe("z-index shortcuts", () => {
+  beforeEach(async () => {
+    await render(
+      <Excalidraw
+        handleKeyboardGlobally={true}
+        initialData={{
+          elements: [
+            API.createElement({ id: "A", x: 0, y: 0, width: 100, height: 100 }),
+            API.createElement({ id: "B", x: 0, y: 0, width: 100, height: 100 }),
+          ],
+        }}
+      />,
+    );
+    // select the topmost element ("B")
+    API.setSelectedElements([h.elements[1]]);
+  });
+
+  const ids = () => h.elements.map((el) => el.id);
+
+  it("CtrlOrCmd+[ sends the selected element backward", () => {
+    expect(ids()).toEqual(["A", "B"]);
+
+    Keyboard.withModifierKeys({ ctrl: true }, () => {
+      Keyboard.codePress(CODES.BRACKET_LEFT);
+    });
+
+    expect(ids()).toEqual(["B", "A"]);
+  });
+
+  // regression: on macOS, "send to back" is CtrlOrCmd+Alt+[. The Alt
+  // modifier must NOT also trigger `sendBackward`, otherwise two actions
+  // match the same shortcut and the action manager cancels both.
+  it("CtrlOrCmd+Alt+[ does not trigger sendBackward", () => {
+    expect(ids()).toEqual(["A", "B"]);
+
+    Keyboard.withModifierKeys({ ctrl: true, alt: true }, () => {
+      Keyboard.codePress(CODES.BRACKET_LEFT);
+    });
+
+    // sendBackward must not have run; order is unchanged
+    expect(ids()).toEqual(["A", "B"]);
+  });
+
+  it("CtrlOrCmd+Alt+] does not trigger bringForward", () => {
+    // select the bottommost element ("A")
+    API.setSelectedElements([h.elements[0]]);
+    expect(ids()).toEqual(["A", "B"]);
+
+    Keyboard.withModifierKeys({ ctrl: true, alt: true }, () => {
+      Keyboard.codePress(CODES.BRACKET_RIGHT);
+    });
+
+    // bringForward must not have run; order is unchanged
+    expect(ids()).toEqual(["A", "B"]);
+  });
+});

--- a/packages/excalidraw/actions/actionZindex.tsx
+++ b/packages/excalidraw/actions/actionZindex.tsx
@@ -37,6 +37,7 @@ export const actionSendBackward = register({
   keyTest: (event) =>
     event[KEYS.CTRL_OR_CMD] &&
     !event.shiftKey &&
+    !event.altKey &&
     event.code === CODES.BRACKET_LEFT,
   PanelComponent: ({ updateData, appState }) => (
     <button
@@ -67,6 +68,7 @@ export const actionBringForward = register({
   keyTest: (event) =>
     event[KEYS.CTRL_OR_CMD] &&
     !event.shiftKey &&
+    !event.altKey &&
     event.code === CODES.BRACKET_RIGHT,
   PanelComponent: ({ updateData, appState }) => (
     <button


### PR DESCRIPTION
Fixes #9534

## Problem

On macOS, the "send to back" (`Cmd+Alt+[`) and "bring to front" (`Cmd+Alt+]`) keyboard shortcuts did nothing, and the console logged:

> Canceling as multiple actions match this shortcut

https://github.com/user-attachments/assets/cc6ffebd-6abd-4773-be5a-039a73255abf

The `sendBackward` / `bringForward` key tests only excluded the `Shift` modifier:

```ts
event[KEYS.CTRL_OR_CMD] && !event.shiftKey && event.code === CODES.BRACKET_LEFT
```

So pressing `Cmd+Alt+[` matched **two** actions at once:

- `sendToBack` (macOS) — `Cmd + Alt + [`
- `sendBackward` — `Cmd + [` and `!shift`, which does not care whether `Alt` is held

The action manager cancels execution when more than one action matches a shortcut (`actions/manager.tsx`), so both were dropped and nothing happened.

This only affected macOS: other platforms disambiguate with `Shift` (`sendToBack` = `Ctrl+Shift+[`, `sendBackward` = `Ctrl+[` && `!shift`), so the `!shift` check already prevented the collision there.

## Solution

### Fixed video

https://github.com/user-attachments/assets/e78b8b49-bdba-45ca-9329-381a3c3ab6ec

Exclude the `Alt` modifier from `sendBackward` / `bringForward` so the macOS `Alt`-based "send to back" / "bring to front" shortcuts resolve to a single action:

```ts
event[KEYS.CTRL_OR_CMD] && !event.shiftKey && !event.altKey && event.code === CODES.BRACKET_LEFT
```

The plain `Cmd+[` / `Cmd+]` (send backward / bring forward) shortcuts are unaffected, and non-macOS behavior is unchanged.

## Tests

Added `actions/actionZindex.test.tsx` asserting that `Cmd+Alt+[` and `Cmd+Alt+]` no longer trigger `sendBackward` / `bringForward` (and that plain `Cmd+[` still does). Verified the new tests fail without the fix.