### PR TITLE
fix: add custom tooltip to icon buttons

### DIFF
--- a/packages/excalidraw/components/IconButton.tsx
+++ b/packages/excalidraw/components/IconButton.tsx
@@ -7,6 +7,8 @@ import type { PointerType } from "@excalidraw/element/types";
 
 import { AbortError } from "../errors";
 
+import { Tooltip } from "./Tooltip";
+
 import "./ToolIcon.scss";
 
 import Spinner from "./Spinner";
@@ -106,8 +108,11 @@ export const IconButton = React.forwardRef(
 
     const lastPointerTypeRef = useRef<PointerType | null>(null);
 
+    const withTooltip = (node: React.ReactNode) =>
+      props.title ? <Tooltip label={props.title}>{node}</Tooltip> : node;
+
     if (props.type === "button" || props.type === "icon") {
-      return (
+      return withTooltip(
         <button
           className={clsx(
             "ToolIcon_type_button",
@@ -124,7 +129,6 @@ export const IconButton = React.forwardRef(
           style={props.style}
           data-testid={props["data-testid"]}
           hidden={props.hidden}
-          title={props.title}
           aria-label={props["aria-label"]}
           type="button"
           onClick={onClick}
@@ -156,14 +160,13 @@ export const IconButton = React.forwardRef(
       );
     }
 
-    return (
+    return withTooltip(
       <button
         className={clsx("ToolIcon", "ToolIcon_type_toggle", sizeCn, className, {
           "ToolIcon--checked": props.checked,
         })}
         type="button"
         style={props.style}
-        title={props.title}
         aria-label={props["aria-label"]}
         aria-keyshortcuts={props["aria-keyshortcuts"]}
         aria-pressed={props.checked}


### PR DESCRIPTION
## Description

Replaces the native browser tooltip used by `IconButton` with the shared `Tooltip` component for consistent tooltip behavior across icon buttons.

Icon buttons without a `title` continue to render normally without a tooltip.

## Changes

- Replaced the native `title` tooltip behavior with the shared `Tooltip` component.
- Applied the custom tooltip behavior across `IconButton` variants.
- Preserved normal button rendering when no tooltip title is provided.

## Screenshort 
Before:

<img width="792" height="111" alt="BeforeIconButton" src="https://github.com/user-attachments/assets/c73d505e-6fef-4fcd-8f49-aee402a0d448" />

After:

<img width="722" height="140" alt="AfterIconButton" src="https://github.com/user-attachments/assets/284a9691-bd35-4bae-b166-141601af8975" />


## Testing

- Tested IconButton tooltips manually in the local development environment.
