### PR TITLE
Update docker-compose to docker compose in docs

### DIFF
--- a/dev-docs/docs/introduction/development.mdx
+++ b/dev-docs/docs/introduction/development.mdx
@@ -80,10 +80,10 @@ yarn test:code
 
 ### Docker Compose
 
-You can use docker-compose to work on Excalidraw locally if you don't want to setup a Node.js env.
+You can use `docker compose` to work on Excalidraw locally if you don't want to setup a Node.js env.
 
 ```bash
-docker-compose up --build -d
+docker compose up --build -d
 ```
 
 ## Self-hosting


### PR DESCRIPTION
Docker's docs prefer `docker compose` to be used instead of the outdated `docker-compose` program.

Source: https://docs.docker.com/compose/gettingstarted