### PR TITLE
fix: render link icon on transparent background

### DIFF
--- a/packages/excalidraw/renderer/staticScene.ts
+++ b/packages/excalidraw/renderer/staticScene.ts
@@ -1,6 +1,5 @@
 import {
   applyDarkModeFilter,
-  COLOR_WHITE,
   FRAME_STYLE,
   THEME,
   throttleRAF,
@@ -206,13 +205,9 @@ const renderLinkIcon = (
         window.devicePixelRatio * appState.zoom.value,
       );
 
-      // Seed a sane default so a corrupted color (silently rejected by the
-      // canvas) falls back to white instead of a stale fillStyle.
-      linkCanvasCacheContext.fillStyle = COLOR_WHITE;
-      linkCanvasCacheContext.fillStyle =
-        appState.viewBackgroundColor || COLOR_WHITE;
-
-      linkCanvasCacheContext.fillRect(0, 0, width, height);
+      // Keep transparent so the (dark-mode filtered) canvas background
+      // shows through
+      linkCanvasCacheContext.clearRect(0, 0, width, height);
 
       if (canvasKey === "elementLink") {
         linkCanvasCacheContext.drawImage(ELEMENT_LINK_IMG, 0, 0, width, height);


### PR DESCRIPTION
This PR fixes the link handle icon background for elements with attached hyperlinks.

Fixes #11844