### PR TITLE
fix(editor): Very small bindables can blow up fixedPoint -> position ratio

### DIFF
--- a/packages/element/src/binding.ts
+++ b/packages/element/src/binding.ts
@@ -114,6 +114,10 @@ export const BASE_BINDING_GAP_ELBOW = 5;
 export const BASE_ARROW_MIN_LENGTH = 10;
 export const FOCUS_POINT_SIZE = 10 / 1.5;
 
+// Below this size (in px) a bindable element has no meaningful interior to
+// anchor a proportional fixedPoint into
+const MIN_BINDABLE_SIZE = 1;
+
 export const getBindingGap = (
   bindTarget: ExcalidrawBindableElement,
   opts: Pick<ExcalidrawArrowElement, "elbowed">,
@@ -1945,12 +1949,28 @@ export const calculateFixedPointForElbowArrowBinding = (
     -hoveredElement.angle as Radians,
   );
 
+  // A point-like element has no interior to anchor a proportional point into,
+  // and outline snapping above can fall back to an unrelated point; bind to
+  // the center so the arrow stays put when the element is later resized.
+  if (
+    hoveredElement.width < MIN_BINDABLE_SIZE ||
+    hoveredElement.height < MIN_BINDABLE_SIZE
+  ) {
+    return { fixedPoint: normalizeFixedPoint([0.5, 0.5]) };
+  }
+
+  // Floor the divisor at the binding gap (rather than at ~0) so that
+  // elements smaller than the gap don't blow up the ratio: the snapped
+  // point sits at most one gap-width outside the outline, so this keeps
+  // the resulting fixedPoint bounded even for zero/near-zero-size elements.
+  const sizeFloor = getBindingGap(hoveredElement, linearElement);
+
   return {
     fixedPoint: normalizeFixedPoint([
       (nonRotatedSnappedGlobalPoint[0] - hoveredElement.x) /
-        Math.max(hoveredElement.width, PRECISION),
+        Math.max(hoveredElement.width, sizeFloor),
       (nonRotatedSnappedGlobalPoint[1] - hoveredElement.y) /
-        Math.max(hoveredElement.height, PRECISION),
+        Math.max(hoveredElement.height, sizeFloor),
     ]),
   };
 };
@@ -1979,13 +1999,29 @@ export const calculateFixedPointForNonElbowArrowBinding = (
     -hoveredElement.angle as Radians,
   );
 
+  // A point-like element has no interior to anchor a proportional point into;
+  // bind to the center so the arrow stays put when the element is later
+  // resized.
+  if (
+    hoveredElement.width < MIN_BINDABLE_SIZE ||
+    hoveredElement.height < MIN_BINDABLE_SIZE
+  ) {
+    return { fixedPoint: normalizeFixedPoint([0.5, 0.5]) };
+  }
+
+  // Floor the divisor at the binding gap (rather than at ~0) so that
+  // elements smaller than the gap don't blow up the ratio: the bound
+  // point sits at most one gap-width outside the outline, so this keeps
+  // the resulting fixedPoint bounded even for zero/near-zero-size elements.
+  const sizeFloor = getBindingGap(hoveredElement, linearElement);
+
   // Calculate the ratio relative to the element's bounds
   const fixedPointX =
     (nonRotatedPoint[0] - hoveredElement.x) /
-    Math.max(hoveredElement.width, PRECISION);
+    Math.max(hoveredElement.width, sizeFloor);
   const fixedPointY =
     (nonRotatedPoint[1] - hoveredElement.y) /
-    Math.max(hoveredElement.height, PRECISION);
+    Math.max(hoveredElement.height, sizeFloor);
 
   return {
     fixedPoint: normalizeFixedPoint([fixedPointX, fixedPointY]),
@@ -2492,6 +2528,9 @@ export const isFixedPoint = (
   );
 };
 
