### PR TITLE
fix: match PWA splash background_color to theme_color

### DIFF
--- a/excalidraw-app/vite.config.mts
+++ b/excalidraw-app/vite.config.mts
@@ -256,7 +256,7 @@ export default defineConfig(({ mode }) => {
           id: "excalidraw",
           display: "standalone",
           theme_color: "#121212",
-          background_color: "#ffffff",
+          background_color: "#121212",
           file_handlers: [
             {
               action: "/",


### PR DESCRIPTION
Closes #6764.

The PWA manifest in `excalidraw-app/vite.config.mts` set `theme_color: "#121212"` but `background_color: "#ffffff"`. `background_color` is what the OS uses to paint the splash screen while the app is launching, so every installed-PWA user got a bright white flash on launch regardless of the dark `theme_color`, which is what #6764 reports as blinding at night.

The manifest spec doesn't support a `prefers-color-scheme`-conditional `background_color`, so rather than inventing a new color, this matches it to the `theme_color` already chosen for this app, removing the mismatch.

## Test plan

1. Build the app and inspect the generated manifest (`background_color` should read `#121212`).
2. Install the app as a PWA and relaunch it; the splash screen background should no longer flash white.
