### PR TITLE
fix(editor): ungroup bound text when dragging group member out of frame

### DIFF
--- a/packages/element/tests/frame.test.tsx
+++ b/packages/element/tests/frame.test.tsx
@@ -1182,4 +1182,56 @@ describe("adding elements to frames", () => {
       expect(h.elements.length).toBe(4);
     });
   });
+
+  describe("alt-dragging group members out of the frame", () => {
+    it("should ungroup bound text of a container dragged out of the frame", () => {
+      const groupFrame = API.createElement({
+        type: "frame",
+        x: 0,
+        y: 0,
+        width: 150,
+        height: 150,
+      });
+      const [container, label] = API.createTextContainer({
+        frameId: groupFrame.id,
+        groupIds: ["group1"],
+      });
+      const other = API.createElement({
+        type: "rectangle",
+        x: 110,
+        y: 110,
+        width: 30,
+        height: 30,
+        frameId: groupFrame.id,
+        groupIds: ["group1"],
+      });
+
+      API.setElements([groupFrame, container, label, other]);
+
+      mouse.select(other);
+      mouse.doubleClickOn(other);
+      expect(h.state.editingGroupId).toBe("group1");
+
+      Keyboard.withModifierKeys({ alt: true }, () => {
+        mouse.downAt(
+          container.x + container.width / 2,
+          container.y + container.height / 2,
+        );
+        mouse.moveTo(500, 500);
+        mouse.up();
+      });
+
+      const containerClone = getCloneByOrigId(container.id);
+      const labelClone = getCloneByOrigId(label.id);
+      expect(containerClone.frameId).toBe(null);
+      expect(containerClone.groupIds).toEqual([]);
+      expect(labelClone.frameId).toBe(null);
+      expect(labelClone.groupIds).toEqual([]);
+
+      expect(container.frameId).toBe(groupFrame.id);
+      expect(container.groupIds).toEqual(["group1"]);
+      expect(label.frameId).toBe(groupFrame.id);
+      expect(label.groupIds).toEqual(["group1"]);
+    });
+  });
 });

--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -11749,14 +11749,30 @@ class App extends React.Component<AppProps, AppState> {
                 const index = element.groupIds.indexOf(
                   this.state.editingGroupId!,
                 );
+                const nextGroupIds = element.groupIds.slice(0, index);
 
                 this.scene.mutateElement(
                   element,
                   {
-                    groupIds: element.groupIds.slice(0, index),
+                    groupIds: nextGroupIds,
                   },
                   { informMutation: false, isDragging: false },
                 );
+
+                const boundText = getBoundTextElement(
+                  element,
+                  this.scene.getNonDeletedElementsMap(),
+                );
+
+                if (boundText) {
+                  this.scene.mutateElement(
+                    boundText,
+                    {
+                      groupIds: nextGroupIds,
+                    },
+                    { informMutation: false, isDragging: false },
+                  );
+                }
               }
 
               nextElements.forEach((element) => {


### PR DESCRIPTION
## Summary

Fixes #9411

When a group member is dragged (or alt-drag duplicated) out of its frame while editing the group, the dragged elements get their group ids removed, but a container's bound text is not part of the selection, so it kept the stale group ids. The leftover id also prevented the "fewer than two members" cleanup from ungrouping the remaining elements.

The dragged element's new group ids are now mirrored onto its bound text, which covers both text containers and labeled arrows.

## Before / After

Before (selecting the rectangle inside the frame also selects the moved-out label):

https://github.com/user-attachments/assets/6d6c2c35-3914-4d41-a8b8-8ad23f9ea464

After:

https://github.com/user-attachments/assets/73445b02-205b-4758-8a03-32b07cb4dac4

## Testing

- Added a regression test that alt-drag duplicates a labeled container out of its frame and checks the group ids of both the container and the label
- Verified manually: dragging a labeled container out of a frame while editing the group now clears the group ids of container and label, and the remaining single member gets ungrouped