### PR TITLE
fix(packages/excalidraw): add accessible names to image export scale options

### DIFF
--- a/packages/excalidraw/components/ImageExportDialog.tsx
+++ b/packages/excalidraw/components/ImageExportDialog.tsx
@@ -293,10 +293,15 @@ const ImageExportModal = ({
               setExportScale(scale);
               actionManager.executeAction(actionChangeExportScale, "ui", scale);
             }}
-            choices={EXPORT_SCALES.map((scale) => ({
-              value: scale,
-              label: `${scale}\u00d7`,
-            }))}
+            choices={EXPORT_SCALES.map((scale) => {
+              const label = `${scale}\u00d7`;
+
+              return {
+                value: scale,
+                label,
+                ariaLabel: label,
+              };
+            })}
           />
         </ExportSetting>
 

--- a/packages/excalidraw/components/ImageExportDialog.tsx
+++ b/packages/excalidraw/components/ImageExportDialog.tsx
@@ -286,23 +286,32 @@ const ImageExportModal = ({
           label={t("imageExportDialog.label.scale")}
           name="exportScale"
         >
-          <RadioGroup
-            name="exportScale"
-            value={exportScale}
-            onChange={(scale) => {
-              setExportScale(scale);
-              actionManager.executeAction(actionChangeExportScale, "ui", scale);
-            }}
-            choices={EXPORT_SCALES.map((scale) => {
-              const label = `${scale}\u00d7`;
+          <div
+            role="radiogroup"
+            aria-label={t("imageExportDialog.label.scale")}
+          >
+            <RadioGroup
+              name="exportScale"
+              value={exportScale}
+              onChange={(scale) => {
+                setExportScale(scale);
+                actionManager.executeAction(
+                  actionChangeExportScale,
+                  "ui",
+                  scale,
+                );
+              }}
+              choices={EXPORT_SCALES.map((scale) => {
+                const label = `${scale}\u00d7`;
 
-              return {
-                value: scale,
-                label,
-                ariaLabel: label,
-              };
-            })}
-          />
+                return {
+                  value: scale,
+                  label,
+                  ariaLabel: label,
+                };
+              })}
+            />
+          </div>
         </ExportSetting>
 
         <div className="ImageExportModal__settings__buttons">

--- a/packages/excalidraw/tests/excalidraw.test.tsx
+++ b/packages/excalidraw/tests/excalidraw.test.tsx
@@ -1,4 +1,4 @@
-import { queryByText, queryByTestId } from "@testing-library/react";
+import { getByRole, queryByText, queryByTestId } from "@testing-library/react";
 import { useMemo } from "react";
 
 import { THEME } from "@excalidraw/common";
@@ -496,5 +496,26 @@ describe("<Excalidraw/>", () => {
     expect(container.querySelector(".excalidraw")).toHaveClass(
       "custom-excalidraw",
     );
+  });
+
+  describe("Test image export dialog", () => {
+    it("exposes accessible names for the export scale options", async () => {
+      const { container } = await render(<Excalidraw />);
+
+      toggleMenu(container);
+      fireEvent.click(queryByTestId(container, "image-export-button")!);
+
+      const imageExportModal = document.querySelector(
+        ".ImageExportModal",
+      ) as HTMLElement;
+
+      for (const scale of [1, 2, 3]) {
+        expect(
+          getByRole(imageExportModal, "radio", {
+            name: `${scale}\u00d7`,
+          }),
+        ).toBeInTheDocument();
+      }
+    });
   });
 });

--- a/packages/excalidraw/tests/excalidraw.test.tsx
+++ b/packages/excalidraw/tests/excalidraw.test.tsx
@@ -499,7 +499,7 @@ describe("<Excalidraw/>", () => {
   });
 
   describe("Test image export dialog", () => {
-    it("exposes accessible names for the export scale options", async () => {
+    it("exposes the export scale options as an accessible radio group", async () => {
       const { container } = await render(<Excalidraw />);
 
       toggleMenu(container);
@@ -508,10 +508,13 @@ describe("<Excalidraw/>", () => {
       const imageExportModal = document.querySelector(
         ".ImageExportModal",
       ) as HTMLElement;
+      const scaleRadioGroup = getByRole(imageExportModal, "radiogroup", {
+        name: "Scale",
+      });
 
       for (const scale of [1, 2, 3]) {
         expect(
-          getByRole(imageExportModal, "radio", {
+          getByRole(scaleRadioGroup, "radio", {
             name: `${scale}\u00d7`,
           }),
         ).toBeInTheDocument();


### PR DESCRIPTION
## Summary

- add accessible names to the `1×`, `2×`, and `3×` radio buttons in the image export dialog
- reuse each option's visible label as its `aria-label`
- add a regression test that queries every scale option by role and accessible name

## Problem

The image export scale values are visually displayed as `1×`, `2×`, and `3×`, but the corresponding radio inputs do not currently have accessible names.

Because the visible text is not semantically associated with each input, assistive technologies expose the controls only as unnamed radio buttons. This makes it difficult for screen reader users to determine which export scale they are selecting.

## Implementation

`RadioGroup` already supports an optional `ariaLabel` for each choice. This PR supplies the existing visible scale label through that API in `ImageExportDialog`.

I kept the change at the call site to avoid changing the behavior of other `RadioGroup` consumers.

There are no intended visual or interaction changes.

## Accessibility tree

### Before

The radio buttons expose their position in the group, but no accessible `name`.


<img width="950" height="245" alt="before-accessibility-tree-en" src="https://github.com/user-attachments/assets/8dc526c1-b23f-4eca-8d00-1f41f15f0701" />

### After

Each radio button is exposed with its corresponding accessible name: `1×`, `2×`, or `3×`.

<img width="950" height="245" alt="after-accessibility-tree-en" src="https://github.com/user-attachments/assets/3d0d26c8-e5eb-459f-bb53-c401994af2c9" />

### UI context

<img width="341" height="361" alt="export-dialog-en" src="https://github.com/user-attachments/assets/7ad8f05c-ef3d-4745-9356-13fe65556182" />


## Testing

- `yarn test:app packages/excalidraw/tests/excalidraw.test.tsx --watch=false`
- `yarn test:app --watch=false`
- `yarn test:typecheck`
- ESLint on the changed files
- `yarn build`
- manually verified the before and after states in Chromium's accessibility tree

Thank you for building and maintaining Excalidraw. I use it regularly and really appreciate the care that goes into the project.

This is a deliberately small proposed fix. If this approach fits the project, please feel free to merge it. If a different implementation would be more appropriate, I'm also happy to revise the PR or follow the maintainers' preferred direction.