### PR TITLE
fix(editor): boundText invariant at getSelectedElements

### DIFF
--- a/packages/element/src/selection.ts
+++ b/packages/element/src/selection.ts
@@ -184,6 +184,7 @@ export const getSelectedElements = (
     if (
       opts?.includeBoundTextElement &&
       isBoundToContainer(element) &&
+      isNonDeletedElement(element) &&
       appState.selectedElementIds[element?.containerId]
     ) {
       selectedElements.push(element as NonDeletedExcalidrawElement);


### PR DESCRIPTION
## Summary
- adds extra guard for nonDeleted in getSelectedElements