### PR TITLE
feat(editor): allow typing an exact zoom percentage

### DIFF
--- a/packages/excalidraw/actions/actionCanvas.test.tsx
+++ b/packages/excalidraw/actions/actionCanvas.test.tsx
@@ -1,0 +1,123 @@
+import { fireEvent, waitFor } from "@testing-library/react";
+import React from "react";
+
+import { MAX_ZOOM, MIN_ZOOM } from "@excalidraw/common";
+
+import { Excalidraw } from "../index";
+import { render } from "../tests/test-utils";
+
+const { h } = window;
+
+const queryContainer = (selector: string) =>
+  document.querySelector<HTMLElement>(selector);
+
+const openZoomInput = () => {
+  const zoomValueButton = queryContainer(".zoom-value-button");
+  expect(zoomValueButton).not.toBe(null);
+  fireEvent.doubleClick(zoomValueButton!);
+  return queryContainer(".zoom-value-input") as HTMLInputElement;
+};
+
+const submitZoom = async (value: string) => {
+  const input = openZoomInput();
+  expect(input).not.toBe(null);
+  fireEvent.change(input, { target: { value } });
+  fireEvent.keyDown(input, { key: "Enter" });
+  await waitFor(() => expect(queryContainer(".zoom-value-input")).toBe(null));
+};
+
+describe("zoom value input", () => {
+  beforeEach(async () => {
+    await render(<Excalidraw />);
+  });
+
+  it("renders the current zoom as a percentage", () => {
+    expect(queryContainer(".zoom-value-button")?.textContent).toBe("100%");
+  });
+
+  it("opens an input on double click, seeded with the current zoom", () => {
+    const input = openZoomInput();
+    expect(input).not.toBe(null);
+    expect(input.value).toBe("100");
+  });
+
+  it("zooms to the typed percentage", async () => {
+    await submitZoom("1800");
+    expect(h.state.zoom.value).toBe(18);
+    expect(queryContainer(".zoom-value-button")?.textContent).toBe("1800%");
+  });
+
+  it("clamps values above MAX_ZOOM", async () => {
+    await submitZoom("999999");
+    expect(h.state.zoom.value).toBe(MAX_ZOOM);
+  });
+
+  it("clamps values below MIN_ZOOM", async () => {
+    await submitZoom("1");
+    expect(h.state.zoom.value).toBe(MIN_ZOOM);
+  });
+
+  it("ignores a non-numeric value", async () => {
+    const zoomBefore = h.state.zoom.value;
+    await submitZoom("abc");
+    expect(h.state.zoom.value).toBe(zoomBefore);
+  });
+
+  it("keeps the viewport center anchored", async () => {
+    const { width, height, offsetLeft, offsetTop } = h.state;
+    const centerX = width / 2 + offsetLeft;
+    const centerY = height / 2 + offsetTop;
+
+    const sceneXBefore = centerX / h.state.zoom.value - h.state.scrollX;
+    const sceneYBefore = centerY / h.state.zoom.value - h.state.scrollY;
+
+    await submitZoom("400");
+
+    const sceneXAfter = centerX / h.state.zoom.value - h.state.scrollX;
+    const sceneYAfter = centerY / h.state.zoom.value - h.state.scrollY;
+
+    expect(sceneXAfter).toBeCloseTo(sceneXBefore);
+    expect(sceneYAfter).toBeCloseTo(sceneYBefore);
+  });
+
+  it("discards the edit on Escape", async () => {
+    const input = openZoomInput();
+    fireEvent.change(input, { target: { value: "500" } });
+    fireEvent.keyDown(input, { key: "Escape" });
+
+    await waitFor(() => expect(queryContainer(".zoom-value-input")).toBe(null));
+    expect(h.state.zoom.value).toBe(1);
+  });
+
+  it("commits on blur", async () => {
+    const input = openZoomInput();
+    fireEvent.change(input, { target: { value: "250" } });
+    fireEvent.blur(input);
+
+    await waitFor(() => expect(h.state.zoom.value).toBe(2.5));
+  });
+});
+
+describe("reset zoom button", () => {
+  it("resets zoom to 100% and is separate from the zoom value", async () => {
+    await render(<Excalidraw />);
+
+    await submitZoom("400");
+    expect(h.state.zoom.value).toBe(4);
+
+    const resetButton = queryContainer(".reset-zoom-button");
+    expect(resetButton).not.toBe(null);
+    fireEvent.click(resetButton!);
+
+    await waitFor(() => expect(h.state.zoom.value).toBe(1));
+  });
+
+  it("does not reset zoom when the zoom value is clicked", async () => {
+    await render(<Excalidraw />);
+
+    await submitZoom("400");
+    fireEvent.click(queryContainer(".zoom-value-button")!);
+
+    expect(h.state.zoom.value).toBe(4);
+  });
+});

