### PR TITLE
fix(editor): don't downscale inserted images that fit within the file size limit

### DIFF
--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -12069,7 +12069,7 @@ class App extends React.Component<AppProps, AppState> {
           });
         } catch (error: any) {
           console.error(
-            "Error trying to resizing image file on insertion",
+            "Error trying to resize image file on insertion",
             error,
           );
         }

--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -12059,15 +12059,20 @@ class App extends React.Component<AppProps, AppState> {
     if (!existingFileData?.dataURL) {
       const { maxWidthOrHeight, maxFileSizeBytes } = this.props.imageOptions;
 
-      try {
-        imageFile = await resizeImageFile(imageFile, {
-          maxWidthOrHeight,
-        });
-      } catch (error: any) {
-        console.error(
-          "Error trying to resizing image file on insertion",
-          error,
-        );
+      // only downscale when the file exceeds the size limit — resizing
+      // re-encodes through canvas, which degrades sharpness and strips
+      // wide-gamut color profiles (#11613)
+      if (imageFile.size > maxFileSizeBytes) {
+        try {
+          imageFile = await resizeImageFile(imageFile, {
+            maxWidthOrHeight,
+          });
+        } catch (error: any) {
+          console.error(
+            "Error trying to resizing image file on insertion",
+            error,
+          );
+        }
       }
 
       if (imageFile.size > maxFileSizeBytes) {

--- a/packages/excalidraw/tests/image.test.tsx
+++ b/packages/excalidraw/tests/image.test.tsx
@@ -136,9 +136,9 @@ describe("image insertion", () => {
     await assert();
   });
 
-  it("passes host-configured max image dimensions to the resize helper", async () => {
+  it("passes host-configured max image dimensions to the resize helper when the file exceeds the size limit", async () => {
     await setupImageTest([DEER_IMAGE_DIMENSIONS], {
-      imageOptions: { maxWidthOrHeight: 2048 },
+      imageOptions: { maxWidthOrHeight: 2048, maxFileSizeBytes: 1024 },
     });
 
     await API.drop([
@@ -151,6 +151,21 @@ describe("image insertion", () => {
         { maxWidthOrHeight: 2048 },
       );
     });
+  });
+
+  it("does not resize images that fit within the size limit", async () => {
+    await setupImageTest([DEER_IMAGE_DIMENSIONS]);
+
+    await API.drop([
+      { kind: "file", file: await API.loadFile("./fixtures/deer.png") },
+    ]);
+
+    await waitFor(() => {
+      expect(h.elements).toEqual([
+        expect.objectContaining(INITIALIZED_IMAGE_PROPS),
+      ]);
+    });
+    expect(blobModule.resizeImageFile).not.toHaveBeenCalled();
   });
 
   it("enforces host-configured max image file size", async () => {

--- a/packages/excalidraw/tests/image.test.tsx
+++ b/packages/excalidraw/tests/image.test.tsx
@@ -154,7 +154,11 @@ describe("image insertion", () => {
   });
 
   it("does not resize images that fit within the size limit", async () => {
-    await setupImageTest([DEER_IMAGE_DIMENSIONS]);
+    // maxWidthOrHeight below the image dimensions — the file must still be
+    // stored untouched since it fits within maxFileSizeBytes
+    await setupImageTest([DEER_IMAGE_DIMENSIONS], {
+      imageOptions: { maxWidthOrHeight: 200 },
+    });
 
     await API.drop([
       { kind: "file", file: await API.loadFile("./fixtures/deer.png") },


### PR DESCRIPTION

   Images were unconditionally downscaled to maxWidthOrHeight (1440px) on
   insertion, re-encoding them through canvas. This permanently blurred
   large images and stripped wide-gamut color profiles, washing out
   colors. Only resize when the file actually exceeds maxFileSizeBytes.

   Fixes #11613