### PR TITLE
fix: PWA build step caps precache max size

### DIFF
--- a/excalidraw-app/vite.config.mts
+++ b/excalidraw-app/vite.config.mts
@@ -223,7 +223,7 @@ export default defineConfig(({ mode }) => {
               },
             },
           ],
-          maximumFileSizeToCacheInBytes: 2.3 * 1024 ** 2, // 2.3MB
+          maximumFileSizeToCacheInBytes: 3 * 1024 ** 2, // 3MB
         },
         manifest: {
           short_name: "Excalidraw",


### PR DESCRIPTION

Title 
---
increase PWA precache max file size limit to 3MB

Summary
---
- Vite's PWA plugin (Workbox generateSW) enforces maximumFileSizeToCacheInBytes — any built asset larger than this limit is silently excluded from the service worker precache manifest.
- The limit was set to 2.3MB, which is no longer enough to cover an asset. Since Workbox now treats a build asset exceeding this limit as a hard build error (per the prior commit on this branch) rather than silently skipping it, this build asset was failing the PWA build.
- Raised maximumFileSizeToCacheInBytes from 2.3 * 1024 ** 2 to 3 * 1024 ** 2 in excalidraw-app/vite.config.mts so the asset is precached instead of breaking the build.