### PR TITLE
fix: add error logging to empty catch block in onWindowMessage

### DIFF
--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -1062,8 +1062,10 @@ class App extends React.Component<AppProps, AppState> {
     let data = null;
     try {
       data = JSON.parse(event.data);
-    } catch (e) {}
-    if (!data) {
+    } catch (e) {
+        console.warn("Error parsing message event data:", e);
+      }
+      if (!data) {
       return;
     }
 


### PR DESCRIPTION
## Description

The empty catch block at App.tsx:1065 silently swallows JSON parse errors from message event data, making debugging impossible.

## Changes
- Added console.warn to log the error in the empty catch block
- Maintains existing graceful fallback behavior

## Related Issue
Closes #11706