--- a/packages/excalidraw/actions/actionCanvas.tsx
+++ b/packages/excalidraw/actions/actionCanvas.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useRef, useState } from "react";
+
 import {
   DEFAULT_CANVAS_BACKGROUND_PICKS,
   MAX_ZOOM,
@@ -249,27 +251,143 @@ export const actionResetZoom = register({
       captureUpdate: CaptureUpdateAction.EVENTUALLY,
     };
   },
-  PanelComponent: ({ updateData }) => {
+  PanelComponent: ({ updateData }) => (
+    <Tooltip label={t("buttons.resetZoom")} style={{ height: "100%" }}>
+      <IconButton
+        type="button"
+        className="reset-zoom-button zoom-button"
+        icon={ZoomResetIcon}
+        title={`${t("buttons.resetZoom")} — ${getShortcutKey("CtrlOrCmd+0")}`}
+        aria-label={t("buttons.resetZoom")}
+        onClick={() => {
+          updateData(null);
+        }}
+      />
+    </Tooltip>
+  ),
+  keyTest: (event) =>
+    (event.code === CODES.ZERO || event.code === CODES.NUM_ZERO) &&
+    (event[KEYS.CTRL_OR_CMD] || event.shiftKey),
+});
+
+export const actionSetZoom = register<number>({
+  name: "setZoom",
+  label: "buttons.setZoom",
+  viewMode: true,
+  navigation: true,
+  trackEvent: { category: "canvas" },
+  predicate: (elements, appState, appProps, app) => app.isNavigationEnabled(),
+  // `value` is a zoom percentage as typed by the user (e.g. 150 for 150%).
+  // Anchored to the viewport center like the other discrete zoom actions —
+  // the pointer is over the zoom widget when the value is committed, so
+  // anchoring there would throw the viewport off at high zoom.
+  perform: (_elements, appState, value, app) => {
+    if (value == null || isNaN(value)) {
+      return false;
+    }
+    const nextState = {
+      ...appState,
+      ...getViewportForZoomWithScrollConstraints(
+        {
+          viewportX: appState.width / 2 + appState.offsetLeft,
+          viewportY: appState.height / 2 + appState.offsetTop,
+          nextZoom: getNormalizedZoom(value / 100),
+        },
+        appState,
+      ),
+      userToFollow: null,
+    };
+    return {
+      appState: nextState,
+      captureUpdate: CaptureUpdateAction.EVENTUALLY,
+    };
+  },
+  PanelComponent: ({ updateData, app }) => {
     const zoomValue = useAppStateValue((appState) => appState.zoom.value);
+    const zoomPercentage = (zoomValue * 100).toFixed(0);
+
+    const [isEditing, setIsEditing] = useState(false);
+    const [inputValue, setInputValue] = useState(zoomPercentage);
+    const inputRef = useRef<HTMLInputElement>(null);
+    // guards against the edit being finished twice: returning focus to the
+    // canvas blurs the input, so Enter/Escape would otherwise be followed by
+    // the blur handler finishing the same edit again
+    const isEditPendingRef = useRef(false);
+
+    useEffect(() => {
+      if (isEditing) {
+        inputRef.current?.focus();
+        inputRef.current?.select();
+      }
+    }, [isEditing]);
+
+    const startEditing = () => {
+      setInputValue(zoomPercentage);
+      isEditPendingRef.current = true;
+      setIsEditing(true);
+    };
+
+    const finishEditing = (shouldCommit: boolean) => {
+      if (!isEditPendingRef.current) {
+        return;
+      }
+      isEditPendingRef.current = false;
+
+      if (shouldCommit) {
+        const nextZoomPercentage = parseFloat(inputValue);
+        // out-of-range values are clamped by `getNormalizedZoom`, but a value
+        // that isn't a number at all is discarded
+        if (!isNaN(nextZoomPercentage)) {
+          updateData(nextZoomPercentage);
+        }
+      }
+
+      setIsEditing(false);
+      app.focusContainer();
+    };
+
+    if (isEditing) {
+      return (
+        <input
+          ref={inputRef}
+          className="zoom-value-input zoom-button"
+          type="text"
+          inputMode="numeric"
+          autoComplete="off"
+          spellCheck="false"
+          aria-label={t("buttons.setZoom")}
+          value={inputValue}
+          onChange={(event) => setInputValue(event.target.value)}
+          onBlur={() => finishEditing(true)}
+          onKeyDown={(event) => {
+            if (event.key === KEYS.ENTER) {
+              finishEditing(true);
+            } else if (event.key === KEYS.ESCAPE) {
+              // Escape is the one key the global handler doesn't ignore for
+              // inputs (see App's onKeyDown), so it would also reach the
+              // canvas and e.g. reset the active tool
+              event.stopPropagation();
+              finishEditing(false);
+            }
+          }}
+        />
+      );
+    }
+
     return (
-      <Tooltip label={t("buttons.resetZoom")} style={{ height: "100%" }}>
+      <Tooltip label={t("buttons.setZoom")} style={{ height: "100%" }}>
         <IconButton
           type="button"
-          className="reset-zoom-button zoom-button"
-          title={t("buttons.resetZoom")}
-          aria-label={t("buttons.resetZoom")}
-          onClick={() => {
-            updateData(null);
-          }}
+          className="zoom-value-button zoom-button"
+          title={t("buttons.setZoom")}
+          aria-label={t("buttons.setZoom")}
+          onDoubleClick={startEditing}
         >
-          {(zoomValue * 100).toFixed(0)}%
+          {zoomPercentage}%
         </IconButton>
       </Tooltip>
     );
   },
-  keyTest: (event) =>
-    (event.code === CODES.ZERO || event.code === CODES.NUM_ZERO) &&
-    (event[KEYS.CTRL_OR_CMD] || event.shiftKey),
 });
 
 // under a viewport lock, zoom-to-fit targets the locked box rather than the