+// Fixed point ratios should stay close to the 0.0-1.0 range.
+const FIXED_POINT_BOUND = 10;
+
 export const normalizeFixedPoint = <T extends FixedPoint>(
   fixedPoint: T,
 ): FixedPoint => {
@@ -2501,18 +2540,22 @@ export const normalizeFixedPoint = <T extends FixedPoint>(
 
   const EPSILON = 0.0001;
 
+  const clamped = fixedPoint.map((ratio) =>
+    clamp(ratio, -FIXED_POINT_BOUND, FIXED_POINT_BOUND),
+  ) as FixedPoint;
+
   // Do not allow a precise 0.5 for fixed point ratio
   // to avoid jumping arrow heading due to floating point imprecision
   if (
-    Math.abs(fixedPoint[0] - 0.5) < EPSILON ||
-    Math.abs(fixedPoint[1] - 0.5) < EPSILON
+    Math.abs(clamped[0] - 0.5) < EPSILON ||
+    Math.abs(clamped[1] - 0.5) < EPSILON
   ) {
-    return fixedPoint.map((ratio) =>
+    return clamped.map((ratio) =>
       Math.abs(ratio - 0.5) < EPSILON ? 0.5001 : ratio,
     ) as FixedPoint;
   }
 
-  return fixedPoint;
+  return clamped;
 };
 
 type Side =

--- a/packages/element/tests/binding.test.tsx
+++ b/packages/element/tests/binding.test.tsx
@@ -16,6 +16,7 @@ import {
 
 import { defaultLang, setLanguage } from "@excalidraw/excalidraw/i18n";
 
+import { bindBindingElement, updateBoundElements } from "../src/binding";
 import { getTransformHandles } from "../src/transformHandles";
 import {
   getTextEditor,
@@ -24,6 +25,7 @@ import {
 
 import type {
   ExcalidrawArrowElement,
+  ExcalidrawBindableElement,
   ExcalidrawLinearElement,
   FixedPointBinding,
 } from "../src/types";
@@ -754,4 +756,58 @@ describe("binding for simple arrows", () => {
       expect(arrow.endBinding).toBe(null);
     });
   });
+});
+
+describe("binding to a point-like (sub-pixel) element", () => {
+  beforeEach(async () => {
+    mouse.reset();
+    await act(() => setLanguage(defaultLang));
+    await render(<Excalidraw handleKeyboardGlobally={true} />);
+  });
+
+  // Regression: binding to a zero/near-zero-size element used to yield an
+  // enormous fixedPoint ratio (offset / ~0), which exploded into an arrow
+  // hundreds of thousands of px wide once the element was resized to a normal
+  // size
+  it.each([
+    ["simple", false],
+    ["elbow", true],
+  ])(
+    "%s arrow binds to the center and stays put when the element grows",
+    (_label, elbowed) => {
+      const rect = API.createElement({
+        type: "rectangle",
+        x: 200,
+        y: 50,
+        width: 0.00005,
+        height: 0.00005,
+      }) as ExcalidrawBindableElement;
+      const arrow = API.createElement({
+        type: "arrow",
+        elbowed,
+        x: 0,
+        y: 50,
+        width: 195,
+        height: 0,
+        points: [pointFrom(0, 0), pointFrom(195, 0)],
+      }) as ExcalidrawArrowElement;
+      API.setElements([rect, arrow]);
+
+      bindBindingElement(arrow, rect, "orbit", "end", h.scene);
+
+      const endBinding = arrow.endBinding as FixedPointBinding;
+      expect(endBinding.elementId).toBe(rect.id);
+      // Point-like element => bind to center (0.5 is normalized to 0.5001)
+      expect(endBinding.fixedPoint[0]).toBeCloseTo(0.5001);
+      expect(endBinding.fixedPoint[1]).toBeCloseTo(0.5001);
+
+      // Grow the element to a normal size and let bound arrows follow
+      h.scene.mutateElement(rect, { width: 300, height: 200 });
+      updateBoundElements(rect, h.scene);
+
+      // The arrow endpoint must track the element (its center), not fly off
+      expect(Math.abs(arrow.width)).toBeLessThan(1000);
+      expect(Math.abs(arrow.height)).toBeLessThan(1000);
+    },
+  );
 });


### PR DESCRIPTION
# Extremely large (1e5+ px) arrows: Unbounded fixedPoint ratio when binding to zero/near-zero-size elements

 Extremely large arrows (issue #11497, stop-gaps in
newElement.ts / elbowArrow.ts normalizeArrowElementUpdate / restore.ts
MAX_LINEAR_PX) are caused by **binding to a zero/near-zero-size bindable
element**:

- `calculateFixedPointForNonElbowArrowBinding` and
  `calculateFixedPointForElbowArrowBinding` (binding.ts) compute
  `ratio = (point - element.x) / Math.max(element.width, PRECISION)` with
  PRECISION = 1e-4, and the arrow endpoint sits a **fixed ~5px binding gap**
  (`getBindingGap`, BASE_BINDING_GAP=5) outside the outline → for a 0-size
  element ratio ≈ -5/1e-4 = **-50,000**.
- `normalizeFixedPoint`/`isFixedPoint` only check finiteness, never range, so
  the poison ratio persists in the document.
- When the bound element is later resized to normal size,
  `getGlobalFixedPointForBindableElement` computes
  `x + width * ratio` → endpoint millions of px away. Affects both simple and
  elbow arrows (both use fixedPoint).