### PR TITLE
fix(editor): prevent esc from exiting fullscreen on macos when modal open

### DIFF
--- a/packages/excalidraw/components/Modal.tsx
+++ b/packages/excalidraw/components/Modal.tsx
@@ -34,6 +34,7 @@ export const Modal: React.FC<{
 
   const handleKeydown = (event: React.KeyboardEvent) => {
     if (event.key === KEYS.ESCAPE) {
+      event.preventDefault();
       event.nativeEvent.stopImmediatePropagation();
       event.stopPropagation();
       props.onCloseRequest();

--- a/packages/excalidraw/components/dropdownMenu/DropdownMenuContent.tsx
+++ b/packages/excalidraw/components/dropdownMenu/DropdownMenuContent.tsx
@@ -61,6 +61,7 @@ const MenuContent = ({
     }
     const onKeyDown = (event: KeyboardEvent) => {
       if (event.key === KEYS.ESCAPE) {
+        event.preventDefault();
         event.stopImmediatePropagation();
         callbacksRef.onClickOutside?.();
       }


### PR DESCRIPTION
# Summary
Adds the line "event.preventDefault();" to the Modal and DropdownMenu Components, preventing the default behavior of exiting fullscreen mode when fullscreened.

Fixes: https://github.com/excalidraw/excalidraw/issues/11759