### PR TITLE
fix: allow canvas wheel pan/zoom while editing a frame name

### DIFF
--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -12714,7 +12714,7 @@ class App extends React.Component<AppProps, AppState> {
           event.target instanceof HTMLTextAreaElement ||
           event.target instanceof HTMLIFrameElement ||
           (event.target instanceof HTMLElement &&
-            event.target.classList.contains(CLASSES.FRAME_NAME))
+            event.target.closest(`.${CLASSES.FRAME_NAME}`) != null)
         )
       ) {
         // prevent zooming the browser (but allow scrolling DOM)

--- a/packages/excalidraw/tests/frameNameWheel.test.tsx
+++ b/packages/excalidraw/tests/frameNameWheel.test.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+
+import { CLASSES } from "@excalidraw/common";
+
+import { Excalidraw } from "../index";
+
+import { API } from "./helpers/api";
+import { render, fireEvent, act, waitFor } from "./test-utils";
+
+const { h } = window;
+
+describe("frame name wheel", () => {
+  it("wheel pans the canvas while editing a frame name", async () => {
+    await render(<Excalidraw />);
+
+    const frame = API.createElement({
+      type: "frame",
+      x: 0,
+      y: 0,
+      width: 200,
+      height: 200,
+    });
+    API.setElements([frame]);
+    act(() => {
+      API.setAppState({ editingFrame: frame.id });
+    });
+
+    // the rename <input> renders inside the .frame-name container
+    let input: HTMLInputElement | null = null;
+    await waitFor(() => {
+      input = document.querySelector(`.${CLASSES.FRAME_NAME} input`);
+      expect(input).not.toBeNull();
+    });
+
+    const scrollYBefore = h.state.scrollY;
+    fireEvent.wheel(input!, { deltaX: 0, deltaY: 100 });
+
+    // wheeling over the rename input should still pan the canvas
+    expect(h.state.scrollY).not.toBe(scrollYBefore);
+  });
+});


### PR DESCRIPTION
## Fixes #9170

### Repro
1. Double-click a frame's name to edit it
2. With the cursor over the rename input, scroll / ctrl+scroll to pan or zoom the canvas → nothing happens
3. Click away to stop editing → wheel works again

### Cause
`handleWheel` only forwards wheel events to the pan/zoom logic when the target is the canvas, a textarea, an iframe, or an element with the `frame-name` class:

```ts
event.target instanceof HTMLElement &&
  event.target.classList.contains(CLASSES.FRAME_NAME)
```

The hover-over-title case was fixed in #10340, but while editing, the rename `<input>` is a **child** of the `.frame-name` element, so `event.target` is the input — which doesn't carry the class — and the handler bails out before panning/zooming.

### Fix
Match against the closest `.frame-name` ancestor instead, so wheel events originating from the rename input are forwarded too:

```ts
event.target instanceof HTMLElement &&
  event.target.closest(`.${CLASSES.FRAME_NAME}`) != null
```

`closest` also matches the element itself, so the hover case keeps working.

### Test
Added `frameNameWheel.test.tsx`: enters frame-name edit mode and dispatches a wheel event on the rename input, asserting the canvas scrolls. Fails on master (scroll unchanged), passes with the fix.