### PR TITLE
fix: don't fill arrow label area with background color on export (#11591)

### DIFF
--- a/packages/element/src/renderElement.ts
+++ b/packages/element/src/renderElement.ts
@@ -914,16 +914,14 @@ export const renderElement = (
         const boundTextElement = getBoundTextElement(element, elementsMap);
 
         if (isArrowElement(element) && boundTextElement) {
-          // Draw arrow directly as vector and clear label hole separately.
-          // This avoids temp-canvas bitmap blit which introduces resampling blur.
+          // Draw arrow directly as vector (avoids temp-canvas bitmap blit
+          // which introduces resampling blur) with the bound text area
+          // clipped out, so the arrow is simply not drawn under the label.
+          // Whatever is rendered beneath (background, overlapping elements)
+          // shows through, matching the editor which clears the label area
+          // from the arrow's own cached canvas.
           shiftX = element.width / 2 - (element.x - x1);
           shiftY = element.height / 2 - (element.y - y1);
-
-          context.save();
-          context.rotate(element.angle);
-          context.translate(-shiftX, -shiftY);
-          drawElementOnCanvas(element, rc, context, renderConfig);
-          context.restore();
 
           const [, , , , boundTextCx, boundTextCy] = getElementAbsoluteCoords(
             boundTextElement,
@@ -942,21 +940,22 @@ export const renderElement = (
           const holeWidth = boundTextElement.width + BOUND_TEXT_PADDING * 2;
           const holeHeight = boundTextElement.height + BOUND_TEXT_PADDING * 2;
 
-          const isTransparentHole =
-            "viewBackgroundColor" in appState &&
-            (appState.viewBackgroundColor === "transparent" ||
-              !appState.viewBackgroundColor);
-          if (!isTransparentHole) {
-            context.save();
-            context.fillStyle = applyDarkModeFilter(
-              renderConfig.canvasBackgroundColor,
-              renderConfig.theme === THEME.DARK,
-            );
-            context.fillRect(holeX, holeY, holeWidth, holeHeight);
-            context.restore();
-          } else {
-            context.clearRect(holeX, holeY, holeWidth, holeHeight);
-          }
+          // clip region = generous outer rect covering the whole arrow minus
+          // the label hole (even-odd rule). Built before rotating because the
+          // label stays axis-aligned regardless of the arrow's angle.
+          const maxDim = Math.max(distance(x1, x2), distance(y1, y2));
+          const outerHalf = maxDim + getCanvasPadding(element) * 10;
+
+          context.save();
+          context.beginPath();
+          context.rect(-outerHalf, -outerHalf, outerHalf * 2, outerHalf * 2);
+          context.rect(holeX, holeY, holeWidth, holeHeight);
+          context.clip("evenodd");
+
+          context.rotate(element.angle);
+          context.translate(-shiftX, -shiftY);
+          drawElementOnCanvas(element, rc, context, renderConfig);
+          context.restore();
         } else {
           context.rotate(element.angle);
 

--- a/packages/excalidraw/tests/scene/export.test.ts
+++ b/packages/excalidraw/tests/scene/export.test.ts
@@ -237,6 +237,70 @@ describe("exportToSvg", () => {
   });
 });
 
+// #11591: canvas export used to "repair" the label hole on the shared export
+// canvas — painting it with the background color (or erasing it when the
+// background is transparent). Both overwrite whatever is rendered beneath the
+// label and can visibly differ from the editor, where the arrow is simply not
+// drawn under the label. The arrow must be clipped around the label instead.
+describe("exportToCanvas: arrow with bound text label (#11591)", () => {
+  const createLabeledArrow = () => {
+    const arrow = API.createElement({
+      type: "arrow",
+      id: "arrow-11591",
+      width: 200,
+      height: 0,
+      points: [pointFrom<LocalPoint>(0, 0), pointFrom<LocalPoint>(200, 0)],
+      boundElements: [{ type: "text", id: "label-11591" }],
+    });
+    const label = API.createElement({
+      type: "text",
+      id: "label-11591",
+      text: "label",
+      width: 50,
+      height: 20,
+      containerId: "arrow-11591",
+    });
+    return [arrow, label] as NonDeletedExcalidrawElement[];
+  };
+
+  // draw calls recorded by vitest-canvas-mock
+  const getEvents = (canvas: HTMLCanvasElement) =>
+    (canvas.getContext("2d") as any).__getEvents() as {
+      type: string;
+      props: Record<string, any>;
+    }[];
+
+  it("fills only the background, never the label area", async () => {
+    const canvas = await exportToCanvas({
+      elements: createLabeledArrow(),
+      files: null,
+    });
+
+    const fillRects = getEvents(canvas).filter((e) => e.type === "fillRect");
+    expect(fillRects.length).toBeGreaterThan(0);
+    // a fillRect smaller than the canvas means the label area was painted
+    // over, hiding whatever was rendered beneath it
+    for (const { props } of fillRects) {
+      expect(props.width).toBe(canvas.width);
+      expect(props.height).toBe(canvas.height);
+    }
+  });
+
+  it("does not erase the label area when exporting without background", async () => {
+    const canvas = await exportToCanvas({
+      elements: createLabeledArrow(),
+      appState: { exportBackground: false },
+      files: null,
+    });
+
+    const clearRects = getEvents(canvas).filter((e) => e.type === "clearRect");
+    for (const { props } of clearRects) {
+      expect(props.width).toBe(canvas.width);
+      expect(props.height).toBe(canvas.height);
+    }
+  });
+});
+
 describe("exporting frames", () => {
   const getFrameNameHeight = (exportType: "canvas" | "svg") => {
     const height =


### PR DESCRIPTION
Fixes #11591

### What's going on
When you export an arrow that has a text label, the label area gets filled in
with the canvas background color. If the label is sitting on top of another
shape, that fill covers the shape — so the exported image doesn't match what you
see in the editor, where the shape shows through behind the label.

You can see it in the issue: in the editor the "Arrow label text" label sits
inside the pink container, but on export it gets a white box around it.

### Why it happens
It started with #11492. That PR fixed blurry labeled arrows on export by drawing
the arrow as a vector instead of copying it from a temp canvas. As part of that,
the label gap went from being *cleared* (transparent) to being *filled* with the
background color. On a plain background you don't notice, but it paints over
anything behind the label.

### The fix
Keep the vector drawing from #11492 (arrows stay sharp), but instead of painting
the label area, clip it out while drawing the arrow. The arrow just isn't drawn
under the label, so whatever's behind it shows through — same as the editor.

### Testing
- Added two regression tests in `export.test.ts` that check the export only ever
  fills/clears the whole canvas, never a small box around the label. They fail on
  `master` and pass with this change.
- Ran the full test suite (all passing), plus typecheck and lint.

### Before / after
_Screenshots below._

**Before (master):**
<img width="528" height="117" alt="before-buggy" src="https://github.com/user-attachments/assets/683306b5-be00-4a81-be7b-6835b33a94fa" />

**After (this PR):**
<img width="585" height="128" alt="after-fixed" src="https://github.com/user-attachments/assets/81822700-b2bc-4031-9a96-46728c704fad" />


