### PR TITLE
fix(editor): preserve text editor focus when switching tabs

### DIFF
--- a/packages/excalidraw/wysiwyg/textWysiwyg.tsx
+++ b/packages/excalidraw/wysiwyg/textWysiwyg.tsx
@@ -888,7 +888,13 @@ export const textWysiwyg = ({
       }
 
       // Otherwise, re-enable submit on blur and refocus the editor.
-      editable.onblur = handleSubmit;
+      const handleBlur = () => {
+        if(!document.hasFocus*()) {
+          return;
+        }
+        handleSubmit();
+      }
+      editable.onblur = handleBlur;
       editable.focus();
       if (pendingInitialSelection) {
         editable.setSelectionRange(

--- a/packages/excalidraw/wysiwyg/textWysiwyg.tsx
+++ b/packages/excalidraw/wysiwyg/textWysiwyg.tsx
@@ -889,7 +889,7 @@ export const textWysiwyg = ({
 
       // Otherwise, re-enable submit on blur and refocus the editor.
       const handleBlur = () => {
-        if(!document.hasFocus*()) {
+        if(!document.hasFocus()) {
           return;
         }
         handleSubmit();


### PR DESCRIPTION
Fixes #9304

Prevent textboxes from losing focus when switching between tabs or windows.
