### PR TITLE
fix: display error for invalid hex colors (#9527)

### DIFF
--- a/packages/excalidraw/components/ColorPicker/ColorInput.tsx
+++ b/packages/excalidraw/components/ColorPicker/ColorInput.tsx
@@ -29,6 +29,7 @@ export const ColorInput = ({
 }) => {
   const editorInterface = useEditorInterface();
   const [innerValue, setInnerValue] = useState(color);
+  const [isValid, setIsValid] = useState(true);
   const [activeSection, setActiveColorPickerSection] = useAtom(
     activeColorPickerSectionAtom,
   );
@@ -44,6 +45,9 @@ export const ColorInput = ({
 
       if (color) {
         onChange(color);
+        setIsValid(true);
+      } else {
+        setIsValid(false);
       }
       setInnerValue(value);
     },
@@ -68,7 +72,12 @@ export const ColorInput = ({
   }, [setEyeDropperState]);
 
   return (
-    <div className="color-picker__input-label">
+    <div className="color-picker-input-wrapper">
+      <div
+        className={clsx("color-picker__input-label", {
+          "color-picker__input-label--error": !isValid && innerValue !== "",
+        })}
+      >
       <div className="color-picker__input-hash">#</div>
       <input
         ref={activeSection === "hex" ? inputRef : undefined}
@@ -82,6 +91,7 @@ export const ColorInput = ({
         value={(innerValue || "").replace(/^#/, "")}
         onBlur={() => {
           setInnerValue(color);
+          setIsValid(true);
         }}
         tabIndex={-1}
         onFocus={() => setActiveColorPickerSection("hex")}
@@ -128,6 +138,12 @@ export const ColorInput = ({
             {eyeDropperIcon}
           </div>
         </>
+      )}
+      </div>
+      {!isValid && innerValue !== "" && (
+        <div className="color-picker__input-error">
+          {t("errors.invalidColor")}
+        </div>
       )}
     </div>
   );

--- a/packages/excalidraw/components/ColorPicker/ColorPicker.scss
+++ b/packages/excalidraw/components/ColorPicker/ColorPicker.scss
@@ -383,6 +383,20 @@
       box-shadow: 0 0 0 1px var(--color-primary-darkest);
       border-radius: var(--border-radius-lg);
     }
+
+    &--error {
+      border-color: var(--color-danger);
+      &:focus-within {
+        box-shadow: 0 0 0 1px var(--color-danger);
+      }
+    }
+  }
+
+  .color-picker__input-error {
+    color: var(--color-danger);
+    font-size: 0.75rem;
+    margin: 0 8px 8px 8px;
+    padding: 0 4px;
   }
 
   .color-picker__input-hash {

--- a/packages/excalidraw/locales/en.json
+++ b/packages/excalidraw/locales/en.json
@@ -289,6 +289,7 @@
     "imageInsertError": "Couldn't insert image. Try again later...",
     "fileTooBig": "File is too big. Maximum allowed size is {{maxSize}}.",
     "svgImageInsertError": "Couldn't insert SVG image. The SVG markup looks invalid.",
+    "invalidColor": "Not a valid hex color",
     "failedToFetchImage": "Failed to fetch image.",
     "cannotResolveCollabServer": "Couldn't connect to the collab server. Please reload the page and try again.",
     "importLibraryError": "Couldn't load library",


### PR DESCRIPTION
### Description
Closes #9527 

This PR implements front-end validation in the custom color input field and displays an inline error message when an invalid hexadecimal value is entered (e.g. `zzz`, `#12345`).

### Changes
- **Translation:** Added `invalidColor` to `locales/en.json`.
- **Validation State:** Integrated `isValid` state inside `ColorInput.tsx` to track input validity based on `normalizeInputColor`.
- **UI & Style:** Added CSS styling in `ColorPicker.scss` for the error border and the error message display.
- **Reset Logic:** Reset `isValid` to `true` on input blur (which reverts to the last valid color).