### PR TITLE
fix: preserve dialogs during cross-tab sync

### DIFF
--- a/excalidraw-app/App.tsx
+++ b/excalidraw-app/App.tsx
@@ -570,7 +570,13 @@ const ExcalidrawWrapper = () => {
           const username = importUsernameFromLocalStorage();
           setLangCode(getPreferredLanguage());
           excalidrawAPI.updateScene({
-            ...localDataState,
+            elements: localDataState.elements,
+            appState: localDataState.appState
+              ? {
+                  ...excalidrawAPI.getAppState(),
+                  ...localDataState.appState,
+                }
+              : null,
             captureUpdate: CaptureUpdateAction.NEVER,
           });
           LibraryIndexedDBAdapter.load().then((data) => {

--- a/excalidraw-app/data/localStorage.ts
+++ b/excalidraw-app/data/localStorage.ts
@@ -1,7 +1,4 @@
-import {
-  clearAppStateForLocalStorage,
-  getDefaultAppState,
-} from "@excalidraw/excalidraw/appState";
+import { clearAppStateForLocalStorage } from "@excalidraw/excalidraw/appState";
 
 import type { ExcalidrawElement } from "@excalidraw/element/types";
 import type { AppState } from "@excalidraw/excalidraw/types";
@@ -59,12 +56,12 @@ export const importFromLocalStorage = () => {
   let appState = null;
   if (savedState) {
     try {
-      appState = {
-        ...getDefaultAppState(),
-        ...clearAppStateForLocalStorage(
-          JSON.parse(savedState) as Partial<AppState>,
-        ),
-      };
+      // Keep this partial. On initial load, restoreAppState() fills in defaults.
+      // During tab sync this is applied as a patch, so adding defaults here
+      // would reset transient, tab-local state such as an open dialog.
+      appState = clearAppStateForLocalStorage(
+        JSON.parse(savedState) as Partial<AppState>,
+      );
     } catch (error: any) {
       console.error(error);
       // Do nothing because appState is already null

--- a/excalidraw-app/tests/localStorage.test.tsx
+++ b/excalidraw-app/tests/localStorage.test.tsx
@@ -1,0 +1,42 @@
+import { Excalidraw } from "@excalidraw/excalidraw";
+import { API } from "@excalidraw/excalidraw/tests/helpers/api";
+import { render } from "@excalidraw/excalidraw/tests/test-utils";
+
+import { STORAGE_KEYS } from "../app_constants";
+import { importFromLocalStorage } from "../data/localStorage";
+
+describe("importFromLocalStorage", () => {
+  it("preserves transient app state when applying cross-tab updates", async () => {
+    await render(
+      <Excalidraw
+        initialData={{
+          appState: {
+            openDialog: { name: "help" },
+          },
+        }}
+      />,
+    );
+
+    localStorage.setItem(
+      STORAGE_KEYS.LOCAL_STORAGE_APP_STATE,
+      JSON.stringify({
+        openDialog: null,
+        viewBackgroundColor: "#f8f9fa",
+      }),
+    );
+
+    const { appState } = importFromLocalStorage();
+
+    expect(appState).not.toHaveProperty("openDialog");
+
+    API.updateScene({
+      appState: {
+        ...window.h.state,
+        ...appState,
+      },
+    });
+
+    expect(window.h.state.openDialog).toEqual({ name: "help" });
+    expect(window.h.state.viewBackgroundColor).toBe("#f8f9fa");
+  });
+});


### PR DESCRIPTION
## Summary

Opening Mermaid in a second browser tab currently closes the active Mermaid dialog in the first tab, interrupting the user's work. This change keeps transient UI state local to each tab while continuing to sync persisted scene and preference changes between tabs.

## Root cause

The local-storage importer was filling non-persisted app state with defaults before returning it. Cross-tab sync then applied that result as a full scene update. Since `openDialog` is intentionally not stored, its default `null` value replaced the active dialog in the current tab.

The importer now returns only fields that are actually persisted. Initial page loads still receive defaults through `restoreAppState()`, while cross-tab updates merge persisted fields into the current tab's app state before updating the scene.

## Verification

- Added a regression test that confirms an open dialog survives a cross-tab update while a persisted canvas preference is still synchronized.
- Manually verified the original two-tab Mermaid flow: the first tab keeps its open dialog and exact draft after Mermaid is opened in the second tab.

**PR preview — tab 1 after opening Mermaid in tab 2:**

![The Mermaid dialog and draft remain open after cross-tab synchronization](https://raw.githubusercontent.com/ChiragArora31/excalidraw/pr-assets/pr-assets/11726-mermaid-cross-tab.jpg?v=2)

## Tests

- `yarn test:update` — 110 test files, 1,586 tests passed
- `yarn test:typecheck`
- `yarn test:code`
- `yarn test:other`

Fixes #7435