### PR TITLE
fix: align action removes elements from containing frame (#6851)

### DIFF
--- a/packages/element/src/frame.ts
+++ b/packages/element/src/frame.ts
@@ -723,7 +723,9 @@ export const updateFrameMembershipOfSelectedElements = <
     if (
       element.frameId &&
       !isFrameLikeElement(element) &&
-      !isElementInFrame(element, elementsMap, appState)
+      !isElementInFrame(element, elementsMap, appState, {
+        noOptimization: true,
+      })
     ) {
       elementsToRemove.add(element);
     }
@@ -816,6 +818,10 @@ export const isElementInFrame = (
   opts?: {
     targetFrame?: ExcalidrawFrameLikeElement;
     checkedGroups?: Map<string, boolean>;
+    /** When true, skip the non-drag optimization shortcut so that frame
+     *  membership is re-evaluated even for actions (align, flip, distribute)
+     *  that move elements without a pointer drag. */
+    noOptimization?: boolean;
   },
 ) => {
   const frame =
@@ -838,13 +844,16 @@ export const isElementInFrame = (
   };
 
   if (
+    !opts?.noOptimization &&
     // if the element is not selected, or it is selected but not being dragged,
     // frame membership won't update, so return true
-    !appState.selectedElementIds[_element.id] ||
-    !appState.selectedElementsAreBeingDragged ||
-    // if both frame and element are selected, won't update membership, so return true
-    (appState.selectedElementIds[_element.id] &&
-      appState.selectedElementIds[frame.id])
+    (
+      !appState.selectedElementIds[_element.id] ||
+      !appState.selectedElementsAreBeingDragged ||
+      // if both frame and element are selected, won't update membership, so return true
+      (appState.selectedElementIds[_element.id] &&
+        appState.selectedElementIds[frame.id])
+    )
   ) {
     return true;
   }


### PR DESCRIPTION
## Summary

Elements that are moved inside a frame by align/flip/distribute actions are incorrectly removed from the frame, while elements moved outside their frame remain attached (making them invisible due to frame clipping).

Fixes #6851

## Root cause

`isElementInFrame()` has a performance optimization that short-circuits to return `true` when `selectedElementsAreBeingDragged` is `false`. The comment states: "if the element is not selected, or it is selected but not being dragged, frame membership won't update, so return true".

This assumption is incorrect. Actions like align, flip, and distribute mutate element positions through `scene.mutateElement()` without setting `selectedElementsAreBeingDragged = true`. When `updateFrameMembershipOfSelectedElements()` runs after such an action, the shortcut skips the actual overlap check, leading to stale frame membership.

## Fix

1. Added a `noOptimization` option to `isElementInFrame()` that bypasses the early-return shortcut
2. Passed `noOptimization: true` from `updateFrameMembershipOfSelectedElements()` so frame membership is re-evaluated after any action that may have moved elements

This preserves the optimization for render-time calls (`shouldApplyFrameClip`) where the shortcut is correct, while ensuring correct behavior for actions like align, flip, and distribute.

## Changes

| File | Change |
|------|--------|
| `packages/element/src/frame.ts` | +15 -6 |