### PR TITLE
refactor(root): trim extra whitespace from comment

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -26,7 +26,7 @@ PrB8Ts2LUpepWC1l7zIXFm4ViDULuyWXTEpUcHSsEH8vpd1tckjypxCwkipfZsXx
 iPszy0o0Dx2iArPfWMXlFAI9mvyFCyFC3+nSvfyAUb2C4uZgCwAuyFh/ydPF4DEE
 PQIDAQAB'
 
-# Set the below flags explicitly to false in production mode since vite loads and merges .env.local vars when  running the build command
+# Set the below flags explicitly to false in production mode since vite loads and merges .env.local vars when running the build command
 VITE_APP_DEBUG_ENABLE_TEXT_CONTAINER_BOUNDING_BOX=false
 VITE_APP_COLLAPSE_OVERLAY=false
 # Enable eslint in dev server


### PR DESCRIPTION
### What it does
Trims extra whitespace from comment in `.env.production` on line `29`

### Before
"Set the below flags explicitly to false in production mode since vite loads and merges .env.local vars `when  running` the build command"

### After
"Set the below flags explicitly to false in production mode since vite loads and merges .env.local vars `when running` the build command"

### Testing
Not required