### PR TITLE
fix(app): increase service worker cache limit to 3MB

### DIFF
--- a/excalidraw-app/vite.config.mts
+++ b/excalidraw-app/vite.config.mts
@@ -223,7 +223,7 @@ export default defineConfig(({ mode }) => {
               },
             },
           ],
-          maximumFileSizeToCacheInBytes: 2.3 * 1024 ** 2, // 2.3MB
+          maximumFileSizeToCacheInBytes: 3 * 1024 ** 2, // 3MB
         },
         manifest: {
           short_name: "Excalidraw",


### PR DESCRIPTION
## Summary

- Raises `maximumFileSizeToCacheInBytes` from 2.3MB to 3MB in the Vite/Workbox config to allow larger assets to be cached by the service worker.

## Test plan

- [x] Build the app and verify the service worker caches assets up to 3MB without warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)