### PR TITLE
feat: add local revision history timeline

### DIFF
--- a/excalidraw-app/App.tsx
+++ b/excalidraw-app/App.tsx
@@ -1056,7 +1056,10 @@ const ExcalidrawWrapper = () => {
           }}
         />
 
-        <AppSidebar />
+        <AppSidebar
+          excalidrawAPI={excalidrawAPI}
+          isCollaborating={isCollaborating}
+        />
 
         {errorMessage && (
           <ErrorDialog onClose={() => setErrorMessage("")}>

--- a/excalidraw-app/app_constants.ts
+++ b/excalidraw-app/app_constants.ts
@@ -47,6 +47,7 @@ export const STORAGE_KEYS = {
 
   IDB_LIBRARY: "excalidraw-library",
   IDB_TTD_CHATS: "excalidraw-ttd-chats",
+  IDB_SCENE_HISTORY: "excalidraw-scene-history",
 
   // do not use apart from migrations
   __LEGACY_LOCAL_STORAGE_LIBRARY: "excalidraw-library",

--- a/excalidraw-app/components/AppSidebar.tsx
+++ b/excalidraw-app/components/AppSidebar.tsx
@@ -1,79 +1,112 @@
 import { DefaultSidebar, Sidebar, THEME } from "@excalidraw/excalidraw";
 import {
+  historyIcon,
   messageCircleIcon,
   presentationIcon,
 } from "@excalidraw/excalidraw/components/icons";
 import { LinkButton } from "@excalidraw/excalidraw/components/LinkButton";
 import { useUIAppState } from "@excalidraw/excalidraw/context/ui-appState";
 
+import type { ExcalidrawImperativeAPI } from "@excalidraw/excalidraw/types";
+
+import { HistorySidebar, SceneHistoryProvider } from "./HistorySidebar";
+
 import "./AppSidebar.scss";
 
-export const AppSidebar = () => {
+type AppSidebarProps = {
+  excalidrawAPI: ExcalidrawImperativeAPI | null;
+  isCollaborating: boolean;
+};
+
+export const AppSidebar = ({
+  excalidrawAPI,
+  isCollaborating,
+}: AppSidebarProps) => {
   const { theme, openSidebar } = useUIAppState();
 
   return (
-    <DefaultSidebar>
-      <DefaultSidebar.TabTriggers>
-        <Sidebar.TabTrigger
-          tab="comments"
-          style={{ opacity: openSidebar?.tab === "comments" ? 1 : 0.4 }}
-        >
-          {messageCircleIcon}
-        </Sidebar.TabTrigger>
-        <Sidebar.TabTrigger
-          tab="presentation"
-          style={{ opacity: openSidebar?.tab === "presentation" ? 1 : 0.4 }}
-        >
-          {presentationIcon}
-        </Sidebar.TabTrigger>
-      </DefaultSidebar.TabTriggers>
-      <Sidebar.Tab tab="comments">
-        <div className="app-sidebar-promo-container">
-          <div
-            className="app-sidebar-promo-image"
-            style={{
-              ["--image-source" as any]: `url(/oss_promo_comments_${
-                theme === THEME.DARK ? "dark" : "light"
-              }.jpg)`,
-              opacity: 0.7,
-            }}
-          />
-          <div className="app-sidebar-promo-text">
-            Make comments with Excalidraw+
-          </div>
-          <LinkButton
-            href={`${
-              import.meta.env.VITE_APP_PLUS_LP
-            }/plus?utm_source=excalidraw&utm_medium=app&utm_content=comments_promo#excalidraw-redirect`}
+    <SceneHistoryProvider excalidrawAPI={excalidrawAPI}>
+      <DefaultSidebar>
+        <DefaultSidebar.TabTriggers>
+          {excalidrawAPI && (
+            <Sidebar.TabTrigger
+              aria-label="History"
+              tab="history"
+              style={{ opacity: openSidebar?.tab === "history" ? 1 : 0.4 }}
+              title="History"
+            >
+              {historyIcon}
+            </Sidebar.TabTrigger>
+          )}
+          <Sidebar.TabTrigger
+            tab="comments"
+            style={{ opacity: openSidebar?.tab === "comments" ? 1 : 0.4 }}
           >
-            Sign up now
-          </LinkButton>
-        </div>
-      </Sidebar.Tab>
-      <Sidebar.Tab tab="presentation" className="px-3">
-        <div className="app-sidebar-promo-container">
-          <div
-            className="app-sidebar-promo-image"
-            style={{
-              ["--image-source" as any]: `url(/oss_promo_presentations_${
-                theme === THEME.DARK ? "dark" : "light"
-              }.svg)`,
-              backgroundSize: "60%",
-              opacity: 0.4,
-            }}
-          />
-          <div className="app-sidebar-promo-text">
-            Create presentations with Excalidraw+
-          </div>
-          <LinkButton
-            href={`${
-              import.meta.env.VITE_APP_PLUS_LP
-            }/plus?utm_source=excalidraw&utm_medium=app&utm_content=presentations_promo#excalidraw-redirect`}
+            {messageCircleIcon}
+          </Sidebar.TabTrigger>
+          <Sidebar.TabTrigger
+            tab="presentation"
+            style={{ opacity: openSidebar?.tab === "presentation" ? 1 : 0.4 }}
           >
-            Sign up now
-          </LinkButton>
-        </div>
-      </Sidebar.Tab>
-    </DefaultSidebar>
+            {presentationIcon}
+          </Sidebar.TabTrigger>
+        </DefaultSidebar.TabTriggers>
+        <Sidebar.Tab tab="comments">
+          <div className="app-sidebar-promo-container">
+            <div
+              className="app-sidebar-promo-image"
+              style={{
+                ["--image-source" as any]: `url(/oss_promo_comments_${
+                  theme === THEME.DARK ? "dark" : "light"
+                }.jpg)`,
+                opacity: 0.7,
+              }}
+            />
+            <div className="app-sidebar-promo-text">
+              Make comments with Excalidraw+
+            </div>
+            <LinkButton
+              href={`${
+                import.meta.env.VITE_APP_PLUS_LP
+              }/plus?utm_source=excalidraw&utm_medium=app&utm_content=comments_promo#excalidraw-redirect`}
+            >
+              Sign up now
+            </LinkButton>
+          </div>
+        </Sidebar.Tab>
+        {excalidrawAPI && (
+          <Sidebar.Tab tab="history">
+            <HistorySidebar
+              excalidrawAPI={excalidrawAPI}
+              isCollaborating={isCollaborating}
+            />
+          </Sidebar.Tab>
+        )}
+        <Sidebar.Tab tab="presentation" className="px-3">
+          <div className="app-sidebar-promo-container">
+            <div
+              className="app-sidebar-promo-image"
+              style={{
+                ["--image-source" as any]: `url(/oss_promo_presentations_${
+                  theme === THEME.DARK ? "dark" : "light"
+                }.svg)`,
+                backgroundSize: "60%",
+                opacity: 0.4,
+              }}
+            />
+            <div className="app-sidebar-promo-text">
+              Create presentations with Excalidraw+
+            </div>
+            <LinkButton
+              href={`${
+                import.meta.env.VITE_APP_PLUS_LP
+              }/plus?utm_source=excalidraw&utm_medium=app&utm_content=presentations_promo#excalidraw-redirect`}
+            >
+              Sign up now
+            </LinkButton>
+          </div>
+        </Sidebar.Tab>
+      </DefaultSidebar>
+    </SceneHistoryProvider>
   );
 };

--- a/excalidraw-app/components/HistorySidebar.scss
+++ b/excalidraw-app/components/HistorySidebar.scss
@@ -1,0 +1,226 @@
+.excalidraw {
+  .history-sidebar {
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+    height: 100%;
+    color: var(--text-primary-color);
+  }
+
+  .history-sidebar__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    padding: 0 0.875rem 0.75rem;
+    border-bottom: 1px solid var(--sidebar-border-color);
+
+    h2 {
+      margin: 0;
+      font-size: 1rem;
+      line-height: 1.25;
+      font-weight: 600;
+    }
+  }
+
+  .history-sidebar__count {
+    color: var(--text-muted-color);
+    font-size: 0.75rem;
+    white-space: nowrap;
+  }
+
+  .history-sidebar__notice {
+    margin: 0.75rem 0.875rem 0;
+    padding: 0.625rem 0.75rem;
+    border: 1px solid var(--sidebar-border-color);
+    border-radius: 0.5rem;
+    background: var(--default-bg-color);
+    color: var(--text-muted-color);
+    font-size: 0.8125rem;
+    line-height: 1.35;
+  }
+
+  .history-sidebar__notice--error {
+    color: var(--color-danger);
+    border-color: var(--color-danger);
+  }
+
+  .history-sidebar__timeline {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    min-height: 0;
+    overflow: auto;
+    padding: 0.75rem 0.5rem 5.5rem;
+  }
+
+  .history-sidebar__empty {
+    color: var(--text-muted-color);
+    font-size: 0.875rem;
+    padding: 1rem 0.5rem;
+    text-align: center;
+  }
+
+  .history-sidebar__entry {
+    position: relative;
+    display: grid;
+    grid-template-columns: 1rem 5.5rem minmax(0, 1fr);
+    gap: 0.625rem;
+    width: 100%;
+    min-height: 4.5rem;
+    border: 1px solid transparent;
+    border-radius: 0.5rem;
+    padding: 0.5rem;
+    background: transparent;
+    color: inherit;
+    text-align: left;
+    cursor: pointer;
+
+    &:hover:not(:disabled) {
+      background: var(--button-hover-bg, var(--island-bg-color));
+    }
+
+    &:disabled {
+      cursor: default;
+      opacity: 0.65;
+    }
+  }
+
+  .history-sidebar__entry--selected {
+    border-color: var(--color-primary);
+    background: var(--default-bg-color);
+  }
+
+  .history-sidebar__entry--current {
+    .history-sidebar__marker {
+      border-color: var(--color-primary);
+      background: var(--color-primary);
+    }
+  }
+
+  .history-sidebar__marker {
+    position: relative;
+    width: 0.625rem;
+    height: 0.625rem;
+    align-self: start;
+    margin-top: 1.875rem;
+    border: 2px solid var(--sidebar-border-color);
+    border-radius: 50%;
+    background: var(--sidebar-bg-color);
+
+    &::before,
+    &::after {
+      content: "";
+      position: absolute;
+      left: 50%;
+      width: 1px;
+      height: 2rem;
+      background: var(--sidebar-border-color);
+      transform: translateX(-50%);
+    }
+
+    &::before {
+      bottom: 100%;
+    }
+
+    &::after {
+      top: 100%;
+    }
+  }
+
+  .history-sidebar__thumbnail {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 5.5rem;
+    height: 3.625rem;
+    overflow: hidden;
+    border: 1px solid var(--sidebar-border-color);
+    border-radius: 0.375rem;
+    background: var(--default-bg-color);
+    color: var(--text-muted-color);
+    font-size: 0.75rem;
+
+    img {
+      display: block;
+      max-width: 100%;
+      max-height: 100%;
+      object-fit: contain;
+    }
+  }
+
+  .history-sidebar__entry-body {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    min-width: 0;
+    gap: 0.1875rem;
+  }
+
+  .history-sidebar__entry-title {
+    display: flex;
+    align-items: center;
+    gap: 0.375rem;
+    min-width: 0;
+    font-size: 0.875rem;
+    font-weight: 600;
+    line-height: 1.25;
+  }
+
+  .history-sidebar__current-label {
+    flex: 0 0 auto;
+    color: var(--color-primary);
+    font-size: 0.6875rem;
+    font-weight: 600;
+  }
+
+  .history-sidebar__entry-summary {
+    min-width: 0;
+    overflow: hidden;
+    color: var(--text-muted-color);
+    font-size: 0.75rem;
+    line-height: 1.25;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .history-sidebar__entry-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.125rem 0.5rem;
+    min-width: 0;
+    color: var(--text-muted-color);
+    font-size: 0.75rem;
+    line-height: 1.25;
+  }
+
+  .history-sidebar__actions {
+    position: absolute;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.5rem;
+    padding: 0.75rem;
+    border-top: 1px solid var(--sidebar-border-color);
+    background: var(--sidebar-bg-color);
+  }
+
+  .history-sidebar__cancel-button,
+  .history-sidebar__restore-button {
+    width: 100%;
+    min-width: 0;
+    height: 2.25rem;
+  }
+
+  .history-sidebar__restore-button {
+    --button-bg: var(--color-primary);
+    --button-border: var(--color-primary);
+    --button-color: var(--color-icon-white);
+    --button-hover-bg: var(--color-primary-darker);
+    --button-hover-border: var(--color-primary-darker);
+    --button-hover-color: var(--color-icon-white);
+  }
+}

--- a/excalidraw-app/components/HistorySidebar.tsx
+++ b/excalidraw-app/components/HistorySidebar.tsx
@@ -22,7 +22,10 @@ import type {
 } from "@excalidraw/excalidraw/types";
 
 import { LocalData } from "../data/LocalData";
-import { SceneHistory } from "../data/SceneHistory";
+import {
+  isSceneHistoryDeltaRecordable,
+  SceneHistory,
+} from "../data/SceneHistory";
 
 import "./HistorySidebar.scss";
 
@@ -167,6 +170,7 @@ export const SceneHistoryProvider = ({
 }: SceneHistoryProviderProps) => {
   const sessionIdRef = useRef(createSessionId());
   const recordQueueRef = useRef(Promise.resolve());
+  const isMountedRef = useRef(false);
   const pendingRestoreRef = useRef<{ sourceEntryId: string } | null>(null);
   const [historyData, setHistoryData] = useState<SceneHistoryData | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
@@ -186,6 +190,14 @@ export const SceneHistoryProvider = ({
   }, []);
 
   useEffect(() => {
+    isMountedRef.current = true;
+
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
+
+  useEffect(() => {
     if (!excalidrawAPI) {
       setHistoryData(null);
       setIsLoading(false);
@@ -194,10 +206,9 @@ export const SceneHistoryProvider = ({
 
     let isActive = true;
 
-    const initializeHistory = async () => {
-      setIsLoading(true);
-
-      try {
+    setIsLoading(true);
+    recordQueueRef.current = recordQueueRef.current
+      .then(async () => {
         const scene = getCurrentScene(excalidrawAPI);
         const thumbnail = await createHistoryThumbnail(
           scene.elements,
@@ -212,24 +223,23 @@ export const SceneHistoryProvider = ({
           thumbnail,
         });
 
-        if (isActive) {
+        if (isActive && isMountedRef.current) {
           setHistoryState(nextHistoryData);
           setErrorMessage(null);
         }
-      } catch (error) {
+      })
+      .catch((error) => {
         console.error(error);
 
-        if (isActive) {
+        if (isActive && isMountedRef.current) {
           setErrorMessage("History is unavailable");
         }
-      } finally {
-        if (isActive) {
+      })
+      .finally(() => {
+        if (isActive && isMountedRef.current) {
           setIsLoading(false);
         }
-      }
-    };
-
-    initializeHistory();
+      });
 
     return () => {
       isActive = false;
@@ -241,16 +251,24 @@ export const SceneHistoryProvider = ({
       return;
     }
 
-    return excalidrawAPI.onIncrement((increment) => {
+    let isActive = true;
+    const unsubscribe = excalidrawAPI.onIncrement((increment) => {
       if (increment.type !== "durable" || !("delta" in increment)) {
         return;
       }
 
       const restoreMetadata = pendingRestoreRef.current;
+      if (!isSceneHistoryDeltaRecordable(increment.delta)) {
+        if (restoreMetadata) {
+          pendingRestoreRef.current = null;
+        }
+        return;
+      }
+
+      const scene = getCurrentScene(excalidrawAPI);
       pendingRestoreRef.current = null;
       recordQueueRef.current = recordQueueRef.current
         .then(async () => {
-          const scene = getCurrentScene(excalidrawAPI);
           const thumbnail = await createHistoryThumbnail(
             scene.elements,
             scene.appState,
@@ -267,14 +285,23 @@ export const SceneHistoryProvider = ({
             restoreSourceId: restoreMetadata?.sourceEntryId,
           });
 
-          setHistoryState(nextHistoryData);
-          setErrorMessage(null);
+          if (isActive && isMountedRef.current) {
+            setHistoryState(nextHistoryData);
+            setErrorMessage(null);
+          }
         })
         .catch((error) => {
           console.error(error);
-          setErrorMessage("History was not saved");
+          if (isActive && isMountedRef.current) {
+            setErrorMessage("History was not saved");
+          }
         });
     });
+
+    return () => {
+      isActive = false;
+      unsubscribe();
+    };
   }, [excalidrawAPI, setHistoryState]);
 
   const value = useMemo(
@@ -307,6 +334,8 @@ export const HistorySidebar = ({
     markNextChangeAsRestore,
   } = useSceneHistoryContext();
   const previewOriginRef = useRef<PreviewOrigin | null>(null);
+  const previewRequestIdRef = useRef(0);
+  const isMountedRef = useRef(false);
   const [selectedEntryId, setSelectedEntryId] = useState<string | null>(null);
   const [previewEntryId, setPreviewEntryId] = useState<string | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
@@ -324,12 +353,21 @@ export const HistorySidebar = ({
   const visibleErrorMessage = errorMessage || historyErrorMessage;
 
   useEffect(() => {
+    isMountedRef.current = true;
+
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
+
+  useEffect(() => {
     if (!isPreviewing) {
       setSelectedEntryId(historyData?.currentEntryId ?? null);
     }
   }, [historyData?.currentEntryId, isPreviewing]);
 
   const cancelPreview = useCallback(() => {
+    previewRequestIdRef.current++;
     const origin = previewOriginRef.current;
 
     if (!origin) {
@@ -384,6 +422,8 @@ export const HistorySidebar = ({
       return;
     }
 
+    const requestId = ++previewRequestIdRef.current;
+
     try {
       if (!previewOriginRef.current) {
         previewOriginRef.current = getCurrentScene(excalidrawAPI);
@@ -391,6 +431,10 @@ export const HistorySidebar = ({
       }
 
       const target = await SceneHistory.reconstruct(entry.id);
+
+      if (!isMountedRef.current || previewRequestIdRef.current !== requestId) {
+        return;
+      }
 
       if (!target) {
         setErrorMessage("Version could not be restored");
@@ -411,6 +455,10 @@ export const HistorySidebar = ({
       setPreviewEntryId(entry.id);
       setErrorMessage(null);
     } catch (error) {
+      if (!isMountedRef.current || previewRequestIdRef.current !== requestId) {
+        return;
+      }
+
       console.error(error);
       setErrorMessage("Version could not be previewed");
     }
@@ -422,6 +470,7 @@ export const HistorySidebar = ({
     }
 
     setIsRestoring(true);
+    previewRequestIdRef.current++;
 
     try {
       const target = await SceneHistory.reconstruct(selectedEntry.id);

--- a/excalidraw-app/components/HistorySidebar.tsx
+++ b/excalidraw-app/components/HistorySidebar.tsx
@@ -1,0 +1,571 @@
+import clsx from "clsx";
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+
+import { CaptureUpdateAction } from "@excalidraw/excalidraw";
+import { Button } from "@excalidraw/excalidraw/components/Button";
+import { getNonDeletedElements } from "@excalidraw/element";
+import { exportToCanvas } from "@excalidraw/utils/export";
+
+import type { OrderedExcalidrawElement } from "@excalidraw/element/types";
+import type {
+  AppState,
+  BinaryFiles,
+  ExcalidrawImperativeAPI,
+} from "@excalidraw/excalidraw/types";
+
+import { LocalData } from "../data/LocalData";
+import { SceneHistory } from "../data/SceneHistory";
+
+import "./HistorySidebar.scss";
+
+import type { SceneHistoryData, SceneHistoryEntry } from "../data/SceneHistory";
+
+type HistorySidebarProps = {
+  excalidrawAPI: ExcalidrawImperativeAPI;
+  isCollaborating: boolean;
+};
+
+type SceneHistoryProviderProps = {
+  excalidrawAPI: ExcalidrawImperativeAPI | null;
+  children: React.ReactNode;
+};
+
+type SceneHistoryContextValue = {
+  historyData: SceneHistoryData | null;
+  isLoading: boolean;
+  errorMessage: string | null;
+  sessionId: string;
+  markNextChangeAsRestore: (sourceEntryId: string) => void;
+};
+
+type PreviewOrigin = {
+  elements: readonly OrderedExcalidrawElement[];
+  appState: AppState;
+  files: BinaryFiles;
+};
+
+const THUMBNAIL_MAX_WIDTH = 160;
+const THUMBNAIL_MAX_HEIGHT = 96;
+
+const SceneHistoryContext = createContext<SceneHistoryContextValue | null>(
+  null,
+);
+
+const createSessionId = () => {
+  return (
+    globalThis.crypto?.randomUUID?.() ??
+    `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`
+  );
+};
+
+const createHistoryThumbnail = async (
+  elements: readonly OrderedExcalidrawElement[],
+  appState: AppState,
+  files: BinaryFiles,
+) => {
+  const nonDeletedElements = getNonDeletedElements(elements);
+
+  if (!nonDeletedElements.length) {
+    return null;
+  }
+
+  try {
+    const canvas = await exportToCanvas({
+      elements: nonDeletedElements,
+      appState: {
+        exportBackground: true,
+        exportScale: 1,
+        exportWithDarkMode: appState.exportWithDarkMode,
+        viewBackgroundColor: appState.viewBackgroundColor,
+      },
+      files,
+      exportPadding: 12,
+      getDimensions: (width, height) => {
+        const scale = Math.min(
+          THUMBNAIL_MAX_WIDTH / width,
+          THUMBNAIL_MAX_HEIGHT / height,
+          1,
+        );
+
+        return {
+          width: Math.max(1, Math.round(width * scale)),
+          height: Math.max(1, Math.round(height * scale)),
+          scale,
+        };
+      },
+    });
+
+    return canvas.toDataURL("image/png");
+  } catch (error) {
+    console.warn("Failed to render scene history thumbnail:", error);
+    return null;
+  }
+};
+
+const getCurrentScene = (
+  excalidrawAPI: ExcalidrawImperativeAPI,
+): PreviewOrigin => ({
+  elements:
+    excalidrawAPI.getSceneElementsIncludingDeleted() as readonly OrderedExcalidrawElement[],
+  appState: excalidrawAPI.getAppState(),
+  files: excalidrawAPI.getFiles(),
+});
+
+const addFilesToScene = (
+  excalidrawAPI: ExcalidrawImperativeAPI,
+  files: BinaryFiles,
+) => {
+  const fileData = Object.values(files);
+
+  if (fileData.length) {
+    excalidrawAPI.addFiles(fileData);
+  }
+};
+
+const formatEntryTime = (timestamp: number) => {
+  return new Intl.DateTimeFormat(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  }).format(timestamp);
+};
+
+const getEntryTitle = (entry: SceneHistoryEntry) => {
+  if (entry.kind === "initial") {
+    return "Initial version";
+  }
+
+  if (entry.kind === "restore") {
+    return "Restore";
+  }
+
+  return `Version ${entry.sequence}`;
+};
+
+const useSceneHistoryContext = () => {
+  const context = useContext(SceneHistoryContext);
+
+  if (!context) {
+    throw new Error("SceneHistoryProvider is missing");
+  }
+
+  return context;
+};
+
+export const SceneHistoryProvider = ({
+  excalidrawAPI,
+  children,
+}: SceneHistoryProviderProps) => {
+  const sessionIdRef = useRef(createSessionId());
+  const recordQueueRef = useRef(Promise.resolve());
+  const pendingRestoreRef = useRef<{ sourceEntryId: string } | null>(null);
+  const [historyData, setHistoryData] = useState<SceneHistoryData | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const setHistoryState = useCallback((nextHistoryData: SceneHistoryData) => {
+    setHistoryData(nextHistoryData);
+  }, []);
+
+  const markNextChangeAsRestore = useCallback((sourceEntryId: string) => {
+    pendingRestoreRef.current = { sourceEntryId };
+    window.setTimeout(() => {
+      if (pendingRestoreRef.current?.sourceEntryId === sourceEntryId) {
+        pendingRestoreRef.current = null;
+      }
+    }, 500);
+  }, []);
+
+  useEffect(() => {
+    if (!excalidrawAPI) {
+      setHistoryData(null);
+      setIsLoading(false);
+      return;
+    }
+
+    let isActive = true;
+
+    const initializeHistory = async () => {
+      setIsLoading(true);
+
+      try {
+        const scene = getCurrentScene(excalidrawAPI);
+        const thumbnail = await createHistoryThumbnail(
+          scene.elements,
+          scene.appState,
+          scene.files,
+        );
+        const nextHistoryData = await SceneHistory.ensureInitialized({
+          sessionId: sessionIdRef.current,
+          elements: scene.elements,
+          appState: scene.appState,
+          files: scene.files,
+          thumbnail,
+        });
+
+        if (isActive) {
+          setHistoryState(nextHistoryData);
+          setErrorMessage(null);
+        }
+      } catch (error) {
+        console.error(error);
+
+        if (isActive) {
+          setErrorMessage("History is unavailable");
+        }
+      } finally {
+        if (isActive) {
+          setIsLoading(false);
+        }
+      }
+    };
+
+    initializeHistory();
+
+    return () => {
+      isActive = false;
+    };
+  }, [excalidrawAPI, setHistoryState]);
+
+  useEffect(() => {
+    if (!excalidrawAPI) {
+      return;
+    }
+
+    return excalidrawAPI.onIncrement((increment) => {
+      if (increment.type !== "durable" || !("delta" in increment)) {
+        return;
+      }
+
+      const restoreMetadata = pendingRestoreRef.current;
+      pendingRestoreRef.current = null;
+      recordQueueRef.current = recordQueueRef.current
+        .then(async () => {
+          const scene = getCurrentScene(excalidrawAPI);
+          const thumbnail = await createHistoryThumbnail(
+            scene.elements,
+            scene.appState,
+            scene.files,
+          );
+          const nextHistoryData = await SceneHistory.append({
+            sessionId: sessionIdRef.current,
+            elements: scene.elements,
+            appState: scene.appState,
+            files: scene.files,
+            thumbnail,
+            delta: increment.delta,
+            kind: restoreMetadata ? "restore" : "change",
+            restoreSourceId: restoreMetadata?.sourceEntryId,
+          });
+
+          setHistoryState(nextHistoryData);
+          setErrorMessage(null);
+        })
+        .catch((error) => {
+          console.error(error);
+          setErrorMessage("History was not saved");
+        });
+    });
+  }, [excalidrawAPI, setHistoryState]);
+
+  const value = useMemo(
+    () => ({
+      historyData,
+      isLoading,
+      errorMessage,
+      sessionId: sessionIdRef.current,
+      markNextChangeAsRestore,
+    }),
+    [errorMessage, historyData, isLoading, markNextChangeAsRestore],
+  );
+
+  return (
+    <SceneHistoryContext.Provider value={value}>
+      {children}
+    </SceneHistoryContext.Provider>
+  );
+};
+
+export const HistorySidebar = ({
+  excalidrawAPI,
+  isCollaborating,
+}: HistorySidebarProps) => {
+  const {
+    historyData,
+    isLoading,
+    errorMessage: historyErrorMessage,
+    sessionId,
+    markNextChangeAsRestore,
+  } = useSceneHistoryContext();
+  const previewOriginRef = useRef<PreviewOrigin | null>(null);
+  const [selectedEntryId, setSelectedEntryId] = useState<string | null>(null);
+  const [previewEntryId, setPreviewEntryId] = useState<string | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [isRestoring, setIsRestoring] = useState(false);
+
+  const entries = useMemo(
+    () => [...(historyData?.entries ?? [])].reverse(),
+    [historyData],
+  );
+
+  const selectedEntry = historyData?.entries.find(
+    (entry) => entry.id === selectedEntryId,
+  );
+  const isPreviewing = !!previewEntryId;
+  const visibleErrorMessage = errorMessage || historyErrorMessage;
+
+  useEffect(() => {
+    if (!isPreviewing) {
+      setSelectedEntryId(historyData?.currentEntryId ?? null);
+    }
+  }, [historyData?.currentEntryId, isPreviewing]);
+
+  const cancelPreview = useCallback(() => {
+    const origin = previewOriginRef.current;
+
+    if (!origin) {
+      return;
+    }
+
+    addFilesToScene(excalidrawAPI, origin.files);
+    excalidrawAPI.updateScene({
+      elements: origin.elements,
+      appState: origin.appState,
+      captureUpdate: CaptureUpdateAction.NEVER,
+    });
+    LocalData.resumeSave("scene-history-preview");
+    previewOriginRef.current = null;
+    setPreviewEntryId(null);
+    setSelectedEntryId(historyData?.currentEntryId ?? null);
+  }, [excalidrawAPI, historyData?.currentEntryId]);
+
+  useEffect(() => {
+    if (isCollaborating && previewOriginRef.current) {
+      cancelPreview();
+    }
+  }, [cancelPreview, isCollaborating]);
+
+  useEffect(() => {
+    return () => {
+      const origin = previewOriginRef.current;
+
+      if (!origin || excalidrawAPI.isDestroyed) {
+        LocalData.resumeSave("scene-history-preview");
+        return;
+      }
+
+      addFilesToScene(excalidrawAPI, origin.files);
+      excalidrawAPI.updateScene({
+        elements: origin.elements,
+        appState: origin.appState,
+        captureUpdate: CaptureUpdateAction.NEVER,
+      });
+      LocalData.resumeSave("scene-history-preview");
+      previewOriginRef.current = null;
+    };
+  }, [excalidrawAPI]);
+
+  const previewEntry = async (entry: SceneHistoryEntry) => {
+    if (isCollaborating || isRestoring) {
+      return;
+    }
+
+    if (entry.id === historyData?.currentEntryId) {
+      cancelPreview();
+      return;
+    }
+
+    try {
+      if (!previewOriginRef.current) {
+        previewOriginRef.current = getCurrentScene(excalidrawAPI);
+        LocalData.pauseSave("scene-history-preview");
+      }
+
+      const target = await SceneHistory.reconstruct(entry.id);
+
+      if (!target) {
+        setErrorMessage("Version could not be restored");
+        return;
+      }
+
+      addFilesToScene(excalidrawAPI, target.files);
+      excalidrawAPI.updateScene({
+        elements: target.elements,
+        appState: {
+          ...excalidrawAPI.getAppState(),
+          ...target.appState,
+          viewModeEnabled: true,
+        },
+        captureUpdate: CaptureUpdateAction.NEVER,
+      });
+      setSelectedEntryId(entry.id);
+      setPreviewEntryId(entry.id);
+      setErrorMessage(null);
+    } catch (error) {
+      console.error(error);
+      setErrorMessage("Version could not be previewed");
+    }
+  };
+
+  const restoreSelectedEntry = async () => {
+    if (!selectedEntry || selectedEntry.id === historyData?.currentEntryId) {
+      return;
+    }
+
+    setIsRestoring(true);
+
+    try {
+      const target = await SceneHistory.reconstruct(selectedEntry.id);
+      const origin = previewOriginRef.current;
+
+      if (!target) {
+        setErrorMessage("Version could not be restored");
+        return;
+      }
+
+      if (origin) {
+        addFilesToScene(excalidrawAPI, origin.files);
+        excalidrawAPI.updateScene({
+          elements: origin.elements,
+          appState: origin.appState,
+          captureUpdate: CaptureUpdateAction.NEVER,
+        });
+      }
+
+      LocalData.resumeSave("scene-history-preview");
+      previewOriginRef.current = null;
+      markNextChangeAsRestore(selectedEntry.id);
+      addFilesToScene(excalidrawAPI, target.files);
+      excalidrawAPI.updateScene({
+        elements: target.elements,
+        appState: {
+          ...excalidrawAPI.getAppState(),
+          ...target.appState,
+        },
+        captureUpdate: CaptureUpdateAction.IMMEDIATELY,
+      });
+      excalidrawAPI.setToast({ message: "Version restored" });
+      setPreviewEntryId(null);
+      setErrorMessage(null);
+    } catch (error) {
+      console.error(error);
+      setErrorMessage("Version could not be restored");
+    } finally {
+      setIsRestoring(false);
+    }
+  };
+
+  return (
+    <div className="history-sidebar">
+      <div className="history-sidebar__header">
+        <h2>History</h2>
+        {historyData && (
+          <div className="history-sidebar__count">
+            {historyData.entries.length} versions
+          </div>
+        )}
+      </div>
+
+      {isCollaborating && (
+        <div className="history-sidebar__notice">
+          Restore is paused during live collaboration.
+        </div>
+      )}
+
+      {visibleErrorMessage && (
+        <div className="history-sidebar__notice history-sidebar__notice--error">
+          {visibleErrorMessage}
+        </div>
+      )}
+
+      <div className="history-sidebar__timeline" role="list">
+        {isLoading ? (
+          <div className="history-sidebar__empty">Loading history...</div>
+        ) : entries.length ? (
+          entries.map((entry) => {
+            const isSelected = entry.id === selectedEntryId;
+            const isCurrent = entry.id === historyData?.currentEntryId;
+
+            return (
+              <button
+                className={clsx("history-sidebar__entry", {
+                  "history-sidebar__entry--selected": isSelected,
+                  "history-sidebar__entry--current": isCurrent,
+                })}
+                disabled={isCollaborating || isRestoring}
+                key={entry.id}
+                onClick={() => previewEntry(entry)}
+                role="listitem"
+                type="button"
+              >
+                <span className="history-sidebar__marker" />
+                <span className="history-sidebar__thumbnail">
+                  {entry.thumbnail ? (
+                    <img alt="" src={entry.thumbnail} />
+                  ) : (
+                    <span>
+                      {entry.kind === "initial" ? "Start" : entry.sequence}
+                    </span>
+                  )}
+                </span>
+                <span className="history-sidebar__entry-body">
+                  <span className="history-sidebar__entry-title">
+                    {getEntryTitle(entry)}
+                    {isCurrent && (
+                      <span className="history-sidebar__current-label">
+                        Current
+                      </span>
+                    )}
+                  </span>
+                  <span className="history-sidebar__entry-summary">
+                    {entry.summary}
+                  </span>
+                  <span className="history-sidebar__entry-meta">
+                    <time dateTime={new Date(entry.createdAt).toISOString()}>
+                      {formatEntryTime(entry.createdAt)}
+                    </time>
+                    <span>
+                      {entry.sessionId === sessionId
+                        ? "This session"
+                        : "Previous session"}
+                    </span>
+                  </span>
+                </span>
+              </button>
+            );
+          })
+        ) : (
+          <div className="history-sidebar__empty">No history yet</div>
+        )}
+      </div>
+
+      {isPreviewing && (
+        <div className="history-sidebar__actions">
+          <Button
+            className="history-sidebar__cancel-button"
+            onSelect={cancelPreview}
+            disabled={isRestoring}
+          >
+            Cancel
+          </Button>
+          <Button
+            className="history-sidebar__restore-button"
+            onSelect={restoreSelectedEntry}
+            disabled={isCollaborating || isRestoring}
+          >
+            Restore
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/excalidraw-app/components/HistorySidebar.tsx
+++ b/excalidraw-app/components/HistorySidebar.tsx
@@ -13,6 +13,7 @@ import { CaptureUpdateAction } from "@excalidraw/excalidraw";
 import { Button } from "@excalidraw/excalidraw/components/Button";
 import { getNonDeletedElements } from "@excalidraw/element";
 import { exportToCanvas } from "@excalidraw/utils/export";
+import { isTestEnv } from "@excalidraw/common";
 
 import type { OrderedExcalidrawElement } from "@excalidraw/element/types";
 import type {
@@ -76,7 +77,7 @@ const createHistoryThumbnail = async (
 ) => {
   const nonDeletedElements = getNonDeletedElements(elements);
 
-  if (!nonDeletedElements.length) {
+  if (!nonDeletedElements.length || isTestEnv()) {
     return null;
   }
 

--- a/excalidraw-app/data/LocalData.ts
+++ b/excalidraw-app/data/LocalData.ts
@@ -112,7 +112,7 @@ const isQuotaExceededError = (error: any) => {
   return error instanceof DOMException && error.name === "QuotaExceededError";
 };
 
-type SavingLockTypes = "collaboration";
+type SavingLockTypes = "collaboration" | "scene-history-preview";
 
 export class LocalData {
   private static _save = debounce(

--- a/excalidraw-app/data/SceneHistory.test.ts
+++ b/excalidraw-app/data/SceneHistory.test.ts
@@ -1,4 +1,7 @@
+import type { StoreDelta } from "@excalidraw/element";
+
 import {
+  isSceneHistoryDeltaRecordable,
   reconstructSceneHistoryData,
   trimSceneHistoryData,
 } from "./SceneHistory";
@@ -45,6 +48,36 @@ const createNameDelta = (from: string | null, to: string) => ({
   },
 });
 
+const createStoreDelta = (
+  delta: Partial<{
+    elements: {
+      added: Record<string, unknown>;
+      removed: Record<string, unknown>;
+      updated: Record<string, unknown>;
+    };
+    appState: {
+      delta: {
+        deleted: Record<string, unknown>;
+        inserted: Record<string, unknown>;
+      };
+    };
+  }> = {},
+) =>
+  ({
+    id: "delta",
+    elements: delta.elements ?? {
+      added: {},
+      removed: {},
+      updated: {},
+    },
+    appState: delta.appState ?? {
+      delta: {
+        deleted: {},
+        inserted: {},
+      },
+    },
+  } as unknown as StoreDelta);
+
 const createEntry = (index: number): SceneHistoryEntry => {
   const name = `v${index}`;
 
@@ -72,6 +105,48 @@ const createHistoryData = (entries: SceneHistoryEntry[]): SceneHistoryData => ({
 });
 
 describe("SceneHistory", () => {
+  it("does not record transient-only app state deltas", () => {
+    const delta = createStoreDelta({
+      appState: {
+        delta: {
+          deleted: {
+            selectedElementIds: {},
+          },
+          inserted: {
+            selectedElementIds: {
+              elementId: true,
+            },
+          },
+        },
+      },
+    });
+
+    expect(isSceneHistoryDeltaRecordable(delta)).toBe(false);
+  });
+
+  it("records element and scene-level app state deltas", () => {
+    const elementDelta = createStoreDelta({
+      elements: {
+        added: {},
+        removed: {},
+        updated: {
+          elementId: {
+            deleted: {
+              version: 1,
+            },
+            inserted: {
+              version: 2,
+            },
+          },
+        },
+      },
+    });
+    const nameDelta = createNameDelta(null, "v1") as unknown as StoreDelta;
+
+    expect(isSceneHistoryDeltaRecordable(elementDelta)).toBe(true);
+    expect(isSceneHistoryDeltaRecordable(nameDelta)).toBe(true);
+  });
+
   it("reconstructs a target entry from the previous snapshot and deltas", () => {
     const historyData = createHistoryData([
       createEntry(0),

--- a/excalidraw-app/data/SceneHistory.test.ts
+++ b/excalidraw-app/data/SceneHistory.test.ts
@@ -1,0 +1,104 @@
+import {
+  reconstructSceneHistoryData,
+  trimSceneHistoryData,
+} from "./SceneHistory";
+
+import type {
+  SceneHistoryData,
+  SceneHistoryEntry,
+  SceneHistorySnapshot,
+} from "./SceneHistory";
+
+const createAppState = (name: string | null) => ({
+  name,
+  editingGroupId: null,
+  viewBackgroundColor: "#ffffff",
+  selectedElementIds: {},
+  selectedGroupIds: {},
+  selectedLinearElement: null,
+  croppingElementId: null,
+  lockedMultiSelections: {},
+  activeLockedId: null,
+});
+
+const createSnapshot = (name: string | null): SceneHistorySnapshot => ({
+  elements: [],
+  appState: createAppState(name),
+});
+
+const createNameDelta = (from: string | null, to: string) => ({
+  id: `delta-${to}`,
+  elements: {
+    added: {},
+    removed: {},
+    updated: {},
+  },
+  appState: {
+    delta: {
+      deleted: {
+        name: from,
+      },
+      inserted: {
+        name: to,
+      },
+    },
+  },
+});
+
+const createEntry = (index: number): SceneHistoryEntry => {
+  const name = `v${index}`;
+
+  return {
+    id: `entry-${index}`,
+    kind: index === 0 ? "initial" : "change",
+    sequence: index,
+    createdAt: index,
+    sessionId: "test-session",
+    parentId: index === 0 ? null : `entry-${index - 1}`,
+    summary: "Scene updated",
+    thumbnail: null,
+    fileIds: [],
+    snapshot: index === 0 ? createSnapshot(null) : undefined,
+    delta: index === 0 ? undefined : createNameDelta(`v${index - 1}`, name),
+  };
+};
+
+const createHistoryData = (entries: SceneHistoryEntry[]): SceneHistoryData => ({
+  version: 1,
+  documentId: "test-document",
+  currentEntryId: entries[entries.length - 1]?.id ?? null,
+  entries,
+  files: {},
+});
+
+describe("SceneHistory", () => {
+  it("reconstructs a target entry from the previous snapshot and deltas", () => {
+    const historyData = createHistoryData([
+      createEntry(0),
+      {
+        ...createEntry(1),
+        delta: createNameDelta(null, "v1"),
+      },
+    ]);
+    const target = reconstructSceneHistoryData(historyData, "entry-1");
+
+    expect(target?.appState.name).toBe("v1");
+    expect(target?.appState.selectedElementIds).toEqual({});
+  });
+
+  it("trims old entries while keeping the first retained entry reconstructable", () => {
+    const historyData = createHistoryData(
+      Array.from({ length: 122 }, (_, index) => createEntry(index)),
+    );
+    const trimmedHistoryData = trimSceneHistoryData(historyData);
+    const target = reconstructSceneHistoryData(
+      trimmedHistoryData,
+      trimmedHistoryData.currentEntryId!,
+    );
+
+    expect(trimmedHistoryData.entries).toHaveLength(120);
+    expect(trimmedHistoryData.entries[0].snapshot).toBeDefined();
+    expect(trimmedHistoryData.entries[0].delta).toBeUndefined();
+    expect(target?.appState.name).toBe("v121");
+  });
+});

--- a/excalidraw-app/data/SceneHistory.ts
+++ b/excalidraw-app/data/SceneHistory.ts
@@ -1,0 +1,504 @@
+import {
+  getInitializedImageElements,
+  getObservedAppState,
+  StoreDelta,
+} from "@excalidraw/element";
+import { createStore, get, set } from "idb-keyval";
+
+import type {
+  ExcalidrawElement,
+  FileId,
+  OrderedExcalidrawElement,
+  SceneElementsMap,
+} from "@excalidraw/element/types";
+import type {
+  AppState,
+  BinaryFileData,
+  BinaryFiles,
+  ObservedAppState,
+} from "@excalidraw/excalidraw/types";
+
+import { STORAGE_KEYS } from "../app_constants";
+
+const HISTORY_VERSION = 1;
+const MAX_HISTORY_ENTRIES = 120;
+const SNAPSHOT_INTERVAL = 20;
+const LOCAL_DOCUMENT_ID = "local-default";
+
+export type SceneHistoryEntryKind = "initial" | "change" | "restore";
+
+type SerializedDelta<T> = {
+  deleted: Partial<T>;
+  inserted: Partial<T>;
+};
+
+type SerializedStoreDelta = {
+  id: string;
+  elements: {
+    added: Record<string, SerializedDelta<Partial<ExcalidrawElement>>>;
+    removed: Record<string, SerializedDelta<Partial<ExcalidrawElement>>>;
+    updated: Record<string, SerializedDelta<Partial<ExcalidrawElement>>>;
+  };
+  appState: {
+    delta: SerializedDelta<ObservedAppState>;
+  };
+};
+
+export type SceneHistorySnapshot = {
+  elements: OrderedExcalidrawElement[];
+  appState: ObservedAppState;
+};
+
+export type SceneHistoryEntry = {
+  id: string;
+  kind: SceneHistoryEntryKind;
+  sequence: number;
+  createdAt: number;
+  sessionId: string;
+  parentId: string | null;
+  summary: string;
+  thumbnail: string | null;
+  fileIds: FileId[];
+  delta?: SerializedStoreDelta;
+  snapshot?: SceneHistorySnapshot;
+  restoreSourceId?: string;
+};
+
+export type SceneHistoryData = {
+  version: typeof HISTORY_VERSION;
+  documentId: string;
+  currentEntryId: string | null;
+  entries: SceneHistoryEntry[];
+  files: BinaryFiles;
+};
+
+export type SceneHistoryTargetState = {
+  entry: SceneHistoryEntry;
+  elements: OrderedExcalidrawElement[];
+  appState: Partial<AppState>;
+  files: BinaryFiles;
+};
+
+type SceneHistoryInit = {
+  documentId?: string;
+  sessionId: string;
+  elements: readonly OrderedExcalidrawElement[];
+  appState: AppState;
+  files: BinaryFiles;
+  thumbnail?: string | null;
+};
+
+type SceneHistoryAppend = SceneHistoryInit & {
+  delta: StoreDelta;
+  kind?: Extract<SceneHistoryEntryKind, "change" | "restore">;
+  restoreSourceId?: string;
+};
+
+const store = createStore(
+  `${STORAGE_KEYS.IDB_SCENE_HISTORY}-db`,
+  `${STORAGE_KEYS.IDB_SCENE_HISTORY}-store`,
+);
+
+const createId = () => {
+  return (
+    globalThis.crypto?.randomUUID?.() ??
+    `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`
+  );
+};
+
+const cloneSerializable = <T>(value: T): T => {
+  return JSON.parse(JSON.stringify(value));
+};
+
+const createEmptyHistory = (
+  documentId = LOCAL_DOCUMENT_ID,
+): SceneHistoryData => ({
+  version: HISTORY_VERSION,
+  documentId,
+  currentEntryId: null,
+  entries: [],
+  files: {},
+});
+
+const normalizeObservedAppState = (appState: AppState): ObservedAppState => {
+  const observedAppState = getObservedAppState(appState);
+
+  return cloneSerializable({
+    name: observedAppState.name,
+    editingGroupId: observedAppState.editingGroupId,
+    viewBackgroundColor: observedAppState.viewBackgroundColor,
+    selectedElementIds: observedAppState.selectedElementIds,
+    selectedGroupIds: observedAppState.selectedGroupIds,
+    selectedLinearElement: observedAppState.selectedLinearElement,
+    croppingElementId: observedAppState.croppingElementId,
+    lockedMultiSelections: observedAppState.lockedMultiSelections,
+    activeLockedId: observedAppState.activeLockedId,
+  });
+};
+
+const resetTransientAppState = (
+  appState: Partial<AppState>,
+): Partial<AppState> => {
+  return {
+    ...appState,
+    selectedElementIds: {},
+    selectedGroupIds: {},
+    selectedLinearElement: null,
+    editingGroupId: null,
+    croppingElementId: null,
+    lockedMultiSelections: {},
+    activeLockedId: null,
+  };
+};
+
+export const createSceneHistorySnapshot = ({
+  elements,
+  appState,
+}: {
+  elements: readonly OrderedExcalidrawElement[];
+  appState: AppState;
+}): SceneHistorySnapshot => ({
+  elements: cloneSerializable([...elements]),
+  appState: normalizeObservedAppState(appState),
+});
+
+const getReferencedFileIds = (
+  elements: readonly ExcalidrawElement[],
+): FileId[] => {
+  const ids = new Set<FileId>();
+
+  for (const element of getInitializedImageElements(elements)) {
+    if (!element.isDeleted) {
+      ids.add(element.fileId);
+    }
+  }
+
+  return [...ids];
+};
+
+const collectReferencedFiles = (
+  elements: readonly ExcalidrawElement[],
+  files: BinaryFiles,
+): BinaryFiles => {
+  const referencedFiles: BinaryFiles = {};
+
+  for (const fileId of getReferencedFileIds(elements)) {
+    const file = files[fileId];
+
+    if (file) {
+      referencedFiles[fileId] = cloneSerializable(file) as BinaryFileData;
+    }
+  }
+
+  return referencedFiles;
+};
+
+const pickFiles = (fileIds: readonly FileId[], files: BinaryFiles) => {
+  const nextFiles: BinaryFiles = {};
+
+  for (const fileId of fileIds) {
+    const file = files[fileId];
+
+    if (file) {
+      nextFiles[fileId] = file;
+    }
+  }
+
+  return nextFiles;
+};
+
+const pruneFiles = (
+  entries: readonly SceneHistoryEntry[],
+  files: BinaryFiles,
+): BinaryFiles => {
+  const referencedFileIds = new Set<FileId>();
+
+  for (const entry of entries) {
+    for (const fileId of entry.fileIds) {
+      referencedFileIds.add(fileId);
+    }
+  }
+
+  return pickFiles([...referencedFileIds], files);
+};
+
+const createElementsMap = (
+  elements: readonly OrderedExcalidrawElement[],
+): SceneElementsMap => {
+  return new Map(
+    elements.map((element) => [element.id, element]),
+  ) as SceneElementsMap;
+};
+
+const serializeDelta = (delta: StoreDelta): SerializedStoreDelta => {
+  return cloneSerializable(delta) as SerializedStoreDelta;
+};
+
+const countObjectKeys = (value: unknown) => {
+  return value && typeof value === "object" ? Object.keys(value).length : 0;
+};
+
+export const describeStoreDelta = (delta: StoreDelta): string => {
+  const serializedDelta = serializeDelta(delta);
+  const added = countObjectKeys(serializedDelta.elements.added);
+  const removed = countObjectKeys(serializedDelta.elements.removed);
+  const updated = countObjectKeys(serializedDelta.elements.updated);
+  const appState = countObjectKeys(serializedDelta.appState.delta.inserted);
+  const parts: string[] = [];
+
+  if (added) {
+    parts.push(`${added} added`);
+  }
+  if (updated) {
+    parts.push(`${updated} edited`);
+  }
+  if (removed) {
+    parts.push(`${removed} removed`);
+  }
+  if (appState) {
+    parts.push("view updated");
+  }
+
+  return parts.join(", ") || "Scene updated";
+};
+
+export const reconstructSceneHistoryData = (
+  historyData: SceneHistoryData,
+  entryId: string,
+): SceneHistoryTargetState | null => {
+  const targetIndex = historyData.entries.findIndex(
+    (entry) => entry.id === entryId,
+  );
+
+  if (targetIndex === -1) {
+    return null;
+  }
+
+  let snapshotIndex = targetIndex;
+
+  while (snapshotIndex >= 0 && !historyData.entries[snapshotIndex].snapshot) {
+    snapshotIndex--;
+  }
+
+  const snapshotEntry = historyData.entries[snapshotIndex];
+  const snapshot = snapshotEntry?.snapshot;
+
+  if (!snapshot) {
+    return null;
+  }
+
+  let elementsMap = createElementsMap(snapshot.elements);
+  let appState = snapshot.appState as AppState;
+
+  for (const entry of historyData.entries.slice(
+    snapshotIndex + 1,
+    targetIndex + 1,
+  )) {
+    if (!entry.delta) {
+      continue;
+    }
+
+    [elementsMap, appState] = StoreDelta.applyTo(
+      StoreDelta.restore(entry.delta as any),
+      elementsMap,
+      appState,
+    );
+  }
+
+  const entry = historyData.entries[targetIndex];
+  const elements = Array.from(elementsMap.values());
+
+  return {
+    entry,
+    elements,
+    appState: resetTransientAppState(appState),
+    files: pickFiles(getReferencedFileIds(elements), historyData.files),
+  };
+};
+
+export const trimSceneHistoryData = (
+  historyData: SceneHistoryData,
+): SceneHistoryData => {
+  if (historyData.entries.length <= MAX_HISTORY_ENTRIES) {
+    return {
+      ...historyData,
+      files: pruneFiles(historyData.entries, historyData.files),
+    };
+  }
+
+  const firstKeptIndex = historyData.entries.length - MAX_HISTORY_ENTRIES;
+  const firstKeptEntry = historyData.entries[firstKeptIndex];
+  const reconstructedFirstEntry = reconstructSceneHistoryData(
+    historyData,
+    firstKeptEntry.id,
+  );
+
+  if (!reconstructedFirstEntry) {
+    return historyData;
+  }
+
+  const entries = historyData.entries.slice(firstKeptIndex);
+
+  entries[0] = {
+    ...entries[0],
+    kind: "initial",
+    parentId: null,
+    summary: "History checkpoint",
+    delta: undefined,
+    restoreSourceId: undefined,
+    snapshot: {
+      elements: reconstructedFirstEntry.elements,
+      appState: reconstructedFirstEntry.appState as ObservedAppState,
+    },
+  };
+
+  return {
+    ...historyData,
+    currentEntryId: entries[entries.length - 1]?.id ?? null,
+    entries,
+    files: pruneFiles(entries, historyData.files),
+  };
+};
+
+class SceneHistoryIndexedDBAdapter {
+  private static key = "sceneHistory";
+
+  static async load(documentId = LOCAL_DOCUMENT_ID): Promise<SceneHistoryData> {
+    try {
+      const historyData = await get<SceneHistoryData>(
+        SceneHistoryIndexedDBAdapter.key,
+        store,
+      );
+
+      if (
+        historyData?.version === HISTORY_VERSION &&
+        historyData.documentId === documentId
+      ) {
+        return historyData;
+      }
+    } catch (error) {
+      console.warn("Failed to load scene history from IndexedDB:", error);
+    }
+
+    return createEmptyHistory(documentId);
+  }
+
+  static save(historyData: SceneHistoryData) {
+    return set(SceneHistoryIndexedDBAdapter.key, historyData, store);
+  }
+}
+
+export class SceneHistory {
+  static async load(documentId = LOCAL_DOCUMENT_ID) {
+    return SceneHistoryIndexedDBAdapter.load(documentId);
+  }
+
+  static async ensureInitialized({
+    documentId = LOCAL_DOCUMENT_ID,
+    sessionId,
+    elements,
+    appState,
+    files,
+    thumbnail = null,
+  }: SceneHistoryInit) {
+    const historyData = await SceneHistoryIndexedDBAdapter.load(documentId);
+
+    if (historyData.entries.length) {
+      return historyData;
+    }
+
+    const entry: SceneHistoryEntry = {
+      id: createId(),
+      kind: "initial",
+      sequence: 0,
+      createdAt: Date.now(),
+      sessionId,
+      parentId: null,
+      summary: "Initial version",
+      thumbnail,
+      fileIds: getReferencedFileIds(elements),
+      snapshot: createSceneHistorySnapshot({ elements, appState }),
+    };
+
+    const nextHistoryData = trimSceneHistoryData({
+      ...historyData,
+      currentEntryId: entry.id,
+      entries: [entry],
+      files: {
+        ...historyData.files,
+        ...collectReferencedFiles(elements, files),
+      },
+    });
+
+    await SceneHistoryIndexedDBAdapter.save(nextHistoryData);
+
+    return nextHistoryData;
+  }
+
+  static async append({
+    documentId = LOCAL_DOCUMENT_ID,
+    sessionId,
+    elements,
+    appState,
+    files,
+    thumbnail = null,
+    delta,
+    kind = "change",
+    restoreSourceId,
+  }: SceneHistoryAppend) {
+    const historyData = await SceneHistoryIndexedDBAdapter.load(documentId);
+
+    if (!historyData.entries.length) {
+      return SceneHistory.ensureInitialized({
+        documentId,
+        sessionId,
+        elements,
+        appState,
+        files,
+        thumbnail,
+      });
+    }
+
+    const lastEntry = historyData.entries[historyData.entries.length - 1];
+    const sequence = (lastEntry?.sequence ?? -1) + 1;
+    const isCheckpoint = sequence % SNAPSHOT_INTERVAL === 0;
+    const entry: SceneHistoryEntry = {
+      id: createId(),
+      kind,
+      sequence,
+      createdAt: Date.now(),
+      sessionId,
+      parentId: lastEntry?.id ?? null,
+      summary:
+        kind === "restore"
+          ? "Restored previous version"
+          : describeStoreDelta(delta),
+      thumbnail,
+      fileIds: getReferencedFileIds(elements),
+      delta: serializeDelta(delta),
+      restoreSourceId,
+      snapshot: isCheckpoint
+        ? createSceneHistorySnapshot({ elements, appState })
+        : undefined,
+    };
+    const nextHistoryData = trimSceneHistoryData({
+      ...historyData,
+      currentEntryId: entry.id,
+      entries: historyData.entries.concat(entry),
+      files: {
+        ...historyData.files,
+        ...collectReferencedFiles(elements, files),
+      },
+    });
+
+    await SceneHistoryIndexedDBAdapter.save(nextHistoryData);
+
+    return nextHistoryData;
+  }
+
+  static async reconstruct(entryId: string, documentId = LOCAL_DOCUMENT_ID) {
+    const historyData = await SceneHistoryIndexedDBAdapter.load(documentId);
+
+    return reconstructSceneHistoryData(historyData, entryId);
+  }
+}

--- a/excalidraw-app/data/SceneHistory.ts
+++ b/excalidraw-app/data/SceneHistory.ts
@@ -24,6 +24,10 @@ const HISTORY_VERSION = 1;
 const MAX_HISTORY_ENTRIES = 120;
 const SNAPSHOT_INTERVAL = 20;
 const LOCAL_DOCUMENT_ID = "local-default";
+const RECORDABLE_APP_STATE_KEYS = new Set<keyof ObservedAppState>([
+  "name",
+  "viewBackgroundColor",
+]);
 
 export type SceneHistoryEntryKind = "initial" | "change" | "restore";
 
@@ -238,12 +242,41 @@ const countObjectKeys = (value: unknown) => {
   return value && typeof value === "object" ? Object.keys(value).length : 0;
 };
 
+const getRecordableAppStateKeyCount = (delta: SerializedStoreDelta) => {
+  const keys = new Set([
+    ...Object.keys(delta.appState.delta.deleted),
+    ...Object.keys(delta.appState.delta.inserted),
+  ]);
+  let count = 0;
+
+  for (const key of keys) {
+    if (RECORDABLE_APP_STATE_KEYS.has(key as keyof ObservedAppState)) {
+      count++;
+    }
+  }
+
+  return count;
+};
+
+const isSerializedStoreDeltaRecordable = (delta: SerializedStoreDelta) => {
+  return (
+    countObjectKeys(delta.elements.added) > 0 ||
+    countObjectKeys(delta.elements.removed) > 0 ||
+    countObjectKeys(delta.elements.updated) > 0 ||
+    getRecordableAppStateKeyCount(delta) > 0
+  );
+};
+
+export const isSceneHistoryDeltaRecordable = (delta: StoreDelta): boolean => {
+  return isSerializedStoreDeltaRecordable(serializeDelta(delta));
+};
+
 export const describeStoreDelta = (delta: StoreDelta): string => {
   const serializedDelta = serializeDelta(delta);
   const added = countObjectKeys(serializedDelta.elements.added);
   const removed = countObjectKeys(serializedDelta.elements.removed);
   const updated = countObjectKeys(serializedDelta.elements.updated);
-  const appState = countObjectKeys(serializedDelta.appState.delta.inserted);
+  const appState = getRecordableAppStateKeyCount(serializedDelta);
   const parts: string[] = [];
 
   if (added) {
@@ -447,6 +480,11 @@ export class SceneHistory {
     restoreSourceId,
   }: SceneHistoryAppend) {
     const historyData = await SceneHistoryIndexedDBAdapter.load(documentId);
+    const serializedDelta = serializeDelta(delta);
+
+    if (!isSerializedStoreDeltaRecordable(serializedDelta)) {
+      return historyData;
+    }
 
     if (!historyData.entries.length) {
       return SceneHistory.ensureInitialized({
@@ -475,7 +513,7 @@ export class SceneHistory {
           : describeStoreDelta(delta),
       thumbnail,
       fileIds: getReferencedFileIds(elements),
-      delta: serializeDelta(delta),
+      delta: serializedDelta,
       restoreSourceId,
       snapshot: isCheckpoint
         ? createSceneHistorySnapshot({ elements, appState })


### PR DESCRIPTION
## What changed

- Adds IndexedDB-backed local scene revision history storage for the app.
- Records initial, change, and restore revisions with periodic snapshots for reconstruction.
- Adds a History sidebar tab with timeline entries, thumbnails, preview, cancel, and restore actions.
- Archives referenced binary files so image-containing scenes can be restored from local history.
- Avoids recording preview/transient-only scene updates as durable history entries.
- Skips thumbnail generation in test mode to avoid canvas mock noise during app test runs.

## Demo

![Revision history timeline preview and restore demo](https://raw.githubusercontent.com/rus-artur4ik/excalidraw/pr-11509-demo-assets/.github/pr-assets/11509/excalidraw-history-demo.gif)

Flow shown: create a few scene changes, open the History sidebar tab, preview an older revision, then restore the board to that revision.

## Scope decisions

- This is local-only revision history backed by browser IndexedDB.
- This does not implement Excalidraw+ cloud versioning.
- History is capped and older entries are compacted into a reconstructable snapshot.
- Restore is disabled while live collaboration is active.
- Previewing a revision does not persist that preview into local scene storage.
- Restoring a revision records a new restore entry instead of rewriting the existing history.

## Why

Addresses #8096 by adding a local browser-based revision history experience for the OSS app.

## How to verify

- `corepack yarn test:update`
- `corepack yarn test:app --run excalidraw-app/data/SceneHistory.test.ts`
- `corepack yarn test:typecheck`
- `corepack yarn test:code`
- `corepack yarn test:other`
- `corepack yarn build`
- Manual browser QA: created shapes, opened History, previewed an older version, restored it, and checked desktop/mobile sidebar layout.