### PR TITLE
Replace native language selector with existing menu component

### DIFF
--- a/excalidraw-app/app-language/LanguageList.tsx
+++ b/excalidraw-app/app-language/LanguageList.tsx
@@ -1,27 +1,32 @@
 import { useI18n, languages } from "@excalidraw/excalidraw/i18n";
+import { MainMenu } from "@excalidraw/excalidraw/index";
 import React from "react";
 
 import { useSetAtom } from "../app-jotai";
 
 import { appLangCodeAtom } from "./language-state";
 
-export const LanguageList = ({ style }: { style?: React.CSSProperties }) => {
+export const LanguageList = () => {
   const { t, langCode } = useI18n();
   const setLangCode = useSetAtom(appLangCodeAtom);
 
   return (
-    <select
-      className="dropdown-select dropdown-select__language"
-      onChange={({ target }) => setLangCode(target.value)}
-      value={langCode}
-      aria-label={t("buttons.selectLanguage")}
-      style={style}
-    >
-      {languages.map((lang) => (
-        <option key={lang.code} value={lang.code}>
-          {lang.label}
-        </option>
-      ))}
-    </select>
+    <MainMenu.Sub>
+      <MainMenu.Sub.Trigger>{t("buttons.selectLanguage")}</MainMenu.Sub.Trigger>
+      <MainMenu.Sub.Content>
+        {languages.map((lang) => (
+          <MainMenu.Item
+            key={lang.code}
+            selected={lang.code === langCode}
+            onSelect={(event) => {
+              setLangCode(lang.code);
+              event.preventDefault();
+            }}
+          >
+            {lang.label}
+          </MainMenu.Item>
+        ))}
+      </MainMenu.Sub.Content>
+    </MainMenu.Sub>
   );
 };

--- a/excalidraw-app/components/AppMainMenu.tsx
+++ b/excalidraw-app/components/AppMainMenu.tsx
@@ -78,9 +78,7 @@ export const AppMainMenu: React.FC<{
       <MainMenu.Separator />
       <MainMenu.DefaultItems.Preferences />
       <MainMenu.DefaultItems.ToggleTheme allowSystemTheme theme={props.theme} />
-      <MainMenu.ItemCustom>
-        <LanguageList style={{ width: "100%" }} />
-      </MainMenu.ItemCustom>
+      <LanguageList />
       <MainMenu.DefaultItems.ChangeCanvasBackground />
     </MainMenu>
   );

--- a/excalidraw-app/tests/LanguageList.test.tsx
+++ b/excalidraw-app/tests/LanguageList.test.tsx
@@ -1,5 +1,5 @@
 import { Excalidraw, MainMenu } from "@excalidraw/excalidraw";
-import { defaultLang, languages } from "@excalidraw/excalidraw/i18n";
+import { languages } from "@excalidraw/excalidraw/i18n";
 import { UI } from "@excalidraw/excalidraw/tests/helpers/ui";
 import {
   screen,
@@ -20,9 +20,7 @@ const TestApp = () => {
   return (
     <Excalidraw langCode={langCode}>
       <MainMenu>
-        <MainMenu.ItemCustom>
-          <LanguageList />
-        </MainMenu.ItemCustom>
+        <LanguageList />
       </MainMenu>
     </Excalidraw>
   );
@@ -44,15 +42,20 @@ describe("Test LanguageList", () => {
     expect(screen.queryByTitle(/thin/i)).not.toBeNull();
     fireEvent.click(document.querySelector(".dropdown-menu-button")!);
 
-    fireEvent.change(document.querySelector(".dropdown-select__language")!, {
-      target: { value: TEST_LANG_CODE },
+    // Open language submenu
+    fireEvent.click(screen.getByText("Select language"));
+    // Click French option
+    await waitFor(() => {
+      expect(screen.getByText("Français")).toBeTruthy();
     });
+    fireEvent.click(screen.getByText("Français"));
     // switching to French, `thin` label should no longer exist
     await waitFor(() => expect(screen.queryByTitle(/thin/i)).toBeNull());
-    // reset language
-    fireEvent.change(document.querySelector(".dropdown-select__language")!, {
-      target: { value: defaultLang.code },
+    // Click English to switch back (menu + submenu stay open via preventDefault)
+    await waitFor(() => {
+      expect(screen.getByText("English")).toBeTruthy();
     });
+    fireEvent.click(screen.getByText("English"));
     // switching back to English
     await waitFor(() => expect(screen.queryByTitle(/thin/i)).not.toBeNull());
   });


### PR DESCRIPTION
## Summary

This PR replaces the native HTML `<select>` used for language selection with Excalidraw's existing menu component, making it consistent with the rest of the application's menus.

### Changes

- Replaced the native `<select>` with the existing menu component.
- Preserved the existing language switching functionality.
- Kept the existing i18n logic unchanged.
- Ensured compatibility with both light and dark themes.
- Reused existing UI components for consistency.

### Testing

- [x] Verified language switching works correctly.
- [x] Tested in Light Mode.
- [x] Tested in Dark Mode.
- [x] Verified keyboard navigation.
- [x] No TypeScript or ESLint errors.

Closes #11730
<img width="1357" height="937" alt="image" src="https://github.com/user-attachments/assets/ed3c6b5a-daeb-42f5-b568-11990d354d8b" />
<img width="1033" height="921" alt="image" src="https://github.com/user-attachments/assets/9d3b6324-77f2-441a-8ccf-238a5b262567" />
