### PR TITLE
fix: add .js extension to roughjs imports for ESM strict resolution

### DIFF
--- a/packages/element/src/bounds.ts
+++ b/packages/element/src/bounds.ts
@@ -1,4 +1,4 @@
-import rough from "roughjs/bin/rough";
+import rough from "roughjs/bin/rough.js";
 import {
   arrayToMap,
   type Bounds,

--- a/packages/element/src/renderElement.ts
+++ b/packages/element/src/renderElement.ts
@@ -1,4 +1,4 @@
-import rough from "roughjs/bin/rough";
+import rough from "roughjs/bin/rough.js";
 
 import {
   type GlobalPoint,

--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -2,7 +2,7 @@ import clsx from "clsx";
 import throttle from "lodash.throttle";
 import React, { useContext } from "react";
 import { flushSync } from "react-dom";
-import rough from "roughjs/bin/rough";
+import rough from "roughjs/bin/rough.js";
 import { nanoid } from "nanoid";
 
 import {

--- a/packages/excalidraw/scene/export.ts
+++ b/packages/excalidraw/scene/export.ts
@@ -1,4 +1,4 @@
-import rough from "roughjs/bin/rough";
+import rough from "roughjs/bin/rough.js";
 
 import {
   DEFAULT_EXPORT_PADDING,


### PR DESCRIPTION
Webpack 5 with `resolve.fullySpecified: true` (the default for ESM output)
requires all import paths to include the file extension. The four
`roughjs/bin/rough` imports across the codebase lack the `.js` suffix.

When bundled with Webpack 5 in ESM mode (Docusaurus, Astro, Vite with ESM
output, or any tool that sets `experiments.outputModule: true`), the bundler
emits `Module not found: Error: Can't resolve 'roughjs/bin/rough'` because
`roughjs` ships `roughjs/bin/rough.js` — not `roughjs/bin/rough`.

The fix adds `.js` to all four import sites.

Files changed:
- `packages/excalidraw/components/App.tsx`
- `packages/excalidraw/scene/export.ts`
- `packages/element/src/bounds.ts`
- `packages/element/src/renderElement.ts`