### PR TITLE
fix: add missing de-DE translation for crop editor hints

### DIFF
--- a/packages/excalidraw/locales/de-DE.json
+++ b/packages/excalidraw/locales/de-DE.json
@@ -378,8 +378,8 @@
     "eraserRevert": "",
     "firefox_clipboard_write": "Diese Funktion kann wahrscheinlich aktiviert werden, indem die Einstellung \"dom.events.asyncClipboard.clipboardItem\" auf \"true\" gesetzt wird. Um die Browsereinstellungen in Firefox zu ändern, besuche die Seite \"about:config\".",
     "disableSnapping": "",
-    "enterCropEditor": "",
-    "leaveCropEditor": ""
+    "enterCropEditor": "Doppelklicken Sie auf das Bild oder drücken Sie {{shortcut}}, um das Bild zuzuschneiden",
+    "leaveCropEditor": "Klicken Sie außerhalb des Bildes oder drücken Sie {{shortcut_1}} oder {{shortcut_2}}, um das Zuschneiden zu beenden"
   },
   "canvasError": {
     "cannotShowPreview": "Vorschau kann nicht angezeigt werden",


### PR DESCRIPTION
Fixes #11769

## Summary

Added missing German (de-DE) translations for two crop editor hint keys that were left as empty strings:

- `hints.enterCropEditor` — hint shown when entering the crop editor
- `hints.leaveCropEditor` — hint shown when leaving the crop editor

Previously, the empty strings caused the English fallback text to always display even when `langCode="de-DE"` was set.

## Changes

**Modified:** `packages/excalidraw/locales/de-DE.json`

| Key | Translation |
|-----|-------------|
| `enterCropEditor` | Doppelklicken Sie auf das Bild oder drücken Sie {{shortcut}}, um das Bild zuzuschneiden |
| `leaveCropEditor` | Klicken Sie außerhalb des Bildes oder drücken Sie {{shortcut_1}} oder {{shortcut_2}}, um das Zuschneiden zu beenden |
