### PR TITLE
fix(tests): resolve failing lasso reselection test by initializing boxSelectionMode and viewport dimensions

### DIFF
--- a/packages/excalidraw/tests/selection.test.tsx
+++ b/packages/excalidraw/tests/selection.test.tsx
@@ -153,7 +153,13 @@ describe("box-selection", () => {
 
 describe("lasso reselection", () => {
   beforeEach(async () => {
-    await render(<Excalidraw />);
+    await render(
+      <Excalidraw
+        initialData={{ appState: { boxSelectionMode: "overlap" } }}
+      />,
+    );
+    h.state.width = 1000;
+    h.state.height = 1000;
   });
 
   it("should allow ctrl+alt lasso reselection when starting inside the active common bounds", () => {


### PR DESCRIPTION
## Description

Closes #11856

Fixes a pre-existing failure in `packages/excalidraw/tests/selection.test.tsx` for the test:
> `lasso reselection > should allow ctrl+alt lasso reselection when starting inside the active common bounds`

### Root Cause
1. **Uninitialized `boxSelectionMode`**: The test relies on intersection-based selection ("overlap" mode), but inherited `"contain"` from `appState.ts`.
2. **Unset Canvas Dimensions**: `h.state.width` and `h.state.height` were not set in the `lasso reselection` `beforeEach`. This caused `isElementInViewport` to return `false` for all canvas elements, making `this.app.visibleElements` empty during the test, so the lasso selected zero elements.

---

## Proposed Changes

- Added `initialData={{ appState: { boxSelectionMode: "overlap" } }}` to `<Excalidraw />` in `lasso reselection`'s `beforeEach`.
- Set `h.state.width = 1000` and `h.state.height = 1000` in `beforeEach` to ensure elements pass viewport check.

---

## Verification

Ran the selection test suite locally:

```bash
yarn test packages/excalidraw/tests/selection.test.tsx
