### PR TITLE
feat: show error feedback for invalid hex color codes in color picker

### DIFF
--- a/packages/excalidraw/components/ColorPicker/ColorInput.tsx
+++ b/packages/excalidraw/components/ColorPicker/ColorInput.tsx
@@ -32,6 +32,7 @@ export const ColorInput = ({
   const [activeSection, setActiveColorPickerSection] = useAtom(
     activeColorPickerSectionAtom,
   );
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     setInnerValue(color);
@@ -44,6 +45,11 @@ export const ColorInput = ({
 
       if (color) {
         onChange(color);
+        setError(null);
+      } else if (value.length > 0) {
+        setError(t("colorPicker.invalidHexColor"));
+      } else {
+        setError(null);
       }
       setInnerValue(value);
     },
@@ -82,6 +88,7 @@ export const ColorInput = ({
         value={(innerValue || "").replace(/^#/, "")}
         onBlur={() => {
           setInnerValue(color);
+          setError(null);
         }}
         tabIndex={-1}
         onFocus={() => setActiveColorPickerSection("hex")}
@@ -95,6 +102,11 @@ export const ColorInput = ({
         }}
         placeholder={placeholder}
       />
+      {error && (
+        <div className="color-picker__input-error" role="alert">
+          {error}
+        </div>
+      )}
       {/* TODO reenable on mobile with a better UX */}
       {editorInterface.formFactor !== "phone" && (
         <>

--- a/packages/excalidraw/components/ColorPicker/ColorPicker.scss
+++ b/packages/excalidraw/components/ColorPicker/ColorPicker.scss
@@ -385,6 +385,13 @@
     }
   }
 
+  .color-picker__input-error {
+    color: var(--color-danger);
+    font-size: 0.75rem;
+    padding: 0.25rem 0.5rem;
+    text-align: left;
+  }
+
   .color-picker__input-hash {
     padding: 0 0.25rem;
   }

--- a/packages/excalidraw/locales/en.json
+++ b/packages/excalidraw/locales/en.json
@@ -602,7 +602,8 @@
     "colors": "Colors",
     "shades": "Shades",
     "hexCode": "Hex code",
-    "noShades": "No shades available for this color"
+    "noShades": "No shades available for this color",
+    "invalidHexColor": "Invalid hex color code"
   },
   "overwriteConfirm": {
     "action": {


### PR DESCRIPTION
Closes #9527\n\n- Adds visual error feedback below the custom color hex input when the user types an invalid hex color value.\n- Clears the error on valid input or blur.\n- Adds a new i18n key .\n\n## Changes\n- : track validation error state and render an alert.\n- : style the error message.\n- : add  translation key.