### PR TITLE
fix: correct nFormatter base unit symbol from 'b' to empty string

### DIFF
--- a/packages/common/src/utils.ts
+++ b/packages/common/src/utils.ts
@@ -431,7 +431,7 @@ export const resolvablePromise = <T>() => {
 //https://stackoverflow.com/a/9462382/8418
 export const nFormatter = (num: number, digits: number): string => {
   const si = [
-    { value: 1, symbol: "b" },
+    { value: 1, symbol: "" },
     { value: 1e3, symbol: "k" },
     { value: 1e6, symbol: "M" },
     { value: 1e9, symbol: "G" },


### PR DESCRIPTION
## Description

The nFormatter function was incorrectly using 'b' as the symbol for values < 1000, e.g. returning '500b' instead of just '500'.

## Changes
- Changed base unit symbol from 'b' to empty string ''
- Values under 1000 now correctly display without a suffix

## Related Issue
References #11706