### PR TITLE
fix: link icon chip shows white background in dark theme

### DIFF
--- a/packages/excalidraw/renderer/staticScene.ts
+++ b/packages/excalidraw/renderer/staticScene.ts
@@ -158,13 +158,7 @@ export const frameClip = (
 
 type LinkIconCanvas = HTMLCanvasElement & { zoom: number };
 
-const linkIconCanvasCache: {
-  regularLink: LinkIconCanvas | null;
-  elementLink: LinkIconCanvas | null;
-} = {
-  regularLink: null,
-  elementLink: null,
-};
+const linkIconCanvasCache = new Map<string, LinkIconCanvas>();
 
 const renderLinkIcon = (
   element: NonDeletedExcalidrawElement,
@@ -185,20 +179,21 @@ const renderLinkIcon = (
     context.translate(appState.scrollX + centerX, appState.scrollY + centerY);
     context.rotate(element.angle);
 
-    const canvasKey = isElementLink(element.link)
-      ? "elementLink"
-      : "regularLink";
+    const linkType = isElementLink(element.link) ? "elementLink" : "regularLink";
+    const bgColor = appState.viewBackgroundColor || COLOR_WHITE;
+    const isDark = appState.theme === THEME.DARK;
+    const cacheKey = `${linkType}:${appState.zoom.value}:${bgColor}:${isDark}`;
 
-    let linkCanvas = linkIconCanvasCache[canvasKey];
+    let linkCanvas = linkIconCanvasCache.get(cacheKey);
 
-    if (!linkCanvas || linkCanvas.zoom !== appState.zoom.value) {
+    if (!linkCanvas) {
       linkCanvas = Object.assign(document.createElement("canvas"), {
         zoom: appState.zoom.value,
       });
       linkCanvas.width = width * window.devicePixelRatio * appState.zoom.value;
       linkCanvas.height =
         height * window.devicePixelRatio * appState.zoom.value;
-      linkIconCanvasCache[canvasKey] = linkCanvas;
+      linkIconCanvasCache.set(cacheKey, linkCanvas);
 
       const linkCanvasCacheContext = linkCanvas.getContext("2d")!;
       linkCanvasCacheContext.scale(
@@ -209,12 +204,11 @@ const renderLinkIcon = (
       // Seed a sane default so a corrupted color (silently rejected by the
       // canvas) falls back to white instead of a stale fillStyle.
       linkCanvasCacheContext.fillStyle = COLOR_WHITE;
-      linkCanvasCacheContext.fillStyle =
-        appState.viewBackgroundColor || COLOR_WHITE;
+      linkCanvasCacheContext.fillStyle = applyDarkModeFilter(bgColor, isDark);
 
       linkCanvasCacheContext.fillRect(0, 0, width, height);
 
-      if (canvasKey === "elementLink") {
+      if (linkType === "elementLink") {
         linkCanvasCacheContext.drawImage(ELEMENT_LINK_IMG, 0, 0, width, height);
       } else {
         linkCanvasCacheContext.drawImage(


### PR DESCRIPTION
Fixes #11844

## Problem

Elements with hyperlinks show a link-icon chip in the top-right corner. In dark mode the chip renders on a white background, clashing with the dark canvas. In light mode it is invisible (canvas is also white), so the bug only surfaced in dark theme.

Two root causes, both in `packages/excalidraw/renderer/staticScene.ts`:

**1. Stale cache across theme / background-color changes**
`linkIconCanvasCache` was a plain two-slot object (`regularLink` / `elementLink`) evicted only when zoom changed. Switching to dark mode or changing `viewBackgroundColor` left the old white canvas in the slot — no invalidation.

**2. Background fill ignored the dark-mode filter**
The chip background was painted with `appState.viewBackgroundColor` directly, never passed through `applyDarkModeFilter`. Every other part of the renderer wraps the background through that filter in dark mode; this code did not.

## Fix

- Replace `linkIconCanvasCache` with a `Map<string, LinkIconCanvas>` keyed by `linkType:zoom:bgColor:isDark` — any dimension change gets a fresh canvas automatically.
- Route the fill through `applyDarkModeFilter(bgColor, isDark)` so the chip background matches the actual rendered canvas in both themes.
- Simplify the invalidation guard from `!linkCanvas || linkCanvas.zoom !== appState.zoom.value` to `!linkCanvas` — zoom is now encoded in the key.

No new imports needed; `applyDarkModeFilter` and `THEME` were already imported.