### PR TITLE
fix(element): preserve zero linear dimensions

### DIFF
--- a/packages/element/src/__tests__/transform.test.ts
+++ b/packages/element/src/__tests__/transform.test.ts
@@ -965,4 +965,43 @@ describe("Test Transform", () => {
       });
     });
   });
+
+  it("should preserve explicit zero dimensions for linear elements", () => {
+    const [arrow, line] = convertToExcalidrawElements(
+      [
+        {
+          type: "arrow",
+          x: 100,
+          y: 20,
+          width: 0,
+          height: 80,
+        },
+        {
+          type: "line",
+          x: 200,
+          y: 20,
+          width: 0,
+          height: 80,
+        },
+      ] as ExcalidrawElementSkeleton[],
+      opts,
+    );
+
+    expect(arrow).toMatchObject({
+      width: 0,
+      height: 80,
+      points: [
+        [0, 0],
+        [0, expect.any(Number)],
+      ],
+    });
+    expect(line).toMatchObject({
+      width: 0,
+      height: 80,
+      points: [
+        [0, 0],
+        [0, expect.any(Number)],
+      ],
+    });
+  });
 });

--- a/packages/element/src/transform.ts
+++ b/packages/element/src/transform.ts
@@ -553,8 +553,8 @@ export const convertToExcalidrawElements = (
         break;
       }
       case "line": {
-        const width = element.width || DEFAULT_LINEAR_ELEMENT_PROPS.width;
-        const height = element.height || DEFAULT_LINEAR_ELEMENT_PROPS.height;
+        const width = element.width ?? DEFAULT_LINEAR_ELEMENT_PROPS.width;
+        const height = element.height ?? DEFAULT_LINEAR_ELEMENT_PROPS.height;
         excalidrawElement = newLinearElement({
           width,
           height,
@@ -565,8 +565,8 @@ export const convertToExcalidrawElements = (
         break;
       }
       case "arrow": {
-        const width = element.width || DEFAULT_LINEAR_ELEMENT_PROPS.width;
-        const height = element.height || DEFAULT_LINEAR_ELEMENT_PROPS.height;
+        const width = element.width ?? DEFAULT_LINEAR_ELEMENT_PROPS.width;
+        const height = element.height ?? DEFAULT_LINEAR_ELEMENT_PROPS.height;
         excalidrawElement = newArrowElement({
           width,
           height,

--- a/packages/excalidraw/CHANGELOG.md
+++ b/packages/excalidraw/CHANGELOG.md
@@ -13,6 +13,10 @@ Please add the latest change on the top under the correct section.
 
 ## Unreleased
 
+### Fixes
+
+- Preserved explicit zero dimensions for line and arrow skeletons converted by `convertToExcalidrawElements`. [#11664](https://github.com/excalidraw/excalidraw/pull/11664)
+
 ## Excalidraw API
 
 ### Interaction and UI control (2026-07-05) [#11605](https://github.com/excalidraw/excalidraw/pull/11605)


### PR DESCRIPTION
## Summary

- preserve explicit zero widths when converting line and arrow skeletons
- add regression coverage for vertical linear elements

## Tests

- `yarn test packages/element/src/__tests__/transform.test.ts --run`
- `yarn test:typecheck`
- `yarn test:code`
- `yarn test packages/excalidraw/tests/fitToContent.test.tsx --run`
