### PR TITLE
fix(elements): respect zero coordinates in elbow arrow mutation, guard stale binding unbind

### DIFF
--- a/packages/element/src/binding.ts
+++ b/packages/element/src/binding.ts
@@ -1139,11 +1139,13 @@ export const unbindBindingElement = (
     const boundElement = scene
       .getNonDeletedElementsMap()
       .get(binding.elementId) as NonDeleted<ExcalidrawBindableElement>;
-    scene.mutateElement(boundElement, {
-      boundElements: boundElement.boundElements?.filter(
-        (element) => element.id !== arrow.id,
-      ),
-    });
+    if (boundElement) {
+      scene.mutateElement(boundElement, {
+        boundElements: boundElement.boundElements?.filter(
+          (element) => element.id !== arrow.id,
+        ),
+      });
+    }
   }
 
   scene.mutateElement(arrow, { [field]: null });

--- a/packages/element/src/mutateElement.ts
+++ b/packages/element/src/mutateElement.ts
@@ -62,8 +62,8 @@ export const mutateElement = <TElement extends Mutable<ExcalidrawElement>>(
       ...updateElbowArrowPoints(
         {
           ...(element as ExcalidrawElbowArrowElement),
-          x: updates.x || element.x,
-          y: updates.y || element.y,
+          x: updates.x ?? element.x,
+          y: updates.y ?? element.y,
         },
         elementsMap as NonDeletedSceneElementsMap,
         updates as ElementUpdate<ExcalidrawElbowArrowElement>,

--- a/packages/element/tests/binding.test.tsx
+++ b/packages/element/tests/binding.test.tsx
@@ -16,7 +16,11 @@ import {
 
 import { defaultLang, setLanguage } from "@excalidraw/excalidraw/i18n";
 
-import { bindBindingElement, updateBoundElements } from "../src/binding";
+import {
+  bindBindingElement,
+  updateBoundElements,
+  unbindBindingElement,
+} from "../src/binding";
 import { getTransformHandles } from "../src/transformHandles";
 import {
   getTextEditor,
@@ -811,4 +815,52 @@ describe("binding to a point-like (sub-pixel) element", () => {
       expect(Math.abs(arrow.height)).toBeLessThan(1000);
     },
   );
+});
+
+describe("unbindBindingElement safety", () => {
+  beforeEach(async () => {
+    mouse.reset();
+    await act(() => setLanguage(defaultLang));
+    await render(<Excalidraw handleKeyboardGlobally={true} />);
+  });
+
+  it("should not throw when unbinding from a bound element that no longer exists", () => {
+    const rect = API.createElement({
+      type: "rectangle",
+      x: 200,
+      y: 50,
+      width: 100,
+      height: 100,
+    }) as NonDeleted<ExcalidrawBindableElement>;
+    const arrow = API.createElement({
+      type: "arrow",
+      x: 0,
+      y: 50,
+      width: 195,
+      height: 0,
+      points: [pointFrom(0, 0), pointFrom(195, 0)],
+    }) as NonDeleted<ExcalidrawArrowElement>;
+    API.setElements([rect, arrow]);
+
+    bindBindingElement(arrow, rect, "orbit", "end", h.scene);
+    expect(arrow.endBinding?.elementId).toBe(rect.id);
+
+    // Simulate the bound element having been deleted out from under the
+    // arrow (collab delete-race, undo/redo, or stale paste bindings).
+    // A plain isDeleted flip isn't enough to reproduce this: mutateElement
+    // updates the element in place but does not rebuild the scene's
+    // non-deleted elements map, so the stale reference would still resolve.
+    // Re-running it through setElements forces that rebuild, which is what
+    // actually removes it from getNonDeletedElementsMap().
+    (rect as any).isDeleted = true;
+    API.setElements(h.elements);
+
+    expect(h.scene.getNonDeletedElementsMap().get(rect.id)).toBeUndefined();
+
+    expect(() => {
+      unbindBindingElement(arrow, "end", h.scene);
+    }).not.toThrow();
+
+    expect(arrow.endBinding).toBeNull();
+  });
 });

--- a/packages/element/tests/elbowArrow.test.tsx
+++ b/packages/element/tests/elbowArrow.test.tsx
@@ -207,6 +207,55 @@ describe("elbow arrow routing", () => {
   });
 });
 
