### PR TITLE
fix: case-insensitive keyTest for save shortcut to prevent browser save dialog when editing text (#9281)

### DIFF
--- a/packages/excalidraw/actions/actionExport.tsx
+++ b/packages/excalidraw/actions/actionExport.tsx
@@ -369,7 +369,9 @@ export const actionSaveToActiveFile = register({
     }
   },
   keyTest: (event) =>
-    event.key === KEYS.S && event[KEYS.CTRL_OR_CMD] && !event.shiftKey,
+    event.key.toLowerCase() === KEYS.S &&
+    event[KEYS.CTRL_OR_CMD] &&
+    !event.shiftKey,
 });
 
 export const actionSaveFileToDisk = register({


### PR DESCRIPTION
## Description

When editing text in the WYSIWYG editor, pressing Ctrl/Cmd+S would trigger the browser's native 'Save Page As' dialog instead of saving the .excalidraw file.

## Root Cause

The \keyTest\ for \ctionSaveToActiveFile\ used strict comparison (\event.key === KEYS.S\) which fails when \event.key\ reports uppercase \'S'\ on some keyboard layouts/browsers when Ctrl is held.

## Fix

Made the keyTest case-insensitive by using \event.key.toLowerCase()\, consistent with the existing \ctionSaveFileToDisk\ keyTest.

Fixes #9281