### PR TITLE
fix: keep vertical center anchored when alt-resizing bound text container

### DIFF
--- a/packages/element/src/resizeElements.ts
+++ b/packages/element/src/resizeElements.ts
@@ -919,6 +919,7 @@ export const resizeSingleElement = (
       scene,
       handleDirection,
       shouldMaintainAspectRatio,
+      shouldResizeFromCenter,
     );
 
     updateBoundElements(latestElement, scene);
@@ -1491,7 +1492,13 @@ export const resizeMultipleElements = (
           fontSize: boundTextFontSize,
           angle: isLinearElement(element) ? undefined : angle,
         });
-        handleBindTextResize(element, scene, handleDirection, true);
+        handleBindTextResize(
+          element,
+          scene,
+          handleDirection,
+          true,
+          shouldResizeFromCenter,
+        );
       }
     }
 

--- a/packages/element/src/textElement.ts
+++ b/packages/element/src/textElement.ts
@@ -144,6 +144,7 @@ export const handleBindTextResize = (
   scene: Scene,
   transformHandleType: MaybeTransformHandleType,
   shouldMaintainAspectRatio = false,
+  shouldResizeFromCenter = false,
 ) => {
   const elementsMap = scene.getNonDeletedElementsMap();
   const boundTextElementId = getBoundTextElementId(container);
@@ -190,14 +191,20 @@ export const handleBindTextResize = (
       );
 
       const diff = containerHeight - container.height;
-      // fix the y coord when resizing from ne/nw/n
-      const updatedY =
-        !isArrowElement(container) &&
-        (transformHandleType === "ne" ||
+      // fix the y coord when resizing from ne/nw/n, or keep the vertical center
+      // anchored when resizing from the center (alt/option held)
+      let updatedY = container.y;
+      if (!isArrowElement(container)) {
+        if (shouldResizeFromCenter) {
+          updatedY = container.y - diff / 2;
+        } else if (
+          transformHandleType === "ne" ||
           transformHandleType === "nw" ||
-          transformHandleType === "n")
-          ? container.y - diff
-          : container.y;
+          transformHandleType === "n"
+        ) {
+          updatedY = container.y - diff;
+        }
+      }
       scene.mutateElement(container, {
         height: containerHeight,
         y: updatedY,

--- a/packages/element/tests/resize.test.tsx
+++ b/packages/element/tests/resize.test.tsx
@@ -198,6 +198,30 @@ describe("generic element", () => {
   //   expect(arrow.width + arrow.endBinding!.gap).toBeCloseTo(80, 0);
   // });
 
+  it.each(["n", "s"] as const)(
+    "keeps the vertical center anchored when alt-resizing from %s past the bound text min height",
+    async (handle) => {
+      const rectangle = UI.createElement("rectangle", {
+        width: 200,
+        height: 200,
+      });
+      const label = await UI.editText(
+        rectangle,
+        "line one\nline two\nline three",
+      );
+
+      const prevCenterY = rectangle.y + rectangle.height / 2;
+
+      // Try to shrink past the bound text's minimum height. With alt held, the
+      // container should clamp at min height while keeping its vertical center fixed.
+      const shrinkBy = handle === "n" ? 300 : -300;
+      UI.resize(rectangle, handle, [0, shrinkBy], { alt: true });
+
+      expect(rectangle.y + rectangle.height / 2).toBeCloseTo(prevCenterY);
+      expect(label.y + label.height / 2).toBeCloseTo(prevCenterY);
+    },
+  );
+
   it("resizes with a label", async () => {
     const rectangle = UI.createElement("rectangle", {
       width: 200,


### PR DESCRIPTION
## Summary

Fixes #11479.

When holding **alt** to resize a container with multi-line bound text from the `n` / `s` handles, shrinking past the bound text's minimum height caused the container to drift vertically instead of staying centered.

The y-coordinate fix-up inside `handleBindTextResize` only handled the `ne` / `nw` / `n` directional case and ignored the center-resize mode, so when alt was held the container's vertical center would shift as the bound-text minimum-height clamp kicked in.

## Fix

Thread `shouldResizeFromCenter` through `handleBindTextResize`. When set, the container's `y` is adjusted by `diff / 2` so the vertical center remains fixed; otherwise existing directional behavior is preserved.

Propagated from the two call sites that already know whether the resize is centered:
- `resizeSingleElement` → `handleBindTextResize`
- `resizeMultipleElements` → `handleBindTextResize`

The remaining call sites (`linearElementEditor`, `binding`, `MultiDimension`) don't perform center resizing and keep the default `false`.

This matches the approach proposed by @cTangonan123 in the issue.

## How to test

1. Create a rectangle and add multi-line bound text (e.g. three lines).
2. Hold **alt** and drag the `n` (or `s`) handle inward past the bound text's minimum height.
3. The container should clamp at the minimum height while keeping its vertical center fixed — no upward / downward jump.

A regression test was added in `packages/element/tests/resize.test.tsx` covering both `n` and `s` handles.

## Notes

- Existing callers of `handleBindTextResize` that don't resize from center are unaffected (the new parameter defaults to `false`).
- No public API changes.