### PR TITLE
fix: group chart elements on paste so align doesn't collapse them

### DIFF
--- a/packages/excalidraw/components/PasteChartDialog.tsx
+++ b/packages/excalidraw/components/PasteChartDialog.tsx
@@ -1,6 +1,8 @@
 import React, { useLayoutEffect, useRef, useState } from "react";
 
-import { newTextElement } from "@excalidraw/element";
+import { randomId } from "@excalidraw/common";
+
+import { newElementWith, newTextElement } from "@excalidraw/element";
 
 import type { ChartType } from "@excalidraw/element/types";
 
@@ -196,7 +198,16 @@ export const PasteChartDialog = ({
   }, [onClose]);
 
   const handleChartClick = (chartType: ChartType, elements: ChartElements) => {
-    onInsertElements(elements);
+    // group the chart's elements so the chart behaves as a single unit;
+    // otherwise aligning the selection collapses the bars onto each other
+    const groupId = randomId();
+    onInsertElements(
+      elements.map((element) =>
+        newElementWith(element, {
+          groupIds: [...element.groupIds, groupId],
+        }),
+      ),
+    );
     trackEvent("paste", "chart", chartType);
     onClose();
     focusContainer();


### PR DESCRIPTION
Closes #11355

Pasted chart elements (e.g. a bar chart from spreadsheet data) were inserted ungrouped. Selecting the whole chart and running an align action then aligned each bar independently — since the bars share the same width, aligning their edges left them fully overlapping, collapsing the chart into what looks like a single bar, and the overlapped elements were hard to reselect.

Fix: assign a shared group id to the chart's elements in `handleChartClick` before insertion, so the chart is treated as a single unit by move/align operations. The group id is remapped consistently by `duplicateElements` on insert.

Scoped to `PasteChartDialog`. Typecheck, lint, and `charts.test.ts` pass.

### Repro
1. Paste spreadsheet data, insert as bar chart
2. Select the chart, click an align action (e.g. align left)
3. Before: bars collapse onto each other; after: chart stays intact