### PR TITLE
fix(editor): restore box-selecting line points by dragging on canvas

### DIFF
--- a/packages/element/tests/linearElementEditor.test.tsx
+++ b/packages/element/tests/linearElementEditor.test.tsx
@@ -429,6 +429,36 @@ describe("Test Linear Elements", () => {
       expect(line.points.length).toEqual(3);
     });
 
+    it("should box-select points when dragging on the canvas", () => {
+      createThreePointerLinearElement("line");
+      const line = h.elements[0] as ExcalidrawLinearElement;
+      enterLineEditingMode(line);
+
+      // rubber-band over the last two points (at (90, 70) and (70, 20)),
+      // starting from an empty canvas area. Needs two pointer moves (so no
+      // `drag()`): the first one only creates the selection rectangle,
+      // box-selection kicks in on the next one.
+      fireEvent.pointerDown(interactiveCanvas, { clientX: 55, clientY: 5 });
+      fireEvent.pointerMove(interactiveCanvas, { clientX: 100, clientY: 60 });
+      fireEvent.pointerMove(interactiveCanvas, { clientX: 130, clientY: 100 });
+      fireEvent.pointerUp(interactiveCanvas, { clientX: 130, clientY: 100 });
+
+      expect(h.state.selectedLinearElement?.isEditing).toBe(true);
+      expect(h.state.selectedLinearElement?.selectedPointsIndices).toEqual([
+        1, 2,
+      ]);
+    });
+
+    it("should exit the editor when clicking on the canvas without dragging", () => {
+      createThreePointerLinearElement("line");
+      const line = h.elements[0] as ExcalidrawLinearElement;
+      enterLineEditingMode(line);
+
+      mouse.clickAt(200, 200);
+
+      expect(h.state.selectedLinearElement?.isEditing).toBeFalsy();
+    });
+
     it("should allow dragging line from midpoint in 2 pointer lines", async () => {
       createTwoPointerLinearElement("line");
 

--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -9360,16 +9360,11 @@ class App extends React.Component<AppProps, AppState> {
         }
 
         if (this.state.selectedLinearElement?.isEditing) {
+          // keep the editor open on pointer down — whether to exit is decided
+          // on pointer up (we exit unless a point box-selection occurred),
+          // otherwise dragging on the canvas to box-select points would
+          // immediately exit the editor (#10561)
           this.setState((prevState) => ({
-            selectedLinearElement: prevState.selectedLinearElement
-              ? {
-                  ...prevState.selectedLinearElement,
-                  isEditing:
-                    !!hitElement &&
-                    hitElement.id ===
-                      this.state.selectedLinearElement?.elementId,
-                }
-              : null,
             selectedElementIds: prevState.selectedLinearElement
               ? makeNextSelectedElementIds(
                   {


### PR DESCRIPTION
Fixes #10561

## Problem

Inside the line editor, dragging on empty canvas used to rubber-band-select the
enclosed points. It now closes the editor and deselects the element instead, so
multi-point selection by dragging is impossible.

## Root cause

#9670 added an `isEditing` recompute to the *pointer down* handler in `App.tsx`:

```ts
isEditing: !!hitElement && hitElement.id === this.state.selectedLinearElement?.elementId
```

Any pointer down that misses the line (as occurs at the start of every rubber-band)
exits the editor on the spot, so `LinearElementEditor.handleBoxSelection` (guarded
by `isEditing` on pointer move) never runs and the drag falls through to regular
element box-select. Pointer up already decides the exit correctly, making the
recompute redundant for clicks and harmful for drags.

## Fix

Remove the recompute, keeping the selected-element-ids pinning. Pointer up
continues to decide:

- drag on canvas → enclosed points get selected, editor stays open
- click on empty canvas / another element → editor exits (unchanged)
- `Delete` after box-selecting removes the selected points (works again)

**master**

https://github.com/user-attachments/assets/053a3a69-7367-46c1-9c99-241d954d764c

**this PR**

https://github.com/user-attachments/assets/ecaa1690-905b-4d05-9d4b-4fc62bfdaf94

## Testing

Two regression tests in `linearElementEditor.test.tsx`: box-selecting points keeps
the editor open and selects them (**fails on master**), and clicking without
dragging still exits the editor. `yarn test:all` is clean.
