### PR TITLE
fix: add distinct aria-labels to color picker swatch buttons

### DIFF
--- a/packages/excalidraw/components/ColorPicker/CustomColorList.tsx
+++ b/packages/excalidraw/components/ColorPicker/CustomColorList.tsx
@@ -51,7 +51,7 @@ export const CustomColorList = ({
               setActiveColorPickerSection("custom");
             }}
             title={c}
-            aria-label={label}
+            aria-label={`${label}: ${c}`}
             style={{ "--swatch-color": c }}
             key={i}
           >

--- a/packages/excalidraw/components/ColorPicker/TopPicks.tsx
+++ b/packages/excalidraw/components/ColorPicker/TopPicks.tsx
@@ -8,6 +8,8 @@ import {
   isColorDark,
 } from "@excalidraw/common";
 
+import { t } from "../../i18n";
+
 import type { ColorPickerType } from "./colorPickerUtils";
 
 interface TopPicksProps {
@@ -62,6 +64,7 @@ export const TopPicks = ({
           key={color}
           type="button"
           title={color}
+          aria-label={`${t("colorPicker.color")}: ${color}`}
           onClick={() => onChange(color)}
           data-testid={`color-top-pick-${color}`}
         >


### PR DESCRIPTION
## Summary
Fixes #11641

Color swatch buttons in the color picker didn't expose their specific 
color to screen readers:
- `TopPicks.tsx` swatches only had a `title` attribute, which screen 
  readers don't reliably announce.
- `CustomColorList.tsx` swatches had an `aria-label`, but it was the 
  same generic string across every swatch, so screen reader users 
  couldn't distinguish between colors.

## Changes
- Added `aria-label={`${t("colorPicker.color")}: ${color}`}` to swatch 
  buttons in `TopPicks.tsx`.
- Updated `aria-label` in `CustomColorList.tsx` to include the specific 
  color value: `` `${label}: ${c}` ``.

## Testing
Verified via Chrome DevTools Accessibility pane and VoiceOver that each 
swatch button now announces its distinct color value, for both the 
Top Picks row and the Custom/Most-used colors section.