### PR TITLE
fix: keep documentElement overscroll disabled while editor is mounted (#5588)

### DIFF
--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -2081,11 +2081,15 @@ class App extends React.Component<AppProps, AppState> {
     });
   };
 
-  private toggleOverscrollBehavior(event: React.PointerEvent) {
-    // when pointer inside editor, disable overscroll behavior to prevent
-    // panning to trigger history back/forward on MacOS Chrome
-    document.documentElement.style.overscrollBehaviorX =
-      event.type === "pointerenter" ? "none" : "auto";
+  // disable the documentElement's horizontal overscroll behavior so that
+  // trackpad panning on Chrome (MacOS) cannot accidentally trigger the
+  // browser's back/forward history navigation. Previously this was toggled
+  // on pointer enter/leave, but the window where it was reset to "auto"
+  // could leave Chrome in a state where the very next pan still triggered
+  // the bf gesture (see #5588). Keep it disabled for the lifetime of the
+  // editor instead, and restore it on unmount.
+  private setDocumentOverscrollBehavior(disable: boolean) {
+    document.documentElement.style.overscrollBehaviorX = disable ? "none" : "";
   }
 
   public render() {
@@ -2159,8 +2163,6 @@ class App extends React.Component<AppProps, AppState> {
         onKeyDown={
           this.props.handleKeyboardGlobally ? undefined : this.onKeyDown
         }
-        onPointerEnter={this.toggleOverscrollBehavior}
-        onPointerLeave={this.toggleOverscrollBehavior}
       >
         <ExcalidrawAPIContext.Provider value={this.api}>
           <AppContext.Provider value={this}>
@@ -3099,6 +3101,8 @@ class App extends React.Component<AppProps, AppState> {
     this.excalidrawContainerValue.container =
       this.excalidrawContainerRef.current;
 
+    this.setDocumentOverscrollBehavior(true);
+
     if (isTestEnv() || isDevEnv()) {
       const setState = this.setState.bind(this);
       Object.defineProperties(window.h, {
@@ -3235,7 +3239,7 @@ class App extends React.Component<AppProps, AppState> {
     isSomeElementSelected.clearCache();
     selectGroupsForSelectedElements.clearCache();
     touchTimeout = 0;
-    document.documentElement.style.overscrollBehaviorX = "";
+    this.setDocumentOverscrollBehavior(false);
   }
 
   private onResize = withBatchedUpdates(() => {


### PR DESCRIPTION
## Issue

Closes #5588

On MacOS Chrome, trackpad two-finger panning over the canvas occasionally triggers the browser's back/forward history navigation. The earlier fix (#7671) toggled \`document.documentElement.style.overscrollBehaviorX\` on pointer enter/leave of the editor root. That left a window where the value was reset to \`\"auto\"\` whenever the pointer was outside the editor — and once a bf gesture started and was cancelled in that window, Chrome could keep the trackpad pan in a state where the next pan back over the canvas re-triggered the bf navigation.

## Fix

Drop the pointer-based toggle. Set \`overscroll-behavior-x: none\` on \`document.documentElement\` in \`componentDidMount\` and clear the inline style in \`componentWillUnmount\`. The behavior no longer depends on transient pointer state, so there is no window during which the bf gesture can be armed.

## Trade-off

While the editor is mounted, the host page also loses the horizontal bf gesture on its root. For full-page deployments (excalidraw.com) this is desired; for embedded use it is a minor side effect that is preferable to the bug, and matches the practical behavior most embedders rely on anyway (\`overscroll-behavior-x: none\` is the recommended way to opt out of bf gestures).

## Test

- \`yarn test:typecheck\`, \`yarn test:code\`, \`yarn test:other\` all pass.
- \`packages/excalidraw/tests/App.test.tsx\` still passes.
- Manual: load the editor, two-finger pan rapidly toward both horizontal edges, attempt to start and cancel a bf gesture by panning past the edge, return to canvas — bf navigation no longer fires.

No automated test added: the bug is a browser-gesture side effect on \`overscroll-behavior\` that cannot be exercised inside jsdom.