### PR TITLE
docs: add Code of Conduct

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,131 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances
+  of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards
+of acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned with this Code of Conduct, and will communicate moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by opening a new issue at
+https://github.com/excalidraw/excalidraw/issues and marking it as a
+"Code of Conduct" report, or by contacting the Excalidraw maintainers directly.
+All reports will be handled confidentially and reviewed promptly by the
+maintainers, who are committed to responding within one week.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action that they deem in violation of this Code of
+Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction is allowed with the people involved, including unsolicited
+engagement with those enforcing the Code of Conduct. This includes avoiding
+interactions in community spaces as well as external channels like social
+media. This behavior continues to be a Code of Conduct violation.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including any
+behavior or conduct that a community leader has determined is inappropriate for
+the project.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period. No public or private
+interaction with the people involved, including unsolicited engagement with
+those enforcing the Code of Conduct, is allowed during the ban period. This
+behavior continues to be a Code of Conduct violation.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of harassment, or other conduct
+that a community leader determines is detrimental to the health of the
+community.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this document, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ].
+
+[endership]: https://www.contributor-covenant.org
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq


### PR DESCRIPTION
Refs #6859

Adds a Contributor Covenant v2.1 CODE_OF_CONDUCT.md in .github/ .

Resolves the long-open issue in #6859. As noted on the earlier attempt in #7074, a blocker there was an enforcement contact/mailing address; this version uses the public issue tracker (https://github.com/excalidraw/excalidraw/issues) as the reporting path so it does not block on a private email. Maintainer reports can be handled confidentially.

Happy to switch to a dedicated email if the team prefers.