### PR TITLE
docs: add SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,46 @@
+# Security Policy
+
+## Supported Versions
+
+The latest release of Excalidraw is supported with security updates.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| latest  | :white_check_mark: |
+| < latest | :x:               |
+
+## Reporting a Vulnerability
+
+We take security vulnerabilities seriously and appreciate your efforts to
+disclose them responsibly.
+
+**Please do not open a public issue for security vulnerabilities.**
+
+To report a vulnerability, use GitHub's **"Report a vulnerability"** feature
+(the "Security" tab above the file list), which opens a private, secure channel
+visible only to the repository's security advisors. If that feature is not
+available to you, please open a **private** issue in this repository and mark
+it as confidential.
+
+When reporting, please include:
+
+- A description of the vulnerability and the potential impact.
+- Steps to reproduce (proof of concept).
+- Any suggested fix or mitigation.
+
+### Response Timeline
+
+- We will acknowledge your report within **48 hours**.
+- We will provide a first assessment within **7 days**.
+- We will keep you informed of the fix and release timeline.
+
+## Out of Scope
+
+The following are generally considered out of scope and **will not** receive a
+bounty or be treated as a vulnerability under this policy:
+
+- Theoretical vulnerabilities (e.g. "a malicious actor could craft a request").
+- Issues that require a man-in-the-middle position or a compromised host.
+- Vulnerabilities in third-party libraries that are not part of this
+  repository's pinned versions.
+- Missing security best practices that do not directly lead to a vulnerability.


### PR DESCRIPTION
﻿Closes #11832

Adds a standard SECURITY.md as requested in #11832. Uses GitHub's built-in private "Report a vulnerability" channel as the primary reporting mechanism (no private email needed). Build-free governance PR, pairs with the Code of Conduct added in #11831.
