### PR TITLE
fix(i18n): localize sign-up and sign-in menu items

### DIFF
--- a/excalidraw-app/components/AppMainMenu.tsx
+++ b/excalidraw-app/components/AppMainMenu.tsx
@@ -1,12 +1,12 @@
+import { isDevEnv } from "@excalidraw/common";
 import {
-  loginIcon,
   ExcalLogo,
   eyeIcon,
+  loginIcon,
 } from "@excalidraw/excalidraw/components/icons";
+import { useI18n } from "@excalidraw/excalidraw/i18n";
 import { MainMenu } from "@excalidraw/excalidraw/index";
 import React from "react";
-
-import { isDevEnv } from "@excalidraw/common";
 
 import type { Theme } from "@excalidraw/element/types";
 
@@ -22,6 +22,7 @@ export const AppMainMenu: React.FC<{
   theme: Theme | "system";
   refresh: () => void;
 }> = React.memo((props) => {
+  const { t } = useI18n();
   return (
     <MainMenu>
       <MainMenu.DefaultItems.LoadScene />
@@ -56,7 +57,7 @@ export const AppMainMenu: React.FC<{
         }?utm_source=signin&utm_medium=app&utm_content=hamburger`}
         className="highlighted"
       >
-        {isExcalidrawPlusSignedUser ? "Sign in" : "Sign up"}
+        {isExcalidrawPlusSignedUser ? t("labels.signIn") : t("labels.signUp")}
       </MainMenu.ItemLink>
       {isDevEnv() && (
         <MainMenu.Item

--- a/excalidraw-app/components/AppWelcomeScreen.tsx
+++ b/excalidraw-app/components/AppWelcomeScreen.tsx
@@ -1,5 +1,5 @@
-import { loginIcon } from "@excalidraw/excalidraw/components/icons";
 import { POINTER_EVENTS } from "@excalidraw/common";
+import { loginIcon } from "@excalidraw/excalidraw/components/icons";
 import { useI18n } from "@excalidraw/excalidraw/i18n";
 import { WelcomeScreen } from "@excalidraw/excalidraw/index";
 import React from "react";
@@ -72,7 +72,7 @@ export const AppWelcomeScreen: React.FC<{
               shortcut={null}
               icon={loginIcon}
             >
-              Sign up
+              {t("labels.signUp")}
             </WelcomeScreen.Center.MenuItemLink>
           )}
         </WelcomeScreen.Center.Menu>

--- a/packages/excalidraw/locales/en.json
+++ b/packages/excalidraw/locales/en.json
@@ -1,5 +1,7 @@
 {
   "labels": {
+    "signUp":"Sign up",
+    "signIn":"Sign in",
     "paste": "Paste",
     "pasteAsPlaintext": "Paste as plaintext",
     "pasteCharts": "Paste charts",


### PR DESCRIPTION
## Description

Fixes #11876

Replaced hardcoded `"Sign up"` and `"Sign in"` UI strings in the main menu and welcome screen with dynamic localization calls `t("labels.signUp")` and `t("labels.signIn")`. Also added the source keys to `packages/excalidraw/locales/en.json` so Crowdin can sync the strings for translation across all supported languages.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code cleanup / Refactoring

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or console errors
- [x] I have tested these changes locally in both English and non-English locales
- [x] I have updated `en.json` with the required localization keys

## Screenshots

| Before | After |
| :--- | :--- |
| Hardcoded English in non-English locales | Translates dynamically via `t(...)` keys |
<img width="328" height="644" alt="Screenshot 2026-08-12 at 10 14 21 PM" src="https://github.com/user-attachments/assets/3add24ec-2839-4462-aecd-39c5f1a9df4d" />
