### PR TITLE
fix: iframe-embed analytics throws ReferenceError so the event never fires

### DIFF
--- a/excalidraw-app/index.html
+++ b/excalidraw-app/index.html
@@ -236,8 +236,8 @@
       // if iframe
       if (window.self !== window.top) {
         scriptEle.addEventListener("load", () => {
-          if (window.sa_pageview) {
-            window.window.sa_event(action, {
+          if (window.sa_event) {
+            window.sa_event("embed", {
               category: "iframe",
               label: "embed",
               value: window.location.pathname,


### PR DESCRIPTION
### Problem

In `excalidraw-app/index.html`, the analytics call that fires when the app is loaded inside an iframe throws a `ReferenceError` and so never sends its event:

```js
if (window.sa_pageview) {
  window.window.sa_event(action, {   // `action` is not defined in this scope
    category: "iframe", label: "embed", value: window.location.pathname,
  });
}
```

`action` was a parameter in the `trackEvent()` helper this block was adapted from (`packages/excalidraw/analytics.ts`), but here it's a free variable that's never declared — so the `load` handler throws before `sa_event` runs, and the iframe-embed event is silently never recorded. Two smaller things in the same call: it guards on `window.sa_pageview` but the emitter is `sa_event`, and `window.window` is redundant.

### Fix

Matches the shape of `trackEvent()` exactly — `if (window.sa_event) { window.sa_event(name, { category, label, value }) }` — using the literal event name `"embed"`:

```js
if (window.sa_event) {
  window.sa_event("embed", {
    category: "iframe", label: "embed", value: window.location.pathname,
  });
}
```

2 lines changed, no behaviour beyond making the existing event actually send. Please rename the `"embed"` literal if a different event name fits your Simple Analytics taxonomy — I picked the one that matched the existing `label`.

### Testing

Static: the snippet now parses with no undeclared identifiers (checked via `new Function(...)`), and there's no remaining `window.window` or `action` reference. I don't have your Simple Analytics keys to observe the live event, so I've verified the code path rather than the delivered event — happy to adjust if you'd like it exercised differently.

<sub>I used an AI assistant to find and prepare this; it's credited in the commit trailer. I read and verified the change myself.</sub>
