### PR TITLE
perf: drop unused frameElementsOffsetsMap in resize handler

### DIFF
--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -13464,28 +13464,6 @@ class App extends React.Component<AppProps, AppState> {
       event[KEYS.CTRL_OR_CMD] ? null : this.getEffectiveGridSize(),
     );
 
-    const frameElementsOffsetsMap = new Map<
-      string,
-      {
-        x: number;
-        y: number;
-      }
-    >();
-
-    selectedFrames.forEach((frame) => {
-      const elementsInFrame = getFrameChildren(
-        this.scene.getNonDeletedElements(),
-        frame.id,
-      );
-
-      elementsInFrame.forEach((element) => {
-        frameElementsOffsetsMap.set(frame.id + element.id, {
-          x: element.x - frame.x,
-          y: element.y - frame.y,
-        });
-      });
-    });
-
     // check needed for avoiding flickering when a key gets pressed
     // during dragging
     if (!this.state.selectedElementsAreBeingDragged) {


### PR DESCRIPTION
### What

`frameElementsOffsetsMap` in the resize pointer handler is populated but never read.

It has exactly **two references in the whole repository**, and both are writes:

```
packages/excalidraw/components/App.tsx:13467   const frameElementsOffsetsMap = new Map<…>()
packages/excalidraw/components/App.tsx:13482   frameElementsOffsetsMap.set(frame.id + element.id, …)
```

You can confirm with `git grep -n frameElementsOffsetsMap` — there is no `.get`, no `.has`, no iteration, and it is never passed anywhere or returned.

### Why it costs something

The map is filled inside `handleCanvasPointerMove` → resize, so it runs on **every pointer move during a resize**, and the fill is a nested walk:

```ts
selectedFrames.forEach((frame) => {
  const elementsInFrame = getFrameChildren(this.scene.getNonDeletedElements(), frame.id);
  elementsInFrame.forEach((element) => { frameElementsOffsetsMap.set(...) });
});
```

`getFrameChildren` walks all non-deleted elements once per selected frame, so this is `O(selectedFrames × allElements)` per tick, and the result is discarded. Removing it makes that work disappear; nothing else changes.

### History

Introduced in **feat: introduce frames (#6123)** (2023-06-14) and never read since — the consumer presumably never landed, or was refactored away.

### Safety

- `getFrameChildren` is pure: it builds and returns a new array, it does not mutate its inputs.
- `selectedFrames` is still used at the rotation guard and in the later `selectedFrames.forEach(...)` block.
- `getFrameChildren` is still used elsewhere in `App.tsx`, so the import stays.
- Behavior is unchanged: no observable value depended on the map.

Happy to add a test if you'd like one, though there is no behavior here to assert against.
