### PR TITLE
fix: correct dialog aria-labelledby to match title element id

### DIFF
--- a/packages/excalidraw/components/Dialog.tsx
+++ b/packages/excalidraw/components/Dialog.tsx
@@ -103,19 +103,21 @@ export const Dialog = (props: DialogProps) => {
     props.onCloseRequest();
   };
 
+  const dialogTitleId = props.title ? `${id}-dialog-title` : undefined;
+
   return (
     <Modal
       className={clsx("Dialog", props.className, {
         "Dialog--fullscreen": isFullscreen,
       })}
-      labelledBy="dialog-title"
+      labelledBy={dialogTitleId}
       maxWidth={getDialogSize(props.size)}
       onCloseRequest={onClose}
       closeOnClickOutside={props.closeOnClickOutside}
     >
       <Island ref={setIslandNode}>
         {props.title && (
-          <h2 id={`${id}-dialog-title`} className="Dialog__title">
+          <h2 id={dialogTitleId} className="Dialog__title">
             <span className="Dialog__titleContent">{props.title}</span>
           </h2>
         )}

--- a/packages/excalidraw/components/Modal.tsx
+++ b/packages/excalidraw/components/Modal.tsx
@@ -15,7 +15,7 @@ export const Modal: React.FC<{
   children: React.ReactNode;
   maxWidth?: number;
   onCloseRequest(): void;
-  labelledBy: string;
+  labelledBy?: string;
   theme?: AppState["theme"];
   closeOnClickOutside?: boolean;
 }> = (props) => {
@@ -48,7 +48,7 @@ export const Modal: React.FC<{
       role="dialog"
       aria-modal="true"
       onKeyDown={handleKeydown}
-      aria-labelledby={props.labelledBy}
+      {...(props.labelledBy ? { "aria-labelledby": props.labelledBy } : {})}
     >
       <div
         className="Modal__background"


### PR DESCRIPTION
## Summary

Fixes a broken `aria-labelledby` reference on all Excalidraw dialogs so screen readers can correctly announce dialog titles.

## Problem

`Dialog` passed a hardcoded `labelledBy="dialog-title"` to `Modal`, but the title element used an instance-scoped id (`${id}-dialog-title`). No element with `id="dialog-title"` exists in the DOM, so assistive technologies could not associate dialogs with their titles.

For dialogs rendered with `title={false}`, the invalid `aria-labelledby` was still applied, leaving those modals without any accessible name.

## Solution

- Derive a single `dialogTitleId` in `Dialog` and use it for both the `<h2>` id and the `Modal`'s `labelledBy` prop.
- Make `labelledBy` optional on `Modal` and only set `aria-labelledby` when a label id is provided.

This aligns `Dialog` with the existing pattern used in `Section.tsx`.