### PR TITLE
fix(editor): avoid grid snapping during rotation

### DIFF
--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -12588,11 +12588,17 @@ class App extends React.Component<AppProps, AppState> {
       activeEmbeddable: null,
     });
     const pointerCoords = pointerDownState.lastCoords;
-    let [resizeX, resizeY] = getGridPoint(
-      pointerCoords.x - pointerDownState.resize.offset.x,
-      pointerCoords.y - pointerDownState.resize.offset.y,
-      event[KEYS.CTRL_OR_CMD] ? null : this.getEffectiveGridSize(),
-    );
+    let [resizeX, resizeY] =
+      transformHandleType === "rotation"
+        ? [
+            pointerCoords.x - pointerDownState.resize.offset.x,
+            pointerCoords.y - pointerDownState.resize.offset.y,
+          ]
+        : getGridPoint(
+            pointerCoords.x - pointerDownState.resize.offset.x,
+            pointerCoords.y - pointerDownState.resize.offset.y,
+            event[KEYS.CTRL_OR_CMD] ? null : this.getEffectiveGridSize(),
+          );
 
     const frameElementsOffsetsMap = new Map<
       string,

--- a/packages/excalidraw/tests/rotate.test.tsx
+++ b/packages/excalidraw/tests/rotate.test.tsx
@@ -83,3 +83,15 @@ test("unselected bound arrows update when rotating their target elements", async
   expect(textArrow.points[1][0]).toBeCloseTo(-95.4635969899922, 0);
   expect(textArrow.points[1][1]).toBeCloseTo(-126.8785027399889, 0);
 });
+
+test("grid mode does not snap rotation pointer position", async () => {
+  await render(<Excalidraw gridModeEnabled={true} />);
+  const rectangle = UI.createElement("rectangle", {
+    width: 100,
+    height: 100,
+  });
+
+  UI.rotate(rectangle, [100, 70]);
+
+  expect(rectangle.angle).toBeCloseTo(Math.PI / 2);
+});


### PR DESCRIPTION
### Summary

- Avoid applying grid snapping to the pointer position used for element rotation.
- Add regression coverage for rotating an element to 90 degrees while grid mode is enabled.

Fixes #4057

### Testing

- yarn test:app packages/excalidraw/tests/rotate.test.tsx --watch=false
- yarn test:typecheck
- yarn test:code
- yarn test:other
- yarn test:update