### PR TITLE
feat: shared collaborative revision history

### DIFF
--- a/excalidraw-app/App.tsx
+++ b/excalidraw-app/App.tsx
@@ -679,7 +679,7 @@ const ExcalidrawWrapper = () => {
     appState: AppState,
     files: BinaryFiles,
   ) => {
-    if (collabAPI?.isCollaborating()) {
+    if (collabAPI?.isCollaborating() && !collabAPI.isSyncPaused()) {
       collabAPI.syncElements(elements);
     }
 
@@ -1057,6 +1057,7 @@ const ExcalidrawWrapper = () => {
         />
 
         <AppSidebar
+          collabAPI={collabAPI}
           excalidrawAPI={excalidrawAPI}
           isCollaborating={isCollaborating}
         />

--- a/excalidraw-app/App.tsx
+++ b/excalidraw-app/App.tsx
@@ -1056,7 +1056,10 @@ const ExcalidrawWrapper = () => {
           }}
         />
 
-        <AppSidebar />
+        <AppSidebar
+          excalidrawAPI={excalidrawAPI}
+          isCollaborating={isCollaborating}
+        />
 
         {errorMessage && (
           <ErrorDialog onClose={() => setErrorMessage("")}>

--- a/excalidraw-app/app_constants.ts
+++ b/excalidraw-app/app_constants.ts
@@ -47,6 +47,7 @@ export const STORAGE_KEYS = {
 
   IDB_LIBRARY: "excalidraw-library",
   IDB_TTD_CHATS: "excalidraw-ttd-chats",
+  IDB_SCENE_HISTORY: "excalidraw-scene-history",
 
   // do not use apart from migrations
   __LEGACY_LOCAL_STORAGE_LIBRARY: "excalidraw-library",

--- a/excalidraw-app/collab/Collab.tsx
+++ b/excalidraw-app/collab/Collab.tsx
@@ -125,6 +125,7 @@ export interface CollabAPI {
   resumeSync: CollabInstance["resumeSync"];
   fetchImageFilesFromFirebase: CollabInstance["fetchImageFilesFromFirebase"];
   markNextHistorySaveAsRestore: CollabInstance["markNextHistorySaveAsRestore"];
+  getSceneHistorySessionId: CollabInstance["getSceneHistorySessionId"];
   setUsername: CollabInstance["setUsername"];
   getUsername: CollabInstance["getUsername"];
   getActiveRoomLink: CollabInstance["getActiveRoomLink"];
@@ -147,6 +148,9 @@ class Collab extends PureComponent<CollabProps, CollabState> {
   private collaborators = new Map<SocketId, Collaborator>();
   private sceneHistorySessionId = createSceneHistoryId();
   private pendingHistoryRestoreSourceId: string | null = null;
+  // Only the client that originated a change records it in shared history, so
+  // remote-applied updates aren't misattributed to whoever persists them first.
+  private hasLocalSceneChangeForHistory = false;
   private syncLocks = new Set<string>();
 
   constructor(props: CollabProps) {
@@ -246,6 +250,7 @@ class Collab extends PureComponent<CollabProps, CollabState> {
       resumeSync: this.resumeSync,
       fetchImageFilesFromFirebase: this.fetchImageFilesFromFirebase,
       markNextHistorySaveAsRestore: this.markNextHistorySaveAsRestore,
+      getSceneHistorySessionId: this.getSceneHistorySessionId,
       stopCollaboration: this.stopCollaboration,
       setUsername: this.setUsername,
       getUsername: this.getUsername,
@@ -339,15 +344,18 @@ class Collab extends PureComponent<CollabProps, CollabState> {
       this.resetErrorIndicator();
 
       if (this.isCollaborating() && storedElements) {
+        const isLocalSceneChange = this.hasLocalSceneChangeForHistory;
+        this.hasLocalSceneChangeForHistory = false;
         const restoreSourceId = this.pendingHistoryRestoreSourceId;
         this.pendingHistoryRestoreSourceId = null;
 
-        if (this.portal.roomId && this.portal.roomKey) {
+        if (isLocalSceneChange && this.portal.roomId && this.portal.roomKey) {
           try {
             await appendSceneHistoryToFirebase({
               roomId: this.portal.roomId,
               roomKey: this.portal.roomKey,
               sessionId: this.sceneHistorySessionId,
+              author: this.getUsername() || undefined,
               elements: storedElements as readonly OrderedExcalidrawElement[],
               appState: this.excalidrawAPI.getAppState(),
               kind: restoreSourceId ? "restore" : "change",
@@ -595,6 +603,7 @@ class Collab extends PureComponent<CollabProps, CollabState> {
         captureUpdate: CaptureUpdateAction.NEVER,
       });
 
+      this.hasLocalSceneChangeForHistory = true;
       this.saveCollabRoomToFirebase(getSyncableElements(elements));
     }
 
@@ -989,6 +998,7 @@ class Collab extends PureComponent<CollabProps, CollabState> {
     ) {
       this.portal.broadcastScene(WS_SUBTYPES.UPDATE, elements, false);
       this.lastBroadcastedOrReceivedSceneVersion = getSceneVersion(elements);
+      this.hasLocalSceneChangeForHistory = true;
       this.queueBroadcastAllElements();
     }
   };
@@ -1044,6 +1054,8 @@ class Collab extends PureComponent<CollabProps, CollabState> {
   };
 
   getUsername = () => this.state.username;
+
+  getSceneHistorySessionId = () => this.sceneHistorySessionId;
 
   setActiveRoomLink = (activeRoomLink: string | null) => {
     this.setState({ activeRoomLink });

--- a/excalidraw-app/collab/Collab.tsx
+++ b/excalidraw-app/collab/Collab.tsx
@@ -75,12 +75,14 @@ import {
 import { FileStatusStore } from "../data/fileStatusStore";
 import { LocalData } from "../data/LocalData";
 import {
+  appendSceneHistoryToFirebase,
   isSavedToFirebase,
   loadFilesFromFirebase,
   loadFromFirebase,
   saveFilesToFirebase,
   saveToFirebase,
 } from "../data/firebase";
+import { createSceneHistoryId } from "../data/SceneHistory";
 import {
   importUsernameFromLocalStorage,
   saveUsernameToLocalStorage,
@@ -118,7 +120,11 @@ export interface CollabAPI {
   startCollaboration: CollabInstance["startCollaboration"];
   stopCollaboration: CollabInstance["stopCollaboration"];
   syncElements: CollabInstance["syncElements"];
+  isSyncPaused: CollabInstance["isSyncPaused"];
+  pauseSync: CollabInstance["pauseSync"];
+  resumeSync: CollabInstance["resumeSync"];
   fetchImageFilesFromFirebase: CollabInstance["fetchImageFilesFromFirebase"];
+  markNextHistorySaveAsRestore: CollabInstance["markNextHistorySaveAsRestore"];
   setUsername: CollabInstance["setUsername"];
   getUsername: CollabInstance["getUsername"];
   getActiveRoomLink: CollabInstance["getActiveRoomLink"];
@@ -139,6 +145,9 @@ class Collab extends PureComponent<CollabProps, CollabState> {
   private socketInitializationTimer?: number;
   private lastBroadcastedOrReceivedSceneVersion: number = -1;
   private collaborators = new Map<SocketId, Collaborator>();
+  private sceneHistorySessionId = createSceneHistoryId();
+  private pendingHistoryRestoreSourceId: string | null = null;
+  private syncLocks = new Set<string>();
 
   constructor(props: CollabProps) {
     super(props);
@@ -232,7 +241,11 @@ class Collab extends PureComponent<CollabProps, CollabState> {
       onPointerUpdate: this.onPointerUpdate,
       startCollaboration: this.startCollaboration,
       syncElements: this.syncElements,
+      isSyncPaused: this.isSyncPaused,
+      pauseSync: this.pauseSync,
+      resumeSync: this.resumeSync,
       fetchImageFilesFromFirebase: this.fetchImageFilesFromFirebase,
+      markNextHistorySaveAsRestore: this.markNextHistorySaveAsRestore,
       stopCollaboration: this.stopCollaboration,
       setUsername: this.setUsername,
       getUsername: this.getUsername,
@@ -326,6 +339,25 @@ class Collab extends PureComponent<CollabProps, CollabState> {
       this.resetErrorIndicator();
 
       if (this.isCollaborating() && storedElements) {
+        const restoreSourceId = this.pendingHistoryRestoreSourceId;
+        this.pendingHistoryRestoreSourceId = null;
+
+        if (this.portal.roomId && this.portal.roomKey) {
+          try {
+            await appendSceneHistoryToFirebase({
+              roomId: this.portal.roomId,
+              roomKey: this.portal.roomKey,
+              sessionId: this.sceneHistorySessionId,
+              elements: storedElements as readonly OrderedExcalidrawElement[],
+              appState: this.excalidrawAPI.getAppState(),
+              kind: restoreSourceId ? "restore" : "change",
+              restoreSourceId: restoreSourceId ?? undefined,
+            });
+          } catch (error: any) {
+            console.error("Failed to save shared scene history:", error);
+          }
+        }
+
         this.handleRemoteSceneUpdate(this._reconcileElements(storedElements));
       }
     } catch (error: any) {
@@ -352,6 +384,15 @@ class Collab extends PureComponent<CollabProps, CollabState> {
 
       console.error(error);
     }
+  };
+
+  markNextHistorySaveAsRestore = (sourceEntryId: string) => {
+    this.pendingHistoryRestoreSourceId = sourceEntryId;
+    window.setTimeout(() => {
+      if (this.pendingHistoryRestoreSourceId === sourceEntryId) {
+        this.pendingHistoryRestoreSourceId = null;
+      }
+    }, SYNC_FULL_SCENE_INTERVAL_MS * 2);
   };
 
   stopCollaboration = (keepRemoteState = true) => {
@@ -955,6 +996,18 @@ class Collab extends PureComponent<CollabProps, CollabState> {
   syncElements = (elements: readonly OrderedExcalidrawElement[]) => {
     this.broadcastElements(elements);
     this.queueSaveToFirebase();
+  };
+
+  isSyncPaused = () => {
+    return this.syncLocks.size > 0;
+  };
+
+  pauseSync = (lockType: string) => {
+    this.syncLocks.add(lockType);
+  };
+
+  resumeSync = (lockType: string) => {
+    this.syncLocks.delete(lockType);
   };
 
   queueBroadcastAllElements = throttle(() => {

--- a/excalidraw-app/components/AppSidebar.tsx
+++ b/excalidraw-app/components/AppSidebar.tsx
@@ -1,79 +1,112 @@
 import { DefaultSidebar, Sidebar, THEME } from "@excalidraw/excalidraw";
 import {
+  historyIcon,
   messageCircleIcon,
   presentationIcon,
 } from "@excalidraw/excalidraw/components/icons";
 import { LinkButton } from "@excalidraw/excalidraw/components/LinkButton";
 import { useUIAppState } from "@excalidraw/excalidraw/context/ui-appState";
 
+import type { ExcalidrawImperativeAPI } from "@excalidraw/excalidraw/types";
+
+import { HistorySidebar, SceneHistoryProvider } from "./HistorySidebar";
+
 import "./AppSidebar.scss";
 
-export const AppSidebar = () => {
+type AppSidebarProps = {
+  excalidrawAPI: ExcalidrawImperativeAPI | null;
+  isCollaborating: boolean;
+};
+
+export const AppSidebar = ({
+  excalidrawAPI,
+  isCollaborating,
+}: AppSidebarProps) => {
   const { theme, openSidebar } = useUIAppState();
 
   return (
-    <DefaultSidebar>
-      <DefaultSidebar.TabTriggers>
-        <Sidebar.TabTrigger
-          tab="comments"
-          style={{ opacity: openSidebar?.tab === "comments" ? 1 : 0.4 }}
-        >
-          {messageCircleIcon}
-        </Sidebar.TabTrigger>
-        <Sidebar.TabTrigger
-          tab="presentation"
-          style={{ opacity: openSidebar?.tab === "presentation" ? 1 : 0.4 }}
-        >
-          {presentationIcon}
-        </Sidebar.TabTrigger>
-      </DefaultSidebar.TabTriggers>
-      <Sidebar.Tab tab="comments">
-        <div className="app-sidebar-promo-container">
-          <div
-            className="app-sidebar-promo-image"
-            style={{
-              ["--image-source" as any]: `url(/oss_promo_comments_${
-                theme === THEME.DARK ? "dark" : "light"
-              }.jpg)`,
-              opacity: 0.7,
-            }}
-          />
-          <div className="app-sidebar-promo-text">
-            Make comments with Excalidraw+
-          </div>
-          <LinkButton
-            href={`${
-              import.meta.env.VITE_APP_PLUS_LP
-            }/plus?utm_source=excalidraw&utm_medium=app&utm_content=comments_promo#excalidraw-redirect`}
+    <SceneHistoryProvider excalidrawAPI={excalidrawAPI}>
+      <DefaultSidebar>
+        <DefaultSidebar.TabTriggers>
+          {excalidrawAPI && (
+            <Sidebar.TabTrigger
+              aria-label="History"
+              tab="history"
+              style={{ opacity: openSidebar?.tab === "history" ? 1 : 0.4 }}
+              title="History"
+            >
+              {historyIcon}
+            </Sidebar.TabTrigger>
+          )}
+          <Sidebar.TabTrigger
+            tab="comments"
+            style={{ opacity: openSidebar?.tab === "comments" ? 1 : 0.4 }}
           >
-            Sign up now
-          </LinkButton>
-        </div>
-      </Sidebar.Tab>
-      <Sidebar.Tab tab="presentation" className="px-3">
-        <div className="app-sidebar-promo-container">
-          <div
-            className="app-sidebar-promo-image"
-            style={{
-              ["--image-source" as any]: `url(/oss_promo_presentations_${
-                theme === THEME.DARK ? "dark" : "light"
-              }.svg)`,
-              backgroundSize: "60%",
-              opacity: 0.4,
-            }}
-          />
-          <div className="app-sidebar-promo-text">
-            Create presentations with Excalidraw+
-          </div>
-          <LinkButton
-            href={`${
-              import.meta.env.VITE_APP_PLUS_LP
-            }/plus?utm_source=excalidraw&utm_medium=app&utm_content=presentations_promo#excalidraw-redirect`}
+            {messageCircleIcon}
+          </Sidebar.TabTrigger>
+          <Sidebar.TabTrigger
+            tab="presentation"
+            style={{ opacity: openSidebar?.tab === "presentation" ? 1 : 0.4 }}
           >
-            Sign up now
-          </LinkButton>
-        </div>
-      </Sidebar.Tab>
-    </DefaultSidebar>
+            {presentationIcon}
+          </Sidebar.TabTrigger>
+        </DefaultSidebar.TabTriggers>
+        <Sidebar.Tab tab="comments">
+          <div className="app-sidebar-promo-container">
+            <div
+              className="app-sidebar-promo-image"
+              style={{
+                ["--image-source" as any]: `url(/oss_promo_comments_${
+                  theme === THEME.DARK ? "dark" : "light"
+                }.jpg)`,
+                opacity: 0.7,
+              }}
+            />
+            <div className="app-sidebar-promo-text">
+              Make comments with Excalidraw+
+            </div>
+            <LinkButton
+              href={`${
+                import.meta.env.VITE_APP_PLUS_LP
+              }/plus?utm_source=excalidraw&utm_medium=app&utm_content=comments_promo#excalidraw-redirect`}
+            >
+              Sign up now
+            </LinkButton>
+          </div>
+        </Sidebar.Tab>
+        {excalidrawAPI && (
+          <Sidebar.Tab tab="history">
+            <HistorySidebar
+              excalidrawAPI={excalidrawAPI}
+              isCollaborating={isCollaborating}
+            />
+          </Sidebar.Tab>
+        )}
+        <Sidebar.Tab tab="presentation" className="px-3">
+          <div className="app-sidebar-promo-container">
+            <div
+              className="app-sidebar-promo-image"
+              style={{
+                ["--image-source" as any]: `url(/oss_promo_presentations_${
+                  theme === THEME.DARK ? "dark" : "light"
+                }.svg)`,
+                backgroundSize: "60%",
+                opacity: 0.4,
+              }}
+            />
+            <div className="app-sidebar-promo-text">
+              Create presentations with Excalidraw+
+            </div>
+            <LinkButton
+              href={`${
+                import.meta.env.VITE_APP_PLUS_LP
+              }/plus?utm_source=excalidraw&utm_medium=app&utm_content=presentations_promo#excalidraw-redirect`}
+            >
+              Sign up now
+            </LinkButton>
+          </div>
+        </Sidebar.Tab>
+      </DefaultSidebar>
+    </SceneHistoryProvider>
   );
 };

--- a/excalidraw-app/components/AppSidebar.tsx
+++ b/excalidraw-app/components/AppSidebar.tsx
@@ -13,19 +13,27 @@ import { HistorySidebar, SceneHistoryProvider } from "./HistorySidebar";
 
 import "./AppSidebar.scss";
 
+import type { CollabAPI } from "../collab/Collab";
+
 type AppSidebarProps = {
+  collabAPI: CollabAPI | null;
   excalidrawAPI: ExcalidrawImperativeAPI | null;
   isCollaborating: boolean;
 };
 
 export const AppSidebar = ({
+  collabAPI,
   excalidrawAPI,
   isCollaborating,
 }: AppSidebarProps) => {
   const { theme, openSidebar } = useUIAppState();
 
   return (
-    <SceneHistoryProvider excalidrawAPI={excalidrawAPI}>
+    <SceneHistoryProvider
+      collabAPI={collabAPI}
+      excalidrawAPI={excalidrawAPI}
+      isCollaborating={isCollaborating}
+    >
       <DefaultSidebar>
         <DefaultSidebar.TabTriggers>
           {excalidrawAPI && (
@@ -77,6 +85,7 @@ export const AppSidebar = ({
         {excalidrawAPI && (
           <Sidebar.Tab tab="history">
             <HistorySidebar
+              collabAPI={collabAPI}
               excalidrawAPI={excalidrawAPI}
               isCollaborating={isCollaborating}
             />

--- a/excalidraw-app/components/HistorySidebar.scss
+++ b/excalidraw-app/components/HistorySidebar.scss
@@ -1,0 +1,226 @@
+.excalidraw {
+  .history-sidebar {
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+    height: 100%;
+    color: var(--text-primary-color);
+  }
+
+  .history-sidebar__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    padding: 0 0.875rem 0.75rem;
+    border-bottom: 1px solid var(--sidebar-border-color);
+
+    h2 {
+      margin: 0;
+      font-size: 1rem;
+      line-height: 1.25;
+      font-weight: 600;
+    }
+  }
+
+  .history-sidebar__count {
+    color: var(--text-muted-color);
+    font-size: 0.75rem;
+    white-space: nowrap;
+  }
+
+  .history-sidebar__notice {
+    margin: 0.75rem 0.875rem 0;
+    padding: 0.625rem 0.75rem;
+    border: 1px solid var(--sidebar-border-color);
+    border-radius: 0.5rem;
+    background: var(--default-bg-color);
+    color: var(--text-muted-color);
+    font-size: 0.8125rem;
+    line-height: 1.35;
+  }
+
+  .history-sidebar__notice--error {
+    color: var(--color-danger);
+    border-color: var(--color-danger);
+  }
+
+  .history-sidebar__timeline {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    min-height: 0;
+    overflow: auto;
+    padding: 0.75rem 0.5rem 5.5rem;
+  }
+
+  .history-sidebar__empty {
+    color: var(--text-muted-color);
+    font-size: 0.875rem;
+    padding: 1rem 0.5rem;
+    text-align: center;
+  }
+
+  .history-sidebar__entry {
+    position: relative;
+    display: grid;
+    grid-template-columns: 1rem 5.5rem minmax(0, 1fr);
+    gap: 0.625rem;
+    width: 100%;
+    min-height: 4.5rem;
+    border: 1px solid transparent;
+    border-radius: 0.5rem;
+    padding: 0.5rem;
+    background: transparent;
+    color: inherit;
+    text-align: left;
+    cursor: pointer;
+
+    &:hover:not(:disabled) {
+      background: var(--button-hover-bg, var(--island-bg-color));
+    }
+
+    &:disabled {
+      cursor: default;
+      opacity: 0.65;
+    }
+  }
+
+  .history-sidebar__entry--selected {
+    border-color: var(--color-primary);
+    background: var(--default-bg-color);
+  }
+
+  .history-sidebar__entry--current {
+    .history-sidebar__marker {
+      border-color: var(--color-primary);
+      background: var(--color-primary);
+    }
+  }
+
+  .history-sidebar__marker {
+    position: relative;
+    width: 0.625rem;
+    height: 0.625rem;
+    align-self: start;
+    margin-top: 1.875rem;
+    border: 2px solid var(--sidebar-border-color);
+    border-radius: 50%;
+    background: var(--sidebar-bg-color);
+
+    &::before,
+    &::after {
+      content: "";
+      position: absolute;
+      left: 50%;
+      width: 1px;
+      height: 2rem;
+      background: var(--sidebar-border-color);
+      transform: translateX(-50%);
+    }
+
+    &::before {
+      bottom: 100%;
+    }
+
+    &::after {
+      top: 100%;
+    }
+  }
+
+  .history-sidebar__thumbnail {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 5.5rem;
+    height: 3.625rem;
+    overflow: hidden;
+    border: 1px solid var(--sidebar-border-color);
+    border-radius: 0.375rem;
+    background: var(--default-bg-color);
+    color: var(--text-muted-color);
+    font-size: 0.75rem;
+
+    img {
+      display: block;
+      max-width: 100%;
+      max-height: 100%;
+      object-fit: contain;
+    }
+  }
+
+  .history-sidebar__entry-body {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    min-width: 0;
+    gap: 0.1875rem;
+  }
+
+  .history-sidebar__entry-title {
+    display: flex;
+    align-items: center;
+    gap: 0.375rem;
+    min-width: 0;
+    font-size: 0.875rem;
+    font-weight: 600;
+    line-height: 1.25;
+  }
+
+  .history-sidebar__current-label {
+    flex: 0 0 auto;
+    color: var(--color-primary);
+    font-size: 0.6875rem;
+    font-weight: 600;
+  }
+
+  .history-sidebar__entry-summary {
+    min-width: 0;
+    overflow: hidden;
+    color: var(--text-muted-color);
+    font-size: 0.75rem;
+    line-height: 1.25;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .history-sidebar__entry-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.125rem 0.5rem;
+    min-width: 0;
+    color: var(--text-muted-color);
+    font-size: 0.75rem;
+    line-height: 1.25;
+  }
+
+  .history-sidebar__actions {
+    position: absolute;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.5rem;
+    padding: 0.75rem;
+    border-top: 1px solid var(--sidebar-border-color);
+    background: var(--sidebar-bg-color);
+  }
+
+  .history-sidebar__cancel-button,
+  .history-sidebar__restore-button {
+    width: 100%;
+    min-width: 0;
+    height: 2.25rem;
+  }
+
+  .history-sidebar__restore-button {
+    --button-bg: var(--color-primary);
+    --button-border: var(--color-primary);
+    --button-color: var(--color-icon-white);
+    --button-hover-bg: var(--color-primary-darker);
+    --button-hover-border: var(--color-primary-darker);
+    --button-hover-color: var(--color-icon-white);
+  }
+}

--- a/excalidraw-app/components/HistorySidebar.scss
+++ b/excalidraw-app/components/HistorySidebar.scss
@@ -150,6 +150,19 @@
     }
   }
 
+  .history-sidebar__avatar {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 2.25rem;
+    height: 2.25rem;
+    border-radius: 50%;
+    color: #fff;
+    font-size: 0.8125rem;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+  }
+
   .history-sidebar__entry-body {
     display: flex;
     flex-direction: column;

--- a/excalidraw-app/components/HistorySidebar.tsx
+++ b/excalidraw-app/components/HistorySidebar.tsx
@@ -22,7 +22,10 @@ import type {
 } from "@excalidraw/excalidraw/types";
 
 import { LocalData } from "../data/LocalData";
-import { SceneHistory } from "../data/SceneHistory";
+import {
+  isSceneHistoryDeltaRecordable,
+  SceneHistory,
+} from "../data/SceneHistory";
 
 import "./HistorySidebar.scss";
 
@@ -167,6 +170,7 @@ export const SceneHistoryProvider = ({
 }: SceneHistoryProviderProps) => {
   const sessionIdRef = useRef(createSessionId());
   const recordQueueRef = useRef(Promise.resolve());
+  const isMountedRef = useRef(false);
   const pendingRestoreRef = useRef<{ sourceEntryId: string } | null>(null);
   const [historyData, setHistoryData] = useState<SceneHistoryData | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
@@ -186,6 +190,14 @@ export const SceneHistoryProvider = ({
   }, []);
 
   useEffect(() => {
+    isMountedRef.current = true;
+
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
+
+  useEffect(() => {
     if (!excalidrawAPI) {
       setHistoryData(null);
       setIsLoading(false);
@@ -194,10 +206,9 @@ export const SceneHistoryProvider = ({
 
     let isActive = true;
 
-    const initializeHistory = async () => {
-      setIsLoading(true);
-
-      try {
+    setIsLoading(true);
+    recordQueueRef.current = recordQueueRef.current
+      .then(async () => {
         const scene = getCurrentScene(excalidrawAPI);
         const thumbnail = await createHistoryThumbnail(
           scene.elements,
@@ -212,24 +223,23 @@ export const SceneHistoryProvider = ({
           thumbnail,
         });
 
-        if (isActive) {
+        if (isActive && isMountedRef.current) {
           setHistoryState(nextHistoryData);
           setErrorMessage(null);
         }
-      } catch (error) {
+      })
+      .catch((error) => {
         console.error(error);
 
-        if (isActive) {
+        if (isActive && isMountedRef.current) {
           setErrorMessage("History is unavailable");
         }
-      } finally {
-        if (isActive) {
+      })
+      .finally(() => {
+        if (isActive && isMountedRef.current) {
           setIsLoading(false);
         }
-      }
-    };
-
-    initializeHistory();
+      });
 
     return () => {
       isActive = false;
@@ -241,16 +251,24 @@ export const SceneHistoryProvider = ({
       return;
     }
 
-    return excalidrawAPI.onIncrement((increment) => {
+    let isActive = true;
+    const unsubscribe = excalidrawAPI.onIncrement((increment) => {
       if (increment.type !== "durable" || !("delta" in increment)) {
         return;
       }
 
       const restoreMetadata = pendingRestoreRef.current;
+      if (!isSceneHistoryDeltaRecordable(increment.delta)) {
+        if (restoreMetadata) {
+          pendingRestoreRef.current = null;
+        }
+        return;
+      }
+
+      const scene = getCurrentScene(excalidrawAPI);
       pendingRestoreRef.current = null;
       recordQueueRef.current = recordQueueRef.current
         .then(async () => {
-          const scene = getCurrentScene(excalidrawAPI);
           const thumbnail = await createHistoryThumbnail(
             scene.elements,
             scene.appState,
@@ -267,14 +285,23 @@ export const SceneHistoryProvider = ({
             restoreSourceId: restoreMetadata?.sourceEntryId,
           });
 
-          setHistoryState(nextHistoryData);
-          setErrorMessage(null);
+          if (isActive && isMountedRef.current) {
+            setHistoryState(nextHistoryData);
+            setErrorMessage(null);
+          }
         })
         .catch((error) => {
           console.error(error);
-          setErrorMessage("History was not saved");
+          if (isActive && isMountedRef.current) {
+            setErrorMessage("History was not saved");
+          }
         });
     });
+
+    return () => {
+      isActive = false;
+      unsubscribe();
+    };
   }, [excalidrawAPI, setHistoryState]);
 
   const value = useMemo(
@@ -307,6 +334,8 @@ export const HistorySidebar = ({
     markNextChangeAsRestore,
   } = useSceneHistoryContext();
   const previewOriginRef = useRef<PreviewOrigin | null>(null);
+  const previewRequestIdRef = useRef(0);
+  const isMountedRef = useRef(false);
   const [selectedEntryId, setSelectedEntryId] = useState<string | null>(null);
   const [previewEntryId, setPreviewEntryId] = useState<string | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
@@ -324,12 +353,21 @@ export const HistorySidebar = ({
   const visibleErrorMessage = errorMessage || historyErrorMessage;
 
   useEffect(() => {
+    isMountedRef.current = true;
+
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
+
+  useEffect(() => {
     if (!isPreviewing) {
       setSelectedEntryId(historyData?.currentEntryId ?? null);
     }
   }, [historyData?.currentEntryId, isPreviewing]);
 
   const cancelPreview = useCallback(() => {
+    previewRequestIdRef.current++;
     const origin = previewOriginRef.current;
 
     if (!origin) {
@@ -384,6 +422,8 @@ export const HistorySidebar = ({
       return;
     }
 
+    const requestId = ++previewRequestIdRef.current;
+
     try {
       if (!previewOriginRef.current) {
         previewOriginRef.current = getCurrentScene(excalidrawAPI);
@@ -391,6 +431,10 @@ export const HistorySidebar = ({
       }
 
       const target = await SceneHistory.reconstruct(entry.id);
+
+      if (!isMountedRef.current || previewRequestIdRef.current !== requestId) {
+        return;
+      }
 
       if (!target) {
         setErrorMessage("Version could not be restored");
@@ -411,6 +455,10 @@ export const HistorySidebar = ({
       setPreviewEntryId(entry.id);
       setErrorMessage(null);
     } catch (error) {
+      if (!isMountedRef.current || previewRequestIdRef.current !== requestId) {
+        return;
+      }
+
       console.error(error);
       setErrorMessage("Version could not be previewed");
     }
@@ -422,6 +470,7 @@ export const HistorySidebar = ({
     }
 
     setIsRestoring(true);
+    previewRequestIdRef.current++;
 
     try {
       const target = await SceneHistory.reconstruct(selectedEntry.id);

--- a/excalidraw-app/components/HistorySidebar.tsx
+++ b/excalidraw-app/components/HistorySidebar.tsx
@@ -195,6 +195,43 @@ const getEntryTitle = (entry: SceneHistoryEntry) => {
   return `Version ${entry.sequence}`;
 };
 
+const getAuthorInitials = (name: string) => {
+  const parts = name.trim().split(/\s+/).filter(Boolean);
+
+  if (!parts.length) {
+    return "?";
+  }
+
+  if (parts.length === 1) {
+    return parts[0].slice(0, 2).toUpperCase();
+  }
+
+  return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
+};
+
+const getAuthorColor = (key: string) => {
+  let hash = 0;
+
+  for (let i = 0; i < key.length; i++) {
+    hash = (hash * 31 + key.charCodeAt(i)) | 0;
+  }
+
+  return `hsl(${Math.abs(hash) % 360}, 60%, 45%)`;
+};
+
+const getEntryAuthorLabel = (
+  entry: SceneHistoryEntry,
+  currentSessionId: string,
+) => {
+  const isCurrentSession = entry.sessionId === currentSessionId;
+
+  if (entry.author) {
+    return isCurrentSession ? `${entry.author} (you)` : entry.author;
+  }
+
+  return isCurrentSession ? "This session" : "Previous session";
+};
+
 const useSceneHistoryContext = () => {
   const context = useContext(SceneHistoryContext);
 
@@ -225,6 +262,10 @@ export const SceneHistoryProvider = ({
   const collabRoomId = collabHistorySource?.roomId ?? null;
   const collabRoomKey = collabHistorySource?.roomKey ?? null;
   const isSharedHistory = !!collabHistorySource;
+  const historySessionId =
+    isSharedHistory && collabAPI
+      ? collabAPI.getSceneHistorySessionId()
+      : sessionIdRef.current;
 
   const setHistoryState = useCallback((nextHistoryData: SceneHistoryData) => {
     setHistoryData(nextHistoryData);
@@ -436,13 +477,14 @@ export const SceneHistoryProvider = ({
       isLoading,
       errorMessage,
       isSharedHistory,
-      sessionId: sessionIdRef.current,
+      sessionId: historySessionId,
       markNextChangeAsRestore,
       reconstructEntry,
     }),
     [
       errorMessage,
       historyData,
+      historySessionId,
       isLoading,
       isSharedHistory,
       markNextChangeAsRestore,
@@ -731,7 +773,15 @@ export const HistorySidebar = ({
               >
                 <span className="history-sidebar__marker" />
                 <span className="history-sidebar__thumbnail">
-                  {entry.thumbnail ? (
+                  {entry.author ? (
+                    <span
+                      className="history-sidebar__avatar"
+                      style={{ backgroundColor: getAuthorColor(entry.author) }}
+                      title={entry.author}
+                    >
+                      {getAuthorInitials(entry.author)}
+                    </span>
+                  ) : entry.thumbnail ? (
                     <img alt="" src={entry.thumbnail} />
                   ) : (
                     <span>
@@ -755,11 +805,7 @@ export const HistorySidebar = ({
                     <time dateTime={new Date(entry.createdAt).toISOString()}>
                       {formatEntryTime(entry.createdAt)}
                     </time>
-                    <span>
-                      {entry.sessionId === sessionId
-                        ? "This session"
-                        : "Previous session"}
-                    </span>
+                    <span>{getEntryAuthorLabel(entry, sessionId)}</span>
                   </span>
                 </span>
               </button>

--- a/excalidraw-app/components/HistorySidebar.tsx
+++ b/excalidraw-app/components/HistorySidebar.tsx
@@ -27,10 +27,13 @@ import { getCollaborationLinkData } from "../data";
 import {
   createCollabRestoreElements,
   isSceneHistoryDeltaRecordable,
-  reconstructSceneHistoryData,
+  resetTransientAppState,
   SceneHistory,
 } from "../data/SceneHistory";
-import { subscribeSceneHistoryFromFirebase } from "../data/firebase";
+import {
+  loadSceneHistoryEntryFromFirebase,
+  subscribeSceneHistoryFromFirebase,
+} from "../data/firebase";
 
 import "./HistorySidebar.scss";
 
@@ -247,14 +250,34 @@ export const SceneHistoryProvider = ({
   const reconstructEntry = useCallback(
     async (entryId: string) => {
       if (isSharedHistory) {
-        return historyData
-          ? reconstructSceneHistoryData(historyData, entryId)
-          : null;
+        if (!collabRoomId || !collabRoomKey || !historyData) {
+          return null;
+        }
+
+        const payload = await loadSceneHistoryEntryFromFirebase({
+          roomId: collabRoomId,
+          roomKey: collabRoomKey,
+          entryId,
+        });
+        const entry = historyData.entries.find((item) => item.id === entryId);
+
+        if (!payload || !entry) {
+          return null;
+        }
+
+        return {
+          entry,
+          elements: payload.elements,
+          appState: resetTransientAppState(
+            payload.appState as Partial<AppState>,
+          ),
+          files: {} as BinaryFiles,
+        };
       }
 
       return SceneHistory.reconstruct(entryId);
     },
-    [historyData, isSharedHistory],
+    [collabRoomId, collabRoomKey, historyData, isSharedHistory],
   );
 
   useEffect(() => {
@@ -326,7 +349,6 @@ export const SceneHistoryProvider = ({
 
     const unsubscribe = subscribeSceneHistoryFromFirebase({
       roomId: collabRoomId,
-      roomKey: collabRoomKey,
       onChange: (nextHistoryData) => {
         if (isActive && isMountedRef.current) {
           setHistoryState(nextHistoryData);
@@ -646,6 +668,7 @@ export const HistorySidebar = ({
         appState: {
           ...excalidrawAPI.getAppState(),
           ...target.appState,
+          viewModeEnabled: origin?.appState.viewModeEnabled ?? false,
         },
         captureUpdate: CaptureUpdateAction.IMMEDIATELY,
       });

--- a/excalidraw-app/components/HistorySidebar.tsx
+++ b/excalidraw-app/components/HistorySidebar.tsx
@@ -1,0 +1,571 @@
+import clsx from "clsx";
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+
+import { CaptureUpdateAction } from "@excalidraw/excalidraw";
+import { Button } from "@excalidraw/excalidraw/components/Button";
+import { getNonDeletedElements } from "@excalidraw/element";
+import { exportToCanvas } from "@excalidraw/utils/export";
+
+import type { OrderedExcalidrawElement } from "@excalidraw/element/types";
+import type {
+  AppState,
+  BinaryFiles,
+  ExcalidrawImperativeAPI,
+} from "@excalidraw/excalidraw/types";
+
+import { LocalData } from "../data/LocalData";
+import { SceneHistory } from "../data/SceneHistory";
+
+import "./HistorySidebar.scss";
+
+import type { SceneHistoryData, SceneHistoryEntry } from "../data/SceneHistory";
+
+type HistorySidebarProps = {
+  excalidrawAPI: ExcalidrawImperativeAPI;
+  isCollaborating: boolean;
+};
+
+type SceneHistoryProviderProps = {
+  excalidrawAPI: ExcalidrawImperativeAPI | null;
+  children: React.ReactNode;
+};
+
+type SceneHistoryContextValue = {
+  historyData: SceneHistoryData | null;
+  isLoading: boolean;
+  errorMessage: string | null;
+  sessionId: string;
+  markNextChangeAsRestore: (sourceEntryId: string) => void;
+};
+
+type PreviewOrigin = {
+  elements: readonly OrderedExcalidrawElement[];
+  appState: AppState;
+  files: BinaryFiles;
+};
+
+const THUMBNAIL_MAX_WIDTH = 160;
+const THUMBNAIL_MAX_HEIGHT = 96;
+
+const SceneHistoryContext = createContext<SceneHistoryContextValue | null>(
+  null,
+);
+
+const createSessionId = () => {
+  return (
+    globalThis.crypto?.randomUUID?.() ??
+    `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`
+  );
+};
+
+const createHistoryThumbnail = async (
+  elements: readonly OrderedExcalidrawElement[],
+  appState: AppState,
+  files: BinaryFiles,
+) => {
+  const nonDeletedElements = getNonDeletedElements(elements);
+
+  if (!nonDeletedElements.length) {
+    return null;
+  }
+
+  try {
+    const canvas = await exportToCanvas({
+      elements: nonDeletedElements,
+      appState: {
+        exportBackground: true,
+        exportScale: 1,
+        exportWithDarkMode: appState.exportWithDarkMode,
+        viewBackgroundColor: appState.viewBackgroundColor,
+      },
+      files,
+      exportPadding: 12,
+      getDimensions: (width, height) => {
+        const scale = Math.min(
+          THUMBNAIL_MAX_WIDTH / width,
+          THUMBNAIL_MAX_HEIGHT / height,
+          1,
+        );
+
+        return {
+          width: Math.max(1, Math.round(width * scale)),
+          height: Math.max(1, Math.round(height * scale)),
+          scale,
+        };
+      },
+    });
+
+    return canvas.toDataURL("image/png");
+  } catch (error) {
+    console.warn("Failed to render scene history thumbnail:", error);
+    return null;
+  }
+};
+
+const getCurrentScene = (
+  excalidrawAPI: ExcalidrawImperativeAPI,
+): PreviewOrigin => ({
+  elements:
+    excalidrawAPI.getSceneElementsIncludingDeleted() as readonly OrderedExcalidrawElement[],
+  appState: excalidrawAPI.getAppState(),
+  files: excalidrawAPI.getFiles(),
+});
+
+const addFilesToScene = (
+  excalidrawAPI: ExcalidrawImperativeAPI,
+  files: BinaryFiles,
+) => {
+  const fileData = Object.values(files);
+
+  if (fileData.length) {
+    excalidrawAPI.addFiles(fileData);
+  }
+};
+
+const formatEntryTime = (timestamp: number) => {
+  return new Intl.DateTimeFormat(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  }).format(timestamp);
+};
+
+const getEntryTitle = (entry: SceneHistoryEntry) => {
+  if (entry.kind === "initial") {
+    return "Initial version";
+  }
+
+  if (entry.kind === "restore") {
+    return "Restore";
+  }
+
+  return `Version ${entry.sequence}`;
+};
+
+const useSceneHistoryContext = () => {
+  const context = useContext(SceneHistoryContext);
+
+  if (!context) {
+    throw new Error("SceneHistoryProvider is missing");
+  }
+
+  return context;
+};
+
+export const SceneHistoryProvider = ({
+  excalidrawAPI,
+  children,
+}: SceneHistoryProviderProps) => {
+  const sessionIdRef = useRef(createSessionId());
+  const recordQueueRef = useRef(Promise.resolve());
+  const pendingRestoreRef = useRef<{ sourceEntryId: string } | null>(null);
+  const [historyData, setHistoryData] = useState<SceneHistoryData | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const setHistoryState = useCallback((nextHistoryData: SceneHistoryData) => {
+    setHistoryData(nextHistoryData);
+  }, []);
+
+  const markNextChangeAsRestore = useCallback((sourceEntryId: string) => {
+    pendingRestoreRef.current = { sourceEntryId };
+    window.setTimeout(() => {
+      if (pendingRestoreRef.current?.sourceEntryId === sourceEntryId) {
+        pendingRestoreRef.current = null;
+      }
+    }, 500);
+  }, []);
+
+  useEffect(() => {
+    if (!excalidrawAPI) {
+      setHistoryData(null);
+      setIsLoading(false);
+      return;
+    }
+
+    let isActive = true;
+
+    const initializeHistory = async () => {
+      setIsLoading(true);
+
+      try {
+        const scene = getCurrentScene(excalidrawAPI);
+        const thumbnail = await createHistoryThumbnail(
+          scene.elements,
+          scene.appState,
+          scene.files,
+        );
+        const nextHistoryData = await SceneHistory.ensureInitialized({
+          sessionId: sessionIdRef.current,
+          elements: scene.elements,
+          appState: scene.appState,
+          files: scene.files,
+          thumbnail,
+        });
+
+        if (isActive) {
+          setHistoryState(nextHistoryData);
+          setErrorMessage(null);
+        }
+      } catch (error) {
+        console.error(error);
+
+        if (isActive) {
+          setErrorMessage("History is unavailable");
+        }
+      } finally {
+        if (isActive) {
+          setIsLoading(false);
+        }
+      }
+    };
+
+    initializeHistory();
+
+    return () => {
+      isActive = false;
+    };
+  }, [excalidrawAPI, setHistoryState]);
+
+  useEffect(() => {
+    if (!excalidrawAPI) {
+      return;
+    }
+
+    return excalidrawAPI.onIncrement((increment) => {
+      if (increment.type !== "durable" || !("delta" in increment)) {
+        return;
+      }
+
+      const restoreMetadata = pendingRestoreRef.current;
+      pendingRestoreRef.current = null;
+      recordQueueRef.current = recordQueueRef.current
+        .then(async () => {
+          const scene = getCurrentScene(excalidrawAPI);
+          const thumbnail = await createHistoryThumbnail(
+            scene.elements,
+            scene.appState,
+            scene.files,
+          );
+          const nextHistoryData = await SceneHistory.append({
+            sessionId: sessionIdRef.current,
+            elements: scene.elements,
+            appState: scene.appState,
+            files: scene.files,
+            thumbnail,
+            delta: increment.delta,
+            kind: restoreMetadata ? "restore" : "change",
+            restoreSourceId: restoreMetadata?.sourceEntryId,
+          });
+
+          setHistoryState(nextHistoryData);
+          setErrorMessage(null);
+        })
+        .catch((error) => {
+          console.error(error);
+          setErrorMessage("History was not saved");
+        });
+    });
+  }, [excalidrawAPI, setHistoryState]);
+
+  const value = useMemo(
+    () => ({
+      historyData,
+      isLoading,
+      errorMessage,
+      sessionId: sessionIdRef.current,
+      markNextChangeAsRestore,
+    }),
+    [errorMessage, historyData, isLoading, markNextChangeAsRestore],
+  );
+
+  return (
+    <SceneHistoryContext.Provider value={value}>
+      {children}
+    </SceneHistoryContext.Provider>
+  );
+};
+
+export const HistorySidebar = ({
+  excalidrawAPI,
+  isCollaborating,
+}: HistorySidebarProps) => {
+  const {
+    historyData,
+    isLoading,
+    errorMessage: historyErrorMessage,
+    sessionId,
+    markNextChangeAsRestore,
+  } = useSceneHistoryContext();
+  const previewOriginRef = useRef<PreviewOrigin | null>(null);
+  const [selectedEntryId, setSelectedEntryId] = useState<string | null>(null);
+  const [previewEntryId, setPreviewEntryId] = useState<string | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [isRestoring, setIsRestoring] = useState(false);
+
+  const entries = useMemo(
+    () => [...(historyData?.entries ?? [])].reverse(),
+    [historyData],
+  );
+
+  const selectedEntry = historyData?.entries.find(
+    (entry) => entry.id === selectedEntryId,
+  );
+  const isPreviewing = !!previewEntryId;
+  const visibleErrorMessage = errorMessage || historyErrorMessage;
+
+  useEffect(() => {
+    if (!isPreviewing) {
+      setSelectedEntryId(historyData?.currentEntryId ?? null);
+    }
+  }, [historyData?.currentEntryId, isPreviewing]);
+
+  const cancelPreview = useCallback(() => {
+    const origin = previewOriginRef.current;
+
+    if (!origin) {
+      return;
+    }
+
+    addFilesToScene(excalidrawAPI, origin.files);
+    excalidrawAPI.updateScene({
+      elements: origin.elements,
+      appState: origin.appState,
+      captureUpdate: CaptureUpdateAction.NEVER,
+    });
+    LocalData.resumeSave("scene-history-preview");
+    previewOriginRef.current = null;
+    setPreviewEntryId(null);
+    setSelectedEntryId(historyData?.currentEntryId ?? null);
+  }, [excalidrawAPI, historyData?.currentEntryId]);
+
+  useEffect(() => {
+    if (isCollaborating && previewOriginRef.current) {
+      cancelPreview();
+    }
+  }, [cancelPreview, isCollaborating]);
+
+  useEffect(() => {
+    return () => {
+      const origin = previewOriginRef.current;
+
+      if (!origin || excalidrawAPI.isDestroyed) {
+        LocalData.resumeSave("scene-history-preview");
+        return;
+      }
+
+      addFilesToScene(excalidrawAPI, origin.files);
+      excalidrawAPI.updateScene({
+        elements: origin.elements,
+        appState: origin.appState,
+        captureUpdate: CaptureUpdateAction.NEVER,
+      });
+      LocalData.resumeSave("scene-history-preview");
+      previewOriginRef.current = null;
+    };
+  }, [excalidrawAPI]);
+
+  const previewEntry = async (entry: SceneHistoryEntry) => {
+    if (isCollaborating || isRestoring) {
+      return;
+    }
+
+    if (entry.id === historyData?.currentEntryId) {
+      cancelPreview();
+      return;
+    }
+
+    try {
+      if (!previewOriginRef.current) {
+        previewOriginRef.current = getCurrentScene(excalidrawAPI);
+        LocalData.pauseSave("scene-history-preview");
+      }
+
+      const target = await SceneHistory.reconstruct(entry.id);
+
+      if (!target) {
+        setErrorMessage("Version could not be restored");
+        return;
+      }
+
+      addFilesToScene(excalidrawAPI, target.files);
+      excalidrawAPI.updateScene({
+        elements: target.elements,
+        appState: {
+          ...excalidrawAPI.getAppState(),
+          ...target.appState,
+          viewModeEnabled: true,
+        },
+        captureUpdate: CaptureUpdateAction.NEVER,
+      });
+      setSelectedEntryId(entry.id);
+      setPreviewEntryId(entry.id);
+      setErrorMessage(null);
+    } catch (error) {
+      console.error(error);
+      setErrorMessage("Version could not be previewed");
+    }
+  };
+
+  const restoreSelectedEntry = async () => {
+    if (!selectedEntry || selectedEntry.id === historyData?.currentEntryId) {
+      return;
+    }
+
+    setIsRestoring(true);
+
+    try {
+      const target = await SceneHistory.reconstruct(selectedEntry.id);
+      const origin = previewOriginRef.current;
+
+      if (!target) {
+        setErrorMessage("Version could not be restored");
+        return;
+      }
+
+      if (origin) {
+        addFilesToScene(excalidrawAPI, origin.files);
+        excalidrawAPI.updateScene({
+          elements: origin.elements,
+          appState: origin.appState,
+          captureUpdate: CaptureUpdateAction.NEVER,
+        });
+      }
+
+      LocalData.resumeSave("scene-history-preview");
+      previewOriginRef.current = null;
+      markNextChangeAsRestore(selectedEntry.id);
+      addFilesToScene(excalidrawAPI, target.files);
+      excalidrawAPI.updateScene({
+        elements: target.elements,
+        appState: {
+          ...excalidrawAPI.getAppState(),
+          ...target.appState,
+        },
+        captureUpdate: CaptureUpdateAction.IMMEDIATELY,
+      });
+      excalidrawAPI.setToast({ message: "Version restored" });
+      setPreviewEntryId(null);
+      setErrorMessage(null);
+    } catch (error) {
+      console.error(error);
+      setErrorMessage("Version could not be restored");
+    } finally {
+      setIsRestoring(false);
+    }
+  };
+
+  return (
+    <div className="history-sidebar">
+      <div className="history-sidebar__header">
+        <h2>History</h2>
+        {historyData && (
+          <div className="history-sidebar__count">
+            {historyData.entries.length} versions
+          </div>
+        )}
+      </div>
+
+      {isCollaborating && (
+        <div className="history-sidebar__notice">
+          Restore is paused during live collaboration.
+        </div>
+      )}
+
+      {visibleErrorMessage && (
+        <div className="history-sidebar__notice history-sidebar__notice--error">
+          {visibleErrorMessage}
+        </div>
+      )}
+
+      <div className="history-sidebar__timeline" role="list">
+        {isLoading ? (
+          <div className="history-sidebar__empty">Loading history...</div>
+        ) : entries.length ? (
+          entries.map((entry) => {
+            const isSelected = entry.id === selectedEntryId;
+            const isCurrent = entry.id === historyData?.currentEntryId;
+
+            return (
+              <button
+                className={clsx("history-sidebar__entry", {
+                  "history-sidebar__entry--selected": isSelected,
+                  "history-sidebar__entry--current": isCurrent,
+                })}
+                disabled={isCollaborating || isRestoring}
+                key={entry.id}
+                onClick={() => previewEntry(entry)}
+                role="listitem"
+                type="button"
+              >
+                <span className="history-sidebar__marker" />
+                <span className="history-sidebar__thumbnail">
+                  {entry.thumbnail ? (
+                    <img alt="" src={entry.thumbnail} />
+                  ) : (
+                    <span>
+                      {entry.kind === "initial" ? "Start" : entry.sequence}
+                    </span>
+                  )}
+                </span>
+                <span className="history-sidebar__entry-body">
+                  <span className="history-sidebar__entry-title">
+                    {getEntryTitle(entry)}
+                    {isCurrent && (
+                      <span className="history-sidebar__current-label">
+                        Current
+                      </span>
+                    )}
+                  </span>
+                  <span className="history-sidebar__entry-summary">
+                    {entry.summary}
+                  </span>
+                  <span className="history-sidebar__entry-meta">
+                    <time dateTime={new Date(entry.createdAt).toISOString()}>
+                      {formatEntryTime(entry.createdAt)}
+                    </time>
+                    <span>
+                      {entry.sessionId === sessionId
+                        ? "This session"
+                        : "Previous session"}
+                    </span>
+                  </span>
+                </span>
+              </button>
+            );
+          })
+        ) : (
+          <div className="history-sidebar__empty">No history yet</div>
+        )}
+      </div>
+
+      {isPreviewing && (
+        <div className="history-sidebar__actions">
+          <Button
+            className="history-sidebar__cancel-button"
+            onSelect={cancelPreview}
+            disabled={isRestoring}
+          >
+            Cancel
+          </Button>
+          <Button
+            className="history-sidebar__restore-button"
+            onSelect={restoreSelectedEntry}
+            disabled={isCollaborating || isRestoring}
+          >
+            Restore
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/excalidraw-app/components/HistorySidebar.tsx
+++ b/excalidraw-app/components/HistorySidebar.tsx
@@ -13,6 +13,7 @@ import { CaptureUpdateAction } from "@excalidraw/excalidraw";
 import { Button } from "@excalidraw/excalidraw/components/Button";
 import { getNonDeletedElements } from "@excalidraw/element";
 import { exportToCanvas } from "@excalidraw/utils/export";
+import { isTestEnv } from "@excalidraw/common";
 
 import type { OrderedExcalidrawElement } from "@excalidraw/element/types";
 import type {
@@ -76,7 +77,7 @@ const createHistoryThumbnail = async (
 ) => {
   const nonDeletedElements = getNonDeletedElements(elements);
 
-  if (!nonDeletedElements.length) {
+  if (!nonDeletedElements.length || isTestEnv()) {
     return null;
   }
 

--- a/excalidraw-app/components/HistorySidebar.tsx
+++ b/excalidraw-app/components/HistorySidebar.tsx
@@ -23,22 +23,30 @@ import type {
 } from "@excalidraw/excalidraw/types";
 
 import { LocalData } from "../data/LocalData";
+import { getCollaborationLinkData } from "../data";
 import {
+  createCollabRestoreElements,
   isSceneHistoryDeltaRecordable,
+  reconstructSceneHistoryData,
   SceneHistory,
 } from "../data/SceneHistory";
+import { subscribeSceneHistoryFromFirebase } from "../data/firebase";
 
 import "./HistorySidebar.scss";
 
+import type { CollabAPI } from "../collab/Collab";
 import type { SceneHistoryData, SceneHistoryEntry } from "../data/SceneHistory";
 
 type HistorySidebarProps = {
+  collabAPI: CollabAPI | null;
   excalidrawAPI: ExcalidrawImperativeAPI;
   isCollaborating: boolean;
 };
 
 type SceneHistoryProviderProps = {
+  collabAPI: CollabAPI | null;
   excalidrawAPI: ExcalidrawImperativeAPI | null;
+  isCollaborating: boolean;
   children: React.ReactNode;
 };
 
@@ -46,8 +54,15 @@ type SceneHistoryContextValue = {
   historyData: SceneHistoryData | null;
   isLoading: boolean;
   errorMessage: string | null;
+  isSharedHistory: boolean;
   sessionId: string;
   markNextChangeAsRestore: (sourceEntryId: string) => void;
+  reconstructEntry: (entryId: string) => Promise<{
+    entry: SceneHistoryEntry;
+    elements: OrderedExcalidrawElement[];
+    appState: Partial<AppState>;
+    files: BinaryFiles;
+  } | null>;
 };
 
 type PreviewOrigin = {
@@ -58,16 +73,38 @@ type PreviewOrigin = {
 
 const THUMBNAIL_MAX_WIDTH = 160;
 const THUMBNAIL_MAX_HEIGHT = 96;
+const SCENE_HISTORY_PREVIEW_LOCK = "scene-history-preview";
 
 const SceneHistoryContext = createContext<SceneHistoryContextValue | null>(
   null,
 );
+
+type CollabHistorySource = {
+  roomId: string;
+  roomKey: string;
+};
 
 const createSessionId = () => {
   return (
     globalThis.crypto?.randomUUID?.() ??
     `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`
   );
+};
+
+const getCollabHistorySource = (
+  collabAPI: CollabAPI | null,
+  isCollaborating: boolean,
+): CollabHistorySource | null => {
+  if (!collabAPI || !isCollaborating) {
+    return null;
+  }
+
+  const activeRoomLink = collabAPI.getActiveRoomLink();
+  if (!activeRoomLink) {
+    return null;
+  }
+
+  return getCollaborationLinkData(activeRoomLink);
 };
 
 const createHistoryThumbnail = async (
@@ -166,7 +203,9 @@ const useSceneHistoryContext = () => {
 };
 
 export const SceneHistoryProvider = ({
+  collabAPI,
   excalidrawAPI,
+  isCollaborating,
   children,
 }: SceneHistoryProviderProps) => {
   const sessionIdRef = useRef(createSessionId());
@@ -176,19 +215,47 @@ export const SceneHistoryProvider = ({
   const [historyData, setHistoryData] = useState<SceneHistoryData | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
+  const collabHistorySource = getCollabHistorySource(
+    collabAPI,
+    isCollaborating,
+  );
+  const collabRoomId = collabHistorySource?.roomId ?? null;
+  const collabRoomKey = collabHistorySource?.roomKey ?? null;
+  const isSharedHistory = !!collabHistorySource;
 
   const setHistoryState = useCallback((nextHistoryData: SceneHistoryData) => {
     setHistoryData(nextHistoryData);
   }, []);
 
-  const markNextChangeAsRestore = useCallback((sourceEntryId: string) => {
-    pendingRestoreRef.current = { sourceEntryId };
-    window.setTimeout(() => {
-      if (pendingRestoreRef.current?.sourceEntryId === sourceEntryId) {
-        pendingRestoreRef.current = null;
+  const markNextChangeAsRestore = useCallback(
+    (sourceEntryId: string) => {
+      if (isSharedHistory) {
+        collabAPI?.markNextHistorySaveAsRestore(sourceEntryId);
+        return;
       }
-    }, 500);
-  }, []);
+
+      pendingRestoreRef.current = { sourceEntryId };
+      window.setTimeout(() => {
+        if (pendingRestoreRef.current?.sourceEntryId === sourceEntryId) {
+          pendingRestoreRef.current = null;
+        }
+      }, 500);
+    },
+    [collabAPI, isSharedHistory],
+  );
+
+  const reconstructEntry = useCallback(
+    async (entryId: string) => {
+      if (isSharedHistory) {
+        return historyData
+          ? reconstructSceneHistoryData(historyData, entryId)
+          : null;
+      }
+
+      return SceneHistory.reconstruct(entryId);
+    },
+    [historyData, isSharedHistory],
+  );
 
   useEffect(() => {
     isMountedRef.current = true;
@@ -199,7 +266,7 @@ export const SceneHistoryProvider = ({
   }, []);
 
   useEffect(() => {
-    if (!excalidrawAPI) {
+    if (!excalidrawAPI || isSharedHistory) {
       setHistoryData(null);
       setIsLoading(false);
       return;
@@ -245,10 +312,46 @@ export const SceneHistoryProvider = ({
     return () => {
       isActive = false;
     };
-  }, [excalidrawAPI, setHistoryState]);
+  }, [excalidrawAPI, isSharedHistory, setHistoryState]);
 
   useEffect(() => {
-    if (!excalidrawAPI) {
+    if (!excalidrawAPI || !collabRoomId || !collabRoomKey) {
+      return;
+    }
+
+    let isActive = true;
+
+    setHistoryData(null);
+    setIsLoading(true);
+
+    const unsubscribe = subscribeSceneHistoryFromFirebase({
+      roomId: collabRoomId,
+      roomKey: collabRoomKey,
+      onChange: (nextHistoryData) => {
+        if (isActive && isMountedRef.current) {
+          setHistoryState(nextHistoryData);
+          setErrorMessage(null);
+          setIsLoading(false);
+        }
+      },
+      onError: (error) => {
+        console.error(error);
+
+        if (isActive && isMountedRef.current) {
+          setErrorMessage("Shared history is unavailable");
+          setIsLoading(false);
+        }
+      },
+    });
+
+    return () => {
+      isActive = false;
+      unsubscribe();
+    };
+  }, [collabRoomId, collabRoomKey, excalidrawAPI, setHistoryState]);
+
+  useEffect(() => {
+    if (!excalidrawAPI || isSharedHistory) {
       return;
     }
 
@@ -303,17 +406,26 @@ export const SceneHistoryProvider = ({
       isActive = false;
       unsubscribe();
     };
-  }, [excalidrawAPI, setHistoryState]);
+  }, [excalidrawAPI, isSharedHistory, setHistoryState]);
 
   const value = useMemo(
     () => ({
       historyData,
       isLoading,
       errorMessage,
+      isSharedHistory,
       sessionId: sessionIdRef.current,
       markNextChangeAsRestore,
+      reconstructEntry,
     }),
-    [errorMessage, historyData, isLoading, markNextChangeAsRestore],
+    [
+      errorMessage,
+      historyData,
+      isLoading,
+      isSharedHistory,
+      markNextChangeAsRestore,
+      reconstructEntry,
+    ],
   );
 
   return (
@@ -324,6 +436,7 @@ export const SceneHistoryProvider = ({
 };
 
 export const HistorySidebar = ({
+  collabAPI,
   excalidrawAPI,
   isCollaborating,
 }: HistorySidebarProps) => {
@@ -331,8 +444,10 @@ export const HistorySidebar = ({
     historyData,
     isLoading,
     errorMessage: historyErrorMessage,
+    isSharedHistory,
     sessionId,
     markNextChangeAsRestore,
+    reconstructEntry,
   } = useSceneHistoryContext();
   const previewOriginRef = useRef<PreviewOrigin | null>(null);
   const previewRequestIdRef = useRef(0);
@@ -352,6 +467,27 @@ export const HistorySidebar = ({
   );
   const isPreviewing = !!previewEntryId;
   const visibleErrorMessage = errorMessage || historyErrorMessage;
+
+  const addTargetFilesToScene = useCallback(
+    async (target: {
+      elements: readonly OrderedExcalidrawElement[];
+      files: BinaryFiles;
+    }) => {
+      addFilesToScene(excalidrawAPI, target.files);
+
+      if (isSharedHistory && collabAPI) {
+        const { loadedFiles } = await collabAPI.fetchImageFilesFromFirebase({
+          elements: target.elements,
+          forceFetchFiles: true,
+        });
+
+        if (loadedFiles.length) {
+          excalidrawAPI.addFiles(loadedFiles);
+        }
+      }
+    },
+    [collabAPI, excalidrawAPI, isSharedHistory],
+  );
 
   useEffect(() => {
     isMountedRef.current = true;
@@ -381,24 +517,20 @@ export const HistorySidebar = ({
       appState: origin.appState,
       captureUpdate: CaptureUpdateAction.NEVER,
     });
-    LocalData.resumeSave("scene-history-preview");
+    LocalData.resumeSave(SCENE_HISTORY_PREVIEW_LOCK);
+    collabAPI?.resumeSync(SCENE_HISTORY_PREVIEW_LOCK);
     previewOriginRef.current = null;
     setPreviewEntryId(null);
     setSelectedEntryId(historyData?.currentEntryId ?? null);
-  }, [excalidrawAPI, historyData?.currentEntryId]);
-
-  useEffect(() => {
-    if (isCollaborating && previewOriginRef.current) {
-      cancelPreview();
-    }
-  }, [cancelPreview, isCollaborating]);
+  }, [collabAPI, excalidrawAPI, historyData?.currentEntryId]);
 
   useEffect(() => {
     return () => {
       const origin = previewOriginRef.current;
 
       if (!origin || excalidrawAPI.isDestroyed) {
-        LocalData.resumeSave("scene-history-preview");
+        LocalData.resumeSave(SCENE_HISTORY_PREVIEW_LOCK);
+        collabAPI?.resumeSync(SCENE_HISTORY_PREVIEW_LOCK);
         return;
       }
 
@@ -408,13 +540,14 @@ export const HistorySidebar = ({
         appState: origin.appState,
         captureUpdate: CaptureUpdateAction.NEVER,
       });
-      LocalData.resumeSave("scene-history-preview");
+      LocalData.resumeSave(SCENE_HISTORY_PREVIEW_LOCK);
+      collabAPI?.resumeSync(SCENE_HISTORY_PREVIEW_LOCK);
       previewOriginRef.current = null;
     };
-  }, [excalidrawAPI]);
+  }, [collabAPI, excalidrawAPI]);
 
   const previewEntry = async (entry: SceneHistoryEntry) => {
-    if (isCollaborating || isRestoring) {
+    if (isRestoring) {
       return;
     }
 
@@ -428,21 +561,25 @@ export const HistorySidebar = ({
     try {
       if (!previewOriginRef.current) {
         previewOriginRef.current = getCurrentScene(excalidrawAPI);
-        LocalData.pauseSave("scene-history-preview");
+        LocalData.pauseSave(SCENE_HISTORY_PREVIEW_LOCK);
+        if (isSharedHistory && isCollaborating) {
+          collabAPI?.pauseSync(SCENE_HISTORY_PREVIEW_LOCK);
+        }
       }
 
-      const target = await SceneHistory.reconstruct(entry.id);
+      const target = await reconstructEntry(entry.id);
 
       if (!isMountedRef.current || previewRequestIdRef.current !== requestId) {
         return;
       }
 
       if (!target) {
+        cancelPreview();
         setErrorMessage("Version could not be restored");
         return;
       }
 
-      addFilesToScene(excalidrawAPI, target.files);
+      await addTargetFilesToScene(target);
       excalidrawAPI.updateScene({
         elements: target.elements,
         appState: {
@@ -461,6 +598,7 @@ export const HistorySidebar = ({
       }
 
       console.error(error);
+      cancelPreview();
       setErrorMessage("Version could not be previewed");
     }
   };
@@ -474,7 +612,7 @@ export const HistorySidebar = ({
     previewRequestIdRef.current++;
 
     try {
-      const target = await SceneHistory.reconstruct(selectedEntry.id);
+      const target = await reconstructEntry(selectedEntry.id);
       const origin = previewOriginRef.current;
 
       if (!target) {
@@ -491,18 +629,29 @@ export const HistorySidebar = ({
         });
       }
 
-      LocalData.resumeSave("scene-history-preview");
+      LocalData.resumeSave(SCENE_HISTORY_PREVIEW_LOCK);
+      collabAPI?.resumeSync(SCENE_HISTORY_PREVIEW_LOCK);
       previewOriginRef.current = null;
       markNextChangeAsRestore(selectedEntry.id);
-      addFilesToScene(excalidrawAPI, target.files);
+      await addTargetFilesToScene(target);
+      const restoredElements =
+        isSharedHistory && isCollaborating
+          ? createCollabRestoreElements(
+              target.elements,
+              excalidrawAPI.getSceneElementsIncludingDeleted() as readonly OrderedExcalidrawElement[],
+            )
+          : target.elements;
       excalidrawAPI.updateScene({
-        elements: target.elements,
+        elements: restoredElements,
         appState: {
           ...excalidrawAPI.getAppState(),
           ...target.appState,
         },
         captureUpdate: CaptureUpdateAction.IMMEDIATELY,
       });
+      if (isSharedHistory && isCollaborating) {
+        collabAPI?.syncElements(restoredElements);
+      }
       excalidrawAPI.setToast({ message: "Version restored" });
       setPreviewEntryId(null);
       setErrorMessage(null);
@@ -525,9 +674,9 @@ export const HistorySidebar = ({
         )}
       </div>
 
-      {isCollaborating && (
+      {isCollaborating && isSharedHistory && (
         <div className="history-sidebar__notice">
-          Restore is paused during live collaboration.
+          Shared history is synced for this room.
         </div>
       )}
 
@@ -551,7 +700,7 @@ export const HistorySidebar = ({
                   "history-sidebar__entry--selected": isSelected,
                   "history-sidebar__entry--current": isCurrent,
                 })}
-                disabled={isCollaborating || isRestoring}
+                disabled={isRestoring}
                 key={entry.id}
                 onClick={() => previewEntry(entry)}
                 role="listitem"
@@ -610,7 +759,7 @@ export const HistorySidebar = ({
           <Button
             className="history-sidebar__restore-button"
             onSelect={restoreSelectedEntry}
-            disabled={isCollaborating || isRestoring}
+            disabled={isRestoring}
           >
             Restore
           </Button>

--- a/excalidraw-app/data/LocalData.ts
+++ b/excalidraw-app/data/LocalData.ts
@@ -112,7 +112,7 @@ const isQuotaExceededError = (error: any) => {
   return error instanceof DOMException && error.name === "QuotaExceededError";
 };
 
-type SavingLockTypes = "collaboration";
+type SavingLockTypes = "collaboration" | "scene-history-preview";
 
 export class LocalData {
   private static _save = debounce(

--- a/excalidraw-app/data/SceneHistory.test.ts
+++ b/excalidraw-app/data/SceneHistory.test.ts
@@ -1,6 +1,8 @@
 import type { StoreDelta } from "@excalidraw/element";
+import type { OrderedExcalidrawElement } from "@excalidraw/element/types";
 
 import {
+  createCollabRestoreElements,
   isSceneHistoryDeltaRecordable,
   reconstructSceneHistoryData,
   trimSceneHistoryData,
@@ -104,6 +106,25 @@ const createHistoryData = (entries: SceneHistoryEntry[]): SceneHistoryData => ({
   files: {},
 });
 
+const createElement = ({
+  id,
+  isDeleted = false,
+  version,
+  versionNonce = version,
+}: {
+  id: string;
+  isDeleted?: boolean;
+  version: number;
+  versionNonce?: number;
+}) =>
+  ({
+    id,
+    isDeleted,
+    updated: version,
+    version,
+    versionNonce,
+  } as OrderedExcalidrawElement);
+
 describe("SceneHistory", () => {
   it("does not record transient-only app state deltas", () => {
     const delta = createStoreDelta({
@@ -175,5 +196,25 @@ describe("SceneHistory", () => {
     expect(trimmedHistoryData.entries[0].snapshot).toBeDefined();
     expect(trimmedHistoryData.entries[0].delta).toBeUndefined();
     expect(target?.appState.name).toBe("v121");
+  });
+
+  it("creates collab restore elements with bumped targets and deletion tombstones", () => {
+    const restoredElements = createCollabRestoreElements(
+      [createElement({ id: "existing", version: 1, versionNonce: 10 })],
+      [
+        createElement({ id: "existing", version: 5, versionNonce: 20 }),
+        createElement({ id: "newer", version: 3 }),
+      ],
+    );
+    const existingElement = restoredElements.find(
+      (element) => element.id === "existing",
+    );
+    const deletedElement = restoredElements.find(
+      (element) => element.id === "newer",
+    );
+
+    expect(existingElement?.version).toBeGreaterThan(5);
+    expect(deletedElement?.isDeleted).toBe(true);
+    expect(deletedElement?.version).toBeGreaterThan(3);
   });
 });

--- a/excalidraw-app/data/SceneHistory.test.ts
+++ b/excalidraw-app/data/SceneHistory.test.ts
@@ -1,4 +1,7 @@
+import type { StoreDelta } from "@excalidraw/element";
+
 import {
+  isSceneHistoryDeltaRecordable,
   reconstructSceneHistoryData,
   trimSceneHistoryData,
 } from "./SceneHistory";
@@ -45,6 +48,36 @@ const createNameDelta = (from: string | null, to: string) => ({
   },
 });
 
+const createStoreDelta = (
+  delta: Partial<{
+    elements: {
+      added: Record<string, unknown>;
+      removed: Record<string, unknown>;
+      updated: Record<string, unknown>;
+    };
+    appState: {
+      delta: {
+        deleted: Record<string, unknown>;
+        inserted: Record<string, unknown>;
+      };
+    };
+  }> = {},
+) =>
+  ({
+    id: "delta",
+    elements: delta.elements ?? {
+      added: {},
+      removed: {},
+      updated: {},
+    },
+    appState: delta.appState ?? {
+      delta: {
+        deleted: {},
+        inserted: {},
+      },
+    },
+  } as unknown as StoreDelta);
+
 const createEntry = (index: number): SceneHistoryEntry => {
   const name = `v${index}`;
 
@@ -72,6 +105,48 @@ const createHistoryData = (entries: SceneHistoryEntry[]): SceneHistoryData => ({
 });
 
 describe("SceneHistory", () => {
+  it("does not record transient-only app state deltas", () => {
+    const delta = createStoreDelta({
+      appState: {
+        delta: {
+          deleted: {
+            selectedElementIds: {},
+          },
+          inserted: {
+            selectedElementIds: {
+              elementId: true,
+            },
+          },
+        },
+      },
+    });
+
+    expect(isSceneHistoryDeltaRecordable(delta)).toBe(false);
+  });
+
+  it("records element and scene-level app state deltas", () => {
+    const elementDelta = createStoreDelta({
+      elements: {
+        added: {},
+        removed: {},
+        updated: {
+          elementId: {
+            deleted: {
+              version: 1,
+            },
+            inserted: {
+              version: 2,
+            },
+          },
+        },
+      },
+    });
+    const nameDelta = createNameDelta(null, "v1") as unknown as StoreDelta;
+
+    expect(isSceneHistoryDeltaRecordable(elementDelta)).toBe(true);
+    expect(isSceneHistoryDeltaRecordable(nameDelta)).toBe(true);
+  });
+
   it("reconstructs a target entry from the previous snapshot and deltas", () => {
     const historyData = createHistoryData([
       createEntry(0),

--- a/excalidraw-app/data/SceneHistory.test.ts
+++ b/excalidraw-app/data/SceneHistory.test.ts
@@ -1,0 +1,104 @@
+import {
+  reconstructSceneHistoryData,
+  trimSceneHistoryData,
+} from "./SceneHistory";
+
+import type {
+  SceneHistoryData,
+  SceneHistoryEntry,
+  SceneHistorySnapshot,
+} from "./SceneHistory";
+
+const createAppState = (name: string | null) => ({
+  name,
+  editingGroupId: null,
+  viewBackgroundColor: "#ffffff",
+  selectedElementIds: {},
+  selectedGroupIds: {},
+  selectedLinearElement: null,
+  croppingElementId: null,
+  lockedMultiSelections: {},
+  activeLockedId: null,
+});
+
+const createSnapshot = (name: string | null): SceneHistorySnapshot => ({
+  elements: [],
+  appState: createAppState(name),
+});
+
+const createNameDelta = (from: string | null, to: string) => ({
+  id: `delta-${to}`,
+  elements: {
+    added: {},
+    removed: {},
+    updated: {},
+  },
+  appState: {
+    delta: {
+      deleted: {
+        name: from,
+      },
+      inserted: {
+        name: to,
+      },
+    },
+  },
+});
+
+const createEntry = (index: number): SceneHistoryEntry => {
+  const name = `v${index}`;
+
+  return {
+    id: `entry-${index}`,
+    kind: index === 0 ? "initial" : "change",
+    sequence: index,
+    createdAt: index,
+    sessionId: "test-session",
+    parentId: index === 0 ? null : `entry-${index - 1}`,
+    summary: "Scene updated",
+    thumbnail: null,
+    fileIds: [],
+    snapshot: index === 0 ? createSnapshot(null) : undefined,
+    delta: index === 0 ? undefined : createNameDelta(`v${index - 1}`, name),
+  };
+};
+
+const createHistoryData = (entries: SceneHistoryEntry[]): SceneHistoryData => ({
+  version: 1,
+  documentId: "test-document",
+  currentEntryId: entries[entries.length - 1]?.id ?? null,
+  entries,
+  files: {},
+});
+
+describe("SceneHistory", () => {
+  it("reconstructs a target entry from the previous snapshot and deltas", () => {
+    const historyData = createHistoryData([
+      createEntry(0),
+      {
+        ...createEntry(1),
+        delta: createNameDelta(null, "v1"),
+      },
+    ]);
+    const target = reconstructSceneHistoryData(historyData, "entry-1");
+
+    expect(target?.appState.name).toBe("v1");
+    expect(target?.appState.selectedElementIds).toEqual({});
+  });
+
+  it("trims old entries while keeping the first retained entry reconstructable", () => {
+    const historyData = createHistoryData(
+      Array.from({ length: 122 }, (_, index) => createEntry(index)),
+    );
+    const trimmedHistoryData = trimSceneHistoryData(historyData);
+    const target = reconstructSceneHistoryData(
+      trimmedHistoryData,
+      trimmedHistoryData.currentEntryId!,
+    );
+
+    expect(trimmedHistoryData.entries).toHaveLength(120);
+    expect(trimmedHistoryData.entries[0].snapshot).toBeDefined();
+    expect(trimmedHistoryData.entries[0].delta).toBeUndefined();
+    expect(target?.appState.name).toBe("v121");
+  });
+});

--- a/excalidraw-app/data/SceneHistory.ts
+++ b/excalidraw-app/data/SceneHistory.ts
@@ -1,8 +1,10 @@
 import {
   getInitializedImageElements,
   getObservedAppState,
+  newElementWith,
   StoreDelta,
 } from "@excalidraw/element";
+import { bumpElementVersions } from "@excalidraw/excalidraw/data/restore";
 import { createStore, get, set } from "idb-keyval";
 
 import type {
@@ -20,8 +22,8 @@ import type {
 
 import { STORAGE_KEYS } from "../app_constants";
 
-const HISTORY_VERSION = 1;
-const MAX_HISTORY_ENTRIES = 120;
+export const SCENE_HISTORY_VERSION = 1;
+export const MAX_SCENE_HISTORY_ENTRIES = 120;
 const SNAPSHOT_INTERVAL = 20;
 const LOCAL_DOCUMENT_ID = "local-default";
 const RECORDABLE_APP_STATE_KEYS = new Set<keyof ObservedAppState>([
@@ -69,7 +71,7 @@ export type SceneHistoryEntry = {
 };
 
 export type SceneHistoryData = {
-  version: typeof HISTORY_VERSION;
+  version: typeof SCENE_HISTORY_VERSION;
   documentId: string;
   currentEntryId: string | null;
   entries: SceneHistoryEntry[];
@@ -103,7 +105,7 @@ const store = createStore(
   `${STORAGE_KEYS.IDB_SCENE_HISTORY}-store`,
 );
 
-const createId = () => {
+export const createSceneHistoryId = () => {
   return (
     globalThis.crypto?.randomUUID?.() ??
     `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`
@@ -117,7 +119,7 @@ const cloneSerializable = <T>(value: T): T => {
 const createEmptyHistory = (
   documentId = LOCAL_DOCUMENT_ID,
 ): SceneHistoryData => ({
-  version: HISTORY_VERSION,
+  version: SCENE_HISTORY_VERSION,
   documentId,
   currentEntryId: null,
   entries: [],
@@ -140,7 +142,7 @@ const normalizeObservedAppState = (appState: AppState): ObservedAppState => {
   });
 };
 
-const resetTransientAppState = (
+export const resetTransientAppState = (
   appState: Partial<AppState>,
 ): Partial<AppState> => {
   return {
@@ -166,7 +168,25 @@ export const createSceneHistorySnapshot = ({
   appState: normalizeObservedAppState(appState),
 });
 
-const getReferencedFileIds = (
+export const createCollabRestoreElements = (
+  targetElements: readonly OrderedExcalidrawElement[],
+  currentElements: readonly OrderedExcalidrawElement[],
+): OrderedExcalidrawElement[] => {
+  const targetIds = new Set(targetElements.map((element) => element.id));
+  const bumpedTargetElements = bumpElementVersions(
+    targetElements,
+    currentElements,
+  ) as OrderedExcalidrawElement[];
+  const deletedCurrentOnlyElements = currentElements
+    .filter((element) => !targetIds.has(element.id))
+    .map((element) =>
+      newElementWith(element, { isDeleted: true }, true),
+    ) as OrderedExcalidrawElement[];
+
+  return bumpedTargetElements.concat(deletedCurrentOnlyElements);
+};
+
+export const getReferencedFileIds = (
   elements: readonly ExcalidrawElement[],
 ): FileId[] => {
   const ids = new Set<FileId>();
@@ -352,14 +372,14 @@ export const reconstructSceneHistoryData = (
 export const trimSceneHistoryData = (
   historyData: SceneHistoryData,
 ): SceneHistoryData => {
-  if (historyData.entries.length <= MAX_HISTORY_ENTRIES) {
+  if (historyData.entries.length <= MAX_SCENE_HISTORY_ENTRIES) {
     return {
       ...historyData,
       files: pruneFiles(historyData.entries, historyData.files),
     };
   }
 
-  const firstKeptIndex = historyData.entries.length - MAX_HISTORY_ENTRIES;
+  const firstKeptIndex = historyData.entries.length - MAX_SCENE_HISTORY_ENTRIES;
   const firstKeptEntry = historyData.entries[firstKeptIndex];
   const reconstructedFirstEntry = reconstructSceneHistoryData(
     historyData,
@@ -404,7 +424,7 @@ class SceneHistoryIndexedDBAdapter {
       );
 
       if (
-        historyData?.version === HISTORY_VERSION &&
+        historyData?.version === SCENE_HISTORY_VERSION &&
         historyData.documentId === documentId
       ) {
         return historyData;
@@ -441,7 +461,7 @@ export class SceneHistory {
     }
 
     const entry: SceneHistoryEntry = {
-      id: createId(),
+      id: createSceneHistoryId(),
       kind: "initial",
       sequence: 0,
       createdAt: Date.now(),
@@ -501,7 +521,7 @@ export class SceneHistory {
     const sequence = (lastEntry?.sequence ?? -1) + 1;
     const isCheckpoint = sequence % SNAPSHOT_INTERVAL === 0;
     const entry: SceneHistoryEntry = {
-      id: createId(),
+      id: createSceneHistoryId(),
       kind,
       sequence,
       createdAt: Date.now(),

--- a/excalidraw-app/data/SceneHistory.ts
+++ b/excalidraw-app/data/SceneHistory.ts
@@ -61,6 +61,7 @@ export type SceneHistoryEntry = {
   sequence: number;
   createdAt: number;
   sessionId: string;
+  author?: string | null;
   parentId: string | null;
   summary: string;
   thumbnail: string | null;

--- a/excalidraw-app/data/SceneHistory.ts
+++ b/excalidraw-app/data/SceneHistory.ts
@@ -1,0 +1,504 @@
+import {
+  getInitializedImageElements,
+  getObservedAppState,
+  StoreDelta,
+} from "@excalidraw/element";
+import { createStore, get, set } from "idb-keyval";
+
+import type {
+  ExcalidrawElement,
+  FileId,
+  OrderedExcalidrawElement,
+  SceneElementsMap,
+} from "@excalidraw/element/types";
+import type {
+  AppState,
+  BinaryFileData,
+  BinaryFiles,
+  ObservedAppState,
+} from "@excalidraw/excalidraw/types";
+
+import { STORAGE_KEYS } from "../app_constants";
+
+const HISTORY_VERSION = 1;
+const MAX_HISTORY_ENTRIES = 120;
+const SNAPSHOT_INTERVAL = 20;
+const LOCAL_DOCUMENT_ID = "local-default";
+
+export type SceneHistoryEntryKind = "initial" | "change" | "restore";
+
+type SerializedDelta<T> = {
+  deleted: Partial<T>;
+  inserted: Partial<T>;
+};
+
+type SerializedStoreDelta = {
+  id: string;
+  elements: {
+    added: Record<string, SerializedDelta<Partial<ExcalidrawElement>>>;
+    removed: Record<string, SerializedDelta<Partial<ExcalidrawElement>>>;
+    updated: Record<string, SerializedDelta<Partial<ExcalidrawElement>>>;
+  };
+  appState: {
+    delta: SerializedDelta<ObservedAppState>;
+  };
+};
+
+export type SceneHistorySnapshot = {
+  elements: OrderedExcalidrawElement[];
+  appState: ObservedAppState;
+};
+
+export type SceneHistoryEntry = {
+  id: string;
+  kind: SceneHistoryEntryKind;
+  sequence: number;
+  createdAt: number;
+  sessionId: string;
+  parentId: string | null;
+  summary: string;
+  thumbnail: string | null;
+  fileIds: FileId[];
+  delta?: SerializedStoreDelta;
+  snapshot?: SceneHistorySnapshot;
+  restoreSourceId?: string;
+};
+
+export type SceneHistoryData = {
+  version: typeof HISTORY_VERSION;
+  documentId: string;
+  currentEntryId: string | null;
+  entries: SceneHistoryEntry[];
+  files: BinaryFiles;
+};
+
+export type SceneHistoryTargetState = {
+  entry: SceneHistoryEntry;
+  elements: OrderedExcalidrawElement[];
+  appState: Partial<AppState>;
+  files: BinaryFiles;
+};
+
+type SceneHistoryInit = {
+  documentId?: string;
+  sessionId: string;
+  elements: readonly OrderedExcalidrawElement[];
+  appState: AppState;
+  files: BinaryFiles;
+  thumbnail?: string | null;
+};
+
+type SceneHistoryAppend = SceneHistoryInit & {
+  delta: StoreDelta;
+  kind?: Extract<SceneHistoryEntryKind, "change" | "restore">;
+  restoreSourceId?: string;
+};
+
+const store = createStore(
+  `${STORAGE_KEYS.IDB_SCENE_HISTORY}-db`,
+  `${STORAGE_KEYS.IDB_SCENE_HISTORY}-store`,
+);
+
+const createId = () => {
+  return (
+    globalThis.crypto?.randomUUID?.() ??
+    `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`
+  );
+};
+
+const cloneSerializable = <T>(value: T): T => {
+  return JSON.parse(JSON.stringify(value));
+};
+
+const createEmptyHistory = (
+  documentId = LOCAL_DOCUMENT_ID,
+): SceneHistoryData => ({
+  version: HISTORY_VERSION,
+  documentId,
+  currentEntryId: null,
+  entries: [],
+  files: {},
+});
+
+const normalizeObservedAppState = (appState: AppState): ObservedAppState => {
+  const observedAppState = getObservedAppState(appState);
+
+  return cloneSerializable({
+    name: observedAppState.name,
+    editingGroupId: observedAppState.editingGroupId,
+    viewBackgroundColor: observedAppState.viewBackgroundColor,
+    selectedElementIds: observedAppState.selectedElementIds,
+    selectedGroupIds: observedAppState.selectedGroupIds,
+    selectedLinearElement: observedAppState.selectedLinearElement,
+    croppingElementId: observedAppState.croppingElementId,
+    lockedMultiSelections: observedAppState.lockedMultiSelections,
+    activeLockedId: observedAppState.activeLockedId,
+  });
+};
+
+const resetTransientAppState = (
+  appState: Partial<AppState>,
+): Partial<AppState> => {
+  return {
+    ...appState,
+    selectedElementIds: {},
+    selectedGroupIds: {},
+    selectedLinearElement: null,
+    editingGroupId: null,
+    croppingElementId: null,
+    lockedMultiSelections: {},
+    activeLockedId: null,
+  };
+};
+
+export const createSceneHistorySnapshot = ({
+  elements,
+  appState,
+}: {
+  elements: readonly OrderedExcalidrawElement[];
+  appState: AppState;
+}): SceneHistorySnapshot => ({
+  elements: cloneSerializable([...elements]),
+  appState: normalizeObservedAppState(appState),
+});
+
+const getReferencedFileIds = (
+  elements: readonly ExcalidrawElement[],
+): FileId[] => {
+  const ids = new Set<FileId>();
+
+  for (const element of getInitializedImageElements(elements)) {
+    if (!element.isDeleted) {
+      ids.add(element.fileId);
+    }
+  }
+
+  return [...ids];
+};
+
+const collectReferencedFiles = (
+  elements: readonly ExcalidrawElement[],
+  files: BinaryFiles,
+): BinaryFiles => {
+  const referencedFiles: BinaryFiles = {};
+
+  for (const fileId of getReferencedFileIds(elements)) {
+    const file = files[fileId];
+
+    if (file) {
+      referencedFiles[fileId] = cloneSerializable(file) as BinaryFileData;
+    }
+  }
+
+  return referencedFiles;
+};
+
+const pickFiles = (fileIds: readonly FileId[], files: BinaryFiles) => {
+  const nextFiles: BinaryFiles = {};
+
+  for (const fileId of fileIds) {
+    const file = files[fileId];
+
+    if (file) {
+      nextFiles[fileId] = file;
+    }
+  }
+
+  return nextFiles;
+};
+
+const pruneFiles = (
+  entries: readonly SceneHistoryEntry[],
+  files: BinaryFiles,
+): BinaryFiles => {
+  const referencedFileIds = new Set<FileId>();
+
+  for (const entry of entries) {
+    for (const fileId of entry.fileIds) {
+      referencedFileIds.add(fileId);
+    }
+  }
+
+  return pickFiles([...referencedFileIds], files);
+};
+
+const createElementsMap = (
+  elements: readonly OrderedExcalidrawElement[],
+): SceneElementsMap => {
+  return new Map(
+    elements.map((element) => [element.id, element]),
+  ) as SceneElementsMap;
+};
+
+const serializeDelta = (delta: StoreDelta): SerializedStoreDelta => {
+  return cloneSerializable(delta) as SerializedStoreDelta;
+};
+
+const countObjectKeys = (value: unknown) => {
+  return value && typeof value === "object" ? Object.keys(value).length : 0;
+};
+
+export const describeStoreDelta = (delta: StoreDelta): string => {
+  const serializedDelta = serializeDelta(delta);
+  const added = countObjectKeys(serializedDelta.elements.added);
+  const removed = countObjectKeys(serializedDelta.elements.removed);
+  const updated = countObjectKeys(serializedDelta.elements.updated);
+  const appState = countObjectKeys(serializedDelta.appState.delta.inserted);
+  const parts: string[] = [];
+
+  if (added) {
+    parts.push(`${added} added`);
+  }
+  if (updated) {
+    parts.push(`${updated} edited`);
+  }
+  if (removed) {
+    parts.push(`${removed} removed`);
+  }
+  if (appState) {
+    parts.push("view updated");
+  }
+
+  return parts.join(", ") || "Scene updated";
+};
+
+export const reconstructSceneHistoryData = (
+  historyData: SceneHistoryData,
+  entryId: string,
+): SceneHistoryTargetState | null => {
+  const targetIndex = historyData.entries.findIndex(
+    (entry) => entry.id === entryId,
+  );
+
+  if (targetIndex === -1) {
+    return null;
+  }
+
+  let snapshotIndex = targetIndex;
+
+  while (snapshotIndex >= 0 && !historyData.entries[snapshotIndex].snapshot) {
+    snapshotIndex--;
+  }
+
+  const snapshotEntry = historyData.entries[snapshotIndex];
+  const snapshot = snapshotEntry?.snapshot;
+
+  if (!snapshot) {
+    return null;
+  }
+
+  let elementsMap = createElementsMap(snapshot.elements);
+  let appState = snapshot.appState as AppState;
+
+  for (const entry of historyData.entries.slice(
+    snapshotIndex + 1,
+    targetIndex + 1,
+  )) {
+    if (!entry.delta) {
+      continue;
+    }
+
+    [elementsMap, appState] = StoreDelta.applyTo(
+      StoreDelta.restore(entry.delta as any),
+      elementsMap,
+      appState,
+    );
+  }
+
+  const entry = historyData.entries[targetIndex];
+  const elements = Array.from(elementsMap.values());
+
+  return {
+    entry,
+    elements,
+    appState: resetTransientAppState(appState),
+    files: pickFiles(getReferencedFileIds(elements), historyData.files),
+  };
+};
+
+export const trimSceneHistoryData = (
+  historyData: SceneHistoryData,
+): SceneHistoryData => {
+  if (historyData.entries.length <= MAX_HISTORY_ENTRIES) {
+    return {
+      ...historyData,
+      files: pruneFiles(historyData.entries, historyData.files),
+    };
+  }
+
+  const firstKeptIndex = historyData.entries.length - MAX_HISTORY_ENTRIES;
+  const firstKeptEntry = historyData.entries[firstKeptIndex];
+  const reconstructedFirstEntry = reconstructSceneHistoryData(
+    historyData,
+    firstKeptEntry.id,
+  );
+
+  if (!reconstructedFirstEntry) {
+    return historyData;
+  }
+
+  const entries = historyData.entries.slice(firstKeptIndex);
+
+  entries[0] = {
+    ...entries[0],
+    kind: "initial",
+    parentId: null,
+    summary: "History checkpoint",
+    delta: undefined,
+    restoreSourceId: undefined,
+    snapshot: {
+      elements: reconstructedFirstEntry.elements,
+      appState: reconstructedFirstEntry.appState as ObservedAppState,
+    },
+  };
+
+  return {
+    ...historyData,
+    currentEntryId: entries[entries.length - 1]?.id ?? null,
+    entries,
+    files: pruneFiles(entries, historyData.files),
+  };
+};
+
+class SceneHistoryIndexedDBAdapter {
+  private static key = "sceneHistory";
+
+  static async load(documentId = LOCAL_DOCUMENT_ID): Promise<SceneHistoryData> {
+    try {
+      const historyData = await get<SceneHistoryData>(
+        SceneHistoryIndexedDBAdapter.key,
+        store,
+      );
+
+      if (
+        historyData?.version === HISTORY_VERSION &&
+        historyData.documentId === documentId
+      ) {
+        return historyData;
+      }
+    } catch (error) {
+      console.warn("Failed to load scene history from IndexedDB:", error);
+    }
+
+    return createEmptyHistory(documentId);
+  }
+
+  static save(historyData: SceneHistoryData) {
+    return set(SceneHistoryIndexedDBAdapter.key, historyData, store);
+  }
+}
+
+export class SceneHistory {
+  static async load(documentId = LOCAL_DOCUMENT_ID) {
+    return SceneHistoryIndexedDBAdapter.load(documentId);
+  }
+
+  static async ensureInitialized({
+    documentId = LOCAL_DOCUMENT_ID,
+    sessionId,
+    elements,
+    appState,
+    files,
+    thumbnail = null,
+  }: SceneHistoryInit) {
+    const historyData = await SceneHistoryIndexedDBAdapter.load(documentId);
+
+    if (historyData.entries.length) {
+      return historyData;
+    }
+
+    const entry: SceneHistoryEntry = {
+      id: createId(),
+      kind: "initial",
+      sequence: 0,
+      createdAt: Date.now(),
+      sessionId,
+      parentId: null,
+      summary: "Initial version",
+      thumbnail,
+      fileIds: getReferencedFileIds(elements),
+      snapshot: createSceneHistorySnapshot({ elements, appState }),
+    };
+
+    const nextHistoryData = trimSceneHistoryData({
+      ...historyData,
+      currentEntryId: entry.id,
+      entries: [entry],
+      files: {
+        ...historyData.files,
+        ...collectReferencedFiles(elements, files),
+      },
+    });
+
+    await SceneHistoryIndexedDBAdapter.save(nextHistoryData);
+
+    return nextHistoryData;
+  }
+
+  static async append({
+    documentId = LOCAL_DOCUMENT_ID,
+    sessionId,
+    elements,
+    appState,
+    files,
+    thumbnail = null,
+    delta,
+    kind = "change",
+    restoreSourceId,
+  }: SceneHistoryAppend) {
+    const historyData = await SceneHistoryIndexedDBAdapter.load(documentId);
+
+    if (!historyData.entries.length) {
+      return SceneHistory.ensureInitialized({
+        documentId,
+        sessionId,
+        elements,
+        appState,
+        files,
+        thumbnail,
+      });
+    }
+
+    const lastEntry = historyData.entries[historyData.entries.length - 1];
+    const sequence = (lastEntry?.sequence ?? -1) + 1;
+    const isCheckpoint = sequence % SNAPSHOT_INTERVAL === 0;
+    const entry: SceneHistoryEntry = {
+      id: createId(),
+      kind,
+      sequence,
+      createdAt: Date.now(),
+      sessionId,
+      parentId: lastEntry?.id ?? null,
+      summary:
+        kind === "restore"
+          ? "Restored previous version"
+          : describeStoreDelta(delta),
+      thumbnail,
+      fileIds: getReferencedFileIds(elements),
+      delta: serializeDelta(delta),
+      restoreSourceId,
+      snapshot: isCheckpoint
+        ? createSceneHistorySnapshot({ elements, appState })
+        : undefined,
+    };
+    const nextHistoryData = trimSceneHistoryData({
+      ...historyData,
+      currentEntryId: entry.id,
+      entries: historyData.entries.concat(entry),
+      files: {
+        ...historyData.files,
+        ...collectReferencedFiles(elements, files),
+      },
+    });
+
+    await SceneHistoryIndexedDBAdapter.save(nextHistoryData);
+
+    return nextHistoryData;
+  }
+
+  static async reconstruct(entryId: string, documentId = LOCAL_DOCUMENT_ID) {
+    const historyData = await SceneHistoryIndexedDBAdapter.load(documentId);
+
+    return reconstructSceneHistoryData(historyData, entryId);
+  }
+}

--- a/excalidraw-app/data/SceneHistory.ts
+++ b/excalidraw-app/data/SceneHistory.ts
@@ -24,6 +24,10 @@ const HISTORY_VERSION = 1;
 const MAX_HISTORY_ENTRIES = 120;
 const SNAPSHOT_INTERVAL = 20;
 const LOCAL_DOCUMENT_ID = "local-default";
+const RECORDABLE_APP_STATE_KEYS = new Set<keyof ObservedAppState>([
+  "name",
+  "viewBackgroundColor",
+]);
 
 export type SceneHistoryEntryKind = "initial" | "change" | "restore";
 
@@ -238,12 +242,41 @@ const countObjectKeys = (value: unknown) => {
   return value && typeof value === "object" ? Object.keys(value).length : 0;
 };
 
+const getRecordableAppStateKeyCount = (delta: SerializedStoreDelta) => {
+  const keys = new Set([
+    ...Object.keys(delta.appState.delta.deleted),
+    ...Object.keys(delta.appState.delta.inserted),
+  ]);
+  let count = 0;
+
+  for (const key of keys) {
+    if (RECORDABLE_APP_STATE_KEYS.has(key as keyof ObservedAppState)) {
+      count++;
+    }
+  }
+
+  return count;
+};
+
+const isSerializedStoreDeltaRecordable = (delta: SerializedStoreDelta) => {
+  return (
+    countObjectKeys(delta.elements.added) > 0 ||
+    countObjectKeys(delta.elements.removed) > 0 ||
+    countObjectKeys(delta.elements.updated) > 0 ||
+    getRecordableAppStateKeyCount(delta) > 0
+  );
+};
+
+export const isSceneHistoryDeltaRecordable = (delta: StoreDelta): boolean => {
+  return isSerializedStoreDeltaRecordable(serializeDelta(delta));
+};
+
 export const describeStoreDelta = (delta: StoreDelta): string => {
   const serializedDelta = serializeDelta(delta);
   const added = countObjectKeys(serializedDelta.elements.added);
   const removed = countObjectKeys(serializedDelta.elements.removed);
   const updated = countObjectKeys(serializedDelta.elements.updated);
-  const appState = countObjectKeys(serializedDelta.appState.delta.inserted);
+  const appState = getRecordableAppStateKeyCount(serializedDelta);
   const parts: string[] = [];
 
   if (added) {
@@ -447,6 +480,11 @@ export class SceneHistory {
     restoreSourceId,
   }: SceneHistoryAppend) {
     const historyData = await SceneHistoryIndexedDBAdapter.load(documentId);
+    const serializedDelta = serializeDelta(delta);
+
+    if (!isSerializedStoreDeltaRecordable(serializedDelta)) {
+      return historyData;
+    }
 
     if (!historyData.entries.length) {
       return SceneHistory.ensureInitialized({
@@ -475,7 +513,7 @@ export class SceneHistory {
           : describeStoreDelta(delta),
       thumbnail,
       fileIds: getReferencedFileIds(elements),
-      delta: serializeDelta(delta),
+      delta: serializedDelta,
       restoreSourceId,
       snapshot: isCheckpoint
         ? createSceneHistorySnapshot({ elements, appState })

--- a/excalidraw-app/data/firebase.ts
+++ b/excalidraw-app/data/firebase.ts
@@ -123,6 +123,7 @@ type FirebaseSceneHistoryEntryMeta = {
   sequence: number;
   createdAt: number;
   sessionId: string;
+  author?: string;
   parentId: string | null;
   summary: string;
   fileIds: FileId[];
@@ -143,6 +144,7 @@ type FirebaseSceneHistoryAppend = {
   roomId: string;
   roomKey: string;
   sessionId: string;
+  author?: string;
   elements: readonly OrderedExcalidrawElement[];
   appState: AppState;
   thumbnail?: string | null;
@@ -247,6 +249,7 @@ const buildSceneHistoryDataFromMeta = (
       sequence: storedEntry.sequence,
       createdAt: storedEntry.createdAt,
       sessionId: storedEntry.sessionId,
+      author: storedEntry.author ?? null,
       parentId: storedEntry.parentId ?? null,
       summary: storedEntry.summary,
       thumbnail: null,
@@ -486,6 +489,7 @@ export const appendSceneHistoryToFirebase = async ({
   roomId,
   roomKey,
   sessionId,
+  author,
   elements,
   appState,
   thumbnail = null,
@@ -528,6 +532,8 @@ export const appendSceneHistoryToFirebase = async ({
       sequence,
       createdAt,
       sessionId,
+      // Firestore rejects `undefined`, so only include when present.
+      ...(author ? { author } : {}),
       parentId: meta?.currentEntryId ?? null,
       summary:
         entryKind === "initial"

--- a/excalidraw-app/data/firebase.ts
+++ b/excalidraw-app/data/firebase.ts
@@ -10,14 +10,9 @@ import { getSceneVersion } from "@excalidraw/element";
 import { initializeApp } from "firebase/app";
 import {
   getFirestore,
-  collection,
   doc,
   getDoc,
-  getDocs,
-  limit,
   onSnapshot,
-  orderBy,
-  query,
   runTransaction,
   Bytes,
 } from "firebase/firestore";
@@ -34,7 +29,6 @@ import type {
   BinaryFileData,
   BinaryFileMetadata,
   DataURL,
-  ObservedAppState,
 } from "@excalidraw/excalidraw/types";
 
 import { FILE_CACHE_MAX_AGE_SEC } from "../app_constants";
@@ -44,7 +38,6 @@ import {
   createSceneHistorySnapshot,
   getReferencedFileIds,
   MAX_SCENE_HISTORY_ENTRIES,
-  resetTransientAppState,
   SCENE_HISTORY_VERSION,
 } from "./SceneHistory";
 
@@ -117,14 +110,24 @@ type FirebaseSceneHistoryPayload = SceneHistorySnapshot & {
   thumbnail: string | null;
 };
 
-type FirebaseStoredSceneHistoryEntry = Omit<
-  SceneHistoryEntry,
-  "delta" | "snapshot" | "thumbnail"
-> & {
+type FirebaseStoredSceneHistoryEntry = {
   historyVersion: typeof SCENE_HISTORY_VERSION;
   sceneVersion: number;
   iv: Bytes;
   ciphertext: Bytes;
+};
+
+type FirebaseSceneHistoryEntryMeta = {
+  id: string;
+  kind: SceneHistoryEntryKind;
+  sequence: number;
+  createdAt: number;
+  sessionId: string;
+  parentId: string | null;
+  summary: string;
+  fileIds: FileId[];
+  sceneVersion: number;
+  restoreSourceId?: string;
 };
 
 type FirebaseSceneHistoryMetadata = {
@@ -133,6 +136,7 @@ type FirebaseSceneHistoryMetadata = {
   currentSceneVersion: number | null;
   lastSequence: number;
   updatedAt: number;
+  entries: FirebaseSceneHistoryEntryMeta[];
 };
 
 type FirebaseSceneHistoryAppend = {
@@ -196,19 +200,31 @@ const decryptSceneHistoryPayload = async (
   return JSON.parse(decodedData);
 };
 
+// The hosted Firestore rules only grant access to top-level `scenes/{id}`
+// documents (subcollections and other collections are denied for both reads
+// and writes), so shared history is stored as sibling `scenes` documents keyed
+// off the room id rather than a dedicated collection.
+const SCENE_HISTORY_ID_SUFFIX = "~history";
+
+// `~` namespaces history documents inside the `scenes` collection; a room id
+// containing it would alias another room's history (or its meta) document.
+const assertHistoryRoomId = (roomId: string) => {
+  if (roomId.includes("~")) {
+    throw new Error(`Unexpected "~" in collab room id: ${roomId}`);
+  }
+};
+
 const getSceneHistoryMetaRef = (roomId: string) => {
-  return doc(_getFirestore(), "sceneHistory", roomId);
+  assertHistoryRoomId(roomId);
+  return doc(_getFirestore(), "scenes", `${roomId}${SCENE_HISTORY_ID_SUFFIX}`);
 };
 
-const getSceneHistoryEntriesRef = (roomId: string) => {
-  return collection(getSceneHistoryMetaRef(roomId), "entries");
-};
-
-const getSceneHistoryEntriesQuery = (roomId: string) => {
-  return query(
-    getSceneHistoryEntriesRef(roomId),
-    orderBy("sequence", "desc"),
-    limit(MAX_SCENE_HISTORY_ENTRIES),
+const getSceneHistoryEntryRef = (roomId: string, entryId: string) => {
+  assertHistoryRoomId(roomId);
+  return doc(
+    _getFirestore(),
+    "scenes",
+    `${roomId}${SCENE_HISTORY_ID_SUFFIX}~${entryId}`,
   );
 };
 
@@ -220,40 +236,29 @@ const createEmptySceneHistoryData = (roomId: string): SceneHistoryData => ({
   files: {},
 });
 
-const decodeFirebaseSceneHistoryEntries = async (
+const buildSceneHistoryDataFromMeta = (
   roomId: string,
-  roomKey: string,
-  storedEntries: FirebaseStoredSceneHistoryEntry[],
-): Promise<SceneHistoryData> => {
-  const entries = await Promise.all(
-    [...storedEntries].reverse().map(async (storedEntry) => {
-      const payload = await decryptSceneHistoryPayload(storedEntry, roomKey);
-      const entry: SceneHistoryEntry = {
-        id: storedEntry.id,
-        kind: storedEntry.kind,
-        sequence: storedEntry.sequence,
-        createdAt: storedEntry.createdAt,
-        sessionId: storedEntry.sessionId,
-        parentId: storedEntry.parentId,
-        summary: storedEntry.summary,
-        thumbnail: payload.thumbnail,
-        fileIds: storedEntry.fileIds,
-        restoreSourceId: storedEntry.restoreSourceId,
-        snapshot: {
-          elements: payload.elements,
-          appState: resetTransientAppState(
-            payload.appState as Partial<AppState>,
-          ) as ObservedAppState,
-        },
-      };
-
-      return entry;
+  meta: FirebaseSceneHistoryMetadata | null,
+): SceneHistoryData => {
+  const entries: SceneHistoryEntry[] = (meta?.entries ?? []).map(
+    (storedEntry) => ({
+      id: storedEntry.id,
+      kind: storedEntry.kind,
+      sequence: storedEntry.sequence,
+      createdAt: storedEntry.createdAt,
+      sessionId: storedEntry.sessionId,
+      parentId: storedEntry.parentId ?? null,
+      summary: storedEntry.summary,
+      thumbnail: null,
+      fileIds: storedEntry.fileIds ?? [],
+      restoreSourceId: storedEntry.restoreSourceId,
     }),
   );
 
   return {
     ...createEmptySceneHistoryData(roomId),
-    currentEntryId: entries[entries.length - 1]?.id ?? null,
+    currentEntryId:
+      meta?.currentEntryId ?? entries[entries.length - 1]?.id ?? null,
     entries,
   };
 };
@@ -416,49 +421,64 @@ export const loadFromFirebase = async (
 
 export const loadSceneHistoryFromFirebase = async ({
   roomId,
-  roomKey,
 }: {
   roomId: string;
-  roomKey: string;
 }): Promise<SceneHistoryData> => {
-  const snapshot = await getDocs(getSceneHistoryEntriesQuery(roomId));
-  const storedEntries = snapshot.docs.map(
-    (doc) => doc.data() as FirebaseStoredSceneHistoryEntry,
-  );
+  const snapshot = await getDoc(getSceneHistoryMetaRef(roomId));
+  const meta = snapshot.exists()
+    ? (snapshot.data() as FirebaseSceneHistoryMetadata)
+    : null;
 
-  return decodeFirebaseSceneHistoryEntries(roomId, roomKey, storedEntries);
+  return buildSceneHistoryDataFromMeta(roomId, meta);
 };
 
 export const subscribeSceneHistoryFromFirebase = ({
   roomId,
-  roomKey,
   onChange,
   onError,
 }: {
   roomId: string;
-  roomKey: string;
   onChange: (historyData: SceneHistoryData) => void;
   onError: (error: Error) => void;
 }): Unsubscribe => {
-  let updateId = 0;
-
   return onSnapshot(
-    getSceneHistoryEntriesQuery(roomId),
+    getSceneHistoryMetaRef(roomId),
     (snapshot) => {
-      const currentUpdateId = ++updateId;
-      const storedEntries = snapshot.docs.map(
-        (doc) => doc.data() as FirebaseStoredSceneHistoryEntry,
-      );
+      const meta = snapshot.exists()
+        ? (snapshot.data() as FirebaseSceneHistoryMetadata)
+        : null;
 
-      decodeFirebaseSceneHistoryEntries(roomId, roomKey, storedEntries)
-        .then((historyData) => {
-          if (currentUpdateId === updateId) {
-            onChange(historyData);
-          }
-        })
-        .catch(onError);
+      onChange(buildSceneHistoryDataFromMeta(roomId, meta));
     },
     onError,
+  );
+};
+
+export const loadSceneHistoryEntryFromFirebase = async ({
+  roomId,
+  roomKey,
+  entryId,
+}: {
+  roomId: string;
+  roomKey: string;
+  entryId: string;
+}): Promise<FirebaseSceneHistoryPayload | null> => {
+  const snapshot = await getDoc(getSceneHistoryEntryRef(roomId, entryId));
+
+  if (!snapshot.exists()) {
+    return null;
+  }
+
+  const storedEntry =
+    snapshot.data() as Partial<FirebaseStoredSceneHistoryEntry>;
+
+  if (!storedEntry.iv || !storedEntry.ciphertext) {
+    return null;
+  }
+
+  return decryptSceneHistoryPayload(
+    storedEntry as FirebaseStoredSceneHistoryEntry,
+    roomKey,
   );
 };
 
@@ -481,8 +501,8 @@ export const appendSceneHistoryToFirebase = async ({
   const firestore = _getFirestore();
   const metaRef = getSceneHistoryMetaRef(roomId);
   const entryId = createSceneHistoryId();
-  const entryRef = doc(getSceneHistoryEntriesRef(roomId), entryId);
   const createdAt = Date.now();
+  const fileIds = getReferencedFileIds(elements);
 
   return runTransaction(firestore, async (transaction) => {
     const metaSnapshot = await transaction.get(metaRef);
@@ -498,10 +518,11 @@ export const appendSceneHistoryToFirebase = async ({
       return null;
     }
 
+    const existingEntries = meta?.entries ?? [];
     const sequence = (meta?.lastSequence ?? -1) + 1;
     const entryKind = sequence === 0 ? "initial" : kind;
-    const entry: FirebaseStoredSceneHistoryEntry = {
-      historyVersion: SCENE_HISTORY_VERSION,
+
+    const entryMeta: FirebaseSceneHistoryEntryMeta = {
       id: entryId,
       kind: entryKind,
       sequence,
@@ -514,25 +535,41 @@ export const appendSceneHistoryToFirebase = async ({
           : entryKind === "restore"
           ? "Restored previous version"
           : "Shared scene updated",
-      fileIds: getReferencedFileIds(elements),
-      restoreSourceId,
+      fileIds,
+      sceneVersion,
+      // Firestore rejects `undefined`, so only include when present.
+      ...(restoreSourceId ? { restoreSourceId } : {}),
+    };
+
+    const storedEntry: FirebaseStoredSceneHistoryEntry = {
+      historyVersion: SCENE_HISTORY_VERSION,
       sceneVersion,
       ciphertext: Bytes.fromUint8Array(new Uint8Array(ciphertext)),
       iv: Bytes.fromUint8Array(iv),
     };
 
+    const allEntries = [...existingEntries, entryMeta];
+    const overflow = Math.max(0, allEntries.length - MAX_SCENE_HISTORY_ENTRIES);
+    const trimmedEntries = allEntries.slice(0, overflow);
+    const nextEntries = allEntries.slice(overflow);
+
     const nextMetadata: FirebaseSceneHistoryMetadata = {
       historyVersion: SCENE_HISTORY_VERSION,
-      currentEntryId: entry.id,
+      currentEntryId: entryId,
       currentSceneVersion: sceneVersion,
       lastSequence: sequence,
       updatedAt: createdAt,
+      entries: nextEntries,
     };
 
-    transaction.set(entryRef, entry);
-    transaction.set(metaRef, nextMetadata, { merge: true });
+    transaction.set(getSceneHistoryEntryRef(roomId, entryId), storedEntry);
+    transaction.set(metaRef, nextMetadata);
 
-    return entry;
+    for (const trimmed of trimmedEntries) {
+      transaction.delete(getSceneHistoryEntryRef(roomId, trimmed.id));
+    }
+
+    return entryMeta;
   });
 };
 

--- a/excalidraw-app/data/firebase.ts
+++ b/excalidraw-app/data/firebase.ts
@@ -10,8 +10,14 @@ import { getSceneVersion } from "@excalidraw/element";
 import { initializeApp } from "firebase/app";
 import {
   getFirestore,
+  collection,
   doc,
   getDoc,
+  getDocs,
+  limit,
+  onSnapshot,
+  orderBy,
+  query,
   runTransaction,
   Bytes,
 } from "firebase/firestore";
@@ -28,15 +34,32 @@ import type {
   BinaryFileData,
   BinaryFileMetadata,
   DataURL,
+  ObservedAppState,
 } from "@excalidraw/excalidraw/types";
 
 import { FILE_CACHE_MAX_AGE_SEC } from "../app_constants";
 
+import {
+  createSceneHistoryId,
+  createSceneHistorySnapshot,
+  getReferencedFileIds,
+  MAX_SCENE_HISTORY_ENTRIES,
+  resetTransientAppState,
+  SCENE_HISTORY_VERSION,
+} from "./SceneHistory";
+
 import { getSyncableElements } from ".";
 
 import type { SyncableExcalidrawElement } from ".";
+import type {
+  SceneHistoryData,
+  SceneHistoryEntry,
+  SceneHistoryEntryKind,
+  SceneHistorySnapshot,
+} from "./SceneHistory";
 import type Portal from "../collab/Portal";
 import type { Socket } from "socket.io-client";
+import type { Unsubscribe } from "firebase/firestore";
 
 // private
 // -----------------------------------------------------------------------------
@@ -90,6 +113,39 @@ type FirebaseStoredScene = {
   ciphertext: Bytes;
 };
 
+type FirebaseSceneHistoryPayload = SceneHistorySnapshot & {
+  thumbnail: string | null;
+};
+
+type FirebaseStoredSceneHistoryEntry = Omit<
+  SceneHistoryEntry,
+  "delta" | "snapshot" | "thumbnail"
+> & {
+  historyVersion: typeof SCENE_HISTORY_VERSION;
+  sceneVersion: number;
+  iv: Bytes;
+  ciphertext: Bytes;
+};
+
+type FirebaseSceneHistoryMetadata = {
+  historyVersion: typeof SCENE_HISTORY_VERSION;
+  currentEntryId: string | null;
+  currentSceneVersion: number | null;
+  lastSequence: number;
+  updatedAt: number;
+};
+
+type FirebaseSceneHistoryAppend = {
+  roomId: string;
+  roomKey: string;
+  sessionId: string;
+  elements: readonly OrderedExcalidrawElement[];
+  appState: AppState;
+  thumbnail?: string | null;
+  kind?: Extract<SceneHistoryEntryKind, "change" | "restore">;
+  restoreSourceId?: string;
+};
+
 const encryptElements = async (
   key: string,
   elements: readonly ExcalidrawElement[],
@@ -113,6 +169,93 @@ const decryptElements = async (
     new Uint8Array(decrypted),
   );
   return JSON.parse(decodedData);
+};
+
+const encryptSceneHistoryPayload = async (
+  key: string,
+  payload: FirebaseSceneHistoryPayload,
+): Promise<{ ciphertext: ArrayBuffer; iv: Uint8Array }> => {
+  const json = JSON.stringify(payload);
+  const encoded = new TextEncoder().encode(json);
+  const { encryptedBuffer, iv } = await encryptData(key, encoded);
+
+  return { ciphertext: encryptedBuffer, iv };
+};
+
+const decryptSceneHistoryPayload = async (
+  data: FirebaseStoredSceneHistoryEntry,
+  roomKey: string,
+): Promise<FirebaseSceneHistoryPayload> => {
+  const ciphertext = data.ciphertext.toUint8Array() as Uint8Array<ArrayBuffer>;
+  const iv = data.iv.toUint8Array() as Uint8Array<ArrayBuffer>;
+
+  const decrypted = await decryptData(iv, ciphertext, roomKey);
+  const decodedData = new TextDecoder("utf-8").decode(
+    new Uint8Array(decrypted),
+  );
+  return JSON.parse(decodedData);
+};
+
+const getSceneHistoryMetaRef = (roomId: string) => {
+  return doc(_getFirestore(), "sceneHistory", roomId);
+};
+
+const getSceneHistoryEntriesRef = (roomId: string) => {
+  return collection(getSceneHistoryMetaRef(roomId), "entries");
+};
+
+const getSceneHistoryEntriesQuery = (roomId: string) => {
+  return query(
+    getSceneHistoryEntriesRef(roomId),
+    orderBy("sequence", "desc"),
+    limit(MAX_SCENE_HISTORY_ENTRIES),
+  );
+};
+
+const createEmptySceneHistoryData = (roomId: string): SceneHistoryData => ({
+  version: SCENE_HISTORY_VERSION,
+  documentId: `collab:${roomId}`,
+  currentEntryId: null,
+  entries: [],
+  files: {},
+});
+
+const decodeFirebaseSceneHistoryEntries = async (
+  roomId: string,
+  roomKey: string,
+  storedEntries: FirebaseStoredSceneHistoryEntry[],
+): Promise<SceneHistoryData> => {
+  const entries = await Promise.all(
+    [...storedEntries].reverse().map(async (storedEntry) => {
+      const payload = await decryptSceneHistoryPayload(storedEntry, roomKey);
+      const entry: SceneHistoryEntry = {
+        id: storedEntry.id,
+        kind: storedEntry.kind,
+        sequence: storedEntry.sequence,
+        createdAt: storedEntry.createdAt,
+        sessionId: storedEntry.sessionId,
+        parentId: storedEntry.parentId,
+        summary: storedEntry.summary,
+        thumbnail: payload.thumbnail,
+        fileIds: storedEntry.fileIds,
+        restoreSourceId: storedEntry.restoreSourceId,
+        snapshot: {
+          elements: payload.elements,
+          appState: resetTransientAppState(
+            payload.appState as Partial<AppState>,
+          ) as ObservedAppState,
+        },
+      };
+
+      return entry;
+    }),
+  );
+
+  return {
+    ...createEmptySceneHistoryData(roomId),
+    currentEntryId: entries[entries.length - 1]?.id ?? null,
+    entries,
+  };
 };
 
 class FirebaseSceneVersionCache {
@@ -269,6 +412,128 @@ export const loadFromFirebase = async (
   }
 
   return elements;
+};
+
+export const loadSceneHistoryFromFirebase = async ({
+  roomId,
+  roomKey,
+}: {
+  roomId: string;
+  roomKey: string;
+}): Promise<SceneHistoryData> => {
+  const snapshot = await getDocs(getSceneHistoryEntriesQuery(roomId));
+  const storedEntries = snapshot.docs.map(
+    (doc) => doc.data() as FirebaseStoredSceneHistoryEntry,
+  );
+
+  return decodeFirebaseSceneHistoryEntries(roomId, roomKey, storedEntries);
+};
+
+export const subscribeSceneHistoryFromFirebase = ({
+  roomId,
+  roomKey,
+  onChange,
+  onError,
+}: {
+  roomId: string;
+  roomKey: string;
+  onChange: (historyData: SceneHistoryData) => void;
+  onError: (error: Error) => void;
+}): Unsubscribe => {
+  let updateId = 0;
+
+  return onSnapshot(
+    getSceneHistoryEntriesQuery(roomId),
+    (snapshot) => {
+      const currentUpdateId = ++updateId;
+      const storedEntries = snapshot.docs.map(
+        (doc) => doc.data() as FirebaseStoredSceneHistoryEntry,
+      );
+
+      decodeFirebaseSceneHistoryEntries(roomId, roomKey, storedEntries)
+        .then((historyData) => {
+          if (currentUpdateId === updateId) {
+            onChange(historyData);
+          }
+        })
+        .catch(onError);
+    },
+    onError,
+  );
+};
+
+export const appendSceneHistoryToFirebase = async ({
+  roomId,
+  roomKey,
+  sessionId,
+  elements,
+  appState,
+  thumbnail = null,
+  kind = "change",
+  restoreSourceId,
+}: FirebaseSceneHistoryAppend) => {
+  const sceneVersion = getSceneVersion(elements);
+  const payload: FirebaseSceneHistoryPayload = {
+    ...createSceneHistorySnapshot({ elements, appState }),
+    thumbnail,
+  };
+  const { ciphertext, iv } = await encryptSceneHistoryPayload(roomKey, payload);
+  const firestore = _getFirestore();
+  const metaRef = getSceneHistoryMetaRef(roomId);
+  const entryId = createSceneHistoryId();
+  const entryRef = doc(getSceneHistoryEntriesRef(roomId), entryId);
+  const createdAt = Date.now();
+
+  return runTransaction(firestore, async (transaction) => {
+    const metaSnapshot = await transaction.get(metaRef);
+    const meta = metaSnapshot.exists()
+      ? (metaSnapshot.data() as FirebaseSceneHistoryMetadata)
+      : null;
+
+    if (
+      meta?.historyVersion === SCENE_HISTORY_VERSION &&
+      meta.currentSceneVersion === sceneVersion &&
+      kind !== "restore"
+    ) {
+      return null;
+    }
+
+    const sequence = (meta?.lastSequence ?? -1) + 1;
+    const entryKind = sequence === 0 ? "initial" : kind;
+    const entry: FirebaseStoredSceneHistoryEntry = {
+      historyVersion: SCENE_HISTORY_VERSION,
+      id: entryId,
+      kind: entryKind,
+      sequence,
+      createdAt,
+      sessionId,
+      parentId: meta?.currentEntryId ?? null,
+      summary:
+        entryKind === "initial"
+          ? "Initial version"
+          : entryKind === "restore"
+          ? "Restored previous version"
+          : "Shared scene updated",
+      fileIds: getReferencedFileIds(elements),
+      restoreSourceId,
+      sceneVersion,
+      ciphertext: Bytes.fromUint8Array(new Uint8Array(ciphertext)),
+      iv: Bytes.fromUint8Array(iv),
+    };
+
+    const nextMetadata: FirebaseSceneHistoryMetadata = {
+      historyVersion: SCENE_HISTORY_VERSION,
+      currentEntryId: entry.id,
+      currentSceneVersion: sceneVersion,
+      lastSequence: sequence,
+      updatedAt: createdAt,
+    };
+
+    transaction.set(entryRef, entry);
+    transaction.set(metaRef, nextMetadata, { merge: true });
+
+    return entry;
+  });
 };
 
 export const loadFilesFromFirebase = async (


### PR DESCRIPTION
## Summary

Builds on #11509 (local revision history) and extends it to **live collaboration**: the
revision history becomes shared across all participants of a collab room, survives
reload/relogin, restore is applied for everyone, and each entry shows **who made the
change**.

This addresses the collaborative side of #8096 and the "recover accidental changes to
shared diagrams" use-cases raised there.

> **Heads-up on scope:** this persists shared history in the same Firestore backend used
> by excalidraw.com collaboration. I'm aware version history for the hosted app has been
> discussed as Excalidraw+ territory in #8096, so I'm opening this for product-scope
> feedback rather than assuming it lands as-is. Local mode is untouched.

## Stacked on #11509

This branch contains #11509's commits plus 3 new ones:

- `dab6d00` add shared collab revision history
- `6e64b15` make shared collab revision history actually work
- `d771d3b` show change author in collab revision history

Cleanest review path: land #11509 first, then I rebase and this PR narrows to just the
collab delta.

## What's new (collab layer)

- **Shared storage** — history entries are persisted per room so collaborators see the
  same timeline, and it's still there after offline/relogin. Payloads stay
  end-to-end encrypted with the room key; only metadata (author label, scene versions)
  is open.
- **Restore broadcasts** — restoring a revision updates the scene for every participant,
  not just locally.
- **Change attribution** — each entry records the author's collaboration username; the
  History sidebar shows an avatar + name (and "(you)" for your own entries) instead of the
  local placeholder.
- **Originator-only recording** — only the client that originated a change writes its
  history entry, so authorship is correct and receivers don't double-record.

## How to verify

- `corepack yarn test:typecheck`
- `corepack yarn test:app --run excalidraw-app/data/SceneHistory.test.ts`
- Manual (2 clients): open a collab room as two users and draw from each → both see live
  updates and both appear as authors in the History timeline; restore from one client →
  the board updates for both.

Local checks run for this branch: typecheck, the `SceneHistory` unit tests (5), eslint and
prettier all pass.

---
https://claude.ai/code/session_019yVBjWmkrRBH6hXRmECqp9
