### PR TITLE
fix(editor): should not select deleted bound text

### DIFF
--- a/packages/element/src/selection.ts
+++ b/packages/element/src/selection.ts
@@ -184,6 +184,7 @@ export const getSelectedElements = (
     if (
       opts?.includeBoundTextElement &&
       isBoundToContainer(element) &&
+      isNonDeletedElement(element) &&
       appState.selectedElementIds[element?.containerId]
     ) {
       selectedElements.push(element as NonDeletedExcalidrawElement);


### PR DESCRIPTION
Resolves non-deleted snare triggering.