### PR TITLE
docs: extend CLAUDE.md with more detail, architecture, and nested memory files

### DIFF
--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -1,0 +1,56 @@
+## CI/CD — GitHub Actions Workflows
+
+The `.github/workflows/` directory contains eleven workflows spanning PR validation, post-merge tests, release automation, Docker publishing, Sentry error tracking, and localization coverage. All third-party action references are pinned to commit SHAs (security hardening throughout).
+
+### Branch Model and Trigger Map
+
+Three branches drive automation:
+
+- **`master`** — post-merge tests run here (`test.yml` runs `yarn test:app`).
+- **`release`** — the production gate. Pushing to it triggers five workflows in parallel: npm package release, Docker build verification, Docker publish, Sentry source-map upload, and cancellation of stale prior runs.
+- **`l10n_master`** — Crowdin integration branch. Pushing here rebuilds the translation coverage report and auto-commits changes to `packages/excalidraw/locales/percentages.json`.
+
+### PR Checks (run on pull requests)
+
+| Workflow | What it does |
+|---|---|
+| `cancel.yml` | Cancels stale runs for the PR (and for `release` pushes). Hardcoded workflow IDs: 400555, 400556, 905313, 1451724, 1710116, 3185001, 3438604. |
+| `lint.yml` | Runs `yarn test:other`, `yarn test:code`, `yarn test:typecheck` — covers formatting, linting, and TypeScript. |
+| `size-limit.yml` | Checks the ESM bundle size of `@excalidraw/excalidraw` against a baseline and posts a comment; only triggers on PRs targeting `master`. Installs from `packages/excalidraw` directly, then calls the `build:esm` script. |
+| `test-coverage-pr.yml` | Runs `yarn test:coverage` and posts a Vitest coverage report as a PR comment via `davelosert/vitest-coverage-report-action`. Reports even if tests fail (`if: always()`). |
+| `semantic-pr-title.yml` | Enforces Conventional Commits format with `requireScope: true`. Valid scopes: `app`, `editor`, `packages/excalidraw`, `packages/utils`, `docker`, `repo`. PRs labelled `skip-semantic-title` are exempt. A second job (`label-scope`) auto-applies GitHub labels `s-app`, `s-editor`, or `s-package` derived from the PR title scope, and removes stale scope labels. Only runs on PRs from the same repo (not forks). |
+
+### Release Workflows (trigger: push to `release`)
+
+**`autorelease-excalidraw.yml`** — publishes `@excalidraw/excalidraw` to npm. Runs `yarn release --tag=next --non-interactive`, so all releases go out as `next` pre-release tags. Requires `NPM_TOKEN` secret.
+
+**`build-docker.yml`** — builds the Docker image (`docker build -t excalidraw .`) without pushing. Acts as a build-verification step alongside the publish job.
+
+**`publish-docker.yml`** — builds and pushes to DockerHub as `excalidraw/excalidraw:latest` for three platforms: `linux/amd64`, `linux/arm64`, `linux/arm/v7`. Uses QEMU and Buildx. Requires `DOCKER_USERNAME` and `DOCKER_PASSWORD` secrets.
+
+**`sentry-production.yml`** — builds the web app (`yarn build:app`), installs the Sentry CLI, creates a new Sentry release, associates commits automatically (`--auto`), uploads source maps from `./build/static/js/` with URL prefix `~/static/js`, finalizes the release, and marks it deployed to `production`. Requires `SENTRY_AUTH_TOKEN`, `SENTRY_ORG`, and `SENTRY_PROJECT` secrets.
+
+### Localization Workflow
+
+**`locales-coverage.yml`** (trigger: push to `l10n_master`) — runs `yarn locales-coverage` to regenerate `packages/excalidraw/locales/percentages.json`, commits and pushes it as `Excalidraw Bot` if the file changed, then updates the Crowdin PR description with a coverage summary. Requires a Personal Access Token (`PUSH_TRANSLATIONS_COVERAGE_PAT`) because it needs push and PR-write access beyond `GITHUB_TOKEN` scope.
+
+### Secrets Reference
+
+| Secret | Used by |
+|---|---|
+| `NPM_TOKEN` | `autorelease-excalidraw.yml` |
+| `DOCKER_USERNAME` / `DOCKER_PASSWORD` | `publish-docker.yml` |
+| `SENTRY_AUTH_TOKEN` / `SENTRY_ORG` / `SENTRY_PROJECT` | `sentry-production.yml` |
+| `PUSH_TRANSLATIONS_COVERAGE_PAT` | `locales-coverage.yml` |
+| `GITHUB_TOKEN` | `cancel.yml`, `size-limit.yml`, `semantic-pr-title.yml`, `test-coverage-pr.yml` |
+
+### Other Files
+
+- `.github/FUNDING.yml` — configures the Open Collective funding link (`excalidraw` collective) shown on the GitHub repo page.
+- `.github/copilot-instructions.md` — project coding standards loaded by GitHub Copilot (and referenced by Claude Code). Covers TypeScript preferences, React patterns, naming conventions, error handling, and a note to always include `packages/math/src/types.ts` when writing math-related code.
+- `.github/assets/` — SVG logos for Crowdin, Sentry, and Vercel (used in docs/README).
+
+### Related Documentation
+
+- `.github/copilot-instructions.md` — authoritative coding standards for this project (TypeScript, React, naming, testing guidance).
+- `CONTRIBUTING.md` — contributing guide covering workflow expectations for contributors.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,34 +1,54 @@
 # CLAUDE.md
 
-## Project Structure
+Excalidraw is a **Yarn-workspaces monorepo** split between a publishable whiteboard library and the production web app. The npm library `@excalidraw/excalidraw` (in `packages/excalidraw/`) exposes the embeddable `<Excalidraw>` React component plus an imperative `ExcalidrawImperativeAPI`; `excalidraw-app/` is the excalidraw.com application shell built on top of it. Several lower-level packages (`packages/element/`, `packages/math/`, `packages/common/`, `packages/utils/`, `packages/fractional-indexing/`) supply the canvas engine, geometry, and shared infrastructure.
 
-Excalidraw is a **monorepo** with a clear separation between the core library and the application:
+## How it works
 
-- **`packages/excalidraw/`** - Main React component library published to npm as `@excalidraw/excalidraw`
-- **`excalidraw-app/`** - Full-featured web application (excalidraw.com) that uses the library
-- **`packages/`** - Core packages: `@excalidraw/common`, `@excalidraw/element`, `@excalidraw/math`, `@excalidraw/utils`
-- **`examples/`** - Integration examples (NextJS, browser script)
+The core React component renders the canvas and delegates all element state to `@excalidraw/element`: the `Scene` class (`packages/element/src/index.ts` barrel) is the single authoritative store for the live element list, and `scene.mutateElement()` is the correct call site for changing an element and triggering a re-render. Geometry (hit testing, intersections, transforms) goes through `@excalidraw/math`, which uses branded coordinate types (GlobalPoint vs LocalPoint, Radians vs Degrees) for space safety. Consumers supply `initialData`, receive changes via `onChange(elements, appState, files)` or fine-grained deltas via `onIncrement`, and drive the canvas with `api.updateScene()` / `api.applyDeltas()`. Collaboration is transport-agnostic at the library layer: the host sends deltas from `onIncrement` and applies remote ones via `api.applyDeltas()`; `excalidraw-app/` is the concrete host, wiring Socket.IO + Firebase with end-to-end AES-GCM encryption.
 
-## Development Workflow
+## Build / test / run
 
-1. **Package Development**: Work in `packages/*` for editor features
-2. **App Development**: Work in `excalidraw-app/` for app-specific features
-3. **Testing**: Always run `yarn test:update` before committing
-4. **Type Safety**: Use `yarn test:typecheck` to verify TypeScript
+- `yarn build:packages` (repo root) — builds the `@excalidraw/*` packages; required before running either example.
+- Examples: `examples/with-script-in-browser` runs on port 3001; `examples/with-nextjs` on port 3005.
+- Dev docs are a **separate** project (own `package.json`/lockfile, not in the monorepo): run `yarn start` from inside `dev-docs/` (port 3003).
+- `yarn test:typecheck` (TypeScript checking), `yarn test:update` (run tests with snapshot updates), and `yarn fix` (auto-fix lint/format) are the prior team's documented commands — verify against `package.json` before relying on them.
 
-## Development Commands
+Package builds use esbuild (dev + prod ESM variants); the app uses Vite. Internal packages are wired via path aliases.
 
-```bash
-yarn test:typecheck  # TypeScript type checking
-yarn test:update     # Run all tests (with snapshot updates)
-yarn fix             # Auto-fix formatting and linting issues
-```
+## Consumer / usage surface
 
-## Architecture Notes
+- Library entry points: `<Excalidraw>` component, `ExcalidrawImperativeAPI` (via `onExcalidrawAPI` prop or `useExcalidrawAPI()`), and export/serialization helpers (`exportToCanvas`, `exportToSvg`, `exportToBlob`, `serializeAsJSON`, `loadFromBlob`).
+- `@excalidraw/utils` is the public npm export surface for embedders (`exportToCanvas`, `exportToBlob`, `exportToSvg`, `exportToClipboard`, plus geometric collision/shape helpers); `@excalidraw/math` is also installable standalone.
+- `examples/with-script-in-browser/components/ExampleApp.tsx` is the canonical end-to-end demonstration of the full public API (imperative API, exports, custom tools, slot components, collaborators); the NextJS example imports it directly.
 
-### Package System
+## Codebase map
 
