### PR TITLE
fix(editor): make Help button tooltip consistent with toolbar

### DIFF
--- a/packages/excalidraw/components/HelpButton.tsx
+++ b/packages/excalidraw/components/HelpButton.tsx
@@ -21,4 +21,3 @@ export const HelpButton = (props: HelpButtonProps) => (
     </button>
   </Tooltip>
 );
-

--- a/packages/excalidraw/components/HelpButton.tsx
+++ b/packages/excalidraw/components/HelpButton.tsx
@@ -1,6 +1,7 @@
 import { t } from "../i18n";
 
 import { HelpIcon } from "./icons";
+import { Tooltip } from "./Tooltip";
 
 type HelpButtonProps = {
   name?: string;
@@ -9,13 +10,15 @@ type HelpButtonProps = {
 };
 
 export const HelpButton = (props: HelpButtonProps) => (
-  <button
-    className="help-icon"
-    onClick={props.onClick}
-    type="button"
-    title={`${t("helpDialog.title")} — ?`}
-    aria-label={t("helpDialog.title")}
-  >
-    {HelpIcon}
-  </button>
+  <Tooltip label={`${t("helpDialog.title")} — ?`}>
+    <button
+      className="help-icon"
+      onClick={props.onClick}
+      type="button"
+      aria-label={t("helpDialog.title")}
+    >
+      {HelpIcon}
+    </button>
+  </Tooltip>
 );
+


### PR DESCRIPTION
## Summary

Replace the native `title` attribute on the Help button with the shared `Tooltip` component.

This makes the Help button tooltip consistent with the other toolbar/footer tooltips.

## Before / After

<img width="1045" height="522" alt="Screenshot 2026-07-17 at 10 39 35 PM" src="https://github.com/user-attachments/assets/dffcd609-822d-4738-ba4e-a0174d449c81" />



## Testing

- Ran the app locally
- Verified the Help button displays the shared tooltip
- Verified clicking the Help button still opens the Help dialog