### PR TITLE
Add export readiness warnings

### DIFF
--- a/packages/excalidraw/components/ImageExportDialog.scss
+++ b/packages/excalidraw/components/ImageExportDialog.scss
@@ -76,7 +76,7 @@
         align-items: center;
 
         background: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAMUlEQVQ4T2NkYGAQYcAP3uCTZhw1gGGYhAGBZIA/nYDCgBDAm9BGDWAAJyRCgLaBCAAgXwixzAS0pgAAAABJRU5ErkJggg==")
-          left center;
+        left center;
 
         border: 1px solid var(--ImageExportModal-preview-border);
         border-radius: 12px;
@@ -168,6 +168,24 @@
           padding-top: 32px;
           flex-basis: 100%;
           justify-content: center;
+        }
+      }
+
+      &__warnings {
+        border: 1px solid var(--color-warning);
+        border-radius: var(--border-radius-lg);
+        padding: 0.75rem;
+        margin-top: 1rem;
+        font-size: 0.875rem;
+
+        strong {
+          display: block;
+          margin-bottom: 0.5rem;
+        }
+
+        ul {
+          margin: 0;
+          padding-left: 1.25rem;
         }
       }
     }

--- a/packages/excalidraw/components/ImageExportDialog.tsx
+++ b/packages/excalidraw/components/ImageExportDialog.tsx
@@ -26,6 +26,7 @@ import { useCopyStatus } from "../hooks/useCopiedIndicator";
 
 import { t } from "../i18n";
 import { isSomeElementSelected } from "../scene";
+import { getExportReadinessWarnings } from "../scene/exportReadiness";
 
 import { copyIcon, downloadIcon, helpIcon } from "./icons";
 import { Dialog } from "./Dialog";
@@ -81,9 +82,11 @@ const ImageExportModal = ({
   const [exportWithBackground, setExportWithBackground] = useState(
     appStateSnapshot.exportBackground,
   );
+
   const [embedScene, setEmbedScene] = useState(
     appStateSnapshot.exportEmbedScene,
   );
+
   const [exportScale, setExportScale] = useState(appStateSnapshot.exportScale);
 
   const previewRef = useRef<HTMLDivElement>(null);
@@ -93,7 +96,7 @@ const ImageExportModal = ({
   const { onCopy, copyStatus, resetCopyStatus } = useCopyStatus();
 
   useEffect(() => {
-    // if user changes setting right after export to clipboard, reset the status
+    // if the user changes setting right after export to clipboard, reset the status
     // so they don't have to wait for the timeout to click the button again
     resetCopyStatus();
   }, [
@@ -111,11 +114,14 @@ const ImageExportModal = ({
     exportSelectionOnly,
   );
 
+  const exportReadinessWarnings = getExportReadinessWarnings(exportedElements);
+
   useEffect(() => {
     const previewNode = previewRef.current;
     if (!previewNode) {
       return;
     }
+
     const maxWidth = previewNode.offsetWidth;
     const maxHeight = previewNode.offsetHeight;
     if (!maxWidth) {
@@ -299,6 +305,30 @@ const ImageExportModal = ({
             }))}
           />
         </ExportSetting>
+
+        {exportReadinessWarnings.length > 0 && (
+          <div className="ImageExportModal__settings__warnings">
+            <strong>Export warnings</strong>
+            <ul>
+              {exportReadinessWarnings.map((warning) => (
+                <li key={warning.type}>
+                  {warning.type === "emptyText" &&
+                    `${warning.count} empty text element${
+                      warning.count === 1 ? "" : "s"
+                    } found.`}
+                  {warning.type === "lowOpacity" &&
+                    `${warning.count} element${
+                      warning.count === 1 ? "" : "s"
+                    } with very low opacity found.`}
+                  {warning.type === "farAwayElement" &&
+                    `${warning.count} element${
+                      warning.count === 1 ? "" : "s"
+                    } far away from the main drawing found.`}
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
 
         <div className="ImageExportModal__settings__buttons">
           <FilledButton

--- a/packages/excalidraw/scene/exportReadiness.ts
+++ b/packages/excalidraw/scene/exportReadiness.ts
@@ -1,0 +1,72 @@
+import type { NonDeletedExcalidrawElement } from "@excalidraw/element/types";
+
+export type ExportReadinessWarningType =
+  | "emptyText"
+  | "lowOpacity"
+  | "farAwayElement";
+
+export type ExportReadinessWarning = {
+  type: ExportReadinessWarningType;
+  count: number;
+};
+
+const LOW_OPACITY_THRESHOLD = 10;
+const FAR_AWAY_DISTANCE_THRESHOLD = 5000;
+
+export const getExportReadinessWarnings = (
+  elements: readonly NonDeletedExcalidrawElement[],
+): ExportReadinessWarning[] => {
+  const warnings: ExportReadinessWarning[] = [];
+
+  const emptyTextCount = elements.filter((element) => {
+    return (
+      element.type === "text" &&
+      "text" in element &&
+      element.text.trim().length === 0
+    );
+  }).length;
+
+  const lowOpacityCount = elements.filter((element) => {
+    return element.opacity <= LOW_OPACITY_THRESHOLD;
+  }).length;
+
+  if (emptyTextCount > 0) {
+    warnings.push({
+      type: "emptyText",
+      count: emptyTextCount,
+    });
+  }
+
+  if (lowOpacityCount > 0) {
+    warnings.push({
+      type: "lowOpacity",
+      count: lowOpacityCount,
+    });
+  }
+
+  if (elements.length > 1) {
+    const centerX =
+      elements.reduce((sum, element) => sum + element.x, 0) / elements.length;
+    const centerY =
+      elements.reduce((sum, element) => sum + element.y, 0) / elements.length;
+
+    const farAwayElementCount = elements.filter((element) => {
+      const distanceX = Math.abs(element.x - centerX);
+      const distanceY = Math.abs(element.y - centerY);
+
+      return (
+        distanceX > FAR_AWAY_DISTANCE_THRESHOLD ||
+        distanceY > FAR_AWAY_DISTANCE_THRESHOLD
+      );
+    }).length;
+
+    if (farAwayElementCount > 0) {
+      warnings.push({
+        type: "farAwayElement",
+        count: farAwayElementCount,
+      });
+    }
+  }
+
+  return warnings;
+};


### PR DESCRIPTION
## Summary

This PR adds a first version of optional export readiness warnings to the image export dialog.

The goal is to warn users about possible scene issues before exporting, without blocking the export action.

This PR currently checks for:

* empty text elements
* elements with very low opacity
* elements far away from the main drawing area

If warnings are found, they are shown in the export dialog before the export buttons.

## Related issue

Related to #11522

## What changed

* Added a new export readiness helper for checking exported elements.
* Added a warning section to the image export dialog.
* Added styling for the warning section.

## Testing

I tested this locally by running Excalidraw and opening the image export dialog.

I checked that:

* the export dialog still opens normally
* the PNG, SVG, and copy buttons are still available
* low opacity elements show a warning
* the warning does not block exporting
* normal export flow still works
