### PR TITLE
fix(editor): prevent text creation on dblclick when exiting line editor

### DIFF
--- a/packages/element/tests/linearElementEditor.test.tsx
+++ b/packages/element/tests/linearElementEditor.test.tsx
@@ -335,6 +335,23 @@ describe("Test Linear Elements", () => {
     await getTextEditor();
   });
 
+  it("should not create text on dblclick outside the line editor", () => {
+    createTwoPointerLinearElement("line");
+
+    mouse.doubleClick();
+    expect(h.state.selectedLinearElement?.isEditing).toBe(true);
+
+    // double-clicking outside the line: the first click exits the line
+    // editor, so fire the full pointer sequence the browser produces
+    mouse.clickAt(200, 200);
+    expect(h.state.selectedLinearElement?.isEditing).toBeFalsy();
+    mouse.clickAt(200, 200);
+    mouse.doubleClickAt(200, 200);
+
+    expect(h.state.editingTextElement).toBeNull();
+    expect(h.elements.length).toBe(1);
+  });
+
   describe("Arrowhead toggle on endpoint dblclick", () => {
     // the toggle replaces the element (immutable update), so always re-read
     // the arrow from the scene instead of holding on to a stale reference

--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -703,6 +703,10 @@ class App extends React.Component<AppProps, AppState> {
   /** current frame pointer cords */
   lastPointerMoveCoords: { x: number; y: number } | null = null;
   private lastCompletedCanvasClicks: { x: number; y: number }[] = [];
+  /** whether a line editor was active on the two most recent pointerdowns.
+   * The first click of a double-click exits the line editor, so at dblclick
+   * time the state alone can't tell the gesture started inside one */
+  private lineEditorActiveOnPointerDown: [boolean, boolean] = [false, false];
   /** arrowheads removed via endpoint double-click toggle, so a subsequent
    * toggle can restore the original arrowhead (keyed by `elementId:side`) */
   private removedArrowheads = new Map<string, Arrowhead>();
@@ -7053,9 +7057,12 @@ class App extends React.Component<AppProps, AppState> {
         return;
       }
 
-      // shouldn't edit/create text when inside line editor (often false positive)
-
-      if (!this.state.selectedLinearElement?.isEditing) {
+      // shouldn't edit/create text when inside line editor, including when
+      // the first click of the double-click exited it
+      if (
+        !this.state.selectedLinearElement?.isEditing &&
+        !this.lineEditorActiveOnPointerDown.some(Boolean)
+      ) {
         const container = this.getTextBindableContainerAtPosition(
           sceneX,
           sceneY,
@@ -8374,6 +8381,10 @@ class App extends React.Component<AppProps, AppState> {
     }
 
     this.lastPointerDownEvent = event;
+    this.lineEditorActiveOnPointerDown = [
+      this.lineEditorActiveOnPointerDown[1],
+      !!this.state.selectedLinearElement?.isEditing,
+    ];
 
     // we must exit before we set `cursorButton` state and `savePointer`
     // else it will send pointer state & laser pointer events in collab when


### PR DESCRIPTION
## Summary

Fixes #9496

Double-clicking outside the line editor would exit the editor and immediately create a text element. The existing guard checks whether the line editor is active at dblclick time, but the first click of the double-click has already exited it by then, so the check never catches this case.

The app now tracks whether a line editor was active on the two most recent pointerdowns and skips text creation when the gesture started inside one. Entering the editor, adding midpoints, and creating text with a fresh double-click all behave as before.

## Testing

- Added a regression test firing the full pointer sequence of a double-click outside the line editor; it fails on master (a text element gets created) and passes with this change
- Verified in the app: exiting the editor via double-click no longer spawns the text editor, and a subsequent double-click still creates text