### PR TITLE
docs: remove duplicated words in comments (to to / the the)

### DIFF
--- a/packages/element/src/collision.ts
+++ b/packages/element/src/collision.ts
@@ -327,7 +327,7 @@ export const getAllHoveredElementAtPoint = (
   tolerance?: number,
 ): NonDeleted<ExcalidrawBindableElement>[] => {
   const candidateElements: NonDeleted<ExcalidrawBindableElement>[] = [];
-  // We need to to hit testing from front (end of the array) to back (beginning of the array)
+  // We need to hit testing from front (end of the array) to back (beginning of the array)
   // because array is ordered from lower z-index to highest and we want element z-index
   // with higher z-index
   for (let index = elements.length - 1; index >= 0; --index) {
@@ -393,7 +393,7 @@ export const getHoveredElementForFocusPoint = (
   tolerance?: number,
 ): NonDeleted<ExcalidrawBindableElement> | null => {
   const candidateElements: NonDeleted<ExcalidrawBindableElement>[] = [];
-  // We need to to hit testing from front (end of the array) to back (beginning of the array)
+  // We need to hit testing from front (end of the array) to back (beginning of the array)
   // because array is ordered from lower z-index to highest and we want element z-index
   // with higher z-index
   for (let index = elements.length - 1; index >= 0; --index) {

--- a/packages/element/src/duplicate.ts
+++ b/packages/element/src/duplicate.ts
@@ -496,7 +496,7 @@ const _deepCopyElement = (val: any, depth: number = 0) => {
 
 /**
  * Clones ExcalidrawElement data structure. Does not regenerate id, nonce, or
- * any value. The purpose is to to break object references for immutability
+ * any value. The purpose is to break object references for immutability
  * reasons, whenever we want to keep the original element, but ensure it's not
  * mutated.
  *

--- a/packages/element/src/groups.ts
+++ b/packages/element/src/groups.ts
@@ -238,7 +238,7 @@ export const getSelectedGroupIds = (
     .filter(([groupId, isSelected]) => isSelected)
     .map(([groupId, isSelected]) => groupId);
 
-// given a list of elements, return the the actual group ids that should be selected
+// given a list of elements, return the actual group ids that should be selected
 // or used to update the elements
 export const selectGroupsFromGivenElements = (
   elements: readonly NonDeletedExcalidrawElement[],

--- a/packages/excalidraw/renderer/staticSvgScene.ts
+++ b/packages/excalidraw/renderer/staticSvgScene.ts
@@ -514,7 +514,7 @@ const renderElementToSvg = (
         // We first apply `scale` transforms (horizontal/vertical mirroring)
         // on the <use> element, then apply translation and rotation
         // on the <g> element which wraps the <use>.
-        // Doing this separately is a quick hack to to work around compositing
+        // Doing this separately is a quick hack to work around compositing
         // the transformations correctly (the transform-origin was not being
         // applied correctly).
         if (element.scale[0] !== 1 || element.scale[1] !== 1) {


### PR DESCRIPTION
### WHY

Several code comments contain duplicated words (`to to`, `the the`) — trivial typos in comments only.

### WHAT

Fix 5 comments across `packages/element` and `packages/excalidraw/renderer`:

| File | Before | After |
|------|--------|-------|
| `element/src/duplicate.ts` | `is to to break` | `is to break` |
| `element/src/groups.ts` | `return the the actual` | `return the actual` |
| `element/src/collision.ts` (2x) | `need to to hit` | `need to hit` |
| `excalidraw/renderer/staticSvgScene.ts` | `hack to to work` | `hack to work` |

Comments only; no code or behavior change.