### PR TITLE
feat: show error message for invalid hex color codes in color picker

### DIFF
--- a/packages/excalidraw/components/ColorPicker/ColorInput.tsx
+++ b/packages/excalidraw/components/ColorPicker/ColorInput.tsx
@@ -14,6 +14,28 @@ import { activeColorPickerSectionAtom } from "./colorPickerUtils";
 
 import type { ColorPickerType } from "./colorPickerUtils";
 
+const HEX_CHAR_REGEX = /^[0-9a-f]*$/i;
+
+/**
+ * Returns an error message for an input value that `normalizeInputColor` could
+ * not parse, or `null` when no message should be shown. Only called for values
+ * that already failed to normalize, so valid hex codes (3/4/6/8 chars) and
+ * valid CSS color names never reach here.
+ */
+const getColorErrorMessage = (value: string): string | null => {
+  const stripped = value.replace(/^#/, "");
+  if (!stripped) {
+    return null;
+  }
+  if (HEX_CHAR_REGEX.test(stripped)) {
+    // Hex-like but the wrong length. Skip 1-2 characters so the message
+    // doesn't flash while the user is still typing a valid code.
+    return stripped.length < 3 ? null : t("colorPicker.invalidHexCode");
+  }
+  // Contains non-hex characters and isn't a recognized color name either.
+  return t("colorPicker.invalidColor");
+};
+
 export const ColorInput = ({
   color,
   onChange,
@@ -29,12 +51,14 @@ export const ColorInput = ({
 }) => {
   const editorInterface = useEditorInterface();
   const [innerValue, setInnerValue] = useState(color);
+  const [error, setError] = useState<string | null>(null);
   const [activeSection, setActiveColorPickerSection] = useAtom(
     activeColorPickerSectionAtom,
   );
 
   useEffect(() => {
     setInnerValue(color);
+    setError(null);
   }, [color]);
 
   const changeColor = useCallback(
@@ -44,6 +68,9 @@ export const ColorInput = ({
 
       if (color) {
         onChange(color);
+        setError(null);
+      } else {
+        setError(getColorErrorMessage(value));
       }
       setInnerValue(value);
     },
@@ -68,67 +95,71 @@ export const ColorInput = ({
   }, [setEyeDropperState]);
 
   return (
-    <div className="color-picker__input-label">
-      <div className="color-picker__input-hash">#</div>
-      <input
-        ref={activeSection === "hex" ? inputRef : undefined}
-        style={{ border: 0, padding: 0 }}
-        spellCheck={false}
-        className="color-picker-input"
-        aria-label={label}
-        onChange={(event) => {
-          changeColor(event.target.value);
-        }}
-        value={(innerValue || "").replace(/^#/, "")}
-        onBlur={() => {
-          setInnerValue(color);
-        }}
-        tabIndex={-1}
-        onFocus={() => setActiveColorPickerSection("hex")}
-        onKeyDown={(event) => {
-          if (event.key === KEYS.TAB) {
-            return;
-          } else if (event.key === KEYS.ESCAPE) {
-            eyeDropperTriggerRef.current?.focus();
-          }
-          event.stopPropagation();
-        }}
-        placeholder={placeholder}
-      />
-      {/* TODO reenable on mobile with a better UX */}
-      {editorInterface.formFactor !== "phone" && (
-        <>
-          <div
-            style={{
-              width: "1px",
-              height: "1.25rem",
-              backgroundColor: "var(--default-border-color)",
-            }}
-          />
-          <div
-            ref={eyeDropperTriggerRef}
-            className={clsx("excalidraw-eye-dropper-trigger", {
-              selected: eyeDropperState,
-            })}
-            onClick={() =>
-              setEyeDropperState((s) =>
-                s
-                  ? null
-                  : {
-                      keepOpenOnAlt: false,
-                      onSelect: (color) => onChange(color),
-                      colorPickerType,
-                    },
-              )
+    <>
+      <div className="color-picker__input-label">
+        <div className="color-picker__input-hash">#</div>
+        <input
+          ref={activeSection === "hex" ? inputRef : undefined}
+          style={{ border: 0, padding: 0 }}
+          spellCheck={false}
+          className="color-picker-input"
+          aria-label={label}
+          onChange={(event) => {
+            changeColor(event.target.value);
+          }}
+          value={(innerValue || "").replace(/^#/, "")}
+          onBlur={() => {
+            setInnerValue(color);
+            setError(null);
+          }}
+          tabIndex={-1}
+          onFocus={() => setActiveColorPickerSection("hex")}
+          onKeyDown={(event) => {
+            if (event.key === KEYS.TAB) {
+              return;
+            } else if (event.key === KEYS.ESCAPE) {
+              eyeDropperTriggerRef.current?.focus();
             }
-            title={`${t(
-              "labels.eyeDropper",
-            )} — ${KEYS.I.toLocaleUpperCase()} or ${getShortcutKey("Alt")} `}
-          >
-            {eyeDropperIcon}
-          </div>
-        </>
-      )}
-    </div>
+            event.stopPropagation();
+          }}
+          placeholder={placeholder}
+        />
+        {/* TODO reenable on mobile with a better UX */}
+        {editorInterface.formFactor !== "phone" && (
+          <>
+            <div
+              style={{
+                width: "1px",
+                height: "1.25rem",
+                backgroundColor: "var(--default-border-color)",
+              }}
+            />
+            <div
+              ref={eyeDropperTriggerRef}
+              className={clsx("excalidraw-eye-dropper-trigger", {
+                selected: eyeDropperState,
+              })}
+              onClick={() =>
+                setEyeDropperState((s) =>
+                  s
+                    ? null
+                    : {
+                        keepOpenOnAlt: false,
+                        onSelect: (color) => onChange(color),
+                        colorPickerType,
+                      },
+                )
+              }
+              title={`${t(
+                "labels.eyeDropper",
+              )} — ${KEYS.I.toLocaleUpperCase()} or ${getShortcutKey("Alt")} `}
+            >
+              {eyeDropperIcon}
+            </div>
+          </>
+        )}
+      </div>
+      {error && <div className="color-picker__input-error">{error}</div>}
+    </>
   );
 };

--- a/packages/excalidraw/components/ColorPicker/ColorPicker.scss
+++ b/packages/excalidraw/components/ColorPicker/ColorPicker.scss
@@ -389,6 +389,14 @@
     padding: 0 0.25rem;
   }
 
+  .color-picker__input-error {
+    color: var(--color-danger);
+    font-size: 0.7rem;
+    padding: 0 12px 4px;
+    margin: -4px 8px 0;
+    line-height: 1.2;
+  }
+
   .color-picker-input {
     box-sizing: border-box;
     width: 100%;

--- a/packages/excalidraw/locales/en.json
+++ b/packages/excalidraw/locales/en.json
@@ -601,7 +601,9 @@
     "colors": "Colors",
     "shades": "Shades",
     "hexCode": "Hex code",
-    "noShades": "No shades available for this color"
+    "noShades": "No shades available for this color",
+    "invalidHexCode": "Hex code must be 3, 4, 6, or 8 characters (excluding #)",
+    "invalidColor": "Not a valid color"
   },
   "overwriteConfirm": {
     "action": {


### PR DESCRIPTION
## Summary

The color picker's hex input silently ignores invalid input — typing a value
that can't be parsed just leaves the color unchanged with no feedback (#9527).
This adds an inline error message below the input so the user understands why
nothing happened.

## Behavior

- **Valid** hex codes (3/4/6/8 chars) and CSS color names (e.g. `blue`): applied
  as before, no error shown.
- **Hex-like, wrong length** (e.g. `12345`): `Hex code must be 3, 4, 6, or 8
  characters (excluding #)`.
- **Non-hex / unparseable** (e.g. `zzzzzz`): `Not a valid color`.
- The message is suppressed for 1–2 character input so it doesn't flash while a
  valid code is still being typed, and it clears on blur, on a valid value, or
  when the external `color` prop changes.

Validation is driven by the existing `normalizeInputColor` helper, so anything
it already accepts continues to work unchanged.

## Changes

- `ColorPicker/ColorInput.tsx` — validation, `error` state, and the inline error element.
- `ColorPicker/ColorPicker.scss` — `.color-picker__input-error` styling using the existing `--color-danger` token.
- `locales/en.json` — `colorPicker.invalidHexCode` and `colorPicker.invalidColor` strings.

Closes #9527
