### PR TITLE
fix(editor): re-measure converted text elements once fonts load

### DIFF
--- a/packages/element/src/__tests__/transform.test.ts
+++ b/packages/element/src/__tests__/transform.test.ts
@@ -3,6 +3,8 @@ import { vi } from "vitest";
 
 import {
   convertToExcalidrawElements,
+  hasStaleTextMetrics,
+  clearStaleTextMetrics,
   type ExcalidrawElementSkeleton,
 } from "../transform";
 
@@ -963,6 +965,52 @@ describe("Test Transform", () => {
         versionNonce: expect.any(Number),
         id: expect.any(String),
       });
+    });
+  });
+
+  describe("Test stale text metrics", () => {
+    const elements: ExcalidrawElementSkeleton[] = [
+      { type: "text", x: 0, y: 0, text: "HELLO EXCALIDRAW" },
+      {
+        type: "rectangle",
+        x: 0,
+        y: 100,
+        width: 200,
+        label: { text: "HELLO WORLD!!" },
+      },
+    ];
+
+    it("should mark text elements as stale when fonts are not loaded", () => {
+      const checkSpy = vi.spyOn(document.fonts, "check").mockReturnValue(false);
+
+      const excalidrawElements = convertToExcalidrawElements(elements, opts);
+      const textElements = excalidrawElements.filter(
+        (element) => element.type === "text",
+      );
+
+      expect(textElements.length).toBe(2);
+      textElements.forEach((element) => {
+        expect(hasStaleTextMetrics(element.id)).toBe(true);
+        clearStaleTextMetrics(element.id);
+      });
+
+      checkSpy.mockRestore();
+    });
+
+    it("should not mark text elements as stale when fonts are loaded", () => {
+      const checkSpy = vi.spyOn(document.fonts, "check").mockReturnValue(true);
+
+      const excalidrawElements = convertToExcalidrawElements(elements, opts);
+      const textElements = excalidrawElements.filter(
+        (element) => element.type === "text",
+      );
+
+      expect(textElements.length).toBe(2);
+      textElements.forEach((element) => {
+        expect(hasStaleTextMetrics(element.id)).toBe(false);
+      });
+
+      checkSpy.mockRestore();
     });
   });
 });

--- a/packages/element/src/transform.ts
+++ b/packages/element/src/transform.ts
@@ -30,7 +30,7 @@ import {
   type ElementConstructorOpts,
 } from "./newElement";
 import { measureText, normalizeText } from "./textMeasurements";
-import { isArrowElement } from "./typeChecks";
+import { isArrowElement, isTextElement } from "./typeChecks";
 
 import { syncInvalidIndices } from "./fractionalIndex";
 
@@ -217,6 +217,17 @@ const DEFAULT_LINEAR_ELEMENT_PROPS = {
 };
 
 const DEFAULT_DIMENSION = 100;
+
+// ids of text elements measured before their font faces were loaded, thus
+// with metrics based on a fallback font. The editor re-measures them once
+// the fonts are available (see Fonts.onLoaded).
+const staleTextMetricsIds = new Set<ExcalidrawElement["id"]>();
+
+export const hasStaleTextMetrics = (id: ExcalidrawElement["id"]) =>
+  staleTextMetricsIds.has(id);
+
+export const clearStaleTextMetrics = (id: ExcalidrawElement["id"]) =>
+  staleTextMetricsIds.delete(id);
 
 const bindTextToContainer = (
   container: ExcalidrawElement,
@@ -811,5 +822,18 @@ export const convertToExcalidrawElements = (
     }
   }
 
-  return elementStore.getElements();
+  const convertedElements = elementStore.getElements();
+
+  if (typeof window !== "undefined" && window.document?.fonts?.check) {
+    for (const element of convertedElements) {
+      if (
+        isTextElement(element) &&
+        !window.document.fonts.check(getFontString(element), element.text)
+      ) {
+        staleTextMetricsIds.add(element.id);
+      }
+    }
+  }
+
+  return convertedElements;
 };

--- a/packages/excalidraw/fonts/Fonts.ts
+++ b/packages/excalidraw/fonts/Fonts.ts
@@ -9,6 +9,11 @@ import {
 import { getContainerElement } from "@excalidraw/element";
 import { charWidth } from "@excalidraw/element";
 import { containsCJK } from "@excalidraw/element";
+import {
+  hasStaleTextMetrics,
+  clearStaleTextMetrics,
+  redrawTextBoundingBox,
+} from "@excalidraw/element";
 
 import {
   FONT_METADATA,
@@ -137,6 +142,25 @@ export class Fonts {
         if (container) {
           ShapeCache.delete(container);
         }
+      }
+    }
+
+    // text elements created before their fonts were loaded (i.e. through
+    // `convertToExcalidrawElements`) have metrics based on a fallback font,
+    // so once the actual font is available they need to be re-measured
+    for (const element of this.scene.getNonDeletedElements()) {
+      if (
+        isTextElement(element) &&
+        hasStaleTextMetrics(element.id) &&
+        window.document.fonts.check(getFontString(element), element.text)
+      ) {
+        clearStaleTextMetrics(element.id);
+        redrawTextBoundingBox(
+          element,
+          getContainerElement(element, elementsMap),
+          this.scene,
+        );
+        didUpdate = true;
       }
     }
 


### PR DESCRIPTION
## Summary

Fixes #9180

`convertToExcalidrawElements` measures text synchronously, so when it runs before the font faces have loaded (typical when a host app passes converted elements as initial data), the metrics come from the fallback font and stay wrong even after the actual font loads and renders.

Text elements measured with a not-yet-loaded font are now tracked, and `Fonts.onLoaded` re-measures them and redraws their containers once the font faces become available, as suggested in the issue. Elements converted with fonts already loaded are untouched, and so are diagrams loaded from storage.

## Before / After

| Before | After |
| --- | --- |
| <img alt="before" src="https://github.com/user-attachments/assets/8243b942-247d-4856-b747-7efda6d38534" /> | <img alt="after" src="https://github.com/user-attachments/assets/6638f6d8-8b24-48f4-98c4-9c2bcba249e6" /> |

The text element above is converted with a font that has not loaded yet. Before, it keeps the fallback-font width (203px vs the correct 179px), so the bounding box does not match the rendered glyphs. After, it is re-measured once the font loads.

## Testing

- Added unit tests covering that converted text elements are marked for re-measure only when their fonts are not yet loaded
- Verified in the app by converting elements before the font loaded and checking the element dimensions against the loaded-font measurement