### PR TITLE
fix(editor): state variables sync across group and frame selection/deselection within common bounds

### DIFF
--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -12205,12 +12205,17 @@ class App extends React.Component<AppProps, AppState> {
           } else {
             // add element to selection while keeping prev elements selected
             this.setState((_prevState) => ({
-              selectedElementIds: makeNextSelectedElementIds(
+              ...selectGroupsForSelectedElements(
                 {
-                  ..._prevState.selectedElementIds,
-                  [hitElement!.id]: true,
+                  editingGroupId: _prevState.editingGroupId,
+                  selectedElementIds: {
+                    ..._prevState.selectedElementIds,
+                    [hitElement!.id]: true,
+                  },
                 },
+                this.scene.getNonDeletedElements(),
                 _prevState,
+                this,
               ),
             }));
           }

--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -209,10 +209,10 @@ import {
   getRenderOpacity,
   editGroupForSelectedElement,
   getElementsInGroup,
+  getSelectedGroupForElement,
   getSelectedGroupIdForElement,
   getSelectedGroupIds,
   isElementInGroup,
-  isSelectedViaGroup,
   selectGroupsForSelectedElements,
   syncInvalidIndices,
   syncMovedIndices,
@@ -12092,21 +12092,22 @@ class App extends React.Component<AppProps, AppState> {
           !this.state.selectedLinearElement?.isEditing
         ) {
           if (this.state.selectedElementIds[hitElement.id]) {
-            if (isSelectedViaGroup(this.state, hitElement)) {
+            const selectedGroupId = getSelectedGroupForElement(
+              this.state,
+              hitElement,
+            );
+            if (selectedGroupId) {
               this.setState((_prevState) => {
                 const nextSelectedElementIds = {
                   ..._prevState.selectedElementIds,
                 };
 
-                // We want to unselect all groups hitElement is part of
+                // We want to unselect the groups hitElement is part of
                 // as well as all elements that are part of the groups
                 // hitElement is part of
-                for (const groupedElement of hitElement.groupIds.flatMap(
-                  (groupId) =>
-                    getElementsInGroup(
-                      this.scene.getNonDeletedElements(),
-                      groupId,
-                    ),
+                for (const groupedElement of getElementsInGroup(
+                  this.scene.getNonDeletedElements(),
+                  selectedGroupId,
                 )) {
                   delete nextSelectedElementIds[groupedElement.id];
                 }
@@ -12114,9 +12115,7 @@ class App extends React.Component<AppProps, AppState> {
                 return {
                   selectedGroupIds: {
                     ..._prevState.selectedGroupIds,
-                    ...hitElement.groupIds
-                      .map((gId) => ({ [gId]: false }))
-                      .reduce((prev, acc) => ({ ...prev, ...acc }), {}),
+                    [selectedGroupId]: false,
                   },
                   selectedElementIds: makeNextSelectedElementIds(
                     nextSelectedElementIds,

--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -12101,7 +12101,19 @@ class App extends React.Component<AppProps, AppState> {
                 const nextSelectedElementIds = {
                   ..._prevState.selectedElementIds,
                 };
-
+                // eslint-disable-next-line no-console
+                console.log(
+                  "[deselection] pointer-up deselect-group",
+                  {
+                    branch:
+                      "selectedElementIds[hitElement.id] && selectedGroupId",
+                    hitElementId: hitElement.id,
+                    selectedGroupId,
+                    selectedElementIds: Object.keys(
+                      this.state.selectedElementIds,
+                    ),
+                  },
+                );
                 // We want to unselect the groups hitElement is part of
                 // as well as all elements that are part of the groups
                 // hitElement is part of
@@ -12208,60 +12220,113 @@ class App extends React.Component<AppProps, AppState> {
             // but if new frame(s) exist, removal of it's children would be required.
             this.setState((_prevState) => {
               const elements = this.scene.getNonDeletedElements();
+              const elementsMap = this.scene.getNonDeletedElementsMap();
+              const editingGroupIndex = _prevState.editingGroupId
+                ? hitElement.groupIds.indexOf(_prevState.editingGroupId)
+                : -1;
 
-              const targetSelection = selectGroupsForSelectedElements(
-                {
-                  editingGroupId: _prevState.editingGroupId,
-                  selectedElementIds: {
-                    ..._prevState.selectedElementIds,
-                    [hitElement!.id]: true,
-                  },
-                },
-                elements,
-                _prevState,
-                this,
-              );
+              // we can determine if and which group is to be selected
+              // by it's groupIds index relative to _prevState.editingGroupId
+              const targetGroupId =
+                hitElement.groupIds[
+                  editingGroupIndex > -1
+                    ? editingGroupIndex - 1
+                    : hitElement.groupIds.length - 1
+                ];
 
-              const newSelectedFrameIds = new Set(
-                elements
-                  .filter(
-                    (element) =>
-                      isFrameLikeElement(element) &&
-                      targetSelection.selectedElementIds[element.id] &&
-                      !_prevState.selectedElementIds[element.id],
-                  )
-                  .map((frame) => frame.id),
-              );
+              // get the elements of the group, otherwise it's not in a group
+              const targetElements = targetGroupId
+                ? getElementsInGroup<NonDeletedExcalidrawElement>(
+                  elements,
+                  targetGroupId,
+                )
+                : [hitElement];
 
-              // early return, no new frame introduced
-              if (newSelectedFrameIds.size === 0) {
-                return targetSelection;
-              }
+              const nextSelectedElementIds: Record<
+                ExcalidrawElement["id"],
+                true
+              > = {
+                  ..._prevState.selectedElementIds,
+              };
 
-              const targetSelectedElements = this.scene.getSelectedElements({
-                selectedElementIds: targetSelection.selectedElementIds,
-                elements,
+              const newSelectedFrameIds = new Set<ExcalidrawElement["id"]>();
+              targetElements.forEach((element) => {
+                nextSelectedElementIds[element.id] = true;
+
+                if (
+                  isFrameLikeElement(element) &&
+                  !_prevState.selectedElementIds[element.id]
+                ) {
+                  newSelectedFrameIds.add(element.id);
+                }
               });
 
-              const nextSelectedElements = excludeElementsInFramesFromSelection(
-                targetSelectedElements,
-              );
+              const removedFrameChildIds: ExcalidrawElement["id"][] = [];
 
-              // if a new frame was introduced and none of it's children were
-              // previously selected, we return targetSelection
-              if (
-                nextSelectedElements.length === targetSelectedElements.length
-              ) {
-                return targetSelection;
+              // if there are new frames to be added, we need to remove it's children
+              if (newSelectedFrameIds.size > 0) {
+                for (const selectedElementId of Object.keys(
+                  nextSelectedElementIds,
+                )) {
+                  const selectedElement = elementsMap.get(selectedElementId);
+                  if (
+                    selectedElement?.frameId &&
+                    newSelectedFrameIds.has(selectedElement.frameId)
+                  ) {
+                    delete nextSelectedElementIds[selectedElementId];
+                    removedFrameChildIds.push(selectedElementId);
+                  }
+                }
+
+                if (removedFrameChildIds.length === 0) {
+                  // eslint-disable-next-line no-console
+                  console.log(
+                    "[selection] pointer-up guard:frame-reconciliation-noop",
+                    {
+                      phase: "pointerup",
+                      edgeCase:
+                        "new selected frame(s) but no simultaneous selected children",
+                      hitElementId: hitElement.id,
+                      newSelectedFrameIds: [...newSelectedFrameIds],
+                      nextSelectedElementIds: Object.keys(
+                        nextSelectedElementIds,
+                      ),
+                    },
+                  );
+                } else {
+                  // eslint-disable-next-line no-console
+                  console.log(
+                    "[selection] pointer-up conflict:frame-selected-with-children",
+                    {
+                      phase: "pointerup",
+                      edgeCase:
+                        "new selected frame(s) and children are simultaneously selected",
+                      hitElementId: hitElement.id,
+                      newSelectedFrameIds: [...newSelectedFrameIds],
+                      removedFrameChildIds,
+                      nextSelectedElementIds: Object.keys(
+                        nextSelectedElementIds,
+                      ),
+                    },
+                  );
+                }
+              } else {
+                // eslint-disable-next-line no-console
+                console.log(
+                  "[selection] pointer-up guard:no-newly-selected-frames",
+                  {
+                    phase: "pointer-up",
+                    edgeCase:
+                      "the group or standalone element, adds no new frame, frame-child scan skipped",
+                    hitElementId: hitElement.id,
+                    targetGroupId: targetGroupId ?? null,
+                    targetElementIds: targetElements.map(
+                      (element) => element.id,
+                    ),
+                    nextSelectedElementIds: Object.keys(nextSelectedElementIds),
+                  },
+                );
               }
-
-              const nextSelectedElementIds = nextSelectedElements.reduce(
-                (acc: Record<ExcalidrawElement["id"], true>, element) => {
-                  acc[element.id] = true;
-                  return acc;
-                },
-                {},
-              );
 
               return selectGroupsForSelectedElements(
                 {

--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -12113,7 +12113,7 @@ class App extends React.Component<AppProps, AppState> {
 
                 return {
                   selectedGroupIds: {
-                    ..._prevState.selectedElementIds,
+                    ..._prevState.selectedGroupIds,
                     ...hitElement.groupIds
                       .map((gId) => ({ [gId]: false }))
                       .reduce((prev, acc) => ({ ...prev, ...acc }), {}),

--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -12233,53 +12233,35 @@ class App extends React.Component<AppProps, AppState> {
                   .map((frame) => frame.id),
               );
 
-              // early return, no frame addition via group selection
+              // early return, no new frame introduced
               if (newSelectedFrameIds.size === 0) {
                 return targetSelection;
               }
 
-              const nextSelectedElementIds = {
-                ...targetSelection.selectedElementIds,
-              };
+              const targetSelectedElements = this.scene.getSelectedElements({
+                selectedElementIds: targetSelection.selectedElementIds,
+                elements,
+              });
 
-              const removedGroupIds = new Set<string>();
-              const removedElementIds = new Set<ExcalidrawElement["id"]>();
+              const nextSelectedElements = excludeElementsInFramesFromSelection(
+                targetSelectedElements,
+              );
 
-              for (const elementId of Object.keys(
-                _prevState.selectedElementIds,
-              )) {
-                const element = this.scene.getElement(elementId);
-
-                if (
-                  !element?.frameId ||
-                  !newSelectedFrameIds.has(element.frameId)
-                ) {
-                  continue;
-                }
-
-                const selectedGroupId = getSelectedGroupForElement(
-                  _prevState,
-                  element,
-                );
-
-                if (selectedGroupId) {
-                  // skip elements that have already been removed
-                  if (removedGroupIds.has(selectedGroupId)) {
-                    continue;
-                  }
-
-                  removedGroupIds.add(selectedGroupId);
-                  getElementsInGroup(elements, selectedGroupId).forEach(
-                    (groupedElement) => {
-                      delete nextSelectedElementIds[groupedElement.id];
-                      removedElementIds.add(groupedElement.id);
-                    },
-                  );
-                } else {
-                  delete nextSelectedElementIds[element.id];
-                  removedElementIds.add(element.id);
-                }
+              // if a new frame was introduced and none of it's children were
+              // previously selected, we return targetSelection
+              if (
+                nextSelectedElements.length === targetSelectedElements.length
+              ) {
+                return targetSelection;
               }
+
+              const nextSelectedElementIds = nextSelectedElements.reduce(
+                (acc: Record<ExcalidrawElement["id"], true>, element) => {
+                  acc[element.id] = true;
+                  return acc;
+                },
+                {},
+              );
 
               return selectGroupsForSelectedElements(
                 {

--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -9520,6 +9520,21 @@ class App extends React.Component<AppProps, AppState> {
               });
             }
 
+            if (event.shiftKey) {
+              // eslint-disable-next-line no-console
+              console.log("[selection] pointer-down shift-add:", {
+                hitElementId: hitElement.id,
+                someHitElementIsSelected,
+                hasHitCommonBoundingBoxOfSelectedElements:
+                  pointerDownState.hit
+                    .hasHitCommonBoundingBoxOfSelectedElements,
+                willHandleOnPointerDown:
+                  !someHitElementIsSelected &&
+                  !pointerDownState.hit
+                    .hasHitCommonBoundingBoxOfSelectedElements,
+              });
+            }
+
             // Add hit element to selection. At this point if we're not holding
             // SHIFT the previously selected element(s) were deselected above
             // (make sure you use setState updater to use latest state)
@@ -12203,8 +12218,13 @@ class App extends React.Component<AppProps, AppState> {
             });
           } else {
             // add element to selection while keeping prev elements selected
-            this.setState((_prevState) => ({
-              ...selectGroupsForSelectedElements(
+            // handles deffered case when a group is selected within common bounding
+            // box of selectedElements, early return if no new frames were added
+            // but if new frame(s) exist, removal of it's children would be required.
+            this.setState((_prevState) => {
+              const elements = this.scene.getNonDeletedElements();
+
+              const targetSelection = selectGroupsForSelectedElements(
                 {
                   editingGroupId: _prevState.editingGroupId,
                   selectedElementIds: {
@@ -12212,11 +12232,103 @@ class App extends React.Component<AppProps, AppState> {
                     [hitElement!.id]: true,
                   },
                 },
-                this.scene.getNonDeletedElements(),
+                elements,
                 _prevState,
                 this,
-              ),
-            }));
+              );
+
+              const newSelectedFrameIds = new Set(
+                elements
+                  .filter(
+                    (element) =>
+                      isFrameLikeElement(element) &&
+                      targetSelection.selectedElementIds[element.id] &&
+                      !_prevState.selectedElementIds[element.id],
+                  )
+                  .map((frame) => frame.id),
+              );
+              // eslint-disable-next-line no-console
+              console.log("[selection] pointer-up deferred shift-add", {
+                hitElementId: hitElement!.id,
+                prevSelectedElementIds: Object.keys(
+                  _prevState.selectedElementIds,
+                ),
+                targetSelectedElementIds: Object.keys(
+                  targetSelection.selectedElementIds,
+                ),
+                newSelectedFrameIds: [...newSelectedFrameIds],
+              });
+
+              // early return, no frame addition via group selection
+              if (newSelectedFrameIds.size === 0) {
+                return targetSelection;
+              }
+
+              const nextSelectedElementIds = {
+                ...targetSelection.selectedElementIds,
+              };
+
+              const removedGroupIds = new Set<string>();
+              const removedElementIds = new Set<ExcalidrawElement["id"]>();
+
+              for (const elementId of Object.keys(
+                _prevState.selectedElementIds,
+              )) {
+                const element = this.scene.getElement(elementId);
+
+                if (
+                  !element?.frameId ||
+                  !newSelectedFrameIds.has(element.frameId)
+                ) {
+                  continue;
+                }
+
+                const selectedGroupId = getSelectedGroupForElement(
+                  _prevState,
+                  element,
+                );
+
+                if (selectedGroupId) {
+                  // skip elements that have already been removed
+                  if (removedGroupIds.has(selectedGroupId)) {
+                    continue;
+                  }
+
+                  removedGroupIds.add(selectedGroupId);
+                  getElementsInGroup(elements, selectedGroupId).forEach(
+                    (groupedElement) => {
+                      delete nextSelectedElementIds[groupedElement.id];
+                      removedElementIds.add(groupedElement.id);
+                    },
+                  );
+                } else {
+                  delete nextSelectedElementIds[element.id];
+                  removedElementIds.add(element.id);
+                }
+              }
+
+              // eslint-disable-next-line no-console
+              console.log("[selection] frame/group handling", {
+                hitElementId: hitElement!.id,
+                targetSelectedElementIds: Object.keys(
+                  targetSelection.selectedElementIds,
+                ),
+                newSelectedFrameIds: [...newSelectedFrameIds],
+                removedGroupIds: [...removedGroupIds],
+                removedElementIds: [...removedElementIds],
+                nextSelectedElementIds: Object.keys(nextSelectedElementIds),
+              });
+
+              return selectGroupsForSelectedElements(
+                {
+                  editingGroupId: _prevState.editingGroupId,
+                  selectedElementIds: nextSelectedElementIds,
+                },
+                elements,
+                _prevState,
+                this,
+              );
+            });
           }
         } else {
           this.setState((prevState) => ({

--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -12101,19 +12101,7 @@ class App extends React.Component<AppProps, AppState> {
                 const nextSelectedElementIds = {
                   ..._prevState.selectedElementIds,
                 };
-                // eslint-disable-next-line no-console
-                console.log(
-                  "[deselection] pointer-up deselect-group",
-                  {
-                    branch:
-                      "selectedElementIds[hitElement.id] && selectedGroupId",
-                    hitElementId: hitElement.id,
-                    selectedGroupId,
-                    selectedElementIds: Object.keys(
-                      this.state.selectedElementIds,
-                    ),
-                  },
-                );
+
                 // We want to unselect the groups hitElement is part of
                 // as well as all elements that are part of the groups
                 // hitElement is part of
@@ -12237,16 +12225,16 @@ class App extends React.Component<AppProps, AppState> {
               // get the elements of the group, otherwise it's not in a group
               const targetElements = targetGroupId
                 ? getElementsInGroup<NonDeletedExcalidrawElement>(
-                  elements,
-                  targetGroupId,
-                )
+                    elements,
+                    targetGroupId,
+                  )
                 : [hitElement];
 
               const nextSelectedElementIds: Record<
                 ExcalidrawElement["id"],
                 true
               > = {
-                  ..._prevState.selectedElementIds,
+                ..._prevState.selectedElementIds,
               };
 
               const newSelectedFrameIds = new Set<ExcalidrawElement["id"]>();
@@ -12261,82 +12249,32 @@ class App extends React.Component<AppProps, AppState> {
                 }
               });
 
-              const removedFrameChildIds: ExcalidrawElement["id"][] = [];
-
               // if there are new frames to be added, we need to remove it's children
               if (newSelectedFrameIds.size > 0) {
-                for (const selectedElementId of Object.keys(
-                  nextSelectedElementIds,
-                )) {
-                  const selectedElement = elementsMap.get(selectedElementId);
-                  if (
-                    selectedElement?.frameId &&
-                    newSelectedFrameIds.has(selectedElement.frameId)
-                  ) {
-                    delete nextSelectedElementIds[selectedElementId];
-                    removedFrameChildIds.push(selectedElementId);
-                  }
-                }
-
-                if (removedFrameChildIds.length === 0) {
-                  // eslint-disable-next-line no-console
-                  console.log(
-                    "[selection] pointer-up guard:frame-reconciliation-noop",
-                    {
-                      phase: "pointerup",
-                      edgeCase:
-                        "new selected frame(s) but no simultaneous selected children",
-                      hitElementId: hitElement.id,
-                      newSelectedFrameIds: [...newSelectedFrameIds],
-                      nextSelectedElementIds: Object.keys(
-                        nextSelectedElementIds,
-                      ),
-                    },
-                  );
-                } else {
-                  // eslint-disable-next-line no-console
-                  console.log(
-                    "[selection] pointer-up conflict:frame-selected-with-children",
-                    {
-                      phase: "pointerup",
-                      edgeCase:
-                        "new selected frame(s) and children are simultaneously selected",
-                      hitElementId: hitElement.id,
-                      newSelectedFrameIds: [...newSelectedFrameIds],
-                      removedFrameChildIds,
-                      nextSelectedElementIds: Object.keys(
-                        nextSelectedElementIds,
-                      ),
-                    },
-                  );
-                }
-              } else {
-                // eslint-disable-next-line no-console
-                console.log(
-                  "[selection] pointer-up guard:no-newly-selected-frames",
-                  {
-                    phase: "pointer-up",
-                    edgeCase:
-                      "the group or standalone element, adds no new frame, frame-child scan skipped",
-                    hitElementId: hitElement.id,
-                    targetGroupId: targetGroupId ?? null,
-                    targetElementIds: targetElements.map(
-                      (element) => element.id,
-                    ),
-                    nextSelectedElementIds: Object.keys(nextSelectedElementIds),
+                Object.keys(nextSelectedElementIds).forEach(
+                  (selectedElementId) => {
+                    const selectedElement = elementsMap.get(selectedElementId);
+                    if (
+                      selectedElement?.frameId &&
+                      newSelectedFrameIds.has(selectedElement.frameId)
+                    ) {
+                      delete nextSelectedElementIds[selectedElementId];
+                    }
                   },
                 );
               }
 
-              return selectGroupsForSelectedElements(
-                {
-                  editingGroupId: _prevState.editingGroupId,
-                  selectedElementIds: nextSelectedElementIds,
-                },
-                elements,
-                _prevState,
-                this,
-              );
+              return {
+                ...selectGroupsForSelectedElements(
+                  {
+                    editingGroupId: _prevState.editingGroupId,
+                    selectedElementIds: nextSelectedElementIds,
+                  },
+                  elements,
+                  _prevState,
+                  this,
+                ),
+              };
             });
           }
         } else {

--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -9520,21 +9520,6 @@ class App extends React.Component<AppProps, AppState> {
               });
             }
 
-            if (event.shiftKey) {
-              // eslint-disable-next-line no-console
-              console.log("[selection] pointer-down shift-add:", {
-                hitElementId: hitElement.id,
-                someHitElementIsSelected,
-                hasHitCommonBoundingBoxOfSelectedElements:
-                  pointerDownState.hit
-                    .hasHitCommonBoundingBoxOfSelectedElements,
-                willHandleOnPointerDown:
-                  !someHitElementIsSelected &&
-                  !pointerDownState.hit
-                    .hasHitCommonBoundingBoxOfSelectedElements,
-              });
-            }
-
             // Add hit element to selection. At this point if we're not holding
             // SHIFT the previously selected element(s) were deselected above
             // (make sure you use setState updater to use latest state)
@@ -12247,17 +12232,6 @@ class App extends React.Component<AppProps, AppState> {
                   )
                   .map((frame) => frame.id),
               );
-              // eslint-disable-next-line no-console
-              console.log("[selection] pointer-up deferred shift-add", {
-                hitElementId: hitElement!.id,
-                prevSelectedElementIds: Object.keys(
-                  _prevState.selectedElementIds,
-                ),
-                targetSelectedElementIds: Object.keys(
-                  targetSelection.selectedElementIds,
-                ),
-                newSelectedFrameIds: [...newSelectedFrameIds],
-              });
 
               // early return, no frame addition via group selection
               if (newSelectedFrameIds.size === 0) {
@@ -12306,18 +12280,6 @@ class App extends React.Component<AppProps, AppState> {
                   removedElementIds.add(element.id);
                 }
               }
-
-              // eslint-disable-next-line no-console
-              console.log("[selection] frame/group handling", {
-                hitElementId: hitElement!.id,
-                targetSelectedElementIds: Object.keys(
-                  targetSelection.selectedElementIds,
-                ),
-                newSelectedFrameIds: [...newSelectedFrameIds],
-                removedGroupIds: [...removedGroupIds],
-                removedElementIds: [...removedElementIds],
-                nextSelectedElementIds: Object.keys(nextSelectedElementIds),
-              });
 
               return selectGroupsForSelectedElements(
                 {

--- a/packages/excalidraw/tests/__snapshots__/regressionTests.test.tsx.snap
+++ b/packages/excalidraw/tests/__snapshots__/regressionTests.test.tsx.snap
@@ -526,10 +526,7 @@ exports[`given element A and group of elements B and given both are selected whe
   },
   "selectedElementsAreBeingDragged": false,
   "selectedGroupIds": {
-    "id0": true,
     "id12": false,
-    "id3": true,
-    "id6": true,
   },
   "selectedLinearElement": null,
   "selectionElement": null,
@@ -817,10 +814,7 @@ exports[`given element A and group of elements B and given both are selected whe
         "deleted": {
           "selectedElementIds": {},
           "selectedGroupIds": {
-            "id0": true,
             "id12": false,
-            "id3": true,
-            "id6": true,
           },
         },
         "inserted": {

--- a/packages/excalidraw/tests/selection.test.tsx
+++ b/packages/excalidraw/tests/selection.test.tsx
@@ -1500,3 +1500,113 @@ describe("deselecting", () => {
     expect(h.state.selectedGroupIds).toEqual({ A: false, B: true });
   });
 });
+
+describe("group selection", () => {
+  beforeEach(async () => {
+    await render(<Excalidraw />);
+  });
+
+  it("shift-selects a whole group inside common bounds of a current selected groups", () => {
+    const groupA1 = API.createElement({
+      type: "rectangle",
+      x: 0,
+      y: 0,
+      width: 50,
+      height: 50,
+      groupIds: ["A"],
+    });
+    const groupA2 = API.createElement({
+      type: "rectangle",
+      x: 0,
+      y: 100,
+      width: 50,
+      height: 50,
+      groupIds: ["A"],
+    });
+    const groupB1 = API.createElement({
+      type: "rectangle",
+      x: 400,
+      y: 0,
+      width: 50,
+      height: 50,
+      groupIds: ["B"],
+    });
+    const groupB2 = API.createElement({
+      type: "rectangle",
+      x: 400,
+      y: 100,
+      width: 50,
+      height: 50,
+      groupIds: ["B"],
+    });
+    const groupC1 = API.createElement({
+      type: "rectangle",
+      x: 200,
+      y: 0,
+      width: 50,
+      height: 50,
+      groupIds: ["C"],
+    });
+    const groupC2 = API.createElement({
+      type: "rectangle",
+      x: 200,
+      y: 100,
+      width: 50,
+      height: 50,
+      groupIds: ["C"],
+    });
+    const selectedElements = [groupA1, groupA2, groupB1, groupB2];
+    const elements = [...selectedElements, groupC1, groupC2];
+
+    API.setElements(elements);
+    API.setSelectedElements(selectedElements);
+
+    assertSelectedElements(selectedElements);
+    expect(h.state.selectedGroupIds).toEqual({ A: true, B: true });
+
+    Keyboard.withModifierKeys({ shift: true }, () => {
+      mouse.clickOn(groupC1);
+    });
+
+    assertSelectedElements(elements);
+    expect(h.state.selectedGroupIds).toEqual({ A: true, B: true, C: true });
+  });
+
+  it("shift-selects a group inside common bounds of current selected element", () => {
+    const element = API.createElement({
+      x: 0,
+      y: 0,
+      width: 50,
+      height: 50,
+    });
+    const groupA1 = API.createElement({
+      x: 10,
+      y: 10,
+      width: 50,
+      height: 50,
+      groupIds: ["A"],
+    });
+    const groupA2 = API.createElement({
+      x: 20,
+      y: 20,
+      width: 50,
+      height: 50,
+      groupIds: ["A"],
+    });
+    const selectedElements = [element];
+    const elements = [...selectedElements, groupA1, groupA2];
+
+    API.setElements(elements);
+    API.setSelectedElements(selectedElements);
+
+    assertSelectedElements(selectedElements);
+    expect(h.state.selectedGroupIds).toEqual({});
+
+    Keyboard.withModifierKeys({ shift: true }, () => {
+      mouse.clickAt(10, 10);
+    });
+
+    assertSelectedElements(elements);
+    expect(h.state.selectedGroupIds).toEqual({ A: true });
+  });
+});

--- a/packages/excalidraw/tests/selection.test.tsx
+++ b/packages/excalidraw/tests/selection.test.tsx
@@ -1458,4 +1458,45 @@ describe("deselecting", () => {
     expect(h.state.editingGroupId).toBeNull();
     expect(h.state.selectedGroupIds).toEqual({});
   });
+
+  it("shift deselecting one of multiple selected groups preserves other groups", () => {
+    const groupA1 = API.createElement({
+      type: "rectangle",
+      x: 0,
+      y: 0,
+      groupIds: ["A"],
+    });
+    const groupA2 = API.createElement({
+      type: "rectangle",
+      x: 100,
+      y: 0,
+      groupIds: ["A"],
+    });
+    const groupB1 = API.createElement({
+      type: "rectangle",
+      x: 200,
+      y: 0,
+      groupIds: ["B"],
+    });
+    const groupB2 = API.createElement({
+      type: "rectangle",
+      x: 300,
+      y: 0,
+      groupIds: ["B"],
+    });
+    const elements = [groupA1, groupA2, groupB1, groupB2];
+
+    API.setElements(elements);
+    API.setSelectedElements(elements);
+
+    assertSelectedElements(elements);
+    expect(h.state.selectedGroupIds).toEqual({ A: true, B: true });
+
+    Keyboard.withModifierKeys({ shift: true }, () => {
+      mouse.clickOn(groupA1);
+    });
+
+    assertSelectedElements(groupB1, groupB2);
+    expect(h.state.selectedGroupIds).toEqual({ A: false, B: true });
+  });
 });

--- a/packages/excalidraw/tests/selection.test.tsx
+++ b/packages/excalidraw/tests/selection.test.tsx
@@ -1609,4 +1609,78 @@ describe("group selection", () => {
     assertSelectedElements(elements);
     expect(h.state.selectedGroupIds).toEqual({ A: true });
   });
+
+  it("shift selecting and deselecting a nested group preserves selected siblings", () => {
+    const groupA1 = API.createElement({
+      type: "rectangle",
+      x: 0,
+      y: 0,
+      width: 50,
+      height: 50,
+      groupIds: ["inA", "out"],
+    });
+    const groupA2 = API.createElement({
+      type: "rectangle",
+      x: 0,
+      y: 100,
+      width: 50,
+      height: 50,
+      groupIds: ["inA", "out"],
+    });
+    const groupB1 = API.createElement({
+      type: "rectangle",
+      x: 100,
+      y: 0,
+      width: 50,
+      height: 50,
+      groupIds: ["inB", "out"],
+    });
+    const groupB2 = API.createElement({
+      type: "rectangle",
+      x: 100,
+      y: 100,
+      width: 50,
+      height: 50,
+      groupIds: ["inB", "out"],
+    });
+
+    API.setElements([groupA1, groupA2, groupB1, groupB2]);
+
+    mouse.select(groupA1);
+    mouse.doubleClickOn(groupA1);
+
+    assertSelectedElements(groupA1, groupA2);
+    expect(h.state.editingGroupId).toBe("out");
+    expect(h.state.selectedGroupIds).toEqual({ inA: true });
+
+    Keyboard.withModifierKeys({ shift: true }, () => {
+      mouse.clickOn(groupB1);
+    });
+
+    assertSelectedElements(groupA1, groupA2, groupB1, groupB2);
+    expect(h.state.selectedGroupIds).toEqual({
+      inA: true,
+      inB: true,
+    });
+
+    Keyboard.withModifierKeys({ shift: true }, () => {
+      mouse.clickOn(groupA1);
+    });
+
+    assertSelectedElements(groupB1, groupB2);
+    expect(h.state.selectedGroupIds).toEqual({
+      inA: false,
+      inB: true,
+    });
+
+    Keyboard.withModifierKeys({ shift: true }, () => {
+      mouse.clickOn(groupA1);
+    });
+
+    assertSelectedElements(groupA1, groupA2, groupB1, groupB2);
+    expect(h.state.selectedGroupIds).toEqual({
+      inA: true,
+      inB: true,
+    });
+  });
 });

--- a/packages/excalidraw/tests/selection.test.tsx
+++ b/packages/excalidraw/tests/selection.test.tsx
@@ -1683,4 +1683,113 @@ describe("group selection", () => {
       inB: true,
     });
   });
+
+  it("shift selecting a group containing a frame inside selected bounds, removes selected membership of the frames child", () => {
+    const frame = API.createElement({
+      type: "frame",
+      x: 0,
+      y: 0,
+      width: 100,
+      height: 100,
+      groupIds: ["frame-group"],
+    });
+    const frameChild = API.createElement({
+      type: "rectangle",
+      x: 25,
+      y: 25,
+      width: 50,
+      height: 50,
+      frameId: frame.id,
+    });
+    const groupedElement = API.createElement({
+      type: "rectangle",
+      x: 25,
+      y: 125,
+      width: 50,
+      height: 50,
+      groupIds: ["frame-group"],
+    });
+    const selectedElement = API.createElement({
+      type: "rectangle",
+      x: 25,
+      y: 225,
+      width: 50,
+      height: 50,
+    });
+
+    API.setElements([frameChild, frame, groupedElement, selectedElement]);
+    API.setSelectedElements([frameChild, selectedElement]);
+
+    assertSelectedElements(frameChild, selectedElement);
+
+    Keyboard.withModifierKeys({ shift: true }, () => {
+      mouse.clickOn(groupedElement);
+    });
+
+    assertSelectedElements(frame, groupedElement, selectedElement);
+    expect(h.state.selectedGroupIds).toEqual({ "frame-group": true });
+  });
+
+  it("shift selecting a group containing a frame inside selected bounds, removes selected membership of the frames child group", () => {
+    const frame = API.createElement({
+      type: "frame",
+      x: 0,
+      y: 0,
+      width: 100,
+      height: 100,
+      groupIds: ["frame-group"],
+    });
+    const frameChildA = API.createElement({
+      type: "rectangle",
+      x: 25,
+      y: 25,
+      width: 25,
+      height: 25,
+      frameId: frame.id,
+      groupIds: ["child-group"],
+    });
+    const frameChildB = API.createElement({
+      type: "rectangle",
+      x: 50,
+      y: 50,
+      width: 25,
+      height: 25,
+      frameId: frame.id,
+      groupIds: ["child-group"],
+    });
+    const groupedElement = API.createElement({
+      type: "rectangle",
+      x: 25,
+      y: 125,
+      width: 50,
+      height: 50,
+      groupIds: ["frame-group"],
+    });
+    const selectedElement = API.createElement({
+      type: "rectangle",
+      x: 25,
+      y: 225,
+      width: 50,
+      height: 50,
+    });
+
+    API.setElements([
+      frameChildA,
+      frameChildB,
+      frame,
+      groupedElement,
+      selectedElement,
+    ]);
+    API.setSelectedElements([frameChildA, frameChildB, selectedElement]);
+
+    assertSelectedElements(frameChildA, frameChildB, selectedElement);
+    expect(h.state.selectedGroupIds).toEqual({ "child-group": true });
+
+    Keyboard.withModifierKeys({ shift: true }, () => {
+      mouse.clickOn(groupedElement);
+    });
+
+    assertSelectedElements(frame, groupedElement, selectedElement);
+    expect(h.state.selectedGroupIds).toEqual({ "frame-group": true });
+  });
 });


### PR DESCRIPTION
## Summary

https://github.com/user-attachments/assets/476f907b-1cff-4a20-bcbb-ce4250308f93

Small correction in `App.tsx` where group deselection is handled: `selectedGroupIds` was using `selectedElementIds` for state updates; the primary fix involved using `selectedGroupIds` in its place. Final commit updates deselection for groupId filtering on deselection to use `selectedGroupIds` as a filter for selection state of elements. 

This PR also addresses #6861 cross-group selection, where given a non-selected group is within bounds of selected groups or elements, when the group is selected it would only select the `hitElement` irrespective of its grouping. Fix involved using `selectGroupsForSelectedElements` to extract key state variables.

### Additional Notes
- snapshot was updated for `regressionTests.tsx`
- 4 minimal tests added to `selection.test.tsx`

### Feedback & Collaboration Welcome

Any feedback, suggestions and collaboration offered by the team are always appreciated.

Thanks @dwelle @mtolmacs 

Closes #11842 
Closes #6861 