### PR TITLE
fix(packages/excalidraw): guard missing FontFace.unicodeRange in svg export

### DIFF
--- a/packages/excalidraw/fonts/ExcalidrawFontFace.test.ts
+++ b/packages/excalidraw/fonts/ExcalidrawFontFace.test.ts
@@ -1,0 +1,36 @@
+import { ExcalidrawFontFace } from "./ExcalidrawFontFace";
+
+const createFontFace = (descriptors?: FontFaceDescriptors) => {
+  const fontFace = new ExcalidrawFontFace(
+    "Excalifont",
+    "https://example.com/Excalifont.woff2",
+    descriptors,
+  );
+
+  // simulate a non-browser `FontFace` implementation — the polyfills needed to
+  // run exports in node commonly don't expose `unicodeRange` at all (#10604)
+  Reflect.deleteProperty(fontFace.fontFace, "unicodeRange");
+
+  // we're only exercising the unicode-range gate, so skip fetching & subsetting
+  vi.spyOn(fontFace, "getContent").mockResolvedValue("data:font/woff2;base64,");
+
+  return fontFace;
+};
+
+describe("ExcalidrawFontFace", () => {
+  it("generates css when the host FontFace doesn't expose a unicode range", async () => {
+    await expect(createFontFace().toCSS("Hello")).resolves.toContain(
+      "@font-face",
+    );
+  });
+
+  it("honors the declared unicode range when the host FontFace doesn't expose it", async () => {
+    // cyrillic-only subset
+    const descriptors = { unicodeRange: "U+400-45f" };
+
+    expect(createFontFace(descriptors).toCSS("Hello")).toBeUndefined();
+    await expect(
+      createFontFace(descriptors).toCSS("Привет"),
+    ).resolves.toContain("@font-face");
+  });
+});

--- a/packages/excalidraw/fonts/ExcalidrawFontFace.ts
+++ b/packages/excalidraw/fonts/ExcalidrawFontFace.ts
@@ -8,6 +8,14 @@ export class ExcalidrawFontFace {
   public readonly urls: URL[] | DataURL[];
   public readonly fontFace: FontFace;
 
+  /**
+   * `FontFace#unicodeRange` defaults to `U+0-10FFFF` per spec, but non-browser
+   * `FontFace` implementations (i.e. the polyfills needed to run exports in
+   * node) commonly don't expose it at all, so keep the declared range around
+   * as a fallback.
+   */
+  private readonly declaredUnicodeRange: string;
+
   private static readonly ASSETS_FALLBACK_URL = `https://esm.sh/${
     import.meta.env.PKG_NAME
       ? `${import.meta.env.PKG_NAME}@${import.meta.env.PKG_VERSION}` // is provided during package build
@@ -27,6 +35,8 @@ export class ExcalidrawFontFace {
       weight: "400",
       ...descriptors,
     });
+
+    this.declaredUnicodeRange = descriptors?.unicodeRange || "U+0-10FFFF";
   }
 
   /**
@@ -112,10 +122,13 @@ export class ExcalidrawFontFace {
   }
 
   private getUnicodeRangeRegex() {
+    const unicodeRange =
+      this.fontFace.unicodeRange || this.declaredUnicodeRange;
+
     // using \u{h} or \u{hhhhh} to match any number of hex digits,
     // otherwise we would get an "Invalid Unicode escape" error
     // e.g. U+0-1007F -> \u{0}-\u{1007F}
-    const unicodeRangeRegex = this.fontFace.unicodeRange
+    const unicodeRangeRegex = unicodeRange
       .split(/,\s*/)
       .map((range) => {
         const [start, end] = range.replace("U+", "").split("-");


### PR DESCRIPTION
## Summary

Fixes #10604

`exportToSvg` run outside a browser (node + jsdom + a `FontFace` polyfill, which is how `@excalidraw/utils` gets used server-side) logs one of these per font family and produces an SVG with no embedded fonts:

```
Couldn't transform font-face to css for family "Excalifont" TypeError: Cannot read properties of undefined (reading 'split')
    at A.getUnicodeRangeRegex
    at A.toCSS
    at A.fontFacesStylesGenerator
```

`ExcalidrawFontFace` spreads its descriptors into the host `FontFace` constructor and then reads the unicode range back out via `this.fontFace.unicodeRange`. Per spec that getter defaults to `U+0-10FFFF`, but non-browser `FontFace` implementations commonly don't expose it at all, so the read yields `undefined` and `getUnicodeRangeRegex()` throws on `.split()`.

`Fonts.fontFacesStylesGenerator` catches the throw, logs, and skips that font face — so the failure isn't only console noise: every `@font-face` block is dropped from the exported SVG and the text renders in a fallback font instead of Excalifont / Comic Shanns.

## Changes

- `ExcalidrawFontFace` now keeps the declared unicode range (defaulting to the spec's `U+0-10FFFF`) and falls back to it only when the host `FontFace` doesn't report one.
- Falling back to the *declared* range rather than a blanket full range matters: the bundled fonts are split into per-subset faces (`U+400-45f,U+490-491,U+2116`, the Xiaolai CJK subsets, ...), and a blanket full range would make every subset claim every codepoint and subset the wrong file.
- Behaviour is unchanged anywhere `unicodeRange` is available, i.e. in every browser and in the existing test harness — no snapshots move.

## Testing

- New `packages/excalidraw/fonts/ExcalidrawFontFace.test.ts`. It deletes `unicodeRange` off the host font face to reproduce the polyfill shape from the issue, and asserts both that CSS is still produced and that an explicitly declared subset range is still honoured. Reverting the source change makes both cases fail with the exact `Cannot read properties of undefined (reading 'split')` from the report.
- `yarn test:app --watch=false` — 117 files / 1679 tests pass, no snapshot updates.
- `yarn test:typecheck`, `yarn test:code`, `yarn test:other` all clean.

## Note for maintainers (not changed here)

The `FontFace` polyfill in `setupTests.ts` hard-codes `this.unicodeRange = "U+0000-00FF"` and ignores the descriptors it is handed, so under test every font face is gated to Latin-1 regardless of its real subset. Making the polyfill honour its descriptors does move the `exportToSvg` snapshots, so I left it out of this PR rather than re-recording snapshots in a bug fix — happy to open a separate one if you'd like it corrected.