-- Uses Yarn workspaces for monorepo management
-- Internal packages use path aliases (see `vitest.config.mts`)
-- Build system uses esbuild for packages, Vite for the app
-- TypeScript throughout with strict configuration
+- **excalidraw-core** (`packages/excalidraw/`) — the embeddable React whiteboard editor published as `@excalidraw/excalidraw`.
+- **element-system** (`packages/element/`) — canvas element types, the `Scene` store, mutation/rendering pipeline, binding, text layout, elbow-arrow routing, and undo/redo deltas.
+- **math** (`packages/math/`) — pure 2D geometry/vector math (points, curves, intersections, transforms) with branded coordinate types.
+- **shared-libs** (`packages/common/`, `packages/utils/`, `packages/fractional-indexing/`) — cross-cutting constants/utilities/infra (`@excalidraw/common`), the public embedding export surface (`@excalidraw/utils`), and lexicographic z-order keys (`@excalidraw/fractional-indexing`).
+- **web-app** (`excalidraw-app/`) — the excalidraw.com PWA: real-time collaboration, local/IndexedDB persistence, encrypted share links, Excalidraw+ integration, and AI diagram features. Self-contained, not importable.
+- **examples** (`examples/`) — runnable embedding demos (browser-script Vite app, Next.js app).
+- **dev-docs** (`dev-docs/`) — Docusaurus site powering docs.excalidraw.com, with live editable demos.
+- **ci-cd** (`.github/`) — GitHub Actions: PR checks, post-merge tests, and release workflows (npm, Docker, Sentry, Crowdin l10n).
+- **build-tooling** (`scripts/`) — esbuild package builds, WASM/font codegen, the npm release orchestrator, version stamping, and i18n coverage; invoked via yarn/CI only.
+- **firebase-project** (`firebase-project/`) — Firebase config for collaboration/share-link persistence (see below).
+- **public** (`public/`) — static assets served by the app build (see below).
+
+Flow: a user in the `excalidraw-app/` shell interacts with the `<Excalidraw>` core component → edits flow into the `@excalidraw/element` `Scene` store via `mutateElement` → geometry resolves through `@excalidraw/math` → the canvas re-renders; collaboration deltas surface via `onIncrement` and are sent/applied by the app over Socket.IO + Firebase.
+
+## Firebase project
+
+`firebase-project/` is a standalone Firebase config (not a Node package), deployed with the Firebase CLI independently of the Yarn build. It owns `firebase-project/firestore.rules` (read/write permitted but `list` hard-blocked — intentional, to stop users enumerating each other's drawings), `firebase-project/storage.rules` (open get/write scoped to room and share-link path shapes), and `firebase-project/firestore.indexes.json` (no custom indexes). `.firebaserc` points at project ID `excalidraw-room-persistence`.
+
+## Public
+
+`public/` holds assets served verbatim by the Vite/PWA build: the hand-drawn-style fonts that define Excalidraw's identity (`public/Virgil.woff2`, `public/Cascadia.woff2`, `public/Assistant-Regular.woff2`), the full PWA icon set, and social/OG images. `public/_headers` sets `Access-Control-Allow-Origin: *` globally for cross-origin font/asset loading. `public/service-worker.js` is a one-time migration shim that unregisters itself so CRA-era service workers don't block the Vite PWA (its `sw.js`); removable once migration completes. `public/robots.txt` allows Twitterbot/facebookexternalhit for link previews while blocking general indexing of drawing URLs.
+
+## Documentation
+
+- `README.md` — repository overview and features.
+- `CONTRIBUTING.md` — contributor guide.
+- `.github/copilot-instructions.md` — project coding standards.
+
+Per-package detail lives in each package's own README and area CLAUDE.md.

--- a/dev-docs/CLAUDE.md
+++ b/dev-docs/CLAUDE.md
@@ -1,0 +1,55 @@
+## What This Area Is
+
+The `dev-docs/` directory is the source for Excalidraw's public developer documentation site, published at `https://docs.excalidraw.com`. It is a standalone Docusaurus 2 application — not part of the main Yarn monorepo — with its own `dev-docs/package.json`, `dev-docs/yarn.lock`, and `node_modules`. Run it locally with `yarn start` (port 3003) from inside `dev-docs/`.
+
+## Content Structure
+
+Content is organised into four top-level sidebar sections, defined in `dev-docs/sidebars.js`:
+
+### Introduction
+Developer onboarding: local setup, CodeSandbox links, Docker self-hosting, collaboration server references, and contributing guidance.
+
+### Codebase
+Internal design notes for contributors:
+- `dev-docs/docs/codebase/json-schema.mdx` — the `.excalidraw` file format (type, version, source, elements, appState, files) and the clipboard variant (`excalidraw/clipboard`).
+- `dev-docs/docs/codebase/frames.mdx` — element-ordering invariant for frames: children must precede their frame element in the array, which the renderer depends on for correct clipping and performance.
+
+### @excalidraw/excalidraw
+Full API reference for the npm package. Key sub-sections:
+
+**Props** (`dev-docs/docs/@excalidraw/excalidraw/api/props/`) — all props are optional. Notable ones: `initialData` (scene seed), `excalidrawAPI` (callback that delivers the imperative API object, replacing the old `ref` approach removed in v0.17.0), `onChange` (receives elements + appState + files on every change), `isCollaborating`, `theme`, `UIOptions`, `validateEmbeddable`. Custom data can be stored on any element via a `customData` object.
+
+**ExcalidrawAPI** (`dev-docs/docs/@excalidraw/excalidraw/api/props/excalidraw-api.mdx`) — imperative methods obtained via the `excalidrawAPI` prop callback: `updateScene`, `updateLibrary`, `addFiles`, `resetScene`, `getSceneElements`, `getSceneElementsIncludingDeleted`, `getAppState`, `getFiles`, `scrollToContent`, `refresh`, `setToast`, `setActiveTool`, `setCursor`, `resetCursor`, `toggleSidebar`, `history.clear()`, plus event subscription methods `onChange`, `onPointerDown`, `onPointerUp`. The `ready`/`readyPromise` APIs were removed in v0.17.0.
+
+**Children Components** (`dev-docs/docs/@excalidraw/excalidraw/api/children-components/`) — UI customisation via JSX children of `<Excalidraw>`: `MainMenu`, `WelcomeScreen`, `Sidebar`, `Footer`, `LiveCollaborationTrigger`. The migration to this children-component API is ongoing; some UI surfaces (toolbar, element properties panel) are not yet supported.
+
+**Utils** (`dev-docs/docs/@excalidraw/excalidraw/api/utils/utils-intro.md`) — pure JS helpers exported from the package: serialization (`serializeAsJSON`, `serializeLibraryAsJSON`), blob loading (`loadFromBlob`, `loadLibraryFromBlob`, `loadSceneOrLibraryFromBlob`), geometry (`getCommonBounds`, `elementsOverlappingBBox`, `isElementInsideBBox`, `elementPartiallyOverlapsWithOrContainsBBox`), library helpers (`mergeLibraryItems`, `parseLibraryTokensFromUrl`, `useHandleLibrary`), element predicates (`isLinearElement`, `isInvisiblySmallElement`, `getNonDeletedElements`), coordinate conversion (`sceneCoordsToViewportCoords`, `viewportCoordsToSceneCoords`), i18n (`defaultLang`, `languages`, `useI18n`), and the `useEditorInterface` hook (form-factor detection inside `<Excalidraw>` children). Export utilities are in `dev-docs/docs/@excalidraw/excalidraw/api/utils/export.mdx` and restore utilities in `dev-docs/docs/@excalidraw/excalidraw/api/utils/restore.mdx`.
+
+**Element skeleton** (`dev-docs/docs/@excalidraw/excalidraw/api/excalidraw-element-skeleton.mdx`) and **Constants** (`dev-docs/docs/@excalidraw/excalidraw/api/constants.mdx`) complete the reference.
+
+**Customising styles** (`dev-docs/docs/@excalidraw/excalidraw/customizing-styles.mdx`) and an **FAQ** (`dev-docs/docs/@excalidraw/excalidraw/faq.mdx`) are also included.
+
+### @excalidraw/mermaid-to-excalidraw
+Installation, API reference, and codebase internals for the Mermaid-to-Excalidraw conversion library, including a parser walkthrough and a guide for adding new diagram types (`dev-docs/docs/@excalidraw/mermaid-to-excalidraw/codebase/new-diagram-type.mdx`).
+
+## Live Code Examples
+
+The site uses `@docusaurus/theme-live-codeblock`. Code blocks marked ` ```jsx live ` render as interactive editors. The available scope is defined in `dev-docs/src/theme/ReactLiveScope/index.js`, which loads `@excalidraw/excalidraw` (currently pinned at `0.18.0` in the docs package's dependencies) only on the client side (guarded by `ExecutionEnvironment.canUseDOM`). The scope exports: `Excalidraw` (a wrapper that auto-injects the `theme` from Docusaurus color mode), `Footer`, `MainMenu`, `WelcomeScreen`, `LiveCollaborationTrigger`, `Sidebar`, `useDevice`, `useI18n`, `exportToCanvas`, `convertToExcalidrawElements`, `CaptureUpdateAction`, plus `initialData` (the demo library items in `dev-docs/src/initialData.js`).
+
+`window.EXCALIDRAW_ASSET_PATH` is set to `https://esm.sh/@excalidraw/excalidraw@0.18.0/dist/prod/` inside `ReactLiveScope` so live examples load fonts from the CDN. The Docusaurus config (`dev-docs/docusaurus.config.js`) sets `process.env.IS_PREACT = "false"` globally to prevent the Excalidraw package from throwing on `process` being undefined.
+
+## Infrastructure
+
+- **Deployment**: Vercel (`dev-docs/vercel.json`). The `editUrl` in `docusaurus.config.js` points to `https://github.com/excalidraw/excalidraw/tree/master/dev-docs/` so every page has an "Edit this page" link.
+- **Search**: Algolia DocSearch, configured in `docusaurus.config.js`.
+- **Plugins**: `docusaurus-plugin-sass` (SCSS support), `docusaurus2-dotenv` (env var injection with `systemvars: true`), and a custom inline plugin that disables the `fullySpecified` ESM resolution error and turns off Terser minification.
+- **Webpack quirk**: The custom plugin disables `fullySpecified` module resolution for `.mjs` files to avoid errors from packages that ship partially-spec-compliant ESM.
+- **Color mode**: Respects the OS `prefers-color-scheme` setting.
+
+## Existing Documentation To Consult
+
+The following docs in the repo are directly relevant to this area:
+- `dev-docs/README.md` — how to install, develop, build, and deploy the docs site.
+- `dev-docs/docs/@excalidraw/excalidraw/api/utils/utils-intro.md` — full listing of exported utility functions.
+- `dev-docs/src/pages/markdown-page.md` — minimal example of a plain Markdown page in Docusaurus.
+- `CONTRIBUTING.md` — contributing workflow (referenced from the Introduction section of the docs).

--- a/examples/CLAUDE.md
+++ b/examples/CLAUDE.md
@@ -1,0 +1,52 @@
+## Examples
+
+Two standalone integration examples live under `examples/`, each a self-contained project that consumes `@excalidraw/excalidraw` from the monorepo's build output. They exist to demonstrate real-world embedding patterns and serve as a live reference for the public API surface.
+
+### with-script-in-browser
+
+A Vite-based React app (port 3001) showing the browser-script loading pattern. The library is imported as an ES module and then assigned to `window.ExcalidrawLib` before the React entrypoint runs; the React app reads it back from `window.ExcalidrawLib` to avoid bundler-level coupling. `EXCALIDRAW_ASSET_PATH` is hardcoded in `examples/with-script-in-browser/index.html` to the esm.sh CDN URL so fonts load correctly.
+
+`examples/with-script-in-browser/components/ExampleApp.tsx` is the **canonical showcase component**. It receives the entire library as a prop (`excalidrawLib: typeof TExcalidraw`) so it works whether the library came from a bundle, a CDN, or a local build. The component exercises the full public API:
+
+- `ExcalidrawImperativeAPI` obtained via the `excalidrawAPI` ref callback, used to call `updateScene`, `resetScene`, `addFiles`, `updateLibrary`, `scrollToContent`, `getSceneElements`, `getAppState`, `getFiles`
+- Export functions: `exportToSvg`, `exportToBlob`, `exportToCanvas`, `exportToClipboard`
+- Coordinate helpers: `sceneCoordsToViewportCoords`, `viewportCoordsToSceneCoords`
+- Slot components: `Footer`, `WelcomeScreen`, `MainMenu`, `Sidebar` (with `Sidebar.Tabs`, `Sidebar.Tab`, `Sidebar.TabTriggers`, `Sidebar.Trigger`)
+- `LiveCollaborationTrigger` with a mock collaborators map wired through `updateScene`
+- `TTDDialog` / `TTDDialogTrigger` for text-to-diagram
+- A custom "comment" overlay built entirely outside Excalidraw using a custom tool type (`setActiveTool({ type: "custom", customType: "comment" })`) and pointer event listeners — this is the primary example of layering custom HTML over the canvas
+- Initial data loaded asynchronously via a `resolvablePromise` pattern (deferred Promise with `.resolve` attached) so the API call and the data fetch race safely
+
+`examples/with-script-in-browser/initialData.tsx` provides the seed scene using `ExcalidrawElementSkeleton` (the loose input format accepted by `convertToExcalidrawElements`), including a frame, labeled shapes, arrows with bound endpoints, and an image element referencing a file by `fileId`.
+
+`examples/with-script-in-browser/utils.ts` provides thin helpers copied from the library's own internals: `resolvablePromise`, `distance2d`, a `fileOpen` wrapper over `browser-fs-access`, `withBatchedUpdates`, and `withBatchedUpdatesThrottled`. These exist because examples cannot import from private package paths.
+
+Vite config targets `es2022` to support arbitrary module namespace identifiers (required by the library build; see comment in `examples/with-script-in-browser/vite.config.mts`).
+
+The project has a CodeSandbox config at `examples/with-script-in-browser/.codesandbox/tasks.json` that auto-runs `yarn start` on preview.
+
+### with-nextjs
+
+A Next.js 14 app showing embedding in both the App Router and Pages Router. Dev server runs on port 3005; production start on port 3006. It **reuses ExampleApp directly** by importing it from the sibling example via a relative path: `../../with-script-in-browser/components/ExampleApp` — so any change to ExampleApp affects both examples.
+
+**SSR must be disabled.** Both `examples/with-nextjs/src/app/page.tsx` (App Router) and `examples/with-nextjs/src/pages/excalidraw-in-pages.tsx` (Pages Router) use `next/dynamic` with `{ ssr: false }` for the same reason: Excalidraw references browser APIs and cannot run on the server.
+
+`EXCALIDRAW_ASSET_PATH` is injected via a `<Script strategy="beforeInteractive">` tag set to `window.origin` so the app serves fonts from its own public directory.
+
+The build script copies font files from the monorepo's build output before Next.js builds:
+```
+copy:assets: cp -r ../../packages/excalidraw/dist/prod/fonts ./public
+```
+
+`examples/with-nextjs/next.config.js` sets `ignoreBuildErrors: true` to work around a TypeScript conflict between `jsx: preserve` (required by Next.js) and the monorepo's tsconfig. `transpilePackages: ["../"]` is set so that importing types from outside the Next.js root does not throw.
+
+Both examples deploy to Vercel; each has a `vercel.json` pointing to its respective build output directory.
+
+### Build Dependency
+
+Both examples depend on the monorepo packages being built first (`build:packages` at the repo root). The Next.js example chains it automatically — its `dev`/`build` run `build:workspace` → `build:packages` first. The browser example does not: its `build` is just `vite build`, and it exposes a standalone `build:packages` script you run yourself. Working on an example without first building packages will result in missing or stale imports.
+
+### Relevant Documentation
+
+- `examples/with-nextjs/README.md` — standard Next.js getting-started guide (dev server, deploy)
+- `packages/excalidraw/README.md` — library API reference, the public surface these examples exercise

--- a/excalidraw-app/CLAUDE.md
+++ b/excalidraw-app/CLAUDE.md
@@ -1,0 +1,110 @@
+## What This App Is
+
+The `excalidraw-app/` directory is the production excalidraw.com web application. It wraps the `@excalidraw/excalidraw` React library with real-time collaboration, multi-tier local persistence, encrypted share links, Excalidraw+ cloud integration, and AI features. The Vite build target is `excalidraw-app/build/`.
+
+## App Entry and Routing
+
+`excalidraw-app/index.tsx` registers the service worker (via `vite-plugin-pwa`) and mounts `ExcalidrawApp` from `excalidraw-app/App.tsx`. The top-level `ExcalidrawApp` has a special route: if `window.location.pathname === "/excalidraw-plus-export"` it renders `ExcalidrawPlusIframeExport` (a hidden iframe bridge to Excalidraw+) instead of the full editor. All other paths render the standard editor wrapped in a Jotai `Provider` with a single shared store (`appJotaiStore`).
+
+## Scene Initialization
+
+`initializeScene` in `excalidraw-app/App.tsx` resolves which scene to display, in priority order:
+
+1. **Collaboration room link** (`#room=<roomId>,<roomKey>`) — joins or starts a live session via `collabAPI.startCollaboration`.
+2. **JSON backend snapshot** (`#json=<id>,<key>`) — fetches encrypted scene from the share backend (`VITE_APP_BACKEND_V2_GET_URL`) and decrypts it client-side.
+3. **External URL** (`#url=<encodedUrl>`) — fetches and imports an excalidraw file from an arbitrary URL.
+4. **Local state** — restored from localStorage keys `excalidraw` (elements) and `excalidraw-state` (appState).
+
+When an external scene is loaded and the user already has local work, a confirmation dialog prompts before overwriting. Collab room links never trigger this prompt — they do not override localStorage.
+
+## Collaboration
+
+The `Collab` class in `excalidraw-app/collab/Collab.tsx` orchestrates live collaboration:
+
+- **Session creation**: generates a room ID (10 random bytes, hex-encoded) and an AES-GCM encryption key (22-char base64url via `generateEncryptionKey`). The live URL becomes `#room=<roomId>,<roomKey>`.
+- **Socket.IO connection**: connects to `VITE_APP_WS_SERVER_URL`. On socket connection failure, falls back to loading the scene directly from Firebase Firestore.
+- **End-to-end encryption**: every WebSocket message is encrypted with the room key via Web Crypto AES-GCM before being sent. The server never sees plaintext scene data. Peers decrypt with the key from the URL hash (never sent to the server as the hash is local-only).
+- **`Portal`** (`excalidraw-app/collab/Portal.tsx`) manages the socket I/O layer. It broadcasts five subtypes: `SCENE_INIT` (sent to new joiners), `SCENE_UPDATE` (incremental), `MOUSE_LOCATION` (volatile, ~30 fps), `IDLE_STATUS` (volatile), `USER_VISIBLE_SCENE_BOUNDS` (volatile, used for user-follow viewport sync).
+- **Bandwidth optimization**: UPDATE messages send only elements with a version newer than the last broadcast. A full scene re-sync fires every 20 seconds (`SYNC_FULL_SCENE_INTERVAL_MS = 20000`) as a safeguard against message drops.
+- **Persistence during collab**: room state is also saved to Firebase Firestore in a `scenes/<roomId>` document (encrypted). This ensures late joiners and page reloads can fetch the latest scene even if no peer is online. localStorage saving is paused while collaborating (`LocalData.pauseSave("collaboration")`).
+- **Element reconciliation**: incoming remote elements are merged with local state via `reconcileElements` (conflict resolution by version/updated timestamp), then version-bumped via `bumpElementVersions`.
+- **Image files in collab**: stored encrypted in Firebase Storage at `/files/rooms/<roomId>/`; the `FileManager` tracks fetch/save state per file ID to avoid redundant requests.
+- **Idle detection**: pointer-move events reset an idle timeout; AWAY/IDLE/ACTIVE states are broadcast so the UI shows collaborator presence.
+
+## Persistence Layers
+
+| Data | Storage | Keys / Store | Flush timing |
+|---|---|---|---|
+| Elements + appState | localStorage | `excalidraw`, `excalidraw-state` | 300 ms debounce |
+| Binary files (images) | IndexedDB | `files-db / files-store` via `idb-keyval` | debounced with elements |
+| Library | IndexedDB | `excalidraw-library-db` | on change |
+| TTD chat history | IndexedDB | `excalidraw-ttd-chats-db` | on chat change |
+| Collab username | localStorage | `excalidraw-collab` | immediate |
+| Theme preference | localStorage | `excalidraw-theme` | immediate |
+
+Saving is blocked when `document.hidden` is true (prevents spurious writes on tab switch).
+
+Image files unused for more than 24 hours that are no longer on the canvas are deleted from IDB on fresh load (`LocalData.fileStorage.clearObsoleteFiles`).
+
+### Multi-tab Sync
+
+`excalidraw-app/data/tabSync.ts` stores timestamps in localStorage keys `version-dataState` and `version-files`. When a tab regains focus, it compares its in-memory version to the stored one. If the storage is newer (edited by another tab), the tab pulls fresh state and updates the scene without recording a history step (`CaptureUpdateAction.NEVER`).
+
+## Share Links (Encrypted Snapshots)
+
+`exportToBackend` in `excalidraw-app/data/index.ts` creates a shareable link:
+
+1. Generates a fresh AES encryption key.
+2. Compresses and encrypts the scene JSON.
+3. POSTs the ciphertext to `VITE_APP_BACKEND_V2_POST_URL`; receives a scene `id`.
+4. Uploads image files (compressed + encrypted) to Firebase Storage at `/files/shareLinks/<id>/`.
+5. Returns a URL with fragment `#json=<id>,<encryptionKey>` — the key is only ever in the hash, never sent to the server.
+
+Legacy share links used a fixed IV; `importFromBackend` falls back to the legacy decoder if the new format fails.
+
+## Excalidraw+ Integration
+
+Two integration paths connect excalidraw.com to the paid Excalidraw+ product:
+
+**Export to Excalidraw+** (`excalidraw-app/components/ExportToExcalidrawPlus.tsx`): encrypts the scene, uploads it to Firebase Storage at `/migrations/scenes/<nanoid>/`, then opens `VITE_APP_PLUS_APP/import?excalidraw=<id>,<key>` in a new tab.
+
+**Iframe bridge** (`excalidraw-app/ExcalidrawPlusIframeExport.tsx`, route `/excalidraw-plus-export`): Excalidraw+ embeds excalidraw.com in a hidden iframe and sends `REQUEST_SCENE` postMessages with a JWT signed by `VITE_APP_PLUS_EXPORT_PUBLIC_KEY` (RSASSA-PKCS1-v1_5 / SHA-256). The iframe verifies the JWT using `crypto.subtle`, then reads elements and appState from localStorage and files from IDB and posts them back to the Excalidraw+ origin.
+
+Signed-in users are detected by the presence of the `excplus-auth` cookie (`isExcalidrawPlusSignedUser`). This drives UI differences: the promo banner, command palette entries, and sign-in vs sign-up links.
+
+## AI Features
+
+`excalidraw-app/components/AI.tsx` wires two features against `VITE_APP_AI_BACKEND`:
+
+- **Text-to-diagram** (TTD): streaming chat at `/v1/ai/text-to-diagram/chat-streaming`. Conversation history is persisted across sessions in IndexedDB via `TTDIndexedDBAdapter`.
+- **Diagram-to-code**: exports the selected frame as a JPEG, sends it along with extracted text labels to `/v1/ai/diagram-to-code/generate`, renders the returned HTML in an iframe inside the editor.
+
+Both features show rate-limit messaging (HTTP 429) with a link to Excalidraw+ for higher quotas.
+
+## Theme and Language
+
+Theme persists as `"light"`, `"dark"`, or `"system"` in localStorage (`excalidraw-theme`). System mode tracks the `prefers-color-scheme` media query live. Language is auto-detected by `i18next-browser-languagedetector` on first load and reconciled against the list of supported locales; the detected code is stored by the core library.
+
+## PWA
+
+`excalidraw-app/vite.config.mts` configures Workbox via `vite-plugin-pwa`. The app supports:
+- Installability via `BeforeInstallPromptEvent` (captured before React mounts to avoid missing the browser event).
+- `.excalidraw` file association via `file_handlers` in the Web App Manifest.
+- **Web Share Target**: receives shared `.excalidraw` / `.json` files at `/web-share-target` (PWA POST endpoint).
+- Runtime caching: fonts (CacheFirst 90 days), locales (CacheFirst 30 days), JS chunks (CacheFirst 90 days).
+
+## Error Monitoring
+
+Sentry (`@sentry/browser`) is active on `excalidraw.com` and `staging.excalidraw.com` / `vercel.app`. It captures `console.error` calls (via `captureConsoleIntegration`), attaches feature flags, and strips URL fragments before sending events. Several known benign errors are suppressed: IDB-closing errors, `QuotaExceededError`, dynamic import failures from stale service workers, and a Safari-specific `window.__pad` error.
+
+## Key Environment Variables
+
+- `VITE_APP_WS_SERVER_URL` — Socket.IO collaboration server URL
+- `VITE_APP_BACKEND_V2_GET_URL` / `VITE_APP_BACKEND_V2_POST_URL` — share-link backend
+- `VITE_APP_FIREBASE_CONFIG` — JSON Firebase config (Firestore + Storage)
+- `VITE_APP_AI_BACKEND` — AI features backend
+- `VITE_APP_PLUS_APP` / `VITE_APP_PLUS_LP` — Excalidraw+ app and landing page origins
+- `VITE_APP_PLUS_EXPORT_PUBLIC_KEY` — RSA public key for verifying iframe JWT
+- `VITE_APP_GIT_SHA` — build-time SHA injected for Sentry release tracking
+- `VITE_APP_DISABLE_SENTRY` / `VITE_APP_DISABLE_PREVENT_UNLOAD` — dev override flags
+- `VITE_APP_PORT` — dev server port (default 3000)

--- a/packages/CLAUDE.md
+++ b/packages/CLAUDE.md
@@ -1,0 +1,111 @@
+## @excalidraw/common
+
+The `@excalidraw/common` package (`packages/common/`) is the foundation layer imported by every other package and the app. It publishes shared constants, utility functions, TypeScript type helpers, and internal infrastructure (event bus, observable store, data structures).
+
+### Constants (`constants.ts`)
+
+A single large file that is the authoritative source for all cross-cutting numeric and string constants:
+
+- **Element defaults** — `DEFAULT_FONT_SIZE`, `DEFAULT_FONT_FAMILY` (Excalifont), `DEFAULT_ELEMENT_PROPS` (stroke/fill/roughness/opacity)
+- **Font system** — `FONT_FAMILY` map (name → integer id; id 4 is intentionally unused, formerly Assistant/Obsidian), `FONT_FAMILY_FALLBACKS`, CJK/emoji/generic fallback chains, `FONT_SIZES`
+- **Roundness algorithms** — `ROUNDNESS` enum: `LEGACY` (1), `PROPORTIONAL_RADIUS` (2), `ADAPTIVE_RADIUS` (3, default for rectangles using a fixed 32 px radius)
+- **Tools** — `TOOL_TYPE` object used to identify tools by string without magic strings in call sites
+- **UI** — `CLASSES`, `CURSOR_TYPE`, `POINTER_BUTTON`, `POINTER_EVENTS`, frame styling via `FRAME_STYLE`
+- **MIME types** — `MIME_TYPES`, `STRING_MIME_TYPES`, `IMAGE_MIME_TYPES`, `ALLOWED_PASTE_MIME_TYPES`
+- **Events** — `EVENT` enum for all DOM event names including custom `excalidraw-link` and `menu.itemSelect`
+- **Export** — `EXPORT_IMAGE_TYPES`, `EXPORT_DATA_TYPES`, `VERSIONS` (`excalidraw: 2`, `excalidrawLibrary: 2`)
+- **Timing constants** — `IDLE_THRESHOLD` (60 s), `ACTIVE_THRESHOLD` (3 s), `HYPERLINK_TOOLTIP_DELAY`, `ZOOM_STEP`, `MIN_ZOOM`/`MAX_ZOOM` (0.1–30)
+- **Feature flag** — `getFeatureFlag`/`setFeatureFlag` backed by `localStorage` key `"excalidraw-feature-flags"`; currently the only flag is `COMPLEX_BINDINGS: false`
+
+### Core Utilities (`utils.ts`)
+
+Miscellaneous utilities that span the whole editor:
+
+- **Coordinate transforms** — `viewportCoordsToSceneCoords` and `sceneCoordsToViewportCoords` handle zoom + scroll + canvas offset in both directions
+- **Animation** — `debounce` (with `.flush()`/`.cancel()`), `throttleRAF` (executes once per animation frame with latest args), `easeToValuesRAF` (multi-value exponential ease-out animation via `requestAnimationFrame`)
+- **Array helpers** — `arrayToMap`, `arrayToMapWithIndex`, `arrayToObject`, `arrayToList` (circular doubly-linked list), `findIndex`/`findLastIndex`, `mapFind`, `chunk`, `toIterable`/`toArray`, `reduceToCommonValue`
+- **Branded types** — `toBrandedType`, `Unbrand`, `CombineBrands`, `HasBrand` — a zero-runtime branding system for compile-time type safety on coordinates, IDs, etc.
+- **Assertions** — `assertNever` (exhaustive switch guard, soft mode available), `invariant`
+- **Shallow equality** — `isShallowEqual` supports per-key comparator functions or an explicit key list; used heavily for React render memoization
+- **Environment** — `isTestEnv`, `isDevEnv`, `isProdEnv`, `isRunningInIframe`, `getFrame`
+- **DOM** — `addEventListener` (overloaded, returns unsubscribe fn; accepts falsy targets safely), `queryFocusableElements`, `getNearestScrollableContainer`, `selectNode`/`removeSelection`
+- **Misc** — `isRTL` (detects right-to-left text direction for bidi support), `updateObject` (identity-preserving shallow merge), `memoize` (single-slot cache keyed by object entries), `resolvablePromise`, `promiseTry`, `getFontString`/`getFontFamilyString`
+
+### Type Utilities (`utility-types.ts`)
+
+Pure TypeScript helpers re-exported from `@excalidraw/common`: `Mutable`, `Merge`, `MarkOptional`, `MarkRequired`, `MarkNonNullable`, `MaybePromise`, `MakeBrand`, `SetLike`/`ReadonlySetLike`, `DTO` (strips methods), `MapEntry`, `SameType`.
+
+### Event Infrastructure
+
+**`Emitter<T>`** — minimal pub/sub: `on()` (returns unsubscribe), `once()`, `off()`, `trigger()`, `clear()`.
+
+**`AppEventBus`** — typed event bus built on `Emitter` with two behaviors per event: *cardinality* (`once` / `many`) and *replay* (`none` / `last`). Events declared as `once + replay:last` are awaitable via `bus.on(name)` (returns a Promise). In non-production builds, emitting a `once` event twice throws. Used for app lifecycle signals.
+
+**`VersionedSnapshotStore<T>`** — observable value store with monotonic version counter. `set()` rejects equal values (using custom or `Object.is` comparator). `pull(sinceVersion)` returns immediately if already stale, otherwise returns a Promise that resolves on the next change — enabling long-polling patterns. Subscribers receive `{ version, value }` snapshots.
+
+### Data Structures
+
+- **`BinaryHeap<T>`** — min-heap with `push`, `pop`, `remove`, `rescoreElement`; used by pathfinding (A* in elbow arrow routing)
+- **`Queue`** — serial promise queue: jobs run one at a time in FIFO order
+- **`PromisePool<T>`** — concurrent execution of n promises at a time, wrapping `es6-promise-pool`; preserves insertion-order results via index tuples
+
+### Other Modules
+
+- **`colors.ts`** — `COLOR_PALETTE` constant and dark-mode color transformation (CSS `invert(93%) hue-rotate(180deg)` reproduced in pure math for per-color mapping)
+- **`font-metadata.ts`** — `FONT_METADATA` record: per-font `unitsPerEm`, `ascender`, `descender`, `lineHeight` for correct text measurement; also flags (`deprecated`, `private`, `local`, `fallback`)
+- **`editorInterface.ts`** — `EditorInterface` type (formFactor, desktopUIMode, userAgent, isTouchScreen, canFitSidebar) plus breakpoint constants (`MQ_MAX_MOBILE = 599`, tablet up to 1180 px), device detection helpers (`isDarwin`, `isIOS`, `isFirefox`, etc.), `getFormFactor`, `deriveStylesPanelMode`. Desktop UI mode preference persisted under `"excalidraw.desktopUIMode"` in localStorage.
+- **`keys.ts`** — `KEYS`/`CODES` constants plus `matchKey` which falls back from `event.key` to `event.code` for non-Latin keyboard layouts (Cyrillic, Hebrew, CJK etc.) so shortcuts work internationally
+- **`url.ts`** — `normalizeLink` (sanitize + escape quotes) and `toValidURL` (makes relative URLs fully-qualified; returns `"about:blank"` on invalid input) via `@braintree/sanitize-url`
+- **`bounds.ts`** — `Bounds` tuple type `[minX, minY, maxX, maxY]` and `isBounds` guard
+- **`points.ts`** — `getSizeFromPoints`, `rescalePoints`, `getGridPoint` (snaps to grid)
+- **`random.ts`** — `randomId` (nanoid in prod, deterministic `id0`, `id1`… in test env), `randomInteger`, `reseed` (seeded roughjs `Random`)
+- **`debug.ts`** — `Debug` class: `logTime`/`logTimeAverage`/`logTimeWrap` for interval-based frame-budget profiling; `logChanged` for diffing object snapshots; auto-stops after 600 ms of inactivity
+
+---
+
+## @excalidraw/utils
+
+The `@excalidraw/utils` package (`packages/utils/`) is the **public npm API surface** for embedding. External consumers import `exportToCanvas`, `exportToBlob`, `exportToSvg`, `exportToClipboard` from here rather than from `@excalidraw/excalidraw` directly. It also re-exports `elementsOverlappingBBox` and `getCommonBounds` from `@excalidraw/element` and `MIME_TYPES` from `@excalidraw/common`.
+
+### Export Functions (`export.ts`)
+
+All accept an `ExportOpts` base (`elements`, optional `appState`, `files`) plus function-specific overrides.
+
+- **`exportToCanvas`** — restores elements/appState (via `restoreElements`/`restoreAppState`), then calls the internal `_exportToCanvas`. Supports `maxWidthOrHeight` (mutually exclusive with `getDimensions`) and `exportPadding`.
+- **`exportToBlob`** — wraps `exportToCanvas` then `canvas.toBlob`. When `mimeType` is PNG and `exportEmbedScene` is set, encodes the scene JSON into PNG metadata chunks. JPEG forces `exportBackground: true`.
+- **`exportToSvg`** — delegates to internal `_exportToSvg`; supports `skipInliningFonts` and `reuseImages` flags for performance.
+- **`exportToClipboard`** — dispatches to the appropriate clipboard API based on `type: "png" | "svg" | "json"`.
+
+### Geometric Shapes (`shape.ts`)
+
+Defines **pure geometric shapes** independent of roughjs or element specifics:
+
+- `GeometricShape` — discriminated union: `line` (LineSegment), `polygon`, `curve` (Bézier), `ellipse`, `polyline` (array of LineSegments), `polycurve` (array of Bézier curves)
+- Converters from `ExcalidrawElement` → `GeometricShape`: `getPolygonShape` (rectangle, diamond, frame, image, text), `getEllipseShape`, `getCurveShape` (linear elements via roughjs ops), `getFreedrawShape`, `getClosedCurveShape`
+- Collision helpers: `pointOnEllipse`, `pointInEllipse`, `segmentIntersectRectangleElement`, `getSelectionBoxShape`
+- These shapes are used by hit-testing and lasso selection to avoid depending on rendered geometry.
+
+See `packages/utils/README.md` for usage examples.
+
+---
+
+## @excalidraw/fractional-indexing
+
+The `@excalidraw/fractional-indexing` package (`packages/fractional-indexing/`) provides **order keys for element z-ordering**. It is vendored from the `fractional-indexing` npm package (CC0 license), based on the [Observable notebook by dgreensp](https://observablehq.com/@dgreensp/implementing-fractional-indexing).
+
+### Why Fractional Indexing
+
+Excalidraw maintains canvas elements in a flat ordered array; their position in this array determines paint order (z-order). Naively, reordering requires renumbering all indices. Fractional indexing assigns each element a string key that sorts lexicographically, so inserting between two elements only requires generating one new key between the two neighbors — no other elements change.
+
+### Key Format
+
+Keys use `BASE_62_DIGITS` (`0–9A–Za–z`). A key consists of an **integer part** (whose length is determined by the head character — lowercase letters encode lengths 2–27, uppercase letters encode lengths 2–27 descending) followed by an optional **fractional part**. No trailing zeros are allowed in either part.
+
+The key space is bounded: there is a largest and a smallest valid integer. `generateKeyBetween` throws if the space is exhausted.
+
+### API
+
+- **`generateKeyBetween(a, b)`** — returns a single key `k` such that `a < k < b` lexicographically. Either bound may be `null`/`undefined` (open-ended). Throws if `a >= b`.
+- **`generateNKeysBetween(a, b, n)`** — returns `n` distinct sorted keys between `a` and `b`. Uses divide-and-conquer (picks a midpoint, recurses on both halves) to distribute keys evenly.
+- **`validateOrderKey(key)`** — throws on invalid keys (wrong character set, trailing zeros, out-of-range integer head).
+- **`BASE_62_DIGITS`** — the digit set constant; can be passed to functions for custom alphabets.

--- a/packages/element/CLAUDE.md
+++ b/packages/element/CLAUDE.md
@@ -1,0 +1,170 @@
+## Element System
+
+`@excalidraw/element` is the canonical home for all canvas primitives: their type definitions, creation factories, mutation rules, geometry helpers, rendering pipeline, and higher-level operations like binding, grouping, and z-ordering. Everything that touches a shape's data or how it appears on screen flows through this package. See `packages/element/README.md` for install instructions.
+
+### Element Type Hierarchy
+
+All element types share `_ExcalidrawElementBase` (defined in `packages/element/src/types.ts`), which carries:
+
+- **Identity**: `id` (random id — `nanoid` in prod, deterministic `id0`/`id1`… in tests), `seed` (integer for deterministic roughjs noise)
+- **Geometry**: `x`, `y`, `width`, `height`, `angle` (as branded `Radians` from `@excalidraw/math`)
+- **Style**: `strokeColor`, `backgroundColor`, `fillStyle` (`hachure | cross-hatch | solid | zigzag`), `strokeWidth`, `strokeStyle`, `roundness`, `roughness`, `opacity`
+- **Versioning for collaboration**: `version` (monotonically incremented integer), `versionNonce` (random integer for tie-breaking), `updated` (epoch ms timestamp)
+- **Ordering**: `index` (`FractionalIndex | null`) — fractional string used for conflict-free ordering in multiplayer
+- **Containment**: `groupIds` (ordered deepest-to-shallowest), `frameId`, `boundElements` (arrows and text labels anchored to this element)
+- **Soft delete**: `isDeleted: boolean` — elements are never removed from the scene array; deletion sets this flag
+
+Concrete subtypes:
+
+| TypeScript type | `type` field | Notable extra fields |
+|---|---|---|
+| `ExcalidrawGenericElement` | `rectangle \| diamond \| ellipse \| selection` | — |
+| `ExcalidrawTextElement` | `text` | `fontSize`, `fontFamily`, `text`, `originalText`, `textAlign`, `verticalAlign`, `containerId`, `autoResize`, `lineHeight` |
+| `ExcalidrawLinearElement` | `line \| arrow` | `points: LocalPoint[]`, `startBinding`, `endBinding`, `startArrowhead`, `endArrowhead` |
+| `ExcalidrawArrowElement` | `arrow` | `elbowed: boolean` |
+| `ExcalidrawElbowArrowElement` | `arrow` | `elbowed: true`, `fixedSegments`, `startIsSpecial`, `endIsSpecial` |
+| `ExcalidrawFreeDrawElement` | `freedraw` | `points`, `pressures` (stylus), `simulatePressure` |
+| `ExcalidrawImageElement` | `image` | `fileId`, `status` (`pending \| saved \| error`), `scale` (for axis flip), `crop` |
+| `ExcalidrawFrameElement` | `frame` | `name` |
+| `ExcalidrawMagicFrameElement` | `magicframe` | `name` |
+| `ExcalidrawIframeElement` | `iframe` | `customData.generationData` (AI generation status) |
+| `ExcalidrawEmbeddableElement` | `embeddable` | — |
+
+**Map types**: The codebase uses four Map types — `ElementsMap` (a plain `Map`), plus three branded variants: `NonDeletedElementsMap`, `SceneElementsMap` (all elements including deleted, always ordered by fractional index), and `NonDeletedSceneElementsMap`. The brands prevent accidentally substituting a subset map where the full scene map is required.
+
+### Creating Elements
+
+Factory functions in `packages/element/src/newElement.ts` are the only sanctioned way to create elements:
+
+- `newElement(opts)` — generic (rectangle/diamond/ellipse)
+- `newTextElement(opts)` — measures text and computes initial dimensions immediately
+- `newLinearElement(opts)` — line or arrow; `polygon: true` enables closed polygon mode for lines
+- `newArrowElement(opts)` — `opts.elbowed: true` produces an `ExcalidrawElbowArrowElement` with an empty `fixedSegments` array
+- `newFreeDrawElement(opts)` — includes `pressures` array for pen pressure
+- `newImageElement(opts)` — always starts with `status: "pending"` and `strokeColor: "transparent"`
+- `newFrameElement`, `newMagicFrameElement`, `newEmbeddableElement`, `newIframeElement`
+
+All converge on `_newElementBase`, which assigns a random `id`, random `seed`, `version: 1`, `versionNonce: 0`, `isDeleted: false`, and the current timestamp as `updated`. The package logs a console error (not throws) when coordinates exceed ±1e6.
+
+### Mutation Rules
+
+Two mutation functions in `packages/element/src/mutateElement.ts`:
+
+**`mutateElement(element, elementsMap, updates, options)`** — mutates the element object in place. It:
+1. Short-circuits if no values actually changed (with special deep-equality checks for `points` and `scale`)
+2. For elbow arrows: automatically recalculates the route via `updateElbowArrowPoints` when `points` or `fixedSegments` change
+3. For linear elements: recalculates `width`/`height` from the points bounding box
+4. Deletes the element's `ShapeCache` entry when geometry changes (width/height/points/fileId)
+5. Bumps `version`, randomizes `versionNonce`, updates `updated` timestamp
+
+**WARNING**: `mutateElement` alone does NOT trigger a React re-render. To trigger UI update, use `scene.mutateElement(...)` (which calls `triggerUpdate()` when the version actually changed) or the imperative API.
+
+**`newElementWith(element, updates)`** — immutable version: returns a spread copy with bumped versioning. Used for collaboration reconciliation and history entries where immutability is required.
+
+**`bumpVersion(element, version?)`** — lowest-level: just increments `version`, randomizes `versionNonce`, updates timestamp. Used when the element itself didn't logically change but other participants need to see it as updated.
+
+### Scene
+
+`packages/element/src/Scene.ts` (the `Scene` class) is the live state container:
+
+- Keeps parallel data structures: an ordered `elements` array (the authoritative order), a `SceneElementsMap`, a `nonDeletedElements` array, and a `NonDeletedSceneElementsMap`
+- `replaceAllElements(nextElements)` — the only way to bulk-update; calls `syncInvalidIndices` so fractional indices are always valid, rebuilds all maps, separates frames, triggers update
+- `mutateElement(element, updates, options)` — wraps the low-level `mutateElement` and calls `triggerUpdate()` only when the version actually changed and `options.informMutation` is true
+- `insertElementsAtIndex(elements, index)` — low-level insertion; prefer `app.insertNewElements()` from outside the package
+- `mapElements(iteratee)` — efficient batch update: iterates current elements, only calls `replaceAllElements` if any element reference changed
+- `getSelectedElements(opts)` — cached; cache is keyed on `selectedElementIds` reference + option flags
+- `triggerUpdate()` — regenerates `sceneNonce` (used as a renderer cache key) and fires all registered callbacks
+- `onUpdate(cb)` — subscribe to scene changes; returns an unsubscribe function
+
+### Fractional Index Ordering
+
+Elements carry a `FractionalIndex` string (from the `fractional-indexing` library) in their `index` field. This enables efficient conflict-free ordering during multiplayer reconciliation and undo/redo, without needing full array re-sorts.
+
+Key invariants maintained in `packages/element/src/fractionalIndex.ts`:
+
+- The array order and fractional indices must always be in sync
+- `syncMovedIndices(elements, movedMap)` — after an in-array reorder (z-index moves), updates only the moved elements' indices to fit between their new neighbors
+- `syncInvalidIndices(elements)` — heals elements with `null` or out-of-order indices; called by `replaceAllElements` on every scene update
+- `validateFractionalIndices` — throws in dev/test environments, logs in production; throttled to once per minute and only checked if `window.DEBUG_FRACTIONAL_INDICES` is set in production
+- `orderByFractionalIndex(elements)` — sort by fractional index; used during history application and reconciliation, NOT during normal rendering (array order is the cache)
+
+Bound text elements must sort immediately after their container (`text.index > container.index`); `validateFractionalIndices` enforces this with `includeBoundTextValidation`.
+
+### Shape Cache & Rendering
+
+`packages/element/src/shape.ts` maintains the `ShapeCache` (a WeakMap-backed cache from element to roughjs `Drawable`). Shapes are generated lazily and reused until a geometry change clears the cache entry. The package uses roughjs for the sketchy/hand-drawn appearance; the `seed` field on each element ensures the roughjs noise is deterministic across renders and collaborators.
+
+`packages/element/src/renderElement.ts` renders individual elements to Canvas 2D or an off-screen canvas (for caching). It handles:
+- Rotation (saves/restores canvas transform around element center)
+- Opacity
+- Dark mode filter (`DARK_THEME_FILTER` constant applied via canvas filter)
+- Frame clipping (elements inside frames are clipped to frame bounds)
+- Pending image placeholder
+- Text rendering (line by line, respecting `lineHeight` and `verticalAlign`)
+- ArrowHead rendering via geometry from `bounds.ts`
+
+### Binding System
+
+Arrows and lines can bind their endpoints to "bindable" elements (rectangles, diamonds, ellipses, text, images, iframe, embeddable, frame, magicframe). Binding is defined as a `FixedPointBinding` on `startBinding`/`endBinding`:
+
+```
+{ elementId, fixedPoint: [ratioX, ratioY], mode: "inside" | "orbit" | "skip" }
+```
+
+The `fixedPoint` ratios are 0–1 fractions of the target element's width/height, describing where on the element the arrow endpoint is anchored. `mode: "orbit"` keeps the arrow outside the shape boundary; `mode: "inside"` allows the arrowhead to reach all the way to the fixed point inside the shape.
+
+`packages/element/src/binding.ts` provides:
+- `updateBoundElements(element, scene, opts)` — called after any bindable element moves/resizes; repositions all arrows bound to it
+- `snapToMid(...)` — snaps an arrow endpoint to a bindable element's edge midpoints
+
+(Hit-testing for binding candidates during drag lives in `collision.ts` — see Other Notable Modules.)
+
+### Elbow Arrow Routing
+
+`packages/element/src/elbowArrow.ts` implements orthogonal (axis-aligned) routing for elbow arrows via A\* pathfinding on a sparse grid derived from element bounding boxes. The algorithm avoids routing through other elements. Key behaviors:
+
+- When segments are not fixed, routing is fully automatic based on the `Heading` of exit/entry points on bound elements
+- `fixedSegments` lets users lock specific path segments in place; the router adjusts only the unfixed portions
+- `startIsSpecial`/`endIsSpecial` are internal markers used when a binding side changes orientation (horizontal↔vertical) while fixed segments are present — they temporarily "hide" the first or last segment without losing the points array data
+
+`packages/element/src/heading.ts` defines the cardinal `Heading` type (`[1,0] | [0,1] | [-1,0] | [0,-1]`) used throughout the binding and elbow routing systems.
+
+### Text Bound to Containers
+
+A text element can be bound to a container (rectangle, diamond, ellipse, or arrow) via `containerId`. This creates a two-way link: the container's `boundElements` array includes `{ id: textId, type: "text" }`.
+
+- `textElement.autoResize = true` (default): element width expands to fit content; text does not wrap
+- `textElement.autoResize = false`: text wraps to fill the available container width
+- `wrapText` in `packages/element/src/textWrapping.ts` performs line-breaking using canvas `measureText`
+- `redrawTextBoundingBox` in `packages/element/src/textElement.ts` recomputes text element dimensions and position after any change to text content or container geometry
+- Arrow labels: text bound to an arrow has `angle` forced to 0 and is positioned at the arrow midpoint
+
+### Store & Undo/Redo Infrastructure
+
+`packages/element/src/store.ts` defines the `Store` class that observes every scene commit and produces typed increments for the undo/redo stack and collaboration:
+
+- `CaptureUpdateAction.IMMEDIATELY` — captured immediately into undo stack (normal edits)
+- `CaptureUpdateAction.NEVER` — never recorded (remote updates, scene initialization)
+- `CaptureUpdateAction.EVENTUALLY` — not captured immediately; folded into the next IMMEDIATELY commit (async operations like freedraw, text entry, image drop)
+
+`packages/element/src/delta.ts` defines `Delta<T>` as `{ deleted: Partial<T>, inserted: Partial<T> }`. `ElementsDelta` and `AppStateDelta` extend this for element-level and app-state-level changes respectively. A `StoreDelta` aggregates both for a single undo step.
+
+### Groups and Frames
+
+**Groups**: There is no group object. Membership is expressed as the `groupIds: readonly GroupId[]` array on each element, ordered deepest-to-shallowest. A selection in the UI selects the entire top-level group. `packages/element/src/groups.ts` contains helpers like `getElementsInGroup`, `getSelectedElementsByGroup`, `selectGroup`.
+
+**Frames**: `ExcalidrawFrameElement` and `ExcalidrawMagicFrameElement` are regular elements whose `id` is referenced by other elements' `frameId` field. `packages/element/src/frame.ts` provides `getContainingFrame`, `getFrameChildren`, `elementsAreInFrameBounds`, `elementOverlapsWithFrame`. When elements are rendered inside a frame, they are clipped to the frame boundary.
+
+### Other Notable Modules
+
+- `packages/element/src/bounds.ts` — `getElementAbsoluteCoords` (rotated bounding box corners), `getElementBounds` (includes stroke/arrowhead padding), `getCommonBounds`, `aabbForElement` (axis-aligned), `getDiamondPoints`, `getArrowheadPoints`
+- `packages/element/src/collision.ts` — `isPointInElement`, `intersectElementWithLineSegment`, `getHoveredElementForBinding`, `shouldTestInside`; used for hit testing during pointer events
+- `packages/element/src/resizeElements.ts` — multi-element resize while preserving relative positions, handles text reflow and binding updates
+- `packages/element/src/align.ts` / `packages/element/src/distribute.ts` — align/distribute operations; both call `updateBoundElements` after repositioning
+- `packages/element/src/zindex.ts` — send-to-back/bring-to-front; moves contiguous groups together; respects frame boundaries
+- `packages/element/src/duplicate.ts` — duplicates elements preserving group/frame membership and re-binding arrows to duplicated endpoints
+- `packages/element/src/transform.ts` — bulk-transforms (paste, import from clipboard) a set of elements into the scene; creates a fresh `Scene` instance, resolves binding, and syncs fractional indices
+- `packages/element/src/flowchart.ts` — creates a new shape and an elbow arrow connecting it to an existing flowchart node when the user presses an arrow key with a flowchart-capable element selected
+- `packages/element/src/cropElement.ts` — computes the `ImageCrop` rectangle when the user drags a crop handle on an image; preserves aspect ratio when requested
+- `packages/element/src/typeChecks.ts` — runtime type guard functions (`isTextElement`, `isArrowElement`, `isElbowArrow`, `isBindableElement`, `isBoundToContainer`, `isFrameLikeElement`, etc.); used throughout the codebase to narrow the union type
+- `packages/element/src/linearElementEditor.ts` — `LinearElementEditor` class that manages the editing session for a selected line/arrow (point dragging, midpoint insertion, segment deletion, snapping to grid)

--- a/packages/excalidraw/CLAUDE.md
+++ b/packages/excalidraw/CLAUDE.md
@@ -1,0 +1,173 @@
+## Excalidraw Core Library
+
+This package is the embeddable React whiteboard editor published to npm as `@excalidraw/excalidraw`. It is the npm-consumable core: embedding hosts drop in `<Excalidraw>` and receive a fully functional drawing canvas. The excalidraw.com web app (`excalidraw-app/`) is a separate consumer that wraps this library. See `packages/excalidraw/README.md` for the public API reference.
+
+### Public API Surface
+
+`packages/excalidraw/index.tsx` is the sole public entry point. It exports:
+
+- **`<Excalidraw>`** — the main `React.memo`-wrapped component (exported as `Excalidraw`)
+- **`ExcalidrawAPIProvider`** — a context provider that lets hooks (`useExcalidrawAPI`, `useExcalidrawStateValue`, `useOnExcalidrawStateChange`) work outside the `<Excalidraw>` tree
+- Composable UI slots: `MainMenu`, `Footer`, `WelcomeScreen`, `LiveCollaborationTrigger`, `Sidebar`, `Button`, `CommandPalette`, `Stats`
+- Element utilities: `getNonDeletedElements`, `getCommonBounds`, `mutateElement`, `newElementWith`, `bumpVersion`
+- Export helpers: `exportToCanvas`, `exportToBlob`, `exportToSvg`, `serializeAsJSON`, `loadFromBlob`
+- Data helpers: `restoreElements`, `reconcileElements`
+- Constants: `FONT_FAMILY`, `THEME`, `MIME_TYPES`, `ROUNDNESS`
+- React hooks: `useExcalidrawAPI`, `useExcalidrawStateValue`, `useOnExcalidrawStateChange`
+
+The component fills its parent's full width/height — the parent element must have non-zero dimensions.
+
+### React Props Contract
+
+Key props from `ExcalidrawProps` in `packages/excalidraw/types.ts`:
+
+| Prop | Purpose |
+|------|---------|
+| `initialData` | Starting elements, appState, files, libraryItems |
+| `onChange(elements, appState, files)` | Fires on every change; primary sync hook |
+| `onIncrement(event)` | Fine-grained delta events (`DurableIncrement` \| `EphemeralIncrement`) |
+| `onExcalidrawAPI(api)` | Receive the imperative handle on mount |
+| `isCollaborating` | Enables collaboration UI chrome |
+| `onPointerUpdate({pointer, button, pointersMap})` | Remote cursor broadcast hook |
+| `viewModeEnabled` | Read-only view |
+| `zenModeEnabled` | Hide toolbars |
+| `theme` | `"light"` \| `"dark"` \| `undefined` (auto) |
+| `langCode` | BCP-47 locale code (defaults to `"en"`) |
+| `UIOptions` | Show/hide specific canvas actions and tools |
+| `renderTopLeftUI` / `renderTopRightUI` | Inject custom UI into toolbar corners |
+| `onLinkOpen(element, event)` | Intercept hyperlink clicks on elements |
+| `validateEmbeddable(url)` | Allow/deny iframe embeds |
+| `generateIdForFile(file)` | Custom file ID generation |
+
+### Imperative API
+
+`ExcalidrawImperativeAPI` (defined in `packages/excalidraw/types.ts`) is obtained via `onExcalidrawAPI` or `useExcalidrawAPI()`. Methods include:
+
+- `updateScene(sceneData)` — set elements/appState/files; primary way to drive the scene from outside
+- `applyDeltas(deltas)` — apply collaborative incremental deltas
+- `getSceneElements()` / `getAppState()` / `getFiles()` — read current state
+- `resetScene()` — wipe everything
+- `scrollToContent()` — pan/zoom to fit visible elements
+- `setActiveTool(tool)` — switch the active tool programmatically
+- `refresh()` — force a re-render without state change
+- `updateFrameRendering(opts)` — toggle frame clipping
+- Event subscriptions: `onChange`, `onIncrement`, `onPointerDown`, `onPointerUp`, `onScrollChange`, `onStateChange`, `onEvent`
+
+### Data Model
+
+**ExcalidrawElement** is the core domain object. Every drawn shape is a plain JavaScript object (never a class instance) with a stable `id`. The type hierarchy lives in `@excalidraw/element` (`packages/element/src/types.ts`):
+
+- Shapes: rectangle, diamond, ellipse
+- Linear: arrow, line (multi-point with optional bezier)
+- Text (standalone or bound inside a container shape)
+- Image (references `BinaryFiles` by FileId)
+- Frame / MagicFrame (grouping containers)
+- Embeddable / Iframe
+- FreeDraw (freehand strokes)
+- Selection (transient, never serialized)
+
+All elements share a base with: `id`, `x/y`, `width/height`, `angle` (in radians), `strokeColor`, `backgroundColor`, `fillStyle`, `strokeWidth`, `strokeStyle`, `roughness`, `opacity`, `seed` (RoughJS determinism), `version`, `versionNonce`, `index` (FractionalIndex), `isDeleted`, `groupIds`, `frameId`, `boundElements`, `updated`, `link`, `locked`, `customData`.
+
+Elements are **treated as immutable outside the store** — external code uses `mutateElement()` (exported) or returns new objects from actions. The `version` increments on every change; `versionNonce` is a random value per change enabling conflict resolution in collaboration.
+
+**AppState** (`packages/excalidraw/types.ts`, 70+ properties, initialized in `packages/excalidraw/appState.ts`) captures all transient UI and interaction state: tool selection, zoom/scroll, current item styling defaults, selection sets, resize/rotate flags, collaboration cursors, snap lines, grid config, and more. It is never persisted directly to disk — only `elements` and `files` are canonical.
+
+**BinaryFiles** (`Record<FileId, BinaryFileData>`) stores image content as base64 dataURLs, associated with the canvas (not individual elements). Image elements reference files by `FileId`.
+
+### Component Architecture
+
+`packages/excalidraw/components/App.tsx` is the main orchestrator (~414 KB). It:
+
+- Wires together the Store, History, scene, actions, and UI
+- Manages three canvas layers:
+  1. **StaticCanvas** — background shapes, rendered via `packages/excalidraw/renderer/staticScene.ts`, throttled to the frame rate
+  2. **InteractiveCanvas** — selection boxes, transform handles, snap lines, remote cursors, binding highlights, rendered via `packages/excalidraw/renderer/interactiveScene.ts`
+  3. **NewElementCanvas** — live preview of the element being drawn, via `packages/excalidraw/renderer/renderNewElementScene.ts`
+- Handles pointer events (down/move/up), keyboard shortcuts, gesture (pinch-zoom)
+- Calls `packages/excalidraw/scene/Renderer.ts` to filter visible elements by viewport
+
+`packages/excalidraw/components/InitializeApp.tsx` handles language loading and theme setup before the editor mounts.
+
+### State Management
+
+Three cooperating layers:
+
+1. **Store** (in `@excalidraw/element`): Holds the authoritative element array. On every commit it produces a `StoreIncrement` — either `DurableIncrement` (undoable, includes element and appState deltas) or `EphemeralIncrement` (pointer moves, not undoable). The `CaptureUpdateAction` enum (`IMMEDIATELY`, `EVENTUALLY`, `NEVER`) controls when a change reaches history.
+
+2. **History** (`packages/excalidraw/history.ts`): Maintains undo/redo stacks of `HistoryDelta` objects. Each delta is the inverse of a `StoreDelta`, so undo/redo replays changes from `DurableIncrement` events. Changes that only touch invisible or ephemeral state are filtered out.
+
+3. **Jotai atoms** (`packages/excalidraw/editor-jotai.ts`): Local reactive atoms for UI state not covered by AppState (e.g., i18n strings, search query). `EditorJotaiProvider` and `editorJotaiStore` are exported for use by host apps.
+
+### Actions System
+
+Every user-facing operation (copy, paste, zoom, align, flip, z-index, undo, properties panel changes) is encoded as an action in `packages/excalidraw/actions/`. Each action is defined with `register()` (from `packages/excalidraw/actions/register.ts`) and includes:
+
+- `name: ActionName` — unique identifier
+- `label` / `icon` — for UI generation
+- `predicate(elements, appState, appProps, app)` — whether the action is active/visible
+- `perform(elements, appState, formData, app)` → `ActionResult` — executes the change and returns `{elements, appState, files, captureUpdate}`
+- Optional `PanelComponent` — React component rendered in the properties panel
+- Optional `keyTest` — keyboard shortcut binding
+
+`packages/excalidraw/actions/manager.tsx` auto-generates UI from registered actions. `packages/excalidraw/actions/types.ts` defines `ActionName`, `ActionSource` (`"ui"` | `"keyboard"` | `"contextMenu"` | `"api"` | `"commandPalette"`), and `ActionResult`.
+
+### Element Domain Rules
+
+**Fractional Indexing** — Elements are ordered by `index: FractionalIndex | null` (lexicographic string comparison), not array position. This allows inserting between any two elements without renumbering, and is essential for conflict-free ordering in multiplayer. Index validity after local operations is maintained in `@excalidraw/element` (`packages/element/src/fractionalIndex.ts` — `syncMovedIndices` / `syncInvalidIndices`).
+
+**Arrow Binding** — Arrow/line endpoints bind to shapes via `FixedPointBinding`. When a shape moves, `updateBoundElements()` cascades position updates to all arrows attached to it. Binding is detected via `getHoveredElementForBinding()` during drag.
+
+**Text Binding** — Text elements may be bound inside container shapes (`containerId`). The text auto-wraps and the container auto-resizes to fit. `editingTextElement` in AppState tracks which text is being edited inline.
+
+**Grouping** — `groupIds` is an ordered array; nested groups are supported. `selectedGroupIds` and `editingGroupId` in AppState track the current drill-down level. Double-clicking a group enters group-editing mode.
+
+**Frames** — Frame elements act as named containers. Child elements reference their frame via `frameId`. Frames clip their children on export and during frame-rendering mode. `packages/excalidraw/scene/export.ts` handles frame-aware export.
+
+**Element versioning for reconciliation** — During collaboration, `packages/excalidraw/data/reconcile.ts` merges incoming element arrays against local state, choosing the higher-version element and using `versionNonce` to break ties.
+
+### Collaboration Integration
+
+The library is collaboration-agnostic — it provides the hooks, the host implements the transport:
+
+1. User action → Store commits → `onIncrement(DurableIncrement)` fires with element+appState deltas → host sends to server
+2. Remote update arrives → host calls `api.applyDeltas(deltas)` or `api.updateScene({elements: reconcileElements(...)})`
+3. Remote cursors: host calls `api.updateScene({appState: {collaborators: new Map([...]) }})` to render other users' pointers
+4. `onPointerUpdate` prop broadcasts the local user's cursor position and tool state to the transport layer
+
+`isCollaborating={true}` unlocks collaboration-specific UI (multiplayer presence, "live collaboration" button).
+
+### Export System
+
+- `exportToCanvas(elements, appState, files, opts)` — renders to an `HTMLCanvasElement`
+- `exportToBlob(...)` — resolves to a PNG/JPEG `Blob`
+- `exportToSvg(...)` — returns an `SVGSVGElement`, using `packages/excalidraw/renderer/staticSvgScene.ts` for faithful SVG output
+- `serializeAsJSON(elements, appState, files)` — produces the `.excalidraw` JSON format
+- `loadFromBlob(blob, ...)` — deserializes a `.excalidraw` or `.png` file (PNGs embed JSON in metadata)
+- `packages/excalidraw/data/encryption.ts` supports encrypted export/import
+- `packages/excalidraw/data/restore.ts` handles schema migration when loading older files
+
+### Internationalization
+
+`packages/excalidraw/i18n.ts` supports 40+ languages. A `languages` array lists each locale with code, label, and optional RTL flag. `setLanguage(lang)` async-loads the locale JSON from `packages/excalidraw/locales/` and sets `document.documentElement.dir`/`lang`. The `t(key)` function resolves nested dot-notation keys with English fallback. Translation completeness thresholds are tracked in a percentages file in the locales directory. See `packages/excalidraw/locales/README.md` for contribution instructions.
+
+### Rendering Pipeline (Summary)
+
+```
+User event → App.tsx event handler
+  → action.perform() → ActionResult
+  → store.commit(elements, appState) → StoreIncrement
+  → History records DurableIncrement
+  → onChange / onIncrement callbacks fire
+  → StaticCanvas re-renders (throttled, RoughJS for shapes)
+  → InteractiveCanvas re-renders (selections, handles, cursors)
+```
+
+Only elements intersecting the current viewport are sent to the renderers (filtered by `packages/excalidraw/scene/Renderer.ts`). The static canvas output is cached across zoom changes via a `shouldCacheIgnoreZoom` flag.
+
+### Existing Documentation
+
+- `packages/excalidraw/README.md` — public API reference (props, imperative API, utilities)
+- `packages/excalidraw/locales/README.md` — how to add or update translations
+- `dev-docs/docs/@excalidraw/excalidraw/api/utils/utils-intro.md` — utility function reference
+- `CONTRIBUTING.md` — monorepo setup and contribution workflow
+- `.github/copilot-instructions.md` — project coding standards

--- a/packages/math/CLAUDE.md
+++ b/packages/math/CLAUDE.md
@@ -1,0 +1,103 @@
+## @excalidraw/math
+
+Low-level, pure geometric and vector math library for Excalidraw's canvas engine. It provides branded geometric types, point/vector/curve/shape primitives, and intersection/containment algorithms. All other packages (`@excalidraw/element`, `packages/excalidraw`) depend on these primitives rather than writing their own geometry.
+
+See `packages/math/README.md` for installation instructions.
+
+## Type System and Coordinate Spaces
+
+The central design choice is **branded TypeScript types** that prevent accidentally mixing coordinate spaces at compile time.
+
+- `GlobalPoint` — a `[x, y]` tuple in world/canvas/scene space, branded `excalimath__globalpoint`
+- `LocalPoint` — a `[x, y]` tuple in element-local space, branded `excalimath__localpoint`
+- `Vector` — a `[u, v]` direction/displacement, branded `excalimath__vector`; not interchangeable with points even though both are number tuples
+- `Radians` / `Degrees` — branded `number` subtypes; arithmetic on bare `number` does not satisfy them
+- `InclusiveRange` — branded `[number, number]` pair for 1D interval arithmetic
+- `Line<P>` — infinite line defined by two points; `LineSegment<P>` — bounded by two endpoints
+- `Curve<P>` — cubic Bézier with exactly four control points
+- `Polygon<P>` — closed `Point[]` array (constructor always appends the first point at the end)
+- `Rectangle<P>` — two-point bounding box `[topLeft, bottomRight]`
+- `Triangle<P>` — three-point tuple
+- `Ellipse<P>` — object with `center`, `halfWidth`, `halfHeight` (axis-aligned; rotation handled by callers)
+
+**Ongoing migration**: `GlobalCoord` / `LocalCoord` (`{ x, y }` objects) exist for backward compatibility and carry TODO comments for removal once the codebase fully migrates to tuple points. New code should use `GlobalPoint` / `LocalPoint` tuples.
+
+## Primitive Construction
+
+Every type has a factory function that attaches the brand through a cast (no runtime overhead):
+
+- `pointFrom(x, y)` / `pointFrom({ x, y })` — overloaded; also accepts `GlobalCoord`/`LocalCoord` objects during migration
+- `vector(x, y, originX?, originY?)` — constructs relative to an optional origin
+- `lineSegment(a, b)`, `line(a, b)`, `curve(a, b, c, d)`
+- `ellipse(center, halfWidth, halfHeight)`
+- `polygon(...points)` / `polygonFromPoints(points[])` — automatically closes the ring
+- `rectangle(topLeft, bottomRight)`, `rectangleFromNumberSequence(minX, minY, maxX, maxY)`
+- `rangeInclusive(start, end)`, `rangeInclusiveFromPair([start, end])`
+
+## Key Algorithms
+
+### Cubic Bézier (curve.ts)
+
+`bezierEquation(c, t)` evaluates the standard cubic Bézier formula at parameter `t ∈ [0,1]`.
+
+**Curve–segment intersection** (`curveIntersectLineSegment`): Newton-Raphson with an analytical Jacobian, seeded at three initial guesses (t=0.5, t=0.2, t=0.8 / s=0 each). Returns the first solution found within `[0,1]×[0,1]`; the caller receives at most one intersection point per call. Default tolerance 1e-2, iteration limit 4.
+
+**Arc length** (`curveLength`, `curveLengthAtParameter`): 24-point Legendre-Gauss quadrature using the abscissae/weights stored in `packages/math/src/constants.ts`. Partial length up to parameter `t` scales the integration interval to `[0,t]` before applying the same quadrature.
+
+**Point at arc-length percentage** (`curvePointAtLength`): binary search over `t` using `curveLengthAtParameter`, up to 20 iterations with tolerance = 0.01% of total length.
+
+**Closest point** (`curveClosestPoint`): 30-step uniform coarse sweep to find the best `t`, then bisection refinement within ±1/30 of that step.
+
+**Tangent and normal** (`curveTangent`, `vectorNormal`): analytic derivative of the cubic Bézier; `vectorNormal` returns the right-hand perpendicular `(y, -x)`.
+
+**Offset curves** (`curveOffsetPoints`, `offsetPointsForQuadraticBezier`): samples the curve at uniform `t` steps, computes the normalized normal at each sample, and pushes the point outward by the offset distance. Used to generate stroke-width parallel curves.
+
+**Catmull-Rom spline conversion** (`curveCatmullRomCubicApproxPoints`, `curveCatmullRomQuadraticApproxPoints`): converts a sequence of control points and a tension parameter into a chain of Bézier curves by computing tangent-based control points.
+
+### Ellipse (ellipse.ts)
+
+`ellipseIncludesPoint`: normalized quadratic inequality test (no iteration).
+
+`ellipseDistanceFromPoint`: 3-iteration closest-point-on-ellipse approximation using the parametric foot-of-normal approach, accurate enough for hit testing.
+
+`ellipseSegmentInterceptPoints`: quadratic discriminant on the implicit ellipse equation; returns 0, 1, or 2 intersection points filtered to `t ∈ [0,1]`.
+
+`ellipseLineIntersectionPoints`: same formula without the segment clamp, returning all real intersections with the infinite line.
+
+### Line and Segment (line.ts, segment.ts)
+
+`linesIntersectAt`: solves the 2×2 linear system via determinant; returns null when lines are parallel (D=0).
+
+`segmentsIntersectAt`: cross-product parameterization; returns the intersection only when both parameters `t, u ∈ [0,1)` (endpoint-exclusive on the right).
+
+`distanceToLineSegment`: projects the point onto the segment, clamping to the nearer endpoint when the projection falls outside.
+
+### Polygon (polygon.ts)
+
+`polygonIncludesPoint`: ray-casting (even-odd rule).
+
+`polygonIncludesPointNonZero`: winding number; handles self-intersecting polygons correctly where ray-casting would not.
+
+`pointOnPolygon`: tests all edges via `pointOnLineSegment`.
+
+### Triangle (triangle.ts)
+
+`triangleIncludesPoint`: sign-of-area test using three cross products; returns false for points exactly on the boundary.
+
+### Range (range.ts)
+
+1D interval helpers (`rangesOverlap`, `rangeIntersection`, `rangeIncludesValue`) used by bounding-box overlap tests elsewhere in the engine.
+
+## Numeric Precision
+
+`PRECISION = 10e-5` (0.0001) is the shared tolerance for floating-point equality checks across `pointsEqual`, `pointOnLineSegment`, `ellipseTouchesPoint`, and related predicates. Callers may override it via an optional `threshold` parameter.
+
+`pointDistanceSq` / `vectorMagnitudeSq` are provided specifically to avoid a square root when only comparing magnitudes.
+
+## Angle Utilities (angle.ts)
+
+`normalizeRadians(angle)`: maps any angle to `[0, 2π)`.
+
+`radiansBetweenAngles(a, min, max)`: handles wraparound ranges where `min > max` (e.g., `[5.5, 0.8]`).
+
+`cartesian2Polar([x, y])`: returns `[radius, normalizedAngle]` — the `PolarCoords` tuple.

--- a/scripts/CLAUDE.md
+++ b/scripts/CLAUDE.md
@@ -1,0 +1,65 @@
+## Build Tooling
+
+The `scripts/` directory owns the build, bundling, release, font processing, and i18n coverage tooling for the monorepo. All scripts are CommonJS Node.js programs invoked via `yarn` workspace commands.
+
+### Package ESM Builds
+
+Every publishable package uses esbuild and produces two variants: an unminified dev build with source maps under `dist/dev/`, and a minified production build without source maps under `dist/prod/`. Three build scripts handle the different packaging needs:
+
+- `scripts/buildPackage.js` — builds `@excalidraw/excalidraw`. Entry points are `index.tsx` and any `**/*.chunk.ts` file (code-split chunks). Uses `esbuild-sass-plugin` with a custom `precompile` function that rewrites relative SCSS `@use`/`@forward` paths to `file://` absolute URLs so Sass can resolve them during bundling. `.woff2` files are emitted as file assets. All sibling `@excalidraw/*` packages (`common`, `element`, `math`, `fractional-indexing`) are marked external; `@excalidraw/utils` is aliased to its source directory. Environment variables are loaded from `.env.development` / `.env.production` via `packages/excalidraw/env.cjs`.
+
+- `scripts/buildBase.js` — minimal build for smaller utility packages within `packages/` (used for `common`, `element`, `math`, `fractional-indexing`). Single entry `src/index.ts`, no Sass or woff2 handling. Same external/alias pattern as `buildPackage.js`.
+
+- `scripts/buildUtils.js` — builds `@excalidraw/utils` with ALL `@excalidraw/*` packages aliased to their source directories (including `common`, `element`, `excalidraw`, `math`, `fractional-indexing`, and `utils` itself), making the utils bundle fully self-contained with no external peers. Also includes `sassPlugin()` and `woff2ServerPlugin` (see font section below). In production, `woff2ServerPlugin` receives `{ outdir: \'dist/prod/assets\' }` to trigger TTF generation; in dev, it receives no options and only inlines base64.
+
+### WASM Modules
+
+`scripts/buildWasm.js` converts two committed binary WASM files into TypeScript modules that export a base64 decode function. The source files are `scripts/wasm/woff2.wasm` (from `fonteditor-core`) and `scripts/wasm/hb-subset.wasm` (from `harfbuzzjs`). Running this script regenerates `packages/excalidraw/fonts/wasm/woff2-wasm.ts` and `packages/excalidraw/fonts/wasm/hb-subset-wasm.ts`. The generated files are checked in; the script is only re-run when the upstream WASM modules change. Each generated file embeds its source package\'s name, version, author, and license text as a comment block.
+
+### Font Build Plugins
+
+Font processing is split between two environments:
+
+**Server-side (esbuild)** — `scripts/woff2/woff2-esbuild-plugins.js` exports `woff2ServerPlugin`. When added to an esbuild configuration, it intercepts `.woff2` imports and inlines them as base64 `data:font/woff2;base64,...` strings (needed because esbuild\'s `file` loader is broken in CommonJS and `dataurl` loader produces incorrect URIs). When an `outdir` option is provided, the plugin also generates merged TTF files at build-end: it decompresses woff2 → SNFT → TTF using `wawoff2` and `fonteditor-core`, then calls `pyftmerge` (Python `fonttools` must be installed) to merge multiple unicode-range woff2 files for the same family into a single TTF. Fallback fonts are appended to every family: NotoEmoji and LiberationSans for all fonts; Xiaolai additionally for Excalifont-family fonts (CJK support). The `vhea`/`vmtx` tables are dropped during merge to avoid pyftmerge conflicts. The 2048-unit-em variants under `scripts/woff2/assets/` exist because `pyftmerge` requires all merged fonts to share the same `unitsPerEm`; the Xiaolai family is skipped from TTF generation as it ships as a single TTF already.
+
+**Browser (Vite)** — `scripts/woff2/woff2-vite-plugins.js` exports `woff2BrowserPlugin`. In production builds it does two things: rewrites `packages/excalidraw/fonts/fonts.css` to replace its Assistant font-face definitions with ones that point at the DigitalOcean Spaces CDN (`https://excalidraw.nyc3.cdn.digitaloceanspaces.com/oss/`) with a root-relative fallback URL, and injects a `window.EXCALIDRAW_ASSET_PATH` script and `<link rel="preload">` tags (for Excalifont, Nunito latin range, Assistant-SemiBold, and ComicShanns) into `excalidraw-app/index.html` by replacing `<!-- PLACEHOLDER:EXCALIDRAW_APP_FONTS -->`. This plugin is a no-op during development (`command === \'serve\'`).
+
+### Release Orchestration
+
+`scripts/release.js` is the single entry point for publishing `@excalidraw/*` packages to npm. It accepts three tags:
+
+- `test` (default): publishes with the "test" npm tag; version is `<current-excalidraw-version>-<short-commit-hash>` for idempotent re-runs.
+- `next`: same version scheme, published under the "next" npm tag; `--non-interactive` flag skips prompts for CI use.
+- `latest`: requires an explicit `--version=X.Y.Z`; updates the changelog and prompts to commit before publishing.
+
+Packages are published in dependency order: `common`, `fractional-indexing`, `math`, `element`, `excalidraw`. `@excalidraw/utils` is explicitly excluded and has its own independent release process. Before publishing, the script stamps every `package.json` with the new version and also updates any `@excalidraw/*` entries inside each package\'s `dependencies`. All package JSONs are modified atomically after all are computed, to avoid leaving the repo in a partially-updated state.
+
+The build step inside the release flow runs `yarn --frozen-lockfile` at the root, removes existing build artifacts with `yarn rm:build`, then runs `yarn run build:esm` in each package directory in order.
+
+### Changelog Automation
+
+`scripts/updateChangelog.js` (a module exported for use by `release.js`) finds the previous release by grepping git log for commits matching the message `"release @excalidraw/excalidraw"`, then collects all commits since that commit on `master`. Only conventional commit types `feat`, `fix`, `style`, `refactor`, `perf`, and `build` are included. PR references are converted to GitHub markdown links. Commits without a PR number are flagged as "bad commits" and still included but without a link. The script skips PRs whose numbers already appear in the existing changelog (avoids duplicating package-update entries). The updated content replaces the `## Unreleased` heading with a versioned date heading in `packages/excalidraw/CHANGELOG.md`.
+
+### App Version Stamping
+
+`scripts/build-version.js` runs after the Vite app build. It writes `build/version.json` containing `{"version": "<commit-date-ISO>-<short-commit-hash>"}` (the date comes from the actual HEAD commit timestamp via `git show -s --format=%ct`, not the current wall-clock time) and replaces all `{version}` template literals in `build/index.html`.
+
+### Docs Build Gate
+
+`scripts/buildDocs.js` is a CI utility that diffs HEAD^ against HEAD and exits 0 if no `docs`-containing files changed (skip docs build) or exits 1 if they did (trigger docs build). It is used as a conditional build step for the docs site.
+
+### Node.js Rendering Build
+
+`scripts/build-node.js` is a legacy script that uses `rewire` to patch the CRA (`react-scripts`) webpack config for a headless Node.js build: it disables code splitting, sets a deterministic output filename, targets the `node` platform, and points the entry to `packages/excalidraw/index-node`. The `canvas` npm package (which requires Cairo) must be installed manually and is not part of the standard release flow.
+
+### i18n Coverage
+
+Two scripts manage translation coverage for the locales in `packages/excalidraw/locales/`:
+
+- `scripts/build-locales-coverage.js` computes per-locale translation completion percentages (non-empty leaf keys / total leaf keys, via recursive flatten) and writes `packages/excalidraw/locales/percentages.json`.
+- `scripts/locales-coverage-description.js` reads that percentages file and prints a Markdown table with flags, native language names, Crowdin links, and coverage percentages. The threshold for appearing on production Excalidraw is **85%**; locales below that are shown as `...`.
+
+### Relevant Documentation
+
+- `packages/excalidraw/locales/README.md` — explains how to contribute translations and how the Crowdin integration works.
+- `CONTRIBUTING.md` — covers the general development and release workflow.


### PR DESCRIPTION
## What

Extends the root `CLAUDE.md` into a fuller map of the codebase - the architecture, data flow, and conventions that help an AI assistant (and new contributors) get productive fast - and adds a `CLAUDE.md` per package so detail loads where you're working.

Highlights, all checked against the current source:

- **How it works** - `Scene` (`packages/element`) as the single source of truth, `scene.mutateElement()` as the re-render entry point, `@excalidraw/math`'s branded coordinate types, and the transport-agnostic collaboration layer (the app wiring Socket.IO + Firebase with AES-GCM-encrypted persistence).
- **Per-package memory** - `CLAUDE.md` files for `element` (the `Scene` store + mutation pipeline), `math`, `excalidraw`, the app, `scripts`, and more.
- **Build / test / run** - the `yarn build:packages` prerequisite, example ports (3001 / 3005), dev-docs as a separate project (3003).
- **Codebase map**, plus short **Firebase** and **public/** notes - e.g. `firestore.rules` blocks `list` by design, and `public/service-worker.js` is a self-unregistering migration shim.

I put this together with a codebase-onboarding tool I'm building, then verified every claim against the source by hand. Glad to adjust the style or scope to fit the project - and just as glad to keep it lean if that's your preference.