### PR TITLE
fix: crash when shift-deselecting a group alongside individual elements

### DIFF
--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -11230,7 +11230,7 @@ class App extends React.Component<AppProps, AppState> {
 
                 return {
                   selectedGroupIds: {
-                    ..._prevState.selectedElementIds,
+                    ..._prevState.selectedGroupIds,
                     ...hitElement.groupIds
                       .map((gId) => ({ [gId]: false }))
                       .reduce((prev, acc) => ({ ...prev, ...acc }), {}),

--- a/packages/excalidraw/tests/__snapshots__/regressionTests.test.tsx.snap
+++ b/packages/excalidraw/tests/__snapshots__/regressionTests.test.tsx.snap
@@ -525,10 +525,7 @@ exports[`given element A and group of elements B and given both are selected whe
   },
   "selectedElementsAreBeingDragged": false,
   "selectedGroupIds": {
-    "id0": true,
     "id12": false,
-    "id3": true,
-    "id6": true,
   },
   "selectedLinearElement": null,
   "selectionElement": null,
@@ -817,10 +814,7 @@ exports[`given element A and group of elements B and given both are selected whe
         "deleted": {
           "selectedElementIds": {},
           "selectedGroupIds": {
-            "id0": true,
             "id12": false,
-            "id3": true,
-            "id6": true,
           },
         },
         "inserted": {
@@ -11918,6 +11912,543 @@ exports[`regression tests > shift-click to multiselect, then drag > [end of test
       },
     },
     "id": "id14",
+  },
+]
+`;
+
+exports[`regression tests > shift-deselecting a group while individual elements are selected keeps selectedGroupIds free of element ids > [end of test] appState 1`] = `
+{
+  "activeEmbeddable": null,
+  "activeLockedId": null,
+  "activeTool": {
+    "customType": null,
+    "fromSelection": false,
+    "lastActiveTool": null,
+    "locked": false,
+    "type": "selection",
+  },
+  "bindMode": "orbit",
+  "bindingPreference": "enabled",
+  "boxSelectionMode": "contain",
+  "collaborators": Map {},
+  "contextMenu": null,
+  "croppingElementId": null,
+  "currentHoveredFontFamily": null,
+  "currentItemArrowType": "round",
+  "currentItemBackgroundColor": "transparent",
+  "currentItemEndArrowhead": "arrow",
+  "currentItemFillStyle": "solid",
+  "currentItemFontFamily": 5,
+  "currentItemFontSize": 20,
+  "currentItemOpacity": 100,
+  "currentItemRoughness": 1,
+  "currentItemRoundness": "sharp",
+  "currentItemStartArrowhead": null,
+  "currentItemStrokeColor": "#1e1e1e",
+  "currentItemStrokeStyle": "solid",
+  "currentItemStrokeVariability": "constant",
+  "currentItemStrokeWidthKey": "medium",
+  "currentItemTextAlign": "left",
+  "cursorButton": "up",
+  "defaultSidebarDockedPreference": false,
+  "editingFrame": null,
+  "editingGroupId": null,
+  "editingTextElement": null,
+  "elementsToHighlight": null,
+  "errorMessage": null,
+  "exportBackground": true,
+  "exportEmbedScene": false,
+  "exportScale": 1,
+  "exportWithDarkMode": false,
+  "fileHandle": null,
+  "followedBy": Set {},
+  "frameRendering": {
+    "clip": true,
+    "enabled": true,
+    "name": true,
+    "outline": true,
+  },
+  "frameToHighlight": null,
+  "gridModeEnabled": false,
+  "gridSize": 20,
+  "gridStep": 5,
+  "height": 768,
+  "hoveredElementIds": {},
+  "isBindingEnabled": true,
+  "isCropping": false,
+  "isLoading": false,
+  "isMidpointSnappingEnabled": true,
+  "isResizing": false,
+  "isRotating": false,
+  "lastPointerDownWith": "mouse",
+  "lockedMultiSelections": {},
+  "multiElement": null,
+  "name": "Untitled-201933152653",
+  "newElement": null,
+  "objectsSnapModeEnabled": false,
+  "offsetLeft": 0,
+  "offsetTop": 0,
+  "openDialog": null,
+  "openMenu": null,
+  "openPopup": null,
+  "openSidebar": null,
+  "originSnapOffset": null,
+  "penDetected": false,
+  "penMode": false,
+  "preferredSelectionTool": {
+    "initialized": true,
+    "type": "selection",
+  },
+  "previousSelectedElementIds": {
+    "id0": true,
+    "id3": true,
+    "id6": true,
+    "id9": true,
+  },
+  "resizingElement": null,
+  "scrollX": 0,
+  "scrollY": 0,
+  "scrolledOutside": false,
+  "searchMatches": null,
+  "selectedElementIds": {
+    "id0": true,
+    "id3": true,
+  },
+  "selectedElementsAreBeingDragged": false,
+  "selectedGroupIds": {
+    "id18": false,
+  },
+  "selectedLinearElement": null,
+  "selectionElement": null,
+  "shouldCacheIgnoreZoom": false,
+  "showHyperlinkPopup": false,
+  "showWelcomeScreen": true,
+  "snapLines": [],
+  "stats": {
+    "open": false,
+    "panels": 3,
+  },
+  "suggestedBinding": null,
+  "theme": "light",
+  "toast": null,
+  "userToFollow": null,
+  "viewBackgroundColor": "#ffffff",
+  "viewModeEnabled": false,
+  "width": 1440,
+  "zenModeEnabled": false,
+  "zoom": {
+    "value": 1,
+  },
+}
+`;
+
+exports[`regression tests > shift-deselecting a group while individual elements are selected keeps selectedGroupIds free of element ids > [end of test] number of elements 1`] = `0`;
+
+exports[`regression tests > shift-deselecting a group while individual elements are selected keeps selectedGroupIds free of element ids > [end of test] number of renders 1`] = `24`;
+
+exports[`regression tests > shift-deselecting a group while individual elements are selected keeps selectedGroupIds free of element ids > [end of test] redo stack 1`] = `[]`;
+
+exports[`regression tests > shift-deselecting a group while individual elements are selected keeps selectedGroupIds free of element ids > [end of test] undo stack 1`] = `
+[
+  {
+    "appState": AppStateDelta {
+      "delta": Delta {
+        "deleted": {
+          "selectedElementIds": {
+            "id0": true,
+          },
+        },
+        "inserted": {
+          "selectedElementIds": {},
+        },
+      },
+    },
+    "elements": {
+      "added": {},
+      "removed": {
+        "id0": {
+          "deleted": {
+            "angle": 0,
+            "backgroundColor": "transparent",
+            "boundElements": null,
+            "customData": undefined,
+            "fillStyle": "solid",
+            "frameId": null,
+            "groupIds": [],
+            "height": 10,
+            "index": "a0",
+            "isDeleted": false,
+            "link": null,
+            "locked": false,
+            "opacity": 100,
+            "roughness": 1,
+            "roundness": null,
+            "strokeColor": "#1e1e1e",
+            "strokeStyle": "solid",
+            "strokeWidth": 2,
+            "type": "rectangle",
+            "version": 3,
+            "width": 10,
+            "x": 0,
+            "y": 0,
+          },
+          "inserted": {
+            "isDeleted": true,
+            "version": 2,
+          },
+        },
+      },
+      "updated": {},
+    },
+    "id": "id2",
+  },
+  {
+    "appState": AppStateDelta {
+      "delta": Delta {
+        "deleted": {
+          "selectedElementIds": {
+            "id3": true,
+          },
+        },
+        "inserted": {
+          "selectedElementIds": {
+            "id0": true,
+          },
+        },
+      },
+    },
+    "elements": {
+      "added": {},
+      "removed": {
+        "id3": {
+          "deleted": {
+            "angle": 0,
+            "backgroundColor": "transparent",
+            "boundElements": null,
+            "customData": undefined,
+            "fillStyle": "solid",
+            "frameId": null,
+            "groupIds": [],
+            "height": 10,
+            "index": "a1",
+            "isDeleted": false,
+            "link": null,
+            "locked": false,
+            "opacity": 100,
+            "roughness": 1,
+            "roundness": null,
+            "strokeColor": "#1e1e1e",
+            "strokeStyle": "solid",
+            "strokeWidth": 2,
+            "type": "rectangle",
+            "version": 3,
+            "width": 10,
+            "x": 30,
+            "y": 0,
+          },
+          "inserted": {
+            "isDeleted": true,
+            "version": 2,
+          },
+        },
+      },
+      "updated": {},
+    },
+    "id": "id5",
+  },
+  {
+    "appState": AppStateDelta {
+      "delta": Delta {
+        "deleted": {
+          "selectedElementIds": {
+            "id6": true,
+          },
+        },
+        "inserted": {
+          "selectedElementIds": {
+            "id3": true,
+          },
+        },
+      },
+    },
+    "elements": {
+      "added": {},
+      "removed": {
+        "id6": {
+          "deleted": {
+            "angle": 0,
+            "backgroundColor": "transparent",
+            "boundElements": null,
+            "customData": undefined,
+            "fillStyle": "solid",
+            "frameId": null,
+            "groupIds": [],
+            "height": 10,
+            "index": "a2",
+            "isDeleted": false,
+            "link": null,
+            "locked": false,
+            "opacity": 100,
+            "roughness": 1,
+            "roundness": null,
+            "strokeColor": "#1e1e1e",
+            "strokeStyle": "solid",
+            "strokeWidth": 2,
+            "type": "rectangle",
+            "version": 3,
+            "width": 10,
+            "x": 0,
+            "y": 60,
+          },
+          "inserted": {
+            "isDeleted": true,
+            "version": 2,
+          },
+        },
+      },
+      "updated": {},
+    },
+    "id": "id8",
+  },
+  {
+    "appState": AppStateDelta {
+      "delta": Delta {
+        "deleted": {
+          "selectedElementIds": {
+            "id9": true,
+          },
+        },
+        "inserted": {
+          "selectedElementIds": {
+            "id6": true,
+          },
+        },
+      },
+    },
+    "elements": {
+      "added": {},
+      "removed": {
+        "id9": {
+          "deleted": {
+            "angle": 0,
+            "backgroundColor": "transparent",
+            "boundElements": null,
+            "customData": undefined,
+            "fillStyle": "solid",
+            "frameId": null,
+            "groupIds": [],
+            "height": 10,
+            "index": "a3",
+            "isDeleted": false,
+            "link": null,
+            "locked": false,
+            "opacity": 100,
+            "roughness": 1,
+            "roundness": null,
+            "strokeColor": "#1e1e1e",
+            "strokeStyle": "solid",
+            "strokeWidth": 2,
+            "type": "rectangle",
+            "version": 3,
+            "width": 10,
+            "x": 30,
+            "y": 60,
+          },
+          "inserted": {
+            "isDeleted": true,
+            "version": 2,
+          },
+        },
+      },
+      "updated": {},
+    },
+    "id": "id11",
+  },
+  {
+    "appState": AppStateDelta {
+      "delta": Delta {
+        "deleted": {
+          "selectedElementIds": {
+            "id6": true,
+          },
+        },
+        "inserted": {
+          "selectedElementIds": {
+            "id9": true,
+          },
+        },
+      },
+    },
+    "elements": {
+      "added": {},
+      "removed": {},
+      "updated": {},
+    },
+    "id": "id14",
+  },
+  {
+    "appState": AppStateDelta {
+      "delta": Delta {
+        "deleted": {
+          "selectedElementIds": {
+            "id9": true,
+          },
+        },
+        "inserted": {
+          "selectedElementIds": {},
+        },
+      },
+    },
+    "elements": {
+      "added": {},
+      "removed": {},
+      "updated": {},
+    },
+    "id": "id17",
+  },
+  {
+    "appState": AppStateDelta {
+      "delta": Delta {
+        "deleted": {
+          "selectedGroupIds": {
+            "id18": true,
+          },
+        },
+        "inserted": {
+          "selectedGroupIds": {},
+        },
+      },
+    },
+    "elements": {
+      "added": {},
+      "removed": {},
+      "updated": {
+        "id6": {
+          "deleted": {
+            "groupIds": [
+              "id18",
+            ],
+            "version": 4,
+          },
+          "inserted": {
+            "groupIds": [],
+            "version": 3,
+          },
+        },
+        "id9": {
+          "deleted": {
+            "groupIds": [
+              "id18",
+            ],
+            "version": 4,
+          },
+          "inserted": {
+            "groupIds": [],
+            "version": 3,
+          },
+        },
+      },
+    },
+    "id": "id20",
+  },
+  {
+    "appState": AppStateDelta {
+      "delta": Delta {
+        "deleted": {
+          "selectedElementIds": {
+            "id0": true,
+          },
+          "selectedGroupIds": {},
+        },
+        "inserted": {
+          "selectedElementIds": {
+            "id6": true,
+            "id9": true,
+          },
+          "selectedGroupIds": {
+            "id18": true,
+          },
+        },
+      },
+    },
+    "elements": {
+      "added": {},
+      "removed": {},
+      "updated": {},
+    },
+    "id": "id23",
+  },
+  {
+    "appState": AppStateDelta {
+      "delta": Delta {
+        "deleted": {
+          "selectedElementIds": {
+            "id3": true,
+          },
+        },
+        "inserted": {
+          "selectedElementIds": {},
+        },
+      },
+    },
+    "elements": {
+      "added": {},
+      "removed": {},
+      "updated": {},
+    },
+    "id": "id26",
+  },
+  {
+    "appState": AppStateDelta {
+      "delta": Delta {
+        "deleted": {
+          "selectedElementIds": {
+            "id6": true,
+            "id9": true,
+          },
+          "selectedGroupIds": {
+            "id18": true,
+          },
+        },
+        "inserted": {
+          "selectedElementIds": {},
+          "selectedGroupIds": {},
+        },
+      },
+    },
+    "elements": {
+      "added": {},
+      "removed": {},
+      "updated": {},
+    },
+    "id": "id29",
+  },
+  {
+    "appState": AppStateDelta {
+      "delta": Delta {
+        "deleted": {
+          "selectedElementIds": {},
+          "selectedGroupIds": {
+            "id18": false,
+          },
+        },
+        "inserted": {
+          "selectedElementIds": {
+            "id6": true,
+            "id9": true,
+          },
+          "selectedGroupIds": {
+            "id18": true,
+          },
+        },
+      },
+    },
+    "elements": {
+      "added": {},
+      "removed": {},
+      "updated": {},
+    },
+    "id": "id32",
   },
 ]
 `;

--- a/packages/excalidraw/tests/regressionTests.test.tsx
+++ b/packages/excalidraw/tests/regressionTests.test.tsx
@@ -1079,6 +1079,44 @@ describe("regression tests", () => {
     expect(API.getSelectedElements()).toEqual([rect2.get()]);
   });
 
+  it("shift-deselecting a group while individual elements are selected keeps selectedGroupIds free of element ids", () => {
+    const rectA = UI.createElement("rectangle", { x: 0 });
+    const rectB = UI.createElement("rectangle", { x: 30 });
+
+    const rect1 = UI.createElement("rectangle", { x: 0, y: 60 });
+    const rect2 = UI.createElement("rectangle", { x: 30, y: 60 });
+    UI.group([rect1, rect2]);
+    const groupId = rect1.groupIds[0];
+
+    API.clearSelection();
+
+    // select two individual elements
+    mouse.clickOn(rectA);
+    Keyboard.withModifierKeys({ shift: true }, () => {
+      mouse.clickOn(rectB);
+    });
+
+    // shift-select the whole group
+    Keyboard.withModifierKeys({ shift: true }, () => {
+      mouse.clickOn(rect1);
+    });
+    expect(h.state.selectedGroupIds).toEqual({ [groupId]: true });
+
+    // shift-click a group member to deselect the group (isSelectedViaGroup path)
+    Keyboard.withModifierKeys({ shift: true }, () => {
+      mouse.clickOn(rect2);
+    });
+
+    // selectedGroupIds must only ever hold group ids, never element ids
+    const elementIds = [rectA.id, rectB.id, rect1.id, rect2.id];
+    for (const id of Object.keys(h.state.selectedGroupIds)) {
+      expect(elementIds).not.toContain(id);
+    }
+
+    // the two individual elements stay selected, group members are dropped
+    assertSelectedElements(rectA, rectB);
+  });
+
   it("Cmd/Ctrl-click exclusively select element under pointer", () => {
     const rect1 = UI.createElement("rectangle", { x: 0 });
     const rect2 = UI.createElement("rectangle", { x: 30 });


### PR DESCRIPTION
## Fixes #9004

### Repro
1. Shift-select two individual elements
2. Shift-select a whole group
3. Shift-click a group member to deselect it → **crash**

### Root cause
In the shift-click deselect path (`isSelectedViaGroup`) in `App.tsx`, the next `selectedGroupIds` was built by spreading `selectedElementIds` instead of `selectedGroupIds`:

```ts
selectedGroupIds: {
  ..._prevState.selectedElementIds, // ← element ids leak into the group map
  ...hitElement.groupIds.map((gId) => ({ [gId]: false }))...
}
```

This polluted `selectedGroupIds` with element ids, corrupting group-selection state. The next selection change then operated on the corrupted map and crashed.

### Fix
Spread `selectedGroupIds` instead. One-line change.

### Test
Added a regression test in `regressionTests.test.tsx` that asserts `selectedGroupIds` never holds element ids after the deselect. It fails on `master` (`selectedGroupIds` contains the 4 element ids) and passes with the fix. Also corrects the stale snapshot in the existing "…only element A should be selected" test, which had baked in the buggy `selectedGroupIds`.