### PR TITLE
Add Alt/Option-drag duplicate cursor feedback

### DIFF
--- a/packages/common/src/constants.ts
+++ b/packages/common/src/constants.ts
@@ -31,6 +31,7 @@ export const CURSOR_TYPE = {
   GRAB: "grab",
   POINTER: "pointer",
   MOVE: "move",
+  COPY: "copy",
   AUTO: "",
 };
 export const POINTER_BUTTON = {

--- a/packages/excalidraw/components/App.cursor.ts
+++ b/packages/excalidraw/components/App.cursor.ts
@@ -33,6 +33,7 @@ export class AppCursor {
     | (HTMLCanvasElement & { theme?: AppState["theme"] })
     | null = null;
   private eraserPreviewDataURL: DataURL | null = null;
+  private copyCursorDataURL: string | null = null;
 
   constructor(private app: App) {}
 
@@ -40,9 +41,20 @@ export class AppCursor {
     return this.app.interactiveCanvas;
   }
 
+  private getCopyCursor = () => {
+    if (!this.copyCursorDataURL) {
+      const svg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 18"><circle cx="9" cy="9" r="7" fill="rgba(255,255,255,0.9)" stroke="rgba(0,0,0,0.7)" stroke-width="1"/><path d="M9 5.5v7M5.5 9h7" fill="none" stroke="rgba(0,0,0,0.85)" stroke-width="1.4" stroke-linecap="round"/></svg>`;
+      this.copyCursorDataURL = `url("data:image/svg+xml,${encodeURIComponent(
+        svg,
+      )}") 9 9, copy`;
+    }
+    return this.copyCursorDataURL;
+  };
+
   set = (cursor: string) => {
     if (this.canvas) {
-      this.canvas.style.cursor = cursor;
+      this.canvas.style.cursor =
+        cursor === CURSOR_TYPE.COPY ? this.getCopyCursor() : cursor;
     }
   };
 

--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -8665,6 +8665,10 @@ class App extends React.Component<AppProps, AppState> {
       event,
     );
 
+    // If Alt/Option is already held when pointer down begins, show duplicate
+    // cursor feedback immediately before dragging starts.
+    this.maybeUpdateDuplicateDragCursor(pointerDownState, event.nativeEvent);
+
     if (this.state.activeTool.type === "eraser") {
       this.eraserTrail.startPath(
         pointerDownState.lastCoords.x,
@@ -10315,10 +10319,29 @@ class App extends React.Component<AppProps, AppState> {
     }
   }
 
+  private maybeUpdateDuplicateDragCursor = (
+    pointerDownState: PointerDownState,
+    event: KeyboardEvent | PointerEvent,
+  ) => {
+    if (
+      pointerDownState.hit.allHitElements.some((element) =>
+        this.isASelectedElement(element),
+      ) ||
+      pointerDownState.hit.hasHitCommonBoundingBoxOfSelectedElements
+    ) {
+      if (event.altKey) {
+        this.cursor.set(CURSOR_TYPE.COPY);
+      } else {
+        this.cursor.reset();
+      }
+    }
+  };
+
   private onKeyDownFromPointerDownHandler(
     pointerDownState: PointerDownState,
   ): (event: KeyboardEvent) => void {
     return withBatchedUpdates((event: KeyboardEvent) => {
+      this.maybeUpdateDuplicateDragCursor(pointerDownState, event);
       if (this.maybeHandleResize(pointerDownState, event)) {
         return;
       }
@@ -10332,6 +10355,7 @@ class App extends React.Component<AppProps, AppState> {
     return withBatchedUpdates((event: KeyboardEvent) => {
       // Prevents focus from escaping excalidraw tab
       event.key === KEYS.ALT && event.preventDefault();
+      this.maybeUpdateDuplicateDragCursor(pointerDownState, event);
       if (this.maybeHandleResize(pointerDownState, event)) {
         return;
       }
@@ -10838,6 +10862,12 @@ class App extends React.Component<AppProps, AppState> {
             // should be removed
             selectionElement: null,
           });
+
+          if (event.altKey) {
+            this.cursor.set(CURSOR_TYPE.COPY);
+          } else {
+            this.cursor.reset();
+          }
 
           // We duplicate the selected element if alt is pressed on pointer move
           if (event.altKey && !pointerDownState.hit.hasBeenDuplicated) {

--- a/packages/excalidraw/tests/move.test.tsx
+++ b/packages/excalidraw/tests/move.test.tsx
@@ -169,13 +169,21 @@ describe("duplicate element on move when ALT is clicked", () => {
       renderStaticScene.mockClear();
     }
 
-    fireEvent.pointerDown(canvas, { clientX: 50, clientY: 20 });
+    fireEvent.pointerDown(canvas, {
+      clientX: 50,
+      clientY: 20,
+      altKey: true,
+    });
+    expect(canvas.style.cursor).toContain("url(");
+
     fireEvent.pointerMove(canvas, { clientX: 20, clientY: 40, altKey: true });
+    expect(canvas.style.cursor).toContain("url(");
 
     // firing another pointerMove event with alt key pressed should NOT trigger
     // another duplication
     fireEvent.pointerMove(canvas, { clientX: 20, clientY: 40, altKey: true });
     fireEvent.pointerMove(canvas, { clientX: 10, clientY: 60 });
+    expect(canvas.style.cursor).not.toContain("url(");
     fireEvent.pointerUp(canvas);
 
     expect(renderInteractiveScene.mock.calls.length).toMatchInlineSnapshot(`4`);


### PR DESCRIPTION
This PR updates the duplicate-drag UX so holding Alt/Option and dragging immediately shows the copy cursor feedback.
Before
<img width="567" height="576" alt="image" src="https://github.com/user-attachments/assets/05e0a824-ab30-4e21-ad99-29787402d41a" />
After
<img width="445" height="480" alt="image" src="https://github.com/user-attachments/assets/a001361b-6b1e-441a-834c-51d5657ddf35" />

