### PR TITLE
fix: upgrade websocket-driver to 0.7.5 (CVE-2026-54466)

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "clean-install": "yarn rm:node_modules && yarn install"
   },
   "resolutions": {
-    "strip-ansi": "6.0.1"
+    "strip-ansi": "6.0.1",
+    "websocket-driver": "0.7.5"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10423,10 +10423,10 @@ webpack@^5.88.2:
     watchpack "^2.4.1"
     webpack-sources "^3.2.3"
 
-websocket-driver@>=0.5.1:
-  version "0.7.4"
-  resolved "https://registry.yarnpkg.com/websocket-driver/-/websocket-driver-0.7.4.tgz#89ad5295bbf64b480abcba31e4953aca706f5760"
-  integrity sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==
+websocket-driver@0.7.5, websocket-driver@>=0.5.1:
+  version "0.7.5"
+  resolved "https://registry.yarnpkg.com/websocket-driver/-/websocket-driver-0.7.5.tgz#569d22764ab21f2de20af0e74b411e8ae5a0fa46"
+  integrity sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA==
   dependencies:
     http-parser-js ">=0.5.1"
     safe-buffer ">=5.1.0"


### PR DESCRIPTION
## Summary
Upgrade websocket-driver from 0.7.4 to 0.7.5 to fix CVE-2026-54466.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | CVE-2026-54466 ([GHSA-xv26-6w52-cph6](https://github.com/faye/websocket-driver-node/security/advisories/GHSA-xv26-6w52-cph6)) |
| **Severity** | CRITICAL (CVSS v4 9.2) |
| **Scanner** | trivy |
| **Rule** | `CVE-2026-54466` |
| **File** | `yarn.lock` (dependency: `websocket-driver`) |

**Description**: `websocket-driver` parses the WebSocket frame length header into a JS number. Because JS uses 64-bit floats, a client can send an ever-growing length value that loses precision, causing the driver to misread subsequent payload bytes as message data ("message corruption via abuse of protocol length headers"). Affects all versions `< 0.7.5`; no workaround exists pre-patch. Fixed in 0.7.5 by rejecting frames whose length header exceeds the configured max message length.

## Reachability
`yarn why websocket-driver` traces the only path into the tree as:

```
excalidraw-app -> firebase -> @firebase/database -> faye-websocket -> websocket-driver
```

So it ships as part of the `firebase` npm package that `excalidraw-app` depends on (for storage), not via webpack/build tooling. That said, `excalidraw-app/data/firebase.ts` only imports `firebase/app` and `firebase/storage` — it never imports `firebase/database` (Realtime Database), which is the only Firebase product that pulls in `faye-websocket`/`websocket-driver`. So the vulnerable code is present in the installed dependency tree but isn't on any path Excalidraw actually executes or bundles today. Pinning it is still worthwhile since `yarn.lock` would otherwise happily resolve the `>=0.5.1` range to a vulnerable version for this or any future consumer.

## Changes
- `package.json`: add `"websocket-driver": "0.7.5"` to `resolutions`
- `yarn.lock`: collapses `websocket-driver@>=0.5.1` onto the pinned `0.7.5` (no second copy installed), so the pin actually takes effect on install

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*