### PR TITLE
fix: allow Ctrl+F native find in dialogs (#9276)

### DIFF
--- a/packages/excalidraw/actions/actionToggleSearchMenu.ts
+++ b/packages/excalidraw/actions/actionToggleSearchMenu.ts
@@ -54,5 +54,8 @@ export const actionToggleSearchMenu = register({
   predicate: (element, appState, props) => {
     return props.gridModeEnabled === undefined;
   },
-  keyTest: (event) => event[KEYS.CTRL_OR_CMD] && event.key === KEYS.F,
+  keyTest: (event, appState) =>
+    !appState.openDialog &&
+    event[KEYS.CTRL_OR_CMD] &&
+    event.key === KEYS.F,
 });


### PR DESCRIPTION
---

**Title:** fix: allow Ctrl+F native find in dialogs

## Fixes #9276

### Problem

Pressing `Ctrl+F` while the Help dialog (or any dialog) is open closes the dialog and opens the canvas search panel instead of triggering the browser's native find-in-page.

### Root Cause

The `searchMenu` action's `keyTest` unconditionally matched `Ctrl+F`. The action manager calls `event.preventDefault()` and `event.stopPropagation()` **before** invoking `perform()`. Even though `perform()` already had an early return when `appState.openDialog` is set, the native browser event was already suppressed by that point — resulting in neither native find nor the search menu working.

### Fix

Added `!appState.openDialog` to the `keyTest` function so the action doesn't match at all when a dialog is open. This allows the browser's native `Ctrl+F` to work inside dialogs (e.g. the Help dialog).

```diff
- keyTest: (event) => event[KEYS.CTRL_OR_CMD] && event.key === KEYS.F,
+ keyTest: (event, appState) =>
+   !appState.openDialog &&
+   event[KEYS.CTRL_OR_CMD] &&
+   event.key === KEYS.F,
```

### Testing

- Open Help dialog (`?`) → press `Ctrl+F` → browser's native find-in-page opens ✅
- Close Help dialog → press `Ctrl+F` → canvas search panel opens as before ✅

---