### PR TITLE
fix: correct isLocalLink origin check for external links

### DIFF
--- a/packages/common/src/url.test.ts
+++ b/packages/common/src/url.test.ts
@@ -1,0 +1,36 @@
+import { isLocalLink } from "./url";
+
+describe("@excalidraw/common/url", () => {
+  describe("isLocalLink()", () => {
+    const origin = window.location.origin;
+
+    it("treats same-origin absolute links as local", () => {
+      expect(isLocalLink(`${origin}/scene/123`)).toBe(true);
+      expect(isLocalLink(`${origin}`)).toBe(true);
+    });
+
+    it("treats root-relative links as local", () => {
+      expect(isLocalLink("/scene/123")).toBe(true);
+      expect(isLocalLink("/")).toBe(true);
+    });
+
+    it("treats protocol-relative links as external", () => {
+      // `//host` starts with a slash but points to another origin.
+      expect(isLocalLink("//evil.example/phish")).toBe(false);
+    });
+
+    it("does not treat external links that merely contain the origin as local", () => {
+      expect(isLocalLink(`https://evil.example/?next=${origin}`)).toBe(false);
+      expect(isLocalLink(`https://evil.example/#${origin}`)).toBe(false);
+    });
+
+    it("treats plainly external links as external", () => {
+      expect(isLocalLink("https://other.example/page")).toBe(false);
+    });
+
+    it("handles empty and nullish input", () => {
+      expect(isLocalLink(null)).toBe(false);
+      expect(isLocalLink("")).toBe(false);
+    });
+  });
+});

--- a/packages/common/src/url.ts
+++ b/packages/common/src/url.ts
@@ -11,7 +11,30 @@ export const normalizeLink = (link: string) => {
 };
 
 export const isLocalLink = (link: string | null) => {
-  return !!(link?.includes(location.origin) || link?.startsWith("/"));
+  if (!link) {
+    return false;
+  }
+
+  // Protocol-relative URLs (e.g. `//example.com`) point to another origin, so
+  // they must not be treated as local even though they start with a slash.
+  if (link.startsWith("//")) {
+    return false;
+  }
+
+  // Root-relative links always stay on the current origin.
+  if (link.startsWith("/")) {
+    return true;
+  }
+
+  // For absolute links, compare the actual origin. A plain `includes` check
+  // would wrongly match external links that merely contain the origin
+  // somewhere (e.g. `https://evil.com/?next=<origin>`) or look-alike hosts
+  // (e.g. `<origin>.evil.com`).
+  try {
+    return new URL(link).origin === location.origin;
+  } catch {
+    return false;
+  }
 };
 
 /**


### PR DESCRIPTION
## Problem

`isLocalLink` in `packages/common/src/url.ts` is used to decide whether a link opens in the same tab (`_self`) or a new tab (`_blank`), both for element hyperlinks (`Hyperlink.tsx`) and canvas link clicks (`App.tsx`).

```ts
export const isLocalLink = (link: string | null) => {
  return !!(link?.includes(location.origin) || link?.startsWith("/"));
};
```

Both checks produce false positives, so external links get treated as local and open in the same tab, navigating the user away from the canvas:

- `includes(location.origin)` matches any external link that merely contains the origin somewhere in the string, for example `https://evil.com/?next=<origin>`, or a look-alike host like `<origin>.evil.com`.
- `startsWith("/")` also matches protocol-relative URLs such as `//evil.com`, which point to a different origin.

## Reproduction

With `location.origin === "https://app.example.com"`:

```ts
isLocalLink("//evil.com/phish")                              // true  (should be false)
isLocalLink("https://evil.com/?next=https://app.example.com") // true  (should be false)
isLocalLink("https://app.example.com.evil.com/x")            // true  (should be false)
```

## Fix

Compare the parsed origin instead of doing a substring match:

- root-relative links (`/...`) stay local
- protocol-relative links (`//...`) are external
- absolute links are local only when `new URL(link).origin === location.origin`

Same-origin absolute links and root-relative links keep returning `true`, so there is no change for legitimate local links. Added `url.test.ts` covering the same-origin, root-relative, protocol-relative, contains-origin, and external cases.
