### PR TITLE
fix: show error feedback for invalid hex color input

### DIFF
--- a/packages/excalidraw/components/ColorPicker/ColorInput.tsx
+++ b/packages/excalidraw/components/ColorPicker/ColorInput.tsx
@@ -1,5 +1,5 @@
 import clsx from "clsx";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useId, useRef, useState } from "react";
 
 import { KEYS, normalizeInputColor } from "@excalidraw/common";
 
@@ -54,12 +54,8 @@ export const ColorInput = ({
     [onChange],
   );
 
-  const invalidColorTitle = useMemo(() => {
-    if (!isInvalid) {
-      return undefined;
-    }
-    return t("errors.invalidColor");
-  }, [isInvalid]);
+  const errorId = useId();
+  const invalidColorTitle = isInvalid ? t("errors.invalidColor") : undefined;
 
   const inputRef = useRef<HTMLInputElement>(null);
   const eyeDropperTriggerRef = useRef<HTMLDivElement>(null);
@@ -91,6 +87,7 @@ export const ColorInput = ({
         aria-label={label}
         title={invalidColorTitle}
         aria-invalid={isInvalid}
+        aria-describedby={isInvalid ? errorId : undefined}
         onChange={(event) => {
           changeColor(event.target.value);
         }}
@@ -111,6 +108,15 @@ export const ColorInput = ({
         }}
         placeholder={placeholder}
       />
+      {isInvalid && (
+        <span
+          id={errorId}
+          className="color-picker-input__error-message"
+          aria-live="polite"
+        >
+          {invalidColorTitle}
+        </span>
+      )}
       {/* TODO reenable on mobile with a better UX */}
       {editorInterface.formFactor !== "phone" && (
         <>

--- a/packages/excalidraw/components/ColorPicker/ColorInput.tsx
+++ b/packages/excalidraw/components/ColorPicker/ColorInput.tsx
@@ -1,5 +1,5 @@
 import clsx from "clsx";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { KEYS, normalizeInputColor } from "@excalidraw/common";
 
@@ -29,6 +29,7 @@ export const ColorInput = ({
 }) => {
   const editorInterface = useEditorInterface();
   const [innerValue, setInnerValue] = useState(color);
+  const [isInvalid, setIsInvalid] = useState(false);
   const [activeSection, setActiveColorPickerSection] = useAtom(
     activeColorPickerSectionAtom,
   );
@@ -40,15 +41,25 @@ export const ColorInput = ({
   const changeColor = useCallback(
     (inputValue: string) => {
       const value = inputValue.toLowerCase();
-      const color = normalizeInputColor(value);
+      const normalizedColor = normalizeInputColor(value);
 
-      if (color) {
-        onChange(color);
+      if (normalizedColor) {
+        onChange(normalizedColor);
+        setIsInvalid(false);
+      } else {
+        setIsInvalid(value.trim().length > 0);
       }
       setInnerValue(value);
     },
     [onChange],
   );
+
+  const invalidColorTitle = useMemo(() => {
+    if (!isInvalid) {
+      return undefined;
+    }
+    return t("errors.invalidColor");
+  }, [isInvalid]);
 
   const inputRef = useRef<HTMLInputElement>(null);
   const eyeDropperTriggerRef = useRef<HTMLDivElement>(null);
@@ -74,14 +85,19 @@ export const ColorInput = ({
         ref={activeSection === "hex" ? inputRef : undefined}
         style={{ border: 0, padding: 0 }}
         spellCheck={false}
-        className="color-picker-input"
+        className={clsx("color-picker-input", {
+          "color-picker-input--invalid": isInvalid,
+        })}
         aria-label={label}
+        title={invalidColorTitle}
+        aria-invalid={isInvalid}
         onChange={(event) => {
           changeColor(event.target.value);
         }}
         value={(innerValue || "").replace(/^#/, "")}
         onBlur={() => {
           setInnerValue(color);
+          setIsInvalid(false);
         }}
         tabIndex={-1}
         onFocus={() => setActiveColorPickerSection("hex")}

--- a/packages/excalidraw/components/ColorPicker/ColorPicker.scss
+++ b/packages/excalidraw/components/ColorPicker/ColorPicker.scss
@@ -429,6 +429,14 @@
     }
   }
 
+  .color-picker-input__error-message {
+    grid-column: 1 / -1;
+    font-size: 0.6875rem;
+    color: var(--color-danger);
+    padding-bottom: 0.25rem;
+    line-height: 1.2;
+  }
+
   .color-picker-label-swatch-container {
     border: 1px solid var(--default-border-color);
     border-radius: var(--border-radius-lg);

--- a/packages/excalidraw/components/ColorPicker/ColorPicker.scss
+++ b/packages/excalidraw/components/ColorPicker/ColorPicker.scss
@@ -421,6 +421,12 @@
     &:focus-visible {
       box-shadow: none;
     }
+
+    &.color-picker-input--invalid {
+      border-color: var(--color-danger);
+      color: var(--color-danger);
+      outline: none;
+    }
   }
 
   .color-picker-label-swatch-container {

--- a/packages/excalidraw/locales/en.json
+++ b/packages/excalidraw/locales/en.json
@@ -282,6 +282,7 @@
     "localStorageQuotaExceeded": "Browser storage quota exceeded. Changes will not be saved."
   },
   "errors": {
+    "invalidColor": "Invalid color. Use a valid hex code (e.g. #ff0000, #fff) or color name.",
     "unsupportedFileType": "Unsupported file type.",
     "imageInsertError": "Couldn't insert image. Try again later...",
     "fileTooBig": "File is too big. Maximum allowed size is {{maxSize}}.",


### PR DESCRIPTION
## Problem

Currently, when a user enters an invalid hexadecimal color in the color picker input field, the input is silently ignored. No visual or textual feedback is provided, causing confusion.

Fixes #9527

## Solution

- Added `isInvalid` state to `ColorInput` component
- When input is invalid (non-empty but `normalizeInputColor` returns `null`), the input gets a red border and red text via `color-picker-input--invalid` CSS class
- A descriptive error tooltip appears on hover via the `title` attribute
- Added `aria-invalid` attribute for accessibility
- Error state clears on blur (reverts to last valid color)
- Added `errors.invalidColor` translation string to `en.json`

## Changes

- `packages/excalidraw/components/ColorPicker/ColorInput.tsx` - added `isInvalid` state and error feedback
- `packages/excalidraw/components/ColorPicker/ColorPicker.scss` - added `.color-picker-input--invalid` styles
- `packages/excalidraw/locales/en.json` - added `errors.invalidColor` translation string

## How to Test

1. Open Excalidraw and select any shape or tool with color
2. Open the color picker and click the hex input
3. Type an invalid value like `zzzzzz`, `12`, or `1234567`
4. The input border and text should turn red with a tooltip error message
5. Press Tab or click away - the input reverts to the last valid color