### PR TITLE
fix(editor): show keyboard shortcut in stroke/background picker tooltip

### DIFF
--- a/packages/excalidraw/components/ColorPicker/ColorPicker.tsx
+++ b/packages/excalidraw/components/ColorPicker/ColorPicker.tsx
@@ -15,6 +15,7 @@ import type { ExcalidrawElement } from "@excalidraw/element/types";
 
 import { useAtom } from "../../editor-jotai";
 import { t } from "../../i18n";
+import { getShortcutKey } from "../../shortcut";
 import { useExcalidrawContainer, useStylesPanelMode } from "../App";
 import { ButtonSeparator } from "../ButtonSeparator";
 import { activeEyeDropperAtom } from "../EyeDropper";
@@ -254,8 +255,8 @@ const ColorPickerTrigger = ({
       style={color ? { "--swatch-color": color } : undefined}
       title={
         type === "elementStroke"
-          ? t("labels.showStroke")
-          : t("labels.showBackground")
+          ? `${t("labels.strokeColorPicker")} — ${getShortcutKey("S")}`
+          : `${t("labels.backgroundColorPicker")} — ${getShortcutKey("G")}`
       }
       data-openpopup={type}
       onClick={handleClick}

--- a/packages/excalidraw/locales/en.json
+++ b/packages/excalidraw/locales/en.json
@@ -131,6 +131,8 @@
     "share": "Share",
     "showStroke": "Show stroke color picker",
     "showBackground": "Show background color picker",
+    "strokeColorPicker": "Stroke color picker",
+    "backgroundColorPicker": "Background color picker",
     "showFonts": "Show font picker",
     "toggleTheme": "Toggle light/dark theme",
     "theme": "Theme",


### PR DESCRIPTION
Closes #11695

## Summary
Adds a shortcut hint (S / G) to the Stroke and Background color picker
tooltip, matching the toolbar's existing "label — shortcut" convention
(e.g. "Arrow — A or 5").

## Before / After
<img width="1254" height="422" alt="image" src="https://github.com/user-attachments/assets/15473e01-4430-430e-94ce-b0f7127d52fa" />

* **The background gets the same treatment hovering over its swatch trigger shows “Background color picker — G.”**



## Note on wording
Went with "Stroke color picker — S" (dropping "Show") to match the
toolbar's terse convention and keep the tooltip short. Happy to switch
to "Show stroke color picker — S" if maintainers prefer consistency
with the existing Help dialog wording.