+describe("elbow arrow mutation with zero coordinates", () => {
+  beforeEach(async () => {
+    localStorage.clear();
+    await render(<Excalidraw handleKeyboardGlobally={true} />);
+  });
+
+  it("does not silently drop an origin coordinate of 0 during elbow routing (x)", () => {
+    const arrow = API.createElement({
+      type: "arrow",
+      elbowed: true,
+      x: 100,
+      y: 100,
+      width: 90,
+      height: 200,
+      points: [pointFrom<LocalPoint>(0, 0), pointFrom<LocalPoint>(90, 200)],
+    }) as NonDeleted<ExcalidrawElbowArrowElement>;
+    h.scene.insertElement(arrow);
+
+    // points must be included in the same update for the elbow-routing
+    // branch (and therefore the x/y fallback) to run at all.
+    h.scene.mutateElement(arrow, {
+      x: 0,
+      points: [pointFrom<LocalPoint>(0, 0), pointFrom<LocalPoint>(90, 200)],
+    });
+
+    expect(arrow.x).toEqual(0);
+  });
+
+  it("does not silently drop an origin coordinate of 0 during elbow routing (y)", () => {
+    const arrow = API.createElement({
+      type: "arrow",
+      elbowed: true,
+      x: 100,
+      y: 100,
+      width: 90,
+      height: 200,
+      points: [pointFrom<LocalPoint>(0, 0), pointFrom<LocalPoint>(90, 200)],
+    }) as NonDeleted<ExcalidrawElbowArrowElement>;
+    h.scene.insertElement(arrow);
+
+    h.scene.mutateElement(arrow, {
+      y: 0,
+      points: [pointFrom<LocalPoint>(0, 0), pointFrom<LocalPoint>(90, 200)],
+    });
+
+    expect(arrow.y).toEqual(0);
+  });
+});
+
 describe("elbow arrow ui", () => {
   beforeEach(async () => {
     localStorage.clear();


### PR DESCRIPTION
## Summary

This PR fixes two correctness issues in the element package.

### 1. Respect zero coordinates during element mutation

`packages/element/src/mutateElement.ts`

`mutateElement()` used:

```ts
updates.x || element.x
updates.y || element.y
```

Since `0` is a falsy value, valid coordinates of `0` were ignored and replaced with the previous position. Replacing `||` with `??` preserves legitimate zero values while maintaining the existing fallback behavior for `null` and `undefined`.

### 2. Guard against stale binding lookups

`packages/element/src/binding.ts`

`unbindBindingElement()` looked up the bound element and passed the result directly to `scene.mutateElement()` without verifying that the lookup succeeded.

If the bound element had already been removed (for example, after deletion, undo/redo, collaboration updates, or stale scene data), the lookup could return `undefined`, resulting in a runtime exception. The fix guards the mutation call when the bound element exists.

## Tests

Regression tests were added for both fixes:

- Zero `x` and `y` coordinates are preserved during elbow arrow mutation.
- `unbindBindingElement()` does not throw when the referenced bound element no longer exists.

The new tests fail on the unpatched code and pass after the fixes.

## Verification

- `yarn test:typecheck`
- `yarn test:code`
- `yarn vitest run packages/element/tests/elbowArrow.test.tsx packages/element/tests/binding.test.tsx`

## Scope

Modified files:

- `packages/element/src/mutateElement.ts`
- `packages/element/src/binding.ts`
- `packages/element/tests/elbowArrow.test.tsx`
- `packages/element/tests/binding.test.tsx`