### PR TITLE
feat: make linked text directly clickable

### DIFF
--- a/excalidraw-app/App.tsx
+++ b/excalidraw-app/App.tsx
@@ -451,6 +451,28 @@ const ExcalidrawWrapper = () => {
   });
 
   const [, forceRefresh] = useState(false);
+  const [showLinkIcons, setShowLinkIcons] = useState(() => {
+    try {
+      return (
+        localStorage.getItem(STORAGE_KEYS.LOCAL_STORAGE_SHOW_LINK_ICONS) !==
+        "false"
+      );
+    } catch {
+      return true;
+    }
+  });
+
+  const updateShowLinkIcons = useCallback((show: boolean) => {
+    setShowLinkIcons(show);
+    try {
+      localStorage.setItem(
+        STORAGE_KEYS.LOCAL_STORAGE_SHOW_LINK_ICONS,
+        String(show),
+      );
+    } catch {
+      // Local storage may be unavailable in privacy-restricted contexts.
+    }
+  }, []);
 
   useEffect(() => {
     if (isDevEnv()) {
@@ -946,6 +968,7 @@ const ExcalidrawWrapper = () => {
       })}
     >
       <Excalidraw
+        showLinkIcons={showLinkIcons}
         viewportStatusFrame={viewportStatusFrame}
         userToFollow={userToFollow}
         onChange={onChange}
@@ -1033,6 +1056,8 @@ const ExcalidrawWrapper = () => {
           isCollabEnabled={!isCollabDisabled}
           theme={appTheme}
           refresh={() => forceRefresh((prev) => !prev)}
+          showLinkIcons={showLinkIcons}
+          onShowLinkIconsChange={updateShowLinkIcons}
         />
         <AppWelcomeScreen
           onCollabDialogOpen={onCollabDialogOpen}

--- a/excalidraw-app/app_constants.ts
+++ b/excalidraw-app/app_constants.ts
@@ -42,6 +42,7 @@ export const STORAGE_KEYS = {
   LOCAL_STORAGE_COLLAB: "excalidraw-collab",
   LOCAL_STORAGE_THEME: "excalidraw-theme",
   LOCAL_STORAGE_DEBUG: "excalidraw-debug",
+  LOCAL_STORAGE_SHOW_LINK_ICONS: "excalidraw-show-link-icons",
   VERSION_DATA_STATE: "version-dataState",
   VERSION_FILES: "version-files",
 

--- a/excalidraw-app/components/AppMainMenu.tsx
+++ b/excalidraw-app/components/AppMainMenu.tsx
@@ -4,6 +4,8 @@ import {
   eyeIcon,
 } from "@excalidraw/excalidraw/components/icons";
 import { MainMenu } from "@excalidraw/excalidraw/index";
+import DropdownMenuItemCheckbox from "@excalidraw/excalidraw/components/dropdownMenu/DropdownMenuItemCheckbox";
+import { t } from "@excalidraw/excalidraw/i18n";
 import React from "react";
 
 import { isDevEnv } from "@excalidraw/common";
@@ -21,6 +23,8 @@ export const AppMainMenu: React.FC<{
   isCollabEnabled: boolean;
   theme: Theme | "system";
   refresh: () => void;
+  showLinkIcons: boolean;
+  onShowLinkIconsChange: (showLinkIcons: boolean) => void;
 }> = React.memo((props) => {
   return (
     <MainMenu>
@@ -76,7 +80,19 @@ export const AppMainMenu: React.FC<{
         </MainMenu.Item>
       )}
       <MainMenu.Separator />
-      <MainMenu.DefaultItems.Preferences />
+      <MainMenu.DefaultItems.Preferences
+        additionalItems={
+          <DropdownMenuItemCheckbox
+            checked={props.showLinkIcons}
+            onSelect={(event) => {
+              props.onShowLinkIconsChange(!props.showLinkIcons);
+              event.preventDefault();
+            }}
+          >
+            {t("labels.showLinkIcons")}
+          </DropdownMenuItemCheckbox>
+        }
+      />
       <MainMenu.DefaultItems.ToggleTheme allowSystemTheme theme={props.theme} />
       <MainMenu.ItemCustom>
         <LanguageList style={{ width: "100%" }} />

--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -2586,7 +2586,9 @@ class App extends React.Component<AppProps, AppState> {
                               imageCache: this.imageCache,
                               isExporting: false,
                               renderGrid: isGridModeEnabled(this),
-                              renderLinks: this.isLinksEnabled(),
+                              renderLinks:
+                                this.isLinksEnabled() &&
+                                this.props.showLinkIcons !== false,
                               canvasBackgroundColor:
                                 this.state.viewBackgroundColor,
                               embedsValidationStatus:
@@ -7196,6 +7198,7 @@ class App extends React.Component<AppProps, AppState> {
   private getElementLinkAtPosition = (
     scenePointer: Readonly<{ x: number; y: number }>,
     hitElementMightBeLocked: NonDeletedExcalidrawElement | null,
+    openTextLinkOnModifierClick = false,
   ): NonDeletedExcalidrawElement | undefined => {
     if (hitElementMightBeLocked && hitElementMightBeLocked.locked) {
       return undefined;
@@ -7221,6 +7224,7 @@ class App extends React.Component<AppProps, AppState> {
           this.state,
           pointFrom(scenePointer.x, scenePointer.y),
           this.editorInterface.formFactor === "phone",
+          openTextLinkOnModifierClick,
         )
       ) {
         return element;
@@ -7255,6 +7259,7 @@ class App extends React.Component<AppProps, AppState> {
       this.state,
       pointFrom(lastPointerDownCoords.x, lastPointerDownCoords.y),
       this.editorInterface.formFactor === "phone",
+      this.lastPointerDownEvent![KEYS.CTRL_OR_CMD],
     );
     const lastPointerUpCoords = viewportCoordsToSceneCoords(
       this.lastPointerUpEvent!,
@@ -7266,6 +7271,7 @@ class App extends React.Component<AppProps, AppState> {
       this.state,
       pointFrom(lastPointerUpCoords.x, lastPointerUpCoords.y),
       this.editorInterface.formFactor === "phone",
+      this.lastPointerUpEvent![KEYS.CTRL_OR_CMD],
     );
     if (lastPointerDownHittingLinkIcon && lastPointerUpHittingLinkIcon) {
       hideHyperlinkToolip();
@@ -8034,6 +8040,7 @@ class App extends React.Component<AppProps, AppState> {
       this.hitLinkElement = this.getElementLinkAtPosition(
         scenePointer,
         hitElementMightBeLocked,
+        event[KEYS.CTRL_OR_CMD],
       );
     }
 
@@ -9425,6 +9432,7 @@ class App extends React.Component<AppProps, AppState> {
         this.hitLinkElement = this.getElementLinkAtPosition(
           pointerDownState.origin,
           hitElementMightBeLocked,
+          event[KEYS.CTRL_OR_CMD],
         );
 
         if (this.hitLinkElement) {
@@ -9446,6 +9454,7 @@ class App extends React.Component<AppProps, AppState> {
               y: pointerDownState.origin.y,
             },
             pointerDownState.hit.element,
+            event[KEYS.CTRL_OR_CMD],
           );
           if (hitLinkElement) {
             return false;

--- a/packages/excalidraw/components/hyperlink/helpers.ts
+++ b/packages/excalidraw/components/hyperlink/helpers.ts
@@ -1,7 +1,7 @@
 import { pointFrom, pointRotateRads } from "@excalidraw/math";
 
 import { MIME_TYPES } from "@excalidraw/common";
-import { getElementAbsoluteCoords } from "@excalidraw/element";
+import { getElementAbsoluteCoords, isTextElement } from "@excalidraw/element";
 import { hitElementBoundingBox } from "@excalidraw/element";
 
 import type { GlobalPoint, Radians } from "@excalidraw/math";
@@ -85,13 +85,19 @@ export const isPointHittingLink = (
   appState: AppState,
   [x, y]: GlobalPoint,
   isMobile: boolean,
+  openTextLinkOnModifierClick = false,
 ) => {
-  if (!element.link || appState.selectedElementIds[element.id]) {
+  const isModifierTextLink =
+    openTextLinkOnModifierClick && isTextElement(element);
+  if (
+    !element.link ||
+    (appState.selectedElementIds[element.id] && !isModifierTextLink)
+  ) {
     return false;
   }
   if (
     !isMobile &&
-    appState.viewModeEnabled &&
+    (appState.viewModeEnabled || isModifierTextLink) &&
     hitElementBoundingBox(pointFrom(x, y), element, elementsMap)
   ) {
     return true;

--- a/packages/excalidraw/index.tsx
+++ b/packages/excalidraw/index.tsx
@@ -83,6 +83,7 @@ const ExcalidrawBase = (props: ExcalidrawProps) => {
     renderTopRightUI,
     langCode = defaultLang.code,
     viewModeEnabled,
+    showLinkIcons,
     interaction,
     ui,
     activeTool,
@@ -224,6 +225,7 @@ const ExcalidrawBase = (props: ExcalidrawProps) => {
           renderTopRightUI={renderTopRightUI}
           langCode={langCode}
           viewModeEnabled={viewModeEnabled}
+          showLinkIcons={showLinkIcons}
           interaction={interaction}
           ui={ui}
           activeTool={activeTool}

--- a/packages/excalidraw/locales/en.json
+++ b/packages/excalidraw/locales/en.json
@@ -189,6 +189,7 @@
     "shapeSwitch": "Switch shape",
     "preferences": "Preferences",
     "preferences_toolLock": "Tool lock",
+    "showLinkIcons": "Show link icons",
     "boxSelectionMode": "Select on",
     "boxSelectionContain": "Wrap",
     "boxSelectionOverlap": "Overlap",

--- a/packages/excalidraw/locales/ru-RU.json
+++ b/packages/excalidraw/locales/ru-RU.json
@@ -188,6 +188,7 @@
     "shapeSwitch": "Сменить форму",
     "preferences": "Настройки",
     "preferences_toolLock": "Закрепить инструмент",
+    "showLinkIcons": "Показывать значки ссылок",
     "boxSelectionMode": "",
     "boxSelectionContain": "",
     "boxSelectionOverlap": "",

--- a/packages/excalidraw/tests/interactivity.test.tsx
+++ b/packages/excalidraw/tests/interactivity.test.tsx
@@ -911,6 +911,20 @@ describe("interaction={{ enabled: { links } }}", () => {
     return rect;
   };
 
+  const addText = (link: string) => {
+    const text = API.createElement({
+      type: "text",
+      x: 20,
+      y: 20,
+      width: 120,
+      height: 40,
+      text: "Linked heading",
+    });
+    API.setElements([text]);
+    API.updateElement(text, { link });
+    return text;
+  };
+
   // the link-mode pointerup relies on `hitLinkElement` being set during a
   // preceding pointermove (on non-touchscreen devices), so hover first
   const clickElementCenter = () => {
@@ -969,6 +983,54 @@ describe("interaction={{ enabled: { links } }}", () => {
     expect(windowOpenSpy).not.toHaveBeenCalled();
     // and the click didn't select the element
     expect(h.state.selectedElementIds).toEqual({});
+  });
+
+  it("opens a linked text element with Ctrl/Cmd+click while editing", async () => {
+    await render(<Excalidraw showLinkIcons={false} onLinkOpen={onLinkOpen} />);
+    const linkedText = addText("https://excalidraw.com");
+
+    Keyboard.withModifierKeys({ ctrl: true }, () => {
+      mouse.clickAt(80, 40);
+    });
+
+    expect(onLinkOpenSpy).toHaveBeenCalledTimes(1);
+    expect(onLinkOpenSpy.mock.calls[0][0]).toMatchObject({
+      id: linkedText.id,
+      link: "https://excalidraw.com",
+    });
+    expect(h.state.selectedElementIds).toEqual({});
+  });
+
+  it("opens a linked text element with a regular click in view mode", async () => {
+    await render(
+      <Excalidraw
+        viewModeEnabled={true}
+        showLinkIcons={false}
+        onLinkOpen={onLinkOpen}
+      />,
+    );
+    const linkedText = addText("https://excalidraw.com");
+
+    mouse.reset();
+    mouse.moveTo(80, 40);
+    mouse.clickAt(80, 40);
+
+    expect(onLinkOpenSpy).toHaveBeenCalledTimes(1);
+    expect(onLinkOpenSpy.mock.calls[0][0]).toMatchObject({
+      id: linkedText.id,
+      link: "https://excalidraw.com",
+    });
+    expect(h.state.selectedElementIds).toEqual({});
+  });
+
+  it("selects linked text on regular click while editing", async () => {
+    await render(<Excalidraw showLinkIcons={false} onLinkOpen={onLinkOpen} />);
+    const linkedText = addText("https://excalidraw.com");
+
+    mouse.clickAt(80, 40);
+
+    expect(onLinkOpenSpy).not.toHaveBeenCalled();
+    expect(h.state.selectedElementIds).toEqual({ [linkedText.id]: true });
   });
 
   it("{enabled: {links: true}}: clicking an element without a link does nothing", async () => {

--- a/packages/excalidraw/types.ts
+++ b/packages/excalidraw/types.ts
@@ -849,6 +849,13 @@ export interface ExcalidrawProps {
   langCode?: Language["code"];
   viewModeEnabled?: boolean;
   /**
+   * Whether to draw the link indicator next to linked elements. Disabling the
+   * indicator does not disable link hit-testing or navigation.
+   *
+   * @default true
+   */
+  showLinkIcons?: boolean;
+  /**
    * Whether the editor accepts user input (pointer, keyboard, wheel, touch,
    * clipboard, drag&drop). When `false`, the scene still renders and reacts
    * to programmatic updates (imperative API), but the user cannot affect it


### PR DESCRIPTION
## Summary

- open linked text with a regular click in view mode
- open linked text with Ctrl/Cmd+click while editing
- keep regular clicks available for selecting and editing text
- add an option to hide link icons without disabling navigation
- preserve the existing behavior by showing link icons by default

## Motivation

Linked headings currently require clicking a separate link indicator. This makes
linked text less direct to use, especially in view mode.

The change makes the text itself interactive while preserving the existing
editing workflow and the original link indicators by default.

## Testing

- Added tests for Ctrl/Cmd+click while editing
- Added a test for regular click in view mode
- Added a regression test ensuring regular click still selects text while editing
- `packages/excalidraw/tests/interactivity.test.tsx`: 63 tests passed
- Prettier and ESLint passed for all changed files
- Production Vite build passed

I’d appreciate any feedback. If anything should be changed or improved, I’m happy to update the implementation.