### PR TITLE
fix(editor): localize publish library form validation messages

### DIFF
--- a/packages/excalidraw/components/PublishLibrary.tsx
+++ b/packages/excalidraw/components/PublishLibrary.tsx
@@ -186,7 +186,7 @@ const SingleLibraryItem = ({
             ref={inputRef}
             style={{ width: "80%", padding: "0.2rem" }}
             defaultValue={libItem.name}
-            placeholder="Item name"
+            placeholder={t("publishDialog.itemName")}
             onChange={(event) => {
               onChange(event.target.value, index);
             }}
@@ -249,10 +249,26 @@ const PublishLibrary = ({
   }, [libraryItems]);
 
   const onInputChange = (event: any) => {
+    // A non-empty customValidity keeps the field invalid until it is cleared,
+    // so drop the message set by onInvalid whenever the value changes.
+    event.target.setCustomValidity("");
     setLibraryData({
       ...libraryData,
       [event.target.name]: event.target.value,
     });
+  };
+
+  // The browser renders constraint-validation messages in its own locale, which
+  // ignores the editor's language setting. Supply the translated text instead.
+  const onInvalid = (
+    event: React.SyntheticEvent<HTMLInputElement | HTMLTextAreaElement>,
+  ) => {
+    const target = event.currentTarget;
+    target.setCustomValidity(
+      target.validity.patternMismatch
+        ? t("publishDialog.errors.website")
+        : t("publishDialog.errors.required"),
+    );
   };
 
   const onSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
@@ -433,6 +449,7 @@ const PublishLibrary = ({
                 required
                 value={libraryData.name}
                 onChange={onInputChange}
+                onInvalid={onInvalid}
                 placeholder={t("publishDialog.placeholder.libraryName")}
               />
             </label>
@@ -449,6 +466,7 @@ const PublishLibrary = ({
                 required
                 value={libraryData.description}
                 onChange={onInputChange}
+                onInvalid={onInvalid}
                 placeholder={t("publishDialog.placeholder.libraryDesc")}
               />
             </label>
@@ -465,6 +483,7 @@ const PublishLibrary = ({
                 required
                 value={libraryData.authorName}
                 onChange={onInputChange}
+                onInvalid={onInvalid}
                 placeholder={t("publishDialog.placeholder.authorName")}
               />
             </label>
@@ -497,6 +516,7 @@ const PublishLibrary = ({
                 title={t("publishDialog.errors.website")}
                 value={libraryData.website}
                 onChange={onInputChange}
+                onInvalid={onInvalid}
                 placeholder={t("publishDialog.placeholder.website")}
               />
             </label>


### PR DESCRIPTION
Found this with the editor set to 繁體中文 on an English browser.

The publish library form relies on native constraint validation, so the browser renders the validation text in its own locale rather than the editor's. Every other string in the dialog is translated, then submit gives you this:

| field | today | should be |
| --- | --- | --- |
| name / description / authorName | Please fill out this field. | 必填 |
| website | Please match the requested format. | 請輸入有效的 URL |

`title={t("publishDialog.errors.website")}` on the website input looks like an earlier attempt at this, but the browser shows its own message first so it never really lands.

Fix sets the message in `onInvalid` and clears it in the existing `onInputChange` so a corrected field can go valid again. `publishDialog.errors.required`, `publishDialog.errors.website` and `publishDialog.itemName` all already exist, so there are no new strings and nothing for Crowdin.

Also swapped the hardcoded `placeholder="Item name"` for the key that was already sitting there unused. Happy to split that into its own PR if you'd rather keep this one to the validation.

Nothing else changes — still native validation, still blocks submit on the same fields, `onSubmit` and the per-item checks untouched. Only the text differs.

To check, with the dialog open:

```js
const name = document
  .querySelector(".publish-library form")
  .querySelector('input[name="name"]');
name.checkValidity();
name.validationMessage; // 必填, was "Please fill out this field."
name.validity.valid; // false, still blocks submit
```

`yarn test:typecheck` passes. Typing into a field clears the message and it goes valid, so nothing gets stuck.
