### PR TITLE
docs: add Zenith Hosting deploy option

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ The app hosted at [excalidraw.com](https://excalidraw.com) is a minimal showcase
 
 We'll be adding these features as drop-in plugins for the npm package in the future.
 
+You can also run this app on your own infrastructure. The repository ships a `Dockerfile` and a `docker-compose.yml`, or you can have a managed instance set up for you in one click, with storage, backups and a free subdomain included:
+
+[![Deploy with Zenith](https://cdn.zenith.hosting/buttons/deploy-with-zenith.svg)](https://zenith.hosting/host/excalidraw)
+
 ## Quick start
 
 **Note:** following instructions are for installing the Excalidraw [npm package](https://www.npmjs.com/package/@excalidraw/excalidraw) when integrating Excalidraw into your own app. To run the repository locally for development, please refer to our [Development Guide](https://docs.excalidraw.com/docs/introduction/development).


### PR DESCRIPTION
hey, i work on Zenith Hosting, a startup doing one-click hosting for open source apps. we added Excalidraw to our marketplace, so this PR adds a small "Deploy with Zenith" badge under the Excalidraw.com section (links to https://zenith.hosting/host/excalidraw).

the repo already ships a `Dockerfile` and a `docker-compose.yml`, but the README never mentions you can run the app yourself, so the added line points at those first and offers the managed route as the alternative for people who do not want to run a server.

docs only, one file, three lines added. happy to move it, shorten it, or drop the prose and keep just the badge.

we share a cut of revenue with the projects we host. happy to explain if you're curious: hello@zenith.hosting
