### PR TITLE
refactor: replace UA parsing with isDarwin/isWindows in ShareDialog

### DIFF
--- a/excalidraw-app/share/ShareDialog.tsx
+++ b/excalidraw-app/share/ShareDialog.tsx
@@ -15,7 +15,7 @@ import {
 import { useUIAppState } from "@excalidraw/excalidraw/context/ui-appState";
 import { useCopyStatus } from "@excalidraw/excalidraw/hooks/useCopiedIndicator";
 import { useI18n } from "@excalidraw/excalidraw/i18n";
-import { KEYS, getFrame } from "@excalidraw/common";
+import { KEYS, getFrame, isDarwin, isWindows } from "@excalidraw/common";
 import { useEffect, useRef, useState } from "react";
 
 import { atom, useAtom, useAtomValue } from "../app-jotai";
@@ -34,13 +34,9 @@ export const shareDialogStateAtom = atom<
 >({ isOpen: false });
 
 const getShareIcon = () => {
-  const navigator = window.navigator as any;
-  const isAppleBrowser = /Apple/.test(navigator.vendor);
-  const isWindowsBrowser = navigator.appVersion.indexOf("Win") !== -1;
-
-  if (isAppleBrowser) {
+  if (isDarwin) {
     return shareIOS;
-  } else if (isWindowsBrowser) {
+  } else if (isWindows) {
     return shareWindows;
   }
 


### PR DESCRIPTION
## Summary

Replaces the `getShareIcon()` function's User Agent string parsing with the existing `isDarwin` and `isWindows` utility functions from `@excalidraw/common`.

## Changes

- **Before**: Parsed `navigator.vendor` and `navigator.appVersion` to detect Apple/Windows browsers
- **After**: Uses `isDarwin` and `isWindows` from `@excalidraw/common`, which rely on `navigator.platform` — a more reliable detection method

## Why this approach

Rather than adding a new external dependency, this leverages the existing browser detection utilities already present in the codebase (`packages/common/src/editorInterface.ts`), ensuring consistency across the project.

Closes #9583