### PR TITLE
test(repo): less noisy test output

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,7 @@
+# VITE_DEBUG_DOM
+#   When "true", testing-library failures (waitFor / getBy*) include the full
+#   serialized DOM in the error message. It's off by default because it's noisy.
+#
+#   Flip it to "true" (or use `VITE_DEBUG_DOM=true yarn test`) when you need to
+#   inspect the DOM of a failing test.
+VITE_DEBUG_DOM=false

--- a/setupTests.ts
+++ b/setupTests.ts
@@ -3,6 +3,7 @@ import fs from "fs";
 // vitest.setup.ts
 import "vitest-canvas-mock";
 import "@testing-library/jest-dom";
+import { configure } from "@testing-library/react";
 import { vi } from "vitest";
 
 import polyfill from "./packages/excalidraw/polyfill";
@@ -15,6 +16,21 @@ import {
 
 Object.assign(globalThis, testPolyfills);
 PolyfillLocalStorage();
+
+// By default testing-library dumps the entire serialized DOM into the error
+// message whenever a `waitFor`/`getBy*` fails, which floods the test output
+// (often hundreds of lines of HTML per failure). Strip it out unless
+// VITE_DEBUG_DOM is enabled (see .env.test), e.g. `VITE_DEBUG_DOM=true yarn test`.
+const debugDom = ["true", "1"].includes(process.env.VITE_DEBUG_DOM ?? "");
+if (!debugDom) {
+  configure({
+    getElementError: (message) => {
+      const error = new Error(message ?? undefined);
+      error.name = "TestingLibraryElementError";
+      return error;
+    },
+  });
+}
 
 vi.mock("@excalidraw/common", async (importOriginal) => {
   const module = await importOriginal<typeof import("@excalidraw/common")>();

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -71,6 +71,8 @@ export default defineConfig({
     setupFiles: ["./setupTests.ts"],
     globals: true,
     environment: "jsdom",
+    // don't list skipped tests in the failure tree — keeps output readable
+    hideSkippedTests: true,
     coverage: {
       reporter: ["text", "json-summary", "json", "html", "lcovonly"],
       // Since v2, it ignores empty lines by default and we need to disable it as it affects the coverage


### PR DESCRIPTION
- hide DOM debug output when waitFor/etc. fails

    <img width="597" height="464" alt="2026-06-15_17 59 43-Code_2sz83f8jjK" src="https://github.com/user-attachments/assets/eb4ca4d8-b86b-4c0e-a4af-be80c19ce626" />

- hide skipped tests (in green below) - sadly won't hide pending tests (in red) when you use `it.only`

    <img width="854" height="509" alt="image" src="https://github.com/user-attachments/assets/6da835cc-5742-45f9-a143-4b908ee53576" />
