### PR TITLE
fix: respect selection mode in freeform lasso

### DIFF
--- a/packages/excalidraw/lasso/index.ts
+++ b/packages/excalidraw/lasso/index.ts
@@ -202,6 +202,7 @@ export class LassoTrail extends AnimatedTrail {
         intersectedElements: this.intersectedElements,
         enclosedElements: this.enclosedElements,
         simplifyDistance: 5 / this.app.state.zoom.value,
+        boxSelectionMode: this.app.state.boxSelectionMode,
       });
 
       this.selectElementsFromIds(selectedElementIds);

--- a/packages/excalidraw/lasso/utils.ts
+++ b/packages/excalidraw/lasso/utils.ts
@@ -18,6 +18,7 @@ import {
 
 import type { ElementsSegmentsMap, GlobalPoint } from "@excalidraw/math/types";
 import type { ElementsMap, ExcalidrawElement } from "@excalidraw/element/types";
+import type { BoxSelectionMode } from "@excalidraw/excalidraw/types";
 
 export const getLassoSelectedElementIds = (input: {
   lassoPath: GlobalPoint[];
@@ -27,6 +28,7 @@ export const getLassoSelectedElementIds = (input: {
   intersectedElements: Set<ExcalidrawElement["id"]>;
   enclosedElements: Set<ExcalidrawElement["id"]>;
   simplifyDistance?: number;
+  boxSelectionMode: BoxSelectionMode;
 }): {
   selectedElementIds: string[];
 } => {
@@ -38,6 +40,7 @@ export const getLassoSelectedElementIds = (input: {
     intersectedElements,
     enclosedElements,
     simplifyDistance,
+    boxSelectionMode,
   } = input;
   // simplify the path to reduce the number of points
   let path: GlobalPoint[] = lassoPath;
@@ -82,7 +85,9 @@ export const getLassoSelectedElementIds = (input: {
     }
   }
 
-  const results = [...intersectedElements, ...enclosedElements];
+  const results = boxSelectionMode === "contain"
+    ? [...enclosedElements]
+    : [...intersectedElements, ...enclosedElements];
 
   return {
     selectedElementIds: results,


### PR DESCRIPTION
## Summary

Fixes #11809

The freeform lasso tool currently always behaves as an overlap selection, even when the existing selection mode is set to "wrap"/"contain".

This PR makes the freeform lasso respect the existing `boxSelectionMode` preference:

- `overlap`: select elements intersecting the lasso
- `contain`: select only elements enclosed by the lasso

## Changes

- Pass `boxSelectionMode` through the freeform lasso selection flow.
- Reuse the existing enclosure/intersection checks to determine selected elements.
- Preserve the current overlap behavior when `boxSelectionMode` is `overlap`.

## Testing

Manually verified the freeform lasso behavior with both selection modes.

The existing lasso test suite currently has two failing cases related to linear/group selection and needs further investigation.