### PR TITLE
fix: add help dialog shortcut search

### DIFF
--- a/packages/excalidraw/actions/actionToggleSearchMenu.ts
+++ b/packages/excalidraw/actions/actionToggleSearchMenu.ts
@@ -54,5 +54,6 @@ export const actionToggleSearchMenu = register({
   predicate: (element, appState, props) => {
     return props.gridModeEnabled === undefined;
   },
-  keyTest: (event) => event[KEYS.CTRL_OR_CMD] && event.key === KEYS.F,
+  keyTest: (event, appState) =>
+    event[KEYS.CTRL_OR_CMD] && event.key === KEYS.F && !appState.openDialog,
 });

--- a/packages/excalidraw/components/HelpDialog.scss
+++ b/packages/excalidraw/components/HelpDialog.scss
@@ -18,6 +18,10 @@
       gap: 0.75rem;
     }
 
+    &__search {
+      margin-top: 1rem;
+    }
+
     &__btn {
       --background: var(--color-surface-mid);
 

--- a/packages/excalidraw/components/HelpDialog.tsx
+++ b/packages/excalidraw/components/HelpDialog.tsx
@@ -1,3 +1,4 @@
+import fuzzy from "fuzzy";
 import React from "react";
 
 import { isDarwin, isFirefox, isWindows } from "@excalidraw/common";
@@ -8,11 +9,13 @@ import { actionToggleTheme } from "../actions";
 import { getShortcutFromShortcutName } from "../actions/shortcuts";
 import { probablySupportsClipboardBlob } from "../clipboard";
 import { t } from "../i18n";
+import { deburr } from "../deburr";
 import { getShortcutKey } from "../shortcut";
 
 import { useExcalidrawActionManager } from "./App";
 import { Dialog } from "./Dialog";
-import { ExternalLinkIcon, GithubIcon, youtubeIcon } from "./icons";
+import { TextField } from "./TextField";
+import { ExternalLinkIcon, GithubIcon, searchIcon, youtubeIcon } from "./icons";
 
 import "./HelpDialog.scss";
 
@@ -101,6 +104,12 @@ const Shortcut = ({
   shortcuts: string[];
   isOr?: boolean;
 }) => {
+  const search = React.useContext(ShortcutSearchContext);
+
+  if (!doesShortcutMatchSearch(search, label, shortcuts)) {
+    return null;
+  }
+
   const splitShortcutKeys = shortcuts.map((shortcut) => {
     const keys = shortcut.endsWith("++")
       ? [...shortcut.slice(0, -2).split("+"), "+"]
@@ -125,13 +134,67 @@ const ShortcutKey = (props: { children: React.ReactNode }) => (
   <kbd className="HelpDialog__key" {...props} />
 );
 
+const ShortcutSearchContext = React.createContext("");
+
+const doesShortcutMatchSearch = (
+  query: string,
+  label: string,
+  shortcuts: string[],
+) => {
+  if (!query) {
+    return true;
+  }
+
+  const haystack = deburr(
+    `${label} ${shortcuts.join(" ")}`
+      .toLocaleLowerCase()
+      .replace(/[<>_| -]/g, ""),
+  );
+
+  return fuzzy.test(query, haystack);
+};
+
 export const HelpDialog = ({ onClose }: { onClose?: () => void }) => {
   const actionManager = useExcalidrawActionManager();
+  const [search, setSearch] = React.useState("");
+  const searchInputRef = React.useRef<HTMLInputElement>(null);
+
   const handleClose = React.useCallback(() => {
     if (onClose) {
       onClose();
     }
   }, [onClose]);
+
+  const normalizedSearch = React.useMemo(
+    () =>
+      deburr(
+        search
+          .trim()
+          .toLocaleLowerCase()
+          .replace(/[<>_| -]/g, ""),
+      ),
+    [search],
+  );
+
+  const focusSearch = React.useCallback(
+    (event: React.KeyboardEvent | KeyboardEvent) => {
+      if (event[KEYS.CTRL_OR_CMD] && event.key === KEYS.F) {
+        event.preventDefault();
+        event.stopPropagation();
+        searchInputRef.current?.focus();
+        searchInputRef.current?.select();
+      }
+    },
+    [],
+  );
+
+  React.useEffect(() => {
+    document.addEventListener("keydown", focusSearch, { capture: true });
+
+    return () => {
+      document.removeEventListener("keydown", focusSearch, { capture: true });
+    };
+  }, [focusSearch]);
 
   return (
     <>
@@ -140,379 +203,404 @@ export const HelpDialog = ({ onClose }: { onClose?: () => void }) => {
         title={t("helpDialog.title")}
         className={"HelpDialog"}
       >
-        <Header />
-        <Section title={t("helpDialog.shortcuts")}>
-          <ShortcutIsland
-            className="HelpDialog__island--tools"
-            caption={t("helpDialog.tools")}
-          >
-            <Shortcut label={t("toolBar.hand")} shortcuts={[KEYS.H]} />
-            <Shortcut
-              label={t("toolBar.selection")}
-              shortcuts={[KEYS.V, KEYS["1"]]}
+        <div>
+          <Header />
+          <div className="HelpDialog__search">
+            <TextField
+              ref={searchInputRef}
+              type="search"
+              fullWidth
+              icon={searchIcon}
+              value={search}
+              placeholder={t("helpDialog.searchPlaceholder")}
+              onChange={setSearch}
             />
-            <Shortcut
-              label={t("toolBar.rectangle")}
-              shortcuts={[KEYS.R, KEYS["2"]]}
-            />
-            <Shortcut
-              label={t("toolBar.diamond")}
-              shortcuts={[KEYS.D, KEYS["3"]]}
-            />
-            <Shortcut
-              label={t("toolBar.ellipse")}
-              shortcuts={[KEYS.O, KEYS["4"]]}
-            />
-            <Shortcut
-              label={t("toolBar.arrow")}
-              shortcuts={[KEYS.A, KEYS["5"]]}
-            />
-            <Shortcut
-              label={t("toolBar.line")}
-              shortcuts={[KEYS.L, KEYS["6"]]}
-            />
-            <Shortcut
-              label={t("toolBar.freedraw")}
-              shortcuts={[KEYS.P, KEYS["7"]]}
-            />
-            <Shortcut
-              label={t("toolBar.text")}
-              shortcuts={[KEYS.T, KEYS["8"]]}
-            />
-            <Shortcut label={t("toolBar.image")} shortcuts={[KEYS["9"]]} />
-            <Shortcut
-              label={t("toolBar.eraser")}
-              shortcuts={[KEYS.E, KEYS["0"]]}
-            />
-            <Shortcut label={t("toolBar.frame")} shortcuts={[KEYS.F]} />
-            <Shortcut label={t("toolBar.laser")} shortcuts={[KEYS.K]} />
-            <Shortcut
-              label={t("labels.eyeDropper")}
-              shortcuts={[KEYS.I, "Shift+S", "Shift+G"]}
-            />
-            <Shortcut
-              label={t("helpDialog.editLineArrowPoints")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+Enter")]}
-            />
-            <Shortcut
-              label={t("helpDialog.editText")}
-              shortcuts={[getShortcutKey("Enter")]}
-            />
-            <Shortcut
-              label={t("helpDialog.textNewLine")}
-              shortcuts={[
-                getShortcutKey("Enter"),
-                getShortcutKey("Shift+Enter"),
-              ]}
-            />
-            <Shortcut
-              label={t("helpDialog.textFinish")}
-              shortcuts={[
-                getShortcutKey("Esc"),
-                getShortcutKey("CtrlOrCmd+Enter"),
-              ]}
-            />
-            <Shortcut
-              label={t("helpDialog.curvedArrow")}
-              shortcuts={[
-                "A",
-                t("helpDialog.click"),
-                t("helpDialog.click"),
-                t("helpDialog.click"),
-              ]}
-              isOr={false}
-            />
-            <Shortcut
-              label={t("helpDialog.curvedLine")}
-              shortcuts={[
-                "L",
-                t("helpDialog.click"),
-                t("helpDialog.click"),
-                t("helpDialog.click"),
-              ]}
-              isOr={false}
-            />
-            <Shortcut
-              label={t("helpDialog.cropStart")}
-              shortcuts={[t("helpDialog.doubleClick"), getShortcutKey("Enter")]}
-              isOr={true}
-            />
-            <Shortcut
-              label={t("helpDialog.cropFinish")}
-              shortcuts={[getShortcutKey("Enter"), getShortcutKey("Escape")]}
-              isOr={true}
-            />
-            <Shortcut label={t("toolBar.lock")} shortcuts={[KEYS.Q]} />
-            <Shortcut
-              label={t("helpDialog.preventBinding")}
-              shortcuts={[getShortcutKey("CtrlOrCmd")]}
-            />
-            <Shortcut
-              label={t("toolBar.link")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+K")]}
-            />
-            <Shortcut
-              label={t("toolBar.convertElementType")}
-              shortcuts={["Tab", "Shift+Tab"]}
-              isOr={true}
-            />
-          </ShortcutIsland>
-          <ShortcutIsland
-            className="HelpDialog__island--view"
-            caption={t("helpDialog.view")}
-          >
-            <Shortcut
-              label={t("buttons.zoomIn")}
-              shortcuts={[getShortcutKey("CtrlOrCmd++")]}
-            />
-            <Shortcut
-              label={t("buttons.zoomOut")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+-")]}
-            />
-            <Shortcut
-              label={t("buttons.resetZoom")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+0")]}
-            />
-            <Shortcut
-              label={t("helpDialog.zoomToFit")}
-              shortcuts={["Shift+1"]}
-            />
-            <Shortcut
-              label={t("helpDialog.zoomToSelection")}
-              shortcuts={["Shift+2"]}
-            />
-            <Shortcut
-              label={t("helpDialog.movePageUpDown")}
-              shortcuts={["PgUp/PgDn"]}
-            />
-            <Shortcut
-              label={t("helpDialog.movePageLeftRight")}
-              shortcuts={["Shift+PgUp/PgDn"]}
-            />
-            <Shortcut
-              label={t("buttons.zenMode")}
-              shortcuts={[getShortcutKey("Alt+Z")]}
-            />
-            <Shortcut
-              label={t("buttons.objectsSnapMode")}
-              shortcuts={[getShortcutKey("Alt+S")]}
-            />
-            <Shortcut
-              label={t("labels.toggleGrid")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+'")]}
-            />
-            <Shortcut
-              label={t("labels.viewMode")}
-              shortcuts={[getShortcutKey("Alt+R")]}
-            />
-            {actionManager.isActionEnabled(actionToggleTheme) && (
-              <Shortcut
-                label={t("labels.toggleTheme")}
-                shortcuts={[getShortcutKey("Alt+Shift+D")]}
-              />
-            )}
-            <Shortcut
-              label={t("stats.fullTitle")}
-              shortcuts={[getShortcutKey("Alt+/")]}
-            />
-            <Shortcut
-              label={t("search.title")}
-              shortcuts={[getShortcutFromShortcutName("searchMenu")]}
-            />
-            <Shortcut
-              label={t("commandPalette.title")}
-              shortcuts={
-                isFirefox
-                  ? [getShortcutFromShortcutName("commandPalette")]
-                  : [
-                      getShortcutFromShortcutName("commandPalette"),
-                      getShortcutFromShortcutName("commandPalette", 1),
-                    ]
-              }
-            />
-          </ShortcutIsland>
-          <ShortcutIsland
-            className="HelpDialog__island--editor"
-            caption={t("helpDialog.editor")}
-          >
-            <Shortcut
-              label={t("helpDialog.createFlowchart")}
-              shortcuts={[getShortcutKey(`CtrlOrCmd+Arrow Key`)]}
-              isOr={true}
-            />
-            <Shortcut
-              label={t("helpDialog.navigateFlowchart")}
-              shortcuts={[getShortcutKey(`Alt+Arrow Key`)]}
-              isOr={true}
-            />
-            <Shortcut
-              label={t("labels.moveCanvas")}
-              shortcuts={[
-                getShortcutKey(`Space+${t("helpDialog.drag")}`),
-                getShortcutKey(`Wheel+${t("helpDialog.drag")}`),
-              ]}
-              isOr={true}
-            />
-            <Shortcut
-              label={t("buttons.clearReset")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+Delete")]}
-            />
-            <Shortcut
-              label={t("labels.delete")}
-              shortcuts={[getShortcutKey("Delete")]}
-            />
-            <Shortcut
-              label={t("labels.cut")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+X")]}
-            />
-            <Shortcut
-              label={t("labels.copy")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+C")]}
-            />
-            <Shortcut
-              label={t("labels.paste")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+V")]}
-            />
-            <Shortcut
-              label={t("labels.pasteAsPlaintext")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+Shift+V")]}
-            />
-            <Shortcut
-              label={t("labels.selectAll")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+A")]}
-            />
-            <Shortcut
-              label={t("labels.multiSelect")}
-              shortcuts={[getShortcutKey(`Shift+${t("helpDialog.click")}`)]}
-            />
-            <Shortcut
-              label={t("helpDialog.deepSelect")}
-              shortcuts={[getShortcutKey(`CtrlOrCmd+${t("helpDialog.click")}`)]}
-            />
-            <Shortcut
-              label={t("helpDialog.deepBoxSelect")}
-              shortcuts={[getShortcutKey(`CtrlOrCmd+${t("helpDialog.drag")}`)]}
-            />
-            {/* firefox supports clipboard API under a flag, so we'll
+          </div>
+          <ShortcutSearchContext.Provider value={normalizedSearch}>
+            <Section title={t("helpDialog.shortcuts")}>
+              <ShortcutIsland
+                className="HelpDialog__island--tools"
+                caption={t("helpDialog.tools")}
+              >
+                <Shortcut label={t("toolBar.hand")} shortcuts={[KEYS.H]} />
+                <Shortcut
+                  label={t("toolBar.selection")}
+                  shortcuts={[KEYS.V, KEYS["1"]]}
+                />
+                <Shortcut
+                  label={t("toolBar.rectangle")}
+                  shortcuts={[KEYS.R, KEYS["2"]]}
+                />
+                <Shortcut
+                  label={t("toolBar.diamond")}
+                  shortcuts={[KEYS.D, KEYS["3"]]}
+                />
+                <Shortcut
+                  label={t("toolBar.ellipse")}
+                  shortcuts={[KEYS.O, KEYS["4"]]}
+                />
+                <Shortcut
+                  label={t("toolBar.arrow")}
+                  shortcuts={[KEYS.A, KEYS["5"]]}
+                />
+                <Shortcut
+                  label={t("toolBar.line")}
+                  shortcuts={[KEYS.L, KEYS["6"]]}
+                />
+                <Shortcut
+                  label={t("toolBar.freedraw")}
+                  shortcuts={[KEYS.P, KEYS["7"]]}
+                />
+                <Shortcut
+                  label={t("toolBar.text")}
+                  shortcuts={[KEYS.T, KEYS["8"]]}
+                />
+                <Shortcut label={t("toolBar.image")} shortcuts={[KEYS["9"]]} />
+                <Shortcut
+                  label={t("toolBar.eraser")}
+                  shortcuts={[KEYS.E, KEYS["0"]]}
+                />
+                <Shortcut label={t("toolBar.frame")} shortcuts={[KEYS.F]} />
+                <Shortcut label={t("toolBar.laser")} shortcuts={[KEYS.K]} />
+                <Shortcut
+                  label={t("labels.eyeDropper")}
+                  shortcuts={[KEYS.I, "Shift+S", "Shift+G"]}
+                />
+                <Shortcut
+                  label={t("helpDialog.editLineArrowPoints")}
+                  shortcuts={[getShortcutKey("CtrlOrCmd+Enter")]}
+                />
+                <Shortcut
+                  label={t("helpDialog.editText")}
+                  shortcuts={[getShortcutKey("Enter")]}
+                />
+                <Shortcut
+                  label={t("helpDialog.textNewLine")}
+                  shortcuts={[
+                    getShortcutKey("Enter"),
+                    getShortcutKey("Shift+Enter"),
+                  ]}
+                />
+                <Shortcut
+                  label={t("helpDialog.textFinish")}
+                  shortcuts={[
+                    getShortcutKey("Esc"),
+                    getShortcutKey("CtrlOrCmd+Enter"),
+                  ]}
+                />
+                <Shortcut
+                  label={t("helpDialog.curvedArrow")}
+                  shortcuts={[
+                    "A",
+                    t("helpDialog.click"),
+                    t("helpDialog.click"),
+                    t("helpDialog.click"),
+                  ]}
+                  isOr={false}
+                />
+                <Shortcut
+                  label={t("helpDialog.curvedLine")}
+                  shortcuts={[
+                    "L",
+                    t("helpDialog.click"),
+                    t("helpDialog.click"),
+                    t("helpDialog.click"),
+                  ]}
+                  isOr={false}
+                />
+                <Shortcut
+                  label={t("helpDialog.cropStart")}
+                  shortcuts={[
+                    t("helpDialog.doubleClick"),
+                    getShortcutKey("Enter"),
+                  ]}
+                  isOr={true}
+                />
+                <Shortcut
+                  label={t("helpDialog.cropFinish")}
+                  shortcuts={[
+                    getShortcutKey("Enter"),
+                    getShortcutKey("Escape"),
+                  ]}
+                  isOr={true}
+                />
+                <Shortcut label={t("toolBar.lock")} shortcuts={[KEYS.Q]} />
+                <Shortcut
+                  label={t("helpDialog.preventBinding")}
+                  shortcuts={[getShortcutKey("CtrlOrCmd")]}
+                />
+                <Shortcut
+                  label={t("toolBar.link")}
+                  shortcuts={[getShortcutKey("CtrlOrCmd+K")]}
+                />
+                <Shortcut
+                  label={t("toolBar.convertElementType")}
+                  shortcuts={["Tab", "Shift+Tab"]}
+                  isOr={true}
+                />
+              </ShortcutIsland>
+              <ShortcutIsland
+                className="HelpDialog__island--view"
+                caption={t("helpDialog.view")}
+              >
+                <Shortcut
+                  label={t("buttons.zoomIn")}
+                  shortcuts={[getShortcutKey("CtrlOrCmd++")]}
+                />
+                <Shortcut
+                  label={t("buttons.zoomOut")}
+                  shortcuts={[getShortcutKey("CtrlOrCmd+-")]}
+                />
+                <Shortcut
+                  label={t("buttons.resetZoom")}
+                  shortcuts={[getShortcutKey("CtrlOrCmd+0")]}
+                />
+                <Shortcut
+                  label={t("helpDialog.zoomToFit")}
+                  shortcuts={["Shift+1"]}
+                />
+                <Shortcut
+                  label={t("helpDialog.zoomToSelection")}
+                  shortcuts={["Shift+2"]}
+                />
+                <Shortcut
+                  label={t("helpDialog.movePageUpDown")}
+                  shortcuts={["PgUp/PgDn"]}
+                />
+                <Shortcut
+                  label={t("helpDialog.movePageLeftRight")}
+                  shortcuts={["Shift+PgUp/PgDn"]}
+                />
+                <Shortcut
+                  label={t("buttons.zenMode")}
+                  shortcuts={[getShortcutKey("Alt+Z")]}
+                />
+                <Shortcut
+                  label={t("buttons.objectsSnapMode")}
+                  shortcuts={[getShortcutKey("Alt+S")]}
+                />
+                <Shortcut
+                  label={t("labels.toggleGrid")}
+                  shortcuts={[getShortcutKey("CtrlOrCmd+'")]}
+                />
+                <Shortcut
+                  label={t("labels.viewMode")}
+                  shortcuts={[getShortcutKey("Alt+R")]}
+                />
+                {actionManager.isActionEnabled(actionToggleTheme) && (
+                  <Shortcut
+                    label={t("labels.toggleTheme")}
+                    shortcuts={[getShortcutKey("Alt+Shift+D")]}
+                  />
+                )}
+                <Shortcut
+                  label={t("stats.fullTitle")}
+                  shortcuts={[getShortcutKey("Alt+/")]}
+                />
+                <Shortcut
+                  label={t("search.title")}
+                  shortcuts={[getShortcutFromShortcutName("searchMenu")]}
+                />
+                <Shortcut
+                  label={t("commandPalette.title")}
+                  shortcuts={
+                    isFirefox
+                      ? [getShortcutFromShortcutName("commandPalette")]
+                      : [
+                          getShortcutFromShortcutName("commandPalette"),
+                          getShortcutFromShortcutName("commandPalette", 1),
+                        ]
+                  }
+                />
+              </ShortcutIsland>
+              <ShortcutIsland
+                className="HelpDialog__island--editor"
+                caption={t("helpDialog.editor")}
+              >
+                <Shortcut
+                  label={t("helpDialog.createFlowchart")}
+                  shortcuts={[getShortcutKey(`CtrlOrCmd+Arrow Key`)]}
+                  isOr={true}
+                />
+                <Shortcut
+                  label={t("helpDialog.navigateFlowchart")}
+                  shortcuts={[getShortcutKey(`Alt+Arrow Key`)]}
+                  isOr={true}
+                />
+                <Shortcut
+                  label={t("labels.moveCanvas")}
+                  shortcuts={[
+                    getShortcutKey(`Space+${t("helpDialog.drag")}`),
+                    getShortcutKey(`Wheel+${t("helpDialog.drag")}`),
+                  ]}
+                  isOr={true}
+                />
+                <Shortcut
+                  label={t("buttons.clearReset")}
+                  shortcuts={[getShortcutKey("CtrlOrCmd+Delete")]}
+                />
+                <Shortcut
+                  label={t("labels.delete")}
+                  shortcuts={[getShortcutKey("Delete")]}
+                />
+                <Shortcut
+                  label={t("labels.cut")}
+                  shortcuts={[getShortcutKey("CtrlOrCmd+X")]}
+                />
+                <Shortcut
+                  label={t("labels.copy")}
+                  shortcuts={[getShortcutKey("CtrlOrCmd+C")]}
+                />
+                <Shortcut
+                  label={t("labels.paste")}
+                  shortcuts={[getShortcutKey("CtrlOrCmd+V")]}
+                />
+                <Shortcut
+                  label={t("labels.pasteAsPlaintext")}
+                  shortcuts={[getShortcutKey("CtrlOrCmd+Shift+V")]}
+                />
+                <Shortcut
+                  label={t("labels.selectAll")}
+                  shortcuts={[getShortcutKey("CtrlOrCmd+A")]}
+                />
+                <Shortcut
+                  label={t("labels.multiSelect")}
+                  shortcuts={[getShortcutKey(`Shift+${t("helpDialog.click")}`)]}
+                />
+                <Shortcut
+                  label={t("helpDialog.deepSelect")}
+                  shortcuts={[
+                    getShortcutKey(`CtrlOrCmd+${t("helpDialog.click")}`),
+                  ]}
+                />
+                <Shortcut
+                  label={t("helpDialog.deepBoxSelect")}
+                  shortcuts={[
+                    getShortcutKey(`CtrlOrCmd+${t("helpDialog.drag")}`),
+                  ]}
+                />
+                {/* firefox supports clipboard API under a flag, so we'll
                 show users what they can do in the error message */}
-            {(probablySupportsClipboardBlob || isFirefox) && (
-              <Shortcut
-                label={t("labels.copyAsPng")}
-                shortcuts={[getShortcutKey("Shift+Alt+C")]}
-              />
-            )}
-            <Shortcut
-              label={t("labels.copyStyles")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+Alt+C")]}
-            />
-            <Shortcut
-              label={t("labels.pasteStyles")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+Alt+V")]}
-            />
-            <Shortcut
-              label={t("labels.sendToBack")}
-              shortcuts={[
-                isDarwin
-                  ? getShortcutKey("CtrlOrCmd+Alt+[")
-                  : getShortcutKey("CtrlOrCmd+Shift+["),
-              ]}
-            />
-            <Shortcut
-              label={t("labels.bringToFront")}
-              shortcuts={[
-                isDarwin
-                  ? getShortcutKey("CtrlOrCmd+Alt+]")
-                  : getShortcutKey("CtrlOrCmd+Shift+]"),
-              ]}
-            />
-            <Shortcut
-              label={t("labels.sendBackward")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+[")]}
-            />
-            <Shortcut
-              label={t("labels.bringForward")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+]")]}
-            />
-            <Shortcut
-              label={t("labels.alignTop")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+Shift+Up")]}
-            />
-            <Shortcut
-              label={t("labels.alignBottom")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+Shift+Down")]}
-            />
-            <Shortcut
-              label={t("labels.alignLeft")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+Shift+Left")]}
-            />
-            <Shortcut
-              label={t("labels.alignRight")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+Shift+Right")]}
-            />
-            <Shortcut
-              label={t("labels.duplicateSelection")}
-              shortcuts={[
-                getShortcutKey("CtrlOrCmd+D"),
-                getShortcutKey(`Alt+${t("helpDialog.drag")}`),
-              ]}
-            />
-            <Shortcut
-              label={t("helpDialog.toggleElementLock")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+Shift+L")]}
-            />
-            <Shortcut
-              label={t("buttons.undo")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+Z")]}
-            />
-            <Shortcut
-              label={t("buttons.redo")}
-              shortcuts={
-                isWindows
-                  ? [
-                      getShortcutKey("CtrlOrCmd+Y"),
-                      getShortcutKey("CtrlOrCmd+Shift+Z"),
-                    ]
-                  : [getShortcutKey("CtrlOrCmd+Shift+Z")]
-              }
-            />
-            <Shortcut
-              label={t("labels.group")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+G")]}
-            />
-            <Shortcut
-              label={t("labels.ungroup")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+Shift+G")]}
-            />
-            <Shortcut
-              label={t("labels.flipHorizontal")}
-              shortcuts={[getShortcutKey("Shift+H")]}
-            />
-            <Shortcut
-              label={t("labels.flipVertical")}
-              shortcuts={[getShortcutKey("Shift+V")]}
-            />
-            <Shortcut
-              label={t("labels.showStroke")}
-              shortcuts={[getShortcutKey("S")]}
-            />
-            <Shortcut
-              label={t("labels.showBackground")}
-              shortcuts={[getShortcutKey("G")]}
-            />
-            <Shortcut
-              label={t("labels.showFonts")}
-              shortcuts={[getShortcutKey("Shift+F")]}
-            />
-            <Shortcut
-              label={t("labels.decreaseFontSize")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+Shift+<")]}
-            />
-            <Shortcut
-              label={t("labels.increaseFontSize")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+Shift+>")]}
-            />
-          </ShortcutIsland>
-        </Section>
+                {(probablySupportsClipboardBlob || isFirefox) && (
+                  <Shortcut
+                    label={t("labels.copyAsPng")}
+                    shortcuts={[getShortcutKey("Shift+Alt+C")]}
+                  />
+                )}
+                <Shortcut
+                  label={t("labels.copyStyles")}
+                  shortcuts={[getShortcutKey("CtrlOrCmd+Alt+C")]}
+                />
+                <Shortcut
+                  label={t("labels.pasteStyles")}
+                  shortcuts={[getShortcutKey("CtrlOrCmd+Alt+V")]}
+                />
+                <Shortcut
+                  label={t("labels.sendToBack")}
+                  shortcuts={[
+                    isDarwin
+                      ? getShortcutKey("CtrlOrCmd+Alt+[")
+                      : getShortcutKey("CtrlOrCmd+Shift+["),
+                  ]}
+                />
+                <Shortcut
+                  label={t("labels.bringToFront")}
+                  shortcuts={[
+                    isDarwin
+                      ? getShortcutKey("CtrlOrCmd+Alt+]")
+                      : getShortcutKey("CtrlOrCmd+Shift+]"),
+                  ]}
+                />
+                <Shortcut
+                  label={t("labels.sendBackward")}
+                  shortcuts={[getShortcutKey("CtrlOrCmd+[")]}
+                />
+                <Shortcut
+                  label={t("labels.bringForward")}
+                  shortcuts={[getShortcutKey("CtrlOrCmd+]")]}
+                />
+                <Shortcut
+                  label={t("labels.alignTop")}
+                  shortcuts={[getShortcutKey("CtrlOrCmd+Shift+Up")]}
+                />
+                <Shortcut
+                  label={t("labels.alignBottom")}
+                  shortcuts={[getShortcutKey("CtrlOrCmd+Shift+Down")]}
+                />
+                <Shortcut
+                  label={t("labels.alignLeft")}
+                  shortcuts={[getShortcutKey("CtrlOrCmd+Shift+Left")]}
+                />
+                <Shortcut
+                  label={t("labels.alignRight")}
+                  shortcuts={[getShortcutKey("CtrlOrCmd+Shift+Right")]}
+                />
+                <Shortcut
+                  label={t("labels.duplicateSelection")}
+                  shortcuts={[
+                    getShortcutKey("CtrlOrCmd+D"),
+                    getShortcutKey(`Alt+${t("helpDialog.drag")}`),
+                  ]}
+                />
+                <Shortcut
+                  label={t("helpDialog.toggleElementLock")}
+                  shortcuts={[getShortcutKey("CtrlOrCmd+Shift+L")]}
+                />
+                <Shortcut
+                  label={t("buttons.undo")}
+                  shortcuts={[getShortcutKey("CtrlOrCmd+Z")]}
+                />
+                <Shortcut
+                  label={t("buttons.redo")}
+                  shortcuts={
+                    isWindows
+                      ? [
+                          getShortcutKey("CtrlOrCmd+Y"),
+                          getShortcutKey("CtrlOrCmd+Shift+Z"),
+                        ]
+                      : [getShortcutKey("CtrlOrCmd+Shift+Z")]
+                  }
+                />
+                <Shortcut
+                  label={t("labels.group")}
+                  shortcuts={[getShortcutKey("CtrlOrCmd+G")]}
+                />
+                <Shortcut
+                  label={t("labels.ungroup")}
+                  shortcuts={[getShortcutKey("CtrlOrCmd+Shift+G")]}
+                />
+                <Shortcut
+                  label={t("labels.flipHorizontal")}
+                  shortcuts={[getShortcutKey("Shift+H")]}
+                />
+                <Shortcut
+                  label={t("labels.flipVertical")}
+                  shortcuts={[getShortcutKey("Shift+V")]}
+                />
+                <Shortcut
+                  label={t("labels.showStroke")}
+                  shortcuts={[getShortcutKey("S")]}
+                />
+                <Shortcut
+                  label={t("labels.showBackground")}
+                  shortcuts={[getShortcutKey("G")]}
+                />
+                <Shortcut
+                  label={t("labels.showFonts")}
+                  shortcuts={[getShortcutKey("Shift+F")]}
+                />
+                <Shortcut
+                  label={t("labels.decreaseFontSize")}
+                  shortcuts={[getShortcutKey("CtrlOrCmd+Shift+<")]}
+                />
+                <Shortcut
+                  label={t("labels.increaseFontSize")}
+                  shortcuts={[getShortcutKey("CtrlOrCmd+Shift+>")]}
+                />
+              </ShortcutIsland>
+            </Section>
+          </ShortcutSearchContext.Provider>
+        </div>
       </Dialog>
     </>
   );

--- a/packages/excalidraw/locales/en.json
+++ b/packages/excalidraw/locales/en.json
@@ -453,6 +453,7 @@
     "preventBinding": "Prevent arrow binding",
     "tools": "Tools",
     "shortcuts": "Keyboard shortcuts",
+    "searchPlaceholder": "Search shortcuts",
     "textFinish": "Finish editing (text editor)",
     "textNewLine": "Add new line (text editor)",
     "title": "Help",

--- a/packages/excalidraw/tests/search.test.tsx
+++ b/packages/excalidraw/tests/search.test.tsx
@@ -17,7 +17,7 @@ import { Excalidraw } from "../index";
 import { API } from "./helpers/api";
 import { Keyboard } from "./helpers/ui";
 import { updateTextEditor } from "./queries/dom";
-import { act, render, waitFor } from "./test-utils";
+import { act, render, screen, waitFor } from "./test-utils";
 
 const { h } = window;
 
@@ -73,6 +73,43 @@ describe("search", () => {
       Keyboard.keyPress(KEYS.F);
     });
     expect(searchInput?.matches(":focus")).toBe(true);
+  });
+
+  it("should focus help search instead of opening canvas search on cmd+f in help dialog", async () => {
+    Keyboard.keyPress(KEYS.QUESTION_MARK);
+    expect(h.app.state.openDialog?.name).toBe("help");
+
+    const helpSearchInput = (await screen.findByPlaceholderText(
+      "Search shortcuts",
+    )) as HTMLInputElement;
+    act(() => {
+      helpSearchInput.blur();
+    });
+
+    Keyboard.withModifierKeys({ ctrl: true }, () => {
+      Keyboard.keyPress(KEYS.F);
+    });
+
+    expect(h.app.state.openDialog?.name).toBe("help");
+    expect(h.app.state.openSidebar).toBeNull();
+    expect(helpSearchInput.matches(":focus")).toBe(true);
+  });
+
+  it("should filter help shortcuts", async () => {
+    Keyboard.keyPress(KEYS.QUESTION_MARK);
+
+    const helpSearchInput = (await screen.findByPlaceholderText(
+      "Search shortcuts",
+    )) as HTMLInputElement;
+    expect(screen.getByText("Zoom in")).toBeTruthy();
+    expect(screen.getByText("Undo")).toBeTruthy();
+
+    updateTextEditor(helpSearchInput, "zoom in");
+
+    await waitFor(() => {
+      expect(screen.getByText("Zoom in")).toBeTruthy();
+      expect(screen.queryByText("Undo")).toBeNull();
+    });
   });
 
   it("should match text and cycle through matches on Enter", async () => {


### PR DESCRIPTION
Closes #9276.\n\n## Summary\n- add a searchable input to the help dialog keyboard shortcuts list\n- capture Ctrl/Cmd+F while help is open and focus the help search instead of opening canvas search\n- keep canvas search Ctrl/Cmd+F disabled while any dialog is open\n\n## Tests\n- yarn test:app packages/excalidraw/tests/search.test.tsx --watch=false\n- yarn test:typecheck