### PR TITLE
fix: add contrast halo to laser pointer cursor in light theme

### DIFF
--- a/packages/excalidraw/cursor.ts
+++ b/packages/excalidraw/cursor.ts
@@ -5,18 +5,23 @@ import { isHandToolActive, isEraserActive } from "./appState";
 import type { AppState, DataURL } from "./types";
 
 const laserPointerCursorSVG_tag = `<svg viewBox="0 0 24 24" stroke-width="1" width="28" height="28" xmlns="http://www.w3.org/2000/svg">`;
-const laserPointerCursorBackgroundSVG = `<path d="M6.164 11.755a5.314 5.314 0 0 1-4.932-5.298 5.314 5.314 0 0 1 5.311-5.311 5.314 5.314 0 0 1 5.307 5.113l8.773 8.773a3.322 3.322 0 0 1 0 4.696l-.895.895a3.322 3.322 0 0 1-4.696 0l-8.868-8.868Z" style="fill:#fff"/>`;
+// background silhouette behind the icon, providing a contrast halo so the
+// cursor stays visible against the canvas: a white halo in dark theme and a
+// dark halo in light theme
+const laserPointerCursorBackgroundPath = `M6.164 11.755a5.314 5.314 0 0 1-4.932-5.298 5.314 5.314 0 0 1 5.311-5.311 5.314 5.314 0 0 1 5.307 5.113l8.773 8.773a3.322 3.322 0 0 1 0 4.696l-.895.895a3.322 3.322 0 0 1-4.696 0l-8.868-8.868Z`;
+const laserPointerCursorBackgroundSVG_darkMode = `<path d="${laserPointerCursorBackgroundPath}" style="fill:#fff"/>`;
+const laserPointerCursorBackgroundSVG_lightMode = `<path d="${laserPointerCursorBackgroundPath}" style="fill:#1b1b1f"/>`;
 const laserPointerCursorIconSVG = `<path stroke="#1b1b1f" fill="#fff" d="m7.868 11.113 7.773 7.774a2.359 2.359 0 0 0 1.667.691 2.368 2.368 0 0 0 2.357-2.358c0-.625-.248-1.225-.69-1.667L11.201 7.78 9.558 9.469l-1.69 1.643v.001Zm10.273 3.606-3.333 3.333m-3.25-6.583 2 2m-7-7 3 3M3.664 3.625l1 1M2.529 6.922l1.407-.144m5.735-2.932-1.118.866M4.285 9.823l.758-1.194m1.863-6.207-.13 1.408"/>`;
 
 const laserPointerCursorDataURL_lightMode = `data:${
   MIME_TYPES.svg
 },${encodeURIComponent(
-  `${laserPointerCursorSVG_tag}${laserPointerCursorIconSVG}</svg>`,
+  `${laserPointerCursorSVG_tag}${laserPointerCursorBackgroundSVG_lightMode}${laserPointerCursorIconSVG}</svg>`,
 )}`;
 const laserPointerCursorDataURL_darkMode = `data:${
   MIME_TYPES.svg
 },${encodeURIComponent(
-  `${laserPointerCursorSVG_tag}${laserPointerCursorBackgroundSVG}${laserPointerCursorIconSVG}</svg>`,
+  `${laserPointerCursorSVG_tag}${laserPointerCursorBackgroundSVG_darkMode}${laserPointerCursorIconSVG}</svg>`,
 )}`;
 
 export const resetCursor = (interactiveCanvas: HTMLCanvasElement | null) => {


### PR DESCRIPTION
Closes #11476

The laser pointer cursor builds its data URL from a background silhouette plus the icon, but the background was only included in the dark-theme URL. In light theme the cursor was just the icon with no outline, so it was barely visible against bright canvas backgrounds.

This renders a dark halo in light theme, mirroring the white halo already used in dark theme — same silhouette path, inverted fill.

Single-file change in `packages/excalidraw/cursor.ts`. Typecheck, lint, and `laser.test.tsx` pass.