### PR TITLE
feat: add Alt+drag shortcut to create arrow bend point without enteri…

### DIFF
--- a/bend-point-shortcut.patch
+++ b/bend-point-shortcut.patch
@@ -1,0 +1,119 @@
+diff --git a/packages/element/src/linearElementEditor.ts b/packages/element/src/linearElementEditor.ts
+index 243f1f7..192a980 100644
+--- a/packages/element/src/linearElementEditor.ts
++++ b/packages/element/src/linearElementEditor.ts
+@@ -788,13 +788,18 @@ export class LinearElementEditor {
+     element: ExcalidrawLinearElement,
+     elementsMap: ElementsMap,
+     appState: InteractiveCanvasAppState,
++    force = false,
+   ): (GlobalPoint | null)[] => {
+     const boundText = getBoundTextElement(element, elementsMap);
+ 
+-    // Since its not needed outside editor unless 2 pointer lines or bound text
++    // Since its not needed outside editor unless 2 pointer lines, bound
++    // text, or the caller explicitly asked to bypass this (e.g. the user
++    // is holding the "add bend point" modifier on a selected-but-not-
++    // editing arrow)
+     if (
+       !isElbowArrow(element) &&
+       !appState.selectedLinearElement?.isEditing &&
++      !force &&
+       element.points.length > 2 &&
+       !boundText
+     ) {
+@@ -840,6 +845,7 @@ export class LinearElementEditor {
+     scenePointer: { x: number; y: number },
+     appState: AppState,
+     elementsMap: ElementsMap,
++    force = false,
+   ): GlobalPoint | null => {
+     const { elementId } = linearElementEditor;
+     const element = LinearElementEditor.getElement(elementId, elementsMap);
+@@ -863,6 +869,7 @@ export class LinearElementEditor {
+     if (
+       points.length >= 3 &&
+       !appState.selectedLinearElement?.isEditing &&
++      !force &&
+       !isElbowArrow(element)
+     ) {
+       return null;
+@@ -890,6 +897,7 @@ export class LinearElementEditor {
+       element,
+       elementsMap,
+       appState,
++      force,
+     );
+ 
+     while (index < midPoints.length) {
+@@ -998,6 +1006,7 @@ export class LinearElementEditor {
+     appState: AppState,
+     midPoint: GlobalPoint,
+     elementsMap: ElementsMap,
++    force = false,
+   ) {
+     const element = LinearElementEditor.getElement(
+       linearElementEditor.elementId,
+@@ -1010,6 +1019,7 @@ export class LinearElementEditor {
+       element,
+       elementsMap,
+       appState,
++      force,
+     );
+     let index = 0;
+     while (index < midPoints.length) {
+@@ -1058,6 +1068,7 @@ export class LinearElementEditor {
+       scenePointer,
+       appState,
+       elementsMap,
++      event.altKey,
+     );
+     const point = pointFrom<GlobalPoint>(scenePointer.x, scenePointer.y);
+     let segmentMidpointIndex = null;
+@@ -1068,6 +1079,7 @@ export class LinearElementEditor {
+         appState,
+         segmentMidpoint,
+         elementsMap,
++        event.altKey,
+       );
+     } else if (event.altKey && appState.selectedLinearElement?.isEditing) {
+       if (linearElementEditor.lastUncommittedPoint == null) {
+diff --git a/packages/excalidraw/components/App.tsx b/packages/excalidraw/components/App.tsx
+index 0e57321..5f91b4e 100644
+--- a/packages/excalidraw/components/App.tsx
++++ b/packages/excalidraw/components/App.tsx
+@@ -7898,6 +7898,7 @@ class App extends React.Component<AppProps, AppState> {
+           this.state.selectedLinearElement,
+           scenePointerX,
+           scenePointerY,
++          event.altKey,
+         );
+       }
+ 
+@@ -8058,6 +8059,7 @@ class App extends React.Component<AppProps, AppState> {
+           this.state.selectedLinearElement,
+           scenePointerX,
+           scenePointerY,
++          event.altKey,
+         );
+       }
+     }
+@@ -8115,6 +8117,10 @@ class App extends React.Component<AppProps, AppState> {
+     linearElementEditor: LinearElementEditor,
+     scenePointerX: number,
+     scenePointerY: number,
++    // when true, bend-point (segment midpoint) hit-testing is allowed even
++    // for arrows that already have 3+ points and are not in full edit mode —
++    // used for the alt-drag "add bend point" shortcut
++    force = false,
+   ) {
+     const elementsMap = this.scene.getNonDeletedElementsMap();
+ 
+@@ -8150,6 +8156,7 @@ class App extends React.Component<AppProps, AppState> {
+             { x: scenePointerX, y: scenePointerY },
+             this.state,
+             this.scene.getNonDeletedElementsMap(),
++            force,
+           );
+         const isHoveringAPointHandle = isElbowArrow(element)
+           ? hoverPointIndex === 0 ||

--- a/packages/element/src/linearElementEditor.ts
+++ b/packages/element/src/linearElementEditor.ts
@@ -788,13 +788,18 @@ export class LinearElementEditor {
     element: ExcalidrawLinearElement,
     elementsMap: ElementsMap,
     appState: InteractiveCanvasAppState,
+    force = false,
   ): (GlobalPoint | null)[] => {
     const boundText = getBoundTextElement(element, elementsMap);
 
-    // Since its not needed outside editor unless 2 pointer lines or bound text
+    // Since its not needed outside editor unless 2 pointer lines, bound
+    // text, or the caller explicitly asked to bypass this (e.g. the user
+    // is holding the "add bend point" modifier on a selected-but-not-
+    // editing arrow)
     if (
       !isElbowArrow(element) &&
       !appState.selectedLinearElement?.isEditing &&
+      !force &&
       element.points.length > 2 &&
       !boundText
     ) {
@@ -840,6 +845,7 @@ export class LinearElementEditor {
     scenePointer: { x: number; y: number },
     appState: AppState,
     elementsMap: ElementsMap,
+    force = false,
   ): GlobalPoint | null => {
     const { elementId } = linearElementEditor;
     const element = LinearElementEditor.getElement(elementId, elementsMap);
@@ -863,6 +869,7 @@ export class LinearElementEditor {
     if (
       points.length >= 3 &&
       !appState.selectedLinearElement?.isEditing &&
+      !force &&
       !isElbowArrow(element)
     ) {
       return null;
@@ -890,6 +897,7 @@ export class LinearElementEditor {
       element,
       elementsMap,
       appState,
+      force,
     );
 
     while (index < midPoints.length) {
@@ -998,6 +1006,7 @@ export class LinearElementEditor {
     appState: AppState,
     midPoint: GlobalPoint,
     elementsMap: ElementsMap,
+    force = false,
   ) {
     const element = LinearElementEditor.getElement(
       linearElementEditor.elementId,
@@ -1010,6 +1019,7 @@ export class LinearElementEditor {
       element,
       elementsMap,
       appState,
+      force,
     );
     let index = 0;
     while (index < midPoints.length) {
@@ -1058,6 +1068,7 @@ export class LinearElementEditor {
       scenePointer,
       appState,
       elementsMap,
+      event.altKey,
     );
     const point = pointFrom<GlobalPoint>(scenePointer.x, scenePointer.y);
     let segmentMidpointIndex = null;
@@ -1068,6 +1079,7 @@ export class LinearElementEditor {
         appState,
         segmentMidpoint,
         elementsMap,
+        event.altKey,
       );
     } else if (event.altKey && appState.selectedLinearElement?.isEditing) {
       if (linearElementEditor.lastUncommittedPoint == null) {

--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -7898,6 +7898,7 @@ class App extends React.Component<AppProps, AppState> {
           this.state.selectedLinearElement,
           scenePointerX,
           scenePointerY,
+          event.altKey,
         );
       }
 
@@ -8058,6 +8059,7 @@ class App extends React.Component<AppProps, AppState> {
           this.state.selectedLinearElement,
           scenePointerX,
           scenePointerY,
+          event.altKey,
         );
       }
     }
@@ -8115,6 +8117,10 @@ class App extends React.Component<AppProps, AppState> {
     linearElementEditor: LinearElementEditor,
     scenePointerX: number,
     scenePointerY: number,
+    // when true, bend-point (segment midpoint) hit-testing is allowed even
+    // for arrows that already have 3+ points and are not in full edit mode —
+    // used for the alt-drag "add bend point" shortcut
+    force = false,
   ) {
     const elementsMap = this.scene.getNonDeletedElementsMap();
 
@@ -8150,6 +8156,7 @@ class App extends React.Component<AppProps, AppState> {
             { x: scenePointerX, y: scenePointerY },
             this.state,
             this.scene.getNonDeletedElementsMap(),
+            force,
           );
         const isHoveringAPointHandle = isElbowArrow(element)
           ? hoverPointIndex === 0 ||


### PR DESCRIPTION
## What this PR does

Lets users add a new bend point to an already-selected arrow by holding 
**Alt** and dragging along any segment — without first right-clicking 
and choosing "Edit Arrow."

Closes #11751

## Background

Adding a bend point via segment-midpoint drag already works today, but 
only once the arrow's `isEditing` state is true. Once an arrow already 
has 3+ points, `LinearElementEditor.getEditorMidPoints` and 
`getSegmentMidpointHitCoords` stop reporting any hittable midpoint unless 
`isEditing` is true, so all the drag/insert logic downstream never gets 
a chance to run.

## Approach

- Added an optional `force` parameter to `getEditorMidPoints`, 
  `getSegmentMidpointHitCoords`, and `getSegmentMidPointIndex`, which 
  bypasses the `isEditing` check when set.
- `LinearElementEditor.handlePointerDown` now passes `event.altKey` as 
  that flag, so an Alt+drag on a segment inserts a point there even when 
  the arrow is only selected, not in edit mode.
- Threaded `event.altKey` through `handleHoverSelectedLinearElement`'s two 
  call sites in `App.tsx` as well, so the existing midpoint-highlight and 
  pointer-cursor hover feedback shows up on hover — before the user even 
  presses down — matching the discoverability ask in the issue.
- No rendering changes were needed: `renderElbowArrowMidPointHighlight` 
  already fires off `segmentMidPointHoveredCoords` regardless of edit 
  mode, so it "just works" once the hit-test stops refusing.

## Testing

Manually tested: draw an arrow, add one bend point (drag its current 
midpoint), select it without entering Edit Arrow, hold Alt, and drag 
along a segment — a new bend point is added at the correct position.

[] Will add a unit test in linearElementEditor.test.tsx covering the 
force-flag path with an arrow that already has 3+ points, if the approach 
gets a thumbs up.


https://github.com/user-attachments/assets/3c33d2ae-393a-40e0-9d39-c559c4c188b1



## Notes

Used **Alt** as the modifier since Ctrl/Cmd already toggles edit mode for 
simple arrows, and Alt is only otherwise used *inside* edit mode (for 
appending points). Open to changing this if maintainers prefer a 
different convention.