### PR TITLE
fix(sw): cache preloaded fonts for offline usage

### DIFF
--- a/excalidraw-app/vite.config.mts
+++ b/excalidraw-app/vite.config.mts
@@ -7,7 +7,10 @@ import { VitePWA } from "vite-plugin-pwa";
 import checker from "vite-plugin-checker";
 import { createHtmlPlugin } from "vite-plugin-html";
 import Sitemap from "vite-plugin-sitemap";
-import { woff2BrowserPlugin } from "../scripts/woff2/woff2-vite-plugins";
+import {
+  woff2BrowserPlugin,
+  OSS_FONTS_CDN,
+} from "../scripts/woff2/woff2-vite-plugins";
 export default defineConfig(({ mode }) => {
   // To load .env variables
   const envVars = loadEnv(mode, `../`);
@@ -173,6 +176,24 @@ export default defineConfig(({ mode }) => {
             // via a static import from the main bundle, defeating lazy
             // loading. So we exclude it by name instead.
             "**/CodeMirrorEditor-*.js",
+          ],
+          additionalManifestEntries: [
+            {
+              url: `${OSS_FONTS_CDN}fonts/Excalifont/Excalifont-Regular-a88b72a24fb54c9f94e3b5fdaa7481c9.woff2`,
+              revision: null,
+            },
+            {
+              url: `${OSS_FONTS_CDN}fonts/Nunito/Nunito-Regular-XRXI3I6Li01BKofiOc5wtlZ2di8HDIkhdTQ3j6zbXWjgeg.woff2`,
+              revision: null,
+            },
+            {
+              url: `${OSS_FONTS_CDN}fonts/Assistant/Assistant-SemiBold.woff2`,
+              revision: null,
+            },
+            {
+              url: `${OSS_FONTS_CDN}fonts/ComicShanns/ComicShanns-Regular-279a7b317d12eb88de06167bd672b4b4.woff2`,
+              revision: null,
+            },
           ],
           runtimeCaching: [
             {

--- a/scripts/woff2/woff2-vite-plugins.js
+++ b/scripts/woff2/woff2-vite-plugins.js
@@ -2,6 +2,9 @@
 const OSS_FONTS_CDN = "https://excalidraw.nyc3.cdn.digitaloceanspaces.com/oss/";
 const OSS_FONTS_FALLBACK = "/";
 
+module.exports.OSS_FONTS_CDN = OSS_FONTS_CDN;
+module.exports.OSS_FONTS_FALLBACK = OSS_FONTS_FALLBACK;
+
 /**
  * Custom vite plugin for auto-prefixing `EXCALIDRAW_ASSET_PATH` woff2 fonts in `excalidraw-app`.
  *


### PR DESCRIPTION
### Summary
This PR fixes the issue where preloaded fonts were not being cached by the service worker, causing them to fail when loading in offline mode on subsequent visits.

Closes #1423

### Details
- Currently, `index.html` replaces the font placeholder with `<link rel="preload" as="font" ...>` tags for the default fonts hosted on the CDN.
- Since these fonts are preloaded during the initial HTML parsing before the Service Worker is registered or active, they bypass the service worker's `runtimeCaching` interceptors on the first load. When users subsequently go offline, the preloaded fonts fail to load from the CDN.
- To fix this, we exported `OSS_FONTS_CDN` from `scripts/woff2/woff2-vite-plugins.js` and added the four preloaded fonts to `workbox.additionalManifestEntries` in `excalidraw-app/vite.config.mts`.
- This ensures the fonts are successfully precached during the service worker installation phase and are available offline.
