### PR TITLE
fix(editor): ignore IME composition keys in search navigation

### DIFF
--- a/packages/excalidraw/components/SearchMenu.tsx
+++ b/packages/excalidraw/components/SearchMenu.tsx
@@ -316,6 +316,12 @@ export const SearchMenu = () => {
         event.target instanceof HTMLElement &&
         event.target.closest(".layer-ui__search")
       ) {
+        // ignore the Enter/arrow keys that confirm or move through an IME
+        // composition so they don't also jump between search matches
+        if (event.isComposing || event.keyCode === 229) {
+          return;
+        }
+
         if (stableState.searchMatches.items.length) {
           if (event.key === KEYS.ENTER) {
             event.stopPropagation();


### PR DESCRIPTION
The search panel jumps between matches on a keypress that is part of an in-progress IME composition.

`SearchMenu` registers a window `keydown` handler (capture phase). When there are matches and the event target is inside `.layer-ui__search`, it moves to the next/previous match on Enter, ArrowDown and ArrowUp:

```ts
if (event.key === KEYS.ENTER) {
  event.stopPropagation();
  stableState.goToNextItem();
}
```

So when you search for CJK text and press Enter to confirm the IME conversion (or press the arrow keys to move through the candidate list), that same keydown also runs the match navigation and the canvas scrolls to another match while you are still composing.

The editor already handles this in its other text inputs. `ProjectName` has:

```ts
if (event.nativeEvent.isComposing || event.keyCode === 229) {
  return;
}
```

and `textWysiwyg` uses the same check on the native event. This applies that guard to the search handler, so Enter/Arrow during a composition no longer move between matches. For a normal keypress (`isComposing === false`, real `keyCode`) nothing changes.

I didn't add a unit test: the existing guards aren't covered either, and jsdom doesn't dispatch `isComposing` reliably, so reproducing it needs a real IME. I checked the branch by hand; the guard is a no-op for non-composition keys and only skips navigation while composing. Glad to add a test if you'd prefer one.
