### PR TITLE
fix: bump node version to 20 due to incompatible module marked@16.4.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "vitest-canvas-mock": "0.3.3"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.0.0"
   },
   "homepage": ".",
   "prettier": "@excalidraw/prettier-config",


### PR DESCRIPTION
During the `yarn install --frozen-lockfile` with the node version 18.20.8, the install ran into an error 
``` bash
yarn install --frozen-lockfile
yarn install v1.22.22
[1/5] Validating package.json...
[2/5] Resolving packages...
warning Resolution field "strip-ansi@6.0.1" is incompatible with requested version "strip-ansi@^7.0.1"
warning Resolution field "strip-ansi@6.0.1" is incompatible with requested version "strip-ansi@^7.0.1"
warning Resolution field "strip-ansi@6.0.1" is incompatible with requested version "strip-ansi@^7.0.1"
[3/5] Fetching packages...
warning vscode-languageclient@7.0.0: The engine "vscode" appears to be invalid.
error marked@16.4.2: The engine "node" is incompatible with this module. Expected version ">= 20". Got "18.20.8"
error Found incompatible module.
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
```

This would mean that the developers/contributors updated a dependency that requires Node 20+, but they forgot to update the minimum requirements in their package.json.