--- a/packages/excalidraw/actions/types.ts
+++ b/packages/excalidraw/actions/types.ts
@@ -91,6 +91,7 @@ export type ActionName =
   | "zoomIn"
   | "zoomOut"
   | "resetZoom"
+  | "setZoom"
   | "zoomToFit"
   | "zoomToFitSelection"
   | "zoomToFitSelectionInViewport"

--- a/packages/excalidraw/components/Actions.scss
+++ b/packages/excalidraw/components/Actions.scss
@@ -24,7 +24,8 @@
   }
 }
 
-.reset-zoom-button {
+.zoom-value-button,
+.zoom-value-input {
   border-left: 0 !important;
   border-right: 0 !important;
   padding: 0 0.625rem !important;
@@ -33,7 +34,28 @@
   color: var(--text-primary-color);
 }
 
-.zoom-out-button {
+// scoped through `.zoom-actions` so it outranks the app-wide `input[type="text"]`
+// and `input:focus-visible` rules in styles.scss
+.excalidraw {
+  .zoom-actions .zoom-value-input {
+    // must match the button it replaces, so the bar doesn't resize mid-edit
+    box-sizing: border-box;
+    height: var(--lg-button-size);
+    margin: 0;
+    border: 0;
+    outline: none;
+    appearance: none;
+    text-align: center;
+    font-family: inherit;
+    color: var(--text-primary-color);
+
+    &:focus-visible {
+      box-shadow: none;
+    }
+  }
+}
+
+.reset-zoom-button {
   border-top-left-radius: var(--border-radius-lg) !important;
   border-bottom-left-radius: var(--border-radius-lg) !important;
 
@@ -44,7 +66,16 @@
   .ToolIcon__icon {
     border-top-right-radius: 0 !important;
     border-bottom-right-radius: 0 !important;
+
+    // the icon itself must stay upright when the button is mirrored for RTL
+    :root[dir="rtl"] & {
+      transform: scaleX(-1);
+    }
   }
+}
+
+.zoom-out-button {
+  border-radius: 0 !important;
 }
 
 .zoom-in-button {

--- a/packages/excalidraw/components/Actions.tsx
+++ b/packages/excalidraw/components/Actions.tsx
@@ -865,8 +865,9 @@ export const ZoomActions = ({
 }) => (
   <Stack.Col gap={1} className={CLASSES.ZOOM_ACTIONS}>
     <Stack.Row align="center">
-      {renderAction("zoomOut")}
       {renderAction("resetZoom")}
+      {renderAction("zoomOut")}
+      {renderAction("setZoom")}
       {renderAction("zoomIn")}
     </Stack.Row>
   </Stack.Col>

--- a/packages/excalidraw/components/IconButton.tsx
+++ b/packages/excalidraw/components/IconButton.tsx
@@ -38,11 +38,13 @@ type IconButtonProps =
       type: "button";
       children?: React.ReactNode;
       onClick?(event: React.MouseEvent): void;
+      onDoubleClick?(event: React.MouseEvent): void;
     })
   | (IconButtonBaseProps & {
       type: "icon";
       children?: React.ReactNode;
       onClick?(): void;
+      onDoubleClick?(event: React.MouseEvent): void;
     })
   // a stateful (pressed/unpressed) tool button
   | (IconButtonBaseProps & {
@@ -128,6 +130,7 @@ export const IconButton = React.forwardRef(
           aria-label={props["aria-label"]}
           type="button"
           onClick={onClick}
+          onDoubleClick={props.onDoubleClick}
           ref={innerRef}
           disabled={isLoading || props.isLoading || !!props.disabled}
         >

--- a/packages/excalidraw/locales/en.json
+++ b/packages/excalidraw/locales/en.json
@@ -236,6 +236,7 @@
     "zoomIn": "Zoom in",
     "zoomOut": "Zoom out",
     "resetZoom": "Reset zoom",
+    "setZoom": "Double-click to set zoom level",
     "menu": "Menu",
     "done": "Done",
     "edit": "Edit",


### PR DESCRIPTION
Closes #11760 

The zoom control only supported incremental adjustment, so reaching a specific zoom level meant repeated clicks or a careful scroll.

Double clicking the zoom percentage now turns it into an input; values outside MIN_ZOOM/MAX_ZOOM are clamped by the existing getNormalizedZoom. The percentage label previously doubled as the reset-zoom button, which conflicts with editing it, so reset moves to its own icon button using the icon and label the action already declared.

Zoom is anchored to the viewport center, consistent with the other discrete zoom actions -- the pointer sits over the zoom widget when the value is committed, so anchoring there would throw the viewport off at high zoom.

Happy for suggestions! 



https://github.com/user-attachments/assets/300d2bfd-7b14-4244-a4e9-bbb2ab5f74f7

