### PR TITLE
feat: Make linear element snapping not dependent on sloppiness

### DIFF
--- a/packages/element/src/bounds.ts
+++ b/packages/element/src/bounds.ts
@@ -283,6 +283,22 @@ export const getElementAbsoluteCoords = (
   ];
 };
 
+export const getElementAbsoluteVisualCoords = (
+  element: ExcalidrawElement,
+  elementsMap: ElementsMap,
+  includeBoundText: boolean = false,
+): [number, number, number, number, number, number] => {
+  if (isLinearElement(element)) {
+    return LinearElementEditor.getElementAbsoluteVisualCoords(
+      element,
+      elementsMap,
+      includeBoundText,
+    );
+  } else {
+    return getElementAbsoluteCoords(element, elementsMap, includeBoundText);
+  }
+};
+
 /*
  * for a given element, `getElementLineSegments` returns line segments
  * that can be used for visual collision detection (useful for frames)
@@ -1013,6 +1029,46 @@ export const getResizedElementAbsoluteCoords = (
     maxX + element.x,
     maxY + element.y,
   ];
+};
+
+export const getResizedElementAbsoluteVisualCoords = (
+  element: ExcalidrawElement,
+  nextWidth: number,
+  nextHeight: number,
+  normalizePoints: boolean,
+): Bounds => {
+  if (isLinearElement(element)) {
+    const points = rescalePoints(
+      0,
+      nextWidth,
+      rescalePoints(1, nextHeight, element.points, normalizePoints),
+      normalizePoints,
+    );
+
+    const gen = rough.generator();
+    const curve = !element.roundness
+      ? gen.linearPath(
+          points as [number, number][],
+          generateRoughOptions(element),
+        )
+      : gen.curve(points as [number, number][], generateRoughOptions(element));
+
+    const ops = getCurvePathOps(curve);
+    const [minX, minY, maxX, maxY] = getMinMaxXYFromCurvePathOps(ops);
+    return [
+      minX + element.x,
+      minY + element.y,
+      maxX + element.x,
+      maxY + element.y,
+    ];
+  } else {
+    return getResizedElementAbsoluteCoords(
+      element,
+      nextWidth,
+      nextHeight,
+      normalizePoints,
+    );
+  }
 };
 
 export const getElementPointsCoords = (

--- a/packages/element/src/bounds.ts
+++ b/packages/element/src/bounds.ts
@@ -25,10 +25,8 @@ import type {
   Radians,
 } from "@excalidraw/math";
 import type { AppState } from "@excalidraw/excalidraw/types";
-import type { Mutable } from "@excalidraw/common/utility-types";
 
 import { generateRoughOptions } from "./shape";
-import { ShapeCache } from "./shape";
 import { LinearElementEditor } from "./linearElementEditor";
 import { getBoundTextElement, getContainerElement } from "./textElement";
 import {
@@ -50,7 +48,6 @@ import { intersectElementWithLineSegment } from "./collision";
 import { elementOverlapsWithFrame, getContainingFrame } from "./frame";
 
 import type { Drawable, Op } from "roughjs/bin/core";
-import type { Point as RoughPoint } from "roughjs/bin/geometry";
 import type {
   Arrowhead,
   ElementsMap,
@@ -905,29 +902,6 @@ export const getArrowheadPoints = (
   }
 
   return [tx, ty, x3, y3, x4, y4];
-};
-
-// TODO reuse shape.ts
-const generateLinearElementShape = (
-  element: ExcalidrawLinearElement,
-): Drawable => {
-  const generator = rough.generator();
-  const options = generateRoughOptions(element);
-
-  const method = (() => {
-    if (element.roundness) {
-      return "curve";
-    }
-    if (options.fill) {
-      return "polygon";
-    }
-    return "linearPath";
-  })();
-
-  return generator[method](
-    element.points as Mutable<LocalPoint>[] as RoughPoint[],
-    options,
-  );
 };
 
 const getLinearElementRotatedBounds = (

--- a/packages/element/src/bounds.ts
+++ b/packages/element/src/bounds.ts
@@ -938,43 +938,13 @@ const getLinearElementRotatedBounds = (
 ): Bounds => {
   const boundTextElement = getBoundTextElement(element, elementsMap);
 
-  if (element.points.length < 2) {
-    const [pointX, pointY] = element.points[0];
-    const [x, y] = pointRotateRads(
-      pointFrom(element.x + pointX, element.y + pointY),
-      pointFrom(cx, cy),
-      element.angle,
-    );
-
-    let coords: Bounds = [x, y, x, y];
-    if (boundTextElement) {
-      const coordsWithBoundText = LinearElementEditor.getMinMaxXYWithBoundText(
-        element,
-        elementsMap,
-        [x, y, x, y],
-        boundTextElement,
-      );
-      coords = [
-        coordsWithBoundText[0],
-        coordsWithBoundText[1],
-        coordsWithBoundText[2],
-        coordsWithBoundText[3],
-      ];
-    }
-    return coords;
-  }
-
-  // first element is always the curve
-  const cachedShape = ShapeCache.get(element, null)?.[0];
-  const shape = cachedShape ?? generateLinearElementShape(element);
-  const ops = getCurvePathOps(shape);
-  const transformXY = ([x, y]: GlobalPoint) =>
-    pointRotateRads<GlobalPoint>(
+  const transformXY = ([x, y]: LocalPoint) =>
+    pointRotateRads<LocalPoint>(
       pointFrom(element.x + x, element.y + y),
       pointFrom(cx, cy),
       element.angle,
     );
-  const res = getMinMaxXYFromCurvePathOps(ops, transformXY);
+  const res = getBoundsFromPoints(element.points.map(transformXY));
   let coords: Bounds = [res[0], res[1], res[2], res[3]];
   if (boundTextElement) {
     const coordsWithBoundText = LinearElementEditor.getMinMaxXYWithBoundText(
@@ -1062,26 +1032,7 @@ export const getResizedElementAbsoluteCoords = (
     normalizePoints,
   );
 
-  let bounds: Bounds;
-
-  if (isFreeDrawElement(element)) {
-    // Free Draw
-    bounds = getBoundsFromPoints(points);
-  } else {
-    // Line
-    const gen = rough.generator();
-    const curve = !element.roundness
-      ? gen.linearPath(
-          points as [number, number][],
-          generateRoughOptions(element),
-        )
-      : gen.curve(points as [number, number][], generateRoughOptions(element));
-
-    const ops = getCurvePathOps(curve);
-    bounds = getMinMaxXYFromCurvePathOps(ops);
-  }
-
-  const [minX, minY, maxX, maxY] = bounds;
+  const [minX, minY, maxX, maxY] = getBoundsFromPoints(points);
   return [
     minX + element.x,
     minY + element.y,

--- a/packages/element/src/cropElement.ts
+++ b/packages/element/src/cropElement.ts
@@ -16,8 +16,8 @@ import { type Point } from "points-on-curve";
 
 import {
   elementCenterPoint,
-  getElementAbsoluteCoords,
-  getResizedElementAbsoluteCoords,
+  getElementAbsoluteVisualCoords,
+  getResizedElementAbsoluteVisualCoords,
 } from "./bounds";
 
 import type { TransformHandleType } from "./transformHandles";
@@ -411,7 +411,7 @@ const recomputeOrigin = (
   height: number,
   shouldMaintainAspectRatio?: boolean,
 ) => {
-  const [x1, y1, x2, y2] = getResizedElementAbsoluteCoords(
+  const [x1, y1, x2, y2] = getResizedElementAbsoluteVisualCoords(
     stateAtCropStart,
     stateAtCropStart.width,
     stateAtCropStart.height,
@@ -422,7 +422,7 @@ const recomputeOrigin = (
   const startCenter: any = pointCenter(startTopLeft, startBottomRight);
 
   const [newBoundsX1, newBoundsY1, newBoundsX2, newBoundsY2] =
-    getResizedElementAbsoluteCoords(stateAtCropStart, width, height, true);
+    getResizedElementAbsoluteVisualCoords(stateAtCropStart, width, height, true);
   const newBoundsWidth = newBoundsX2 - newBoundsX1;
   const newBoundsHeight = newBoundsY2 - newBoundsY1;
 
@@ -482,7 +482,7 @@ export const getUncroppedImageElement = (
   if (element.crop) {
     const { width, height } = getUncroppedWidthAndHeight(element);
 
-    const [x1, y1, x2, y2, cx, cy] = getElementAbsoluteCoords(
+    const [x1, y1, x2, y2, cx, cy] = getElementAbsoluteVisualCoords(
       element,
       elementsMap,
     );

--- a/packages/element/src/linearElementEditor.ts
+++ b/packages/element/src/linearElementEditor.ts
@@ -11,8 +11,6 @@ import {
   curvePointAtLength,
 } from "@excalidraw/math";
 
-import { getCurvePathOps } from "@excalidraw/utils/shape";
-
 import {
   DRAGGING_THRESHOLD,
   KEYS,
@@ -62,7 +60,7 @@ import { mutateElement } from "./mutateElement";
 import { getBoundTextElement, handleBindTextResize } from "./textElement";
 import { isArrowElement, isBindingElement, isElbowArrow } from "./typeChecks";
 
-import { ShapeCache, toggleLinePolygonState } from "./shape";
+import { toggleLinePolygonState } from "./shape";
 
 import { getLockedLinearCursorAlignSize } from "./sizeHelpers";
 

--- a/packages/element/src/linearElementEditor.ts
+++ b/packages/element/src/linearElementEditor.ts
@@ -54,7 +54,7 @@ import {
 import {
   getElementAbsoluteCoords,
   getElementPointsCoords,
-  getMinMaxXYFromCurvePathOps,
+  getBoundsFromPoints,
 } from "./bounds";
 
 import { headingIsHorizontal, vectorToHeading } from "./heading";
@@ -2018,12 +2018,7 @@ export class LinearElementEditor {
     elementsMap: ElementsMap,
     includeBoundText: boolean = false,
   ): [number, number, number, number, number, number] => {
-    const shape = ShapeCache.generateElementShape(element, null);
-
-    // first element is always the curve
-    const ops = getCurvePathOps(shape[0]);
-
-    const [minX, minY, maxX, maxY] = getMinMaxXYFromCurvePathOps(ops);
+    const [minX, minY, maxX, maxY] = getBoundsFromPoints(element.points);
     const x1 = minX + element.x;
     const y1 = minY + element.y;
     const x2 = maxX + element.x;

--- a/packages/element/src/linearElementEditor.ts
+++ b/packages/element/src/linearElementEditor.ts
@@ -11,6 +11,8 @@ import {
   curvePointAtLength,
 } from "@excalidraw/math";
 
+import { getCurvePathOps } from "@excalidraw/utils/shape";
+
 import {
   DRAGGING_THRESHOLD,
   KEYS,
@@ -52,6 +54,7 @@ import {
 import {
   getElementAbsoluteCoords,
   getElementPointsCoords,
+  getMinMaxXYFromCurvePathOps,
   getBoundsFromPoints,
 } from "./bounds";
 
@@ -60,7 +63,7 @@ import { mutateElement } from "./mutateElement";
 import { getBoundTextElement, handleBindTextResize } from "./textElement";
 import { isArrowElement, isBindingElement, isElbowArrow } from "./typeChecks";
 
-import { toggleLinePolygonState } from "./shape";
+import { ShapeCache, toggleLinePolygonState } from "./shape";
 
 import { getLockedLinearCursorAlignSize } from "./sizeHelpers";
 
@@ -2016,7 +2019,41 @@ export class LinearElementEditor {
     elementsMap: ElementsMap,
     includeBoundText: boolean = false,
   ): [number, number, number, number, number, number] => {
-    const [minX, minY, maxX, maxY] = getBoundsFromPoints(element.points);
+    const bounds = getBoundsFromPoints(element.points);
+    return LinearElementEditor.getElementAbsoluteCoordsFromBounds(
+      bounds,
+      element,
+      elementsMap,
+      includeBoundText,
+    );
+  };
+
+  static getElementAbsoluteVisualCoords = (
+    element: ExcalidrawLinearElement,
+    elementsMap: ElementsMap,
+    includeBoundText: boolean = false,
+  ): [number, number, number, number, number, number] => {
+    const shape = ShapeCache.generateElementShape(element, null);
+
+    // first element is always the curve
+    const ops = getCurvePathOps(shape[0]);
+
+    const bounds = getMinMaxXYFromCurvePathOps(ops);
+    return LinearElementEditor.getElementAbsoluteCoordsFromBounds(
+      bounds,
+      element,
+      elementsMap,
+      includeBoundText,
+    );
+  };
+
+  private static getElementAbsoluteCoordsFromBounds = (
+    bounds: Bounds,
+    element: ExcalidrawLinearElement,
+    elementsMap: ElementsMap,
+    includeBoundText: boolean = false,
+  ): [number, number, number, number, number, number] => {
+    const [minX, minY, maxX, maxY] = bounds;
     const x1 = minX + element.x;
     const y1 = minY + element.y;
     const x2 = maxX + element.x;

--- a/packages/element/src/renderElement.ts
+++ b/packages/element/src/renderElement.ts
@@ -42,7 +42,7 @@ import type {
   InteractiveCanvasRenderConfig,
 } from "@excalidraw/excalidraw/scene/types";
 
-import { getElementAbsoluteCoords, getElementBounds } from "./bounds";
+import { getElementAbsoluteVisualCoords, getElementBounds } from "./bounds";
 import { getUncroppedImageElement } from "./cropElement";
 import { LinearElementEditor } from "./linearElementEditor";
 import {
@@ -165,7 +165,7 @@ const cappedElementCanvasSize = (
 
   const padding = getCanvasPadding(element);
 
-  const [x1, y1, x2, y2] = getElementAbsoluteCoords(element, elementsMap);
+  const [x1, y1, x2, y2] = getElementAbsoluteVisualCoords(element, elementsMap);
   const elementWidth =
     isLinearElement(element) || isFreeDrawElement(element)
       ? distance(x1, x2)
@@ -227,7 +227,7 @@ const generateElementCanvas = (
   let canvasOffsetY = 0;
 
   if (isLinearElement(element) || isFreeDrawElement(element)) {
-    const [x1, y1] = getElementAbsoluteCoords(element, elementsMap);
+    const [x1, y1] = getElementAbsoluteVisualCoords(element, elementsMap);
 
     canvasOffsetX =
       element.x > x1
@@ -592,7 +592,7 @@ const drawElementFromCanvas = (
 ) => {
   const element = elementWithCanvas.element;
   const padding = getCanvasPadding(element);
-  const [x1, y1, x2, y2] = getElementAbsoluteCoords(element, allElementsMap);
+  const [x1, y1, x2, y2] = getElementAbsoluteVisualCoords(element, allElementsMap);
   const cx = ((x1 + x2) / 2 + appState.scrollX) * window.devicePixelRatio;
   const cy = ((y1 + y2) / 2 + appState.scrollY) * window.devicePixelRatio;
 
@@ -606,7 +606,7 @@ const drawElementFromCanvas = (
     // rect (even-odd) instead of baking a rotated arrow copy with a cleared
     // hole into a separate (`maxDim`-squared!) canvas. The hole stays
     // axis-aligned in scene space while the blit below rotates.
-    const [, , , , boundTextCx, boundTextCy] = getElementAbsoluteCoords(
+    const [, , , , boundTextCx, boundTextCy] = getElementAbsoluteVisualCoords(
       boundTextElement,
       allElementsMap,
     );
@@ -780,7 +780,7 @@ export const renderElement = (
     }
     case "freedraw": {
       if (renderConfig.isExporting) {
-        const [x1, y1, x2, y2] = getElementAbsoluteCoords(element, elementsMap);
+        const [x1, y1, x2, y2] = getElementAbsoluteVisualCoords(element, elementsMap);
         const cx = (x1 + x2) / 2 + appState.scrollX;
         const cy = (y1 + y2) / 2 + appState.scrollY;
         const shiftX = (x2 - x1) / 2 - (element.x - x1);
@@ -823,7 +823,7 @@ export const renderElement = (
     case "iframe":
     case "embeddable": {
       if (renderConfig.isExporting) {
-        const [x1, y1, x2, y2] = getElementAbsoluteCoords(element, elementsMap);
+        const [x1, y1, x2, y2] = getElementAbsoluteVisualCoords(element, elementsMap);
         const centerX = (x1 + x2) / 2;
         const centerY = (y1 + y2) / 2;
         const cx = centerX + appState.scrollX;
@@ -857,7 +857,7 @@ export const renderElement = (
           shiftX = element.width / 2 - (element.x - x1);
           shiftY = element.height / 2 - (element.y - y1);
 
-          const [, , , , boundTextCx, boundTextCy] = getElementAbsoluteCoords(
+          const [, , , , boundTextCx, boundTextCy] = getElementAbsoluteVisualCoords(
             boundTextElement,
             elementsMap,
           );

--- a/packages/element/tests/bounds.test.ts
+++ b/packages/element/tests/bounds.test.ts
@@ -12,6 +12,7 @@ import type { LocalPoint } from "@excalidraw/math";
 import {
   elementsOverlappingBBox,
   getElementAbsoluteCoords,
+  getElementAbsoluteVisualCoords,
   getElementBounds,
 } from "../src/bounds";
 
@@ -103,6 +104,40 @@ describe("getElementAbsoluteCoords", () => {
     );
 
     expect(cleanCoords).toEqual(cartoonyCoords);
+  });
+});
+
+describe("getElementAbsoluteVisualCoords", () => {
+  it("takes roughness into account", () => {
+    const clean = {
+      ..._ce({
+        t: "line",
+        x: 449.58203125,
+        y: 186.0625,
+        w: 170.12890625,
+        h: 92.48828125,
+        a: 0.6447741904932416,
+      }),
+      points: [
+        pointFrom<LocalPoint>(0, 0),
+        pointFrom<LocalPoint>(67.33984375, 92.48828125),
+        pointFrom<LocalPoint>(-102.7890625, 52.15625),
+      ],
+      roughness: ROUGHNESS.architect,
+    } as ExcalidrawElement;
+
+    const cartoony = {
+      ...clean,
+      roughness: ROUGHNESS.cartoonist,
+    } as ExcalidrawElement;
+
+    const cleanCoords = getElementAbsoluteVisualCoords(clean, arrayToMap([clean]));
+    const cartoonyCoords = getElementAbsoluteVisualCoords(
+      cartoony,
+      arrayToMap([cartoony]),
+    );
+
+    expect(cleanCoords).not.toEqual(cartoonyCoords);
   });
 });
 

--- a/packages/element/tests/bounds.test.ts
+++ b/packages/element/tests/bounds.test.ts
@@ -139,10 +139,10 @@ describe("getElementBounds", () => {
     } as ExcalidrawLinearElement;
 
     const [x1, y1, x2, y2] = getElementBounds(element, arrayToMap([element]));
-    expect(x1).toEqual(360.9291017525165);
-    expect(y1).toEqual(185.24770129343722);
-    expect(x2).toEqual(481.4815539037601);
-    expect(y2).toEqual(319.8162855827246);
+    expect(x1).toEqual(360.3176068760539);
+    expect(y1).toEqual(185.90654264413516);
+    expect(x2).toEqual(473.8171188951176);
+    expect(y2).toEqual(320.391865303557);
   });
 });
 

--- a/packages/element/tests/bounds.test.ts
+++ b/packages/element/tests/bounds.test.ts
@@ -1,5 +1,10 @@
 import { pointFrom } from "@excalidraw/math";
-import { arrayToMap, type Bounds, ROUNDNESS } from "@excalidraw/common";
+import {
+  arrayToMap,
+  type Bounds,
+  ROUNDNESS,
+  ROUGHNESS,
+} from "@excalidraw/common";
 import { API } from "@excalidraw/excalidraw/tests/helpers/api";
 
 import type { LocalPoint } from "@excalidraw/math";
@@ -66,6 +71,38 @@ describe("getElementAbsoluteCoords", () => {
     const element = _ce({ x: 0, y: 10, w: 0, h: 10 });
     const [, , , y2] = getElementAbsoluteCoords(element, arrayToMap([element]));
     expect(y2).toEqual(20);
+  });
+
+  it("ignores roughness", () => {
+    const clean = {
+      ..._ce({
+        t: "line",
+        x: 449.58203125,
+        y: 186.0625,
+        w: 170.12890625,
+        h: 92.48828125,
+        a: 0.6447741904932416,
+      }),
+      points: [
+        pointFrom<LocalPoint>(0, 0),
+        pointFrom<LocalPoint>(67.33984375, 92.48828125),
+        pointFrom<LocalPoint>(-102.7890625, 52.15625),
+      ],
+      roughness: ROUGHNESS.architect,
+    } as ExcalidrawElement;
+
+    const cartoony = {
+      ...clean,
+      roughness: ROUGHNESS.cartoonist,
+    } as ExcalidrawElement;
+
+    const cleanCoords = getElementAbsoluteCoords(clean, arrayToMap([clean]));
+    const cartoonyCoords = getElementAbsoluteCoords(
+      cartoony,
+      arrayToMap([cartoony]),
+    );
+
+    expect(cleanCoords).toEqual(cartoonyCoords);
   });
 });
 
@@ -143,6 +180,37 @@ describe("getElementBounds", () => {
     expect(y1).toEqual(185.90654264413516);
     expect(x2).toEqual(473.8171188951176);
     expect(y2).toEqual(320.391865303557);
+  });
+
+  it("ignores roughness", () => {
+    const clean = {
+      ..._ce({
+        t: "line",
+        x: 449.58203125,
+        y: 186.0625,
+        w: 170.12890625,
+        h: 92.48828125,
+        a: 0.6447741904932416,
+      }),
+      points: [
+        pointFrom<LocalPoint>(0, 0),
+        pointFrom<LocalPoint>(67.33984375, 92.48828125),
+        pointFrom<LocalPoint>(-102.7890625, 52.15625),
+      ],
+      roughness: ROUGHNESS.architect,
+    } as ExcalidrawElement;
+
+    const cartoony = {
+      ...clean,
+      roughness: ROUGHNESS.cartoonist,
+    } as ExcalidrawElement;
+
+    const cleanCoords = getElementAbsoluteCoords(clean, arrayToMap([clean]));
+    const cartoonyCoords = getElementAbsoluteCoords(
+      cartoony,
+      arrayToMap([cartoony]),
+    );
+    expect(cleanCoords).toEqual(cartoonyCoords);
   });
 });
 

--- a/packages/element/tests/linearElementEditor.test.tsx
+++ b/packages/element/tests/linearElementEditor.test.tsx
@@ -1315,7 +1315,7 @@ describe("Test Linear Elements", () => {
           20,
           105,
           80,
-          "55.45894",
+          55,
           45,
         ]
       `);
@@ -1326,7 +1326,7 @@ describe("Test Linear Elements", () => {
         .toMatchInlineSnapshot(`
           {
             "height": 130,
-            "width": "366.11716",
+            "width": 370,
           }
         `);
 
@@ -1338,7 +1338,7 @@ describe("Test Linear Elements", () => {
         ),
       ).toMatchInlineSnapshot(`
         {
-          "x": "271.11716",
+          "x": 275,
           "y": 45,
         }
       `);
@@ -1355,9 +1355,9 @@ describe("Test Linear Elements", () => {
         [
           20,
           35,
-          "501.11716",
+          505,
           95,
-          "205.45894",
+          205,
           "52.50000",
         ]
       `);

--- a/packages/element/tests/resize.test.tsx
+++ b/packages/element/tests/resize.test.tsx
@@ -7,6 +7,7 @@ import {
   getSizeFromPoints,
   reseed,
   arrayToMap,
+  ROUGHNESS,
 } from "@excalidraw/common";
 
 import { API } from "@excalidraw/excalidraw/tests/helpers/api";
@@ -474,6 +475,25 @@ describe("line element", () => {
 
     expect(prevSmallestX - smallestX).toBeCloseTo(10);
     expect(biggestX - prevBiggestX).toBeCloseTo(10);
+  });
+
+  it("ignores roughness when resizing", () => {
+    const clean = UI.createElement("line", {
+      points,
+      roughness: ROUGHNESS.architect,
+    });
+    const cartoony = UI.createElement("line", {
+      points,
+      roughness: ROUGHNESS.cartoonist,
+    });
+
+    UI.resize(clean, "se", [30, 30]);
+    UI.resize(cartoony, "se", [30, 30]);
+
+    expect(clean.x).toBe(cartoony.x);
+    expect(clean.y).toBe(cartoony.y);
+    expect(clean.width).toBe(cartoony.width);
+    expect(clean.height).toBe(cartoony.height);
   });
 });
 

--- a/packages/excalidraw/tests/helpers/ui.ts
+++ b/packages/excalidraw/tests/helpers/ui.ts
@@ -492,6 +492,7 @@ export class UI {
       height: initialHeight = initialWidth,
       angle = 0,
       points: initialPoints,
+      roughness = 0,
     }: {
       position?: number;
       x?: number;
@@ -501,6 +502,7 @@ export class UI {
       height?: number;
       angle?: number;
       points?: T extends "line" | "arrow" | "freedraw" ? LocalPoint[] : never;
+      roughness?: number;
     } = {},
   ): Element<T> & {
     /** Returns the actual, current element from the elements array, instead
@@ -554,6 +556,12 @@ export class UI {
     if (angle !== 0) {
       act(() => {
         h.app.scene.mutateElement(origElement, { angle });
+      });
+    }
+
+    if (roughness !== 0) {
+      act(() => {
+        h.app.scene.mutateElement(origElement, { roughness });
       });
     }
 


### PR DESCRIPTION
## Issue

Sloppiness & randomness affects the snapping of linear elements, which makes it difficult to use artist & cartoonist when using snapping. I wanted to draw linear elements aligned to a grid, and it's impossible to do without using architect sloppiness (unless you never move or resize the elements at all).

## Fix

I fixed this by changing linear elements' bounds & absolute coords calculations to be based on the element's points instead of real curve, to make the calculation consistent with how basic shapes' (rectangles, circles, diamonds) bounds are calculated (and how freedraw would, if its stroke had a sloppiness setting).

I added 2 visual functions for the few cases that do care about visual bounds:

- `getElementAbsoluteVisualCoords`
- `getResizedElementAbsoluteVisualCoords`

And used them in `renderElement.ts` and `cropElement.ts`.

## Updated tests

There were 2 tests that expected a curved arrow's bounds to include the curve. This is no longer the case, so the 2 tests' expectations have been updated accordingly.

- `getElementBounds > curved line`
- Multiple parts of `Test Linear Elements > Test bound text element > should resize and position the bound text and bounding box correctly when 3 pointer arrow element resized`
  - Expected absolute coords before resize
  - Expected dimensions after resize
  - Expected position of bound text
  - Expected absolute coords after resize
  
## Added tests

- `getElementAbsoluteCoords > ignores roughness`
- `getElementAbsoluteVisualCoords > takes roughness into account`
- `getElementBounds > ignores roughness`
- `line element > ignores roughness when resizing`
  - Unsure whether should test `getResizedElementAbsoluteCoords` directly instead. There weren't any existing tests for that function.

Additionally, edited `UI.createElement` to support roughness, to enable `line element > ignores roughness when resizing` test.