### PR TITLE
fix: allow Ctrl+S save shortcut when editing text elements

### DIFF
--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -5445,7 +5445,9 @@ class App extends React.Component<AppProps, AppState> {
         // inside an input
         (isWritableElement(event.target) &&
           // unless pressing escape (finalize action)
-          event.key !== KEYS.ESCAPE) ||
+          event.key !== KEYS.ESCAPE &&
+          // unless pressing save shortcut (Ctrl/Cmd+S)
+          !(event[KEYS.CTRL_OR_CMD] && event.key.toLowerCase() === KEYS.S)) ||
         // or unless using arrows (to move between buttons)
         (isArrowKey(event.key) && isInputLike(event.target))
       ) {


### PR DESCRIPTION
Fixes #9281

When editing text in Excalidraw, pressing Ctrl/Cmd+S triggers the browser's native save dialog instead of saving the .excalidraw file.

**Root cause:** In App.tsx, the `onKeyDown` handler has a bail-out block that returns early when the event target is a writable element (textarea). The Ctrl+S shortcut never reaches the action manager, so `event.preventDefault()` is never called.

**Fix:** Added an exception in the bail condition to allow Ctrl/Cmd+S to pass through to the action manager, which calls `preventDefault()` and triggers the normal save flow.