### PR TITLE
fix(editor): preserve text editor focus on window blur (Alt+Tab)

### DIFF
--- a/packages/excalidraw/wysiwyg/textWysiwyg.test.tsx
+++ b/packages/excalidraw/wysiwyg/textWysiwyg.test.tsx
@@ -1,4 +1,5 @@
 import { queryByText } from "@testing-library/react";
+import { vi } from "vitest";
 
 import { pointFrom } from "@excalidraw/math";
 import {
@@ -379,6 +380,130 @@ describe("textWysiwyg", () => {
 
       expect(h.state.editingTextElement).toBe(null);
       expect(await getTextEditor({ waitForEditor: false })).toBe(null);
+    });
+
+    it("should keep editor open when window loses focus (e.g. Alt+Tab)", async () => {
+      const text = API.createElement({
+        type: "text",
+        text: "ola",
+        x: 60,
+        y: 0,
+        width: 100,
+        height: 100,
+      });
+
+      API.setElements([text]);
+      API.setSelectedElements([text]);
+      UI.clickTool("selection");
+
+      Keyboard.keyPress(KEYS.ENTER);
+
+      const editor = await getTextEditor();
+      expect(editor).not.toBe(null);
+      expect(h.state.editingTextElement?.id).toBe(text.id);
+
+      const hasFocusSpy = vi.spyOn(document, "hasFocus").mockReturnValue(false);
+
+      try {
+        fireEvent.blur(editor);
+
+        expect(await getTextEditor({ waitForEditor: false })).not.toBe(null);
+        expect(h.state.editingTextElement?.id).toBe(text.id);
+      } finally {
+        hasFocusSpy.mockRestore();
+      }
+    });
+
+    it("should still submit the editor on blur while the window keeps focus", async () => {
+      const text = API.createElement({
+        type: "text",
+        text: "ola",
+        x: 60,
+        y: 0,
+        width: 100,
+        height: 100,
+      });
+
+      API.setElements([text]);
+      API.setSelectedElements([text]);
+      UI.clickTool("selection");
+
+      Keyboard.keyPress(KEYS.ENTER);
+
+      const editor = await getTextEditor();
+      expect(editor).not.toBe(null);
+      expect(h.state.editingTextElement?.id).toBe(text.id);
+
+      const hasFocusSpy = vi.spyOn(document, "hasFocus").mockReturnValue(true);
+
+      try {
+        // a genuine blur (window still focused) must still commit and close
+        fireEvent.blur(editor);
+
+        expect(await getTextEditor({ waitForEditor: false })).toBe(null);
+        expect(h.state.editingTextElement).toBe(null);
+      } finally {
+        hasFocusSpy.mockRestore();
+      }
+    });
+
+    it("should keep editor open on window blur after a properties-menu interaction", async () => {
+      const text = API.createElement({
+        type: "text",
+        text: "ola",
+        x: 60,
+        y: 0,
+        width: 100,
+        height: 100,
+      });
+
+      API.setElements([text]);
+      API.setSelectedElements([text]);
+      UI.clickTool("selection");
+
+      Keyboard.keyPress(KEYS.ENTER);
+
+      const editor = await getTextEditor();
+      expect(editor).not.toBe(null);
+      expect(h.state.editingTextElement?.id).toBe(text.id);
+
+      // the window pointerdown listener is registered inside a rAF; flush it
+      await act(async () => {
+        await new Promise((resolve) =>
+          requestAnimationFrame(() => resolve(null)),
+        );
+      });
+
+      // Simulate interacting with the shape-actions / properties menu. This
+      // runs temporarilyDisableSubmit(), which nulls the textarea's own blur
+      // submit and arms a window "blur" listener as the fallback teardown path.
+      const propertiesEl = document.createElement("div");
+      propertiesEl.classList.add("properties-content");
+      document.body.appendChild(propertiesEl);
+
+      try {
+        fireEvent.pointerDown(propertiesEl);
+
+        // sanity: the interaction disabled the textarea's own onblur, so the
+        // window-blur listener is now the only remaining teardown path — this
+        // is what guarantees the assertion below exercises that second path.
+        expect(editor.onblur).toBe(null);
+
+        const hasFocusSpy = vi
+          .spyOn(document, "hasFocus")
+          .mockReturnValue(false);
+
+        try {
+          fireEvent.blur(window);
+
+          expect(await getTextEditor({ waitForEditor: false })).not.toBe(null);
+          expect(h.state.editingTextElement?.id).toBe(text.id);
+        } finally {
+          hasFocusSpy.mockRestore();
+        }
+      } finally {
+        propertiesEl.remove();
+      }
     });
 
     // FIXME too flaky. No one knows why.

--- a/packages/excalidraw/wysiwyg/textWysiwyg.tsx
+++ b/packages/excalidraw/wysiwyg/textWysiwyg.tsx
@@ -838,6 +838,16 @@ export const textWysiwyg = ({
     });
   };
 
