### PR TITLE
fix(editor): do not swallow taps that interrupt menu scroll animation on iOS

### DIFF
--- a/packages/excalidraw/components/dropdownMenu/DropdownMenu.test.tsx
+++ b/packages/excalidraw/components/dropdownMenu/DropdownMenu.test.tsx
@@ -11,6 +11,19 @@ import {
   fireEvent,
 } from "../../tests/test-utils";
 
+const openMainMenu = async (container: HTMLElement) => {
+  fireEvent.click(getByTestId(container, "main-menu-trigger"));
+  expect(window.h.state.openMenu).toBe("canvas");
+  await waitFor(() => {
+    expect(
+      document.querySelector('[data-testid="search-menu-button"]'),
+    ).not.toBeNull();
+  });
+};
+
+const getSearchMenuItem = () =>
+  document.querySelector<HTMLElement>('[data-testid="search-menu-button"]')!;
+
 describe("Test <DropdownMenu/>", () => {
   it("should", async () => {
     const { container } = await render(<Excalidraw />);
@@ -23,6 +36,110 @@ describe("Test <DropdownMenu/>", () => {
     await waitFor(() => {
       Keyboard.keyDown(KEYS.ESCAPE);
       expect(window.h.state.openMenu).toBe(null);
+    });
+  });
+
+  describe("tap during scroll animation (issue #9204)", () => {
+    const pointerEventInit = {
+      pointerType: "touch",
+      isPrimary: true,
+      button: 0,
+      clientX: 10,
+      clientY: 10,
+    } as const;
+
+    it("activates the item when the browser suppresses the click (iOS momentum/rubber-band scroll)", async () => {
+      const { container } = await render(<Excalidraw />);
+      await openMainMenu(container);
+
+      const item = getSearchMenuItem();
+      const onClickSpy = vi.fn();
+      item.addEventListener("click", onClickSpy);
+
+      // Simulate iOS: a tap (pointer down/up without movement) whose `click`
+      // event the browser suppresses because it interrupted a scroll animation.
+      fireEvent.pointerDown(item, pointerEventInit);
+      fireEvent.pointerUp(item, pointerEventInit);
+
+      // The tap should still activate the item (menu closes) via the fallback.
+      await waitFor(() => {
+        expect(window.h.state.openMenu).toBe(null);
+      });
+
+      // exactly one click was replayed — no duplicates
+      expect(onClickSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not double-activate when the native click is delivered", async () => {
+      const { container } = await render(<Excalidraw />);
+      await openMainMenu(container);
+
+      const item = getSearchMenuItem();
+      const onClickSpy = vi.fn();
+      item.addEventListener("click", onClickSpy);
+
+      // Settled menu: pointer up is followed by the native click.
+      fireEvent.pointerDown(item, pointerEventInit);
+      fireEvent.pointerUp(item, pointerEventInit);
+      fireEvent.click(item);
+
+      await waitFor(() => {
+        expect(window.h.state.openMenu).toBe(null);
+      });
+
+      // the native click wins and the fallback is cancelled
+      expect(onClickSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not activate items when the pointer moved (real drag/scroll)", async () => {
+      const { container } = await render(<Excalidraw />);
+      await openMainMenu(container);
+
+      const item = getSearchMenuItem();
+      const onClickSpy = vi.fn();
+      item.addEventListener("click", onClickSpy);
+
+      fireEvent.pointerDown(item, pointerEventInit);
+      // drag beyond the dragging threshold
+      fireEvent.pointerMove(item, {
+        ...pointerEventInit,
+        clientX: 10,
+        clientY: 60,
+      });
+      fireEvent.pointerUp(item, { ...pointerEventInit, clientY: 60 });
+
+      // let any (incorrectly scheduled) fallback fire
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      expect(onClickSpy).not.toHaveBeenCalled();
+      expect(window.h.state.openMenu).toBe("canvas");
+    });
+
+    it("keeps working for regular mouse clicks", async () => {
+      const { container } = await render(<Excalidraw />);
+      await openMainMenu(container);
+
+      const item = getSearchMenuItem();
+
+      fireEvent.pointerDown(item, {
+        pointerType: "mouse",
+        isPrimary: true,
+        button: 0,
+        clientX: 10,
+        clientY: 10,
+      });
+      fireEvent.pointerUp(item, {
+        pointerType: "mouse",
+        isPrimary: true,
+        button: 0,
+        clientX: 10,
+        clientY: 10,
+      });
+      fireEvent.click(item);
+
+      await waitFor(() => {
+        expect(window.h.state.openMenu).toBe(null);
+      });
     });
   });
 });

--- a/packages/excalidraw/components/dropdownMenu/DropdownMenu.test.tsx
+++ b/packages/excalidraw/components/dropdownMenu/DropdownMenu.test.tsx
@@ -48,7 +48,7 @@ describe("Test <DropdownMenu/>", () => {
       clientY: 10,
     } as const;
 
-    it("activates the item when the browser suppresses the click (iOS momentum/rubber-band scroll)", async () => {
+    it("activates the item when no native click follows the tap", async () => {
       const { container } = await render(<Excalidraw />);
       await openMainMenu(container);
 
@@ -56,12 +56,13 @@ describe("Test <DropdownMenu/>", () => {
       const onClickSpy = vi.fn();
       item.addEventListener("click", onClickSpy);
 
-      // Simulate iOS: a tap (pointer down/up without movement) whose `click`
-      // event the browser suppresses because it interrupted a scroll animation.
+      // Simulate the event sequence produced on iOS when a tap interrupts a
+      // scroll animation: pointer down/up are delivered but the browser does
+      // not dispatch a `click` (WebKit suppresses it). The fallback should
+      // replay the click so the item activates.
       fireEvent.pointerDown(item, pointerEventInit);
       fireEvent.pointerUp(item, pointerEventInit);
 
-      // The tap should still activate the item (menu closes) via the fallback.
       await waitFor(() => {
         expect(window.h.state.openMenu).toBe(null);
       });
@@ -89,6 +90,30 @@ describe("Test <DropdownMenu/>", () => {
 
       // the native click wins and the fallback is cancelled
       expect(onClickSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not re-run the action when a native click arrives after the fallback fired", async () => {
+      const { container } = await render(<Excalidraw />);
+      await openMainMenu(container);
+
+      const item = getSearchMenuItem();
+
+      // tap without a native click → fallback activates the item and closes
+      // the menu (action ran exactly once)
+      fireEvent.pointerDown(item, pointerEventInit);
+      fireEvent.pointerUp(item, pointerEventInit);
+
+      await waitFor(() => {
+        expect(window.h.state.openMenu).toBe(null);
+      });
+
+      // a late native click (as if the browser finally delivered it) must not
+      // re-run the action — the menu stays closed
+      fireEvent.click(item);
+
+      await waitFor(() => {
+        expect(window.h.state.openMenu).toBe(null);
+      });
     });
 
     it("does not activate items when the pointer moved (real drag/scroll)", async () => {

--- a/packages/excalidraw/components/dropdownMenu/DropdownMenu.test.tsx
+++ b/packages/excalidraw/components/dropdownMenu/DropdownMenu.test.tsx
@@ -92,30 +92,6 @@ describe("Test <DropdownMenu/>", () => {
       expect(onClickSpy).toHaveBeenCalledTimes(1);
     });
 
-    it("does not re-run the action when a native click arrives after the fallback fired", async () => {
-      const { container } = await render(<Excalidraw />);
-      await openMainMenu(container);
-
-      const item = getSearchMenuItem();
-
-      // tap without a native click → fallback activates the item and closes
-      // the menu (action ran exactly once)
-      fireEvent.pointerDown(item, pointerEventInit);
-      fireEvent.pointerUp(item, pointerEventInit);
-
-      await waitFor(() => {
-        expect(window.h.state.openMenu).toBe(null);
-      });
-
-      // a late native click (as if the browser finally delivered it) must not
-      // re-run the action — the menu stays closed
-      fireEvent.click(item);
-
-      await waitFor(() => {
-        expect(window.h.state.openMenu).toBe(null);
-      });
-    });
-
     it("does not activate items when the pointer moved (real drag/scroll)", async () => {
       const { container } = await render(<Excalidraw />);
       await openMainMenu(container);

--- a/packages/excalidraw/components/dropdownMenu/DropdownMenuContent.tsx
+++ b/packages/excalidraw/components/dropdownMenu/DropdownMenuContent.tsx
@@ -5,6 +5,7 @@ import { CLASSES, EVENT, KEYS } from "@excalidraw/common";
 
 import { DropdownMenu as DropdownMenuPrimitive } from "radix-ui";
 
+import { useTapClickFallback } from "../../hooks/useTapClickFallback";
 import { useOutsideClick } from "../../hooks/useOutsideClick";
 import { useStable } from "../../hooks/useStable";
 import { useEditorInterface } from "../App";
@@ -35,6 +36,18 @@ const MenuContent = ({
 }) => {
   const editorInterface = useEditorInterface();
   const menuRef = useRef<HTMLDivElement>(null);
+
+  // recover taps whose `click` got suppressed by an in-flight scroll animation
+  // (momentum / rubber-band on iOS) — see issue #9204
+  const tapClickFallbackRef = useTapClickFallback<HTMLDivElement>();
+
+  const setMenuRefs = useCallback(
+    (node: HTMLDivElement | null) => {
+      menuRef.current = node;
+      tapClickFallbackRef(node);
+    },
+    [tapClickFallbackRef],
+  );
 
   const callbacksRef = useStable({ onClickOutside });
 
@@ -86,7 +99,7 @@ const MenuContent = ({
   return (
     <DropdownMenuContentPropsContext.Provider value={{ onSelect }}>
       <DropdownMenuPrimitive.Content
-        ref={menuRef}
+        ref={setMenuRefs}
         className={classNames}
         style={style}
         data-testid="dropdown-menu"

--- a/packages/excalidraw/components/dropdownMenu/DropdownMenuSubContent.tsx
+++ b/packages/excalidraw/components/dropdownMenu/DropdownMenuSubContent.tsx
@@ -4,6 +4,7 @@ import { DropdownMenu as DropdownMenuPrimitive } from "radix-ui";
 
 import { useCallback, useState } from "react";
 
+import { useTapClickFallback } from "../../hooks/useTapClickFallback";
 import { useEditorInterface } from "../App";
 import { Island } from "../Island";
 import Stack from "../Stack";
@@ -20,26 +21,34 @@ const DropdownMenuSubContent = ({
 }) => {
   const editorInterface = useEditorInterface();
 
+  // recover taps whose `click` got suppressed by an in-flight scroll animation
+  // (momentum / rubber-band on iOS) — see issue #9204
+  const tapClickFallbackRef = useTapClickFallback<HTMLDivElement>();
+
   const classNames = clsx(`dropdown-menu dropdown-submenu ${className}`, {
     "dropdown-menu--mobile": editorInterface.formFactor === "phone",
   }).trim();
 
-  const callbacksRef = useCallback((node: HTMLDivElement | null) => {
-    if (node) {
-      const parentContainer = node.closest(".dropdown-menu-container");
-      const parentRect = parentContainer?.getBoundingClientRect();
-      if (parentRect) {
-        const menuWidth = node.getBoundingClientRect().width;
+  const callbacksRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      tapClickFallbackRef(node);
+      if (node) {
+        const parentContainer = node.closest(".dropdown-menu-container");
+        const parentRect = parentContainer?.getBoundingClientRect();
+        if (parentRect) {
+          const menuWidth = node.getBoundingClientRect().width;
 
-        const viewportWidth = window.innerWidth;
-        const spaceRemaining = viewportWidth - parentRect.right;
-        if (spaceRemaining < menuWidth + 20) {
-          setSideOffset(spaceRemaining - menuWidth + BASE_ALIGN_OFFSET);
-          setAlignOffset(BASE_ALIGN_OFFSET + 8);
+          const viewportWidth = window.innerWidth;
+          const spaceRemaining = viewportWidth - parentRect.right;
+          if (spaceRemaining < menuWidth + 20) {
+            setSideOffset(spaceRemaining - menuWidth + BASE_ALIGN_OFFSET);
+            setAlignOffset(BASE_ALIGN_OFFSET + 8);
+          }
         }
       }
-    }
-  }, []);
+    },
+    [tapClickFallbackRef],
+  );
 
   const [sideOffset, setSideOffset] = useState(BASE_SIDE_OFFSET);
   const [alignOffset, setAlignOffset] = useState(BASE_ALIGN_OFFSET);

--- a/packages/excalidraw/hooks/useTapClickFallback.test.tsx
+++ b/packages/excalidraw/hooks/useTapClickFallback.test.tsx
@@ -16,10 +16,12 @@ const TOUCH_POINTER = {
 
 const Harness = ({
   onButtonClick,
+  onSecondButtonClick,
   disabled = false,
   onNonInteractiveClick,
 }: {
   onButtonClick: () => void;
+  onSecondButtonClick?: () => void;
   disabled?: boolean;
   onNonInteractiveClick?: () => void;
 }) => {
@@ -35,6 +37,9 @@ const Harness = ({
       >
         button
       </button>
+      <button type="button" data-testid="btn-2" onClick={onSecondButtonClick}>
+        button 2
+      </button>
       <div data-testid="non-interactive" onClick={onNonInteractiveClick}>
         not interactive
       </div>
@@ -44,6 +49,8 @@ const Harness = ({
 
 const getBtn = () =>
   document.querySelector<HTMLButtonElement>('[data-testid="btn"]')!;
+const getSecondBtn = () =>
+  document.querySelector<HTMLButtonElement>('[data-testid="btn-2"]')!;
 const getNonInteractive = () =>
   document.querySelector<HTMLElement>('[data-testid="non-interactive"]')!;
 
@@ -139,6 +146,42 @@ describe("useTapClickFallback", () => {
     unmount();
   });
 
+  it("does not activate when pointerup is far from pointerdown even without a pointermove", async () => {
+    const onClick = vi.fn();
+    const { unmount } = render(<Harness onButtonClick={onClick} />);
+
+    // no pointermove is delivered, but the pointerup coordinates show the
+    // pointer moved well beyond the threshold
+    fireEvent.pointerDown(getBtn(), TOUCH_POINTER);
+    fireEvent.pointerUp(getBtn(), { ...TOUCH_POINTER, clientY: 60 });
+    await flushFallbackTimer();
+
+    expect(onClick).not.toHaveBeenCalled();
+
+    unmount();
+  });
+
+  it("does not activate when pointerdown and pointerup are on different interactive elements", async () => {
+    const onClick = vi.fn();
+    const onSecondButtonClick = vi.fn();
+    const { unmount } = render(
+      <Harness
+        onButtonClick={onClick}
+        onSecondButtonClick={onSecondButtonClick}
+      />,
+    );
+
+    // slide from button 1 to button 2 within the tap threshold
+    fireEvent.pointerDown(getBtn(), TOUCH_POINTER);
+    fireEvent.pointerUp(getSecondBtn(), TOUCH_POINTER);
+    await flushFallbackTimer();
+
+    expect(onClick).not.toHaveBeenCalled();
+    expect(onSecondButtonClick).not.toHaveBeenCalled();
+
+    unmount();
+  });
+
   it("ignores non-touch pointers (mouse/trackpad/pen are left alone)", async () => {
     const onClick = vi.fn();
     const { unmount } = render(<Harness onButtonClick={onClick} />);
@@ -214,6 +257,28 @@ describe("useTapClickFallback", () => {
     unmount();
   });
 
+  it("disarms the latch on a new pointerdown on another element", async () => {
+    const onClick = vi.fn();
+    const onSecondButtonClick = vi.fn();
+    const { unmount } = render(
+      <Harness
+        onButtonClick={onClick}
+        onSecondButtonClick={onSecondButtonClick}
+      />,
+    );
+
+    tap(getBtn());
+    await waitFor(() => expect(onClick).toHaveBeenCalledTimes(1));
+
+    // a new pointer interaction on a different element must disarm the old
+    // latch, so a subsequent legitimate click on the old target is not eaten
+    fireEvent.pointerDown(getSecondBtn(), TOUCH_POINTER);
+    fireEvent.click(getBtn());
+    expect(onClick).toHaveBeenCalledTimes(2);
+
+    unmount();
+  });
+
   it("disarms the latch on keydown (keyboard activation not swallowed)", async () => {
     const onClick = vi.fn();
     const { unmount } = render(<Harness onButtonClick={onClick} />);
@@ -227,6 +292,22 @@ describe("useTapClickFallback", () => {
       '[data-testid="container"]',
     )!;
     fireEvent.keyDown(container, { key: "Enter" });
+    fireEvent.click(getBtn());
+    expect(onClick).toHaveBeenCalledTimes(2);
+
+    unmount();
+  });
+
+  it("expires the latch so later legitimate clicks are never swallowed", async () => {
+    const onClick = vi.fn();
+    const { unmount } = render(<Harness onButtonClick={onClick} />);
+
+    tap(getBtn());
+    await waitFor(() => expect(onClick).toHaveBeenCalledTimes(1));
+
+    // wait past the latch's short self-expiry window
+    await new Promise((resolve) => setTimeout(resolve, 300));
+
     fireEvent.click(getBtn());
     expect(onClick).toHaveBeenCalledTimes(2);
 

--- a/packages/excalidraw/hooks/useTapClickFallback.test.tsx
+++ b/packages/excalidraw/hooks/useTapClickFallback.test.tsx
@@ -1,0 +1,235 @@
+import "pepjs";
+
+import React from "react";
+
+import { fireEvent, render, waitFor } from "@testing-library/react";
+
+import { useTapClickFallback } from "./useTapClickFallback";
+
+const TOUCH_POINTER = {
+  pointerType: "touch",
+  isPrimary: true,
+  button: 0,
+  clientX: 10,
+  clientY: 10,
+} as const;
+
+const Harness = ({
+  onButtonClick,
+  disabled = false,
+  onNonInteractiveClick,
+}: {
+  onButtonClick: () => void;
+  disabled?: boolean;
+  onNonInteractiveClick?: () => void;
+}) => {
+  const containerRef = useTapClickFallback<HTMLDivElement>();
+
+  return (
+    <div ref={containerRef} data-testid="container">
+      <button
+        type="button"
+        data-testid="btn"
+        disabled={disabled}
+        onClick={onButtonClick}
+      >
+        button
+      </button>
+      <div data-testid="non-interactive" onClick={onNonInteractiveClick}>
+        not interactive
+      </div>
+    </div>
+  );
+};
+
+const getBtn = () =>
+  document.querySelector<HTMLButtonElement>('[data-testid="btn"]')!;
+const getNonInteractive = () =>
+  document.querySelector<HTMLElement>('[data-testid="non-interactive"]')!;
+
+const tap = (element: HTMLElement) => {
+  fireEvent.pointerDown(element, TOUCH_POINTER);
+  fireEvent.pointerUp(element, TOUCH_POINTER);
+};
+
+const flushFallbackTimer = () =>
+  new Promise((resolve) => setTimeout(resolve, 50));
+
+describe("useTapClickFallback", () => {
+  it("replays the click when the browser suppresses it and swallows a late native click", async () => {
+    const onClick = vi.fn();
+    const { unmount } = render(<Harness onButtonClick={onClick} />);
+
+    // touch tap without a native click (the event sequence produced on iOS
+    // when the tap interrupts a scroll animation)
+    tap(getBtn());
+
+    // fallback fires after one event-loop turn
+    await waitFor(() => expect(onClick).toHaveBeenCalledTimes(1));
+
+    // a late native click arriving after the fallback must be swallowed —
+    // the button must not be activated a second time
+    fireEvent.click(getBtn());
+    expect(onClick).toHaveBeenCalledTimes(1);
+
+    unmount();
+  });
+
+  it("lets the native click win when it arrives before the fallback", async () => {
+    const onClick = vi.fn();
+    const { unmount } = render(<Harness onButtonClick={onClick} />);
+
+    tap(getBtn());
+    // native click arrives right after pointerup (settled menu)
+    fireEvent.click(getBtn());
+    expect(onClick).toHaveBeenCalledTimes(1);
+
+    await flushFallbackTimer();
+    expect(onClick).toHaveBeenCalledTimes(1);
+
+    unmount();
+  });
+
+  it("does not activate disabled controls", async () => {
+    const onClick = vi.fn();
+    const { unmount } = render(<Harness onButtonClick={onClick} disabled />);
+
+    tap(getBtn());
+    await flushFallbackTimer();
+
+    expect(onClick).not.toHaveBeenCalled();
+
+    unmount();
+  });
+
+  it("does not activate non-interactive elements", async () => {
+    const onClick = vi.fn();
+    const onNonInteractiveClick = vi.fn();
+    const { unmount } = render(
+      <Harness
+        onButtonClick={onClick}
+        onNonInteractiveClick={onNonInteractiveClick}
+      />,
+    );
+
+    tap(getNonInteractive());
+    await flushFallbackTimer();
+
+    expect(onNonInteractiveClick).not.toHaveBeenCalled();
+
+    unmount();
+  });
+
+  it("does not activate when the pointer moved (real drag/scroll)", async () => {
+    const onClick = vi.fn();
+    const { unmount } = render(<Harness onButtonClick={onClick} />);
+
+    fireEvent.pointerDown(getBtn(), TOUCH_POINTER);
+    // drag beyond the dragging threshold
+    fireEvent.pointerMove(getBtn(), {
+      ...TOUCH_POINTER,
+      clientX: 10,
+      clientY: 60,
+    });
+    fireEvent.pointerUp(getBtn(), { ...TOUCH_POINTER, clientY: 60 });
+    await flushFallbackTimer();
+
+    expect(onClick).not.toHaveBeenCalled();
+
+    unmount();
+  });
+
+  it("ignores non-touch pointers (mouse/trackpad/pen are left alone)", async () => {
+    const onClick = vi.fn();
+    const { unmount } = render(<Harness onButtonClick={onClick} />);
+
+    fireEvent.pointerDown(getBtn(), {
+      pointerType: "mouse",
+      isPrimary: true,
+      button: 0,
+      clientX: 10,
+      clientY: 10,
+    });
+    fireEvent.pointerUp(getBtn(), {
+      pointerType: "mouse",
+      isPrimary: true,
+      button: 0,
+      clientX: 10,
+      clientY: 10,
+    });
+    await flushFallbackTimer();
+
+    // no fallback for mouse; a regular mouse click still works
+    expect(onClick).not.toHaveBeenCalled();
+    fireEvent.click(getBtn());
+    expect(onClick).toHaveBeenCalledTimes(1);
+
+    unmount();
+  });
+
+  it("cleans up after pointercancel and keeps working", async () => {
+    const onClick = vi.fn();
+    const { unmount } = render(<Harness onButtonClick={onClick} />);
+
+    fireEvent.pointerDown(getBtn(), TOUCH_POINTER);
+    fireEvent.pointerCancel(getBtn(), TOUCH_POINTER);
+    await flushFallbackTimer();
+
+    expect(onClick).not.toHaveBeenCalled();
+
+    // no stale state: a subsequent normal click still works
+    fireEvent.click(getBtn());
+    expect(onClick).toHaveBeenCalledTimes(1);
+
+    unmount();
+  });
+
+  it("does not leave timers or listeners behind after unmount", async () => {
+    const onClick = vi.fn();
+    const { unmount } = render(<Harness onButtonClick={onClick} />);
+
+    fireEvent.pointerDown(getBtn(), TOUCH_POINTER);
+    unmount();
+    await flushFallbackTimer();
+
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it("disarms the latch on a new tap of the same element", async () => {
+    const onClick = vi.fn();
+    const { unmount } = render(<Harness onButtonClick={onClick} />);
+
+    tap(getBtn());
+    await waitFor(() => expect(onClick).toHaveBeenCalledTimes(1));
+
+    // a new deliberate tap on the same element: its native click must not be
+    // swallowed by the previous gesture's latch
+    tap(getBtn());
+    fireEvent.click(getBtn());
+    expect(onClick).toHaveBeenCalledTimes(2);
+
+    await flushFallbackTimer();
+    expect(onClick).toHaveBeenCalledTimes(2);
+
+    unmount();
+  });
+
+  it("disarms the latch on keydown (keyboard activation not swallowed)", async () => {
+    const onClick = vi.fn();
+    const { unmount } = render(<Harness onButtonClick={onClick} />);
+
+    tap(getBtn());
+    await waitFor(() => expect(onClick).toHaveBeenCalledTimes(1));
+
+    // keyboard activation dispatches a click without a pointerdown — the
+    // keydown must disarm the latch so the click is not swallowed
+    const container = document.querySelector<HTMLElement>(
+      '[data-testid="container"]',
+    )!;
+    fireEvent.keyDown(container, { key: "Enter" });
+    fireEvent.click(getBtn());
+    expect(onClick).toHaveBeenCalledTimes(2);
+
+    unmount();
+  });
+});

--- a/packages/excalidraw/hooks/useTapClickFallback.ts
+++ b/packages/excalidraw/hooks/useTapClickFallback.ts
@@ -1,0 +1,188 @@
+import { useCallback, useEffect, useState } from "react";
+
+import { DRAGGING_THRESHOLD } from "@excalidraw/common";
+
+type TapGesture = {
+  x: number;
+  y: number;
+  moved: boolean;
+  /** the element the tap ended on (hit-tested by the browser) */
+  target: Element | null;
+  fallbackTimer: number | null;
+  /** whether a native click was delivered before the fallback timer ran */
+  nativeClickFired: boolean;
+  /** whether we already replayed the click ourselves */
+  fallbackFired: boolean;
+  /** set while we're dispatching our own synthetic click */
+  dispatchingFallback: boolean;
+};
+
+/**
+ * Recovers "ghost clicks" in scrollable menus on iOS (iPad/iPhone).
+ *
+ * When a tap interrupts an active scroll animation (momentum scroll or the
+ * rubber-band/elastic overscroll at the edges), WebKit deliberately suppresses
+ * the resulting `click` event so the tap is treated as "stop the scroll" and
+ * not as an activation (see https://github.com/WebKit/WebKit/commit/21aada2).
+ * Because Radix menu items are activated via `click`, the tap is silently
+ * dropped even though the menu item is already visible under the finger —
+ * the user has to wait for the scroll to settle and tap again.
+ *
+ * This hook observes pointer events inside the menu and, when a tap (pointer
+ * up without significant movement) does not produce a native `click` within a
+ * single event-loop turn, replays one click on the tapped element so the menu
+ * item activates as intended.
+ *
+ * Safety properties:
+ * - Real drags (movement > `DRAGGING_THRESHOLD`) never activate.
+ * - When the browser delivers the native click (mouse, trackpad, settled
+ *   touch), it wins: the fallback is cancelled, so there is no double
+ *   activation and existing behavior is unchanged.
+ * - If the fallback fires and a late native click still arrives, the native
+ *   click is swallowed to avoid activating the item twice.
+ * - Keyboard navigation is untouched (no pointer events involved).
+ */
+export const useTapClickFallback = <T extends HTMLElement>() => {
+  const [element, setElement] = useState<T | null>(null);
+  const elementRef = useCallback((node: T | null) => setElement(node), []);
+
+  useEffect(() => {
+    if (!element) {
+      return;
+    }
+
+    let gesture: TapGesture | null = null;
+
+    const clearFallbackTimer = () => {
+      if (gesture?.fallbackTimer != null) {
+        window.clearTimeout(gesture.fallbackTimer);
+        gesture.fallbackTimer = null;
+      }
+    };
+
+    const reset = () => {
+      clearFallbackTimer();
+      gesture = null;
+    };
+
+    const onPointerDown = (event: PointerEvent) => {
+      if (event.isPrimary === false) {
+        return;
+      }
+      if (event.pointerType === "mouse" && event.button !== 0) {
+        return;
+      }
+
+      reset();
+      gesture = {
+        x: event.clientX,
+        y: event.clientY,
+        moved: false,
+        target: event.target instanceof Element ? event.target : null,
+        fallbackTimer: null,
+        nativeClickFired: false,
+        fallbackFired: false,
+        dispatchingFallback: false,
+      };
+    };
+
+    const onPointerMove = (event: PointerEvent) => {
+      if (!gesture || gesture.moved) {
+        return;
+      }
+      const dx = event.clientX - gesture.x;
+      const dy = event.clientY - gesture.y;
+      if (Math.hypot(dx, dy) > DRAGGING_THRESHOLD) {
+        gesture.moved = true;
+      }
+    };
+
+    const onPointerUp = (event: PointerEvent) => {
+      if (!gesture || gesture.moved) {
+        return;
+      }
+      if (event.isPrimary === false) {
+        return;
+      }
+      if (event.pointerType === "mouse" && event.button !== 0) {
+        return;
+      }
+
+      // `pointerup` target is hit-tested by the browser, i.e. the element the
+      // finger/cursor was over when released — exactly the element the browser
+      // would have clicked (and whose click it may have suppressed).
+      const target =
+        event.target instanceof Element ? event.target : gesture.target;
+      gesture.target = target;
+      if (!target || !element.contains(target)) {
+        reset();
+        return;
+      }
+
+      // The browser may deliver the native click right after this event (the
+      // menu settled) or suppress it (the tap interrupted a scroll animation).
+      // Give the native click a single event-loop turn to arrive; if it
+      // doesn't, replay the click ourselves.
+      gesture.fallbackTimer = window.setTimeout(() => {
+        // note: `gesture` may be nulled out by the effect cleanup if the menu
+        // closes synchronously while replaying the click below, so capture the
+        // gesture in a local variable first
+        const currentGesture = gesture;
+        if (!currentGesture) {
+          return;
+        }
+        const { nativeClickFired, target: tapTarget } = currentGesture;
+        if (!nativeClickFired && tapTarget instanceof HTMLElement) {
+          currentGesture.fallbackFired = true;
+          currentGesture.dispatchingFallback = true;
+          // Click the closest anchor when present so that its default
+          // navigation behavior runs, otherwise the tapped element itself
+          // (the click bubbles up to the containing menu item).
+          const clickTarget =
+            (tapTarget.closest("a[href]") as HTMLElement | null) ?? tapTarget;
+          clickTarget.click();
+          currentGesture.dispatchingFallback = false;
+        }
+        reset();
+      }, 0);
+    };
+
+    const onPointerCancel = () => {
+      reset();
+    };
+
+    // Swallow a native click that arrives after we already replayed the click
+    // (otherwise the menu item would be activated twice).
+    const onClickCapture = (event: MouseEvent) => {
+      if (!gesture || gesture.dispatchingFallback) {
+        return;
+      }
+      if (!element.contains(event.target as Node)) {
+        return;
+      }
+      if (gesture.fallbackFired) {
+        event.preventDefault();
+        event.stopPropagation();
+      } else {
+        gesture.nativeClickFired = true;
+      }
+    };
+
+    element.addEventListener("pointerdown", onPointerDown, true);
+    element.addEventListener("pointermove", onPointerMove, true);
+    element.addEventListener("pointerup", onPointerUp, true);
+    element.addEventListener("pointercancel", onPointerCancel, true);
+    element.addEventListener("click", onClickCapture, true);
+
+    return () => {
+      reset();
+      element.removeEventListener("pointerdown", onPointerDown, true);
+      element.removeEventListener("pointermove", onPointerMove, true);
+      element.removeEventListener("pointerup", onPointerUp, true);
+      element.removeEventListener("pointercancel", onPointerCancel, true);
+      element.removeEventListener("click", onClickCapture, true);
+    };
+  }, [element]);
+
+  return elementRef;
+};

--- a/packages/excalidraw/hooks/useTapClickFallback.ts
+++ b/packages/excalidraw/hooks/useTapClickFallback.ts
@@ -17,30 +17,66 @@ type TapGesture = {
   dispatchingFallback: boolean;
 };
 
+/** elements a replayed click is allowed to activate */
+const ACTIVATABLE_SELECTOR = [
+  "button",
+  "a[href]",
+  "input",
+  "select",
+  "textarea",
+  '[role^="menuitem"]',
+  '[role="button"]',
+  '[role="link"]',
+  '[role="switch"]',
+].join(", ");
+
+const DISABLED_SELECTOR = "[disabled], [aria-disabled='true'], [data-disabled]";
+
 /**
- * Recovers "ghost clicks" in scrollable menus on iOS (iPad/iPhone).
+ * Resolves the element a replayed click should be dispatched on, or `null`
+ * when the tap landed on something that must not be activated (disabled
+ * controls, separators, empty menu space, non-interactive content).
+ */
+const resolveActivationTarget = (target: Element): HTMLElement | null => {
+  const el = target.closest<HTMLElement>(ACTIVATABLE_SELECTOR);
+  if (!el || el.closest(DISABLED_SELECTOR)) {
+    return null;
+  }
+  return el;
+};
+
+/**
+ * Recovers "ghost clicks" in scrollable menus on touch devices (iPad/iPhone).
  *
  * When a tap interrupts an active scroll animation (momentum scroll or the
  * rubber-band/elastic overscroll at the edges), WebKit deliberately suppresses
  * the resulting `click` event so the tap is treated as "stop the scroll" and
- * not as an activation (see https://github.com/WebKit/WebKit/commit/21aada2).
- * Because Radix menu items are activated via `click`, the tap is silently
- * dropped even though the menu item is already visible under the finger —
- * the user has to wait for the scroll to settle and tap again.
+ * not as an activation (documented behavior, see
+ * https://github.com/WebKit/WebKit/commit/21aada2). Because Radix menu items
+ * are activated via `click`, the tap is silently dropped even though the menu
+ * item is already visible under the finger — the user has to wait for the
+ * scroll to settle and tap again.
  *
- * This hook observes pointer events inside the menu and, when a tap (pointer
- * up without significant movement) does not produce a native `click` within a
- * single event-loop turn, replays one click on the tapped element so the menu
- * item activates as intended.
+ * This hook observes pointer events inside the menu and, when a touch tap
+ * (pointer up without significant movement) does not produce a native `click`
+ * within a single event-loop turn, replays one click on the tapped element so
+ * the menu item activates as intended. It never inspects scroll state — it
+ * only reacts to the browser delivering (or not delivering) the `click`.
  *
  * Safety properties:
+ * - Only touch pointers are considered; mouse/trackpad/pen are left alone
+ *   (mouse clicks are dispatched synchronously and can never be suppressed).
+ * - Only interactive, non-disabled elements (`button`, `a[href]`, menu items,
+ *   inputs, etc.) are replayed onto — empty space, separators and other
+ *   non-interactive content are never activated.
  * - Real drags (movement > `DRAGGING_THRESHOLD`) never activate.
- * - When the browser delivers the native click (mouse, trackpad, settled
- *   touch), it wins: the fallback is cancelled, so there is no double
- *   activation and existing behavior is unchanged.
- * - If the fallback fires and a late native click still arrives, the native
- *   click is swallowed to avoid activating the item twice.
- * - Keyboard navigation is untouched (no pointer events involved).
+ * - When the browser delivers the native click (settled menu), it wins: the
+ *   fallback is cancelled, so there is no double activation.
+ * - If the fallback fires and a late native click still arrives, the late
+ *   click is swallowed (event-driven latch) so the item is not activated
+ *   twice; the latch is disarmed by any new pointer interaction or keydown on
+ *   the menu, so subsequent intentional clicks keep working.
+ * - Keyboard navigation is untouched.
  */
 export const useTapClickFallback = <T extends HTMLElement>() => {
   const [element, setElement] = useState<T | null>(null);
@@ -52,6 +88,11 @@ export const useTapClickFallback = <T extends HTMLElement>() => {
     }
 
     let gesture: TapGesture | null = null;
+    // Event-driven latch: after we replay a click, the next native click that
+    // arrives on the same element is the (late) one the browser suppressed —
+    // swallow it so the item isn't activated twice. Deliberately kept outside
+    // the gesture lifecycle: it must survive `reset()`.
+    let swallowTarget: HTMLElement | null = null;
 
     const clearFallbackTimer = () => {
       if (gesture?.fallbackTimer != null) {
@@ -66,10 +107,16 @@ export const useTapClickFallback = <T extends HTMLElement>() => {
     };
 
     const onPointerDown = (event: PointerEvent) => {
-      if (event.isPrimary === false) {
+      // Any new pointer interaction supersedes a pending swallow, so the
+      // following real click is never eaten.
+      if (swallowTarget && swallowTarget.contains(event.target as Node)) {
+        swallowTarget = null;
+      }
+
+      if (event.pointerType !== "touch") {
         return;
       }
-      if (event.pointerType === "mouse" && event.button !== 0) {
+      if (event.isPrimary === false) {
         return;
       }
 
@@ -101,16 +148,16 @@ export const useTapClickFallback = <T extends HTMLElement>() => {
       if (!gesture || gesture.moved) {
         return;
       }
-      if (event.isPrimary === false) {
+      if (event.pointerType !== "touch") {
         return;
       }
-      if (event.pointerType === "mouse" && event.button !== 0) {
+      if (event.isPrimary === false) {
         return;
       }
 
       // `pointerup` target is hit-tested by the browser, i.e. the element the
-      // finger/cursor was over when released — exactly the element the browser
-      // would have clicked (and whose click it may have suppressed).
+      // finger was over when released — exactly the element the browser would
+      // have clicked (and whose click it may have suppressed).
       const target =
         event.target instanceof Element ? event.target : gesture.target;
       gesture.target = target;
@@ -132,16 +179,17 @@ export const useTapClickFallback = <T extends HTMLElement>() => {
           return;
         }
         const { nativeClickFired, target: tapTarget } = currentGesture;
-        if (!nativeClickFired && tapTarget instanceof HTMLElement) {
-          currentGesture.fallbackFired = true;
-          currentGesture.dispatchingFallback = true;
-          // Click the closest anchor when present so that its default
-          // navigation behavior runs, otherwise the tapped element itself
-          // (the click bubbles up to the containing menu item).
-          const clickTarget =
-            (tapTarget.closest("a[href]") as HTMLElement | null) ?? tapTarget;
-          clickTarget.click();
-          currentGesture.dispatchingFallback = false;
+        if (!nativeClickFired && tapTarget) {
+          const clickTarget = resolveActivationTarget(tapTarget);
+          if (clickTarget) {
+            currentGesture.fallbackFired = true;
+            currentGesture.dispatchingFallback = true;
+            clickTarget.click();
+            currentGesture.dispatchingFallback = false;
+            // arm the latch: a late native click on this element must not
+            // activate it a second time
+            swallowTarget = clickTarget;
+          }
         }
         reset();
       }, 0);
@@ -151,19 +199,29 @@ export const useTapClickFallback = <T extends HTMLElement>() => {
       reset();
     };
 
+    const onKeyDown = () => {
+      // a keyboard activation (Enter/Space on a focused item) dispatches a
+      // click without a pointerdown — disarm so it is never swallowed
+      swallowTarget = null;
+    };
+
     // Swallow a native click that arrives after we already replayed the click
     // (otherwise the menu item would be activated twice).
     const onClickCapture = (event: MouseEvent) => {
-      if (!gesture || gesture.dispatchingFallback) {
+      if (gesture?.dispatchingFallback) {
         return;
       }
       if (!element.contains(event.target as Node)) {
         return;
       }
-      if (gesture.fallbackFired) {
+      if (swallowTarget && swallowTarget.contains(event.target as Node)) {
+        swallowTarget = null;
         event.preventDefault();
         event.stopPropagation();
-      } else {
+        reset();
+        return;
+      }
+      if (gesture) {
         gesture.nativeClickFired = true;
       }
     };
@@ -173,6 +231,7 @@ export const useTapClickFallback = <T extends HTMLElement>() => {
     element.addEventListener("pointerup", onPointerUp, true);
     element.addEventListener("pointercancel", onPointerCancel, true);
     element.addEventListener("click", onClickCapture, true);
+    element.addEventListener("keydown", onKeyDown);
 
     return () => {
       reset();
@@ -181,6 +240,7 @@ export const useTapClickFallback = <T extends HTMLElement>() => {
       element.removeEventListener("pointerup", onPointerUp, true);
       element.removeEventListener("pointercancel", onPointerCancel, true);
       element.removeEventListener("click", onClickCapture, true);
+      element.removeEventListener("keydown", onKeyDown);
     };
   }, [element]);
 

--- a/packages/excalidraw/hooks/useTapClickFallback.ts
+++ b/packages/excalidraw/hooks/useTapClickFallback.ts
@@ -6,8 +6,8 @@ type TapGesture = {
   x: number;
   y: number;
   moved: boolean;
-  /** the element the tap ended on (hit-tested by the browser) */
-  target: Element | null;
+  /** activatable element under the pointer at pointerdown (or `null`) */
+  downTarget: HTMLElement | null;
   fallbackTimer: number | null;
   /** whether a native click was delivered before the fallback timer ran */
   nativeClickFired: boolean;
@@ -37,13 +37,28 @@ const DISABLED_SELECTOR = "[disabled], [aria-disabled='true'], [data-disabled]";
  * when the tap landed on something that must not be activated (disabled
  * controls, separators, empty menu space, non-interactive content).
  */
-const resolveActivationTarget = (target: Element): HTMLElement | null => {
+const resolveActivationTarget = (
+  target: Element | null,
+): HTMLElement | null => {
+  if (!target) {
+    return null;
+  }
   const el = target.closest<HTMLElement>(ACTIVATABLE_SELECTOR);
   if (!el || el.closest(DISABLED_SELECTOR)) {
     return null;
   }
   return el;
 };
+
+/**
+ * How long the late-click latch stays armed after we replay a click.
+ *
+ * A late native click (if the browser delivers it at all) belongs to the same
+ * tap and is dispatched within a few event-loop turns of the pointerup, so a
+ * short bound is enough to swallow it while guaranteeing that clicks coming
+ * much later (e.g. synthesized by assistive technology) are never eaten.
+ */
+const SWALLOW_DISARM_TIMEOUT = 250; // ms
 
 /**
  * Recovers "ghost clicks" in scrollable menus on touch devices (iPad/iPhone).
@@ -58,10 +73,19 @@ const resolveActivationTarget = (target: Element): HTMLElement | null => {
  * scroll to settle and tap again.
  *
  * This hook observes pointer events inside the menu and, when a touch tap
- * (pointer up without significant movement) does not produce a native `click`
- * within a single event-loop turn, replays one click on the tapped element so
- * the menu item activates as intended. It never inspects scroll state — it
- * only reacts to the browser delivering (or not delivering) the `click`.
+ * does not produce a native `click` within a single event-loop turn, replays
+ * one click on the tapped element so the menu item activates as intended. It
+ * never inspects scroll state — it only reacts to the browser delivering (or
+ * not delivering) the `click`.
+ *
+ * A tap qualifies only when all of the following hold:
+ * - it is a primary touch pointer;
+ * - the pointer stayed within `DRAGGING_THRESHOLD` between `pointerdown` and
+ *   `pointerup` (the full down→up displacement is checked even if the browser
+ *   never delivered a `pointermove`);
+ * - `pointerdown` and `pointerup` resolved to the same interactive,
+ *   non-disabled element (sliding between items, or from/to empty space,
+ *   never activates).
  *
  * Safety properties:
  * - Only touch pointers are considered; mouse/trackpad/pen are left alone
@@ -69,13 +93,13 @@ const resolveActivationTarget = (target: Element): HTMLElement | null => {
  * - Only interactive, non-disabled elements (`button`, `a[href]`, menu items,
  *   inputs, etc.) are replayed onto — empty space, separators and other
  *   non-interactive content are never activated.
- * - Real drags (movement > `DRAGGING_THRESHOLD`) never activate.
  * - When the browser delivers the native click (settled menu), it wins: the
  *   fallback is cancelled, so there is no double activation.
  * - If the fallback fires and a late native click still arrives, the late
- *   click is swallowed (event-driven latch) so the item is not activated
- *   twice; the latch is disarmed by any new pointer interaction or keydown on
- *   the menu, so subsequent intentional clicks keep working.
+ *   click is swallowed so the item is not activated twice. The latch is
+ *   disarmed by any new pointer interaction or keydown on the menu and
+ *   self-expires after a short window, so later clicks (including those
+ *   synthesized by assistive technology) are never swallowed.
  * - Keyboard navigation is untouched.
  */
 export const useTapClickFallback = <T extends HTMLElement>() => {
@@ -88,11 +112,14 @@ export const useTapClickFallback = <T extends HTMLElement>() => {
     }
 
     let gesture: TapGesture | null = null;
-    // Event-driven latch: after we replay a click, the next native click that
-    // arrives on the same element is the (late) one the browser suppressed —
-    // swallow it so the item isn't activated twice. Deliberately kept outside
-    // the gesture lifecycle: it must survive `reset()`.
+
+    // Latch: after we replay a click, the next native click that arrives on
+    // the same element is the (late) one the browser suppressed — swallow it
+    // so the item isn't activated twice. Kept outside the gesture lifecycle
+    // (it must survive `reset()`) and always short-lived (see
+    // `SWALLOW_DISARM_TIMEOUT`).
     let swallowTarget: HTMLElement | null = null;
+    let swallowDisarmTimer: number | null = null;
 
     const clearFallbackTimer = () => {
       if (gesture?.fallbackTimer != null) {
@@ -106,12 +133,27 @@ export const useTapClickFallback = <T extends HTMLElement>() => {
       gesture = null;
     };
 
-    const onPointerDown = (event: PointerEvent) => {
-      // Any new pointer interaction supersedes a pending swallow, so the
-      // following real click is never eaten.
-      if (swallowTarget && swallowTarget.contains(event.target as Node)) {
-        swallowTarget = null;
+    const disarmSwallow = () => {
+      if (swallowDisarmTimer != null) {
+        window.clearTimeout(swallowDisarmTimer);
+        swallowDisarmTimer = null;
       }
+      swallowTarget = null;
+    };
+
+    const armSwallow = (target: HTMLElement) => {
+      disarmSwallow();
+      swallowTarget = target;
+      swallowDisarmTimer = window.setTimeout(() => {
+        swallowDisarmTimer = null;
+        swallowTarget = null;
+      }, SWALLOW_DISARM_TIMEOUT);
+    };
+
+    const onPointerDown = (event: PointerEvent) => {
+      // Any new pointer interaction inside the menu supersedes a pending
+      // swallow, so the following real click is never eaten.
+      disarmSwallow();
 
       if (event.pointerType !== "touch") {
         return;
@@ -125,7 +167,9 @@ export const useTapClickFallback = <T extends HTMLElement>() => {
         x: event.clientX,
         y: event.clientY,
         moved: false,
-        target: event.target instanceof Element ? event.target : null,
+        downTarget: resolveActivationTarget(
+          event.target instanceof Element ? event.target : null,
+        ),
         fallbackTimer: null,
         nativeClickFired: false,
         fallbackFired: false,
@@ -155,13 +199,24 @@ export const useTapClickFallback = <T extends HTMLElement>() => {
         return;
       }
 
-      // `pointerup` target is hit-tested by the browser, i.e. the element the
-      // finger was over when released — exactly the element the browser would
-      // have clicked (and whose click it may have suppressed).
-      const target =
-        event.target instanceof Element ? event.target : gesture.target;
-      gesture.target = target;
-      if (!target || !element.contains(target)) {
+      const downTarget = gesture.downTarget;
+      const upTarget = resolveActivationTarget(
+        event.target instanceof Element ? event.target : null,
+      );
+
+      // Only replay when the tap started and ended on the same activatable
+      // element — sliding between items, or from/to empty space, never
+      // activates.
+      if (!downTarget || !upTarget || upTarget !== downTarget) {
+        reset();
+        return;
+      }
+
+      // Full down→up displacement, computed from the final coordinates even if
+      // no `pointermove` was delivered (some scroll paths skip it).
+      const dx = event.clientX - gesture.x;
+      const dy = event.clientY - gesture.y;
+      if (Math.hypot(dx, dy) > DRAGGING_THRESHOLD) {
         reset();
         return;
       }
@@ -178,18 +233,14 @@ export const useTapClickFallback = <T extends HTMLElement>() => {
         if (!currentGesture) {
           return;
         }
-        const { nativeClickFired, target: tapTarget } = currentGesture;
-        if (!nativeClickFired && tapTarget) {
-          const clickTarget = resolveActivationTarget(tapTarget);
-          if (clickTarget) {
-            currentGesture.fallbackFired = true;
-            currentGesture.dispatchingFallback = true;
-            clickTarget.click();
-            currentGesture.dispatchingFallback = false;
-            // arm the latch: a late native click on this element must not
-            // activate it a second time
-            swallowTarget = clickTarget;
-          }
+        if (!currentGesture.nativeClickFired) {
+          currentGesture.fallbackFired = true;
+          currentGesture.dispatchingFallback = true;
+          downTarget.click();
+          currentGesture.dispatchingFallback = false;
+          // arm the latch: a late native click on this element must not
+          // activate it a second time
+          armSwallow(downTarget);
         }
         reset();
       }, 0);
@@ -202,7 +253,7 @@ export const useTapClickFallback = <T extends HTMLElement>() => {
     const onKeyDown = () => {
       // a keyboard activation (Enter/Space on a focused item) dispatches a
       // click without a pointerdown — disarm so it is never swallowed
-      swallowTarget = null;
+      disarmSwallow();
     };
 
     // Swallow a native click that arrives after we already replayed the click
@@ -215,7 +266,7 @@ export const useTapClickFallback = <T extends HTMLElement>() => {
         return;
       }
       if (swallowTarget && swallowTarget.contains(event.target as Node)) {
-        swallowTarget = null;
+        disarmSwallow();
         event.preventDefault();
         event.stopPropagation();
         reset();
@@ -234,6 +285,7 @@ export const useTapClickFallback = <T extends HTMLElement>() => {
     element.addEventListener("keydown", onKeyDown);
 
     return () => {
+      disarmSwallow();
       reset();
       element.removeEventListener("pointerdown", onPointerDown, true);
       element.removeEventListener("pointermove", onPointerMove, true);


### PR DESCRIPTION
## Summary

Fixes the "ghost click" experience on iPad/iPhone: after scrolling a menu (e.g. the main menu or the more-actions menu) the menu keeps decelerating / rubber-banding, and a deliberate tap on a visible menu item is dropped — the user has to wait until the scroll fully settles and tap again.

**Root cause (documented browser behavior)**

Since iOS 13, WebKit deliberately suppresses the `click` event for a tap that interrupts an in-flight scroll animation (momentum deceleration or rubber-band overscroll) so the tap is treated as "stop the scroll" rather than an activation (WebKit/WebKit@21aada2). Radix `DropdownMenuItem`s are activated exclusively via `click`, so such a tap is silently dropped even though the item is already visible under the finger. This affects every scrollable Radix dropdown in the editor on iOS. This PR does **not** detect or inspect scrolling state — it only reacts to the browser delivering (or not delivering) the `click`.

## Fix

Adds a `useTapClickFallback` hook attached to the scrollable `DropdownMenuContent` / `DropdownMenuSubContent`:

- Observes `pointerdown` / `pointermove` / `pointerup` inside the menu. **Touch pointers only** — mouse/trackpad/pen are never touched (mouse clicks are dispatched synchronously and cannot be suppressed).
- A tap qualifies for the fallback only when: the pointer stayed within the existing `DRAGGING_THRESHOLD` between `pointerdown` and `pointerup` (the full down→up displacement is checked even if no `pointermove` was delivered), **and** `pointerdown`/`pointerup` resolved to the **same** interactive, non-disabled element (sliding between items, or from/to empty space, never activates).
- Only interactive, non-disabled elements are replayed onto (`button`, `a[href]`, menu items, inputs, etc.). Empty space, separators, disabled items and other non-interactive content are never activated.
- When the browser delivers the native click (settled menu), the native click wins and the fallback is cancelled — no double activation.
- If the fallback fires and a late native click still arrives, a short-lived, event-driven latch swallows it so the item is not activated twice. The latch is disarmed by any new pointer interaction or `keydown` inside the menu and self-expires after a short window, so later clicks (including clicks synthesized by assistive technology) are never swallowed.
- Keyboard navigation is untouched.

Inertia/elastic scrolling itself is left fully intact — only the swallowed click is recovered.

## Tests

The automated tests verify the **fallback logic** against synthetic event sequences in jsdom (`pointerdown` + `pointerup` with no `click` dispatched, matching the event sequence WebKit produces when a tap interrupts a scroll animation). They do **not** reproduce real iOS momentum scrolling; the real inertial / rubber-band behavior was verified manually on a physical iPad (see [Manual verification](#manual-verification) below).

- `packages/excalidraw/hooks/useTapClickFallback.test.tsx` (direct hook unit tests — the primary proof of the late-click latch):
  - fallback replays the click and swallows a late native click (operation fires exactly once);
  - native click arriving before the fallback wins (exactly once);
  - disabled controls are not activated;
  - non-interactive elements are not activated;
  - drag beyond the threshold (with and without a delivered `pointermove`) does not activate;
  - `pointerdown`/`pointerup` on different interactive elements does not activate;
  - non-touch pointers (mouse) never trigger the fallback;
  - `pointercancel` leaves no stale state;
  - unmount leaves no lingering timers/listeners;
  - the latch is disarmed by a new tap of the same element, by a new pointer interaction on another element, and by `keydown`;
  - the latch self-expires, so later legitimate clicks (e.g. assistive technology) are never swallowed.
- `packages/excalidraw/components/dropdownMenu/DropdownMenu.test.tsx` (integration):
  - tap without a native click activates the menu item (menu closes);
  - native click wins without double activation;
  - drag does not activate; regular mouse click still works.

Ran locally:

- `yarn test:app --watch=false` — passed
- `yarn test:typecheck` — passed
- `yarn test:code` (eslint) — passed
- `yarn test:other` (prettier) — passed

## Manual verification

Manually verified by the contributor on a physical iPad using Safari and the PR preview deployment.

- Before the fix, tapping a visible menu item while the menu was still decelerating or rubber-banding could be ignored.
- With this PR, the same interaction activates the intended menu item exactly once.
- Momentum scrolling and edge rubber-banding remain intact.
- No obvious regressions were observed in normal tapping or menu scrolling.

Fixes #9204
