### PR TITLE
fix(editor): command palette shows mixed languages after switching la…

### DIFF
--- a/excalidraw-app/App.tsx
+++ b/excalidraw-app/App.tsx
@@ -1067,7 +1067,7 @@ const ExcalidrawWrapper = () => {
         <CommandPalette
           customCommandPaletteItems={[
             {
-              label: t("labels.liveCollaboration"),
+              label: () => t("labels.liveCollaboration"),
               category: DEFAULT_CATEGORIES.app,
               keywords: [
                 "team",
@@ -1086,7 +1086,7 @@ const ExcalidrawWrapper = () => {
               },
             },
             {
-              label: t("roomDialog.button_stopSession"),
+              label: () => t("roomDialog.button_stopSession"),
               category: DEFAULT_CATEGORIES.app,
               predicate: () => !!collabAPI?.isCollaborating(),
               keywords: [
@@ -1108,7 +1108,7 @@ const ExcalidrawWrapper = () => {
               },
             },
             {
-              label: t("labels.share"),
+              label: () => t("labels.share"),
               category: DEFAULT_CATEGORIES.app,
               predicate: true,
               icon: share,
@@ -1150,7 +1150,7 @@ const ExcalidrawWrapper = () => {
               },
             },
             {
-              label: t("labels.followUs"),
+              label: () => t("labels.followUs"),
               icon: XBrandIcon,
               category: DEFAULT_CATEGORIES.links,
               predicate: true,
@@ -1164,7 +1164,7 @@ const ExcalidrawWrapper = () => {
               },
             },
             {
-              label: t("labels.discordChat"),
+              label: () => t("labels.discordChat"),
               category: DEFAULT_CATEGORIES.links,
               predicate: true,
               icon: DiscordIcon,
@@ -1212,7 +1212,7 @@ const ExcalidrawWrapper = () => {
               : [ExcalidrawPlusCommand, ExcalidrawPlusAppCommand]),
 
             {
-              label: t("overwriteConfirm.action.excalidrawPlus.button"),
+              label: () => t("overwriteConfirm.action.excalidrawPlus.button"),
               category: DEFAULT_CATEGORIES.export,
               icon: exportToPlus,
               predicate: true,
@@ -1229,7 +1229,7 @@ const ExcalidrawWrapper = () => {
               },
             },
             {
-              label: t("labels.installPWA"),
+              label: () => t("labels.installPWA"),
               category: DEFAULT_CATEGORIES.app,
               predicate: () => !!pwaEvent,
               perform: () => {

--- a/packages/excalidraw/components/CommandPalette/CommandPalette.test.tsx
+++ b/packages/excalidraw/components/CommandPalette/CommandPalette.test.tsx
@@ -1,0 +1,107 @@
+import { Excalidraw } from "../../index";
+import { setLanguage, t } from "../../i18n";
+import { API } from "../../tests/helpers/api";
+import { act, render, waitFor } from "../../tests/test-utils";
+
+import { CommandPalette } from "./CommandPalette";
+
+import type { CommandPaletteItem } from "./types";
+
+const openCommandPalette = () => {
+  act(() => {
+    API.setAppState({ openDialog: { name: "commandPalette" } });
+  });
+};
+
+const getCommandLabels = () =>
+  Array.from(
+    document.querySelectorAll(".command-palette-dialog .command-item .name"),
+  ).map((el) => el.textContent ?? "");
+
+describe("CommandPalette", () => {
+  afterEach(async () => {
+    // reset language so other tests aren't affected
+    await act(async () => {
+      await setLanguage({ code: "en", label: "English" });
+    });
+  });
+
+  it("re-translates built-in command labels when the language changes while open (#11569)", async () => {
+    await render(
+      <Excalidraw>
+        <CommandPalette />
+      </Excalidraw>,
+    );
+
+    openCommandPalette();
+
+    // labels start out in English
+    await waitFor(() => {
+      const labels = getCommandLabels();
+      expect(labels.length).toBeGreaterThan(0);
+      expect(labels).toContain("Canvas background");
+    });
+
+    // switch language while the palette is open
+    await act(async () => {
+      await setLanguage({ code: "hi-IN", label: "हिन्दी" });
+    });
+
+    // labels should now all be in Hindi, with no stale English labels left over
+    await waitFor(() => {
+      const labels = getCommandLabels();
+      expect(labels).toContain("चित्रपटल पृष्ठभूमि");
+      expect(labels).not.toContain("Canvas background");
+    });
+  });
+
+  it("re-translates custom command labels passed as a function on language change (#11569)", async () => {
+    // a function label is resolved lazily on each language change; a plain
+    // string label is captured once and intentionally does not update.
+    const customItems: CommandPaletteItem[] = [
+      {
+        label: () => t("labels.share"),
+        category: "App",
+        predicate: true,
+        perform: () => {},
+      },
+      {
+        label: t("labels.share"),
+        category: "App",
+        predicate: true,
+        perform: () => {},
+      },
+    ];
+
+    await render(
+      <Excalidraw>
+        <CommandPalette customCommandPaletteItems={customItems} />
+      </Excalidraw>,
+    );
+
+    const englishShare = t("labels.share");
+
+    openCommandPalette();
+
+    await waitFor(() => {
+      const labels = getCommandLabels();
+      // both the lazy and the plain-string item render in English initially
+      expect(labels.filter((l) => l === englishShare)).toHaveLength(2);
+    });
+
+    await act(async () => {
+      await setLanguage({ code: "hi-IN", label: "हिन्दी" });
+    });
+
+    const hindiShare = t("labels.share");
+    expect(hindiShare).not.toEqual(englishShare);
+
+    await waitFor(() => {
+      const labels = getCommandLabels();
+      // the function label re-translates to Hindi...
+      expect(labels).toContain(hindiShare);
+      // ...while the plain-string label stays in its originally-captured value
+      expect(labels).toContain(englishShare);
+    });
+  });
+});

--- a/packages/excalidraw/components/CommandPalette/CommandPalette.tsx
+++ b/packages/excalidraw/components/CommandPalette/CommandPalette.tsx
@@ -30,7 +30,7 @@ import { trackEvent } from "../../analytics";
 import { useUIAppState } from "../../context/ui-appState";
 import { deburr } from "../../deburr";
 import { atom, useAtom, editorJotaiStore } from "../../editor-jotai";
-import { t } from "../../i18n";
+import { t, useI18n } from "../../i18n";
 import {
   useApp,
   useAppProps,
@@ -75,13 +75,13 @@ import {
 import * as defaultItems from "./defaultCommandPaletteItems";
 import "./CommandPalette.scss";
 
-import type { CommandPaletteItem } from "./types";
+import type { CommandPaletteItem, ResolvedCommandPaletteItem } from "./types";
 import type { AppProps, AppState, LibraryItem, UIAppState } from "../../types";
 import type { ShortcutName } from "../../actions/shortcuts";
 import type { TranslationKeys } from "../../i18n";
 import type { Action } from "../../actions/types";
 
-const lastUsedPaletteItem = atom<CommandPaletteItem | null>(null);
+const lastUsedPaletteItem = atom<ResolvedCommandPaletteItem | null>(null);
 
 export const DEFAULT_CATEGORIES = {
   app: "App",
@@ -204,10 +204,11 @@ function CommandPaletteInner({
   const setAppState = useExcalidrawSetAppState();
   const appProps = useAppProps();
   const actionManager = useExcalidrawActionManager();
+  const { langCode } = useI18n();
 
   const [lastUsed, setLastUsed] = useAtom(lastUsedPaletteItem);
   const [allCommands, setAllCommands] = useState<
-    MarkRequired<CommandPaletteItem, "haystack" | "order">[] | null
+    MarkRequired<ResolvedCommandPaletteItem, "haystack" | "order">[] | null
   >(null);
 
   const inputRef = useRef<HTMLInputElement>(null);
@@ -219,7 +220,7 @@ function CommandPaletteInner({
   });
 
   const [libraryItemsData] = useAtom(libraryItemsAtom);
-  const libraryCommands: CommandPaletteItem[] = useMemo(() => {
+  const libraryCommands: ResolvedCommandPaletteItem[] = useMemo(() => {
     return (
       libraryItemsData.libraryItems
         ?.filter(
@@ -614,11 +615,20 @@ function CommandPaletteInner({
         ...additionalCommands,
         ...(customCommandPaletteItems || []),
       ].map((command) => {
+        // resolve lazy labels so the rest of the palette can treat the
+        // label as a plain string (used as React key, haystack, and the
+        // identity key for selection / last-used matching). Resolving here
+        // (inside the `langCode`-dependent effect) keeps custom item labels
+        // in sync with the active language (#11569).
+        const label =
+          typeof command.label === "function" ? command.label() : command.label;
+
         return {
           ...command,
+          label,
           icon: command.icon || boltIcon,
           order: command.order ?? getCategoryOrder(command.category),
-          haystack: `${deburr(command.label.toLocaleLowerCase())} ${
+          haystack: `${deburr(label.toLocaleLowerCase())} ${
             command.keywords?.join(" ") || ""
           }`,
         };
@@ -640,13 +650,14 @@ function CommandPaletteInner({
     setLastUsed,
     setAppState,
     libraryCommands,
+    langCode,
   ]);
 
   const [commandSearch, setCommandSearch] = useState("");
   const [currentCommand, setCurrentCommand] =
-    useState<CommandPaletteItem | null>(null);
+    useState<ResolvedCommandPaletteItem | null>(null);
   const [commandsByCategory, setCommandsByCategory] = useState<
-    Record<string, CommandPaletteItem[]>
+    Record<string, ResolvedCommandPaletteItem[]>
   >({});
 
   const closeCommandPalette = (cb?: () => void) => {
@@ -660,7 +671,7 @@ function CommandPaletteInner({
   };
 
   const executeCommand = (
-    command: CommandPaletteItem,
+    command: ResolvedCommandPaletteItem,
     event: React.MouseEvent | React.KeyboardEvent | KeyboardEvent,
   ) => {
     if (uiAppState.openDialog?.name === "commandPalette") {
@@ -679,7 +690,7 @@ function CommandPaletteInner({
   };
 
   const isCommandAvailable = useStableCallback(
-    (command: CommandPaletteItem) => {
+    (command: ResolvedCommandPaletteItem) => {
       if (command.viewMode === false && uiAppState.viewModeEnabled) {
         return false;
       }
@@ -823,8 +834,13 @@ function CommandPaletteInner({
       return;
     }
 
-    const getNextCommandsByCategory = (commands: CommandPaletteItem[]) => {
-      const nextCommandsByCategory: Record<string, CommandPaletteItem[]> = {};
+    const getNextCommandsByCategory = (
+      commands: ResolvedCommandPaletteItem[],
+    ) => {
+      const nextCommandsByCategory: Record<
+        string,
+        ResolvedCommandPaletteItem[]
+      > = {};
       for (const command of commands) {
         if (nextCommandsByCategory[command.category]) {
           nextCommandsByCategory[command.category].push(command);
@@ -999,7 +1015,7 @@ const CommandItem = ({
   appState,
   size = "small",
 }: {
-  command: CommandPaletteItem;
+  command: ResolvedCommandPaletteItem;
   isSelected: boolean;
   disabled?: boolean;
   onMouseMove: () => void;

--- a/packages/excalidraw/components/CommandPalette/types.ts
+++ b/packages/excalidraw/components/CommandPalette/types.ts
@@ -2,7 +2,13 @@ import type { ActionManager } from "../../actions/manager";
 import type { Action } from "../../actions/types";
 
 export type CommandPaletteItem = {
-  label: string;
+  /**
+   * Command label. Pass a function to have it resolved lazily on each
+   * language change, so labels stay in sync with the active language
+   * (see #11569). Plain strings are captured at creation time and won't
+   * update when the language changes.
+   */
+  label: string | (() => string);
   /** additional keywords to match against
    * (appended to haystack, not displayed) */
   keywords?: string[];
@@ -22,4 +28,13 @@ export type CommandPaletteItem = {
     actionManager: ActionManager;
     event: React.MouseEvent | React.KeyboardEvent | KeyboardEvent;
   }) => void;
+};
+
+/**
+ * A {@link CommandPaletteItem} after its (possibly lazy) `label` has been
+ * resolved to a string. Used internally once commands have been built, so
+ * the rest of the palette can treat `label` as a plain string.
+ */
+export type ResolvedCommandPaletteItem = Omit<CommandPaletteItem, "label"> & {
+  label: string;
 };


### PR DESCRIPTION
# fix: command palette shows a mix of languages after switching language (#11569)

Fixes #11569

## What

After switching the UI language back and forth (e.g. English → Hindi → English) with the command palette open, some command labels stayed in the previous language while the rest updated. This PR makes **all** command palette labels — built-in *and* app-provided custom ones — re-translate on language change.

## Why it happened

Two independent causes:

1. **Built-in labels** — the effect in `CommandPalette.tsx` that builds the commands (and calls `t()` on each label) reads its inputs through `useStable` (stable identity by design) and didn't list `langCode` in its deps, so it never re-ran on a language change.
2. **Custom items** (`customCommandPaletteItems` from `excalidraw-app/App.tsx`, e.g. Live collaboration / Share) — these call `t()` in the app component, which re-renders on the app language atom *before* the locale JSON is loaded async by `setLanguage`, and doesn't re-render again afterwards. So their labels were captured stale.

## Changes

- `CommandPalette.tsx` — add `langCode` (via `useI18n()`) to the command-building effect's dependency array so labels re-translate while the palette is open.
- `types.ts` / `CommandPalette.tsx` — allow `CommandPaletteItem.label` to be `string | (() => string)`; the function form is resolved **inside** the `langCode`-dependent effect (i.e. within the editor, where the language atom lives). A `ResolvedCommandPaletteItem` type carries the resolved string label downstream (it's used as the React `key`, the search haystack, and the identity key for selection / last-used matching).
- `excalidraw-app/App.tsx` — pass translated custom labels as `label: () => t("...")` so they resolve at the right time.
- Added `CommandPalette.test.tsx` covering re-translation of built-in and custom labels on language change.

## Testing

- `yarn test:typecheck` 
- `yarn test` (new `CommandPalette` tests) 
- Manual, end-to-end: open the command palette, switch language back and forth — all labels now update together, no stale leftovers.

## Notes

- Plain-string custom labels are still captured at creation time (they won't auto-update on language change); pass a `() => t("...")` function for labels that need to follow the active language. This is documented on the `label` type.
- Approaches that were ruled out (and why) are described in #11569.