### PR TITLE
fix(editor): resolve z-index shortcut conflict on macOS

### DIFF
--- a/packages/excalidraw/actions/actionZindex.tsx
+++ b/packages/excalidraw/actions/actionZindex.tsx
@@ -37,6 +37,7 @@ export const actionSendBackward = register({
   keyTest: (event) =>
     event[KEYS.CTRL_OR_CMD] &&
     !event.shiftKey &&
+    !event.altKey &&
     event.code === CODES.BRACKET_LEFT,
   PanelComponent: ({ updateData, appState }) => (
     <button
@@ -67,6 +68,7 @@ export const actionBringForward = register({
   keyTest: (event) =>
     event[KEYS.CTRL_OR_CMD] &&
     !event.shiftKey &&
+    !event.altKey &&
     event.code === CODES.BRACKET_RIGHT,
   PanelComponent: ({ updateData, appState }) => (
     <button

--- a/packages/excalidraw/tests/actionZindex.test.tsx
+++ b/packages/excalidraw/tests/actionZindex.test.tsx
@@ -1,0 +1,84 @@
+import { vi } from "vitest";
+
+import { CODES, KEYS } from "@excalidraw/common";
+
+import {
+  actionSendBackward,
+  actionBringForward,
+  actionSendToBack,
+  actionBringToFront,
+} from "../actions/actionZindex";
+
+// Simulate macOS, where the "send to back" / "bring to front" shortcuts use
+// CtrlOrCmd+Alt+[ / CtrlOrCmd+Alt+] (see https://github.com/excalidraw/excalidraw/issues/9535).
+vi.mock("@excalidraw/common", async (importOriginal) => {
+  const module = await importOriginal<typeof import("@excalidraw/common")>();
+  return {
+    __esmodule: true,
+    ...module,
+    isDarwin: true,
+    KEYS: {
+      ...module.KEYS,
+      CTRL_OR_CMD: "metaKey",
+    },
+  };
+});
+
+const zIndexActions = [
+  actionSendBackward,
+  actionBringForward,
+  actionSendToBack,
+  actionBringToFront,
+];
+
+// names of z-index actions whose keyTest matches the given event
+const matchingActionNames = (event: Partial<KeyboardEvent>) =>
+  zIndexActions
+    .filter((action) => (action.keyTest as any)?.(event))
+    .map((action) => action.name);
+
+describe("z-index keyboard shortcuts", () => {
+  // The manager dispatches a shortcut only when *exactly one* action matches it
+  // (manager.tsx: `if (data.length !== 1) return false`). If two match, both are
+  // canceled and the shortcut does nothing — the #9535 bug on macOS, where
+  // CtrlOrCmd+Alt+[ also satisfied the plain CtrlOrCmd+[ (send backward) test.
+  it("CtrlOrCmd+Alt+[ matches only sendToBack", () => {
+    const event = {
+      [KEYS.CTRL_OR_CMD]: true,
+      altKey: true,
+      shiftKey: false,
+      code: CODES.BRACKET_LEFT,
+    } as Partial<KeyboardEvent>;
+    expect(matchingActionNames(event)).toEqual(["sendToBack"]);
+  });
+
+  it("CtrlOrCmd+Alt+] matches only bringToFront", () => {
+    const event = {
+      [KEYS.CTRL_OR_CMD]: true,
+      altKey: true,
+      shiftKey: false,
+      code: CODES.BRACKET_RIGHT,
+    } as Partial<KeyboardEvent>;
+    expect(matchingActionNames(event)).toEqual(["bringToFront"]);
+  });
+
+  it("plain CtrlOrCmd+[ / CtrlOrCmd+] still match send backward / bring forward", () => {
+    expect(
+      matchingActionNames({
+        [KEYS.CTRL_OR_CMD]: true,
+        altKey: false,
+        shiftKey: false,
+        code: CODES.BRACKET_LEFT,
+      } as Partial<KeyboardEvent>),
+    ).toEqual(["sendBackward"]);
+
+    expect(
+      matchingActionNames({
+        [KEYS.CTRL_OR_CMD]: true,
+        altKey: false,
+        shiftKey: false,
+        code: CODES.BRACKET_RIGHT,
+      } as Partial<KeyboardEvent>),
+    ).toEqual(["bringForward"]);
+  });
+});


### PR DESCRIPTION
## Problem

On macOS, the **Send to Back** (`Cmd+Alt+[`) and **Bring to Front** (`Cmd+Alt+]`) keyboard shortcuts do nothing. The console logs `Canceling as multiple actions match this shortcut`.

Fixes #9535

## Cause

The action manager dispatches a shortcut only when *exactly one* action's `keyTest` matches (`manager.tsx`: `if (data.length !== 1) return false`).

The plain-bracket actions — `actionSendBackward` (`CtrlOrCmd+[`) and `actionBringForward` (`CtrlOrCmd+]`) — exclude `shiftKey` but not `altKey`. On macOS, `actionSendToBack` / `actionBringToFront` use `CtrlOrCmd+Alt+[` / `CtrlOrCmd+Alt+]`, so those combos satisfy **both** the plain and the modified action — two actions match, and the manager cancels them.

(There is no conflict on Windows/Linux, where send-to-back / bring-to-front use `Shift`, which the plain-bracket test already excludes.)

## Fix

Exclude `altKey` from the plain-bracket `keyTest`s, restoring mutual exclusivity. No behavior change on Windows/Linux.

## Testing

- Added `packages/excalidraw/tests/actionZindex.test.tsx`, asserting that exactly one z-index action matches each shortcut on macOS — and that plain `CtrlOrCmd+[` / `CtrlOrCmd+]` still match send backward / bring forward. The macOS cases fail on `master` and pass with this change.
- `yarn test:typecheck` and `yarn test:code` (eslint) are clean.
- The existing z-order suite (`contextmenu.test.tsx`) passes unchanged.

---

Supersedes the abandoned #11017 and #11417 (both closed without review), adding the regression test coverage they lacked.
