### PR TITLE
feat(editor): support pasting images from HTML data URL src

### DIFF
--- a/packages/excalidraw/clipboard.test.ts
+++ b/packages/excalidraw/clipboard.test.ts
@@ -127,6 +127,24 @@ describe("parseClipboard()", () => {
         value: "https://example.com/image2.png",
       },
     ]);
+    // -------------------------------------------------------------------------
+    const dataURL =
+      "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==";
+    clipboardData = await parseClipboard(
+      await parseDataTransferEvent(
+        createPasteEvent({
+          types: {
+            "text/html": `<img src="${dataURL}" />`,
+          },
+        }),
+      ),
+    );
+    expect(clipboardData.mixedContent).toEqual([
+      {
+        type: "imageUrl",
+        value: dataURL,
+      },
+    ]);
   });
 
   it("should parse text content alongside <image> `src` urls out of text/html", async () => {

--- a/packages/excalidraw/clipboard.ts
+++ b/packages/excalidraw/clipboard.ts
@@ -220,7 +220,7 @@ function parseHTMLTree(el: ChildNode) {
       }
     } else if (node instanceof HTMLImageElement) {
       const url = node.getAttribute("src");
-      if (url && url.startsWith("http")) {
+      if (url && (url.startsWith("http") || url.startsWith("data:image/"))) {
         result.push({ type: "imageUrl", value: url });
       }
     } else {


### PR DESCRIPTION
## Summary

Fixes #9933

Pasting HTML that contains an `<img>` with a `data:` URL `src` currently drops the image, since `parseHTMLTree` only accepts `http(s)` URLs. Depending on the clipboard's plain-text fallback, the paste either silently loses the image or dumps the raw base64 string onto the canvas as a huge text element.

This lets `data:image/` srcs through. The rest of the paste pipeline already handles them, as `ImageURLToFile` fetches the URL and `fetch` supports data URLs natively. Non-image data URLs keep being ignored, same as other non-http srcs.

## Before / After

| Before | After |
| --- | --- |
| <img alt="before" src="https://github.com/user-attachments/assets/8ecce484-c05f-44db-a888-c657fd8ed976" /> | <img alt="after" src="https://github.com/user-attachments/assets/6e6328bc-2bd0-4f96-bf3b-09eb8f56287a" /> |

## Testing

- Added a data URL case to the existing `parseClipboard()` tests
- Verified in the app by putting HTML with `<img src="data:image/png;base64,...">` on the OS clipboard and pasting: the image is now inserted as an image element