### PR TITLE
fix(packages/excalidraw): show error for invalid hex color input

### DIFF
--- a/packages/excalidraw/components/ColorPicker/ColorInput.tsx
+++ b/packages/excalidraw/components/ColorPicker/ColorInput.tsx
@@ -10,9 +10,12 @@ import { useEditorInterface } from "../App";
 import { activeEyeDropperAtom } from "../EyeDropper";
 import { eyeDropperIcon } from "../icons";
 
-import { activeColorPickerSectionAtom } from "./colorPickerUtils";
+import {
+  activeColorPickerSectionAtom,
+  getHexColorInputError,
+} from "./colorPickerUtils";
 
-import type { ColorPickerType } from "./colorPickerUtils";
+import type { ColorPickerType, HexColorInputError } from "./colorPickerUtils";
 
 export const ColorInput = ({
   color,
@@ -29,21 +32,28 @@ export const ColorInput = ({
 }) => {
   const editorInterface = useEditorInterface();
   const [innerValue, setInnerValue] = useState(color);
+  const [validationError, setValidationError] =
+    useState<HexColorInputError | null>(null);
   const [activeSection, setActiveColorPickerSection] = useAtom(
     activeColorPickerSectionAtom,
   );
 
   useEffect(() => {
     setInnerValue(color);
+    setValidationError(null);
   }, [color]);
 
   const changeColor = useCallback(
     (inputValue: string) => {
       const value = inputValue.toLowerCase();
-      const color = normalizeInputColor(value);
+      const error = getHexColorInputError(value);
+      setValidationError(error);
 
-      if (color) {
-        onChange(color);
+      if (!error) {
+        const normalizedColor = normalizeInputColor(value);
+        if (normalizedColor) {
+          onChange(normalizedColor);
+        }
       }
       setInnerValue(value);
     },
@@ -68,66 +78,88 @@ export const ColorInput = ({
   }, [setEyeDropperState]);
 
   return (
-    <div className="color-picker__input-label">
-      <div className="color-picker__input-hash">#</div>
-      <input
-        ref={activeSection === "hex" ? inputRef : undefined}
-        style={{ border: 0, padding: 0 }}
-        spellCheck={false}
-        className="color-picker-input"
-        aria-label={label}
-        onChange={(event) => {
-          changeColor(event.target.value);
-        }}
-        value={(innerValue || "").replace(/^#/, "")}
-        onBlur={() => {
-          setInnerValue(color);
-        }}
-        tabIndex={-1}
-        onFocus={() => setActiveColorPickerSection("hex")}
-        onKeyDown={(event) => {
-          if (event.key === KEYS.TAB) {
-            return;
-          } else if (event.key === KEYS.ESCAPE) {
-            eyeDropperTriggerRef.current?.focus();
+    <div className="color-picker__input-wrapper">
+      <div
+        className={clsx("color-picker__input-label", {
+          "color-picker__input-label--invalid": validationError,
+        })}
+      >
+        <div className="color-picker__input-hash">#</div>
+        <input
+          ref={activeSection === "hex" ? inputRef : undefined}
+          style={{ border: 0, padding: 0 }}
+          spellCheck={false}
+          className="color-picker-input"
+          aria-label={label}
+          aria-invalid={validationError ? true : undefined}
+          aria-describedby={
+            validationError ? "color-picker-hex-error" : undefined
           }
-          event.stopPropagation();
-        }}
-        placeholder={placeholder}
-      />
-      {/* TODO reenable on mobile with a better UX */}
-      {editorInterface.formFactor !== "phone" && (
-        <>
-          <div
-            style={{
-              width: "1px",
-              height: "1.25rem",
-              backgroundColor: "var(--default-border-color)",
-            }}
-          />
-          <div
-            ref={eyeDropperTriggerRef}
-            className={clsx("excalidraw-eye-dropper-trigger", {
-              selected: eyeDropperState,
-            })}
-            onClick={() =>
-              setEyeDropperState((s) =>
-                s
-                  ? null
-                  : {
-                      keepOpenOnAlt: false,
-                      onSelect: (color) => onChange(color),
-                      colorPickerType,
-                    },
-              )
+          onChange={(event) => {
+            changeColor(event.target.value);
+          }}
+          value={(innerValue || "").replace(/^#/, "")}
+          onBlur={() => {
+            setInnerValue(color);
+            setValidationError(null);
+          }}
+          tabIndex={-1}
+          onFocus={() => setActiveColorPickerSection("hex")}
+          onKeyDown={(event) => {
+            if (event.key === KEYS.TAB) {
+              return;
+            } else if (event.key === KEYS.ESCAPE) {
+              eyeDropperTriggerRef.current?.focus();
             }
-            title={`${t(
-              "labels.eyeDropper",
-            )} — ${KEYS.I.toLocaleUpperCase()} or ${getShortcutKey("Alt")} `}
-          >
-            {eyeDropperIcon}
-          </div>
-        </>
+            event.stopPropagation();
+          }}
+          placeholder={placeholder}
+        />
+        {/* TODO reenable on mobile with a better UX */}
+        {editorInterface.formFactor !== "phone" && (
+          <>
+            <div
+              style={{
+                width: "1px",
+                height: "1.25rem",
+                backgroundColor: "var(--default-border-color)",
+              }}
+            />
+            <div
+              ref={eyeDropperTriggerRef}
+              className={clsx("excalidraw-eye-dropper-trigger", {
+                selected: eyeDropperState,
+              })}
+              onClick={() =>
+                setEyeDropperState((s) =>
+                  s
+                    ? null
+                    : {
+                        keepOpenOnAlt: false,
+                        onSelect: (color) => onChange(color),
+                        colorPickerType,
+                      },
+                )
+              }
+              title={`${t(
+                "labels.eyeDropper",
+              )} — ${KEYS.I.toLocaleUpperCase()} or ${getShortcutKey("Alt")} `}
+            >
+              {eyeDropperIcon}
+            </div>
+          </>
+        )}
+      </div>
+      {validationError && (
+        <div
+          id="color-picker-hex-error"
+          className="color-picker__input-error"
+          role="alert"
+        >
+          {validationError === "invalidCharacters"
+            ? t("colorPicker.invalidHexCharacters")
+            : t("colorPicker.invalidHexLength")}
+        </div>
       )}
     </div>
   );

--- a/packages/excalidraw/components/ColorPicker/ColorPicker.scss
+++ b/packages/excalidraw/components/ColorPicker/ColorPicker.scss
@@ -383,6 +383,21 @@
       box-shadow: 0 0 0 1px var(--color-primary-darkest);
       border-radius: var(--border-radius-lg);
     }
+
+    &--invalid {
+      border-color: var(--color-danger);
+    }
+  }
+
+  .color-picker__input-wrapper {
+    margin: 0 0 4px;
+  }
+
+  .color-picker__input-error {
+    color: var(--color-danger);
+    font-size: 0.75rem;
+    line-height: 1.25;
+    margin: -4px 8px 8px;
   }
 
   .color-picker__input-hash {

--- a/packages/excalidraw/components/ColorPicker/colorPickerUtils.ts
+++ b/packages/excalidraw/components/ColorPicker/colorPickerUtils.ts
@@ -100,3 +100,22 @@ export type ColorPickerType =
   | "canvasBackground"
   | "elementBackground"
   | "elementStroke";
+
+export type HexColorInputError = "invalidCharacters" | "invalidLength";
+
+/** Validates hex input in the color picker's # field (3/4/6/8 hex digits). */
+export const getHexColorInputError = (
+  value: string,
+): HexColorInputError | null => {
+  const hex = value.trim().replace(/^#/, "");
+  if (!hex) {
+    return null;
+  }
+  if (!/^[0-9a-fA-F]+$/.test(hex)) {
+    return "invalidCharacters";
+  }
+  if (![3, 4, 6, 8].includes(hex.length)) {
+    return "invalidLength";
+  }
+  return null;
+};

--- a/packages/excalidraw/locales/en.json
+++ b/packages/excalidraw/locales/en.json
@@ -604,6 +604,8 @@
     "colors": "Colors",
     "shades": "Shades",
     "hexCode": "Hex code",
+    "invalidHexCharacters": "Invalid characters in hex code",
+    "invalidHexLength": "Hex code must be 3, 4, 6, or 8 characters (excluding #)",
     "noShades": "No shades available for this color"
   },
   "overwriteConfirm": {

--- a/packages/excalidraw/tests/colorPickerUtils.test.ts
+++ b/packages/excalidraw/tests/colorPickerUtils.test.ts
@@ -1,0 +1,29 @@
+import { getHexColorInputError } from "../components/ColorPicker/colorPickerUtils";
+
+describe("getHexColorInputError", () => {
+  it("returns null for empty input", () => {
+    expect(getHexColorInputError("")).toBe(null);
+    expect(getHexColorInputError("   ")).toBe(null);
+  });
+
+  it("returns null for valid hex lengths", () => {
+    expect(getHexColorInputError("abc")).toBe(null);
+    expect(getHexColorInputError("abcd")).toBe(null);
+    expect(getHexColorInputError("ff0000")).toBe(null);
+    expect(getHexColorInputError("#ff000080")).toBe(null);
+  });
+
+  it("returns invalidLength for wrong digit counts from issue #9527", () => {
+    expect(getHexColorInputError("1")).toBe("invalidLength");
+    expect(getHexColorInputError("12")).toBe("invalidLength");
+    expect(getHexColorInputError("12345")).toBe("invalidLength");
+    expect(getHexColorInputError("1234567")).toBe("invalidLength");
+    expect(getHexColorInputError("123456789")).toBe("invalidLength");
+  });
+
+  it("returns invalidCharacters for non-hex input", () => {
+    expect(getHexColorInputError("zzzzzz")).toBe("invalidCharacters");
+    expect(getHexColorInputError("blue")).toBe("invalidCharacters");
+    expect(getHexColorInputError("12g456")).toBe("invalidCharacters");
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #9527.

## Changes

- `getHexColorInputError()` — validates 3/4/6/8 hex digits; rejects non-hex characters and named colors in the `#` field
- `ColorInput.tsx` — inline error message with `aria-invalid` / `role="alert"`
- i18n strings in `en.json`
- Unit tests in `colorPickerUtils.test.ts`

## Test plan

- [x] `./node_modules/.bin/vitest run packages/excalidraw/tests/colorPickerUtils.test.ts`
- [ ] Manual: open color picker → enter `blue` or `gg0000` in the hex field → inline error appears; enter `ff00aa` → color applies
