### PR TITLE
fix(ttd): allow horizontal drag selection in prompt input

### DIFF
--- a/packages/excalidraw/components/TTDDialog/Chat/Chat.scss
+++ b/packages/excalidraw/components/TTDDialog/Chat/Chat.scss
@@ -121,7 +121,7 @@ $verticalBreakpoint: 861px;
       line-height: 1.5;
       min-height: 24px;
       max-height: 120px;
-      overflow-x: hidden;
+      overflow-x: auto;
       border: none !important;
       background: transparent !important;
       color: var(--color-on-surface);
@@ -320,9 +320,11 @@ $verticalBreakpoint: 861px;
         &:nth-child(1) {
           animation-delay: -0.32s;
         }
+
         &:nth-child(2) {
           animation-delay: -0.16s;
         }
+
         &:nth-child(3) {
           animation-delay: 0s;
         }
@@ -366,6 +368,7 @@ $verticalBreakpoint: 861px;
       &:hover {
         color: var(--link-color-hover);
       }
+
       &:active {
         color: var(--link-color-active);
       }
@@ -378,12 +381,14 @@ $verticalBreakpoint: 861px;
   }
 
   @keyframes typing {
+
     0%,
     80%,
     100% {
       transform: scale(0.8);
       opacity: 0.4;
     }
+
     40% {
       transform: scale(1);
       opacity: 1;
@@ -391,10 +396,12 @@ $verticalBreakpoint: 861px;
   }
 
   @keyframes blink {
+
     0%,
     50% {
       opacity: 1;
     }
+
     51%,
     100% {
       opacity: 0;


### PR DESCRIPTION
## Summary

Fixes an issue in the **Text to diagram** AI modal where selecting text from right to left in the prompt box wouldn't scroll to show text on the left.

## Problem

When typing a long prompt into the chat input, dragging to select text backwards (right to left) gets stuck at the visible left edge. The text doesn't scroll right to reveal preceding words because `overflow-x: hidden` blocks the browser's native `scrollLeft` drag-selection scrolling.

## Fix

Replaced `overflow-x: hidden` with `overflow-x: auto` on `.chat-interface__input` in `Chat.scss`. This unblocks native horizontal drag-selection scrolling.

## Test Plan

- [x] Verified locally on `http://localhost:3001` by typing a long prompt and drag-selecting text from right to left.
- [x] Ran `yarn test` (`TTDDialog` suite: 107/107 passed).
- [x] Ran `yarn test:typecheck` (0 errors).

<img width="2940" height="1912" alt="image" src="https://github.com/user-attachments/assets/68fac8d0-0418-43a9-8b88-074c55e29bfd" />
