### PR TITLE
fix(i18n): fallback to key path for missing translations

### DIFF
--- a/packages/excalidraw/i18n.ts
+++ b/packages/excalidraw/i18n.ts
@@ -143,12 +143,10 @@ export const t = (
     fallback;
   if (translation === undefined) {
     const errorMessage = `Can't find translation for ${path}`;
-    // in production, don't blow up the app on a missing translation key
-    if (import.meta.env.PROD) {
-      console.warn(errorMessage);
-      return "";
-    }
-    throw new Error(errorMessage);
+    // fallback to the key path so the UI stays functional instead of showing
+    // blank text (prod) or crashing (dev) when a translation key is missing
+    console.warn(errorMessage);
+    return path;
   }
 
   if (replacement) {


### PR DESCRIPTION
Summary

This PR improves i18n robustness by ensuring that missing translation keys do not result in blank UI or runtime errors.

What changed

Returns the translation key path (menu.file.open) when a translation is missing, instead of returning an empty string or throwing an error
Removes environment-specific handling to ensure consistent behavior across development and production
Keeps warning logs for missing translation keys to help identify incomplete translations

Behavior before

Missing key in production → blank UI
Missing key in development → possible error or crash
Inconsistent fallback behavior across environments

Behavior after

Missing key → displays the key path as a fallback
No runtime crashes or blank text due to missing translations
Consistent behavior in both dev and production

Why this change is needed

This prevents UI breakage when translation keys are missing or not yet added to locale files, while still making it visible that a translation is missing via console warnings.

Notes
This does not change the TypeScript constraint (NestedKeyOf<typeof fallbackLangData>), which ensures only valid keys from en.json are allowed at compile time.
The change only improves runtime safety and user-facing stability.