### PR TITLE
fix: remove identical conditional branches in ColorPicker toggle

### DIFF
--- a/packages/excalidraw/components/ColorPicker/ColorPicker.tsx
+++ b/packages/excalidraw/components/ColorPicker/ColorPicker.tsx
@@ -331,16 +331,10 @@ export const ColorPicker = ({
             mode={type === "elementStroke" ? "stroke" : "background"}
             editingTextElement={!!appState.editingTextElement}
             onToggle={() => {
-              // atomic switch: if another popup is open, close it first, then open this one next tick
-              if (appState.openPopup === type) {
-                // toggle off on same trigger
-                updateData({ openPopup: null });
-              } else if (appState.openPopup) {
-                updateData({ openPopup: type });
-              } else {
-                // open this one
-                updateData({ openPopup: type });
-              }
+              // toggle off on same trigger, otherwise open this one
+              updateData({
+                openPopup: appState.openPopup === type ? null : type,
+              });
             }}
           />
           {/* popup content */}


### PR DESCRIPTION
The `else if (appState.openPopup)` arm and the final `else` in the `onToggle` handler are byte-identical — both set `openPopup: type`. The comment above them describes an "atomic switch" (close the other popup first, then open this one next tick) that the code never actually implements.

This collapses the dead conditional into a plain toggle, which is the actual behavior, and fixes the comment to match. No behavior change.