### PR TITLE
fix(editor): finalize multi-point drawing on toolbar tool switch

### DIFF
--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -5920,6 +5920,14 @@ class App extends React.Component<AppProps, AppState> {
       return;
     }
 
+    // finalize any in-progress multi-point drawing, else the editor is left
+    // with a stale `multiElement` state pointing to the unfinished element
+    // (elbow arrows are excluded as they finalize through their own
+    // pointer-driven path)
+    if (this.state.multiElement && !isElbowArrow(this.state.multiElement)) {
+      this.actionManager.executeAction(actionFinalize);
+    }
+
     const isToggleTool = TOGGLE_TOOLS.includes(tool.type);
     const toggle = opts.toggle === true && isToggleTool;
 

--- a/packages/excalidraw/tests/multiPointCreate.test.tsx
+++ b/packages/excalidraw/tests/multiPointCreate.test.tsx
@@ -224,4 +224,38 @@ describe("multi point mode in linear elements", () => {
     expect(renderStaticScene.mock.calls.length).toMatchInlineSnapshot(`7`);
     expect(h.elements.length).toEqual(1);
   });
+
+  it("finalizes multi-point line when switching tool via toolbar", async () => {
+    const { getByToolName, container } = await render(<Excalidraw />);
+    // select tool
+    const tool = getByToolName("line");
+    fireEvent.click(tool);
+
+    const canvas = container.querySelector("canvas.interactive")!;
+    // first point is added on pointer down
+    fireEvent.pointerDown(canvas, { clientX: 30, clientY: 30 });
+
+    // second point, enable multi point
+    fireEvent.pointerUp(canvas, { clientX: 30, clientY: 30 });
+    fireEvent.pointerMove(canvas, { clientX: 50, clientY: 60 });
+
+    // commit second point
+    fireEvent.pointerDown(canvas, { clientX: 50, clientY: 60 });
+    fireEvent.pointerUp(canvas);
+    fireEvent.pointerMove(canvas, { clientX: 100, clientY: 140 });
+
+    expect(h.state.multiElement).not.toBe(null);
+
+    // switching tool via toolbar should finalize the multi-point line
+    fireEvent.click(getByToolName("selection"));
+
+    expect(h.state.multiElement).toBe(null);
+    expect(h.state.activeTool.type).toEqual("selection");
+    expect(h.elements.length).toEqual(1);
+
+    const line = h.elements[0] as ExcalidrawLinearElement;
+    expect(line.isDeleted).toBe(false);
+    // the uncommitted trailing point is trimmed
+    expect(line.points.length).toEqual(2);
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #9257

Switching tools via the toolbar while drawing a multi-point arrow or line left the editor with a stale `multiElement` state: the tool switched but the editor still thought a drawing was in progress, breaking subsequent selection and eraser interactions. Keyboard tool shortcuts are already blocked during drawing, but toolbar clicks became possible as a side effect of the pointer-events changes in #9086.

Switching tools now finalizes the in-progress element first, same as pressing Enter or Escape, and then applies the new tool. Elbow arrows are excluded as they finalize through their own pointer-driven path.

There was an earlier attempt in #9259 which inlined the finalization logic; this PR reuses `actionFinalize` instead.

## Testing

- Added a regression test switching tool via the toolbar mid multi-point draw; it fails on master (stale `multiElement`) and passes with this change
- Verified in the app: switching to selection or a shape tool mid-arrow commits the arrow (trailing preview point trimmed) and the editor behaves normally afterwards