### PR TITLE
fix(repo): remove deprecated public property from vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,4 @@
 {
-  "public": true,
   "headers": [
     {
       "source": "/(.*)",


### PR DESCRIPTION
## Problem

The Vercel deployment check fails schema validation:

```
The `vercel.json` schema validation failed with the following message: should NOT have additional property `public`
```

`public` was removed from the `vercel.json` schema. It controlled source/log visibility and is now configured in Vercel project settings, not the file.

## Fix

Remove the `"public": true` property. No build or deployment behavior change; project visibility is unaffected (it is a dashboard setting).

## Root cause

There is no `public`-specific changelog. The trigger is Vercel enabling strict JSON-schema validation for `vercel.json`:

1. `public` was deprecated and dropped from the published schema. The live schema at https://openapi.vercel.sh/vercel.json no longer defines `public` and sets `"additionalProperties": false`.
2. Vercel then enforced that schema at deploy time ([Schema autocomplete and validation for vercel.json](https://vercel.com/changelog/schema-autocomplete-and-validation-for-vercel-json)).
3. Strict validation plus `additionalProperties: false` turns the deprecated property into a hard deploy failure.

Per Vercel's docs, the property "had no effect and is no longer accepted by the validator" ([vercel.json configuration](https://vercel.com/docs/project-configuration/vercel-json)).
