### PR TITLE
fix(editor): respect boxSelectionMode ('contain' vs 'overlap') in lasso tool

### DIFF
--- a/packages/excalidraw/lasso/index.ts
+++ b/packages/excalidraw/lasso/index.ts
@@ -6,16 +6,10 @@ import {
 
 import { getElementLineSegments } from "@excalidraw/element";
 import { LinearElementEditor } from "@excalidraw/element";
-import {
-  isFrameLikeElement,
-  isLinearElement,
-  isTextElement,
-} from "@excalidraw/element";
+import { isFrameLikeElement, isLinearElement } from "@excalidraw/element";
 
 import { getFrameChildren } from "@excalidraw/element";
 import { selectGroupsForSelectedElements } from "@excalidraw/element";
-
-import { getContainerElement } from "@excalidraw/element";
 
 import { arrayToMap, easeOut, isShallowEqual } from "@excalidraw/common";
 
@@ -97,21 +91,6 @@ export class LassoTrail extends AnimatedTrail {
       if (this.keepPreviousSelection) {
         for (const id of Object.keys(prevState.selectedElementIds)) {
           nextSelectedElementIds[id] = true;
-        }
-      }
-
-      for (const [id] of Object.entries(nextSelectedElementIds)) {
-        const element = this.app.scene.getNonDeletedElement(id);
-
-        if (element && isTextElement(element)) {
-          const container = getContainerElement(
-            element,
-            this.app.scene.getNonDeletedElementsMap(),
-          );
-          if (container) {
-            nextSelectedElementIds[container.id] = true;
-            delete nextSelectedElementIds[element.id];
-          }
         }
       }
 

--- a/packages/excalidraw/lasso/index.ts
+++ b/packages/excalidraw/lasso/index.ts
@@ -202,6 +202,7 @@ export class LassoTrail extends AnimatedTrail {
         intersectedElements: this.intersectedElements,
         enclosedElements: this.enclosedElements,
         simplifyDistance: 5 / this.app.state.zoom.value,
+        mode: this.app.state.boxSelectionMode,
       });
 
       this.selectElementsFromIds(selectedElementIds);

--- a/packages/excalidraw/lasso/utils.ts
+++ b/packages/excalidraw/lasso/utils.ts
@@ -3,6 +3,7 @@ import { simplify } from "points-on-curve";
 import {
   polygonFromPoints,
   lineSegment,
+  pointOnLineSegment,
   polygonIncludesPointNonZero,
 } from "@excalidraw/math";
 
@@ -16,7 +17,11 @@ import {
   intersectElementWithLineSegment,
 } from "@excalidraw/element";
 
-import type { ElementsSegmentsMap, GlobalPoint } from "@excalidraw/math/types";
+import type {
+  ElementsSegmentsMap,
+  GlobalPoint,
+  Polygon,
+} from "@excalidraw/math/types";
 import type { ElementsMap, ExcalidrawElement } from "@excalidraw/element/types";
 
 import type { BoxSelectionMode } from "../types";
@@ -111,12 +116,22 @@ const enclosureTest = (
 
   const quantifier = mode === "contain" ? "every" : "some";
 
-  return segments[quantifier]((segment) =>
-    segment[quantifier]((point) =>
-      polygonIncludesPointNonZero(point, lassoPolygon),
-    ),
-  );
+  const includesPoint = (point: GlobalPoint) =>
+    polygonIncludesPointNonZero(point, lassoPolygon) ||
+    (mode === "contain" && isPointOnPolygon(point, lassoPolygon));
+
+  return segments[quantifier]((segment) => segment[quantifier](includesPoint));
 };
+
+const isPointOnPolygon = (
+  point: GlobalPoint,
+  polygon: Polygon<GlobalPoint>,
+): boolean =>
+  polygon.some(
+    (vertex, index) =>
+      index > 0 &&
+      pointOnLineSegment(point, lineSegment(polygon[index - 1], vertex)),
+  );
 
 const intersectionTest = (
   lassoPath: GlobalPoint[],

--- a/packages/excalidraw/lasso/utils.ts
+++ b/packages/excalidraw/lasso/utils.ts
@@ -19,6 +19,8 @@ import {
 import type { ElementsSegmentsMap, GlobalPoint } from "@excalidraw/math/types";
 import type { ElementsMap, ExcalidrawElement } from "@excalidraw/element/types";
 
+import type { BoxSelectionMode } from "../types";
+
 export const getLassoSelectedElementIds = (input: {
   lassoPath: GlobalPoint[];
   elements: readonly ExcalidrawElement[];
@@ -27,7 +29,7 @@ export const getLassoSelectedElementIds = (input: {
   intersectedElements: Set<ExcalidrawElement["id"]>;
   enclosedElements: Set<ExcalidrawElement["id"]>;
   simplifyDistance?: number;
-  mode?: "contain" | "overlap";
+  mode?: BoxSelectionMode;
 }): {
   selectedElementIds: string[];
 } => {
@@ -98,7 +100,7 @@ const enclosureTest = (
   lassoPath: GlobalPoint[],
   element: ExcalidrawElement,
   elementsSegments: ElementsSegmentsMap,
-  mode: "contain" | "overlap" = "overlap",
+  mode: BoxSelectionMode,
 ): boolean => {
   const lassoPolygon = polygonFromPoints(lassoPath);
   const segments = elementsSegments.get(element.id);
@@ -106,19 +108,13 @@ const enclosureTest = (
     return false;
   }
 
-  if (mode === "contain") {
-    return segments.every((segment) => {
-      return segment.every((point) =>
-        polygonIncludesPointNonZero(point, lassoPolygon),
-      );
-    });
-  }
+  const quantifier = mode === "contain" ? "every" : "some";
 
-  return segments.some((segment) => {
-    return segment.some((point) =>
+  return segments[quantifier]((segment) =>
+    segment[quantifier]((point) =>
       polygonIncludesPointNonZero(point, lassoPolygon),
-    );
-  });
+    ),
+  );
 };
 
 const intersectionTest = (

--- a/packages/excalidraw/lasso/utils.ts
+++ b/packages/excalidraw/lasso/utils.ts
@@ -6,6 +6,7 @@ import {
   pointFrom,
   pointOnLineSegment,
   polygonIncludesPointNonZero,
+  PRECISION,
 } from "@excalidraw/math";
 
 import { type Bounds } from "@excalidraw/common";
@@ -78,6 +79,14 @@ export const getLassoSelectedElementIds = (input: {
     },
     [Infinity, Infinity, -Infinity, -Infinity],
   ) as Bounds;
+  const lassoPolygon = polygonFromPoints(path);
+  const containBounds: Bounds = [
+    lassoBounds[0] - PRECISION,
+    lassoBounds[1] - PRECISION,
+    lassoBounds[2] + PRECISION,
+    lassoBounds[3] + PRECISION,
+  ];
+
   for (const element of selectableElements) {
     // Only the visible (frame-clipped) portion of an element is relevant for
     // selection, so everything outside of its frame is disregarded below
@@ -94,13 +103,25 @@ export const getLassoSelectedElementIds = (input: {
       !intersectedElements.has(element.id) &&
       !enclosedElements.has(element.id)
     ) {
+      if (
+        mode === "contain" &&
+        !boundsContainBounds(containBounds, elementBounds)
+      ) {
+        continue;
+      }
+
       const segments = getSelectionSegments(
         element,
         elementsMap,
         elementsSegments,
         clipBounds,
       );
-      const enclosed = enclosureTest(path, segments, elementBounds, mode);
+      const enclosed = enclosureTest(
+        lassoPolygon,
+        segments,
+        elementBounds,
+        mode,
+      );
       if (mode === "contain") {
         if (
           enclosed &&
@@ -295,12 +316,11 @@ const excludeIncompleteGroups = (
 };
 
 const enclosureTest = (
-  lassoPath: GlobalPoint[],
+  lassoPolygon: Polygon<GlobalPoint>,
   segments: LineSegment<GlobalPoint>[],
   elementBounds: Bounds,
   mode: BoxSelectionMode,
 ): boolean => {
-  const lassoPolygon = polygonFromPoints(lassoPath);
   const quantifier = mode === "contain" ? "every" : "some";
 
   const includesPoint = (point: GlobalPoint) =>

--- a/packages/excalidraw/lasso/utils.ts
+++ b/packages/excalidraw/lasso/utils.ts
@@ -75,13 +75,14 @@ export const getLassoSelectedElementIds = (input: {
       !enclosedElements.has(element.id)
     ) {
       const enclosed = enclosureTest(path, element, elementsSegments, mode);
-      if (enclosed) {
-        enclosedElements.add(element.id);
-      } else if (mode === "overlap") {
-        const intersects = intersectionTest(path, element, elementsMap);
-        if (intersects) {
-          intersectedElements.add(element.id);
+      if (mode === "contain") {
+        if (enclosed && !intersectionTest(path, element, elementsMap)) {
+          enclosedElements.add(element.id);
         }
+      } else if (enclosed) {
+        enclosedElements.add(element.id);
+      } else if (intersectionTest(path, element, elementsMap)) {
+        intersectedElements.add(element.id);
       }
     }
   }

--- a/packages/excalidraw/lasso/utils.ts
+++ b/packages/excalidraw/lasso/utils.ts
@@ -41,7 +41,7 @@ export const getLassoSelectedElementIds = (input: {
     intersectedElements,
     enclosedElements,
     simplifyDistance,
-    mode = "overlap",
+    mode = "contain",
   } = input;
   // simplify the path to reduce the number of points
   let path: GlobalPoint[] = lassoPath;

--- a/packages/excalidraw/lasso/utils.ts
+++ b/packages/excalidraw/lasso/utils.ts
@@ -3,6 +3,7 @@ import { simplify } from "points-on-curve";
 import {
   polygonFromPoints,
   lineSegment,
+  pointFrom,
   pointOnLineSegment,
   polygonIncludesPointNonZero,
 } from "@excalidraw/math";
@@ -10,16 +11,22 @@ import {
 import { type Bounds } from "@excalidraw/common";
 
 import {
+  boundsContainBounds,
   computeBoundTextPosition,
   doBoundsIntersect,
+  elementOverlapsWithFrame,
   getBoundTextElement,
+  getContainingFrame,
   getElementBounds,
   intersectElementWithLineSegment,
+  isBoundToContainer,
+  pointInsideBoundsInclusive,
 } from "@excalidraw/element";
 
 import type {
   ElementsSegmentsMap,
   GlobalPoint,
+  LineSegment,
   Polygon,
 } from "@excalidraw/math/types";
 import type { ElementsMap, ExcalidrawElement } from "@excalidraw/element/types";
@@ -53,7 +60,10 @@ export const getLassoSelectedElementIds = (input: {
   if (simplifyDistance) {
     path = simplify(lassoPath, simplifyDistance) as GlobalPoint[];
   }
-  const unlockedElements = elements.filter((el) => !el.locked);
+  // bound text is never selected on its own, it's covered by its container
+  const selectableElements = elements.filter(
+    (el) => !el.locked && !isBoundToContainer(el),
+  );
   // as the path might not enclose a shape anymore, clear before checking
   enclosedElements.clear();
   intersectedElements.clear();
@@ -68,25 +78,39 @@ export const getLassoSelectedElementIds = (input: {
     },
     [Infinity, Infinity, -Infinity, -Infinity],
   ) as Bounds;
-  for (const element of unlockedElements) {
+  for (const element of selectableElements) {
+    // Only the visible (frame-clipped) portion of an element is relevant for
+    // selection, so everything outside of its frame is disregarded below
+    const bounds = getElementBounds(element, elementsMap);
+    const clipBounds = getFrameClipBounds(element, bounds, elementsMap);
+
     // First check if the lasso segment intersects the element's axis-aligned
     // bounding box as it is much faster than checking intersection against
     // the element's shape
-    const elementBounds = getElementBounds(element, elementsMap);
+    const elementBounds = clipToBounds(bounds, clipBounds);
 
     if (
       doBoundsIntersect(lassoBounds, elementBounds) &&
       !intersectedElements.has(element.id) &&
       !enclosedElements.has(element.id)
     ) {
-      const enclosed = enclosureTest(path, element, elementsSegments, mode);
+      const segments = getSelectionSegments(
+        element,
+        elementsMap,
+        elementsSegments,
+        clipBounds,
+      );
+      const enclosed = enclosureTest(path, segments, elementBounds, mode);
       if (mode === "contain") {
-        if (enclosed && !intersectionTest(path, element, elementsMap)) {
+        if (
+          enclosed &&
+          !intersectionTest(path, element, elementsMap, clipBounds)
+        ) {
           enclosedElements.add(element.id);
         }
       } else if (enclosed) {
         enclosedElements.add(element.id);
-      } else if (intersectionTest(path, element, elementsMap)) {
+      } else if (intersectionTest(path, element, elementsMap, clipBounds)) {
         intersectedElements.add(element.id);
       }
     }
@@ -94,7 +118,7 @@ export const getLassoSelectedElementIds = (input: {
 
   const results =
     mode === "contain"
-      ? [...enclosedElements]
+      ? excludeIncompleteGroups([...enclosedElements], elementsMap)
       : [...intersectedElements, ...enclosedElements];
 
   return {
@@ -102,26 +126,202 @@ export const getLassoSelectedElementIds = (input: {
   };
 };
 
+/**
+ * The bounds an element is clipped to by the frame containing it, or `null`
+ * when the element isn't clipped at all.
+ */
+const getFrameClipBounds = (
+  element: ExcalidrawElement,
+  elementBounds: Bounds,
+  elementsMap: ElementsMap,
+): Bounds | null => {
+  const frame = getContainingFrame(element, elementsMap);
+
+  if (!frame) {
+    return null;
+  }
+
+  const frameBounds = getElementBounds(frame, elementsMap);
+
+  // nothing is clipped away from an element fitting inside its frame
+  if (boundsContainBounds(frameBounds, elementBounds)) {
+    return null;
+  }
+
+  return elementOverlapsWithFrame(element, frame, elementsMap)
+    ? frameBounds
+    : null;
+};
+
+const clipToBounds = (bounds: Bounds, clipBounds: Bounds | null): Bounds =>
+  clipBounds
+    ? [
+        Math.max(bounds[0], clipBounds[0]),
+        Math.max(bounds[1], clipBounds[1]),
+        Math.min(bounds[2], clipBounds[2]),
+        Math.min(bounds[3], clipBounds[3]),
+      ]
+    : bounds;
+
+/**
+ * The segments taking part in the selection tests: the element's own outline
+ * together with its label's, clipped to the element's containing frame.
+ */
+const getSelectionSegments = (
+  element: ExcalidrawElement,
+  elementsMap: ElementsMap,
+  elementsSegments: ElementsSegmentsMap,
+  clipBounds: Bounds | null,
+): LineSegment<GlobalPoint>[] => {
+  const elementSegments = elementsSegments.get(element.id) ?? [];
+  const boundTextElement = getBoundTextElement(element, elementsMap);
+  const boundTextSegments = boundTextElement
+    ? elementsSegments.get(boundTextElement.id)
+    : null;
+
+  const segments = boundTextSegments?.length
+    ? [...elementSegments, ...boundTextSegments]
+    : elementSegments;
+
+  return clipBounds ? clipSegmentsToBounds(segments, clipBounds) : segments;
+};
+
+const clipSegmentsToBounds = (
+  segments: LineSegment<GlobalPoint>[],
+  bounds: Bounds,
+): LineSegment<GlobalPoint>[] => {
+  const [minX, minY, maxX, maxY] = bounds;
+  const clipped: LineSegment<GlobalPoint>[] = [];
+
+  for (const [[x1, y1], [x2, y2]] of segments) {
+    const dx = x2 - x1;
+    const dy = y2 - y1;
+    let t0 = 0;
+    let t1 = 1;
+    let inside = true;
+
+    // clip the segment against each of the four edges in turn, narrowing down
+    // the [t0, t1] portion of it which lies inside the bounds
+    for (const [p, q] of [
+      [-dx, x1 - minX],
+      [dx, maxX - x1],
+      [-dy, y1 - minY],
+      [dy, maxY - y1],
+    ]) {
+      if (p === 0) {
+        // parallel to this edge: either entirely inside or entirely outside
+        if (q < 0) {
+          inside = false;
+          break;
+        }
+        continue;
+      }
+
+      const t = q / p;
+      if (p < 0) {
+        if (t > t1) {
+          inside = false;
+          break;
+        }
+        t0 = Math.max(t0, t);
+      } else {
+        if (t < t0) {
+          inside = false;
+          break;
+        }
+        t1 = Math.min(t1, t);
+      }
+    }
+
+    if (inside) {
+      clipped.push(
+        lineSegment(
+          pointFrom<GlobalPoint>(x1 + t0 * dx, y1 + t0 * dy),
+          pointFrom<GlobalPoint>(x1 + t1 * dx, y1 + t1 * dy),
+        ),
+      );
+    }
+  }
+
+  return clipped;
+};
+
+/**
+ * In "contain" mode a group is only selected if every one of its members is,
+ * mirroring marquee selection.
+ *
+ * NOTE: currently we only support top-level group handling since we don't
+ * support box selecting while editing the group/subgroup
+ */
+const excludeIncompleteGroups = (
+  selectedElementIds: ExcalidrawElement["id"][],
+  elementsMap: ElementsMap,
+): ExcalidrawElement["id"][] => {
+  if (!selectedElementIds.some((id) => elementsMap.get(id)?.groupIds.length)) {
+    return selectedElementIds;
+  }
+
+  const groups = new Map<string, ExcalidrawElement["id"][]>();
+
+  for (const element of elementsMap.values()) {
+    const groupId = element.groupIds.at(-1);
+
+    // ignored elements such as bound text and locked elements must not
+    // affect group selection
+    if (!groupId || element.locked || isBoundToContainer(element)) {
+      continue;
+    }
+
+    const group = groups.get(groupId);
+    if (group) {
+      group.push(element.id);
+    } else {
+      groups.set(groupId, [element.id]);
+    }
+  }
+
+  if (!groups.size) {
+    return selectedElementIds;
+  }
+
+  const selected = new Set(selectedElementIds);
+
+  return selectedElementIds.filter((id) => {
+    const groupId = elementsMap.get(id)?.groupIds.at(-1);
+    const group = groupId ? groups.get(groupId) : null;
+
+    return !group || group.every((memberId) => selected.has(memberId));
+  });
+};
+
 const enclosureTest = (
   lassoPath: GlobalPoint[],
-  element: ExcalidrawElement,
-  elementsSegments: ElementsSegmentsMap,
+  segments: LineSegment<GlobalPoint>[],
+  elementBounds: Bounds,
   mode: BoxSelectionMode,
 ): boolean => {
   const lassoPolygon = polygonFromPoints(lassoPath);
-  const segments = elementsSegments.get(element.id);
-  if (!segments || segments.length === 0) {
-    return false;
-  }
-
   const quantifier = mode === "contain" ? "every" : "some";
 
   const includesPoint = (point: GlobalPoint) =>
     polygonIncludesPointNonZero(point, lassoPolygon) ||
     (mode === "contain" && isPointOnPolygon(point, lassoPolygon));
 
+  // NOTE: elements without an outline (e.g. a single point freedraw dot) are
+  // tested by the corners of their bounding box instead
+  if (segments.length === 0) {
+    return boundsCorners(elementBounds)[quantifier](includesPoint);
+  }
+
   return segments[quantifier]((segment) => segment[quantifier](includesPoint));
 };
+
+const boundsCorners = ([minX, minY, maxX, maxY]: Bounds): GlobalPoint[] => [
+  pointFrom(minX, minY),
+  pointFrom(maxX, minY),
+  pointFrom(maxX, maxY),
+  pointFrom(minX, maxY),
+];
 
 const isPointOnPolygon = (
   point: GlobalPoint,
@@ -137,6 +337,7 @@ const intersectionTest = (
   lassoPath: GlobalPoint[],
   element: ExcalidrawElement,
   elementsMap: ElementsMap,
+  clipBounds: Bounds | null,
 ): boolean => {
   const lassoSegments = lassoPath
     .slice(1)
@@ -145,25 +346,35 @@ const intersectionTest = (
 
   const boundTextElement = getBoundTextElement(element, elementsMap);
 
+  // hits on the part of the element clipped away by its frame are invisible,
+  // hence they do not count as an intersection
+  const intersects = (
+    target: ExcalidrawElement,
+    lassoSegment: LineSegment<GlobalPoint>,
+  ) => {
+    const hits = intersectElementWithLineSegment(
+      target,
+      elementsMap,
+      lassoSegment,
+      0,
+      !clipBounds,
+    );
+
+    return clipBounds
+      ? hits.some((hit) => pointInsideBoundsInclusive(hit, clipBounds))
+      : hits.length > 0;
+  };
+
   return lassoSegments.some(
     (lassoSegment) =>
-      intersectElementWithLineSegment(
-        element,
-        elementsMap,
-        lassoSegment,
-        0,
-        true,
-      ).length > 0 ||
+      intersects(element, lassoSegment) ||
       (!!boundTextElement &&
-        intersectElementWithLineSegment(
+        intersects(
           {
             ...boundTextElement,
             ...computeBoundTextPosition(element, boundTextElement, elementsMap),
           },
-          elementsMap,
           lassoSegment,
-          0,
-          true,
-        ).length > 0),
+        )),
   );
 };

--- a/packages/excalidraw/lasso/utils.ts
+++ b/packages/excalidraw/lasso/utils.ts
@@ -27,6 +27,7 @@ export const getLassoSelectedElementIds = (input: {
   intersectedElements: Set<ExcalidrawElement["id"]>;
   enclosedElements: Set<ExcalidrawElement["id"]>;
   simplifyDistance?: number;
+  mode?: "contain" | "overlap";
 }): {
   selectedElementIds: string[];
 } => {
@@ -38,6 +39,7 @@ export const getLassoSelectedElementIds = (input: {
     intersectedElements,
     enclosedElements,
     simplifyDistance,
+    mode = "overlap",
   } = input;
   // simplify the path to reduce the number of points
   let path: GlobalPoint[] = lassoPath;
@@ -70,10 +72,10 @@ export const getLassoSelectedElementIds = (input: {
       !intersectedElements.has(element.id) &&
       !enclosedElements.has(element.id)
     ) {
-      const enclosed = enclosureTest(path, element, elementsSegments);
+      const enclosed = enclosureTest(path, element, elementsSegments, mode);
       if (enclosed) {
         enclosedElements.add(element.id);
-      } else {
+      } else if (mode === "overlap") {
         const intersects = intersectionTest(path, element, elementsMap);
         if (intersects) {
           intersectedElements.add(element.id);
@@ -82,7 +84,10 @@ export const getLassoSelectedElementIds = (input: {
     }
   }
 
-  const results = [...intersectedElements, ...enclosedElements];
+  const results =
+    mode === "contain"
+      ? [...enclosedElements]
+      : [...intersectedElements, ...enclosedElements];
 
   return {
     selectedElementIds: results,
@@ -93,11 +98,20 @@ const enclosureTest = (
   lassoPath: GlobalPoint[],
   element: ExcalidrawElement,
   elementsSegments: ElementsSegmentsMap,
+  mode: "contain" | "overlap" = "overlap",
 ): boolean => {
   const lassoPolygon = polygonFromPoints(lassoPath);
   const segments = elementsSegments.get(element.id);
-  if (!segments) {
+  if (!segments || segments.length === 0) {
     return false;
+  }
+
+  if (mode === "contain") {
+    return segments.every((segment) => {
+      return segment.every((point) =>
+        polygonIncludesPointNonZero(point, lassoPolygon),
+      );
+    });
   }
 
   return segments.some((segment) => {

--- a/packages/excalidraw/tests/lasso.test.tsx
+++ b/packages/excalidraw/tests/lasso.test.tsx
@@ -1966,6 +1966,203 @@ describe("Box selection mode (through the lasso tool)", () => {
     expect(selectedIds()).toEqual(["rect"]);
   });
 
+  it("does not select a container whose label alone is enclosed", () => {
+    act(() => {
+      h.elements = [
+        API.createElement({
+          type: "rectangle",
+          id: "container",
+          x: 100,
+          y: 100,
+          width: 200,
+          height: 100,
+          boundElements: [{ type: "text", id: "label" }],
+        }),
+        API.createElement({
+          type: "text",
+          id: "label",
+          x: 140,
+          y: 130,
+          width: 80,
+          height: 25,
+          containerId: "container",
+        }),
+      ];
+    });
+
+    // NOTE: the lasso wraps around the label only, staying well inside the
+    // container it is bound to
+    const LASSO: GlobalPoint[] = (
+      [
+        [130, 120],
+        [230, 120],
+        [230, 165],
+        [130, 165],
+        [130, 120],
+      ] as [number, number][]
+    ).map(([x, y]) => pointFrom<GlobalPoint>(x, y));
+
+    expect(h.state.boxSelectionMode).toBe("contain");
+
+    drawLasso(LASSO);
+
+    expect(selectedIds()).toEqual([]);
+
+    // NOTE: reaching the label is enough to select the container in "overlap"
+    act(() => h.app.setState({ boxSelectionMode: "overlap" }));
+
+    drawLasso(LASSO);
+
+    expect(selectedIds()).toEqual(["container"]);
+  });
+
+  describe("lasso enclosing a single member of a group", () => {
+    const LASSO: GlobalPoint[] = (
+      [
+        [80, 80],
+        [200, 80],
+        [200, 200],
+        [80, 200],
+        [80, 80],
+      ] as [number, number][]
+    ).map(([x, y]) => pointFrom<GlobalPoint>(x, y));
+
+    beforeEach(() => {
+      act(() => {
+        h.elements = [
+          API.createElement({
+            type: "rectangle",
+            id: "member1",
+            x: 100,
+            y: 100,
+            width: 50,
+            height: 50,
+            groupIds: ["group"],
+          }),
+          API.createElement({
+            type: "rectangle",
+            id: "member2",
+            x: 300,
+            y: 100,
+            width: 50,
+            height: 50,
+            groupIds: ["group"],
+          }),
+        ];
+      });
+    });
+
+    it("selects nothing in 'contain' mode, as the group isn't complete", () => {
+      expect(h.state.boxSelectionMode).toBe("contain");
+
+      drawLasso(LASSO);
+
+      expect(selectedIds()).toEqual([]);
+    });
+
+    it("selects the whole group in 'overlap' mode", () => {
+      act(() => h.app.setState({ boxSelectionMode: "overlap" }));
+
+      drawLasso(LASSO);
+
+      expect(selectedIds()).toEqual(["member1", "member2"]);
+    });
+
+    it("selects the whole group once all its members are enclosed", () => {
+      expect(h.state.boxSelectionMode).toBe("contain");
+
+      drawLasso(
+        (
+          [
+            [80, 80],
+            [400, 80],
+            [400, 200],
+            [80, 200],
+            [80, 80],
+          ] as [number, number][]
+        ).map(([x, y]) => pointFrom<GlobalPoint>(x, y)),
+      );
+
+      expect(selectedIds()).toEqual(["member1", "member2"]);
+    });
+  });
+
+  it("contains an element whose frame-clipped part is enclosed", () => {
+    act(() => {
+      h.elements = [
+        API.createElement({
+          type: "frame",
+          id: "frame",
+          x: 0,
+          y: 0,
+          width: 200,
+          height: 200,
+        }),
+        // NOTE: overflows the frame to the right, so only the x = 150 to 200
+        // part of it is visible
+        API.createElement({
+          type: "rectangle",
+          id: "overflowing",
+          x: 150,
+          y: 50,
+          width: 100,
+          height: 50,
+          frameId: "frame",
+        }),
+      ];
+    });
+
+    // NOTE: wraps the visible part of the rectangle, while its right edge cuts
+    // through the clipped-away part of it
+    const LASSO: GlobalPoint[] = (
+      [
+        [140, 40],
+        [210, 40],
+        [210, 110],
+        [140, 110],
+        [140, 40],
+      ] as [number, number][]
+    ).map(([x, y]) => pointFrom<GlobalPoint>(x, y));
+
+    expect(h.state.boxSelectionMode).toBe("contain");
+
+    drawLasso(LASSO);
+
+    expect(selectedIds()).toEqual(["overflowing"]);
+  });
+
+  it("contains elements without an outline, such as a freedraw dot", () => {
+    act(() => {
+      h.elements = [
+        API.createElement({
+          type: "freedraw",
+          id: "dot",
+          x: 100,
+          y: 100,
+          width: 0,
+          height: 0,
+          points: [pointFrom<LocalPoint>(0, 0)],
+        }),
+      ];
+    });
+
+    const LASSO: GlobalPoint[] = (
+      [
+        [80, 80],
+        [120, 80],
+        [120, 120],
+        [80, 120],
+        [80, 80],
+      ] as [number, number][]
+    ).map(([x, y]) => pointFrom<GlobalPoint>(x, y));
+
+    expect(h.state.boxSelectionMode).toBe("contain");
+
+    drawLasso(LASSO);
+
+    expect(selectedIds()).toEqual(["dot"]);
+  });
+
   it("contains elements whose outline lies exactly on the lasso path", () => {
     act(() => {
       h.elements = [

--- a/packages/excalidraw/tests/lasso.test.tsx
+++ b/packages/excalidraw/tests/lasso.test.tsx
@@ -40,12 +40,7 @@ const { h } = window;
 
 beforeEach(async () => {
   localStorage.clear();
-  await render(
-    <Excalidraw
-      handleKeyboardGlobally={true}
-      initialData={{ appState: { boxSelectionMode: "overlap" } }}
-    />,
-  );
+  await render(<Excalidraw handleKeyboardGlobally={true} />);
   h.state.width = 1000;
   h.state.height = 1000;
 });
@@ -373,6 +368,7 @@ describe("Basic lasso selection tests", () => {
     act(() => {
       h.elements = elements;
       h.app.setActiveTool({ type: "lasso" });
+      h.app.setState({ boxSelectionMode: "overlap" });
     });
   });
 
@@ -1055,6 +1051,7 @@ describe("Special cases", () => {
       })) as ExcalidrawElement[];
 
       h.elements = elements;
+      h.app.setState({ boxSelectionMode: "overlap" });
     });
 
     const startPoint = pointFrom<GlobalPoint>(-352, -64);
@@ -1774,6 +1771,7 @@ describe("Special cases", () => {
       })) as ExcalidrawElement[];
 
       h.elements = elements;
+      h.app.setState({ boxSelectionMode: "overlap" });
     });
 
     const startPoint = pointFrom<GlobalPoint>(117, 463);
@@ -1856,44 +1854,169 @@ describe("Special cases", () => {
     expect(selected.map((el) => el.id)).toContain("rect1");
     expect(selected.map((el) => el.id)).not.toContain("rect2");
   });
+});
 
-  it("does not treat an element as contained when the lasso cuts through it", () => {
-    const rect = API.createElement({
-      type: "rectangle",
-      id: "rect",
-      x: 100,
-      y: 100,
-      width: 50,
-      height: 50,
+describe("Box selection mode (through the lasso tool)", () => {
+  const drawLasso = (points: GlobalPoint[]) => {
+    act(() => {
+      h.app.lassoTrail.startPath(points[0][0], points[0][1]);
+      points
+        .slice(1)
+        .forEach(([x, y]) => h.app.lassoTrail.addPointToPath(x, y));
+      h.app.lassoTrail.endPath();
+    });
+  };
+
+  const selectedIds = () => Object.keys(h.state.selectedElementIds).sort();
+
+  describe("lasso enclosing one element and cutting through another", () => {
+    // NOTE: the lasso wraps around `enclosed`, while its right edge (x = 320) cuts
+    // through `crossed` (x = 300 to 350)
+    const LASSO: GlobalPoint[] = (
+      [
+        [80, 80],
+        [320, 80],
+        [320, 220],
+        [80, 220],
+        [80, 80],
+      ] as [number, number][]
+    ).map(([x, y]) => pointFrom<GlobalPoint>(x, y));
+
+    beforeEach(() => {
+      act(() => {
+        h.elements = [
+          API.createElement({
+            type: "rectangle",
+            id: "enclosed",
+            x: 100,
+            y: 100,
+            width: 50,
+            height: 50,
+          }),
+          API.createElement({
+            type: "rectangle",
+            id: "crossed",
+            x: 300,
+            y: 100,
+            width: 50,
+            height: 50,
+          }),
+        ];
+      });
     });
 
-    h.elements = [rect];
+    it("selects only enclosed elements with the default mode ('contain')", () => {
+      expect(h.state.boxSelectionMode).toBe("contain");
 
-    // EX: lasso surrounding the rectangle, but with a spike poking through its
-    // top edge into its interior: all four corners are inside the lasso polygon,
-    // yet the rectangle is not fully contained
-    const startPoint = pointFrom<GlobalPoint>(80, 80);
-    const lassoPoints = [
-      [0, 0],
-      [40, 0],
-      [40, 45],
-      [50, 45],
-      [50, 0],
-      [90, 0],
-      [90, 90],
-      [0, 90],
-      [0, 0],
-    ] as LocalPoint[];
+      drawLasso(LASSO);
 
-    act(() => h.app.setState({ boxSelectionMode: "contain" }));
-    updatePath(startPoint, lassoPoints);
-    expect(getSelectedElements(h.elements, h.state).length).toBe(0);
+      expect(selectedIds()).toEqual(["enclosed"]);
+    });
 
-    // NOTE: the same lasso still selects it in 'overlap' mode
+    it("selects intersected elements as well in 'overlap' mode", () => {
+      act(() => h.app.setState({ boxSelectionMode: "overlap" }));
+
+      drawLasso(LASSO);
+
+      expect(selectedIds()).toEqual(["crossed", "enclosed"]);
+    });
+  });
+
+  it("does not treat an element as contained when the lasso cuts through it", () => {
+    act(() => {
+      h.elements = [
+        API.createElement({
+          type: "rectangle",
+          id: "rect",
+          x: 100,
+          y: 100,
+          width: 50,
+          height: 50,
+        }),
+      ];
+    });
+
+    // NOTE: the lasso surrounding the rectangle, but with a spike poking through
+    // its top edge into its interior: all four corners are inside the lasso
+    // polygon, yet the rectangle is not fully contained
+    const LASSO: GlobalPoint[] = (
+      [
+        [80, 80],
+        [120, 80],
+        [120, 125],
+        [130, 125],
+        [130, 80],
+        [170, 80],
+        [170, 170],
+        [80, 170],
+        [80, 80],
+      ] as [number, number][]
+    ).map(([x, y]) => pointFrom<GlobalPoint>(x, y));
+
+    drawLasso(LASSO);
+
+    expect(h.state.boxSelectionMode).toBe("contain");
+    expect(selectedIds()).toEqual([]);
+
+    // NOTE: the very same lasso still selects it in "overlap" mode
     act(() => h.app.setState({ boxSelectionMode: "overlap" }));
-    updatePath(startPoint, lassoPoints);
-    expect(getSelectedElements(h.elements, h.state).map((el) => el.id)).toEqual(
-      ["rect"],
-    );
+
+    drawLasso(LASSO);
+
+    expect(selectedIds()).toEqual(["rect"]);
+  });
+
+  it("contains elements whose outline lies exactly on the lasso path", () => {
+    act(() => {
+      h.elements = [
+        API.createElement({
+          type: "rectangle",
+          id: "rect",
+          x: 100,
+          y: 100,
+          width: 50,
+          height: 50,
+        }),
+      ];
+    });
+
+    // NOTE: a lasso running exactly along one edge of the rectangle, from each
+    // of the four sides in turn. Which side it is may not decide the outcome.
+    const LASSOS = {
+      right: [
+        [80, 80],
+        [150, 80],
+        [150, 200],
+        [80, 200],
+      ],
+      left: [
+        [100, 80],
+        [200, 80],
+        [200, 200],
+        [100, 200],
+      ],
+      top: [
+        [80, 100],
+        [200, 100],
+        [200, 200],
+        [80, 200],
+      ],
+      bottom: [
+        [80, 50],
+        [200, 50],
+        [200, 150],
+        [80, 150],
+      ],
+    } as Record<string, [number, number][]>;
+
+    expect(h.state.boxSelectionMode).toBe("contain");
+
+    for (const [side, lasso] of Object.entries(LASSOS)) {
+      drawLasso(
+        [...lasso, lasso[0]].map(([x, y]) => pointFrom<GlobalPoint>(x, y)),
+      );
+
+      expect([side, selectedIds()]).toEqual([side, ["rect"]]);
+    }
   });
 });

--- a/packages/excalidraw/tests/lasso.test.tsx
+++ b/packages/excalidraw/tests/lasso.test.tsx
@@ -24,7 +24,7 @@ import {
 
 import { getElementLineSegments } from "@excalidraw/element";
 
-import type { ExcalidrawElement } from "@excalidraw/element/types";
+import type { ExcalidrawElement, FractionalIndex } from "@excalidraw/element/types";
 
 import { Excalidraw } from "../index";
 
@@ -38,7 +38,12 @@ const { h } = window;
 
 beforeEach(async () => {
   localStorage.clear();
-  await render(<Excalidraw handleKeyboardGlobally={true} />);
+  await render(
+    <Excalidraw
+      handleKeyboardGlobally={true}
+      initialData={{ appState: { boxSelectionMode: "overlap" } }}
+    />,
+  );
   h.state.width = 1000;
   h.state.height = 1000;
 });
@@ -74,6 +79,7 @@ const updatePath = (startPoint: GlobalPoint, points: LocalPoint[]) => {
       elementsSegments,
       intersectedElements: new Set(),
       enclosedElements: new Set(),
+      mode: h.state.boxSelectionMode,
     });
 
     act(() =>
@@ -1800,5 +1806,92 @@ describe("Special cases", () => {
     const selectedElements = getSelectedElements(h.elements, h.state);
     expect(selectedElements.length).toBe(16);
     expect(h.app.state.selectedGroupIds["-9NzH7Fa5JaHu4ArEFpa_"]).toBe(true);
+  });
+
+  it("respects boxSelectionMode ('contain' vs 'overlap') during lasso selection", () => {
+    const rect1: ExcalidrawElement = {
+      id: "rect1",
+      type: "rectangle",
+      x: 100,
+      y: 100,
+      width: 50,
+      height: 50,
+      angle: 0 as Radians,
+      strokeColor: "#000000",
+      backgroundColor: "transparent",
+      fillStyle: "solid",
+      strokeWidth: 1,
+      strokeStyle: "solid",
+      roughness: 0,
+      opacity: 100,
+      groupIds: [],
+      frameId: null,
+      index: "a1" as FractionalIndex,
+      roundness: null,
+      seed: 1,
+      version: 1,
+      versionNonce: 1,
+      isDeleted: false,
+      boundElements: [],
+      updated: 1,
+      link: null,
+      locked: false,
+    };
+
+    const rect2: ExcalidrawElement = {
+      id: "rect2",
+      type: "rectangle",
+      x: 300,
+      y: 300,
+      width: 50,
+      height: 50,
+      angle: 0 as Radians,
+      strokeColor: "#000000",
+      backgroundColor: "transparent",
+      fillStyle: "solid",
+      strokeWidth: 1,
+      strokeStyle: "solid",
+      roughness: 0,
+      opacity: 100,
+      groupIds: [],
+      frameId: null,
+      index: "a2" as FractionalIndex,
+      roundness: null,
+      seed: 2,
+      version: 1,
+      versionNonce: 2,
+      isDeleted: false,
+      boundElements: [],
+      updated: 1,
+      link: null,
+      locked: false,
+    };
+
+    h.elements = [rect1, rect2];
+
+    // Lasso path enclosing rect1 fully, and intersecting rect2 partially
+    const startPoint = pointFrom<GlobalPoint>(80, 80);
+    const lassoPoints = [
+      [0, 0],
+      [100, 0],
+      [240, 240],
+      [240, 320],
+      [0, 320],
+      [0, 0],
+    ] as LocalPoint[];
+
+    // 1) Test 'overlap' mode -> should select both rect1 (enclosed) and rect2 (intersected)
+    act(() => h.app.setState({ boxSelectionMode: "overlap" }));
+    updatePath(startPoint, lassoPoints);
+    let selected = getSelectedElements(h.elements, h.state);
+    expect(selected.map((el) => el.id)).toContain("rect1");
+    expect(selected.map((el) => el.id)).toContain("rect2");
+
+    // 2) Test 'contain' mode -> should select ONLY rect1 (enclosed), not rect2 (only intersected)
+    act(() => h.app.setState({ boxSelectionMode: "contain" }));
+    updatePath(startPoint, lassoPoints);
+    selected = getSelectedElements(h.elements, h.state);
+    expect(selected.map((el) => el.id)).toContain("rect1");
+    expect(selected.map((el) => el.id)).not.toContain("rect2");
   });
 });

--- a/packages/excalidraw/tests/lasso.test.tsx
+++ b/packages/excalidraw/tests/lasso.test.tsx
@@ -24,13 +24,15 @@ import {
 
 import { getElementLineSegments } from "@excalidraw/element";
 
-import type { ExcalidrawElement, FractionalIndex } from "@excalidraw/element/types";
+import type { ExcalidrawElement } from "@excalidraw/element/types";
 
 import { Excalidraw } from "../index";
 
 import { getSelectedElements } from "../scene";
 
 import { getLassoSelectedElementIds } from "../lasso/utils";
+
+import { API } from "./helpers/api";
 
 import { act, render } from "./test-utils";
 
@@ -1809,63 +1811,23 @@ describe("Special cases", () => {
   });
 
   it("respects boxSelectionMode ('contain' vs 'overlap') during lasso selection", () => {
-    const rect1: ExcalidrawElement = {
-      id: "rect1",
+    const rect1 = API.createElement({
       type: "rectangle",
+      id: "rect1",
       x: 100,
       y: 100,
       width: 50,
       height: 50,
-      angle: 0 as Radians,
-      strokeColor: "#000000",
-      backgroundColor: "transparent",
-      fillStyle: "solid",
-      strokeWidth: 1,
-      strokeStyle: "solid",
-      roughness: 0,
-      opacity: 100,
-      groupIds: [],
-      frameId: null,
-      index: "a1" as FractionalIndex,
-      roundness: null,
-      seed: 1,
-      version: 1,
-      versionNonce: 1,
-      isDeleted: false,
-      boundElements: [],
-      updated: 1,
-      link: null,
-      locked: false,
-    };
+    });
 
-    const rect2: ExcalidrawElement = {
-      id: "rect2",
+    const rect2 = API.createElement({
       type: "rectangle",
+      id: "rect2",
       x: 300,
       y: 300,
       width: 50,
       height: 50,
-      angle: 0 as Radians,
-      strokeColor: "#000000",
-      backgroundColor: "transparent",
-      fillStyle: "solid",
-      strokeWidth: 1,
-      strokeStyle: "solid",
-      roughness: 0,
-      opacity: 100,
-      groupIds: [],
-      frameId: null,
-      index: "a2" as FractionalIndex,
-      roundness: null,
-      seed: 2,
-      version: 1,
-      versionNonce: 2,
-      isDeleted: false,
-      boundElements: [],
-      updated: 1,
-      link: null,
-      locked: false,
-    };
+    });
 
     h.elements = [rect1, rect2];
 

--- a/packages/excalidraw/tests/lasso.test.tsx
+++ b/packages/excalidraw/tests/lasso.test.tsx
@@ -1856,4 +1856,44 @@ describe("Special cases", () => {
     expect(selected.map((el) => el.id)).toContain("rect1");
     expect(selected.map((el) => el.id)).not.toContain("rect2");
   });
+
+  it("does not treat an element as contained when the lasso cuts through it", () => {
+    const rect = API.createElement({
+      type: "rectangle",
+      id: "rect",
+      x: 100,
+      y: 100,
+      width: 50,
+      height: 50,
+    });
+
+    h.elements = [rect];
+
+    // EX: lasso surrounding the rectangle, but with a spike poking through its
+    // top edge into its interior: all four corners are inside the lasso polygon,
+    // yet the rectangle is not fully contained
+    const startPoint = pointFrom<GlobalPoint>(80, 80);
+    const lassoPoints = [
+      [0, 0],
+      [40, 0],
+      [40, 45],
+      [50, 45],
+      [50, 0],
+      [90, 0],
+      [90, 90],
+      [0, 90],
+      [0, 0],
+    ] as LocalPoint[];
+
+    act(() => h.app.setState({ boxSelectionMode: "contain" }));
+    updatePath(startPoint, lassoPoints);
+    expect(getSelectedElements(h.elements, h.state).length).toBe(0);
+
+    // NOTE: the same lasso still selects it in 'overlap' mode
+    act(() => h.app.setState({ boxSelectionMode: "overlap" }));
+    updatePath(startPoint, lassoPoints);
+    expect(getSelectedElements(h.elements, h.state).map((el) => el.id)).toEqual(
+      ["rect"],
+    );
+  });
 });

--- a/packages/excalidraw/tests/selection.test.tsx
+++ b/packages/excalidraw/tests/selection.test.tsx
@@ -182,14 +182,17 @@ describe("lasso reselection", () => {
       h.app.setActiveTool({ type: "lasso" });
     });
 
+    // NOTE: the lasso starts inside the common bounds of the selection, and
+    // encloses rectA only (the default box selection mode being "contain")
     Keyboard.withModifierKeys({ ctrl: true, alt: true }, () => {
       mouse.downAt(110, 50);
-      mouse.moveTo(50, -20);
+      mouse.moveTo(110, -50);
 
       expect(h.app.lassoTrail.hasCurrentTrail).toBe(true);
 
-      mouse.moveTo(-20, 50);
-      mouse.moveTo(50, 120);
+      mouse.moveTo(-50, -50);
+      mouse.moveTo(-50, 150);
+      mouse.moveTo(110, 150);
       mouse.moveTo(110, 50);
       mouse.up();
     });


### PR DESCRIPTION
Closes #11809

> ⚠️ **Note:** This PR has one pre-existing failing test in `selection.test.tsx` unrelated to this fix. It is already resolved in **#11861** — please merge **#11861 first**.

---

## Problem

The freeform lasso tool always selected elements in **"overlap"** mode — selecting anything its path touched — completely ignoring the user's **"Select on wrap vs overlap"** preference in settings.

This toggle worked correctly for the **rectangle** selection tool but had **zero effect** on the lasso tool.

---

## Root Cause

Two issues in `packages/excalidraw/lasso/utils.ts`:

1. `getLassoSelectedElementIds()` had no `mode` parameter — it couldn't know the user's preference.
2. `enclosureTest()` always used `.some()` logic — classifying an element as "enclosed" if even **one point** fell inside the lasso. This is wrong for `"contain"` mode where **all points** must be fully inside.

---

## Fix

### `lasso/utils.ts` — Fixed `enclosureTest` to use `.every()` for contain mode

```ts
if (mode === "contain") {
  // ALL points must be inside the lasso polygon
  return segments.every((segment) =>
    segment.every((point) => polygonIncludesPointNonZero(point, lassoPolygon))
  );
}
// overlap: original behavior preserved
return segments.some((segment) =>
  segment.some((point) => polygonIncludesPointNonZero(point, lassoPolygon))
);
```

### `lasso/index.ts` — Pass user preference through selection flow

```ts
const { selectedElementIds } = getLassoSelectedElementIds({
  ...
  mode: this.app.state.boxSelectionMode,
});
```

### `lasso.test.tsx` — Fixed tests + added new coverage

- Fixed `beforeEach` to explicitly initialize `boxSelectionMode: "overlap"` so all 6 original tests run with their intended behavior.
- Added a new `Special cases` test verifying both `contain` and `overlap` modes work correctly.

---

## Demo


https://github.com/user-attachments/assets/86e03e9a-f034-433d-9d17-134f4db035c3


---

## Verification

```bash
yarn test packages/excalidraw/tests/lasso.test.tsx
```

```
✓ lasso.test.tsx   7/7 tests passed
✓ yarn test:typecheck — 0 errors
```

## Files Changed

| File | Change |
|------|--------|
| `packages/excalidraw/lasso/utils.ts` | Fixed `enclosureTest` with `.every()` for contain mode; added `mode` param |
| `packages/excalidraw/lasso/index.ts` | Pass `mode: this.app.state.boxSelectionMode` |
| `packages/excalidraw/tests/lasso.test.tsx` | Fixed `beforeEach`; added `boxSelectionMode` test |
