### PR TITLE
chore(editor): streamline getSelectedElementsByGroup

### DIFF
--- a/packages/element/src/groups.ts
+++ b/packages/element/src/groups.ts
@@ -423,9 +423,7 @@ export const getSelectedElementsByGroup = (
   const selectedGroupIds = getSelectedGroupIds(appState);
   const isSingleSelectedGroupCase =
     selectedGroupIds.length === 1 &&
-    selectedElements.every((element) =>
-      element.groupIds.includes(selectedGroupIds[0]),
-    );
+    selectedElements.every((element) => isSelectedViaGroup(appState, element));
 
   selectedElements.forEach((element) => {
     // skip dependent boundTextElements, they are appended after their container

--- a/packages/element/src/groups.ts
+++ b/packages/element/src/groups.ts
@@ -438,7 +438,7 @@ export const getSelectedElementsByGroup = (
     );
 
     if (!selectedGroupId) {
-      bucketKey = element.id;
+      bucketKey = `${element.id}_element`;
     } else {
       // if only one group is selected, grouping is based on inner hierarchy
       const keyIndex = isSingleSelectedGroupCase
@@ -446,7 +446,10 @@ export const getSelectedElementsByGroup = (
         : element.groupIds.indexOf(selectedGroupId);
 
       // edge case: single selected group where element is non member of inner group
-      bucketKey = keyIndex < 0 ? element.id : element.groupIds[keyIndex];
+      bucketKey =
+        keyIndex < 0
+          ? `${element.id}_element`
+          : `${element.groupIds[keyIndex]}_group`;
     }
 
     const currentBucketMembers = buckets.get(bucketKey) ?? [];

--- a/packages/element/src/groups.ts
+++ b/packages/element/src/groups.ts
@@ -415,76 +415,60 @@ export const getNewGroupIdsForDuplication = (
 // given a list of selected elements, return the element grouped by their immediate group selected state
 // in the case if only one group is selected and all elements selected are within the group, it will respect group hierarchy in accordance to their nested grouping order
 export const getSelectedElementsByGroup = (
-  selectedElements: ExcalidrawElement[],
+  selectedElements: NonDeletedExcalidrawElement[],
   elementsMap: ElementsMap,
   appState: Readonly<Pick<AppState, "selectedGroupIds" | "editingGroupId">>,
 ): NonDeletedExcalidrawElement[][] => {
+  const groups: Map<string, NonDeletedExcalidrawElement[]> = new Map();
+  const elements: Map<string, NonDeletedExcalidrawElement[]> = new Map();
   const selectedGroupIds = getSelectedGroupIds(appState);
-  const unboundElements = selectedElements.filter(
-    (element) => !isBoundToContainer(element),
-  );
-  const groups: Map<string, ExcalidrawElement[]> = new Map();
-  const elements: Map<string, ExcalidrawElement[]> = new Map();
+  const isSingleSelectedGroupCase =
+    selectedGroupIds.length === 1 &&
+    selectedElements.every((element) =>
+      element.groupIds.includes(selectedGroupIds[0]),
+    );
 
-  // helper function to add an element to the elements map
-  const addToElementsMap = (element: ExcalidrawElement) => {
-    // elements
-    const currentElementMembers = elements.get(element.id) || [];
-    const boundTextElement = getBoundTextElement(element, elementsMap);
-
-    if (boundTextElement) {
-      currentElementMembers.push(boundTextElement);
+  selectedElements.forEach((element) => {
+    // skip dependent boundTextElements, they are incl. at the end of each iteration
+    if (isBoundToContainer(element)) {
+      return;
     }
-    elements.set(element.id, [...currentElementMembers, element]);
-  };
 
-  // helper function to add an element to the groups map
-  const addToGroupsMap = (element: ExcalidrawElement, groupId: string) => {
-    // groups
-    const currentGroupMembers = groups.get(groupId) || [];
-    const boundTextElement = getBoundTextElement(element, elementsMap);
-
-    if (boundTextElement) {
-      currentGroupMembers.push(boundTextElement);
-    }
-    groups.set(groupId, [...currentGroupMembers, element]);
-  };
-
-  // helper function to handle the case where a single group is selected
-  // and all elements selected are within the group, it will respect group hierarchy in accordance to
-  // their nested grouping order
-  const handleSingleSelectedGroupCase = (
-    element: ExcalidrawElement,
-    selectedGroupId: GroupId,
-  ) => {
-    const indexOfSelectedGroupId = element.groupIds.indexOf(selectedGroupId, 0);
-    const nestedGroupCount = element.groupIds.slice(
-      0,
-      indexOfSelectedGroupId,
-    ).length;
-    return nestedGroupCount > 0
-      ? addToGroupsMap(element, element.groupIds[indexOfSelectedGroupId - 1])
-      : addToElementsMap(element);
-  };
-
-  const isAllInSameGroup = selectedElements.every((element) =>
-    isSelectedViaGroup(appState, element),
-  );
-
-  unboundElements.forEach((element) => {
+    let bucketType: "group" | "element";
+    let bucketKey: string;
     const selectedGroupId = getSelectedGroupIdForElement(
       element,
       appState.selectedGroupIds,
     );
+
     if (!selectedGroupId) {
-      addToElementsMap(element);
-    } else if (selectedGroupIds.length === 1 && isAllInSameGroup) {
-      handleSingleSelectedGroupCase(element, selectedGroupId);
+      bucketType = "element";
+      bucketKey = element.id;
     } else {
-      addToGroupsMap(element, selectedGroupId);
+      // if only one group is selected, grouping is based on inner hierarchy
+      const keyIndex = isSingleSelectedGroupCase
+        ? element.groupIds.indexOf(selectedGroupId) - 1
+        : element.groupIds.indexOf(selectedGroupId);
+
+      if (keyIndex < 0) {
+        bucketType = "element";
+        bucketKey = element.id;
+      } else {
+        bucketType = "group";
+        bucketKey = element.groupIds[keyIndex];
+      }
     }
+
+    const bucketMap = bucketType === "group" ? groups : elements;
+    const currentBucketMembers = bucketMap.get(bucketKey) ?? [];
+    const boundTextElement = getBoundTextElement(element, elementsMap);
+
+    // preserve boundtext after container ordering
+    bucketMap.set(bucketKey, [
+      ...currentBucketMembers,
+      element,
+      ...(boundTextElement ? [boundTextElement] : []),
+    ]);
   });
-  return Array.from(groups.values()).concat(
-    Array.from(elements.values()),
-  ) as NonDeletedExcalidrawElement[][];
+  return [...groups.values(), ...elements.values()];
 };

--- a/packages/element/src/groups.ts
+++ b/packages/element/src/groups.ts
@@ -419,8 +419,7 @@ export const getSelectedElementsByGroup = (
   elementsMap: ElementsMap,
   appState: Readonly<Pick<AppState, "selectedGroupIds" | "editingGroupId">>,
 ): NonDeletedExcalidrawElement[][] => {
-  const groups: Map<string, NonDeletedExcalidrawElement[]> = new Map();
-  const elements: Map<string, NonDeletedExcalidrawElement[]> = new Map();
+  const buckets: Map<string, NonDeletedExcalidrawElement[]> = new Map();
   const selectedGroupIds = getSelectedGroupIds(appState);
   const isSingleSelectedGroupCase =
     selectedGroupIds.length === 1 &&
@@ -429,12 +428,11 @@ export const getSelectedElementsByGroup = (
     );
 
   selectedElements.forEach((element) => {
-    // skip dependent boundTextElements, they are incl. at the end of each iteration
+    // skip dependent boundTextElements, they are appended after their container
     if (isBoundToContainer(element)) {
       return;
     }
 
-    let bucketType: "group" | "element";
     let bucketKey: string;
     const selectedGroupId = getSelectedGroupIdForElement(
       element,
@@ -442,7 +440,6 @@ export const getSelectedElementsByGroup = (
     );
 
     if (!selectedGroupId) {
-      bucketType = "element";
       bucketKey = element.id;
     } else {
       // if only one group is selected, grouping is based on inner hierarchy
@@ -450,25 +447,19 @@ export const getSelectedElementsByGroup = (
         ? element.groupIds.indexOf(selectedGroupId) - 1
         : element.groupIds.indexOf(selectedGroupId);
 
-      if (keyIndex < 0) {
-        bucketType = "element";
-        bucketKey = element.id;
-      } else {
-        bucketType = "group";
-        bucketKey = element.groupIds[keyIndex];
-      }
+      // edge case: single selected group where element is non member of inner group
+      bucketKey = keyIndex < 0 ? element.id : element.groupIds[keyIndex];
     }
 
-    const bucketMap = bucketType === "group" ? groups : elements;
-    const currentBucketMembers = bucketMap.get(bucketKey) ?? [];
+    const currentBucketMembers = buckets.get(bucketKey) ?? [];
     const boundTextElement = getBoundTextElement(element, elementsMap);
 
     // preserve boundtext after container ordering
-    bucketMap.set(bucketKey, [
+    buckets.set(bucketKey, [
       ...currentBucketMembers,
       element,
       ...(boundTextElement ? [boundTextElement] : []),
     ]);
   });
-  return [...groups.values(), ...elements.values()];
+  return [...buckets.values()];
 };

--- a/packages/element/tests/align.test.tsx
+++ b/packages/element/tests/align.test.tsx
@@ -1009,4 +1009,89 @@ describe("aligning", () => {
     expect(API.getSelectedElements()[1].x).toEqual(150);
     expect(API.getSelectedElements()[2].x).toEqual(100);
   });
+
+  const createAndSelectGroupWithBoundTextAndRectangle = () => {
+    const groupId = "group-with-bound-text";
+
+    // container is vertically/horizontally centered around its bound text
+    const container = API.createElement({
+      type: "rectangle",
+      id: "container",
+      x: 100,
+      y: 100,
+      width: 100,
+      height: 100,
+      groupIds: [groupId],
+      boundElements: [{ type: "text", id: "bound-text" }],
+    });
+
+    const boundText = API.createElement({
+      type: "text",
+      id: "bound-text",
+      x: 120,
+      y: 140,
+      width: 60,
+      height: 20,
+      containerId: container.id,
+      groupIds: [groupId],
+    });
+
+    const groupedRectangle = API.createElement({
+      type: "rectangle",
+      id: "grouped-rectangle",
+      x: 100,
+      y: 200,
+      width: 100,
+      height: 100,
+      groupIds: [groupId],
+    });
+
+    const standaloneRectangle = API.createElement({
+      type: "rectangle",
+      id: "standalone-rectangle",
+      x: 0,
+      y: 0,
+      width: 100,
+      height: 100,
+    });
+
+    API.setElements([
+      container,
+      boundText,
+      groupedRectangle,
+      standaloneRectangle,
+    ]);
+
+    API.setSelectedElements([container, groupedRectangle, standaloneRectangle]);
+
+    return { container, boundText, groupedRectangle, standaloneRectangle };
+  };
+
+  it("keeps a bound text within its container when aligning a group to the top", () => {
+    const { container, boundText, groupedRectangle, standaloneRectangle } =
+      createAndSelectGroupWithBoundTextAndRectangle();
+
+    API.executeAction(actionAlignTop);
+
+    expect(API.getElement(standaloneRectangle).y).toEqual(0);
+    expect(API.getElement(container).y).toEqual(0);
+    expect(API.getElement(groupedRectangle).y).toEqual(100);
+
+    expect(API.getElement(boundText).y).toEqual(40);
+    expect(API.getElement(boundText).x).toEqual(120);
+  });
+
+  it("keeps a bound text within its container when aligning a group to the left", () => {
+    const { container, boundText, groupedRectangle, standaloneRectangle } =
+      createAndSelectGroupWithBoundTextAndRectangle();
+
+    API.executeAction(actionAlignLeft);
+
+    expect(API.getElement(standaloneRectangle).x).toEqual(0);
+    expect(API.getElement(container).x).toEqual(0);
+    expect(API.getElement(groupedRectangle).x).toEqual(0);
+
+    expect(API.getElement(boundText).x).toEqual(20);
+    expect(API.getElement(boundText).y).toEqual(140);
+  });
 });


### PR DESCRIPTION
## Summary
This is a refactor of my first contribution to the project #9721 . After spending more time in the codebase, I wanted to take a swing and see if I could clean it up and reduce some redundancy, while preserving existing behavior.

In the PR are two separate approaches:
1. The first commit streamlines the function, removing some redundant operations, while still keeping in line the clear separation between what are elements and groups, initial feedback shared by @mrazator 🙏
2. ~~The later commit was an attempt to preserve z-index sorted ordering.~~ Using a similar approach by @dwelle on defragmenting groups in #11269. To my understanding, ~~the selectedElements passed to the function do maintain z-index ordering.~~ if the return value of the 2D array is flattened, it will maintain similar ordering of selectedElements with the inclusion of boundText, based on selected state.

### Notes about ordering
I did a rough comparison between the sequence and length of selectedElements and the final output to confirm the ordering behavior.

From what I observed
- Grouping scenarios behave as expected.
- All previously written tests for these functions continue to pass.
- One thing, though and it's more as a note, is that for non-grouped containers with bound text, the bound text is not included in selectedElements, while the function output does extract and add all selected bound text elements.

### Feedback welcome

feedback and suggestions are always welcome.

Thanks @dwelle @mtolmacs @mrazator