### PR TITLE
fix(editor): document Shift+drag axis lock in Help dialog

### DIFF
--- a/packages/excalidraw/components/HelpDialog.tsx
+++ b/packages/excalidraw/components/HelpDialog.tsx
@@ -393,6 +393,10 @@ export const HelpDialog = ({ onClose }: { onClose?: () => void }) => {
               label={t("helpDialog.deepBoxSelect")}
               shortcuts={[getShortcutKey(`CtrlOrCmd+${t("helpDialog.drag")}`)]}
             />
+            <Shortcut
+              label={t("helpDialog.constrainedDrag")}
+              shortcuts={[getShortcutKey(`Shift+${t("helpDialog.drag")}`)]}
+            />
             {/* firefox supports clipboard API under a flag, so we'll
                 show users what they can do in the error message */}
             {(probablySupportsClipboardBlob || isFirefox) && (

--- a/packages/excalidraw/locales/en.json
+++ b/packages/excalidraw/locales/en.json
@@ -439,6 +439,7 @@
     "click": "click",
     "deepSelect": "Deep select",
     "deepBoxSelect": "Deep select within box, and prevent dragging",
+    "constrainedDrag": "Constrain dragging to horizontal / vertical axis",
     "createFlowchart": "Create a flowchart from a generic element",
     "navigateFlowchart": "Navigate a flowchart",
     "curvedArrow": "Curved arrow",


### PR DESCRIPTION
Fixes #11609

Holding Shift while dragging a selection constrains movement to the horizontal or vertical axis (see `lockDirection` in `App.tsx`), but this was not documented anywhere in the Help dialog.

This adds a "Constrain dragging to horizontal / vertical axis — Shift+drag" entry to the Editor section of the Help dialog, right after the other drag-modifier shortcuts, following the same pattern as the existing `deepBoxSelect` entry.

Only `en.json` is updated since other locales are managed via Crowdin.