### PR TITLE
fix(editor): make z-order shortcuts work across keyboard layouts (#9535)

### DIFF
--- a/packages/common/src/keys.ts
+++ b/packages/common/src/keys.ts
@@ -140,6 +140,23 @@ export const isArrowKey = (key: string) =>
   key === KEYS.ARROW_DOWN ||
   key === KEYS.ARROW_UP;
 
+/**
+ * Matches the `]` / `}` key across keyboard layouts (used by the z-order
+ * shortcuts). On non-US layouts the `]` character lives on a different physical
+ * key, so `event.code` stays on that physical key (e.g. `Digit9` on a German
+ * layout) while `event.key` is the produced character — hence the fallback.
+ */
+export const isBracketRightKey = (
+  event: KeyboardEvent | React.KeyboardEvent<Element>,
+) =>
+  event.code === CODES.BRACKET_RIGHT || event.key === "]" || event.key === "}";
+
+/** Matches the `[` / `{` key across layouts. See {@link isBracketRightKey}. */
+export const isBracketLeftKey = (
+  event: KeyboardEvent | React.KeyboardEvent<Element>,
+) =>
+  event.code === CODES.BRACKET_LEFT || event.key === "[" || event.key === "{";
+
 export const shouldResizeFromCenter = (event: MouseEvent | KeyboardEvent) =>
   event.altKey;
 

--- a/packages/excalidraw/actions/actionZindex.test.tsx
+++ b/packages/excalidraw/actions/actionZindex.test.tsx
@@ -1,0 +1,125 @@
+import {
+  actionBringForward,
+  actionBringToFront,
+  actionSendBackward,
+  actionSendToBack,
+} from "./actionZindex";
+
+// The z-order keyTests only read from the event, so the remaining
+// (appState, elements, app) arguments can be stubbed.
+const runKeyTest = (
+  action: { keyTest?: (...args: any[]) => boolean | undefined },
+  init: KeyboardEventInit,
+) =>
+  action.keyTest?.(
+    new KeyboardEvent("keydown", init),
+    {} as any,
+    [] as any,
+    {} as any,
+  ) ?? false;
+
+// On non-US layouts the `[` / `]` characters live on a different physical key,
+// so `event.code` no longer reports `Bracket*`, but `event.key` still holds the
+// produced character. These tests are written for the non-mac (Ctrl) bindings,
+// which is what the test environment resolves `CTRL_OR_CMD` to.
+describe("actionZindex keyboard shortcuts (regression for #9535)", () => {
+  describe("bringForward — Ctrl+]", () => {
+    it("matches on a US layout (BracketRight physical key)", () => {
+      expect(
+        runKeyTest(actionBringForward, {
+          key: "]",
+          code: "BracketRight",
+          ctrlKey: true,
+        }),
+      ).toBe(true);
+    });
+
+    it("matches when `]` is produced by another physical key (non-US layout)", () => {
+      expect(
+        runKeyTest(actionBringForward, {
+          key: "]",
+          code: "Digit9",
+          ctrlKey: true,
+        }),
+      ).toBe(true);
+    });
+
+    it("does not match the shifted `}` (reserved for bringToFront)", () => {
+      expect(
+        runKeyTest(actionBringForward, {
+          key: "}",
+          code: "BracketRight",
+          ctrlKey: true,
+          shiftKey: true,
+        }),
+      ).toBe(false);
+    });
+
+    it("does not match without the Ctrl modifier", () => {
+      expect(
+        runKeyTest(actionBringForward, { key: "]", code: "BracketRight" }),
+      ).toBe(false);
+    });
+  });
+
+  describe("sendBackward — Ctrl+[", () => {
+    it("matches across layouts", () => {
+      expect(
+        runKeyTest(actionSendBackward, {
+          key: "[",
+          code: "BracketLeft",
+          ctrlKey: true,
+        }),
+      ).toBe(true);
+      expect(
+        runKeyTest(actionSendBackward, {
+          key: "[",
+          code: "Digit8",
+          ctrlKey: true,
+        }),
+      ).toBe(true);
+    });
+  });
+
+  describe("bringToFront — Ctrl+Shift+]", () => {
+    it("matches the shifted `}` across layouts", () => {
+      expect(
+        runKeyTest(actionBringToFront, {
+          key: "}",
+          code: "BracketRight",
+          ctrlKey: true,
+          shiftKey: true,
+        }),
+      ).toBe(true);
+      expect(
+        runKeyTest(actionBringToFront, {
+          key: "}",
+          code: "Digit9",
+          ctrlKey: true,
+          shiftKey: true,
+        }),
+      ).toBe(true);
+    });
+  });
+
+  describe("sendToBack — Ctrl+Shift+[", () => {
+    it("matches the shifted `{` across layouts", () => {
+      expect(
+        runKeyTest(actionSendToBack, {
+          key: "{",
+          code: "BracketLeft",
+          ctrlKey: true,
+          shiftKey: true,
+        }),
+      ).toBe(true);
+      expect(
+        runKeyTest(actionSendToBack, {
+          key: "{",
+          code: "Digit8",
+          ctrlKey: true,
+          shiftKey: true,
+        }),
+      ).toBe(true);
+    });
+  });
+});

--- a/packages/excalidraw/actions/actionZindex.tsx
+++ b/packages/excalidraw/actions/actionZindex.tsx
@@ -1,4 +1,9 @@
-import { KEYS, CODES, isDarwin } from "@excalidraw/common";
+import {
+  KEYS,
+  isDarwin,
+  isBracketLeftKey,
+  isBracketRightKey,
+} from "@excalidraw/common";
 
 import {
   moveOneLeft,
@@ -35,9 +40,7 @@ export const actionSendBackward = register({
   },
   keyPriority: 40,
   keyTest: (event) =>
-    event[KEYS.CTRL_OR_CMD] &&
-    !event.shiftKey &&
-    event.code === CODES.BRACKET_LEFT,
+    event[KEYS.CTRL_OR_CMD] && !event.shiftKey && isBracketLeftKey(event),
   PanelComponent: ({ updateData, appState }) => (
     <button
       type="button"
@@ -65,9 +68,7 @@ export const actionBringForward = register({
   },
   keyPriority: 40,
   keyTest: (event) =>
-    event[KEYS.CTRL_OR_CMD] &&
-    !event.shiftKey &&
-    event.code === CODES.BRACKET_RIGHT,
+    event[KEYS.CTRL_OR_CMD] && !event.shiftKey && isBracketRightKey(event),
   PanelComponent: ({ updateData, appState }) => (
     <button
       type="button"
@@ -95,12 +96,8 @@ export const actionSendToBack = register({
   },
   keyTest: (event) =>
     isDarwin
-      ? event[KEYS.CTRL_OR_CMD] &&
-        event.altKey &&
-        event.code === CODES.BRACKET_LEFT
-      : event[KEYS.CTRL_OR_CMD] &&
-        event.shiftKey &&
-        event.code === CODES.BRACKET_LEFT,
+      ? event[KEYS.CTRL_OR_CMD] && event.altKey && isBracketLeftKey(event)
+      : event[KEYS.CTRL_OR_CMD] && event.shiftKey && isBracketLeftKey(event),
   PanelComponent: ({ updateData, appState }) => (
     <button
       type="button"
@@ -133,12 +130,8 @@ export const actionBringToFront = register({
   },
   keyTest: (event) =>
     isDarwin
-      ? event[KEYS.CTRL_OR_CMD] &&
-        event.altKey &&
-        event.code === CODES.BRACKET_RIGHT
-      : event[KEYS.CTRL_OR_CMD] &&
-        event.shiftKey &&
-        event.code === CODES.BRACKET_RIGHT,
+      ? event[KEYS.CTRL_OR_CMD] && event.altKey && isBracketRightKey(event)
+      : event[KEYS.CTRL_OR_CMD] && event.shiftKey && isBracketRightKey(event),
   PanelComponent: ({ updateData, appState }) => (
     <button
       type="button"


### PR DESCRIPTION
## Fixes #9535

### Problem
The z-order keyboard shortcuts don't fire on non-US keyboard layouts.

`actionBringToFront` / `actionBringForward` / `actionSendToBack` / `actionSendBackward` matched the bracket keys purely on **`event.code`** (`BracketRight` / `BracketLeft`). `event.code` reflects the **physical key position** on a US layout, so on layouts where `[` / `]` live on a different physical key (AZERTY, QWERTZ, etc.) the shortcuts silently do nothing — matching the report in #9535.

### Fix
Also match the **produced character** via `event.key`, so the shortcut works regardless of layout. This follows the non-latin-layout convention already documented in `packages/common/src/keys.ts` (`matchKey` / `KeyCodeMap`).

- Added `isBracketRightKey` / `isBracketLeftKey` helpers in `keys.ts` (they accept the shifted `}` / `{` too, so the `Shift` variants keep working).
- Updated the four z-order `keyTest`s in `actionZindex.tsx` to use them.
- Added `actionZindex.test.tsx` covering: US layout (by `code`), non-US layout (by `key`, e.g. `]` on `Digit9`), the shifted to-front/to-back variants, and negative cases (missing modifier, wrong variant).

### Testing
- `yarn test:app run actions/actionZindex.test.tsx` — 7 passing
- `yarn test:typecheck` — clean
- `yarn eslint` / `prettier` — clean
- Existing `contextmenu.test.tsx` (which exercises these actions) — 17 passing

### Notes
No change to the shortcuts themselves or to the US-layout behavior; this only broadens matching so the existing shortcuts also fire on other layouts.
