### PR TITLE
build: reuse Docker dependency layer across source changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,22 @@ FROM --platform=${BUILDPLATFORM} node:24@sha256:8530f76a96d88820d288761f022e3189
 
 WORKDIR /opt/node_app
 
-COPY . .
+COPY package.json yarn.lock .npmrc ./
+COPY excalidraw-app/package.json ./excalidraw-app/
+COPY packages/common/package.json ./packages/common/
+COPY packages/element/package.json ./packages/element/
+COPY packages/excalidraw/package.json ./packages/excalidraw/
+COPY packages/fractional-indexing/package.json ./packages/fractional-indexing/
+COPY packages/laser-pointer/package.json ./packages/laser-pointer/
+COPY packages/math/package.json ./packages/math/
+COPY packages/utils/package.json ./packages/utils/
 
 # do not ignore optional dependencies:
 # Error: Cannot find module @rollup/rollup-linux-x64-gnu
 RUN --mount=type=cache,target=/root/.cache/yarn \
     npm_config_target_arch=${TARGETARCH} yarn --frozen-lockfile --network-timeout 600000
+
+COPY . .
 
 ARG NODE_ENV=production
 


### PR DESCRIPTION
## Summary

Reduce unnecessary Docker build-cache growth and avoid reinstalling dependencies when only application source files change.

The dependency installation layer is now based on `package.json`, `yarn.lock`, `.npmrc`, and the included workspace manifests. The remaining build context is copied after dependencies are installed.

## Problem

The current Dockerfile copies the entire build context before installing dependencies:

```dockerfile
COPY . .

RUN --mount=type=cache,target=/root/.cache/yarn \
    npm_config_target_arch=${TARGETARCH} yarn --frozen-lockfile --network-timeout 600000
```

Any change to a file included in the build context invalidates the `COPY` layer. This also invalidates the following dependency installation layer, even when none of the dependency manifests have changed.

Because the dependency installation layer can be significantly larger than the source-copy and application-build layers, repeated source-only builds can unnecessarily increase BuildKit cache usage in addition to increasing rebuild time.

## Changes

The build stage now follows this order:

1. Copy `package.json`, `yarn.lock`, and `.npmrc`
2. Copy the package manifests for the included Yarn workspaces
3. Install dependencies
4. Copy the remaining build context
5. Build the application

The existing dependency installation command, application build command, and final Nginx stage remain unchanged.

## Verification

- Ran `docker buildx build --check --file Dockerfile .`
- Completed a Docker build successfully
- Modified only `excalidraw-app/App.tsx` and rebuilt the image
- Confirmed that the dependency installation step remained cached:

```text
[build 12/14] RUN --mount=type=cache,target=/root/.cache/yarn \
    npm_config_target_arch=${TARGETARCH} yarn --frozen-lockfile --network-timeout 600000
CACHED
```

- Confirmed that `COPY . .` and `yarn build:app:docker` were rerun
- Confirmed that the final Nginx image was created successfully
- Reverted the temporary source change after verification

## Impact

Source-only changes no longer invalidate the dependency installation layer. Only layers downstream of the dependency installation step are invalidated and rebuilt.

Dependency installation is still rerun when `package.json`, a workspace manifest, `yarn.lock`, `.npmrc`, the Node base image, or relevant Dockerfile instructions change.

This change is limited to Docker build caching. It does not intentionally change application behavior, Nginx configuration, build output, or runtime behavior.
