### PR TITLE
feat: add one-click action to flip arrow direction

### DIFF
--- a/packages/excalidraw/actions/actionProperties.test.tsx
+++ b/packages/excalidraw/actions/actionProperties.test.tsx
@@ -13,6 +13,8 @@ import { API } from "../tests/helpers/api";
 import { UI } from "../tests/helpers/ui";
 import { render } from "../tests/test-utils";
 
+import { actionFlipArrowDirection } from "./actionProperties";
+
 describe("element locking", () => {
   beforeEach(async () => {
     await render(<Excalidraw />);
@@ -225,6 +227,35 @@ describe("element locking", () => {
       expect(queryByTestId(document.body, `font-family-code`)).toHaveClass(
         "active",
       );
+    });
+
+    it("should swap start and end arrowheads", () => {
+      const arrow = API.createElement({
+        type: "arrow",
+        x: 10,
+        y: 20,
+        points: [
+          [0, 0],
+          [100, 50],
+        ] as any,
+        startArrowhead: "arrow",
+        endArrowhead: null,
+      });
+
+      API.setElements([arrow]);
+      API.setSelectedElements([arrow]);
+
+      API.executeAction(actionFlipArrowDirection);
+
+      const updatedArrow = API.getSelectedElement() as any;
+      expect(updatedArrow.x).toBe(10);
+      expect(updatedArrow.y).toBe(20);
+      expect(updatedArrow.points).toEqual([
+        [0, 0],
+        [100, 50],
+      ]);
+      expect(updatedArrow.startArrowhead).toBe(null);
+      expect(updatedArrow.endArrowhead).toBe("arrow");
     });
   });
 });

--- a/packages/excalidraw/actions/actionProperties.tsx
+++ b/packages/excalidraw/actions/actionProperties.tsx
@@ -144,6 +144,7 @@ import {
   ArrowheadCardinalityZeroOrOneIcon,
   strokeVariabilityConstantIcon,
   strokeVariabilityVariableIcon,
+  arrowsExchangeIcon,
 } from "../components/icons";
 
 import { Fonts } from "../fonts";
@@ -1808,6 +1809,29 @@ const getArrowheadOptions = (flip: boolean) => {
   } as const;
 };
 
+export const actionFlipArrowDirection = register({
+  name: "flipArrowDirection",
+  label: "labels.flipArrowDirection",
+  trackEvent: { category: "element" },
+  perform: (elements, appState, value, app) => {
+    const updatedElements = changeProperty(elements, appState, (el) => {
+      if (isLinearElement(el) && canHaveArrowheads(el.type)) {
+        return newElementWith(el, {
+          startArrowhead: el.endArrowhead,
+          endArrowhead: el.startArrowhead,
+        });
+      }
+      return el;
+    });
+
+    return {
+      elements: updatedElements,
+      appState,
+      captureUpdate: CaptureUpdateAction.IMMEDIATELY,
+    };
+  },
+});
+
 export const actionChangeArrowhead = register<{
   position: "start" | "end";
   type: Arrowhead;
@@ -1895,6 +1919,15 @@ export const actionChangeArrowhead = register<{
                 hasSelection ? null : appState.currentItemEndArrowhead,
             )}
             onChange={(value) => updateData({ position: "end", type: value })}
+          />
+          <IconButton
+            type="button"
+            icon={arrowsExchangeIcon}
+            title={t("labels.flipArrowDirection")}
+            aria-label={t("labels.flipArrowDirection")}
+            onClick={() => {
+              app.actionManager.executeAction(actionFlipArrowDirection);
+            }}
           />
         </div>
       </fieldset>

--- a/packages/excalidraw/actions/types.ts
+++ b/packages/excalidraw/actions/types.ts
@@ -71,6 +71,7 @@ export type ActionName =
   | "changeFreedrawMode"
   | "changeStrokeStyle"
   | "changeArrowhead"
+  | "flipArrowDirection"
   | "changeArrowType"
   | "changeArrowProperties"
   | "changeOpacity"

--- a/packages/excalidraw/components/icons.tsx
+++ b/packages/excalidraw/components/icons.tsx
@@ -2254,6 +2254,15 @@ export const flipHorizontal = createIcon(
   tablerIconProps,
 );
 
+export const arrowsExchangeIcon = createIcon(
+  <g strokeWidth={1.5}>
+    <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+    <path d="M5 8h14M15 4l4 4l-4 4" />
+    <path d="M19 16H5M9 12l-4 4l4 4" />
+  </g>,
+  tablerIconProps,
+);
+
 export const paintIcon = createIcon(
   <g strokeWidth={1.25}>
     <path stroke="none" d="M0 0h24v24H0z" fill="none" />

--- a/packages/excalidraw/locales/en.json
+++ b/packages/excalidraw/locales/en.json
@@ -127,6 +127,7 @@
     "distributeVertically": "Distribute vertically",
     "flipHorizontal": "Flip horizontal",
     "flipVertical": "Flip vertical",
+    "flipArrowDirection": "Flip arrow direction",
     "viewMode": "View mode",
     "share": "Share",
     "showStroke": "Show stroke color picker",

--- a/packages/excalidraw/types.ts
+++ b/packages/excalidraw/types.ts
@@ -52,6 +52,7 @@ import type {
 import type { GlobalPoint } from "@excalidraw/math";
 
 import type { Action } from "./actions/types";
+import type { ActionManager } from "./actions/manager";
 import type { Spreadsheet } from "./charts";
 import type { ClipboardData } from "./clipboard";
 import type App from "./components/App";
@@ -1034,6 +1035,7 @@ export type AppProps = Merge<
 /** A subset of App class properties that we need to use elsewhere
  * in the app, eg Manager. Factored out into a separate type to keep DRY. */
 export type AppClassProperties = {
+  actionManager: ActionManager;
   props: AppProps;
   state: AppState;
   api: App["api"];


### PR DESCRIPTION
## Summary
Fixes #7852.
Adds a one-click action to flip an arrow's direction by swapping its start and end arrowheads.

Previously, reversing an arrow's direction required manually updating both arrowhead controls. This change introduces a dedicated toolbar action that performs the swap in a single click, making the workflow faster and more convenient.

## Before/After
<img width="637" height="316" alt="Screenshot 2026-07-20 at 11 04 31 AM" src="https://github.com/user-attachments/assets/014b5fb1-5934-4eab-9974-81930f4ff4f9" />

https://github.com/user-attachments/assets/c45dd6e3-40d7-4294-9841-55be32d6fb60




## Changes

- Added a new `flipArrowDirection` action.
- Added a toolbar button with a flip-direction icon.
- Added the corresponding localization string.
- Added tests covering the new behavior.