### PR TITLE
fix(editor): show keyboard shortcuts in color picker tooltips

### DIFF
--- a/packages/excalidraw/components/ColorPicker/ColorPicker.tsx
+++ b/packages/excalidraw/components/ColorPicker/ColorPicker.tsx
@@ -254,8 +254,8 @@ const ColorPickerTrigger = ({
       style={color ? { "--swatch-color": color } : undefined}
       title={
         type === "elementStroke"
-          ? t("labels.showStroke")
-          : t("labels.showBackground")
+          ? `${t("labels.showStroke")} — S`
+          : `${t("labels.showBackground")} — G`
       }
       data-openpopup={type}
       onClick={handleClick}


### PR DESCRIPTION
## Summary

This PR updates the Stroke and Background color picker tooltips to display their corresponding keyboard shortcuts for consistency with other toolbar tooltips.

## Changes

- Updated the Stroke color picker tooltip to:
  - `Show stroke color picker — S`
- Updated the Background color picker tooltip to:
  - `Show background color picker — G`

## Why

Toolbar buttons such as Rectangle and Arrow already include keyboard shortcuts in their tooltips. Adding shortcuts to the Stroke and Background color picker tooltips makes the user experience more consistent and improves discoverability of keyboard shortcuts.

Fixes #<11695>