### PR TITLE
fix(Range): correct slider position and gradient direction in RTL layouts

### DIFF
--- a/packages/excalidraw/components/Range.scss
+++ b/packages/excalidraw/components/Range.scss
@@ -49,7 +49,7 @@
   .zero-label {
     position: absolute;
     bottom: 0;
-    left: 4px;
+    inset-inline-start: 4px;
     font-size: 12px;
     color: var(--text-primary-color);
   }

--- a/packages/excalidraw/components/Range.tsx
+++ b/packages/excalidraw/components/Range.tsx
@@ -42,8 +42,16 @@ export const Range = ({
       const progress = ((value - min) / (max - min || 1)) * 100;
       const position =
         (progress / 100) * (inputWidth - thumbWidth) + thumbWidth / 2;
-      valueElement.style.left = `${position}px`;
-      rangeElement.style.background = `linear-gradient(to right, var(--color-slider-track) 0%, var(--color-slider-track) ${progress}%, var(--button-bg) ${progress}%, var(--button-bg) 100%)`;
+      const isRTL = document.documentElement.getAttribute("dir") === "rtl";
+      if (isRTL) {
+        valueElement.style.left = "";
+        valueElement.style.right = `${position}px`;
+        rangeElement.style.background = `linear-gradient(to left, var(--color-slider-track) 0%, var(--color-slider-track) ${progress}%, var(--button-bg) ${progress}%, var(--button-bg) 100%)`;
+      } else {
+        valueElement.style.right = "";
+        valueElement.style.left = `${position}px`;
+        rangeElement.style.background = `linear-gradient(to right, var(--color-slider-track) 0%, var(--color-slider-track) ${progress}%, var(--button-bg) ${progress}%, var(--button-bg) 100%)`;
+      }
     }
   }, [max, min, value]);
 


### PR DESCRIPTION
## Summary

The opacity/transparency `Range` slider rendered incorrectly in RTL locales (Arabic, Hebrew, Farsi):

- The value bubble was positioned with `valueElement.style.left`, which is direction-unaware — in RTL the minimum end is on the right, so the bubble appeared on the wrong side.
- The track fill used `linear-gradient(to right, ...)`, also direction-unaware, so the filled portion tracked the wrong direction.
- `.zero-label` used the physical `left: 4px` instead of a logical property.

## Fix

Detect RTL via `document.documentElement.getAttribute("dir") === "rtl"` inside the existing `useEffect` and branch on it:

- LTR (unchanged): `style.left` + `linear-gradient(to right, ...)`
- RTL: `style.right` + `linear-gradient(to left, ...)`

Also replace `left: 4px` on `.zero-label` with `inset-inline-start: 4px` so the label always anchors to the start edge.

Fixes #9710