### PR TITLE
fix: make canvas search results order stable

### DIFF
--- a/packages/excalidraw/components/SearchMenu.tsx
+++ b/packages/excalidraw/components/SearchMenu.tsx
@@ -797,8 +797,8 @@ const handleSearch = debounce(
       isFrameLikeElement(el),
     ) as ExcalidrawFrameLikeElement[];
 
-    texts.sort((a, b) => a.y - b.y);
-    frames.sort((a, b) => a.y - b.y);
+    texts.sort((a, b) => a.id.localeCompare(b.id));
+    frames.sort((a, b) => a.id.localeCompare(b.id));
 
     const textMatches: SearchMatchItem[] = [];
 

--- a/packages/excalidraw/tests/search.test.tsx
+++ b/packages/excalidraw/tests/search.test.tsx
@@ -194,4 +194,37 @@ describe("search", () => {
       expect(h.app.state.searchMatches?.matches.length).toBe(3);
     });
   });
+
+  it("should maintain stable search results order when elements are moved", async () => {
+    const scrollIntoViewMock = jest.fn();
+    window.HTMLElement.prototype.scrollIntoView = scrollIntoViewMock;
+
+    const elem1 = API.createElement({ type: "text", text: "test 1", y: 100 });
+    const elem2 = API.createElement({ type: "text", text: "test 2", y: 0 });
+    API.setElements([elem1, elem2]);
+
+    Keyboard.withModifierKeys({ ctrl: true }, () => {
+      Keyboard.keyPress(KEYS.F);
+    });
+
+    const searchInput = await querySearchInput();
+    updateTextEditor(searchInput, "test");
+
+    await waitFor(() => {
+      expect(h.app.state.searchMatches?.matches.length).toBe(2);
+    });
+
+    const initialMatchElementIds = h.app.state.searchMatches?.matches.map(
+      (m) => m.id,
+    );
+
+    API.updateElement(elem1, { y: -100 });
+
+    await waitFor(() => {
+      const updatedMatchElementIds = h.app.state.searchMatches?.matches.map(
+        (m) => m.id,
+      );
+      expect(updatedMatchElementIds).toEqual(initialMatchElementIds);
+    });
+  });
 });


### PR DESCRIPTION
Fixes #9503

**What**
Changes the search result sorting in `SearchMenu.tsx` from being y-coordinate based to being based on `element.id`.

**Why**
Sorting by position (`y`) means that if the user drags an element that happens to be in the search results, its vertical position changes, which causes the search list to re-evaluate and jump around unpredictably. Using the `element.id` ensures a completely deterministic and stable ordering regardless of how the elements are moved on the canvas.

**How it was tested**
The code was manually updated to replace the positional sorting with `localeCompare` on the element ID.