### PR TITLE
fix(editor): fix low-contrast hover text on exit-view-mode button in dark mode

### DIFF
--- a/packages/excalidraw/components/LayerUI.scss
+++ b/packages/excalidraw/components/LayerUI.scss
@@ -180,7 +180,8 @@
   }
 
   .theme--dark {
-    .plus-banner {
+    .plus-banner,
+    .disable-view-mode {
       &:hover {
         color: black !important;
       }


### PR DESCRIPTION
## Summary

### Problem

In dark mode, hovering the **Exit View Mode** button in the mobile toolbar renders white text on a light-colored hover background, resulting in poor contrast and reduced readability.

### Root cause

The `.disable-view-mode:hover` selector sets `color: white` on the primary hover background. In dark mode, the primary color is light, making the white text difficult to read. A similar component (`.plus-banner`) already includes a dark-mode override that switches the hover text to black, but the same override was missing for `.disable-view-mode`.

### Solution

Apply the existing dark-mode hover text color override to `.disable-view-mode`, making the hover text black in dark mode. This keeps the behavior consistent with similar UI elements while improving readability.

Confirmed the change is scoped to the dark-mode hover state and does not affect light mode or other components.
