### PR TITLE
fix: don't snap rotation to the grid (#4057)

### DIFF
--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -12565,10 +12565,15 @@ class App extends React.Component<AppProps, AppState> {
       activeEmbeddable: null,
     });
     const pointerCoords = pointerDownState.lastCoords;
+    // grid snapping applies to position (move/resize), but must not be applied
+    // when rotating, otherwise the snapped pointer quantizes the rotation angle
+    // and prevents reaching exact angles such as 90° (#4057)
     let [resizeX, resizeY] = getGridPoint(
       pointerCoords.x - pointerDownState.resize.offset.x,
       pointerCoords.y - pointerDownState.resize.offset.y,
-      event[KEYS.CTRL_OR_CMD] ? null : this.getEffectiveGridSize(),
+      transformHandleType === "rotation" || event[KEYS.CTRL_OR_CMD]
+        ? null
+        : this.getEffectiveGridSize(),
     );
 
     const frameElementsOffsetsMap = new Map<

--- a/packages/excalidraw/tests/rotate.test.tsx
+++ b/packages/excalidraw/tests/rotate.test.tsx
@@ -6,7 +6,9 @@ import { reseed } from "@excalidraw/common";
 import { Excalidraw } from "../index";
 
 import { UI } from "./helpers/ui";
-import { render, unmountComponent } from "./test-utils";
+import { act, render, unmountComponent } from "./test-utils";
+
+const { h } = window;
 
 unmountComponent();
 
@@ -82,4 +84,26 @@ test("unselected bound arrows update when rotating their target elements", async
   expect(textArrow.points[0]).toEqual([0, 0]);
   expect(textArrow.points[1][0]).toBeCloseTo(-95.4635969899922, 0);
   expect(textArrow.points[1][1]).toBeCloseTo(-126.8785027399889, 0);
+});
+
+// https://github.com/excalidraw/excalidraw/issues/4057
+test("can rotate to an exact angle while grid mode is enabled", async () => {
+  await render(<Excalidraw />);
+  const rectangle = UI.createElement("rectangle", {
+    x: 0,
+    y: 0,
+    width: 200,
+    height: 100,
+  });
+
+  act(() => {
+    h.setState({ gridModeEnabled: true });
+  });
+
+  // the rotation handle sits directly above the center (100, 50); dragging it
+  // level with the center should rotate the element to exactly 90°. Grid
+  // snapping must not quantize the pointer used to derive the angle (#4057).
+  UI.rotate(rectangle, [60, 70]);
+
+  expect(rectangle.angle).toBeCloseTo(Math.PI / 2, 5);
 });


### PR DESCRIPTION
## What changed
- Grid snapping is no longer applied to the pointer when using the rotation handle.
- Added a regression test that rotates an element to an exact 90° with grid mode enabled.

## Why
Fixes #4057. With grid mode on, the pointer that derives the rotation angle was snapped to the grid along with move/resize. Because the angle comes from `atan2(pointerY - cy, pointerX - cx)`, snapping the pointer quantizes the angle, so exact angles like 90° become unreachable while a grid is active.

Grid snapping is only meaningful for position (move/resize), so it's now skipped for `transformHandleType === "rotation"`. Resize and move snapping are unchanged.

## Testing
- `yarn test:typecheck` passes.
- New test `can rotate to an exact angle while grid mode is enabled` fails on `master` (angle ≈ 1.736 rad instead of π/2) and passes with this change.
- `rotate`, `resize`, `move`, `dragCreate`, and `selection` suites pass.

## Notes for maintainers
- One-line behavioral change in `maybeHandleResize`; the rest is the test.
- The same handler computes `resizeX/resizeY` for both resize and rotation, so the guard is scoped to the rotation handle only.
