### PR TITLE
fix: proper test to detect when the pressure is simulated or not

### DIFF
--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -9819,7 +9819,7 @@ class App extends React.Component<AppProps, AppState> {
       y: gridY,
     });
 
-    const simulatePressure = event.pressure === 0.5;
+    const simulatePressure = event.pointerType !== "pen";
 
     const strokeVariability = this.state.currentItemStrokeVariability;
 


### PR DESCRIPTION
When using a tablet for drawing, pen pressure was simulated despite the device being capable of real pressure sensitivity. This fix has been validated on Wacom tablets and iPads.