### PR TITLE
fix: add tooltips to sidebar icons

### DIFF
--- a/excalidraw-app/components/AppSidebar.tsx
+++ b/excalidraw-app/components/AppSidebar.tsx
@@ -4,7 +4,9 @@ import {
   presentationIcon,
 } from "@excalidraw/excalidraw/components/icons";
 import { LinkButton } from "@excalidraw/excalidraw/components/LinkButton";
+import { Tooltip } from "@excalidraw/excalidraw/components/Tooltip";
 import { useUIAppState } from "@excalidraw/excalidraw/context/ui-appState";
+import { t } from "@excalidraw/excalidraw/i18n";
 
 import "./AppSidebar.scss";
 
@@ -71,18 +73,24 @@ export const AppSidebar = () => {
   return (
     <DefaultSidebar>
       <DefaultSidebar.TabTriggers>
-        <Sidebar.TabTrigger
-          tab="comments"
-          style={{ opacity: openSidebar?.tab === "comments" ? 1 : 0.4 }}
-        >
-          {messageCircleIcon}
-        </Sidebar.TabTrigger>
-        <Sidebar.TabTrigger
-          tab="presentation"
-          style={{ opacity: openSidebar?.tab === "presentation" ? 1 : 0.4 }}
-        >
-          {presentationIcon}
-        </Sidebar.TabTrigger>
+        <Tooltip label={t("sidebar.comments")}>
+          <Sidebar.TabTrigger
+            tab="comments"
+            style={{ opacity: openSidebar?.tab === "comments" ? 1 : 0.4 }}
+            aria-label={t("sidebar.comments")}
+          >
+            {messageCircleIcon}
+          </Sidebar.TabTrigger>
+        </Tooltip>
+        <Tooltip label={t("sidebar.presentation")}>
+          <Sidebar.TabTrigger
+            tab="presentation"
+            style={{ opacity: openSidebar?.tab === "presentation" ? 1 : 0.4 }}
+            aria-label={t("sidebar.presentation")}
+          >
+            {presentationIcon}
+          </Sidebar.TabTrigger>
+        </Tooltip>
       </DefaultSidebar.TabTriggers>
       <Sidebar.Tab tab="comments">
         <div className="app-sidebar-promo-container">

--- a/packages/excalidraw/components/DefaultSidebar.test.tsx
+++ b/packages/excalidraw/components/DefaultSidebar.test.tsx
@@ -5,6 +5,7 @@ import { DEFAULT_SIDEBAR } from "@excalidraw/common";
 import { DefaultSidebar } from "../index";
 import {
   fireEvent,
+  GlobalTestState,
   waitFor,
   withExcalidrawDimensions,
 } from "../tests/test-utils";
@@ -17,6 +18,25 @@ import {
 const { h } = window;
 
 describe("DefaultSidebar", () => {
+  it("should label default sidebar tab buttons", async () => {
+    await assertExcalidrawWithSidebar(
+      <DefaultSidebar />,
+      DEFAULT_SIDEBAR.name,
+      async () => {
+        const sidebar =
+          GlobalTestState.renderResult.container.querySelector<HTMLElement>(
+            ".sidebar",
+          );
+
+        expect(sidebar).not.toBe(null);
+        expect(
+          sidebar!.querySelector('[aria-label="Find on canvas"]'),
+        ).not.toBe(null);
+        expect(sidebar!.querySelector('[aria-label="Library"]')).not.toBe(null);
+      },
+    );
+  });
+
   it("when `docked={undefined}` & `onDock={undefined}`, should allow docking", async () => {
     await assertExcalidrawWithSidebar(
       <DefaultSidebar />,

--- a/packages/excalidraw/components/DefaultSidebar.tsx
+++ b/packages/excalidraw/components/DefaultSidebar.tsx
@@ -11,6 +11,7 @@ import type { MarkOptional, Merge } from "@excalidraw/common/utility-types";
 
 import { useTunnels } from "../context/tunnels";
 import { useUIAppState } from "../context/ui-appState";
+import { t } from "../i18n";
 
 import "../components/dropdownMenu/DropdownMenu.scss";
 
@@ -18,6 +19,7 @@ import { useExcalidrawSetAppState } from "./App";
 import { LibraryMenu } from "./LibraryMenu";
 import { SearchMenu } from "./SearchMenu";
 import { Sidebar } from "./Sidebar/Sidebar";
+import { Tooltip } from "./Tooltip";
 import { withInternalFallback } from "./hoc/withInternalFallback";
 import { LibraryIcon, searchIcon } from "./icons";
 
@@ -99,12 +101,22 @@ export const DefaultSidebar = Object.assign(
           <Sidebar.Tabs>
             <Sidebar.Header>
               <Sidebar.TabTriggers>
-                <Sidebar.TabTrigger tab={CANVAS_SEARCH_TAB}>
-                  {searchIcon}
-                </Sidebar.TabTrigger>
-                <Sidebar.TabTrigger tab={LIBRARY_SIDEBAR_TAB}>
-                  {LibraryIcon}
-                </Sidebar.TabTrigger>
+                <Tooltip label={t("search.title")}>
+                  <Sidebar.TabTrigger
+                    tab={CANVAS_SEARCH_TAB}
+                    aria-label={t("search.title")}
+                  >
+                    {searchIcon}
+                  </Sidebar.TabTrigger>
+                </Tooltip>
+                <Tooltip label={t("toolBar.library")}>
+                  <Sidebar.TabTrigger
+                    tab={LIBRARY_SIDEBAR_TAB}
+                    aria-label={t("toolBar.library")}
+                  >
+                    {LibraryIcon}
+                  </Sidebar.TabTrigger>
+                </Tooltip>
                 <DefaultSidebarTabTriggersTunnel.Out />
               </Sidebar.TabTriggers>
             </Sidebar.Header>

--- a/packages/excalidraw/components/Sidebar/SidebarHeader.tsx
+++ b/packages/excalidraw/components/Sidebar/SidebarHeader.tsx
@@ -43,14 +43,16 @@ export const SidebarHeader = ({
             </Button>
           </Tooltip>
         )}
-        <Button
-          data-testid="sidebar-close"
-          className="sidebar__close"
-          onSelect={props.onCloseRequest}
-          aria-label={t("buttons.close")}
-        >
-          {CloseIcon}
-        </Button>
+        <Tooltip label={t("buttons.close")}>
+          <Button
+            data-testid="sidebar-close"
+            className="sidebar__close"
+            onSelect={props.onCloseRequest}
+            aria-label={t("buttons.close")}
+          >
+            {CloseIcon}
+          </Button>
+        </Tooltip>
       </div>
     </div>
   );

--- a/packages/excalidraw/locales/en.json
+++ b/packages/excalidraw/locales/en.json
@@ -740,5 +740,9 @@
     "spacebar": "Space",
     "delete": "Delete",
     "mmb": "Scroll wheel"
+  },
+  "sidebar": {
+    "comments": "Comments",
+    "presentation": "Presentation"
   }
 }


### PR DESCRIPTION
## Summary

Adds tooltips and accessible labels to the sidebar icon buttons for:

- Search
- Library
- Comments
- Presentation
- Close

Adds English locale entries for the Comments and Presentation labels.

Fixes #11731

## Testing

- Manually verified that each tooltip appears on hover
- Confirmed the sidebar buttons still work
- Added a test for the Search and Library accessible labels
- Ran ESLint on the changed files
- Ran:

  `yarn test:app packages/excalidraw/components/DefaultSidebar.test.tsx --watch=false`