### PR TITLE
fix: coerce restored `collaborators` to a Map

### DIFF
--- a/packages/excalidraw/data/restore.ts
+++ b/packages/excalidraw/data/restore.ts
@@ -1147,6 +1147,13 @@ export const restoreAppState = (
       isFiniteNumber(appState.gridStep) ? appState.gridStep : DEFAULT_GRID_STEP,
     ),
     editingFrame: null,
+    // `collaborators` is a Map, which `JSON.stringify` turns into `{}`, so a
+    // persisted-and-reimported appState yields a plain object here. Coerce it
+    // back to a Map to avoid `collaborators.forEach/.has is not a function`.
+    collaborators:
+      nextAppState.collaborators instanceof Map
+        ? nextAppState.collaborators
+        : new Map(),
   };
 };
 

--- a/packages/excalidraw/tests/data/restore.test.ts
+++ b/packages/excalidraw/tests/data/restore.test.ts
@@ -881,6 +881,35 @@ describe("restoreAppState", () => {
     );
   });
 
+  it("should coerce a JSON-serialized `collaborators` back to a Map", () => {
+    // `JSON.stringify` turns the `collaborators` Map into `{}`; reimporting
+    // such an appState must not yield a plain object (would crash on
+    // `collaborators.forEach`/`.has`).
+    const serializedAppState = JSON.parse(JSON.stringify(getDefaultAppState()));
+    expect(serializedAppState.collaborators).toEqual({});
+
+    const restoredAppState = restore.restoreAppState(serializedAppState, null);
+    expect(restoredAppState.collaborators).toBeInstanceOf(Map);
+    expect(restoredAppState.collaborators.size).toBe(0);
+  });
+
+  it("should preserve a `collaborators` Map passed through restore", () => {
+    const collaborators = new Map<any, any>([["socket-1", { username: "a" }]]);
+    const stubImportedAppState = {
+      ...getDefaultAppState(),
+      collaborators,
+    } as any;
+
+    const restoredAppState = restore.restoreAppState(
+      stubImportedAppState,
+      null,
+    );
+    expect(restoredAppState.collaborators).toBeInstanceOf(Map);
+    expect(
+      restoredAppState.collaborators.get("socket-1" as any)?.username,
+    ).toBe("a");
+  });
+
   it("when imported data state has a not allowed Excalidraw Element Types", () => {
     const stubImportedAppState: any = getDefaultAppState();
 


### PR DESCRIPTION
## Fixes #8637

### Repro
```tsx
const appState = excalidrawAPI.getAppState();
// collaborators serializes to {} via JSON.stringify
<Excalidraw initialData={{ appState: JSON.parse(JSON.stringify(appState)) }} />
```
Reusing a saved appState crashes with `collaborators.forEach is not a function` (also `.has`).

### Cause
`appState.collaborators` is a `Map`. `JSON.stringify` turns a `Map` into `{}`, so a persisted-and-reimported appState carries `collaborators` as a plain object. `restoreAppState` copied that value through unchanged (the default-key loop prefers the supplied value), so the restored state held an object where the editor expects a `Map` — and `.forEach` / `.has` calls on it throw.

### Fix
Coerce `collaborators` back to a `Map` in `restoreAppState` — kept as-is if already a `Map`, otherwise reset to an empty `Map` (the serialized entries carry no usable live-collaborator state).

### Test
Added two cases to `restore.test.ts`:
- a JSON-serialized appState (`collaborators === {}`) restores to an empty `Map` — fails on master (`expected {} to be an instance of Map`), passes with the fix
- a real `Map` passed through restore is preserved