### PR TITLE
fix: use correct byteOffset and byteLength when creating DataView

### DIFF
--- a/packages/excalidraw/data/encode.ts
+++ b/packages/excalidraw/data/encode.ts
@@ -199,11 +199,11 @@ function dataView(
       );
     }
     const method = `setUint${DATA_VIEW_BITS_MAP[bytes]}` as const;
-    new DataView(buffer.buffer)[method](offset, value);
+    new DataView(buffer.buffer, buffer.byteOffset, buffer.byteLength)[method](offset, value);
     return buffer;
   }
   const method = `getUint${DATA_VIEW_BITS_MAP[bytes]}` as const;
-  return new DataView(buffer.buffer)[method](offset);
+  return new DataView(buffer.buffer, buffer.byteOffset, buffer.byteLength)[method](offset);
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
## Description

The concatBuffers utility was using 'new DataView(buffer.buffer)' which can access an ArrayBuffer that is much larger than the actual data when the Uint8Array is a subarray.

## Changes
- Changed to 'new DataView(buffer.buffer, buffer.byteOffset, buffer.byteLength)'
- Applied to both getter and setter overloads

## Related Issue
Closes #11711