### PR TITLE
docs: Updated docker-compose command to use new syntax

### DIFF
--- a/dev-docs/docs/introduction/development.mdx
+++ b/dev-docs/docs/introduction/development.mdx
@@ -83,7 +83,7 @@ yarn test:code
 You can use docker-compose to work on Excalidraw locally if you don't want to setup a Node.js env.
 
 ```bash
-docker-compose up --build -d
+docker compose up --build -d
 ```
 
 ## Self-hosting


### PR DESCRIPTION
Was running into docker compose issues when I noticed the Docker Compose v1 syntax.

"Docker Compose v1 (docker-compose), a Python-based tool for defining multi-container applications, has been superseded by Compose v2 (docker compose)" Via the docker docs 

https://docs.docker.com/retired/#docker-compose-v1-replaced-by-compose-v2