### PR TITLE
 allow browser find in help dialog (fixes #9276)

### DIFF
--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -5768,7 +5768,9 @@ class App extends React.Component<AppProps, AppState> {
         // inside an input
         (isWritableElement(event.target) &&
           // unless pressing escape (finalize action)
-          event.key !== KEYS.ESCAPE) ||
+          event.key !== KEYS.ESCAPE &&
+          // unless pressing CTRL+S (to save)
+          !(event[KEYS.CTRL_OR_CMD] && event.key.toLowerCase() === KEYS.S)) ||
         // or unless using arrows (to move between buttons)
         (isArrowKey(event.key) && isInputLike(event.target))
       ) {

--- a/packages/excalidraw/components/SearchMenu.tsx
+++ b/packages/excalidraw/components/SearchMenu.tsx
@@ -287,12 +287,13 @@ export const SearchMenu = () => {
       }
 
       if (event[KEYS.CTRL_OR_CMD] && event.key === KEYS.F) {
-        event.preventDefault();
-        event.stopPropagation();
-
+        // Allow browser's native find to work when a dialog is open
         if (app.state.openDialog) {
           return;
         }
+
+        event.preventDefault();
+        event.stopPropagation();
 
         if (!searchInputRef.current?.matches(":focus")) {
           if (app.state.openDialog) {


### PR DESCRIPTION
Ctrl+F didn't work in the help dialog. SearchMenu.tsx was preventing the default behavior globally, then checking if a dialog was open and doing nothing. Moved the dialog check before preventDefault() so browser find works when dialogs are open.
