### PR TITLE
fix: add tooltips to sidebar header icons

### DIFF
--- a/excalidraw-app/components/AppSidebar.tsx
+++ b/excalidraw-app/components/AppSidebar.tsx
@@ -6,6 +6,8 @@ import {
 import { LinkButton } from "@excalidraw/excalidraw/components/LinkButton";
 import { useUIAppState } from "@excalidraw/excalidraw/context/ui-appState";
 
+import { Tooltip } from "@excalidraw/excalidraw/components/Tooltip";
+
 import "./AppSidebar.scss";
 
 type SidebarPromoCopyProps = {
@@ -71,18 +73,22 @@ export const AppSidebar = () => {
   return (
     <DefaultSidebar>
       <DefaultSidebar.TabTriggers>
-        <Sidebar.TabTrigger
-          tab="comments"
-          style={{ opacity: openSidebar?.tab === "comments" ? 1 : 0.4 }}
-        >
-          {messageCircleIcon}
-        </Sidebar.TabTrigger>
-        <Sidebar.TabTrigger
-          tab="presentation"
-          style={{ opacity: openSidebar?.tab === "presentation" ? 1 : 0.4 }}
-        >
-          {presentationIcon}
-        </Sidebar.TabTrigger>
+        <Tooltip label="Comments">
+          <Sidebar.TabTrigger
+            tab="comments"
+            style={{ opacity: openSidebar?.tab === "comments" ? 1 : 0.4 }}
+          >
+            {messageCircleIcon}
+          </Sidebar.TabTrigger>
+        </Tooltip>
+        <Tooltip label="Presentation">
+          <Sidebar.TabTrigger
+            tab="presentation"
+            style={{ opacity: openSidebar?.tab === "presentation" ? 1 : 0.4 }}
+          >
+            {presentationIcon}
+          </Sidebar.TabTrigger>
+        </Tooltip>
       </DefaultSidebar.TabTriggers>
       <Sidebar.Tab tab="comments">
         <div className="app-sidebar-promo-container">

--- a/excalidraw-app/components/AppSidebar.tsx
+++ b/excalidraw-app/components/AppSidebar.tsx
@@ -7,6 +7,7 @@ import { LinkButton } from "@excalidraw/excalidraw/components/LinkButton";
 import { useUIAppState } from "@excalidraw/excalidraw/context/ui-appState";
 
 import { Tooltip } from "@excalidraw/excalidraw/components/Tooltip";
+import { t } from "@excalidraw/excalidraw/i18n";
 
 import "./AppSidebar.scss";
 
@@ -73,18 +74,20 @@ export const AppSidebar = () => {
   return (
     <DefaultSidebar>
       <DefaultSidebar.TabTriggers>
-        <Tooltip label="Comments">
+        <Tooltip label={t("sidebar.comments")}>
           <Sidebar.TabTrigger
             tab="comments"
             style={{ opacity: openSidebar?.tab === "comments" ? 1 : 0.4 }}
+            aria-label={t("sidebar.comments")}
           >
             {messageCircleIcon}
           </Sidebar.TabTrigger>
         </Tooltip>
-        <Tooltip label="Presentation">
+        <Tooltip label={t("sidebar.presentation")}>
           <Sidebar.TabTrigger
             tab="presentation"
             style={{ opacity: openSidebar?.tab === "presentation" ? 1 : 0.4 }}
+            aria-label={t("sidebar.presentation")}
           >
             {presentationIcon}
           </Sidebar.TabTrigger>

--- a/packages/excalidraw/components/DefaultSidebar.test.tsx
+++ b/packages/excalidraw/components/DefaultSidebar.test.tsx
@@ -5,6 +5,7 @@ import { DEFAULT_SIDEBAR } from "@excalidraw/common";
 import { DefaultSidebar } from "../index";
 import {
   fireEvent,
+  GlobalTestState,
   waitFor,
   withExcalidrawDimensions,
 } from "../tests/test-utils";
@@ -17,6 +18,25 @@ import {
 const { h } = window;
 
 describe("DefaultSidebar", () => {
+  it("should label default sidebar tab buttons", async () => {
+    await assertExcalidrawWithSidebar(
+      <DefaultSidebar />,
+      DEFAULT_SIDEBAR.name,
+      async () => {
+        const sidebar =
+          GlobalTestState.renderResult.container.querySelector<HTMLElement>(
+            ".sidebar",
+          );
+
+        expect(sidebar).not.toBe(null);
+        expect(
+          sidebar!.querySelector('[aria-label="Find on canvas"]'),
+        ).not.toBe(null);
+        expect(sidebar!.querySelector('[aria-label="Library"]')).not.toBe(null);
+      },
+    );
+  });
+
   it("when `docked={undefined}` & `onDock={undefined}`, should allow docking", async () => {
     await assertExcalidrawWithSidebar(
       <DefaultSidebar />,

--- a/packages/excalidraw/components/DefaultSidebar.tsx
+++ b/packages/excalidraw/components/DefaultSidebar.tsx
@@ -18,6 +18,7 @@ import { useExcalidrawSetAppState } from "./App";
 import { LibraryMenu } from "./LibraryMenu";
 import { SearchMenu } from "./SearchMenu";
 import { Sidebar } from "./Sidebar/Sidebar";
+import { Tooltip } from "./Tooltip";
 import { withInternalFallback } from "./hoc/withInternalFallback";
 import { LibraryIcon, searchIcon } from "./icons";
 
@@ -99,12 +100,16 @@ export const DefaultSidebar = Object.assign(
           <Sidebar.Tabs>
             <Sidebar.Header>
               <Sidebar.TabTriggers>
-                <Sidebar.TabTrigger tab={CANVAS_SEARCH_TAB}>
-                  {searchIcon}
-                </Sidebar.TabTrigger>
-                <Sidebar.TabTrigger tab={LIBRARY_SIDEBAR_TAB}>
-                  {LibraryIcon}
-                </Sidebar.TabTrigger>
+                <Tooltip label="Search">
+                  <Sidebar.TabTrigger tab={CANVAS_SEARCH_TAB}>
+                    {searchIcon}
+                  </Sidebar.TabTrigger>
+                </Tooltip>
+                <Tooltip label="Library">
+                  <Sidebar.TabTrigger tab={LIBRARY_SIDEBAR_TAB}>
+                    {LibraryIcon}
+                  </Sidebar.TabTrigger>
+                </Tooltip>
                 <DefaultSidebarTabTriggersTunnel.Out />
               </Sidebar.TabTriggers>
             </Sidebar.Header>

--- a/packages/excalidraw/components/DefaultSidebar.tsx
+++ b/packages/excalidraw/components/DefaultSidebar.tsx
@@ -11,6 +11,7 @@ import type { MarkOptional, Merge } from "@excalidraw/common/utility-types";
 
 import { useTunnels } from "../context/tunnels";
 import { useUIAppState } from "../context/ui-appState";
+import { t } from "../i18n";
 
 import "../components/dropdownMenu/DropdownMenu.scss";
 
@@ -100,13 +101,19 @@ export const DefaultSidebar = Object.assign(
           <Sidebar.Tabs>
             <Sidebar.Header>
               <Sidebar.TabTriggers>
-                <Tooltip label="Search">
-                  <Sidebar.TabTrigger tab={CANVAS_SEARCH_TAB}>
+                <Tooltip label={t("search.title")}>
+                  <Sidebar.TabTrigger
+                    tab={CANVAS_SEARCH_TAB}
+                    aria-label={t("search.title")}
+                  >
                     {searchIcon}
                   </Sidebar.TabTrigger>
                 </Tooltip>
-                <Tooltip label="Library">
-                  <Sidebar.TabTrigger tab={LIBRARY_SIDEBAR_TAB}>
+                <Tooltip label={t("toolBar.library")}>
+                  <Sidebar.TabTrigger
+                    tab={LIBRARY_SIDEBAR_TAB}
+                    aria-label={t("toolBar.library")}
+                  >
                     {LibraryIcon}
                   </Sidebar.TabTrigger>
                 </Tooltip>

--- a/packages/excalidraw/components/Sidebar/SidebarHeader.tsx
+++ b/packages/excalidraw/components/Sidebar/SidebarHeader.tsx
@@ -43,14 +43,16 @@ export const SidebarHeader = ({
             </Button>
           </Tooltip>
         )}
-        <Button
-          data-testid="sidebar-close"
-          className="sidebar__close"
-          onSelect={props.onCloseRequest}
-          aria-label={t("buttons.close")}
-        >
-          {CloseIcon}
-        </Button>
+        <Tooltip label={t("buttons.close")}>
+          <Button
+            data-testid="sidebar-close"
+            className="sidebar__close"
+            onSelect={props.onCloseRequest}
+            aria-label={t("buttons.close")}
+          >
+            {CloseIcon}
+          </Button>
+        </Tooltip>
       </div>
     </div>
   );

--- a/packages/excalidraw/locales/en.json
+++ b/packages/excalidraw/locales/en.json
@@ -742,5 +742,9 @@
     "spacebar": "Space",
     "delete": "Delete",
     "mmb": "Scroll wheel"
+  },
+  "sidebar": {
+    "comments": "Comments",
+    "presentation": "Presentation"
   }
 }


### PR DESCRIPTION
Fixes #11731

## Summary
Added tooltips to icon-only buttons in the sidebar header that were missing them, for better discoverability and consistency with the existing pin/dock button tooltip.

## Changes
| File | What was added |
|---|---|
| `DefaultSidebar.tsx` | Tooltips on Search and Library tab icons |
| `AppSidebar.tsx` | Tooltips on Comments and Presentation tab icons |
| `SidebarHeader.tsx` | Tooltip on the Close button |

## Screenshots

**Close button**

| Before | After |
|---|---|
| <img width="480" height="647" alt="image" src="https://github.com/user-attachments/assets/31286446-b8b8-45d3-8c02-004ab2664d28" /> | <img width="480" height="647" alt="image" src="https://github.com/user-attachments/assets/c915693e-24fa-4aab-888e-42fcc2494217" /> |

**Header icons**

| Before | After |
|---|---|
| <img width="480" height="647" alt="image" src="https://github.com/user-attachments/assets/13fd5f0d-f5fb-4cbf-b9a6-7e2fbaae3a41" /> | <img width="480" height="647" alt="image" src="https://github.com/user-attachments/assets/589bde35-09ce-4f65-9f6a-6a910ab04d7a" /> |

## Approach
- Used the existing `<Tooltip>` component already in the codebase — no new dependencies.
- Wrapped `<Tooltip>` outside `<Sidebar.TabTrigger>` / `<Button>` so the tooltip position is calculated from the full button bounding rect (including padding), matching the pin/dock icon's tooltip gap.
- The pin/dock button already had a tooltip — no change needed there.
- The sidebar trigger button (opens the sidebar from the toolbar) was left unchanged since it already has a visible text label.

## Note
Also added a tooltip to the close button, which wasn't explicitly listed in the original issue but had the same gap.