### PR TITLE
fix: add tooltips to library sidebar header icons

### DIFF
--- a/excalidraw-app/components/AppSidebar.tsx
+++ b/excalidraw-app/components/AppSidebar.tsx
@@ -5,6 +5,7 @@ import {
 } from "@excalidraw/excalidraw/components/icons";
 import { LinkButton } from "@excalidraw/excalidraw/components/LinkButton";
 import { useUIAppState } from "@excalidraw/excalidraw/context/ui-appState";
+import { Tooltip } from "@excalidraw/excalidraw/components/Tooltip";
 
 import "./AppSidebar.scss";
 
@@ -71,18 +72,24 @@ export const AppSidebar = () => {
   return (
     <DefaultSidebar>
       <DefaultSidebar.TabTriggers>
-        <Sidebar.TabTrigger
-          tab="comments"
-          style={{ opacity: openSidebar?.tab === "comments" ? 1 : 0.4 }}
-        >
-          {messageCircleIcon}
-        </Sidebar.TabTrigger>
-        <Sidebar.TabTrigger
-          tab="presentation"
-          style={{ opacity: openSidebar?.tab === "presentation" ? 1 : 0.4 }}
-        >
-          {presentationIcon}
-        </Sidebar.TabTrigger>
+        <Tooltip label="Comments">
+          <Sidebar.TabTrigger
+            tab="comments"
+            style={{ opacity: openSidebar?.tab === "comments" ? 1 : 0.4 }}
+            aria-label="Comments"
+          >
+            {messageCircleIcon}
+          </Sidebar.TabTrigger>
+        </Tooltip>
+        <Tooltip label="Presentation">
+          <Sidebar.TabTrigger
+            tab="presentation"
+            style={{ opacity: openSidebar?.tab === "presentation" ? 1 : 0.4 }}
+            aria-label="Presentation"
+          >
+            {presentationIcon}
+          </Sidebar.TabTrigger>
+        </Tooltip>
       </DefaultSidebar.TabTriggers>
       <Sidebar.Tab tab="comments">
         <div className="app-sidebar-promo-container">

--- a/packages/excalidraw/components/DefaultSidebar.tsx
+++ b/packages/excalidraw/components/DefaultSidebar.tsx
@@ -14,12 +14,16 @@ import { useUIAppState } from "../context/ui-appState";
 
 import "../components/dropdownMenu/DropdownMenu.scss";
 
+import { t } from "../i18n";
+
 import { useExcalidrawSetAppState } from "./App";
 import { LibraryMenu } from "./LibraryMenu";
 import { SearchMenu } from "./SearchMenu";
 import { Sidebar } from "./Sidebar/Sidebar";
 import { withInternalFallback } from "./hoc/withInternalFallback";
 import { LibraryIcon, searchIcon } from "./icons";
+
+import { Tooltip } from "./Tooltip";
 
 import type { SidebarProps, SidebarTriggerProps } from "./Sidebar/common";
 
@@ -99,12 +103,16 @@ export const DefaultSidebar = Object.assign(
           <Sidebar.Tabs>
             <Sidebar.Header>
               <Sidebar.TabTriggers>
-                <Sidebar.TabTrigger tab={CANVAS_SEARCH_TAB}>
-                  {searchIcon}
-                </Sidebar.TabTrigger>
-                <Sidebar.TabTrigger tab={LIBRARY_SIDEBAR_TAB}>
-                  {LibraryIcon}
-                </Sidebar.TabTrigger>
+                <Tooltip label={t("search.title")}>
+                  <Sidebar.TabTrigger tab={CANVAS_SEARCH_TAB}>
+                    {searchIcon}
+                  </Sidebar.TabTrigger>
+                </Tooltip>
+                <Tooltip label={t("toolBar.library")}>
+                  <Sidebar.TabTrigger tab={LIBRARY_SIDEBAR_TAB}>
+                    {LibraryIcon}
+                  </Sidebar.TabTrigger>
+                </Tooltip>
                 <DefaultSidebarTabTriggersTunnel.Out />
               </Sidebar.TabTriggers>
             </Sidebar.Header>


### PR DESCRIPTION
## Summary

Adds missing tooltips to the library sidebar header icons.

### Changes

- Added tooltip for Search icon
- Added tooltip for Library icon
- Added tooltip for Comments icon
- Added tooltip for Presentation icon
- Added tooltip for Close buttons

This makes the sidebar header icons consistent with the existing Pin.