### PR TITLE
fix: show helpful error message on filesystem permission error (fixes #5951)

### DIFF
--- a/packages/excalidraw/actions/actionExport.tsx
+++ b/packages/excalidraw/actions/actionExport.tsx
@@ -21,7 +21,10 @@ import { Tooltip } from "../components/Tooltip";
 import { ExportIcon, questionCircle, saveAs } from "../components/icons";
 import { loadFromJSON, saveAsJSON } from "../data";
 import { isImageFileHandle } from "../data/blob";
-import { nativeFileSystemSupported } from "../data/filesystem";
+import {
+  isFilesystemPermissionError,
+  nativeFileSystemSupported,
+} from "../data/filesystem";
 
 import { resaveAsImageWithScene } from "../data/resave";
 
@@ -358,10 +361,14 @@ export const actionSaveToActiveFile = register({
       } else {
         console.warn(error);
       }
+
       return {
         captureUpdate: CaptureUpdateAction.NEVER,
         appState: {
           toast: null,
+          ...(isFilesystemPermissionError(error) && {
+            errorMessage: t("errors.filesystemPermissionError"),
+          }),
         },
       };
     } finally {
@@ -409,10 +416,14 @@ export const actionSaveFileToDisk = register({
       } else {
         console.warn(error);
       }
+
       return {
         captureUpdate: CaptureUpdateAction.NEVER,
         appState: {
           toast: null,
+          ...(isFilesystemPermissionError(error) && {
+            errorMessage: t("errors.filesystemPermissionError"),
+          }),
         },
       };
     } finally {

--- a/packages/excalidraw/data/filesystem.test.ts
+++ b/packages/excalidraw/data/filesystem.test.ts
@@ -1,0 +1,28 @@
+import { isFilesystemPermissionError } from "./filesystem";
+
+describe("isFilesystemPermissionError", () => {
+  it("returns true for a NotAllowedError", () => {
+    const error = new DOMException("blocked", "NotAllowedError");
+    expect(isFilesystemPermissionError(error)).toBe(true);
+  });
+
+  it("returns true for a SecurityError", () => {
+    const error = new DOMException("blocked", "SecurityError");
+    expect(isFilesystemPermissionError(error)).toBe(true);
+  });
+
+  it("returns false for an AbortError (user cancelled the picker)", () => {
+    const error = new DOMException("cancelled", "AbortError");
+    expect(isFilesystemPermissionError(error)).toBe(false);
+  });
+
+  it("returns false for a generic Error", () => {
+    expect(isFilesystemPermissionError(new Error("boom"))).toBe(false);
+  });
+
+  it("returns false for non-error values", () => {
+    expect(isFilesystemPermissionError(null)).toBe(false);
+    expect(isFilesystemPermissionError(undefined)).toBe(false);
+    expect(isFilesystemPermissionError("NotAllowedError")).toBe(false);
+  });
+});

--- a/packages/excalidraw/data/filesystem.ts
+++ b/packages/excalidraw/data/filesystem.ts
@@ -46,6 +46,25 @@ export const fileOpen = async <M extends boolean | undefined = false>(opts: {
   return (await normalizeFile(files)) as RetType;
 };
 
+/**
+ * Detects whether a given error was thrown because the browser (or the
+ * underlying OS/organization policy) denied access to the local file
+ * system, as opposed to the user simply cancelling the file picker
+ * (`AbortError`) or some other unrelated failure.
+ *
+ * Browsers that support the File System Access API throw a `NotAllowedError`
+ * (sometimes surfaced as `SecurityError`) when:
+ * - the user has explicitly blocked file system access for the site, or
+ * - the permission is unavailable because it was disabled by a system
+ *   administrator/enterprise policy (the corresponding browser setting is
+ *   then usually shown as grayed out).
+ */
+export const isFilesystemPermissionError = (error: unknown): boolean => {
+  const name = (error as { name?: unknown } | null | undefined)?.name;
+
+  return name === "NotAllowedError" || name === "SecurityError";
+};
+
 export const fileSave = (
   blob: Blob | Promise<Blob>,
   opts: {

--- a/packages/excalidraw/locales/en.json
+++ b/packages/excalidraw/locales/en.json
@@ -309,7 +309,8 @@
     },
     "asyncPasteFailedOnRead": "Couldn't paste (couldn't read from system clipboard).",
     "asyncPasteFailedOnParse": "Couldn't paste.",
-    "copyToSystemClipboardFailed": "Couldn't copy to clipboard."
+    "copyToSystemClipboardFailed": "Couldn't copy to clipboard.",
+    "filesystemPermissionError": "Excalidraw doesn't have permission to save to the file system — this can happen if it was denied in your browser, or disabled by an organization policy (if the setting appears grayed out). Try \"Save to disk\" instead, or check your browser's site permissions."
   },
   "toolBar": {
     "selection": "Selection",


### PR DESCRIPTION
Fixes #5951.

When saving/exporting to the local file system fails because the browser (or an org/IT policy) denies File System Access API permission, the error was silently swallowed — only `console.error`'d, with no feedback to the user, who had no idea their file wasn't actually saved.

## Approach

This adds a small check that recognizes the specific browser errors thrown when file system access is blocked — `NotAllowedError` / `SecurityError` — as opposed to other kinds of failures (e.g. a full disk) that already behave fine today. When a save fails for that specific reason, we now show the same error dialog Excalidraw already uses elsewhere, with a short message explaining the likely cause — a browser setting, or an IT/org policy behind the "grayed out" toggle mentioned in the issue — and suggesting to try "Save to disk" instead, or check the browser's site permissions. No new UI was introduced, and no other error path was changed.

## Related work

- #6411 attempted the same fix for this issue back in 2023, but has been dormant since (no activity, targets a pre-monorepo file path that no longer exists). This PR follows the same general approach, updated for the current codebase.
- @dwelle mentioned in this issue (2023) leaning towards falling back to a different save API instead of showing an error, similar in spirit to what #11563 now does for the export flow (falls back to a plain download when the native picker is blocked). I'd argue the two are complementary rather than competing: a silent fallback works well for *export*, but for `actionSaveToActiveFile` specifically it risks a mismatch — the user believes their existing file on disk was updated, when in fact a new copy silently went to Downloads instead. Surfacing a message keeps that flow honest even if a fallback is added later; happy to adjust based on maintainer preference between the two (or use both together).

## Testing

- `data/filesystem.test.ts` (new): 5 unit tests for `isFilesystemPermissionError` — NotAllowedError, SecurityError, AbortError (should NOT trigger, that's just a user cancel), a generic Error, and non-error values.
- Full suite (`yarn test`) passes: 109 files / 1490 tests, no regressions.
- `yarn eslint --max-warnings=0` clean on touched files.

---
This is my first contribution to this project — happy to adjust anything that doesn't follow the project's conventions in order to get this merged.