### PR TITLE
docs: fix duplicated "the the" typo in API docs and code comment

### DIFF
--- a/dev-docs/docs/@excalidraw/excalidraw/api/props/excalidraw-api.mdx
+++ b/dev-docs/docs/@excalidraw/excalidraw/api/props/excalidraw-api.mdx
@@ -372,7 +372,7 @@ This API has the below signature. It sets the `tool` passed in param as the acti
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
 | `type` | [ToolType](https://github.com/excalidraw/excalidraw/blob/master/packages/excalidraw/types.ts#L91) | `selection` | The tool type which should be set as active tool |
-| `locked` | `boolean` | `false` | Indicates whether the the active tool should be locked. It behaves the same way when using the `lock` tool in the editor interface |
+| `locked` | `boolean` | `false` | Indicates whether the active tool should be locked. It behaves the same way when using the `lock` tool in the editor interface |
 
 ## setCursor
 

--- a/packages/element/src/groups.ts
+++ b/packages/element/src/groups.ts
@@ -234,7 +234,7 @@ export const getSelectedGroupIds = (
     .filter(([groupId, isSelected]) => isSelected)
     .map(([groupId, isSelected]) => groupId);
 
-// given a list of elements, return the the actual group ids that should be selected
+// given a list of elements, return the actual group ids that should be selected
 // or used to update the elements
 export const selectGroupsFromGivenElements = (
   elements: readonly NonDeleted<ExcalidrawElement>[],


### PR DESCRIPTION
Fixes two instances of the duplicated word `the the`:

- `dev-docs/docs/@excalidraw/excalidraw/api/props/excalidraw-api.mdx` — "Indicates whether the the active tool should be locked" → "whether the active tool"
- `packages/element/src/groups.ts` — comment "return the the actual group ids" → "return the actual group ids"

Documentation/comment-only change; no functional impact.