### PR TITLE
fix: prevent canvas search when dialog is open

### DIFF
--- a/packages/excalidraw/actions/actionToggleSearchMenu.ts
+++ b/packages/excalidraw/actions/actionToggleSearchMenu.ts
@@ -56,5 +56,6 @@ export const actionToggleSearchMenu = register({
   predicate: (element, appState, props) => {
     return props.gridModeEnabled === undefined;
   },
-  keyTest: (event) => event[KEYS.CTRL_OR_CMD] && event.key === KEYS.F,
+  keyTest: (event, appState) =>
+    event[KEYS.CTRL_OR_CMD] && event.key === KEYS.F && !appState.openDialog,
 });


### PR DESCRIPTION
This is an independent contribution.

## Summary

Prevent the Ctrl+F (Cmd+F) keyboard shortcut from triggering the canvas search when a dialog is open.

## Root Cause

The `actionToggleSearchMenu` keyTest matched Ctrl+F unconditionally. When a dialog was open (e.g., help dialog, library sidebar), pressing Ctrl+F would:
1. Match the keyTest (always true for Ctrl+F)
2. Call event.preventDefault() in the action manager before perform()
3. perform() would then check openDialog and return false
4. Result: browser native find was suppressed, dialog closed, no search appeared

## Fix

Added `!appState.openDialog` check to the keyTest function so the action is only triggered when no dialog is active. This allows the browser native find behavior to work normally when a dialog is open, and prevents the search menu from conflicting with dialog interactions.

## Testing

- Press Ctrl+F with help dialog open: browser find should work normally
- Press Ctrl+F with no dialog open: canvas search should open as before
- Press Ctrl+F with other dialogs open (library, element link): browser find should work normally

Closes #9276