### PR TITLE
feat(editor): allow switching arrow types via shape switcher when bound (#9656)

### DIFF
--- a/packages/element/src/newElement.ts
+++ b/packages/element/src/newElement.ts
@@ -48,6 +48,7 @@ import type {
   ElementsMap,
   ExcalidrawArrowElement,
   ExcalidrawElbowArrowElement,
+  FixedPointBinding,
   ExcalidrawLineElement,
 } from "./types";
 
@@ -501,6 +502,8 @@ export const newArrowElement = <T extends boolean>(
     points?: ExcalidrawArrowElement["points"];
     elbowed?: T;
     fixedSegments?: ExcalidrawElbowArrowElement["fixedSegments"] | null;
+    startBinding?: FixedPointBinding | null;
+    endBinding?: FixedPointBinding | null;
   } & ElementConstructorOpts,
 ): T extends true
   ? NonDeleted<ExcalidrawElbowArrowElement>
@@ -509,8 +512,8 @@ export const newArrowElement = <T extends boolean>(
     return {
       ..._newElementBase<ExcalidrawElbowArrowElement>(opts.type, opts),
       points: opts.points || [],
-      startBinding: null,
-      endBinding: null,
+      startBinding: opts.startBinding || null,
+      endBinding: opts.endBinding || null,
       startArrowhead: opts.startArrowhead || null,
       endArrowhead: opts.endArrowhead || null,
       elbowed: true,
@@ -523,8 +526,8 @@ export const newArrowElement = <T extends boolean>(
   return {
     ..._newElementBase<ExcalidrawArrowElement>(opts.type, opts),
     points: opts.points || [],
-    startBinding: null,
-    endBinding: null,
+    startBinding: opts.startBinding || null,
+    endBinding: opts.endBinding || null,
     startArrowhead: opts.startArrowhead || null,
     endArrowhead: opts.endArrowhead || null,
     elbowed: false,

--- a/packages/excalidraw/components/ConvertElementTypePopup.tsx
+++ b/packages/excalidraw/components/ConvertElementTypePopup.tsx
@@ -134,6 +134,13 @@ const isConvertibleLinearType = (
   elementType === "arrow" ||
   CONVERTIBLE_LINEAR_TYPES.has(elementType as ConvertibleLinearTypes);
 
+const LINEAR_TYPE_ICONS: Record<ConvertibleLinearTypes, ReactNode> = {
+  line: LineIcon,
+  sharpArrow: sharpArrowIcon,
+  curvedArrow: roundArrowIcon,
+  elbowArrow: elbowArrowIcon,
+};
+
 export const convertElementTypePopupAtom = atom<{
   type: "panel";
 } | null>(null);
@@ -294,12 +301,10 @@ const Panel = ({
 
   const SHAPES: [string, ReactNode][] =
     conversionType === "linear"
-      ? [
-          ["line", LineIcon],
-          ["sharpArrow", sharpArrowIcon],
-          ["curvedArrow", roundArrowIcon],
-          ["elbowArrow", elbowArrowIcon],
-        ]
+      ? getAvailableLinearConvertibleTypes(linearElements).map((type) => [
+          type,
+          LINEAR_TYPE_ICONS[type],
+        ])
       : conversionType === "generic"
       ? [
           ["rectangle", RectangleIcon],
@@ -512,15 +517,19 @@ export const convertElementTypes = (
       filterLinearConvertibleElements(selectedElements);
 
     if (!nextType) {
+      const availableTypes = getAvailableLinearConvertibleTypes(
+        convertibleLinearElements,
+      );
+
       const commonSubType = reduceToCommonValue(
         convertibleLinearElements,
         getLinearElementSubType,
       );
 
-      const index = commonSubType ? LINEAR_TYPES.indexOf(commonSubType) : -1;
+      const index = commonSubType ? availableTypes.indexOf(commonSubType) : -1;
       nextType =
-        LINEAR_TYPES[
-          (index + LINEAR_TYPES.length + advancement) % LINEAR_TYPES.length
+        availableTypes[
+          (index + availableTypes.length + advancement) % availableTypes.length
         ];
     }
 
@@ -654,13 +663,23 @@ export const getConversionTypeFromElements = (
   return null;
 };
 
-const isEligibleLinearElement = (element: ExcalidrawElement) => {
-  return (
-    isLinearElement(element) &&
-    (!isArrowElement(element) ||
-      (!isArrowBoundToElement(element) && !hasBoundTextElement(element)))
-  );
-};
+const isEligibleLinearElement = (element: ExcalidrawElement) =>
+  isLinearElement(element) &&
+  (!isArrowElement(element) || !hasBoundTextElement(element));
+
+// A bound arrow can't be converted into a plain line: a line is not bindable,
+// so the conversion would silently drop the binding. Such arrows can still
+// switch between the arrow subtypes, so we only remove `line` from the
+// available targets (while preserving the binding across the conversion).
+const cannotConvertToLine = (element: ExcalidrawElement) =>
+  isArrowElement(element) && isArrowBoundToElement(element);
+
+const getAvailableLinearConvertibleTypes = (
+  elements: readonly ExcalidrawElement[],
+): readonly ConvertibleLinearTypes[] =>
+  elements.some(cannotConvertToLine)
+    ? LINEAR_TYPES.filter((type) => type !== "line")
+    : LINEAR_TYPES;
 
 const toCacheKey = (
   elementId: ExcalidrawElement["id"],
@@ -874,6 +893,9 @@ const convertElementType = <
           }),
         );
       }
+      // switching between arrow subtypes keeps any bindings: `newArrowElement`
+      // carries over the `startBinding`/`endBinding` spread from the source
+      // element (a plain line has none)
       case "sharpArrow": {
         return bumpVersion(
           newArrowElement({

--- a/packages/excalidraw/tests/convertElementType.test.tsx
+++ b/packages/excalidraw/tests/convertElementType.test.tsx
@@ -1,6 +1,10 @@
 import { ROUNDNESS } from "@excalidraw/common";
+import { getLinearElementSubType } from "@excalidraw/element";
 
-import { convertElementTypes } from "../components/ConvertElementTypePopup";
+import {
+  convertElementTypes,
+  getConversionTypeFromElements,
+} from "../components/ConvertElementTypePopup";
 import { Excalidraw } from "../index";
 
 import { API } from "./helpers/api";
@@ -42,5 +46,98 @@ describe("convert element type", () => {
 
     expect(h.elements[0].type).toBe("rectangle");
     expect(h.elements[0].roundness?.type).toBe(ROUNDNESS.ADAPTIVE_RADIUS);
+  });
+
+  // #9656
+  describe("arrows bound to elements", () => {
+    const setupBoundArrow = () => {
+      const rectangle = API.createElement({
+        type: "rectangle",
+        x: 300,
+        y: 0,
+        width: 100,
+        height: 100,
+      });
+      const arrow = API.createElement({
+        type: "arrow",
+        x: 0,
+        y: 50,
+        width: 250,
+        height: 0,
+        endBinding: {
+          elementId: rectangle.id,
+          fixedPoint: [0.5, 0.5],
+          mode: "orbit",
+        },
+      });
+
+      API.setElements([rectangle, arrow]);
+      API.setSelectedElements([arrow]);
+
+      return arrow;
+    };
+
+    it("keeps a bound arrow eligible for the shape switcher", () => {
+      const arrow = setupBoundArrow();
+
+      // previously returned `null`, which disabled the Tab switcher entirely
+      expect(getConversionTypeFromElements([arrow])).toBe("linear");
+    });
+
+    it("switches a bound arrow between arrow subtypes and keeps the binding", () => {
+      const arrow = setupBoundArrow();
+
+      act(() => {
+        convertElementTypes(h.app, {
+          conversionType: "linear",
+          nextType: "curvedArrow",
+        });
+      });
+
+      const converted = h.elements.find((element) => element.id === arrow.id)!;
+      expect(getLinearElementSubType(converted as any)).toBe("curvedArrow");
+      expect((converted as any).endBinding).not.toBeNull();
+    });
+
+    it("never cycles a bound arrow into a line", () => {
+      const arrow = setupBoundArrow();
+
+      // cycle through more steps than there are target types so any `line`
+      // in the rotation would be hit
+      const visitedSubTypes = new Set<string>();
+      for (let i = 0; i < 4; i++) {
+        act(() => {
+          convertElementTypes(h.app, {
+            conversionType: "linear",
+            direction: "right",
+          });
+        });
+        const current = h.elements.find((element) => element.id === arrow.id)!;
+        visitedSubTypes.add(getLinearElementSubType(current as any));
+      }
+
+      expect(visitedSubTypes.has("line")).toBe(false);
+    });
+
+    it("still allows an unbound arrow to convert into a line", () => {
+      const arrow = API.createElement({
+        type: "arrow",
+        x: 0,
+        y: 0,
+        width: 100,
+        height: 0,
+      });
+      API.setElements([arrow]);
+      API.setSelectedElements([arrow]);
+
+      act(() => {
+        convertElementTypes(h.app, {
+          conversionType: "linear",
+          nextType: "line",
+        });
+      });
+
+      expect(getLinearElementSubType(h.elements[0] as any)).toBe("line");
+    });
   });
 });


### PR DESCRIPTION
## Fixes #9656

### Problem
When either end of an arrow is bound to an element, the **Tab shape switcher** is disabled entirely — you can't switch the arrow between subtypes (sharp / curved / elbow). `isEligibleLinearElement` treated any bound arrow as non-convertible, so `getConversionTypeFromElements` returned `null` and the switcher never opened.

### Decision on the issue
Maintainers agreed on the direction in the thread:
- @Mrazator: *"Switching between different arrow types (sharp / curved / angled) should still be possible."*
- @zsviczian: *"Maybe we could not show the line option if the arrow is bound to an element."*
- @dwelle: *"Yep, let's do this (not showing the line option)."*

The rationale: a line is not bindable, so converting a bound arrow → line would silently unbind it. Arrow-subtype switching has no such problem.

### Changes
- **Re-enable the switcher for bound arrows.** `isEligibleLinearElement` no longer excludes bound arrows (labeled arrows stay excluded, unchanged).
- **Hide the `line` target for bound arrows.** A single `getAvailableLinearConvertibleTypes` helper removes `line` from the options when the selection contains a bound arrow — used both by the popup and by Tab-cycling, so neither can reach `line`.
- **Preserve the binding across conversion.** `newArrowElement` now honors `startBinding`/`endBinding` from its opts instead of always nulling them, so switching a bound arrow's subtype keeps it attached. (Other callers pass no bindings and are unaffected.)

### Testing
Extended `convertElementType.test.tsx`:
- a bound arrow is eligible for the switcher (`getConversionTypeFromElements` → `"linear"`)
- switching a bound arrow to another subtype keeps its `endBinding`
- cycling a bound arrow never lands on `line`
- an **unbound** arrow can still convert to `line` (no regression)

Verified locally:
- `convertElementType` — 5 passing
- binding/transform/flowchart/linear suites (`transform`, `arrowBinding`, `flowchart`, `linearElementEditor`) — 101 passing (covers the `newArrowElement` change)
- `duplicate`, `clipboard`, `regressionTests` — 114 passing
- `yarn test:typecheck`, `eslint`, `prettier` — clean
