### PR TITLE
feat: implement element & frame layer visibility toggle (#9599)

### DIFF
--- a/packages/element/src/__tests__/visibility.test.ts
+++ b/packages/element/src/__tests__/visibility.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import { isElementVisible } from "../typeChecks";
+import type { ExcalidrawElement, ExcalidrawFrameElement } from "../types";
+
+describe("Element Visibility", () => {
+  it("should return true when element isVisible is true or undefined", () => {
+    const visibleElement = {
+      id: "elem1",
+      type: "rectangle",
+      isVisible: true,
+    } as unknown as ExcalidrawElement;
+
+    const defaultElement = {
+      id: "elem2",
+      type: "rectangle",
+    } as unknown as ExcalidrawElement;
+
+    expect(isElementVisible(visibleElement)).toBe(true);
+    expect(isElementVisible(defaultElement)).toBe(true);
+  });
+
+  it("should return false when element isVisible is false", () => {
+    const hiddenElement = {
+      id: "elem3",
+      type: "rectangle",
+      isVisible: false,
+    } as unknown as ExcalidrawElement;
+
+    expect(isElementVisible(hiddenElement)).toBe(false);
+  });
+
+  it("should return false when parent frame or frame layer is hidden", () => {
+    const frame = {
+      id: "frame1",
+      type: "frame",
+      name: "Frame 1",
+      isVisible: true,
+      layers: [
+        { id: "layer1", name: "Background", isVisible: false },
+        { id: "layer2", name: "Foreground", isVisible: true },
+      ],
+    } as unknown as ExcalidrawFrameElement;
+
+    const childInHiddenLayer = {
+      id: "elem4",
+      type: "rectangle",
+      frameId: "frame1",
+      layerId: "layer1",
+      isVisible: true,
+    } as unknown as ExcalidrawElement;
+
+    const childInVisibleLayer = {
+      id: "elem5",
+      type: "rectangle",
+      frameId: "frame1",
+      layerId: "layer2",
+      isVisible: true,
+    } as unknown as ExcalidrawElement;
+
+    const elementsMap = new Map<string, ExcalidrawElement>([
+      ["frame1", frame],
+      ["elem4", childInHiddenLayer],
+      ["elem5", childInVisibleLayer],
+    ]);
+
+    expect(isElementVisible(childInHiddenLayer, elementsMap)).toBe(false);
+    expect(isElementVisible(childInVisibleLayer, elementsMap)).toBe(true);
+  });
+});

--- a/packages/element/src/collision.ts
+++ b/packages/element/src/collision.ts
@@ -46,6 +46,7 @@ import {
   isImageElement,
   isLinearElement,
   isTextElement,
+  isElementVisible,
 } from "./typeChecks";
 import {
   deconstructDiamondElement,
@@ -776,6 +777,9 @@ export const isPointInElement = (
   element: ExcalidrawElement,
   elementsMap: ElementsMap,
 ) => {
+  if (!isElementVisible(element, elementsMap)) {
+    return false;
+  }
   if (
     (isLinearElement(element) || isFreeDrawElement(element)) &&
     !isPathALoop(element.points)

--- a/packages/element/src/index.ts
+++ b/packages/element/src/index.ts
@@ -1,6 +1,7 @@
 import { toIterable } from "@excalidraw/common";
 
 import { isInvisiblySmallElement } from "./sizeHelpers";
+import { isElementVisible } from "./typeChecks";
 
 import type {
   ExcalidrawElement,
@@ -49,7 +50,7 @@ export const getVisibleElements = (
 ): readonly NonDeletedExcalidrawElement[] =>
   elements.filter(
     (el): el is NonDeletedExcalidrawElement =>
-      isNonDeletedElement(el) && !isInvisiblySmallElement(el),
+      isNonDeletedElement(el) && !isInvisiblySmallElement(el) && isElementVisible(el),
   );
 
 export const getNonDeletedElements = <T extends ExcalidrawElement>(

--- a/packages/element/src/newElement.ts
+++ b/packages/element/src/newElement.ts
@@ -74,6 +74,8 @@ export type ElementConstructorOpts = MarkOptional<
   | "locked"
   | "opacity"
   | "customData"
+  | "isVisible"
+  | "layerId"
 >;
 
 const _newElementBase = <T extends ExcalidrawElement>(
@@ -98,6 +100,8 @@ const _newElementBase = <T extends ExcalidrawElement>(
     boundElements = null,
     link = null,
     locked = DEFAULT_ELEMENT_PROPS.locked,
+    isVisible = true,
+    layerId = null,
     ...rest
   }: ElementConstructorOpts & Omit<Partial<ExcalidrawGenericElement>, "type">,
 ) => {
@@ -154,6 +158,8 @@ const _newElementBase = <T extends ExcalidrawElement>(
     updated: getUpdatedTimestamp(),
     link,
     locked,
+    isVisible,
+    layerId,
     customData: rest.customData,
   };
   return element;

--- a/packages/element/src/renderElement.ts
+++ b/packages/element/src/renderElement.ts
@@ -62,6 +62,7 @@ import {
   hasBoundTextElement,
   isMagicFrameElement,
   isImageElement,
+  isElementVisible,
 } from "./typeChecks";
 import { getContainingFrame } from "./frame";
 import { getCornerRadius } from "./utils";
@@ -206,6 +207,9 @@ const generateElementCanvas = (
   renderConfig: StaticCanvasRenderConfig,
   appState: StaticCanvasAppState | InteractiveCanvasAppState,
 ): ExcalidrawElementWithCanvas | null => {
+  if (!isElementVisible(element, elementsMap)) {
+    return null;
+  }
   const canvas = document.createElement("canvas");
   const context = canvas.getContext("2d")!;
   const padding = getCanvasPadding(element);

--- a/packages/element/src/selection.ts
+++ b/packages/element/src/selection.ts
@@ -13,6 +13,7 @@ import {
   isFrameLikeElement,
   isLinearElement,
   isTextElement,
+  isElementVisible,
 } from "./typeChecks";
 import { getFrameChildren } from "./frame";
 
@@ -31,7 +32,7 @@ import type {
 } from "./types";
 
 const shouldIgnoreElementFromSelection = (element: ExcalidrawElement) =>
-  element.locked || isBoundToContainer(element);
+  element.locked || isBoundToContainer(element) || !isElementVisible(element);
 
 const excludeElementsFromFrames = <T extends ExcalidrawElement>(
   selectedElements: readonly T[],

--- a/packages/element/src/typeChecks.ts
+++ b/packages/element/src/typeChecks.ts
@@ -29,6 +29,7 @@ import type {
   ExcalidrawLineElement,
   ExcalidrawFlowchartNodeElement,
   ExcalidrawLinearElementSubType,
+  ElementsMap,
 } from "./types";
 
 export const isInitializedImageElement = <T extends ExcalidrawElement>(
@@ -412,4 +413,33 @@ export const isEligibleFrameChildType = (type: ElementOrToolType) => {
       return false;
     }
   }
+};
+
+export const isElementVisible = (
+  element: ExcalidrawElement | null | undefined,
+  elementsMap?: ElementsMap | Map<string, ExcalidrawElement> | null,
+): boolean => {
+  if (!element) {
+    return false;
+  }
+  if (element.isVisible === false) {
+    return false;
+  }
+  if (element.frameId && elementsMap) {
+    const parentFrame = elementsMap.get(element.frameId) as
+      | ExcalidrawFrameLikeElement
+      | undefined;
+    if (parentFrame) {
+      if (parentFrame.isVisible === false) {
+        return false;
+      }
+      if (element.layerId && parentFrame.layers) {
+        const layer = parentFrame.layers.find((l) => l.id === element.layerId);
+        if (layer && !layer.isVisible) {
+          return false;
+        }
+      }
+    }
+  }
+  return true;
 };

--- a/packages/element/src/types.ts
+++ b/packages/element/src/types.ts
@@ -79,6 +79,10 @@ type _ExcalidrawElementBase = Readonly<{
   link: string | null;
   locked: boolean;
   customData?: Record<string, any>;
+  /** Visibility flag. When false, element is skipped in rendering and hit-testing. */
+  isVisible?: boolean;
+  /** Optional layer identifier linking this element to a specific Frame Layer. */
+  layerId?: string | null;
 }>;
 
 export type ExcalidrawSelectionElement = _ExcalidrawElementBase & {
@@ -160,14 +164,23 @@ export type InitializedExcalidrawImageElement = MarkNonNullable<
   "fileId"
 >;
 
+export type FrameLayer = {
+  id: string;
+  name: string;
+  isVisible: boolean;
+  color?: string;
+};
+
 export type ExcalidrawFrameElement = _ExcalidrawElementBase & {
   type: "frame";
   name: string | null;
+  layers?: readonly FrameLayer[];
 };
 
 export type ExcalidrawMagicFrameElement = _ExcalidrawElementBase & {
   type: "magicframe";
   name: string | null;
+  layers?: readonly FrameLayer[];
 };
 
 export type ExcalidrawFrameLikeElement =

--- a/packages/excalidraw/actions/actionToggleElementVisibility.tsx
+++ b/packages/excalidraw/actions/actionToggleElementVisibility.tsx
@@ -1,0 +1,105 @@
+import { arrayToMap } from "@excalidraw/common";
+import {
+  newElementWith,
+  CaptureUpdateAction,
+} from "@excalidraw/element";
+import type { ExcalidrawElement } from "@excalidraw/element/types";
+import { register } from "./register";
+import { getSelectedElements } from "../scene";
+
+export const EyeIcon = (
+  <svg
+    aria-hidden="true"
+    focusable="false"
+    role="img"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    className="excalidraw-icon"
+  >
+    <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
+    <circle cx="12" cy="12" r="3" />
+  </svg>
+);
+
+export const EyeClosedIcon = (
+  <svg
+    aria-hidden="true"
+    focusable="false"
+    role="img"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    className="excalidraw-icon"
+  >
+    <path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24" />
+    <line x1="1" y1="1" x2="23" y2="23" />
+  </svg>
+);
+
+const shouldHideElements = (elements: readonly ExcalidrawElement[]) =>
+  elements.some((el) => el.isVisible !== false);
+
+export const actionToggleElementVisibility = register({
+  name: "toggleElementVisibility",
+  label: (elements, appState, app) => {
+    const selected = app.scene.getSelectedElements({
+      selectedElementIds: appState.selectedElementIds,
+      includeBoundTextElement: false,
+    });
+
+    return shouldHideElements(selected)
+      ? "labels.elementVisibility.hide"
+      : "labels.elementVisibility.show";
+  },
+  icon: (appState, elements) => {
+    const selectedElements = getSelectedElements(elements, appState);
+    return shouldHideElements(selectedElements) ? EyeClosedIcon : EyeIcon;
+  },
+  trackEvent: { category: "element" },
+  predicate: (elements, appState, _, app) => {
+    const selectedElements = app.scene.getSelectedElements(appState);
+    return selectedElements.length > 0;
+  },
+  perform: (elements, appState, _, app) => {
+    const selectedElements = app.scene.getSelectedElements({
+      selectedElementIds: appState.selectedElementIds,
+      includeBoundTextElement: true,
+      includeElementsInFrames: true,
+    });
+
+    if (!selectedElements.length) {
+      return false;
+    }
+
+    const hide = shouldHideElements(selectedElements);
+    const selectedElementsMap = arrayToMap(selectedElements);
+
+    const nextElements = elements.map((element) => {
+      if (!selectedElementsMap.has(element.id)) {
+        return element;
+      }
+
+      return newElementWith(element, {
+        isVisible: !hide,
+      });
+    });
+
+    return {
+      elements: nextElements,
+      appState: {
+        ...appState,
+        selectedElementIds: hide ? {} : appState.selectedElementIds,
+      },
+      captureUpdate: CaptureUpdateAction.IMMEDIATELY,
+    };
+  },
+  keyTest: (event) =>
+    (event.metaKey || event.ctrlKey) && event.shiftKey && event.code === "KeyH",
+});

--- a/packages/excalidraw/actions/index.ts
+++ b/packages/excalidraw/actions/index.ts
@@ -91,3 +91,4 @@ export { actionToggleLinearEditor } from "./actionLinearEditor";
 export { actionToggleSearchMenu } from "./actionToggleSearchMenu";
 
 export { actionToggleCropEditor } from "./actionCropEditor";
+export { actionToggleElementVisibility } from "./actionToggleElementVisibility";

--- a/packages/excalidraw/actions/shortcuts.ts
+++ b/packages/excalidraw/actions/shortcuts.ts
@@ -38,6 +38,7 @@ export type ShortcutName =
       | "flipVertical"
       | "hyperlink"
       | "toggleElementLock"
+      | "toggleElementVisibility"
       | "resetZoom"
       | "zoomOut"
       | "zoomIn"
@@ -101,6 +102,7 @@ const shortcutMap: Record<ShortcutName, string[]> = {
   viewMode: [getShortcutKey("Alt+R")],
   hyperlink: [getShortcutKey("CtrlOrCmd+K")],
   toggleElementLock: [getShortcutKey("CtrlOrCmd+Shift+L")],
+  toggleElementVisibility: [getShortcutKey("CtrlOrCmd+Shift+H")],
   resetZoom: [getShortcutKey("CtrlOrCmd+0")],
   zoomOut: [getShortcutKey("CtrlOrCmd+-")],
   zoomIn: [getShortcutKey("CtrlOrCmd++")],

--- a/packages/excalidraw/actions/types.ts
+++ b/packages/excalidraw/actions/types.ts
@@ -138,6 +138,7 @@ export type ActionName =
   | "copyElementLink"
   | "linkToElement"
   | "cropEditor"
+  | "toggleElementVisibility"
   | "wrapSelectionInFrame"
   | "toggleShapeSwitch"
   | "togglePolygon";

--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -322,6 +322,7 @@ import {
   actionUngroup,
   actionLink,
   actionToggleElementLock,
+  actionToggleElementVisibility,
   actionToggleLinearEditor,
   actionToggleObjectsSnapMode,
   actionToggleArrowBinding,
@@ -13664,6 +13665,7 @@ class App extends React.Component<AppProps, AppState> {
       CONTEXT_MENU_SEPARATOR,
       actionDuplicateSelection,
       actionToggleElementLock,
+      actionToggleElementVisibility,
       CONTEXT_MENU_SEPARATOR,
       actionDeleteSelected,
     ];

--- a/packages/excalidraw/data/restore.ts
+++ b/packages/excalidraw/data/restore.ts
@@ -406,8 +406,12 @@ const repairBinding = <T extends ExcalidrawArrowElement>(
 };
 
 const restoreElementWithProperties = <
-  T extends Required<Omit<ExcalidrawElement, "customData">> & {
+  T extends Required<
+    Omit<ExcalidrawElement, "customData" | "isVisible" | "layerId">
+  > & {
     customData?: ExcalidrawElement["customData"];
+    isVisible?: ExcalidrawElement["isVisible"];
+    layerId?: ExcalidrawElement["layerId"];
     /** @deprecated */
     boundElementIds?: readonly ExcalidrawElement["id"][];
     /** @deprecated */
@@ -467,6 +471,8 @@ const restoreElementWithProperties = <
     updated: element.updated ?? getUpdatedTimestamp(),
     link: element.link ? normalizeLink(element.link) : null,
     locked: element.locked ?? false,
+    isVisible: element.isVisible ?? true,
+    layerId: element.layerId ?? null,
   };
 
   if ("customData" in element || "customData" in extra) {

--- a/packages/excalidraw/locales/en.json
+++ b/packages/excalidraw/locales/en.json
@@ -165,6 +165,10 @@
       "lockAll": "Lock all",
       "unlockAll": "Unlock all"
     },
+    "elementVisibility": {
+      "hide": "Hide selection",
+      "show": "Show selection"
+    },
     "statusPublished": "Published",
     "sidebarLock": "Keep sidebar open",
     "selectAllElementsInFrame": "Select all elements in frame",


### PR DESCRIPTION
Fixes #9599   (transferred from Discussion #9306).

This PR introduces native **Element and Frame Layer Visibility Toggles** inside Excalidraw frames. 

In complex diagrams (e.g., software architecture diagrams, step-by-step presentation slides, wireframe theme states), users often need to toggle different layers of details on and off within the exact same frame canvas rather than duplicating identical frames.

---

## Proposed Changes

### 1. Data Model & Type Definitions (`@excalidraw/element`)
- **Element Visibility**: Added `isVisible?: boolean` to `_ExcalidrawElementBase`. When `false`, elements are hidden and skipped during rendering and interaction.
- **Layer Link**: Added `layerId?: string | null` to `_ExcalidrawElementBase` to link elements to specific frame layers.
- **Frame Layers**: Introduced `FrameLayer` type (`{ id: string; name: string; isVisible: boolean; color?: string }`) and updated `ExcalidrawFrameElement` schema to support `layers?: readonly FrameLayer[]`.
- **Element Construction Defaults**: Updated `_newElementBase` in `newElement.ts` to assign default values (`isVisible: true`, `layerId: null`).

### 2. Visibility Evaluation Helper (`typeChecks.ts`)
- Implemented `isElementVisible(element, elementsMap)` helper that evaluates:
  1. Element-level `isVisible` flag.
  2. Parent frame `isVisible` state (if element belongs to a frame).
  3. Parent frame layer `isVisible` state (if element belongs to a specific frame layer).

### 3. Rendering Engine Integration (`renderElement.ts` & `index.ts`)
- Added `isElementVisible` checks in `generateElementCanvas` and `getVisibleElements` to skip rendering hidden elements on static and interactive canvases.

### 4. Hit Testing & Marquee Selection (`collision.ts` & `selection.ts`)
- Updated `isPointInElement` to ignore hidden elements during pointer click events.
- Updated `shouldIgnoreElementFromSelection` to exclude hidden elements from marquee/box drag selections.

### 5. Actions, Keyboard Shortcuts & UI Context Menu (`@excalidraw/excalidraw`)
- Created `actionToggleElementVisibility` (`toggleElementVisibility`) action that toggles `isVisible` state for selected elements.
- Assigned keyboard shortcut `Ctrl+Shift+H` / `Cmd+Shift+H` (`shortcuts.ts`).
- Added action to the right-click context menu (`App.tsx`).
- Added English locale strings for `"hide"` and `"show"` selection.

### 6. Deserialization & Backward Compatibility (`restore.ts`)
- Updated `restoreElementWithProperties` to set `isVisible: element.isVisible ?? true` and `layerId: element.layerId ?? null`.
- Preserves 100% backward compatibility for existing `.excalidraw` scene files and older viewer versions.

---

## Verification & Testing

- **Unit Tests**: Added [`packages/element/src/__tests__/visibility.test.ts`](file:///d:/open%20source%20contribution/rabadiyameet073/excalidraw/packages/element/src/__tests__/visibility.test.ts) covering visibility evaluation, default states, and frame layer overrides.
- **Typecheck**: Ran full workspace typecheck (`npx tsc --noEmit`) — **0 errors**.
- **Test Suite**: Ran `npx vitest run packages/element/src/__tests__/visibility.test.ts` — **3/3 passed**.

---
