### PR TITLE
fix(pwa): raise workbox precache size limit to 3MB

### DIFF
--- a/excalidraw-app/vite.config.mts
+++ b/excalidraw-app/vite.config.mts
@@ -223,7 +223,7 @@ export default defineConfig(({ mode }) => {
               },
             },
           ],
-          maximumFileSizeToCacheInBytes: 2.3 * 1024 ** 2, // 2.3MB
+          maximumFileSizeToCacheInBytes: 3 * 1024 ** 2, // 3MB
         },
         manifest: {
           short_name: "Excalidraw",


### PR DESCRIPTION
## Problem

The production build currently fails outright for me on a clean checkout of `master`:

```
ERROR  error during build:
Error:
  Configure "workbox.maximumFileSizeToCacheInBytes" to change the limit: the default value is 2 MiB.
  Check https://vite-pwa-org.netlify.app/guide/faq.html#missing-assets-from-sw-precache-manifest for more information.
  Assets exceeding the limit:
  - assets/index-*.js is 2.62 MB, and won't be precached.
```

`excalidraw-app/vite.config.mts` already raises `workbox.maximumFileSizeToCacheInBytes` from Workbox's 2 MiB default to 2.3MB, but the main bundle has since grown past that too (2.62MB), so `generateSW` fails the whole build instead of just warning.

## Fix

Raise `maximumFileSizeToCacheInBytes` to 3MB so the service worker precache step succeeds again. This unblocks self-hosted production builds; happy to adjust the exact number or discuss a longer-term fix (e.g. code-splitting the main chunk) if maintainers prefer that route instead.

## Testing

Verified `yarn build:app:docker` completes successfully with this change (previously failed on the same commit without it).