### PR TITLE
fix(app): stop idle detection when collaboration ends

### DIFF
--- a/excalidraw-app/collab/Collab.tsx
+++ b/excalidraw-app/collab/Collab.tsx
@@ -262,19 +262,7 @@ class Collab extends PureComponent<CollabProps, CollabState> {
     window.removeEventListener("offline", this.onOfflineStatusToggle);
     window.removeEventListener(EVENT.BEFORE_UNLOAD, this.beforeUnload);
     window.removeEventListener(EVENT.UNLOAD, this.onUnload);
-    window.removeEventListener(EVENT.POINTER_MOVE, this.onPointerMove);
-    window.removeEventListener(
-      EVENT.VISIBILITY_CHANGE,
-      this.onVisibilityChange,
-    );
-    if (this.activeIntervalId) {
-      window.clearInterval(this.activeIntervalId);
-      this.activeIntervalId = null;
-    }
-    if (this.idleTimeoutId) {
-      window.clearTimeout(this.idleTimeoutId);
-      this.idleTimeoutId = null;
-    }
+    this.removeIdleDetector();
     this.onUmmount?.();
   }
 
@@ -406,6 +394,10 @@ class Collab extends PureComponent<CollabProps, CollabState> {
     this.lastBroadcastedOrReceivedSceneVersion = -1;
     this.portal.close();
     this.fileManager.reset();
+    // stop idle detection when the collab session ends, otherwise the
+    // `document` pointer/visibility listeners (added in `initializeIdleDetector`)
+    // keep firing after the session is over.
+    this.removeIdleDetector();
     if (!opts?.isUnload) {
       this.setIsCollaborating(false);
       this.setActiveRoomLink(null);
@@ -864,6 +856,22 @@ class Collab extends PureComponent<CollabProps, CollabState> {
   private initializeIdleDetector = () => {
     document.addEventListener(EVENT.POINTER_MOVE, this.onPointerMove);
     document.addEventListener(EVENT.VISIBILITY_CHANGE, this.onVisibilityChange);
+  };
+
+  private removeIdleDetector = () => {
+    document.removeEventListener(EVENT.POINTER_MOVE, this.onPointerMove);
+    document.removeEventListener(
+      EVENT.VISIBILITY_CHANGE,
+      this.onVisibilityChange,
+    );
+    if (this.activeIntervalId) {
+      window.clearInterval(this.activeIntervalId);
+      this.activeIntervalId = null;
+    }
+    if (this.idleTimeoutId) {
+      window.clearTimeout(this.idleTimeoutId);
+      this.idleTimeoutId = null;
+    }
   };
 
   setCollaborators(sockets: SocketId[]) {

--- a/excalidraw-app/tests/collab.test.tsx
+++ b/excalidraw-app/tests/collab.test.tsx
@@ -249,4 +249,40 @@ describe("collaboration", () => {
       ]);
     });
   });
+
+  it("idle detector adds and removes the same document listeners", async () => {
+    await render(<ExcalidrawApp />);
+
+    // `window.collab` is the live Collab instance. `initializeIdleDetector` /
+    // `removeIdleDetector` are private, accessed here via index signature.
+    const collab = window.collab as any;
+
+    const addSpy = vi.spyOn(document, "addEventListener");
+    const removeSpy = vi.spyOn(document, "removeEventListener");
+
+    collab.initializeIdleDetector();
+
+    const pointerMove = addSpy.mock.calls.find(
+      ([type]) => type === "pointermove",
+    );
+    const visibilityChange = addSpy.mock.calls.find(
+      ([type]) => type === "visibilitychange",
+    );
+    expect(pointerMove).toBeDefined();
+    expect(visibilityChange).toBeDefined();
+
+    // regression for #10348: listeners must be removed from `document` (where
+    // they were added) using the same handler reference — the bug removed them
+    // from `window`, so they were never actually detached.
+    collab.removeIdleDetector();
+
+    expect(removeSpy).toHaveBeenCalledWith("pointermove", pointerMove![1]);
+    expect(removeSpy).toHaveBeenCalledWith(
+      "visibilitychange",
+      visibilityChange![1],
+    );
+
+    addSpy.mockRestore();
+    removeSpy.mockRestore();
+  });
 });


### PR DESCRIPTION
Inspired by #10348.

That issue reports a *memory leak* from the collab idle-detection listeners not being cleaned up. While investigating I found the leak framing isn't quite right — but there **is** a real bug, just a different one.

## What actually happens

`initializeIdleDetector` adds `pointermove` / `visibilitychange` listeners to **`document`**:

```ts
document.addEventListener(EVENT.POINTER_MOVE, this.onPointerMove);
document.addEventListener(EVENT.VISIBILITY_CHANGE, this.onVisibilityChange);
```

They were only removed in `componentWillUnmount`, and from **`window`**:

```ts
window.removeEventListener(EVENT.POINTER_MOVE, this.onPointerMove);
window.removeEventListener(EVENT.VISIBILITY_CHANGE, this.onVisibilityChange);
```

Two problems:

1. **Wrong target** — they're added on `document` but removed from `window`, so `removeEventListener` never matches anything. Those calls are dead code.
2. **Wrong place** — removal only happens on unmount, but `Collab` is mounted for the whole app lifetime, so unmount rarely runs. There is no cleanup on **stop collaboration** at all.

### Not actually a memory leak

`this.onPointerMove` / `this.onVisibilityChange` are stable class field references, so repeatedly re-adding them to the same target is de-duplicated by the browser — the listener *count* does not grow. So it isn't a memory leak.

The real symptom: **after you stop a collaboration session, the idle handlers keep firing.** Every pointer move still runs `onPointerMove`, which re-schedules the idle/active timers for a session that has already ended.

How to reproduce (no second client needed):
1. Start collaboration.
2. Stop the session.
3. Move the pointer — the idle handler still runs (verified locally via a temporary log: `onPointerMove` keeps firing with `isCollaborating === false`).

#### Reproduce video

We can see the log still there even we stop the session.

https://github.com/user-attachments/assets/3d37b38d-281f-40b9-8a5d-64babff9a239

## Fix

Extract `removeIdleDetector`, which removes the listeners from **`document`** (matching where they were added) and clears the idle/active timers, and call it:

- from `destroySocketClient`, so it runs whenever a session ends (start → stop → no more stray handlers), and
- from `componentWillUnmount`, replacing the old mismatched `window` removals.

## Tests

Added a regression test asserting the idle detector removes the exact same handler references from `document` that it added. Verified it fails when the removal target is reverted to `window`.