+  // If the window itself lost focus (e.g. Alt+Tab, switching tabs), the
+  // textarea also blurs; in that case preserve the editor so the user can
+  // resume typing on return instead of having to click the text again.
+  const handleBlur = () => {
+    if (!document.hasFocus()) {
+      return;
+    }
+    handleSubmit();
+  };
+
   const cleanup = () => {
     // remove events to ensure they don't late-fire
     editable.onblur = null;
@@ -852,7 +862,7 @@ export const textWysiwyg = ({
     window.removeEventListener("wheel", stopEvent, true);
     window.removeEventListener("pointerdown", onPointerDown);
     window.removeEventListener("pointerup", bindBlurEvent);
-    window.removeEventListener("blur", handleSubmit);
+    window.removeEventListener("blur", handleBlur);
     window.removeEventListener("beforeunload", handleSubmit);
     unbindUpdate();
     unsubOnChange();
@@ -888,7 +898,7 @@ export const textWysiwyg = ({
       }
 
       // Otherwise, re-enable submit on blur and refocus the editor.
-      editable.onblur = handleSubmit;
+      editable.onblur = handleBlur;
       editable.focus();
       if (pendingInitialSelection) {
         editable.setSelectionRange(
@@ -903,9 +913,12 @@ export const textWysiwyg = ({
   const temporarilyDisableSubmit = () => {
     editable.onblur = null;
     window.addEventListener("pointerup", bindBlurEvent);
-    // handle edge-case where pointerup doesn't fire e.g. due to user
-    // alt-tabbing away
-    window.addEventListener("blur", handleSubmit);
+    // Handle the edge-case where pointerup doesn't fire e.g. because the user
+    // alt-tabbed away mid-interaction. Route through handleBlur (not
+    // handleSubmit) so a genuine window blur (document.hasFocus() === false)
+    // preserves the editor instead of destroying it — otherwise this second
+    // blur path would re-break #9304 after any properties-menu interaction.
+    window.addEventListener("blur", handleBlur);
   };
 
   // prevent blur when changing properties from the menu


### PR DESCRIPTION
Closes #9304

## Problem

When editing a text element, switching away from the window — Alt+Tab, switching to another app, or switching browser tabs — committed and destroyed the text editor. On return you had to click the text element again to continue editing, unlike a plain textarea (e.g. GitHub's comment box), which simply resumes.

## Root cause

The wysiwyg textarea's blur was wired directly to `handleSubmit`, which tears the editor down on *any* blur — including when the window itself loses focus. Nothing distinguished "focus moved to another element in the document" from "the whole window lost focus".

## Fix

Guard the blur handler with `document.hasFocus()`: on a genuine window blur it returns `false`, so we skip submit and let the browser restore focus to the still-mounted textarea on return. An in-document blur (clicking elsewhere) leaves `hasFocus()` truthy and still submits, exactly as before.

The editor is torn down on window blur via **two** independent paths, so both are routed through the guard:

- `editable.onblur` — the textarea's own blur handler.
- the `window` `"blur"` listener armed by `temporarilyDisableSubmit()` during properties / shape-actions-menu interactions (color, font, align) or middle-click pan. It was wired straight to `handleSubmit` and lingers until cleanup, so guarding only `editable.onblur` silently re-broke the fix after the first menu interaction.

`beforeunload` intentionally keeps calling `handleSubmit`, so in-progress text is still committed on a real page unload/close.

## Tests

Added regression tests in `packages/excalidraw/wysiwyg/textWysiwyg.test.tsx`:

- editor survives a window blur (`document.hasFocus() === false`);
- editor still submits on a same-window blur (`document.hasFocus() === true`), so the guard can't silently disable all blur-submit;
- editor survives a window blur *after a properties-menu interaction* — this exercises the second path and fails without its guard.

## Verification

Verified end-to-end in real Chrome and Edge: with the editor open, Alt+Tab away and back, then typing resumes immediately with no re-click — at blur time `document.hasFocus()` is `false`, so nothing submits and `editingTextElement` is preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
