### PR TITLE
fix(color-picker): show feedback for invalid hex color input

### DIFF
--- a/packages/excalidraw/components/ColorPicker/ColorInput.tsx
+++ b/packages/excalidraw/components/ColorPicker/ColorInput.tsx
@@ -1,5 +1,5 @@
 import clsx from "clsx";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useId, useRef, useState } from "react";
 
 import { KEYS, normalizeInputColor } from "@excalidraw/common";
 
@@ -29,12 +29,17 @@ export const ColorInput = ({
 }) => {
   const editorInterface = useEditorInterface();
   const [innerValue, setInnerValue] = useState(color);
+  // whether the currently typed value is a parseable color; used to surface
+  // a clear error message instead of silently ignoring invalid input
+  const [isValid, setIsValid] = useState(true);
+  const errorMessageId = useId();
   const [activeSection, setActiveColorPickerSection] = useAtom(
     activeColorPickerSectionAtom,
   );
 
   useEffect(() => {
     setInnerValue(color);
+    setIsValid(true);
   }, [color]);
 
   const changeColor = useCallback(
@@ -46,6 +51,8 @@ export const ColorInput = ({
         onChange(color);
       }
       setInnerValue(value);
+      // empty input is treated as "not yet typed" rather than an error
+      setIsValid(value === "" || color !== null);
     },
     [onChange],
   );
@@ -68,67 +75,81 @@ export const ColorInput = ({
   }, [setEyeDropperState]);
 
   return (
-    <div className="color-picker__input-label">
-      <div className="color-picker__input-hash">#</div>
-      <input
-        ref={activeSection === "hex" ? inputRef : undefined}
-        style={{ border: 0, padding: 0 }}
-        spellCheck={false}
-        className="color-picker-input"
-        aria-label={label}
-        onChange={(event) => {
-          changeColor(event.target.value);
-        }}
-        value={(innerValue || "").replace(/^#/, "")}
-        onBlur={() => {
-          setInnerValue(color);
-        }}
-        tabIndex={-1}
-        onFocus={() => setActiveColorPickerSection("hex")}
-        onKeyDown={(event) => {
-          if (event.key === KEYS.TAB) {
-            return;
-          } else if (event.key === KEYS.ESCAPE) {
-            eyeDropperTriggerRef.current?.focus();
-          }
-          event.stopPropagation();
-        }}
-        placeholder={placeholder}
-      />
-      {/* TODO reenable on mobile with a better UX */}
-      {editorInterface.formFactor !== "phone" && (
-        <>
-          <div
-            style={{
-              width: "1px",
-              height: "1.25rem",
-              backgroundColor: "var(--default-border-color)",
-            }}
-          />
-          <div
-            ref={eyeDropperTriggerRef}
-            className={clsx("excalidraw-eye-dropper-trigger", {
-              selected: eyeDropperState,
-            })}
-            onClick={() =>
-              setEyeDropperState((s) =>
-                s
-                  ? null
-                  : {
-                      keepOpenOnAlt: false,
-                      onSelect: (color) => onChange(color),
-                      colorPickerType,
-                    },
-              )
+    <>
+      <div
+        className={clsx("color-picker__input-label", {
+          "has-error": !isValid,
+        })}
+      >
+        <div className="color-picker__input-hash">#</div>
+        <input
+          ref={activeSection === "hex" ? inputRef : undefined}
+          style={{ border: 0, padding: 0 }}
+          spellCheck={false}
+          className="color-picker-input"
+          aria-label={label}
+          aria-invalid={!isValid}
+          aria-describedby={!isValid ? errorMessageId : undefined}
+          onChange={(event) => {
+            changeColor(event.target.value);
+          }}
+          value={(innerValue || "").replace(/^#/, "")}
+          onBlur={() => {
+            setInnerValue(color);
+            setIsValid(true);
+          }}
+          tabIndex={-1}
+          onFocus={() => setActiveColorPickerSection("hex")}
+          onKeyDown={(event) => {
+            if (event.key === KEYS.TAB) {
+              return;
+            } else if (event.key === KEYS.ESCAPE) {
+              eyeDropperTriggerRef.current?.focus();
             }
-            title={`${t(
-              "labels.eyeDropper",
-            )} — ${KEYS.I.toLocaleUpperCase()} or ${getShortcutKey("Alt")} `}
-          >
-            {eyeDropperIcon}
-          </div>
-        </>
+            event.stopPropagation();
+          }}
+          placeholder={placeholder}
+        />
+        {/* TODO reenable on mobile with a better UX */}
+        {editorInterface.formFactor !== "phone" && (
+          <>
+            <div
+              style={{
+                width: "1px",
+                height: "1.25rem",
+                backgroundColor: "var(--default-border-color)",
+              }}
+            />
+            <div
+              ref={eyeDropperTriggerRef}
+              className={clsx("excalidraw-eye-dropper-trigger", {
+                selected: eyeDropperState,
+              })}
+              onClick={() =>
+                setEyeDropperState((s) =>
+                  s
+                    ? null
+                    : {
+                        keepOpenOnAlt: false,
+                        onSelect: (color) => onChange(color),
+                        colorPickerType,
+                      },
+                )
+              }
+              title={`${t(
+                "labels.eyeDropper",
+              )} — ${KEYS.I.toLocaleUpperCase()} or ${getShortcutKey("Alt")} `}
+            >
+              {eyeDropperIcon}
+            </div>
+          </>
+        )}
+      </div>
+      {!isValid && (
+        <div id={errorMessageId} className="color-picker__error" role="alert">
+          {t("colorPicker.invalidColor")}
+        </div>
       )}
-    </div>
+    </>
   );
 };

--- a/packages/excalidraw/components/ColorPicker/ColorPicker.scss
+++ b/packages/excalidraw/components/ColorPicker/ColorPicker.scss
@@ -383,6 +383,21 @@
       box-shadow: 0 0 0 1px var(--color-primary-darkest);
       border-radius: var(--border-radius-lg);
     }
+
+    &.has-error {
+      border-color: var(--color-danger);
+
+      &:focus-within {
+        box-shadow: 0 0 0 1px var(--color-danger);
+      }
+    }
+  }
+
+  .color-picker__error {
+    color: var(--color-danger-darker);
+    font-size: 0.75rem;
+    line-height: 1.2;
+    margin: -4px 8px 4px;
   }
 
   .color-picker__input-hash {

--- a/packages/excalidraw/locales/en.json
+++ b/packages/excalidraw/locales/en.json
@@ -598,7 +598,8 @@
     "colors": "Colors",
     "shades": "Shades",
     "hexCode": "Hex code",
-    "noShades": "No shades available for this color"
+    "noShades": "No shades available for this color",
+    "invalidColor": "Invalid color. Use a format like #RRGGBB."
   },
   "overwriteConfirm": {
     "action": {

--- a/packages/excalidraw/locales/pt-BR.json
+++ b/packages/excalidraw/locales/pt-BR.json
@@ -576,7 +576,8 @@
     "colors": "Cores",
     "shades": "Tons",
     "hexCode": "Código hexadecimal",
-    "noShades": "Sem tons disponíveis para essa cor"
+    "noShades": "Sem tons disponíveis para essa cor",
+    "invalidColor": "Cor inválida. Utilize o formato #RRGGBB."
   },
   "overwriteConfirm": {
     "action": {

--- a/packages/excalidraw/tests/colorInputFeedback.test.tsx
+++ b/packages/excalidraw/tests/colorInputFeedback.test.tsx
@@ -1,0 +1,69 @@
+import React from "react";
+
+import { Excalidraw } from "../index";
+import { Pointer, UI } from "../tests/helpers/ui";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  togglePopover,
+} from "../tests/test-utils";
+
+const mouse = new Pointer("mouse");
+
+describe("ColorInput invalid color feedback", () => {
+  beforeEach(async () => {
+    await render(<Excalidraw handleKeyboardGlobally={true} />);
+  });
+
+  afterEach(async () => {
+    // https://github.com/floating-ui/floating-ui/issues/1908#issuecomment-1301553793
+    await act(async () => {});
+  });
+
+  const drawRectAndOpenStrokePopover = () => {
+    UI.clickTool("rectangle");
+    mouse.down(10, 10);
+    mouse.up(20, 20);
+    togglePopover("Stroke");
+  };
+
+  const getHexInput = () =>
+    document.querySelector<HTMLInputElement>(".color-picker-input")!;
+
+  it("shows an error message and marks the input invalid for a bad hex color", () => {
+    drawRectAndOpenStrokePopover();
+
+    const input = getHexInput();
+    expect(input).toBeTruthy();
+    expect(input.getAttribute("aria-invalid")).toBe("false");
+
+    fireEvent.change(input, { target: { value: "zzzzzz" } });
+
+    expect(input.getAttribute("aria-invalid")).toBe("true");
+    expect(screen.getByText(/Invalid color/i)).toBeTruthy();
+  });
+
+  it("treats an incomplete hex (#12345) as invalid", () => {
+    drawRectAndOpenStrokePopover();
+
+    const input = getHexInput();
+    fireEvent.change(input, { target: { value: "12345" } });
+
+    expect(input.getAttribute("aria-invalid")).toBe("true");
+    expect(screen.getByRole("alert")).toBeTruthy();
+  });
+
+  it("clears the error once a valid color is typed", () => {
+    drawRectAndOpenStrokePopover();
+
+    const input = getHexInput();
+    fireEvent.change(input, { target: { value: "zzzzzz" } });
+    expect(input.getAttribute("aria-invalid")).toBe("true");
+
+    fireEvent.change(input, { target: { value: "ff0000" } });
+    expect(input.getAttribute("aria-invalid")).toBe("false");
+    expect(screen.queryByText(/Invalid color/i)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Closes #9527.

This PR adds inline feedback for invalid hexadecimal color values in the color picker input.

Previously, invalid values such as `zzzzzz`, `12345`, or other malformed hex codes were silently ignored, leaving users without any indication of why the color did not change.

## Changes

- Adds validation feedback for invalid hex color input.
- Displays an inline error message when the typed value is invalid.
- Marks the field as invalid with `aria-invalid`.
- Links the input to the error message with `aria-describedby`.
- Adds localized error messages.
- Adds tests for invalid and valid color input behavior.

## Testing

Ran locally:

```bash
yarn vitest run colorInputFeedback colorInput.test
yarn test:typecheck