### PR TITLE
feat: viewport-based font sizing

### DIFF
--- a/packages/excalidraw/actions/actionProperties.tsx
+++ b/packages/excalidraw/actions/actionProperties.tsx
@@ -147,6 +147,7 @@ import {
 } from "../components/icons";
 
 import { Fonts } from "../fonts";
+import { getFontSizePreset, getViewportBasedFontSizes } from "../fontSize";
 import { getLanguage, t } from "../i18n";
 import {
   canHaveArrowheads,
@@ -159,12 +160,18 @@ import {
   withCaretPositionPreservation,
   restoreCaretPosition,
 } from "../hooks/useTextEditorFocus";
+import { useAppStateValue } from "../hooks/useAppStateValue";
 
 import { getShortcutKey } from "../shortcut";
 
 import { register } from "./register";
 
-import type { AppClassProperties, AppState, Primitive } from "../types";
+import type {
+  AppClassProperties,
+  AppState,
+  FontSizePreset,
+  Primitive,
+} from "../types";
 
 const FONT_SIZE_RELATIVE_INCREASE_STEP = 0.1;
 
@@ -876,100 +883,130 @@ export const actionChangeOpacity = register<ExcalidrawElement["opacity"]>({
   },
 });
 
-export const actionChangeFontSize = register<ExcalidrawTextElement["fontSize"]>(
-  {
-    name: "changeFontSize",
-    label: "labels.fontSize",
-    trackEvent: false,
-    perform: (elements, appState, value, app) => {
-      return changeFontSize(
-        elements,
-        appState,
-        app,
-        () => {
-          invariant(value, "actionChangeFontSize: Expected a font size value");
-          return value;
-        },
-        value,
-      );
-    },
-    PanelComponent: ({ elements, appState, updateData, app, data }) => {
-      const { isCompact } = getStylesPanelInfo(app);
+type ChangeFontSizeData =
+  | ExcalidrawTextElement["fontSize"]
+  | {
+      fontSize: ExcalidrawTextElement["fontSize"];
+      preset: FontSizePreset | null;
+    };
 
-      return (
-        <fieldset>
-          <legend>{t("labels.fontSize")}</legend>
-          <div className="buttonList">
-            <RadioSelection
-              group="font-size"
-              options={[
-                {
-                  value: FONT_SIZES.sm,
-                  text: t("labels.small"),
-                  icon: FontSizeSmallIcon,
-                  testId: "fontSize-small",
-                },
-                {
-                  value: FONT_SIZES.md,
-                  text: t("labels.medium"),
-                  icon: FontSizeMediumIcon,
-                  testId: "fontSize-medium",
-                },
-                {
-                  value: FONT_SIZES.lg,
-                  text: t("labels.large"),
-                  icon: FontSizeLargeIcon,
-                  testId: "fontSize-large",
-                },
-                {
-                  value: FONT_SIZES.xl,
-                  text: t("labels.veryLarge"),
-                  icon: FontSizeExtraLargeIcon,
-                  testId: "fontSize-veryLarge",
-                },
-              ]}
-              value={getFormValue(
-                elements,
-                app,
-                (element) => {
-                  if (isTextElement(element)) {
-                    return element.fontSize;
-                  }
-                  const boundTextElement = getBoundTextElement(
-                    element,
-                    app.scene.getNonDeletedElementsMap(),
-                  );
-                  if (boundTextElement) {
-                    return boundTextElement.fontSize;
-                  }
-                  return null;
-                },
-                (element) =>
-                  isTextElement(element) ||
-                  getBoundTextElement(
-                    element,
-                    app.scene.getNonDeletedElementsMap(),
-                  ) !== null,
-                (hasSelection) =>
-                  hasSelection
-                    ? null
-                    : appState.currentItemFontSize || DEFAULT_FONT_SIZE,
-              )}
-              onChange={(value) => {
-                withCaretPositionPreservation(
-                  () => updateData(value),
-                  isCompact,
-                  !!appState.editingTextElement,
-                  data?.onPreventClose,
-                );
-              }}
-            />
-          </div>
-        </fieldset>
-      );
-    },
+export const actionChangeFontSize = register<ChangeFontSizeData>({
+  name: "changeFontSize",
+  label: "labels.fontSize",
+  trackEvent: false,
+  perform: (elements, appState, value, app) => {
+    const fontSize = typeof value === "number" ? value : value?.fontSize;
+    const preset = typeof value === "number" ? null : value?.preset ?? null;
+
+    invariant(fontSize, "actionChangeFontSize: Expected a font size value");
+
+    const result = changeFontSize(
+      elements,
+      appState,
+      app,
+      () => fontSize,
+      fontSize,
+    );
+
+    return {
+      ...result,
+      appState: {
+        ...result.appState,
+        currentItemFontSizePreset: preset,
+      },
+    };
   },
-);
+  PanelComponent: ({ elements, appState, updateData, app, data }) => {
+    const { isCompact } = getStylesPanelInfo(app);
+    const zoom = useAppStateValue((appState) => appState.zoom.value);
+    const fontSizes = appState.viewportBasedFontSizingEnabled
+      ? getViewportBasedFontSizes(appState.height, zoom)
+      : FONT_SIZES;
+    const hasSelection =
+      !!appState.editingTextElement ||
+      isSomeElementSelected(getNonDeletedElements(elements), appState);
+    const selectedFontSize = getFormValue(
+      elements,
+      app,
+      (element) => {
+        if (isTextElement(element)) {
+          return element.fontSize;
+        }
+        const boundTextElement = getBoundTextElement(
+          element,
+          app.scene.getNonDeletedElementsMap(),
+        );
+        if (boundTextElement) {
+          return boundTextElement.fontSize;
+        }
+        return null;
+      },
+      (element) =>
+        isTextElement(element) ||
+        getBoundTextElement(element, app.scene.getNonDeletedElementsMap()) !==
+          null,
+      (hasSelection) =>
+        hasSelection ? null : appState.currentItemFontSize || DEFAULT_FONT_SIZE,
+    );
+    const selectedPreset = appState.viewportBasedFontSizingEnabled
+      ? hasSelection
+        ? null
+        : appState.currentItemFontSizePreset
+      : getFontSizePreset(selectedFontSize, FONT_SIZES);
+
+    return (
+      <fieldset>
+        <legend>{t("labels.fontSize")}</legend>
+        <div className="buttonList">
+          <RadioSelection<FontSizePreset>
+            group="font-size"
+            options={[
+              {
+                value: "sm",
+                text: t("labels.small"),
+                icon: FontSizeSmallIcon,
+                testId: "fontSize-small",
+              },
+              {
+                value: "md",
+                text: t("labels.medium"),
+                icon: FontSizeMediumIcon,
+                testId: "fontSize-medium",
+              },
+              {
+                value: "lg",
+                text: t("labels.large"),
+                icon: FontSizeLargeIcon,
+                testId: "fontSize-large",
+              },
+              {
+                value: "xl",
+                text: t("labels.veryLarge"),
+                icon: FontSizeExtraLargeIcon,
+                testId: "fontSize-veryLarge",
+              },
+            ]}
+            value={selectedPreset}
+            onChange={(preset) => {
+              withCaretPositionPreservation(
+                () =>
+                  updateData({
+                    fontSize: fontSizes[preset],
+                    preset: appState.viewportBasedFontSizingEnabled
+                      ? preset
+                      : null,
+                  }),
+                isCompact,
+                !!appState.editingTextElement,
+                data?.onPreventClose,
+              );
+            }}
+          />
+        </div>
+      </fieldset>
+    );
+  },
+});
 
 export const actionDecreaseFontSize = register({
   name: "decreaseFontSize",

--- a/packages/excalidraw/appState.ts
+++ b/packages/excalidraw/appState.ts
@@ -33,6 +33,8 @@ export const getDefaultAppState = (): Omit<
     currentItemFillStyle: DEFAULT_ELEMENT_PROPS.fillStyle,
     currentItemFontFamily: DEFAULT_FONT_FAMILY,
     currentItemFontSize: DEFAULT_FONT_SIZE,
+    currentItemFontSizePreset: null,
+    viewportBasedFontSizingEnabled: false,
     currentItemOpacity: DEFAULT_ELEMENT_PROPS.opacity,
     currentItemRoughness: DEFAULT_ELEMENT_PROPS.roughness,
     currentItemStrokeVariability: "constant",
@@ -159,6 +161,12 @@ const APP_STATE_STORAGE_CONF = (<
   currentItemFillStyle: { browser: true, export: false, server: false },
   currentItemFontFamily: { browser: true, export: false, server: false },
   currentItemFontSize: { browser: true, export: false, server: false },
+  currentItemFontSizePreset: { browser: true, export: false, server: false },
+  viewportBasedFontSizingEnabled: {
+    browser: true,
+    export: false,
+    server: false,
+  },
   currentItemRoundness: {
     browser: true,
     export: false,

--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -361,6 +361,7 @@ import Library, { distributeLibraryItemsOnSquareGrid } from "../data/library";
 import { restoreAppState, restoreElements } from "../data/restore";
 import { getCenter, getDistance } from "../gesture";
 import { History } from "../history";
+import { getCurrentItemFontSize } from "../fontSize";
 import { defaultLang, getLanguage, languages, setLanguage, t } from "../i18n";
 
 import {
@@ -4875,7 +4876,7 @@ class App extends React.Component<AppProps, AppState> {
       roughness: this.state.currentItemRoughness,
       opacity: this.state.currentItemOpacity,
       text,
-      fontSize: this.state.currentItemFontSize,
+      fontSize: getCurrentItemFontSize(this.state),
       fontFamily: this.state.currentItemFontFamily,
       textAlign: DEFAULT_TEXT_ALIGN,
       verticalAlign: DEFAULT_VERTICAL_ALIGN,
@@ -6747,7 +6748,8 @@ class App extends React.Component<AppProps, AppState> {
 
     const lineHeight =
       existingTextElement?.lineHeight || getLineHeight(fontFamily);
-    const fontSize = this.state.currentItemFontSize;
+    const fontSize =
+      existingTextElement?.fontSize ?? getCurrentItemFontSize(this.state);
 
     if (
       !existingTextElement &&

--- a/packages/excalidraw/components/main-menu/DefaultItems.tsx
+++ b/packages/excalidraw/components/main-menu/DefaultItems.tsx
@@ -525,6 +525,28 @@ const PreferencesToggleMidpointSnappingItem = () => {
   );
 };
 
+const PreferencesToggleViewportBasedFontSizingItem = () => {
+  const { t } = useI18n();
+  const appState = useUIAppState();
+  const setAppState = useExcalidrawSetAppState();
+
+  return (
+    <DropdownMenuItemCheckbox
+      checked={appState.viewportBasedFontSizingEnabled}
+      data-testid="toggle-viewport-based-font-sizing"
+      onSelect={(event) => {
+        setAppState({
+          viewportBasedFontSizingEnabled:
+            !appState.viewportBasedFontSizingEnabled,
+        });
+        event.preventDefault();
+      }}
+    >
+      {t("labels.viewportBasedFontSizing")}
+    </DropdownMenuItemCheckbox>
+  );
+};
+
 export const PreferencesToggleGridModeItem = () => {
   const { t } = useI18n();
   const actionManager = useExcalidrawActionManager();
@@ -626,6 +648,7 @@ export const Preferences = ({
             <PreferencesToggleElementPropertiesItem />
             <PreferencesToggleArrowBindingItem />
             <PreferencesToggleMidpointSnappingItem />
+            <PreferencesToggleViewportBasedFontSizingItem />
           </>
         )}
         {additionalItems}
@@ -639,6 +662,8 @@ Preferences.BoxSelectionMode = PreferencesBoxSelectionModeItem;
 Preferences.ToggleSnapMode = PreferencesToggleSnapModeItem;
 Preferences.ToggleArrowBinding = PreferencesToggleArrowBindingItem;
 Preferences.ToggleMidpointSnapping = PreferencesToggleMidpointSnappingItem;
+Preferences.ToggleViewportBasedFontSizing =
+  PreferencesToggleViewportBasedFontSizingItem;
 Preferences.ToggleGridMode = PreferencesToggleGridModeItem;
 Preferences.ToggleZenMode = PreferencesToggleZenModeItem;
 Preferences.ToggleViewMode = PreferencesToggleViewModeItem;

--- a/packages/excalidraw/fontSize.ts
+++ b/packages/excalidraw/fontSize.ts
@@ -1,0 +1,64 @@
+import { MIN_FONT_SIZE } from "@excalidraw/common";
+
+import type { FONT_SIZES } from "@excalidraw/common";
+
+import type { AppState, FontSizePreset } from "./types";
+
+const VIEWPORT_FONT_SIZE_RATIOS: Record<FontSizePreset, number> = {
+  sm: 0.01,
+  md: 0.02,
+  lg: 0.04,
+  xl: 0.06,
+};
+
+export const getViewportBasedFontSizes = (
+  viewportHeight: number,
+  zoom: AppState["zoom"]["value"],
+): Record<FontSizePreset, number> => {
+  const getFontSize = (ratio: number) =>
+    Math.max(MIN_FONT_SIZE, (viewportHeight * ratio) / zoom);
+
+  return {
+    sm: getFontSize(VIEWPORT_FONT_SIZE_RATIOS.sm),
+    md: getFontSize(VIEWPORT_FONT_SIZE_RATIOS.md),
+    lg: getFontSize(VIEWPORT_FONT_SIZE_RATIOS.lg),
+    xl: getFontSize(VIEWPORT_FONT_SIZE_RATIOS.xl),
+  };
+};
+
+export const getCurrentItemFontSize = (
+  appState: Pick<
+    AppState,
+    | "currentItemFontSize"
+    | "currentItemFontSizePreset"
+    | "viewportBasedFontSizingEnabled"
+    | "height"
+    | "zoom"
+  >,
+) => {
+  if (
+    appState.viewportBasedFontSizingEnabled &&
+    appState.currentItemFontSizePreset
+  ) {
+    return getViewportBasedFontSizes(appState.height, appState.zoom.value)[
+      appState.currentItemFontSizePreset
+    ];
+  }
+
+  return appState.currentItemFontSize;
+};
+
+export const getFontSizePreset = (
+  fontSize: number | null,
+  fontSizes: typeof FONT_SIZES | Record<FontSizePreset, number>,
+): FontSizePreset | null => {
+  if (fontSize === null) {
+    return null;
+  }
+
+  return (
+    (Object.keys(fontSizes) as FontSizePreset[]).find(
+      (preset) => fontSizes[preset] === fontSize,
+    ) ?? null
+  );
+};

--- a/packages/excalidraw/locales/en.json
+++ b/packages/excalidraw/locales/en.json
@@ -192,7 +192,8 @@
     "boxSelectionContain": "Wrap",
     "boxSelectionOverlap": "Overlap",
     "arrowBinding": "Arrow binding",
-    "midpointSnapping": "Snap to midpoints"
+    "midpointSnapping": "Snap to midpoints",
+    "viewportBasedFontSizing": "Viewport-based font sizing"
   },
   "elementLink": {
     "title": "Link to object",

--- a/packages/excalidraw/tests/appState.test.tsx
+++ b/packages/excalidraw/tests/appState.test.tsx
@@ -4,12 +4,20 @@ import { EXPORT_DATA_TYPES, MIME_TYPES } from "@excalidraw/common";
 
 import type { ExcalidrawTextElement } from "@excalidraw/element/types";
 
-import { getDefaultAppState } from "../appState";
-import { Excalidraw } from "../index";
+import { clearAppStateForLocalStorage, getDefaultAppState } from "../appState";
+import { Excalidraw, MainMenu } from "../index";
+import { getNormalizedZoom } from "../scene";
 
 import { API } from "./helpers/api";
-import { Pointer, UI } from "./helpers/ui";
-import { fireEvent, queryByTestId, render, waitFor } from "./test-utils";
+import { Keyboard, Pointer, UI } from "./helpers/ui";
+import { getTextEditor, updateTextEditor } from "./queries/dom";
+import {
+  fireEvent,
+  queryByTestId,
+  render,
+  toggleMenu,
+  waitFor,
+} from "./test-utils";
 
 const { h } = window;
 
@@ -84,5 +92,87 @@ describe("appState", () => {
     mouse.clickAt(100, 100);
 
     expect((h.elements[0] as ExcalidrawTextElement).fontSize).toBe(16);
+  });
+
+  it("uses viewport-relative font-size presets without resizing on zoom", async () => {
+    const { container } = await render(
+      <Excalidraw
+        initialData={{
+          appState: {
+            viewportBasedFontSizingEnabled: true,
+          },
+        }}
+      />,
+    );
+
+    API.setAppState({
+      height: 1200,
+      zoom: { value: getNormalizedZoom(2) },
+    });
+    UI.clickTool("text");
+
+    fireEvent.click(queryByTestId(container, "fontSize-small")!);
+    expect(h.state.currentItemFontSize).toBe(12);
+    expect(h.state.currentItemFontSizePreset).toBe("sm");
+
+    fireEvent.click(queryByTestId(container, "fontSize-medium")!);
+    expect(h.state.currentItemFontSize).toBe(24);
+    expect(h.state.currentItemFontSizePreset).toBe("md");
+
+    fireEvent.click(queryByTestId(container, "fontSize-large")!);
+    expect(h.state.currentItemFontSize).toBe(36);
+    expect(h.state.currentItemFontSizePreset).toBe("lg");
+
+    fireEvent.click(queryByTestId(container, "fontSize-veryLarge")!);
+    expect(h.state.currentItemFontSize).toBe(48);
+    expect(h.state.currentItemFontSizePreset).toBe("xl");
+
+    const mouse = new Pointer("mouse");
+    mouse.clickAt(100, 100);
+    const editor = await getTextEditor();
+    updateTextEditor(editor, "first");
+    Keyboard.exitTextEditor(editor);
+
+    expect((h.elements[0] as ExcalidrawTextElement).fontSize).toBe(48);
+    expect(queryByTestId(container, "fontSize-veryLarge")).not.toBeChecked();
+
+    API.setSelectedElements([]);
+    UI.clickTool("text");
+    expect(queryByTestId(container, "fontSize-veryLarge")).toBeChecked();
+
+    // The app-wide XL preset is resolved again at the new zoom for new text.
+    API.setAppState({
+      zoom: { value: getNormalizedZoom(1) },
+    });
+    mouse.clickAt(300, 300);
+
+    expect((h.elements[0] as ExcalidrawTextElement).fontSize).toBe(48);
+    expect((h.elements[1] as ExcalidrawTextElement).fontSize).toBe(96);
+    expect(h.state.currentItemFontSizePreset).toBe("xl");
+    expect(
+      clearAppStateForLocalStorage(h.state).currentItemFontSizePreset,
+    ).toBe("xl");
+  });
+
+  it("toggles and persists viewport-based font sizing as a preference", async () => {
+    const { container } = await render(
+      <Excalidraw>
+        <MainMenu>
+          <MainMenu.DefaultItems.Preferences.ToggleViewportBasedFontSizing />
+        </MainMenu>
+      </Excalidraw>,
+    );
+
+    expect(h.state.viewportBasedFontSizingEnabled).toBe(false);
+
+    toggleMenu(container);
+    fireEvent.click(
+      queryByTestId(container, "toggle-viewport-based-font-sizing")!,
+    );
+
+    expect(h.state.viewportBasedFontSizingEnabled).toBe(true);
+    expect(
+      clearAppStateForLocalStorage(h.state).viewportBasedFontSizingEnabled,
+    ).toBe(true);
   });
 });

--- a/packages/excalidraw/types.ts
+++ b/packages/excalidraw/types.ts
@@ -175,6 +175,8 @@ export type ActiveTool =
       customType: string;
     };
 
+export type FontSizePreset = "sm" | "md" | "lg" | "xl";
+
 export type SidebarName = string;
 export type SidebarTabName = string;
 
@@ -424,6 +426,8 @@ export interface AppState {
   currentItemOpacity: number;
   currentItemFontFamily: FontFamilyValues;
   currentItemFontSize: number;
+  currentItemFontSizePreset: FontSizePreset | null;
+  viewportBasedFontSizingEnabled: boolean;
   currentItemTextAlign: TextAlign;
   currentItemStartArrowhead: Arrowhead | null;
   currentItemEndArrowhead: Arrowhead | null;


### PR DESCRIPTION
When this new preference is enabled, font sizes are no longer absolute, but instead relative sizes based on viewport zoom (8% of viewport height for XL for example). I find myself manually scaling up fonts when at the furtherst out zoom of my viewport, this intends to smooth out that experience.


https://github.com/user-attachments/assets/ce50b5f1-4c54-4b0e-9703-e36544fc7b54

