### PR TITLE
fix: prevent browser save dialog when editing text (fixes #9281)

### DIFF
--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -5768,7 +5768,9 @@ class App extends React.Component<AppProps, AppState> {
         // inside an input
         (isWritableElement(event.target) &&
           // unless pressing escape (finalize action)
-          event.key !== KEYS.ESCAPE) ||
+          event.key !== KEYS.ESCAPE &&
+          // unless pressing CTRL+S (to save)
+          !(event[KEYS.CTRL_OR_CMD] && event.key.toLowerCase() === KEYS.S)) ||
         // or unless using arrows (to move between buttons)
         (isArrowKey(event.key) && isInputLike(event.target))
       ) {


### PR DESCRIPTION
When editing text, CTRL+S was triggering the browser's save dialog instead of saving the file. The keyboard handler in App.tsx was returning early for writable elements before the action manager could prevent the event. Added an exception for CTRL+S alongside the existing ESCAPE check.
