### PR TITLE
Fix/strokes at start with small offsets

### DIFF
--- a/packages/element/src/shape.ts
+++ b/packages/element/src/shape.ts
@@ -1257,12 +1257,18 @@ const med = (A: number[], B: number[]) => {
   return [(A[0] + B[0]) / 2, (A[1] + B[1]) / 2];
 };
 
-// Trim SVG path data so number are each two decimal points. This
-// improves SVG exports, and prevents rendering errors on points
-// with long decimals.
-const TO_FIXED_PRECISION = /(\s?[A-Z]?,?-?[0-9]*\.[0-9]{0,2})(([0-9]|e|-)*)/g;
+//Shape coordinates must be rounded to fixed precision arithmetically.
+//Truncation of excessive decimal values fails on numbers in exponential notation 
+const roundSvgCoordinate = (value: number) => {
+  const rounded = Math.round(value * 100) / 100;
+  return Object.is(rounded, -0) ? 0 : rounded;
+};
 
-const getSvgPathFromStroke = (points: number[][]): string => {
+const roundSvgPoint = ([x, y]: number[]) =>
+  [roundSvgCoordinate(x), roundSvgCoordinate(y)] as [number, number];
+
+//Function exported for testing purposes only
+export const getSvgPathFromStroke = (points: number[][]): string => {
   if (!points.length) {
     return "";
   }
@@ -1272,17 +1278,25 @@ const getSvgPathFromStroke = (points: number[][]): string => {
   return points
     .reduce(
       (acc, point, i, arr) => {
+        const roundedPoint = roundSvgPoint(point);
+
         if (i === max) {
-          acc.push(point, med(point, arr[0]), "L", arr[0], "Z");
+          acc.push(
+            roundedPoint,
+            roundSvgPoint(med(point, arr[0])),
+            "L",
+            roundSvgPoint(arr[0]),
+            "Z",
+          );
         } else {
-          acc.push(point, med(point, arr[i + 1]));
+          acc.push(roundedPoint, roundSvgPoint(med(point, arr[i + 1])));
         }
+
         return acc;
       },
-      ["M", points[0], "Q"],
+      ["M", roundSvgPoint(points[0]), "Q"] as (string | number[])[],
     )
-    .join(" ")
-    .replace(TO_FIXED_PRECISION, "$1");
+    .join(" ");
 };
 
 // -----------------------------------------------------------------------------

--- a/packages/element/tests/shape.test.ts
+++ b/packages/element/tests/shape.test.ts
@@ -1,0 +1,15 @@
+import { getSvgPathFromStroke } from "../src/shape";
+
+describe("getSvgPathFromStroke", () => {
+  it("Small values in exponential notation rounded correctly", () => {
+    const outline = [
+      [8.572527594031472e-17, -1.4],
+      [1.4, 1.7145055188062944e-16],
+      [-8.572527594031472e-17, 1.4],
+    ];
+
+    expect(getSvgPathFromStroke(outline)).toBe(
+      "M 0,-1.4 Q 0,-1.4 0.7,-0.7 1.4,0 0.7,0.7 0,1.4 0,0 L 0,-1.4 Z",
+    );
+  });
+});


### PR DESCRIPTION
### Problem : 
If freeform drawing points contained very small offsets (sub-pixel), then  : 
 - generated outline coordinates might be formatted in exponential form (like 8.7654321e-17)
 - which would be incorrectly truncated (to 8.76) with a regex
 - and then formatted as an svg with invalid corrdinates
 - all above would cause rogue vertical/horizontal strokes to be rendered around the points with small offsets (see an example below).
 
###  Solutuion : 
 Round the outline coordinates to 2 decimal points using `Math` instead of a regex.


###  Problem example : 
<img width="1271" height="896" alt="image" src="https://github.com/user-attachments/assets/35d2a4b8-7779-4f09-be79-06a4321297de" />
