### PR TITLE
feat: Replace stroke width presets with slider

### DIFF
--- a/packages/excalidraw/actions/actionProperties.test.tsx
+++ b/packages/excalidraw/actions/actionProperties.test.tsx
@@ -109,7 +109,7 @@ describe("element locking", () => {
       expect(crossHatchButton).toBe(null);
     });
 
-    it("should highlight common stroke width of selected elements", () => {
+    it("should show common stroke width of selected elements", () => {
       const rect1 = API.createElement({
         type: "rectangle",
         strokeWidth: STROKE_WIDTH.thin,
@@ -121,14 +121,17 @@ describe("element locking", () => {
       API.setElements([rect1, rect2]);
       API.setSelectedElements([rect1, rect2]);
 
-      const thinStrokeWidthButton = queryByTestId(
+      const strokeWidthSlider = queryByTestId(
         document.body,
-        `strokeWidth-thin`,
-      );
-      expect(thinStrokeWidthButton).toBeChecked();
+        `strokeWidth`,
+      ) as HTMLInputElement;
+      expect(strokeWidthSlider.value).toBe(`${STROKE_WIDTH.thin}`);
+      expect(strokeWidthSlider.min).toBe("1");
+      expect(strokeWidthSlider.max).toBe("12");
+      expect(strokeWidthSlider.step).toBe("1");
     });
 
-    it("should not highlight any stroke width button if no common style", () => {
+    it("should show stroke width slider if no common style", () => {
       const rect1 = API.createElement({
         type: "rectangle",
         strokeWidth: STROKE_WIDTH.thin,
@@ -140,16 +143,12 @@ describe("element locking", () => {
       API.setElements([rect1, rect2]);
       API.setSelectedElements([rect1, rect2]);
 
-      expect(queryByTestId(document.body, `strokeWidth-thin`)).not.toBe(null);
-      expect(
-        queryByTestId(document.body, `strokeWidth-thin`),
-      ).not.toBeChecked();
-      expect(
-        queryByTestId(document.body, `strokeWidth-bold`),
-      ).not.toBeChecked();
-      expect(
-        queryByTestId(document.body, `strokeWidth-extraBold`),
-      ).not.toBeChecked();
+      const strokeWidthSlider = queryByTestId(
+        document.body,
+        `strokeWidth`,
+      ) as HTMLInputElement;
+      expect(strokeWidthSlider).not.toBe(null);
+      expect(strokeWidthSlider.value).toBe(`${STROKE_WIDTH.bold}`);
     });
 
     it("should show properties of different element types when selected", () => {
@@ -164,7 +163,9 @@ describe("element locking", () => {
       API.setElements([rect, text]);
       API.setSelectedElements([rect, text]);
 
-      expect(queryByTestId(document.body, `strokeWidth-bold`)).toBeChecked();
+      expect(
+        (queryByTestId(document.body, `strokeWidth`) as HTMLInputElement).value,
+      ).toBe(`${STROKE_WIDTH.bold}`);
       expect(queryByTestId(document.body, `font-family-code`)).toHaveClass(
         "active",
       );

--- a/packages/excalidraw/actions/actionProperties.tsx
+++ b/packages/excalidraw/actions/actionProperties.tsx
@@ -12,7 +12,6 @@ import {
   DEFAULT_FONT_SIZE,
   FONT_FAMILY,
   ROUNDNESS,
-  STROKE_WIDTH,
   VERTICAL_ALIGN,
   KEYS,
   randomInteger,
@@ -105,8 +104,6 @@ import {
   SloppinessArtistIcon,
   SloppinessCartoonistIcon,
   StrokeWidthBaseIcon,
-  StrokeWidthBoldIcon,
-  StrokeWidthExtraBoldIcon,
   FontSizeSmallIcon,
   FontSizeMediumIcon,
   FontSizeLargeIcon,
@@ -462,6 +459,12 @@ export const actionChangeBackgroundColor = register<
   },
 });
 
+const STROKE_WIDTH_RANGE = {
+  min: 1,
+  max: 12,
+  step: 1,
+};
+
 export const actionChangeFillStyle = register<ExcalidrawElement["fillStyle"]>({
   name: "changeFillStyle",
   label: "labels.fill",
@@ -551,55 +554,45 @@ export const actionChangeStrokeWidth = register<
   label: "labels.strokeWidth",
   trackEvent: false,
   perform: (elements, appState, value) => {
+    const nextStrokeWidth = value ?? appState.currentItemStrokeWidth;
+    const strokeWidth = Math.min(
+      STROKE_WIDTH_RANGE.max,
+      Math.max(STROKE_WIDTH_RANGE.min, nextStrokeWidth),
+    );
+
     return {
       elements: changeProperty(elements, appState, (el) =>
         newElementWith(el, {
-          strokeWidth: value,
+          strokeWidth,
         }),
       ),
-      appState: { ...appState, currentItemStrokeWidth: value },
+      appState: { ...appState, currentItemStrokeWidth: strokeWidth },
       captureUpdate: CaptureUpdateAction.IMMEDIATELY,
     };
   },
-  PanelComponent: ({ elements, appState, updateData, app, data }) => (
-    <fieldset>
-      <legend>{t("labels.strokeWidth")}</legend>
-      <div className="buttonList">
-        <RadioSelection
-          group="stroke-width"
-          options={[
-            {
-              value: STROKE_WIDTH.thin,
-              text: t("labels.thin"),
-              icon: StrokeWidthBaseIcon,
-              testId: "strokeWidth-thin",
-            },
-            {
-              value: STROKE_WIDTH.bold,
-              text: t("labels.bold"),
-              icon: StrokeWidthBoldIcon,
-              testId: "strokeWidth-bold",
-            },
-            {
-              value: STROKE_WIDTH.extraBold,
-              text: t("labels.extraBold"),
-              icon: StrokeWidthExtraBoldIcon,
-              testId: "strokeWidth-extraBold",
-            },
-          ]}
-          value={getFormValue(
-            elements,
-            app,
-            (element) => element.strokeWidth,
-            (element) => element.hasOwnProperty("strokeWidth"),
-            (hasSelection) =>
-              hasSelection ? null : appState.currentItemStrokeWidth,
-          )}
-          onChange={(value) => updateData(value)}
-        />
-      </div>
-    </fieldset>
-  ),
+  PanelComponent: ({ elements, appState, updateData, app }) => {
+    const strokeWidth = getFormValue(
+      elements,
+      app,
+      (element) => element.strokeWidth,
+      (element) => element.hasOwnProperty("strokeWidth"),
+      (hasSelection) => (hasSelection ? null : appState.currentItemStrokeWidth),
+    );
+
+    return (
+      <Range
+        label={t("labels.strokeWidth")}
+        value={strokeWidth ?? appState.currentItemStrokeWidth}
+        hasCommonValue={strokeWidth !== null}
+        onChange={updateData}
+        min={STROKE_WIDTH_RANGE.min}
+        max={STROKE_WIDTH_RANGE.max}
+        step={STROKE_WIDTH_RANGE.step}
+        minLabel={`${STROKE_WIDTH_RANGE.min}px`}
+        testId="strokeWidth"
+      />
+    );
+  },
 });
 
 export const actionChangeSloppiness = register<ExcalidrawElement["roughness"]>({


### PR DESCRIPTION
While using Excalidraw, I often felt that the free-draw tool lacked flexibility in stroke thickness, especially for finer sketches. This PR adds a stroke width slider, allowing users to choose thinner or thicker strokes based on their needs. It also helps address the concern raised in Issue #3693 regarding the limited free-draw stroke width options.

Changes Made
- Added stroke width slider (1px–12px)
- Applied selected width to free-draw strokes
- Maintained consistency with existing stroke settings across Excalidraw

Picture After Implementation:
<img width="1917" height="1197" alt="image" src="https://github.com/user-attachments/assets/f6dabe13-86ca-49cd-9325-2736b100916c" />

Picture Before Implementation:
<img width="1889" height="1163" alt="image" src="https://github.com/user-attachments/assets/0ad5f935-35d3-4375-a820-6b3e910167c2" />
