### PR TITLE
(feat: editor) add an editor transaction system

### DIFF
--- a/TRANSACTION_SYSTEM.md
+++ b/TRANSACTION_SYSTEM.md
@@ -1,0 +1,249 @@
+# Excalidraw Transaction System — Design Document
+
+> Status: Design / WIP. Branch `transactions-v2` (commits `7ed99ab3` "adds transaction system", `c1833204` "Refactored transaction system"). Audience: editor contributors working on undo/redo, scene mutation, collaboration, and async/streaming features.
+
+## Context
+
+Excalidraw already has a mature **Store → History → Delta** stack that turns scene mutations into undoable increments. It works well for discrete actions, but it has two structural weaknesses:
+
+1. **Capture is implicit and scattered.** To make a change undoable you must remember to call `store.scheduleCapture()` at the right place. There are ~15 such call sites in `App.tsx`. Forgetting one yields a non-undoable change; calling it twice (or alongside the render-cycle commit) risks splitting one logical action into several history entries.
+2. **There is no first-class "scope".** A multi-step gesture (drag/resize/rotate spanning many render frames) or an async operation (AI streaming, image load) has no explicit begin/commit boundary and no way to _abort and revert_ cleanly. The old system leans on `CaptureUpdateAction.EVENTUALLY` to defer intermediate frames, which is subtle and easy to misuse.
+
+The **Transaction system** introduces an explicit `begin → update → commit | rollback` scope layered _on top of_ the existing Store/History machinery. It batches everything touched between `begin()` and `commit()` into exactly **one** history entry, and offers `rollback()` to discard a scope without polluting history. It currently governs the **pointer-interaction lifecycle**; the legacy `scheduleCapture` path remains live for discrete actions. The intended outcome is a clearer, less error-prone capture model and native support for streaming/abortable operations.
+
+## Goals
+
+- Provide an explicit, scoped capture API: **one transaction = one undo/redo entry**, regardless of how many mutations or render frames it spans.
+- Support **streaming / async** operations (e.g. many chunks arriving over time) that collapse into a single undoable unit, while remaining visible on-canvas as they arrive.
+- Provide **rollback** that restores the transaction's touched elements/appState to their `begin()`-time baseline _without_ recording any history entry, while leaving untouched elements (incl. other concurrent transactions' committed work) intact.
+- Support **concurrent** independent scopes (keyed transactions) plus an always-on **default** transaction for the common pointer-gesture case.
+- Keep the system **decoupled and testable** — it depends on a narrow injected interface, not the whole `App`.
+- Reuse the existing `Delta` / `StoreDelta` / `History` machinery rather than inventing a parallel undo stack.
+
+## Non-Goals
+
+- **Not** a rewrite or replacement of the Store/Delta model. Transactions _produce_ a `StoreDelta` and hand it to the existing `History`.
+- **Not** (yet) a full migration of every `scheduleCapture()` site. Discrete actions still use the legacy path; the two coexist (see _Coexistence_).
+- **Not** a transactional guarantee over the _scene mutation_ itself. The scene is mutated through the normal flow ("transparent" model); a transaction only **observes** and **batches** — it does not gate or roll back individual `mutateElement` calls atomically.
+- **Not** a collaboration/CRDT conflict resolver. Remote sync still flows through `CaptureUpdateAction.NEVER`; transaction interaction with mid-gesture remote updates is an open edge case (see below).
+- **Not** nested transactions under the same key (explicitly rejected — duplicate keys throw).
+
+---
+
+## Part 1 — Background: the existing Store / History / Delta system
+
+### Data model
+
+| Concept | Type | Meaning |
+| --- | --- | --- |
+| Snapshot | `StoreSnapshot` | Immutable `{ elements, appState(observed), metadata }`. The "last known committed" state. `maybeClone(action, els, appState)` returns the same instance if nothing changed. |
+| Change | `StoreChange` | Reference-diff of changed elements + changed observed-appState props between two snapshots. |
+| Delta | `StoreDelta` | `{ id, elements: ElementsDelta, appState: AppStateDelta }`. The _invertible_ description of a change. `calculate`, `inverse`, `applyTo`, `squash`, `isEmpty`. |
+| Element delta | `ElementsDelta` | `{ added, removed, updated }`, each a `Record<id, Delta<ElementPartial>>`. |
+| Increment | `StoreIncrement` | Emitted from `store.commit()`. `DurableIncrement` carries a `delta` (undoable); `EphemeralIncrement` does not. |
+
+Files: `packages/element/src/store.ts`, `packages/element/src/delta.ts`, `packages/excalidraw/history.ts`.
+
+### `CaptureUpdateAction` — the capture policy
+
+`store.ts` defines three policies (`store.ts:38-72`):
+
+- **`IMMEDIATELY`** — durable & undoable. `commit()` emits a `DurableIncrement` (with delta) **and** advances the snapshot. Used for ordinary user edits.
+- **`NEVER`** — applied but never undoable. Emits an `EphemeralIncrement` and **advances the snapshot**. Used for remote/collab updates and initial scene load.
+- **`EVENTUALLY`** — deferred. Emits an `EphemeralIncrement` and **does NOT advance the snapshot**, so the change is folded into the next `IMMEDIATELY`. Used for intermediate async states (freedraw strokes, etc.).
+
+Precedence when several are scheduled in one cycle: `IMMEDIATELY > NEVER > EVENTUALLY`.
+
+### How capture flows today
+
+```mermaid
+sequenceDiagram
+    participant U as User action
+    participant App as App (mutateElement/setState)
+    participant Store
+    participant Hist as History
+    U->>App: mutate scene
+    App->>Store: store.scheduleCapture()  (IMMEDIATELY)
+    Note over App: React batches setState
+    App->>App: componentDidUpdate
+    App->>Store: store.commit(elements, appState)   (App.tsx:3561)
+    Store->>Store: snapshot.maybeClone(IMMEDIATELY) → DurableIncrement(delta)
+    Store-->>Hist: onDurableIncrementEmitter → history.record(delta)  (App.tsx:3150)
+    Hist->>Hist: push HistoryDelta.inverse(delta) to undoStack
+```
+
+`history.record(delta)` (`history.ts:117`) ignores empty deltas and anything that is already a `HistoryDelta`, pushes the **inverse** onto `undoStack`, and clears `redoStack` only when _elements_ changed (so a bare click doesn't wipe redo).
+
+### How undo/redo flows today
+
+`History.undo/redo → perform()` (`history.ts:157`): pop a `HistoryDelta`, `applyTo` the current elements/appState (excluding `version`/`versionNonce` so each undo counts as a fresh action for collaboration), `scheduleMicroAction(IMMEDIATELY)` so the inverse is re-emitted for sync, then push the re-inverted entry to the opposite stack. The undo/redo _action_ itself returns `CaptureUpdateAction.NEVER` to avoid recording the undo as new history.
+
+### Limitations (the motivation)
+
+- `scheduleCapture()` is scattered across ~15 sites in `App.tsx` — easy to miss or double-fire.
+- Granularity is coupled to the React commit cycle; multi-frame gestures and async pipelines need careful `EVENTUALLY` juggling to avoid producing several entries.
+- No explicit scope ⇒ no clean **abort/rollback** primitive.
+
+---
+
+## Part 2 — The Transaction system
+
+Files: `packages/excalidraw/transaction.ts` (implementation), `packages/excalidraw/tests/transaction.test.tsx` (tests), wiring in `packages/excalidraw/components/App.tsx`, public surface in `packages/excalidraw/types.ts`.
+
+### Key concepts
+
+- **Transparent capture.** The scene is mutated through the _normal_ flow (`mutateElement`, `setState`). The transaction is told _after the fact_ which elements/keys were touched via `update()`. `commit()` does **not** re-apply anything — the scene is already in its final state; commit only _computes the delta and records it_.
+- **Frozen baseline.** At `begin()` the transaction **deep-copies** every scene element into `prevSnapshot` (`transaction.ts:75-82`). Because the scene mutates element objects _in place_, copying is required — otherwise the "before" would mutate into the "after" and the delta would be empty.
+- **Consolidation.** Any number of `update()` calls across any number of frames collapse into one `StoreDelta` at `commit()`, hence one history entry.
+- **Scoped, NEVER-based rollback.** `rollback()` reverts only the elements / observed-appState keys the transaction registered via `update()` — restoring their deep-copied `begin()`-time baselines _merged over the current scene_ — via `applyUpdate()`, and records **no** history entry. Because it is scoped (not whole-scene), work committed by other concurrent transactions is preserved.
+- **Default vs keyed.** A single always-active **default** transaction (auto-restarts after each commit/rollback) handles the common pointer-gesture case. **Keyed** transactions are explicit, named, can run **concurrently**, and are used for longer/async scopes.
+
+### API surface
+
+`TransactionContext` (the injected dependency — keeps `store`/`history` private):
+
+```ts
+interface TransactionContext {
+  getElementsMap: () => SceneElementsMap; // current scene, incl. deleted
+  getAppState: () => AppState;
+  getSnapshot: () => StoreSnapshot;
+  setSnapshot: (snapshot: StoreSnapshot) => void; // keep store snapshot in sync on commit
+  recordHistory: (delta: StoreDelta) => void; // = history.record
+  applyUpdate: (d: { elements; appState }) => void; // = updateScene (rollback)
+}
+```
+
+`Transaction`:
+
+| Member | Behaviour |
+| --- | --- |
+| `id`, `status` | `"active" \| "committed" \| "rolled-back"` |
+| `update(changes)` | Register touched element ids / appState keys; capture each one's baseline on first touch. **No scene side-effect.** Throws if not active. |
+| `commit()` | Compute `StoreDelta` from frozen baseline → current; if non-empty `recordHistory(delta)`; **sync the store snapshot**; mark committed; run `onDone`. Throws if not active. |
+| `rollback()` | Revert this transaction's touched ids to their frozen deep-copied baselines (ids it _added_ are dropped) merged over the _current_ scene, plus touched observed-appState keys, via `applyUpdate`; **no history**; mark rolled-back; run `onDone`. Throws if not active. |
+
+`TransactionManager`:
+
+| Method | Behaviour |
+| --- | --- |
+| `begin(key?)` | No key ⇒ (re)start the default transaction. With key ⇒ open a keyed transaction; **throws if that key is already active**. |
+| `get()` / `get(key)` | Default transaction / keyed-or-`undefined`. |
+| `commit(key?)` / `rollback(key?)` | Resolve then commit/rollback (default when no key). |
+| `rollbackAll()` | Roll back every keyed transaction and the default (default auto-restarts). |
+
+Exposed publicly as `transactionManager` on `ExcalidrawImperativeAPI` (`types.ts:1019`).
+
+### Lifecycle
+
+```mermaid
+stateDiagram-v2
+    [*] --> active: begin()
+    active --> active: update()
+    active --> committed: commit()  (records 1 delta + syncs snapshot)
+    active --> rolled_back: rollback()  (restores baseline, no history)
+    committed --> [*]
+    rolled_back --> [*]
+    note right of committed
+      update/commit/rollback now throw (assertActive)
+      default txn auto-restarts via onDone → begin()
+      keyed txn removes itself from the map
+    end note
+```
+
+### Commit internals (`transaction.ts:125-186`)
+
+```mermaid
+sequenceDiagram
+    participant T as Transaction.commit()
+    participant Ctx as TransactionContext
+    T->>Ctx: getElementsMap() / getAppState()
+    T->>T: prevElements = baseline of touched ids (frozen)
+    T->>T: nextElements = deep-copy of current touched ids
+    T->>T: prev/next appState = only touched keys
+    T->>T: ElementsDelta.calculate + AppStateDelta.calculate → StoreDelta
+    alt delta not empty
+        T->>Ctx: recordHistory(storeDelta)  → history.record
+    end
+    T->>Ctx: setSnapshot(snapshot.maybeClone(IMMEDIATELY, current...))
+    Note over T: status = committed, then onDone
+```
+
+**Why sync the snapshot?** The durable-increment path normally advances `store.snapshot` as a side effect of emitting. The transaction bypasses that path (it calls `history.record` directly), so it must advance the snapshot itself. Undo/redo re-base their inverse deltas against `store.snapshot`; a stale snapshot would make **redo** compute against the wrong baseline and fail to restore the change (`transaction.ts:170-182`).
+
+> **Future direction.** This `setSnapshot` write-back is a coupling artifact of coexistence: while the legacy path still owns `store.snapshot`, the transaction has to keep it in sync. Once _all_ capture flows are migrated into the transaction system (so nothing else mutates `store.snapshot`), the baseline could be owned by the transaction/history layer instead — e.g. `History` (or a dedicated snapshot namespace) holds the canonical "last committed" snapshot, and undo/redo re-base against _that_ rather than reaching into `store.snapshot`. The transaction already deep-copies a frozen baseline at `begin()`, so promoting that to the authoritative snapshot is a natural next step. That would remove the dual-write coupling, drop the `getSnapshot`/`setSnapshot` members from `TransactionContext`, and make snapshot ownership a single, explicit responsibility.
+
+---
+
+## Part 3 — Integration & coexistence with the legacy path
+
+The transaction system does **not** replace the Store/History path on this branch — it is wired into the **pointer-interaction lifecycle** while the legacy `scheduleCapture` path stays live for everything else. Both ultimately call `history.record()`.
+
+```mermaid
+flowchart TD
+    subgraph Legacy["Legacy path (still live)"]
+      SC["store.scheduleCapture() — ~15 sites<br/>(paste, delete, duplicate, …)"] --> CM["store.commit() — App.tsx:3561"]
+      CM --> DI["onDurableIncrementEmitter — App.tsx:3150"]
+      DI --> REC
+    end
+    subgraph Txn["Transaction path (pointer gestures)"]
+      PD["pointerDown → begin() — App.tsx:7674"] --> UPD["each render → get().update() — App.tsx:3562"]
+      UPD --> PU["pointerUp → commit() — App.tsx:11540"]
+      PU --> RC["context.recordHistory"]
+      RC --> REC
+    end
+    REC["history.record(delta)"] --> US["undoStack"]
+```
+
+Wiring summary (`App.tsx`):
+
+- **Init** `App.tsx:839-849` — `new TransactionManager({ getElementsMap, getAppState, getSnapshot, setSnapshot, recordHistory: history.record, applyUpdate: updateScene })`.
+- **pointerDown** `App.tsx:7674` — `transactionManager.begin()` restarts the default transaction.
+- **componentDidUpdate** `App.tsx:3561-3565` — `store.commit(...)` **then** `transactionManager.get().update({ elements, appState })` every render.
+- **pointerUp** `App.tsx:11540-11541` — `transactionManager.commit()`; the old `this.store.scheduleCapture()` here is **commented out** (this is the one site already migrated).
+
+**Why this doesn't double-record:** during a pointer gesture the end-of-gesture `scheduleCapture()` is commented out, so `store.commit()` emits only _ephemeral_ increments (no history) and the transaction's `commit()` produces the single durable entry. For **discrete** actions (keyboard delete, paste) there is no `begin()`/`commit()` pair, so `scheduleCapture()` drives the legacy path normally; the default transaction's `update()` registers those changes but is never committed for them, and the next `pointerDown` restarts the default, discarding the stale registrations.
+
+---
+
+## Part 4 — Scenarios it solves
+
+1. **Multi-frame pointer gesture → one entry.** Drag/resize/rotate emit `update()` every render; `commit()` at pointerUp yields a single undoable delta covering the whole gesture.
+2. **Streaming / async collapse.** A keyed transaction spanning N async chunks: each chunk mutates the scene and calls `update()`, so it is _visible immediately_ but _not recorded_; a single `commit()` records all N as one entry. One undo removes all; one redo restores all. (Test: "collapses many async chunks into a single undoable/redoable unit".)
+3. **Incremental in-place mutation.** A streamed element whose `width` ratchets `10 → 40 → 90 → 160 → 250` collapses to one entry; undo returns to `10`, redo to `250`. The frozen deep-copy baseline is what makes the in-place mutations detectable. (Test: "collapses incremental in-place mutations …".)
+4. **Abortable gesture.** `rollback()` restores the elements/appState the transaction touched to their `begin()` baseline with no history pollution — e.g. Escape mid-drag, or an operation that fails partway.
+5. **Concurrent scopes.** Multiple keyed transactions run alongside the default and each other; each commits/rolls back **independently** — a rollback reverts only its own touched elements, so it never undoes another transaction's already-committed work.
+6. **Atomic abort-all.** `rollbackAll()` reverts every keyed transaction and the default in one call.
+
+---
+
+## Part 5 — Edge cases & known limitations
+
+- **Empty commit is safe.** No `update()`, or a no-op net change ⇒ `StoreDelta.isEmpty()` ⇒ nothing recorded. (Test: "commit() without prior update() does not crash".)
+- **In-place mutation visibility (commit).** Handled correctly: `prevSnapshot` is **deep-copied** at `begin()`, and `commit()` also deep-copies the _current_ touched elements into `nextElements`, freezing both ends before `ElementsDelta.calculate`.
+- **Rollback is scoped & deep-copied.** `rollback()` reverts only the elements the transaction registered via `update()`, restoring the deep-copied `begin()` baselines held in `originalElementStates` (added ids are dropped) _merged over the current scene_. This (a) correctly reverts **in-place property mutations** — the baseline is a deep copy, not a live reference — and (b) preserves work committed by **other concurrent transactions**, since untouched elements are taken from the current scene rather than rewound to a whole-scene `begin()`-time snapshot. (This replaced the earlier whole-scene `captureRollbackState()` approach, which stored live references and clobbered concurrent commits.)
+- **Shared-element write-write conflict (accepted).** If two concurrent transactions both register the _same_ element and one rolls back after the other committed it, the rollback still reverts that element to its own baseline, clobbering the committed value. This is an inherent write-write conflict and is out of scope — the system is not a CRDT conflict resolver (see _Non-Goals_).
+- **State-machine guards.** `update`/`commit`/`rollback` after a transaction has finished throw via `assertActive`; duplicate keyed `begin(key)` throws. (Tests cover all four.)
+- **Default auto-restart timing.** The default transaction restarts itself inside `onDone` (`begin()` with no key). Any uncommitted `update()`s registered on the default outside a pointer gesture are discarded on the next `pointerDown`.
+- **`onIncrement` consumers bypassed (integration gap).** Transaction `commit()` calls `history.record` directly and does **not** emit through `onStoreIncrementEmitter`. External consumers subscribed via the `onIncrement` prop (used for persistence/collab sync) therefore do **not** receive the consolidated durable delta produced by a transaction. They still see the _ephemeral_ increments during the gesture. This needs attention before transactions drive collab-synced changes.
+- **Double-record risk if both paths fire.** Any `scheduleCapture()` (IMMEDIATELY) that runs _during_ an active pointer transaction would produce its own durable increment recorded by the legacy path, in addition to the transaction's commit — two entries for one logical change. The migration commented out the pointerUp `scheduleCapture()` precisely to avoid this; new code must not reintroduce it inside a gesture.
+- **Mid-gesture remote update (collaboration).** The baseline is frozen at `begin()`. If a remote `NEVER` update lands between `begin()` and `commit()`, the committed delta is computed against the frozen baseline and could fold remote changes into the local undo entry (or conflict). Transaction/remote interleaving is not yet specified.
+- **Ordering in `componentDidUpdate`.** `store.commit()` runs _before_ `transactionManager.get().update()` (3561 → 3562). Legacy durable increments are therefore recorded before the transaction registers the same frame's touches; harmless given the no-double-record reasoning above, but the ordering is load-bearing.
+
+---
+
+## Appendix — File / symbol reference
+
+| Symbol | Location |
+| --- | --- |
+| `Transaction`, `TransactionManager`, `TransactionContext` | `packages/excalidraw/transaction.ts` |
+| `Transaction.commit()` snapshot-sync rationale | `packages/excalidraw/transaction.ts:170-182` |
+| `Transaction.rollback()` (scoped, deep-copied baselines) | `packages/excalidraw/transaction.ts` |
+| Tests (default / keyed / commit / rollback / concurrent / streaming) | `packages/excalidraw/tests/transaction.test.tsx` |
+| TransactionManager init | `packages/excalidraw/components/App.tsx:839-849` |
+| `begin()` on pointerDown | `packages/excalidraw/components/App.tsx:7674` |
+| `store.commit` + `get().update` per render | `packages/excalidraw/components/App.tsx:3561-3565` |
+| `commit()` on pointerUp (legacy `scheduleCapture` commented) | `packages/excalidraw/components/App.tsx:11540-11541` |
+| Legacy durable-increment → history.record | `packages/excalidraw/components/App.tsx:3150-3151` |
+| `Store`, `StoreSnapshot`, `StoreDelta`, `CaptureUpdateAction` | `packages/element/src/store.ts` |
+| `Delta`, `ElementsDelta`, `AppStateDelta` | `packages/element/src/delta.ts` |
+| `History`, `HistoryDelta`, undo/redo `perform()` | `packages/excalidraw/history.ts` |

--- a/packages/element/src/store.ts
+++ b/packages/element/src/store.ts
@@ -365,7 +365,7 @@ export class Store {
         case CaptureUpdateAction.IMMEDIATELY:
           this.emitDurableIncrement(nextSnapshot, change, delta);
           break;
-        // both never and eventually emit an ephemeral increment
+        // never and eventually emit an ephemeral increment
         case CaptureUpdateAction.NEVER:
         case CaptureUpdateAction.EVENTUALLY:
           this.emitEphemeralIncrement(nextSnapshot, change);
@@ -376,7 +376,7 @@ export class Store {
     } finally {
       // update the snapshot no-matter what, as it would mess up with the next action
       switch (action) {
-        // both immediately and never update the snapshot, unlike eventually
+        // immediately, never, and broadcast update the snapshot, unlike eventually
         case CaptureUpdateAction.IMMEDIATELY:
         case CaptureUpdateAction.NEVER:
           this.snapshot = nextSnapshot;

--- a/packages/excalidraw/actions/actionProperties.tsx
+++ b/packages/excalidraw/actions/actionProperties.tsx
@@ -73,6 +73,7 @@ import type {
   ExcalidrawLinearElement,
   ExcalidrawTextElement,
   FontFamilyValues,
+  SceneElementsMap,
   TextAlign,
   VerticalAlign,
 } from "@excalidraw/element/types";
@@ -711,11 +712,36 @@ export const actionChangeStrokeStyle = register<
   ),
 });
 
+/**
+ * Key for the transaction opened while the opacity slider is being dragged.
+ * Dragging emits an `onChange` per step; scoping them to one transaction
+ * collapses the whole drag into a single undo entry (see PanelComponent).
+ */
+const OPACITY_TRANSACTION_KEY = "opacity";
+
 export const actionChangeOpacity = register<ExcalidrawElement["opacity"]>({
   name: "changeOpacity",
   label: "labels.opacity",
   trackEvent: false,
-  perform: (elements, appState, value) => {
+  perform: (elements, appState, value, app) => {
+    const nextAppState = { ...appState, currentItemOpacity: value };
+
+    // While the slider is being dragged an "opacity" transaction is open.
+    // Register the touched elements/appState so its commit consolidates the
+    // whole drag into one history entry, and defer capture to that commit.
+    // Outside a drag (e.g. programmatic calls) fall back to capturing now.
+    const transaction = app.transactionManager.get(OPACITY_TRANSACTION_KEY);
+    if (transaction) {
+      transaction.update({
+        elements: arrayToMap(
+          getSelectedElements(elements, appState, {
+            includeBoundTextElement: true,
+          }),
+        ) as SceneElementsMap,
+        appState: nextAppState,
+      });
+    }
+
     return {
       elements: changeProperty(
         elements,
@@ -726,8 +752,10 @@ export const actionChangeOpacity = register<ExcalidrawElement["opacity"]>({
           }),
         true,
       ),
-      appState: { ...appState, currentItemOpacity: value },
-      captureUpdate: CaptureUpdateAction.IMMEDIATELY,
+      appState: nextAppState,
+      captureUpdate: transaction
+        ? CaptureUpdateAction.EVENTUALLY
+        : CaptureUpdateAction.IMMEDIATELY,
     };
   },
   PanelComponent: ({ elements, appState, app, updateData }) => {
@@ -744,7 +772,19 @@ export const actionChangeOpacity = register<ExcalidrawElement["opacity"]>({
         label={t("labels.opacity")}
         value={opacity ?? appState.currentItemOpacity}
         hasCommonValue={opacity !== null}
-        onChange={updateData}
+        onChange={(value) => {
+          // Open a transaction for the duration of the drag (idempotent — the
+          // slider can emit many onChange events before it is released).
+          if (!app.transactionManager.get(OPACITY_TRANSACTION_KEY)) {
+            app.transactionManager.begin(OPACITY_TRANSACTION_KEY);
+          }
+          updateData(value);
+        }}
+        onChangeEnd={() => {
+          // Drag finished → record the single consolidated history entry.
+          // No-op if no transaction is open.
+          app.transactionManager.commit(OPACITY_TRANSACTION_KEY);
+        }}
         min={0}
         max={100}
         step={10}

--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -454,6 +454,7 @@ import NewElementCanvas from "./canvases/NewElementCanvas";
 import { isPointHittingLink } from "./hyperlink/helpers";
 import { MagicIcon, copyIcon, fullscreenIcon } from "./icons";
 import { AppStateObserver, type OnStateChange } from "./AppStateObserver";
+import { TransactionManager } from "../transaction";
 
 import { findShapeByKey } from "./shapes";
 
@@ -640,8 +641,9 @@ class App extends React.Component<AppProps, AppState> {
   public library: AppClassProperties["library"];
   public libraryItemsFromStorage: LibraryItems | undefined;
   public id: string;
-  private store: Store;
-  private history: History;
+  public store: Store;
+  public history: History;
+  public transactionManager: TransactionManager;
   public excalidrawContainerValue: {
     container: HTMLDivElement | null;
     id: string;
@@ -782,6 +784,7 @@ class App extends React.Component<AppProps, AppState> {
       onUserFollow: (cb) => this.onUserFollowEmitter.on(cb),
       onStateChange: this.onStateChange,
       onEvent: this.onEvent,
+      transactionManager: this.transactionManager,
     };
     return api;
   }
@@ -833,6 +836,7 @@ class App extends React.Component<AppProps, AppState> {
 
     this.store = new Store(this);
     this.history = new History(this.store);
+    this.transactionManager = new TransactionManager(this);
 
     this.excalidrawContainerValue = {
       container: this.excalidrawContainerRef.current,
@@ -3134,7 +3138,7 @@ class App extends React.Component<AppProps, AppState> {
     }
 
     this.store.onDurableIncrementEmitter.on((increment) => {
-      this.history.record(increment.delta);
+      // this.history.record(increment.delta);
     });
 
     // per. optimmisation, only subscribe if there is the `onIncrement` prop registered, to avoid unnecessary computation
@@ -3545,6 +3549,10 @@ class App extends React.Component<AppProps, AppState> {
     }
 
     this.store.commit(elementsMap, this.state);
+    this.transactionManager.default.update({
+      elements: elementsMap,
+      appState: this.state,
+    });
 
     // Do not notify consumers if we're still loading the scene. Among other
     // potential issues, this fixes a case where the tab isn't focused during
@@ -7653,6 +7661,7 @@ class App extends React.Component<AppProps, AppState> {
   private handleCanvasPointerDown = (
     event: React.PointerEvent<HTMLElement>,
   ) => {
+    this.transactionManager.createDefault();
     const selectedElements = this.scene.getSelectedElements(this.state);
 
     // If Ctrl is not held, ensure isBindingEnabled reflects the user preference.
@@ -11518,7 +11527,8 @@ class App extends React.Component<AppProps, AppState> {
           this.state.selectedElementIds,
         )
       ) {
-        this.store.scheduleCapture();
+        this.transactionManager.default.commit();
+        // this.store.scheduleCapture();
       }
 
       if (

--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -641,8 +641,8 @@ class App extends React.Component<AppProps, AppState> {
   public library: AppClassProperties["library"];
   public libraryItemsFromStorage: LibraryItems | undefined;
   public id: string;
-  public store: Store;
-  public history: History;
+  private store: Store;
+  private history: History;
   public transactionManager: TransactionManager;
   public excalidrawContainerValue: {
     container: HTMLDivElement | null;
@@ -836,7 +836,17 @@ class App extends React.Component<AppProps, AppState> {
 
     this.store = new Store(this);
     this.history = new History(this.store);
-    this.transactionManager = new TransactionManager(this);
+    this.transactionManager = new TransactionManager({
+      getElementsMap: () => this.scene.getElementsMapIncludingDeleted(),
+      getAppState: () => this.state,
+      getSnapshot: () => this.store.snapshot,
+      setSnapshot: (snapshot) => {
+        this.store.snapshot = snapshot;
+      },
+      recordHistory: (delta) => this.history.record(delta),
+      applyUpdate: ({ elements, appState }) =>
+        this.updateScene({ elements, appState }),
+    });
 
     this.excalidrawContainerValue = {
       container: this.excalidrawContainerRef.current,
@@ -3138,7 +3148,7 @@ class App extends React.Component<AppProps, AppState> {
     }
 
     this.store.onDurableIncrementEmitter.on((increment) => {
-      // this.history.record(increment.delta);
+      this.history.record(increment.delta);
     });
 
     // per. optimmisation, only subscribe if there is the `onIncrement` prop registered, to avoid unnecessary computation
@@ -3549,7 +3559,7 @@ class App extends React.Component<AppProps, AppState> {
     }
 
     this.store.commit(elementsMap, this.state);
-    this.transactionManager.default.update({
+    this.transactionManager.get().update({
       elements: elementsMap,
       appState: this.state,
     });
@@ -7661,7 +7671,7 @@ class App extends React.Component<AppProps, AppState> {
   private handleCanvasPointerDown = (
     event: React.PointerEvent<HTMLElement>,
   ) => {
-    this.transactionManager.createDefault();
+    this.transactionManager.begin();
     const selectedElements = this.scene.getSelectedElements(this.state);
 
     // If Ctrl is not held, ensure isBindingEnabled reflects the user preference.
@@ -11527,7 +11537,7 @@ class App extends React.Component<AppProps, AppState> {
           this.state.selectedElementIds,
         )
       ) {
-        this.transactionManager.default.commit();
+        this.transactionManager.commit();
         // this.store.scheduleCapture();
       }
 

--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -433,6 +433,8 @@ import { getShortcutKey } from "../shortcut";
 
 import { tryParseSpreadsheet } from "../charts";
 
+import { TransactionManager } from "../transaction";
+
 import ConvertElementTypePopup, {
   getConversionTypeFromElements,
   convertElementTypePopupAtom,
@@ -454,7 +456,6 @@ import NewElementCanvas from "./canvases/NewElementCanvas";
 import { isPointHittingLink } from "./hyperlink/helpers";
 import { MagicIcon, copyIcon, fullscreenIcon } from "./icons";
 import { AppStateObserver, type OnStateChange } from "./AppStateObserver";
-import { TransactionManager } from "../transaction";
 
 import { findShapeByKey } from "./shapes";
 

--- a/packages/excalidraw/components/Range.tsx
+++ b/packages/excalidraw/components/Range.tsx
@@ -6,6 +6,13 @@ export type RangeProps = {
   label: React.ReactNode;
   value: number;
   onChange: (value: number) => void;
+  /**
+   * Fired when an interaction with the slider finishes (pointer released,
+   * keyboard step released, or focus lost). Useful to close a transaction
+   * opened on the first `onChange` so the whole drag collapses into a single
+   * undo entry.
+   */
+  onChangeEnd?: () => void;
   min?: number;
   max?: number;
   step?: number;
@@ -18,6 +25,7 @@ export const Range = ({
   label,
   value,
   onChange,
+  onChangeEnd,
   min = 0,
   max = 100,
   step = 10,
@@ -65,6 +73,9 @@ export const Range = ({
           onChange={(event) => {
             onChange(+event.target.value);
           }}
+          onPointerUp={onChangeEnd}
+          onKeyUp={onChangeEnd}
+          onBlur={onChangeEnd}
           value={value}
           className="range-input"
           data-testid={testId}

--- a/packages/excalidraw/tests/transaction.test.tsx
+++ b/packages/excalidraw/tests/transaction.test.tsx
@@ -1,0 +1,478 @@
+import React from "react";
+
+import { arrayToMap, reseed } from "@excalidraw/common";
+
+import type { SceneElementsMap } from "@excalidraw/element/types";
+
+import { createRedoAction, createUndoAction } from "../actions/actionHistory";
+import { Excalidraw } from "../index";
+
+import { API } from "./helpers/api";
+import { GlobalTestState, act, render, unmountComponent } from "./test-utils";
+
+const { h } = window;
+
+describe("TransactionManager", () => {
+  beforeEach(async () => {
+    unmountComponent();
+    reseed(7);
+    await render(<Excalidraw />);
+    Object.assign(document, {
+      elementFromPoint: () => GlobalTestState.canvas,
+    });
+  });
+
+  describe("default transaction", () => {
+    it("is active on mount", () => {
+      expect(h.app.transactionManager.default.status).toBe("active");
+    });
+
+    it("commit() records an undo entry for scene changes and auto-restarts a fresh default", () => {
+      const rect = API.createElement({ type: "rectangle" });
+      const before = h.app.transactionManager.default;
+
+      // Transparent model: the scene is mutated through the normal flow, then the
+      // touched elements are registered with the transaction.
+      API.setElements([rect]);
+      const historyLengthBefore = h.history.undoStack.length;
+      before.update({ elements: arrayToMap([rect]) as SceneElementsMap });
+
+      act(() => {
+        before.commit();
+      });
+
+      expect(before.status).toBe("committed");
+      expect(h.elements.some((el) => el.id === rect.id)).toBe(true);
+      expect(h.history.undoStack.length).toBeGreaterThan(historyLengthBefore);
+
+      const after = h.app.transactionManager.default;
+      expect(after).not.toBe(before);
+      expect(after.status).toBe("active");
+    });
+
+    it("rollback() restores scene and auto-restarts a fresh default", () => {
+      const rect = API.createElement({ type: "rectangle" });
+      API.setElements([rect]);
+
+      // Default was created at mount (0 elements). Externally add another element.
+      const newRect = API.createElement({ type: "rectangle" });
+      API.setElements([rect, newRect]);
+      expect(h.elements.filter((el) => !el.isDeleted).length).toBe(2);
+
+      const before = h.app.transactionManager.default;
+
+      act(() => {
+        before.rollback();
+      });
+
+      // Rolled back to mount state (0 elements — rollbackState was captured at mount).
+      expect(before.status).toBe("rolled-back");
+      expect(h.elements.filter((el) => !el.isDeleted).length).toBe(0);
+
+      const after = h.app.transactionManager.default;
+      expect(after).not.toBe(before);
+      expect(after.status).toBe("active");
+    });
+
+    it("rollback() does not add an undo history entry", () => {
+      const rect = API.createElement({ type: "rectangle" });
+      const historyLengthBefore = h.history.undoStack.length;
+
+      h.app.transactionManager.default.update({
+        elements: arrayToMap([rect]) as SceneElementsMap,
+      });
+      act(() => {
+        h.app.transactionManager.default.rollback();
+      });
+
+      expect(h.history.undoStack.length).toBe(historyLengthBefore);
+    });
+  });
+
+  describe("keyed transactions", () => {
+    it("begin() returns an active transaction", () => {
+      const txn = h.app.transactionManager.begin("txA");
+      expect(txn.status).toBe("active");
+    });
+
+    it("get() retrieves an active transaction by key", () => {
+      const txn = h.app.transactionManager.begin("txA");
+      expect(h.app.transactionManager.get("txA")).toBe(txn);
+    });
+
+    it("get() returns undefined for unknown key", () => {
+      expect(h.app.transactionManager.get("nonexistent")).toBeUndefined();
+    });
+
+    it("begin() throws if key is already active", () => {
+      h.app.transactionManager.begin("txA");
+      expect(() => h.app.transactionManager.begin("txA")).toThrow();
+    });
+
+    describe("update()", () => {
+      it("registering an element does not by itself affect the scene", () => {
+        const rect = API.createElement({ type: "rectangle" });
+        const historyLengthBefore = h.history.undoStack.length;
+
+        const txn = h.app.transactionManager.begin("txA");
+        act(() => {
+          txn.update({ elements: arrayToMap([rect]) as SceneElementsMap });
+        });
+
+        // update() only registers the element; it does not add it to the scene
+        expect(h.elements.some((el) => el.id === rect.id)).toBe(false);
+        expect(h.history.undoStack.length).toBe(historyLengthBefore);
+      });
+
+      it("throws after commit", () => {
+        const txn = h.app.transactionManager.begin("txA");
+        act(() => {
+          txn.commit();
+        });
+        expect(() => txn.update({})).toThrow();
+      });
+
+      it("throws after rollback", () => {
+        const txn = h.app.transactionManager.begin("txA");
+        act(() => {
+          txn.rollback();
+        });
+        expect(() => txn.update({})).toThrow();
+      });
+    });
+
+    describe("commit()", () => {
+      it("records an undo history entry for scene changes", () => {
+        const rect = API.createElement({ type: "rectangle" });
+
+        const txn = h.app.transactionManager.begin("txA");
+        API.setElements([rect]);
+        const historyLengthBefore = h.history.undoStack.length;
+        txn.update({ elements: arrayToMap([rect]) as SceneElementsMap });
+
+        act(() => {
+          txn.commit();
+        });
+
+        expect(h.elements.some((el) => el.id === rect.id)).toBe(true);
+        expect(txn.status).toBe("committed");
+        expect(h.history.undoStack.length).toBeGreaterThan(historyLengthBefore);
+      });
+
+      it("commit() without prior update() does not crash", () => {
+        const txn = h.app.transactionManager.begin("txA");
+        expect(() => {
+          act(() => {
+            txn.commit();
+          });
+        }).not.toThrow();
+        expect(txn.status).toBe("committed");
+      });
+
+      it("removes transaction from keyed map after commit", () => {
+        const txn = h.app.transactionManager.begin("txA");
+        act(() => {
+          txn.commit();
+        });
+        expect(h.app.transactionManager.get("txA")).toBeUndefined();
+      });
+
+      it("throws when called twice", () => {
+        const txn = h.app.transactionManager.begin("txA");
+        act(() => {
+          txn.commit();
+        });
+        expect(() => txn.commit()).toThrow();
+      });
+
+      it("undo after commit() removes the committed element", () => {
+        const rect = API.createElement({ type: "rectangle" });
+        const undoAction = createUndoAction(h.history);
+
+        const txn = h.app.transactionManager.begin("txA");
+        API.setElements([rect]);
+        txn.update({ elements: arrayToMap([rect]) as SceneElementsMap });
+
+        act(() => {
+          txn.commit();
+        });
+        expect(
+          h.elements.some((el) => el.id === rect.id && !el.isDeleted),
+        ).toBe(true);
+
+        act(() => {
+          API.executeAction(undoAction);
+        });
+        expect(
+          h.elements.some((el) => el.id === rect.id && !el.isDeleted),
+        ).toBe(false);
+      });
+
+      it("redo after undo re-applies the committed element", () => {
+        const rect = API.createElement({ type: "rectangle" });
+        const undoAction = createUndoAction(h.history);
+        const redoAction = createRedoAction(h.history);
+
+        const txn = h.app.transactionManager.begin("txA");
+        API.setElements([rect]);
+        txn.update({ elements: arrayToMap([rect]) as SceneElementsMap });
+
+        act(() => {
+          txn.commit();
+        });
+
+        act(() => {
+          API.executeAction(undoAction);
+        });
+        expect(
+          h.elements.some((el) => el.id === rect.id && !el.isDeleted),
+        ).toBe(false);
+
+        act(() => {
+          API.executeAction(redoAction);
+        });
+        expect(
+          h.elements.some((el) => el.id === rect.id && !el.isDeleted),
+        ).toBe(true);
+      });
+
+      it("detects an in-place mutation and supports undo/redo", () => {
+        const rect = API.createElement({ type: "rectangle", x: 0 });
+        API.setElements([rect]);
+        const undoAction = createUndoAction(h.history);
+        const redoAction = createRedoAction(h.history);
+
+        const txn = h.app.transactionManager.begin("txA");
+        const historyLengthBefore = h.history.undoStack.length;
+
+        // Mutate in place (same object reference the scene holds).
+        act(() => {
+          h.app.scene.mutateElement(rect, { x: 100 });
+        });
+        txn.update({ elements: arrayToMap([rect]) as SceneElementsMap });
+
+        act(() => {
+          txn.commit();
+        });
+
+        expect(h.history.undoStack.length).toBeGreaterThan(historyLengthBefore);
+        expect(h.elements.find((el) => el.id === rect.id)?.x).toBe(100);
+
+        act(() => {
+          API.executeAction(undoAction);
+        });
+        expect(h.elements.find((el) => el.id === rect.id)?.x).toBe(0);
+
+        act(() => {
+          API.executeAction(redoAction);
+        });
+        expect(h.elements.find((el) => el.id === rect.id)?.x).toBe(100);
+      });
+    });
+
+    describe("rollback()", () => {
+      it("restores elements to the state at begin() time", () => {
+        const rect = API.createElement({ type: "rectangle" });
+        API.setElements([rect]);
+
+        const txn = h.app.transactionManager.begin("txA");
+
+        // Modify scene externally (not via txn.update)
+        const newRect = API.createElement({ type: "rectangle" });
+        API.setElements([rect, newRect]);
+        expect(h.elements.filter((el) => !el.isDeleted).length).toBe(2);
+
+        act(() => {
+          txn.rollback();
+        });
+
+        expect(txn.status).toBe("rolled-back");
+        expect(h.elements.filter((el) => !el.isDeleted).length).toBe(1);
+        expect(h.elements.some((el) => el.id === rect.id)).toBe(true);
+      });
+
+      it("discards registered changes without recording history", () => {
+        const rect = API.createElement({ type: "rectangle" });
+        const txn = h.app.transactionManager.begin("txA");
+        const historyLengthBefore = h.history.undoStack.length;
+
+        act(() => {
+          txn.update({ elements: arrayToMap([rect]) as SceneElementsMap });
+          txn.rollback();
+        });
+
+        // element was only registered, never applied to the scene; no history entry
+        expect(h.elements.some((el) => el.id === rect.id)).toBe(false);
+        expect(h.history.undoStack.length).toBe(historyLengthBefore);
+      });
+
+      it("removes transaction from keyed map after rollback", () => {
+        const txn = h.app.transactionManager.begin("txA");
+        act(() => {
+          txn.rollback();
+        });
+        expect(h.app.transactionManager.get("txA")).toBeUndefined();
+      });
+
+      it("throws when called twice", () => {
+        const txn = h.app.transactionManager.begin("txA");
+        act(() => {
+          txn.rollback();
+        });
+        expect(() => txn.rollback()).toThrow();
+      });
+    });
+
+    describe("concurrent transactions", () => {
+      it("two transactions can be active simultaneously", () => {
+        const txnA = h.app.transactionManager.begin("txA");
+        const txnB = h.app.transactionManager.begin("txB");
+        expect(txnA.status).toBe("active");
+        expect(txnB.status).toBe("active");
+        act(() => {
+          txnA.commit();
+          txnB.commit();
+        });
+        expect(txnA.status).toBe("committed");
+        expect(txnB.status).toBe("committed");
+      });
+
+      it("rollbackAll() reverts all keyed transactions and the default", () => {
+        const rectA = API.createElement({ type: "rectangle" });
+        const rectB = API.createElement({ type: "rectangle" });
+
+        const txnA = h.app.transactionManager.begin("txA");
+        const txnB = h.app.transactionManager.begin("txB");
+        const defaultBefore = h.app.transactionManager.default;
+
+        txnA.update({ elements: arrayToMap([rectA]) as SceneElementsMap });
+        txnB.update({ elements: arrayToMap([rectB]) as SceneElementsMap });
+
+        act(() => {
+          h.app.transactionManager.rollbackAll();
+        });
+
+        expect(txnA.status).toBe("rolled-back");
+        expect(txnB.status).toBe("rolled-back");
+        expect(defaultBefore.status).toBe("rolled-back");
+
+        // default auto-restarts
+        expect(h.app.transactionManager.default).not.toBe(defaultBefore);
+        expect(h.app.transactionManager.default.status).toBe("active");
+      });
+
+      it("rollbackAll() is a no-op for keyed when none are active", () => {
+        const defaultBefore = h.app.transactionManager.default;
+        expect(() => {
+          act(() => {
+            h.app.transactionManager.rollbackAll();
+          });
+        }).not.toThrow();
+        // default still auto-restarts
+        expect(h.app.transactionManager.default).not.toBe(defaultBefore);
+        expect(h.app.transactionManager.default.status).toBe("active");
+      });
+    });
+  });
+
+  describe("streaming (long async transaction)", () => {
+    const tick = () => new Promise((resolve) => setTimeout(resolve, 1));
+
+    it("collapses many async chunks into a single undoable/redoable unit", async () => {
+      const undoAction = createUndoAction(h.history);
+      const redoAction = createRedoAction(h.history);
+      const historyLengthBefore = h.history.undoStack.length;
+
+      // a long-lived keyed transaction, kept open across async chunk boundaries
+      const txn = h.app.transactionManager.begin("stream");
+      const streamed: ReturnType<typeof API.createElement>[] = [];
+
+      const CHUNKS = 5;
+      for (let i = 0; i < CHUNKS; i++) {
+        // simulate a streaming gap (next token / network chunk)
+        await tick();
+
+        const el = API.createElement({ type: "rectangle", x: i * 50 });
+        streamed.push(el);
+        // render the chunk incrementally through the normal scene flow
+        API.setElements([...streamed]);
+        txn.update({ elements: arrayToMap([el]) as SceneElementsMap });
+
+        // chunk is visible immediately, but nothing is committed to history yet
+        expect(h.elements.filter((e) => !e.isDeleted)).toHaveLength(i + 1);
+        expect(h.history.undoStack.length).toBe(historyLengthBefore);
+      }
+
+      act(() => {
+        txn.commit();
+      });
+
+      // the whole stream becomes one consolidated history entry
+      expect(txn.status).toBe("committed");
+      expect(h.history.undoStack.length).toBe(historyLengthBefore + 1);
+      expect(h.elements.filter((e) => !e.isDeleted)).toHaveLength(CHUNKS);
+
+      // a single undo removes the entire streamed sequence
+      act(() => {
+        API.executeAction(undoAction);
+      });
+      expect(h.elements.filter((e) => !e.isDeleted)).toHaveLength(0);
+
+      // a single redo restores the entire streamed sequence
+      act(() => {
+        API.executeAction(redoAction);
+      });
+      expect(h.elements.filter((e) => !e.isDeleted)).toHaveLength(CHUNKS);
+      for (const el of streamed) {
+        expect(
+          h.elements.some((e) => e.id === el.id && !e.isDeleted),
+        ).toBe(true);
+      }
+    });
+
+    it("collapses incremental in-place mutations of a streamed element into one unit", async () => {
+      const rect = API.createElement({ type: "rectangle", width: 10 });
+      API.setElements([rect]);
+
+      const undoAction = createUndoAction(h.history);
+      const redoAction = createRedoAction(h.history);
+
+      // begin AFTER the element exists, so the baseline captures width: 10
+      const txn = h.app.transactionManager.begin("stream");
+      const historyLengthBefore = h.history.undoStack.length;
+
+      // an element that "grows" as tokens stream in (e.g. text/box being generated)
+      const widths = [40, 90, 160, 250];
+      for (const width of widths) {
+        await tick();
+        act(() => {
+          h.app.scene.mutateElement(rect, { width });
+        });
+        txn.update({ elements: arrayToMap([rect]) as SceneElementsMap });
+
+        // the growth is visible live, but not yet recorded
+        expect(h.elements.find((e) => e.id === rect.id)?.width).toBe(width);
+        expect(h.history.undoStack.length).toBe(historyLengthBefore);
+      }
+
+      act(() => {
+        txn.commit();
+      });
+
+      expect(h.history.undoStack.length).toBe(historyLengthBefore + 1);
+      expect(h.elements.find((e) => e.id === rect.id)?.width).toBe(250);
+
+      // one undo collapses all incremental growth back to the starting width
+      act(() => {
+        API.executeAction(undoAction);
+      });
+      expect(h.elements.find((e) => e.id === rect.id)?.width).toBe(10);
+
+      // one redo re-applies the final streamed width
+      act(() => {
+        API.executeAction(redoAction);
+      });
+      expect(h.elements.find((e) => e.id === rect.id)?.width).toBe(250);
+    });
+  });
+});

--- a/packages/excalidraw/tests/transaction.test.tsx
+++ b/packages/excalidraw/tests/transaction.test.tsx
@@ -24,12 +24,29 @@ describe("TransactionManager", () => {
 
   describe("default transaction", () => {
     it("is active on mount", () => {
-      expect(h.app.transactionManager.default.status).toBe("active");
+      expect(h.app.transactionManager.get().status).toBe("active");
+    });
+
+    it("get() (no key) returns the current default transaction", () => {
+      const manager = h.app.transactionManager;
+      expect(manager.get()).toBe(manager.get());
+      expect(manager.get().status).toBe("active");
+    });
+
+    it("begin() (no key) restarts the default with a fresh transaction", () => {
+      const manager = h.app.transactionManager;
+      const before = manager.get();
+
+      const restarted = manager.begin();
+
+      expect(restarted).not.toBe(before);
+      expect(restarted).toBe(manager.get());
+      expect(restarted.status).toBe("active");
     });
 
     it("commit() records an undo entry for scene changes and auto-restarts a fresh default", () => {
       const rect = API.createElement({ type: "rectangle" });
-      const before = h.app.transactionManager.default;
+      const before = h.app.transactionManager.get();
 
       // Transparent model: the scene is mutated through the normal flow, then the
       // touched elements are registered with the transaction.
@@ -45,7 +62,7 @@ describe("TransactionManager", () => {
       expect(h.elements.some((el) => el.id === rect.id)).toBe(true);
       expect(h.history.undoStack.length).toBeGreaterThan(historyLengthBefore);
 
-      const after = h.app.transactionManager.default;
+      const after = h.app.transactionManager.get();
       expect(after).not.toBe(before);
       expect(after.status).toBe("active");
     });
@@ -59,7 +76,7 @@ describe("TransactionManager", () => {
       API.setElements([rect, newRect]);
       expect(h.elements.filter((el) => !el.isDeleted).length).toBe(2);
 
-      const before = h.app.transactionManager.default;
+      const before = h.app.transactionManager.get();
 
       act(() => {
         before.rollback();
@@ -69,7 +86,7 @@ describe("TransactionManager", () => {
       expect(before.status).toBe("rolled-back");
       expect(h.elements.filter((el) => !el.isDeleted).length).toBe(0);
 
-      const after = h.app.transactionManager.default;
+      const after = h.app.transactionManager.get();
       expect(after).not.toBe(before);
       expect(after.status).toBe("active");
     });
@@ -78,11 +95,11 @@ describe("TransactionManager", () => {
       const rect = API.createElement({ type: "rectangle" });
       const historyLengthBefore = h.history.undoStack.length;
 
-      h.app.transactionManager.default.update({
+      h.app.transactionManager.get().update({
         elements: arrayToMap([rect]) as SceneElementsMap,
       });
       act(() => {
-        h.app.transactionManager.default.rollback();
+        h.app.transactionManager.get().rollback();
       });
 
       expect(h.history.undoStack.length).toBe(historyLengthBefore);
@@ -343,7 +360,7 @@ describe("TransactionManager", () => {
 
         const txnA = h.app.transactionManager.begin("txA");
         const txnB = h.app.transactionManager.begin("txB");
-        const defaultBefore = h.app.transactionManager.default;
+        const defaultBefore = h.app.transactionManager.get();
 
         txnA.update({ elements: arrayToMap([rectA]) as SceneElementsMap });
         txnB.update({ elements: arrayToMap([rectB]) as SceneElementsMap });
@@ -357,20 +374,20 @@ describe("TransactionManager", () => {
         expect(defaultBefore.status).toBe("rolled-back");
 
         // default auto-restarts
-        expect(h.app.transactionManager.default).not.toBe(defaultBefore);
-        expect(h.app.transactionManager.default.status).toBe("active");
+        expect(h.app.transactionManager.get()).not.toBe(defaultBefore);
+        expect(h.app.transactionManager.get().status).toBe("active");
       });
 
       it("rollbackAll() is a no-op for keyed when none are active", () => {
-        const defaultBefore = h.app.transactionManager.default;
+        const defaultBefore = h.app.transactionManager.get();
         expect(() => {
           act(() => {
             h.app.transactionManager.rollbackAll();
           });
         }).not.toThrow();
         // default still auto-restarts
-        expect(h.app.transactionManager.default).not.toBe(defaultBefore);
-        expect(h.app.transactionManager.default.status).toBe("active");
+        expect(h.app.transactionManager.get()).not.toBe(defaultBefore);
+        expect(h.app.transactionManager.get().status).toBe("active");
       });
     });
   });

--- a/packages/excalidraw/tests/transaction.test.tsx
+++ b/packages/excalidraw/tests/transaction.test.tsx
@@ -4,11 +4,19 @@ import { arrayToMap, reseed } from "@excalidraw/common";
 
 import type { SceneElementsMap } from "@excalidraw/element/types";
 
+import { actionChangeOpacity } from "../actions";
 import { createRedoAction, createUndoAction } from "../actions/actionHistory";
 import { Excalidraw } from "../index";
 
 import { API } from "./helpers/api";
-import { GlobalTestState, act, render, unmountComponent } from "./test-utils";
+import {
+  GlobalTestState,
+  act,
+  fireEvent,
+  render,
+  screen,
+  unmountComponent,
+} from "./test-utils";
 
 const { h } = window;
 
@@ -67,22 +75,26 @@ describe("TransactionManager", () => {
       expect(after.status).toBe("active");
     });
 
-    it("rollback() restores scene and auto-restarts a fresh default", () => {
+    it("rollback() reverts registered changes and auto-restarts a fresh default", () => {
+      // Default was created at mount (0 elements).
+      const before = h.app.transactionManager.get();
+
+      // Add elements through the normal flow and register them with the default.
       const rect = API.createElement({ type: "rectangle" });
       API.setElements([rect]);
-
-      // Default was created at mount (0 elements). Externally add another element.
+      before.update({ elements: arrayToMap([rect]) as SceneElementsMap });
       const newRect = API.createElement({ type: "rectangle" });
       API.setElements([rect, newRect]);
+      before.update({
+        elements: arrayToMap([rect, newRect]) as SceneElementsMap,
+      });
       expect(h.elements.filter((el) => !el.isDeleted).length).toBe(2);
-
-      const before = h.app.transactionManager.get();
 
       act(() => {
         before.rollback();
       });
 
-      // Rolled back to mount state (0 elements — rollbackState was captured at mount).
+      // Both were added after begin() (mount, 0 elements) → removed on rollback.
       expect(before.status).toBe("rolled-back");
       expect(h.elements.filter((el) => !el.isDeleted).length).toBe(0);
 
@@ -288,13 +300,35 @@ describe("TransactionManager", () => {
     });
 
     describe("rollback()", () => {
-      it("restores elements to the state at begin() time", () => {
+      it("reverts registered changes to the state at begin() time", () => {
         const rect = API.createElement({ type: "rectangle" });
         API.setElements([rect]);
 
         const txn = h.app.transactionManager.begin("txA");
 
-        // Modify scene externally (not via txn.update)
+        // Add a new element through the normal flow and register it with the txn.
+        const newRect = API.createElement({ type: "rectangle" });
+        API.setElements([rect, newRect]);
+        txn.update({ elements: arrayToMap([newRect]) as SceneElementsMap });
+        expect(h.elements.filter((el) => !el.isDeleted).length).toBe(2);
+
+        act(() => {
+          txn.rollback();
+        });
+
+        // newRect was added after begin() → removed; rect (present at begin) stays.
+        expect(txn.status).toBe("rolled-back");
+        expect(h.elements.filter((el) => !el.isDeleted).length).toBe(1);
+        expect(h.elements.some((el) => el.id === rect.id)).toBe(true);
+      });
+
+      it("leaves elements it never registered untouched", () => {
+        const rect = API.createElement({ type: "rectangle" });
+        API.setElements([rect]);
+
+        const txn = h.app.transactionManager.begin("txA");
+
+        // Add an element through the normal flow but do NOT register it.
         const newRect = API.createElement({ type: "rectangle" });
         API.setElements([rect, newRect]);
         expect(h.elements.filter((el) => !el.isDeleted).length).toBe(2);
@@ -303,9 +337,32 @@ describe("TransactionManager", () => {
           txn.rollback();
         });
 
+        // Nothing was registered, so rollback is a no-op on the scene.
         expect(txn.status).toBe("rolled-back");
-        expect(h.elements.filter((el) => !el.isDeleted).length).toBe(1);
-        expect(h.elements.some((el) => el.id === rect.id)).toBe(true);
+        expect(h.elements.filter((el) => !el.isDeleted).length).toBe(2);
+        expect(h.elements.some((el) => el.id === newRect.id)).toBe(true);
+      });
+
+      it("reverts an in-place property mutation it registered", () => {
+        const rect = API.createElement({ type: "rectangle", x: 0 });
+        API.setElements([rect]);
+
+        const txn = h.app.transactionManager.begin("txA");
+
+        // Mutate in place (same object reference the scene holds), then register.
+        act(() => {
+          h.app.scene.mutateElement(rect, { x: 250 });
+        });
+        txn.update({ elements: arrayToMap([rect]) as SceneElementsMap });
+        expect(h.elements.find((el) => el.id === rect.id)?.x).toBe(250);
+
+        act(() => {
+          txn.rollback();
+        });
+
+        // Restored to the deep-copied begin() baseline, not the live (mutated) ref.
+        expect(txn.status).toBe("rolled-back");
+        expect(h.elements.find((el) => el.id === rect.id)?.x).toBe(0);
       });
 
       it("discards registered changes without recording history", () => {
@@ -352,6 +409,48 @@ describe("TransactionManager", () => {
         });
         expect(txnA.status).toBe("committed");
         expect(txnB.status).toBe("committed");
+      });
+
+      it("rollback() of one transaction preserves another's committed work", () => {
+        const rectA = API.createElement({ type: "rectangle", x: 0 });
+        const rectB = API.createElement({ type: "rectangle", x: 0 });
+        API.setElements([rectA, rectB]);
+
+        const txnA = h.app.transactionManager.begin("txA");
+        const txnB = h.app.transactionManager.begin("txB");
+
+        // txnB edits rectB and adds rectC, then commits — all disjoint from txnA.
+        const rectC = API.createElement({ type: "rectangle" });
+        act(() => {
+          h.app.scene.mutateElement(rectB, { x: 200 });
+          API.setElements([rectA, rectB, rectC]);
+        });
+        txnB.update({
+          elements: arrayToMap([rectB, rectC]) as SceneElementsMap,
+        });
+        act(() => {
+          txnB.commit();
+        });
+
+        // txnA edits rectA, then rolls back after txnB already committed.
+        act(() => {
+          h.app.scene.mutateElement(rectA, { x: 300 });
+        });
+        txnA.update({ elements: arrayToMap([rectA]) as SceneElementsMap });
+        act(() => {
+          txnA.rollback();
+        });
+
+        expect(txnB.status).toBe("committed");
+        expect(txnA.status).toBe("rolled-back");
+
+        // txnB's committed work survives txnA's rollback...
+        expect(
+          h.elements.some((el) => el.id === rectC.id && !el.isDeleted),
+        ).toBe(true);
+        expect(h.elements.find((el) => el.id === rectB.id)?.x).toBe(200);
+        // ...while txnA's own edit is reverted.
+        expect(h.elements.find((el) => el.id === rectA.id)?.x).toBe(0);
       });
 
       it("rollbackAll() reverts all keyed transactions and the default", () => {
@@ -441,9 +540,9 @@ describe("TransactionManager", () => {
       });
       expect(h.elements.filter((e) => !e.isDeleted)).toHaveLength(CHUNKS);
       for (const el of streamed) {
-        expect(
-          h.elements.some((e) => e.id === el.id && !e.isDeleted),
-        ).toBe(true);
+        expect(h.elements.some((e) => e.id === el.id && !e.isDeleted)).toBe(
+          true,
+        );
       }
     });
 
@@ -490,6 +589,67 @@ describe("TransactionManager", () => {
         API.executeAction(redoAction);
       });
       expect(h.elements.find((e) => e.id === rect.id)?.width).toBe(250);
+    });
+  });
+
+  // The opacity slider is the first concrete action wired to the transaction
+  // system: dragging it emits one `onChange` per step, which without scoping
+  // would litter the undo stack with one entry per step.
+  describe("actionChangeOpacity integration", () => {
+    it("collapses an opacity slider drag into a single undo entry", () => {
+      const undoAction = createUndoAction(h.history);
+      const redoAction = createRedoAction(h.history);
+
+      const rect = API.createElement({ type: "rectangle", opacity: 100 });
+      API.setElements([rect]);
+      API.setSelectedElements([rect]);
+
+      const slider = screen.getByTestId("opacity");
+      const undoLengthBefore = h.history.undoStack.length;
+
+      // Each drag step is applied live but deferred (no history yet) because an
+      // "opacity" transaction is open for the duration of the drag.
+      for (const value of [80, 60, 40, 20]) {
+        fireEvent.change(slider, { target: { value: `${value}` } });
+        expect(h.elements[0].opacity).toBe(value);
+        expect(h.history.undoStack.length).toBe(undoLengthBefore);
+      }
+
+      // Releasing the slider commits the transaction → exactly one undo entry.
+      fireEvent.pointerUp(slider);
+      expect(h.app.transactionManager.get("opacity")).toBeUndefined();
+      expect(h.history.undoStack.length).toBe(undoLengthBefore + 1);
+      expect(h.elements[0].opacity).toBe(20);
+
+      // One undo reverts the whole drag back to the starting opacity.
+      act(() => {
+        API.executeAction(undoAction);
+      });
+      expect(h.elements[0].opacity).toBe(100);
+
+      // One redo re-applies the final opacity.
+      act(() => {
+        API.executeAction(redoAction);
+      });
+      expect(h.elements[0].opacity).toBe(20);
+    });
+
+    it("falls back to immediate capture when no slider transaction is open", () => {
+      const rect = API.createElement({ type: "rectangle", opacity: 100 });
+      API.setElements([rect]);
+      API.setSelectedElements([rect]);
+
+      const undoLengthBefore = h.history.undoStack.length;
+
+      // Invoking the action without an open "opacity" transaction (e.g.
+      // programmatically) records immediately, preserving legacy behaviour.
+      act(() => {
+        h.app.actionManager.executeAction(actionChangeOpacity, "api", 50);
+      });
+
+      expect(h.elements[0].opacity).toBe(50);
+      expect(h.app.transactionManager.get("opacity")).toBeUndefined();
+      expect(h.history.undoStack.length).toBe(undoLengthBefore + 1);
     });
   });
 });

--- a/packages/excalidraw/transaction.ts
+++ b/packages/excalidraw/transaction.ts
@@ -14,13 +14,37 @@ import type {
 } from "@excalidraw/element/types";
 
 import type { AppState, ObservedAppState } from "./types";
-import type App from "./components/App";
 
 type TransactionStatus = "active" | "committed" | "rolled-back";
 
 export interface TransactionUpdate {
   elements?: SceneElementsMap;
   appState?: AppState | ObservedAppState;
+}
+
+/**
+ * The narrow set of editor capabilities the transaction system needs.
+ *
+ * Injecting this (instead of the whole `App`) keeps the system decoupled and
+ * testable, and lets the host keep its `store`/`history` private — they are
+ * reached only through these closures.
+ */
+export interface TransactionContext {
+  /** Current scene elements, including deleted. */
+  getElementsMap: () => SceneElementsMap;
+  /** Current app state. */
+  getAppState: () => AppState;
+  /** Current store snapshot. */
+  getSnapshot: () => StoreSnapshot;
+  /** Replace the store snapshot (used to keep it in sync on commit). */
+  setSnapshot: (snapshot: StoreSnapshot) => void;
+  /** Push a durable delta onto the undo stack. */
+  recordHistory: (delta: StoreDelta) => void;
+  /** Apply elements/appState back to the scene (used by rollback). */
+  applyUpdate: (data: {
+    elements: readonly OrderedExcalidrawElement[];
+    appState: AppState;
+  }) => void;
 }
 
 interface RollbackState {
@@ -32,7 +56,7 @@ export class Transaction {
   readonly id: string = randomId();
   private _status: TransactionStatus = "active";
 
-  readonly originalElementStates = new Map<
+  private readonly originalElementStates = new Map<
     string,
     OrderedExcalidrawElement | null
   >();
@@ -41,7 +65,7 @@ export class Transaction {
   private prevSnapshot: StoreSnapshot;
 
   constructor(
-    private readonly app: App,
+    private readonly context: TransactionContext,
     private readonly rollbackState: RollbackState,
     private readonly onDone: () => void,
   ) {
@@ -49,12 +73,13 @@ export class Transaction {
     // place (mutateElement), so without copying, these references would mutate to
     // their final state and commit() would compute an empty delta.
     const baselineElements = new Map() as SceneElementsMap;
-    for (const element of this.app.scene
-      .getElementsMapIncludingDeleted()
-      .values()) {
+    for (const element of this.context.getElementsMap().values()) {
       baselineElements.set(element.id, deepCopyElement(element));
     }
-    this.prevSnapshot = StoreSnapshot.create(baselineElements, this.app.state);
+    this.prevSnapshot = StoreSnapshot.create(
+      baselineElements,
+      this.context.getAppState(),
+    );
   }
 
   get status(): TransactionStatus {
@@ -109,45 +134,51 @@ export class Transaction {
       string,
       OrderedExcalidrawElement
     >() as SceneElementsMap;
-    const currentSnapshot = StoreSnapshot.create(
-      this.app.scene.getElementsMapIncludingDeleted(),
-      this.app.state,
-    );
+    const currentElements = this.context.getElementsMap();
+    const currentAppState = this.context.getAppState();
 
     for (const [elementId, originalState] of this.originalElementStates) {
       if (originalState !== null) {
         prevElements.set(elementId, originalState);
       }
-      const current = currentSnapshot.elements.get(elementId);
+      const current = currentElements.get(elementId);
       if (current) {
         nextElements.set(elementId, deepCopyElement(current));
       }
     }
 
     // ── Build appState pseudo-snapshots (only touched fields) ─────────────
-    const prevAppState = { ...currentSnapshot.appState };
+    const observedAppState = StoreSnapshot.create(
+      currentElements,
+      currentAppState,
+    ).appState;
+    const prevAppState = { ...observedAppState };
     for (const key of this.touchedAppStateKeys) {
       (prevAppState as Record<string, unknown>)[key] =
         this.originalAppState[key];
     }
-    const nextAppState = currentSnapshot.appState;
+    const nextAppState = observedAppState;
 
     const elementsDelta = ElementsDelta.calculate(prevElements, nextElements);
     const appStateDelta = AppStateDelta.calculate(prevAppState, nextAppState);
     const storeDelta = StoreDelta.create(elementsDelta, appStateDelta);
 
     if (!storeDelta.isEmpty()) {
-      this.app.history.record(storeDelta);
+      this.context.recordHistory(storeDelta);
     }
 
     // Keep the store snapshot in sync with the committed scene, mirroring the
     // store's durable-increment flow. Undo/redo re-base their inverse deltas
-    // against `store.snapshot`; if it stayed stale the redo entry would be
-    // computed from the wrong baseline and redo would not restore the change.
-    this.app.store.snapshot = this.app.store.snapshot.maybeClone(
-      CaptureUpdateAction.IMMEDIATELY,
-      this.app.scene.getElementsMapIncludingDeleted(),
-      this.app.state,
+    // against the snapshot; if it stayed stale the redo entry would be computed
+    // from the wrong baseline and redo would not restore the change.
+    this.context.setSnapshot(
+      this.context
+        .getSnapshot()
+        .maybeClone(
+          CaptureUpdateAction.IMMEDIATELY,
+          currentElements,
+          currentAppState,
+        ),
     );
 
     this._status = "committed";
@@ -155,13 +186,12 @@ export class Transaction {
   }
 
   /**
-   * Revert: restore scene to begin()-state and reset store snapshot directly.
-   * No history entry. Synchronous — no render cycle required for snapshot reset.
+   * Revert: restore the scene to the begin()-time state. No history entry.
    */
   rollback(): void {
     this.assertActive();
 
-    this.app.updateScene({
+    this.context.applyUpdate({
       elements: this.rollbackState.elements,
       appState: this.rollbackState.appState,
     });
@@ -181,31 +211,51 @@ export class Transaction {
 
 export class TransactionManager {
   private keyed = new Map<string, Transaction>();
-  private defaultTxn: Transaction;
+  /** The always-active default transaction. Auto-restarts after commit/rollback. */
+  private defaultTxn!: Transaction;
 
-  constructor(private readonly app: App) {
-    this.defaultTxn = this.createDefault();
+  constructor(private readonly context: TransactionContext) {
+    this.begin();
   }
 
-  /** The always-active default transaction. Auto-restarts after commit or rollback. */
-  get default(): Transaction {
-    return this.defaultTxn;
-  }
+  /**
+   * Open a transaction. With no key, (re)starts the always-active default
+   * transaction. With a key, opens a keyed transaction — throws if one with that
+   * key is already active.
+   */
+  begin(key?: string): Transaction {
+    if (key === undefined) {
+      // the default transaction auto-restarts itself once it finishes
+      this.defaultTxn = this.create(() => this.begin());
+      return this.defaultTxn;
+    }
 
-  /** Open a new keyed transaction. Throws if a transaction with that key is already active. */
-  begin(key: string): Transaction {
     if (this.keyed.has(key)) {
       throw new Error(`Transaction "${key}" is already active.`);
     }
-    const txn = new Transaction(this.app, this.captureRollbackState(), () =>
-      this.keyed.delete(key),
-    );
+    const txn = this.create(() => this.keyed.delete(key));
     this.keyed.set(key, txn);
     return txn;
   }
 
-  get(key: string): Transaction | undefined {
-    return this.keyed.get(key);
+  /**
+   * Get a transaction. With no key, returns the default transaction; with a key,
+   * returns the matching keyed transaction (or undefined).
+   */
+  get(): Transaction;
+  get(key: string): Transaction | undefined;
+  get(key?: string): Transaction | undefined {
+    return this.resolve(key);
+  }
+
+  /** Commit the keyed transaction (or the default when no key is given). */
+  commit(key?: string): void {
+    this.resolve(key)?.commit();
+  }
+
+  /** Rollback the keyed transaction (or the default when no key is given). */
+  rollback(key?: string): void {
+    this.resolve(key)?.rollback();
   }
 
   /** Rollback all keyed transactions and the default transaction (default auto-restarts). */
@@ -216,21 +266,18 @@ export class TransactionManager {
     this.defaultTxn.rollback();
   }
 
-  createDefault(): Transaction {
-    this.defaultTxn = new Transaction(
-      this.app,
-      this.captureRollbackState(),
-      () => {
-        this.defaultTxn = this.createDefault();
-      },
-    );
-    return this.defaultTxn;
+  private create(onDone: () => void): Transaction {
+    return new Transaction(this.context, this.captureRollbackState(), onDone);
+  }
+
+  private resolve(key?: string): Transaction | undefined {
+    return key === undefined ? this.defaultTxn : this.keyed.get(key);
   }
 
   private captureRollbackState(): RollbackState {
     return {
-      elements: this.app.scene.getElementsIncludingDeleted(),
-      appState: this.app.state,
+      elements: Array.from(this.context.getElementsMap().values()),
+      appState: this.context.getAppState(),
     };
   }
 }

--- a/packages/excalidraw/transaction.ts
+++ b/packages/excalidraw/transaction.ts
@@ -47,11 +47,6 @@ export interface TransactionContext {
   }) => void;
 }
 
-interface RollbackState {
-  elements: readonly OrderedExcalidrawElement[];
-  appState: AppState;
-}
-
 export class Transaction {
   readonly id: string = randomId();
   private _status: TransactionStatus = "active";
@@ -66,7 +61,6 @@ export class Transaction {
 
   constructor(
     private readonly context: TransactionContext,
-    private readonly rollbackState: RollbackState,
     private readonly onDone: () => void,
   ) {
     // Freeze the baseline by deep-copying elements. The scene mutates elements in
@@ -186,14 +180,53 @@ export class Transaction {
   }
 
   /**
-   * Revert: restore the scene to the begin()-time state. No history entry.
+   * Revert the elements / appState keys this transaction registered via update()
+   * back to their begin()-time baseline. No history entry.
+   *
+   * Scoped, not whole-scene: the revert is merged over the *current* scene, so work
+   * committed by other concurrent transactions (added/removed/edited elements this
+   * transaction never touched) is preserved. The baselines are the deep copies frozen
+   * at begin() (`originalElementStates`), so in-place property mutations are reverted too.
+   *
+   * Shared-element conflict: if another transaction committed an element this one also
+   * registered, rollback still reverts it to this transaction's baseline (clobbering the
+   * committed value). That is an inherent write-write conflict — out of scope (the system
+   * is not a CRDT conflict resolver).
    */
   rollback(): void {
     this.assertActive();
 
+    // Start from the current scene so other transactions' committed work survives.
+    const nextElements = new Map(
+      this.context.getElementsMap(),
+    ) as SceneElementsMap;
+
+    for (const [id, originalState] of this.originalElementStates) {
+      if (originalState === null) {
+        // Didn't exist at begin() → this transaction added it → drop it.
+        nextElements.delete(id);
+      } else {
+        // Restore the frozen baseline. Re-copy so the live scene can't alias and
+        // mutate our baseline after rollback.
+        nextElements.set(id, deepCopyElement(originalState));
+      }
+    }
+
+    // Restore only the touched *observed* appState keys over the current appState.
+    // Non-observed keys have no baseline (they are absent from the observed
+    // snapshot) and must not be clobbered with `undefined`. This mirrors commit(),
+    // which likewise operates purely in observed-appState space.
+    const nextAppState = { ...this.context.getAppState() };
+    for (const key of this.touchedAppStateKeys) {
+      if (key in this.prevSnapshot.appState) {
+        (nextAppState as Record<string, unknown>)[key] =
+          this.originalAppState[key];
+      }
+    }
+
     this.context.applyUpdate({
-      elements: this.rollbackState.elements,
-      appState: this.rollbackState.appState,
+      elements: Array.from(nextElements.values()),
+      appState: nextAppState,
     });
 
     this._status = "rolled-back";
@@ -267,17 +300,10 @@ export class TransactionManager {
   }
 
   private create(onDone: () => void): Transaction {
-    return new Transaction(this.context, this.captureRollbackState(), onDone);
+    return new Transaction(this.context, onDone);
   }
 
   private resolve(key?: string): Transaction | undefined {
     return key === undefined ? this.defaultTxn : this.keyed.get(key);
-  }
-
-  private captureRollbackState(): RollbackState {
-    return {
-      elements: Array.from(this.context.getElementsMap().values()),
-      appState: this.context.getAppState(),
-    };
   }
 }

--- a/packages/excalidraw/transaction.ts
+++ b/packages/excalidraw/transaction.ts
@@ -1,0 +1,236 @@
+import { randomId } from "@excalidraw/common";
+import {
+  AppStateDelta,
+  CaptureUpdateAction,
+  deepCopyElement,
+  ElementsDelta,
+  StoreDelta,
+  StoreSnapshot,
+} from "@excalidraw/element";
+
+import type {
+  OrderedExcalidrawElement,
+  SceneElementsMap,
+} from "@excalidraw/element/types";
+
+import type { AppState, ObservedAppState } from "./types";
+import type App from "./components/App";
+
+type TransactionStatus = "active" | "committed" | "rolled-back";
+
+export interface TransactionUpdate {
+  elements?: SceneElementsMap;
+  appState?: AppState | ObservedAppState;
+}
+
+interface RollbackState {
+  elements: readonly OrderedExcalidrawElement[];
+  appState: AppState;
+}
+
+export class Transaction {
+  readonly id: string = randomId();
+  private _status: TransactionStatus = "active";
+
+  readonly originalElementStates = new Map<
+    string,
+    OrderedExcalidrawElement | null
+  >();
+  private readonly touchedAppStateKeys = new Set<string>();
+  private readonly originalAppState: Record<string, unknown> = {};
+  private prevSnapshot: StoreSnapshot;
+
+  constructor(
+    private readonly app: App,
+    private readonly rollbackState: RollbackState,
+    private readonly onDone: () => void,
+  ) {
+    // Freeze the baseline by deep-copying elements. The scene mutates elements in
+    // place (mutateElement), so without copying, these references would mutate to
+    // their final state and commit() would compute an empty delta.
+    const baselineElements = new Map() as SceneElementsMap;
+    for (const element of this.app.scene
+      .getElementsMapIncludingDeleted()
+      .values()) {
+      baselineElements.set(element.id, deepCopyElement(element));
+    }
+    this.prevSnapshot = StoreSnapshot.create(baselineElements, this.app.state);
+  }
+
+  get status(): TransactionStatus {
+    return this._status;
+  }
+
+  /**
+   * Register touched elements / appState keys, capturing their original (baseline)
+   * state on first touch. No scene side-effect — the scene is mutated elsewhere.
+   */
+  update(changes: TransactionUpdate): void {
+    this.assertActive();
+
+    if (changes.elements) {
+      for (const el of changes.elements.values()) {
+        const id = el.id;
+        if (!this.originalElementStates.has(id)) {
+          this.originalElementStates.set(
+            id,
+            this.prevSnapshot.elements.get(id) ?? null,
+          );
+        }
+      }
+    }
+
+    if (changes.appState) {
+      for (const key of Object.keys(changes.appState)) {
+        if (!this.touchedAppStateKeys.has(key)) {
+          this.touchedAppStateKeys.add(key);
+          this.originalAppState[key] = (
+            this.prevSnapshot.appState as Record<string, unknown>
+          )[key];
+        }
+      }
+    }
+  }
+
+  /**
+   * Record a single consolidated history delta for everything touched since the
+   * transaction began (frozen baseline vs. current scene). Transparent model: the
+   * scene is already mutated through the normal flow, so commit() does not re-apply.
+   */
+  commit(): void {
+    this.assertActive();
+
+    // ── Build element-scoped pseudo-snapshots ──────────────────────────────
+    const prevElements = new Map<
+      string,
+      OrderedExcalidrawElement
+    >() as SceneElementsMap;
+    const nextElements = new Map<
+      string,
+      OrderedExcalidrawElement
+    >() as SceneElementsMap;
+    const currentSnapshot = StoreSnapshot.create(
+      this.app.scene.getElementsMapIncludingDeleted(),
+      this.app.state,
+    );
+
+    for (const [elementId, originalState] of this.originalElementStates) {
+      if (originalState !== null) {
+        prevElements.set(elementId, originalState);
+      }
+      const current = currentSnapshot.elements.get(elementId);
+      if (current) {
+        nextElements.set(elementId, deepCopyElement(current));
+      }
+    }
+
+    // ── Build appState pseudo-snapshots (only touched fields) ─────────────
+    const prevAppState = { ...currentSnapshot.appState };
+    for (const key of this.touchedAppStateKeys) {
+      (prevAppState as Record<string, unknown>)[key] =
+        this.originalAppState[key];
+    }
+    const nextAppState = currentSnapshot.appState;
+
+    const elementsDelta = ElementsDelta.calculate(prevElements, nextElements);
+    const appStateDelta = AppStateDelta.calculate(prevAppState, nextAppState);
+    const storeDelta = StoreDelta.create(elementsDelta, appStateDelta);
+
+    if (!storeDelta.isEmpty()) {
+      this.app.history.record(storeDelta);
+    }
+
+    // Keep the store snapshot in sync with the committed scene, mirroring the
+    // store's durable-increment flow. Undo/redo re-base their inverse deltas
+    // against `store.snapshot`; if it stayed stale the redo entry would be
+    // computed from the wrong baseline and redo would not restore the change.
+    this.app.store.snapshot = this.app.store.snapshot.maybeClone(
+      CaptureUpdateAction.IMMEDIATELY,
+      this.app.scene.getElementsMapIncludingDeleted(),
+      this.app.state,
+    );
+
+    this._status = "committed";
+    this.onDone();
+  }
+
+  /**
+   * Revert: restore scene to begin()-state and reset store snapshot directly.
+   * No history entry. Synchronous — no render cycle required for snapshot reset.
+   */
+  rollback(): void {
+    this.assertActive();
+
+    this.app.updateScene({
+      elements: this.rollbackState.elements,
+      appState: this.rollbackState.appState,
+    });
+
+    this._status = "rolled-back";
+    this.onDone();
+  }
+
+  private assertActive(): void {
+    if (this._status !== "active") {
+      throw new Error(
+        `Transaction "${this.id}" is already ${this._status} and cannot be used.`,
+      );
+    }
+  }
+}
+
+export class TransactionManager {
+  private keyed = new Map<string, Transaction>();
+  private defaultTxn: Transaction;
+
+  constructor(private readonly app: App) {
+    this.defaultTxn = this.createDefault();
+  }
+
+  /** The always-active default transaction. Auto-restarts after commit or rollback. */
+  get default(): Transaction {
+    return this.defaultTxn;
+  }
+
+  /** Open a new keyed transaction. Throws if a transaction with that key is already active. */
+  begin(key: string): Transaction {
+    if (this.keyed.has(key)) {
+      throw new Error(`Transaction "${key}" is already active.`);
+    }
+    const txn = new Transaction(this.app, this.captureRollbackState(), () =>
+      this.keyed.delete(key),
+    );
+    this.keyed.set(key, txn);
+    return txn;
+  }
+
+  get(key: string): Transaction | undefined {
+    return this.keyed.get(key);
+  }
+
+  /** Rollback all keyed transactions and the default transaction (default auto-restarts). */
+  rollbackAll(): void {
+    for (const txn of this.keyed.values()) {
+      txn.rollback();
+    }
+    this.defaultTxn.rollback();
+  }
+
+  createDefault(): Transaction {
+    this.defaultTxn = new Transaction(
+      this.app,
+      this.captureRollbackState(),
+      () => {
+        this.defaultTxn = this.createDefault();
+      },
+    );
+    return this.defaultTxn;
+  }
+
+  private captureRollbackState(): RollbackState {
+    return {
+      elements: this.app.scene.getElementsIncludingDeleted(),
+      appState: this.app.state,
+    };
+  }
+}

--- a/packages/excalidraw/types.ts
+++ b/packages/excalidraw/types.ts
@@ -1016,6 +1016,7 @@ export interface ExcalidrawImperativeAPI {
   ) => UnsubscribeCallback;
   onStateChange: InstanceType<typeof App>["onStateChange"];
   onEvent: InstanceType<typeof App>["onEvent"];
+  transactionManager: InstanceType<typeof App>["transactionManager"];
 }
 
 export type FrameNameBounds = {

--- a/packages/excalidraw/types.ts
+++ b/packages/excalidraw/types.ts
@@ -818,6 +818,7 @@ export type AppClassProperties = {
   files: BinaryFiles;
   editorInterface: App["editorInterface"];
   scene: App["scene"];
+  transactionManager: App["transactionManager"];
   syncActionResult: App["syncActionResult"];
   fonts: App["fonts"];
   pasteFromClipboard: App["pasteFromClipboard"];


### PR DESCRIPTION
# Summary

Introduces an explicit `begin → update → commit | rollback` scope on top of the existing `Store/History/Delta` machinery, so that any number of scene mutations spanning many render frames (or async chunks) collapse into exactly one undo/redo entry with a clean `rollback()` to abort a scope without polluting history.

It's wired to drag elements action and `actionChangeOpacity` so a full opacity-slider drag becomes a single undo entry.

A full design doc is included at `TRANSACTION_SYSTEM.md`

## What's included

Core system `packages/excalidraw/transaction.ts`
- **Transaction:** `update()` registers touched element ids / observed-appState keys (capturing a deep-copied frozen baseline at begin()); commit() computes one consolidated `StoreDelta` and records it; `rollback()` reverts only this transaction's touched ids/keys merged over the current scene (no history).
- **TransactionManager:** an always-active default transaction (auto-restarts after commit/rollback) for the pointer-gesture case, plus concurrent keyed transactions for explicit/async scopes.
- **Transparent model:** the scene is still mutated through the normal flow; the transaction only observes and batches — `commit()` re-applies nothing.
- **Decoupled**: depends on a narrow injected `TransactionContext`, not on App (keeps store/history private).

### Out of scope
Not a rewrite of the Store/Delta model, not a full migration of every capture site, not a collaboration/CRDT conflict resolver.

## Motivation

The current `Store → History` path has two structural weaknesses:
1. Capture is implicit and scattered — ~15 `store.scheduleCapture()` sites in `App.tsx`; forgetting one yields a non-undoable change, double-firing splits one logical action into several entries.
2. No first-class scope, multi-frame gestures and async pipelines lean on `CaptureUpdateAction.EVENTUALLY` juggling, and there is no clean abort/rollback primitive.

The opacity slider is a concrete instance: it emits one `onChange` per step, so dragging 100 → 10 previously recorded ~9 separate undo entries.

## Testing
`yarn test`
`yarn test:typecheck`

## Known limitations

- `commit()` calls `history.record` directly and does not emit through `onStoreIncrementEmitter`, so external `onIncrement` consumers (persistence/collab) don't yet see the consolidated delta, needs attention before transactions drive collab-synced changes.
- Mid-gesture remote (NEVER) updates interleaving with an open transaction is unspecified.
- Shared-element write-write conflict between concurrent transactions is accepted/out of scope (not a CRDT resolver).
- The legacy `scheduleCapture` path remains live for all other actions; migrating the remaining actions off `captureUpdate` is future work.
