### PR TITLE
fix: resolve implicit symbol-to-string conversion in FILE_EXTENSION type

### DIFF
--- a/examples/with-script-in-browser/utils.ts
+++ b/examples/with-script-in-browser/utils.ts
@@ -2,9 +2,9 @@ import { MIME_TYPES } from "@excalidraw/excalidraw";
 import { fileOpen as _fileOpen } from "browser-fs-access";
 import { unstable_batchedUpdates } from "react-dom";
 
-type FILE_EXTENSION = Exclude<keyof typeof MIME_TYPES, "binary">;
+type FILE_EXTENSION = Exclude<Extract<keyof typeof MIME_TYPES, string>, "binary">;
 
-export type ResolvablePromise<T> = Promise<T> & {
+export type ResolvablePromise<T> = Promise<T> & { 
   resolve: [T] extends [undefined] ? (value?: T) => void : (value: T) => void;
   reject: (error: Error) => void;
 };


### PR DESCRIPTION
## Summary

`FILE_EXTENSION` is derived from `keyof typeof MIME_TYPES`. TypeScript widens 
this to include `symbol`, even though every key in `MIME_TYPES` is a string 
at runtime. This causes a real type error at `utils.ts:47`:

    Implicit conversion of a 'symbol' to a 'string' will fail at runtime.

Since `examples/with-script-in-browser` has its own `tsconfig.json` and is 
excluded from the root `tsconfig.json`, this error never gets caught by 
`yarn test:typecheck` in CI.

## Fix

Narrowed the `keyof` result to string keys only using `Extract<..., string>` 
before excluding `"binary"`. This removes the `symbol` possibility with no 
change to runtime behavior.

## Testing

Ran `npx tsc --noEmit -p tsconfig.json` inside `examples/with-script-in-browser`:
- Before: 13 errors (12 expected "cannot find module" path-alias errors, 
  plus the real symbol/string error)
- After: 12 errors (only the expected path-alias errors remain)