### PR TITLE
feat (control panel): develop highlight pen features. 

### DIFF
--- a/packages/common/src/constants.ts
+++ b/packages/common/src/constants.ts
@@ -491,6 +491,7 @@ export const TOOL_TYPE = {
   arrow: "arrow",
   line: "line",
   freedraw: "freedraw",
+  highlighter: "highlighter",
   text: "text",
   image: "image",
   eraser: "eraser",

--- a/packages/element/src/comparisons.ts
+++ b/packages/element/src/comparisons.ts
@@ -7,8 +7,6 @@ export const hasBackground = (type: ElementOrToolType) =>
   type === "ellipse" ||
   type === "diamond" ||
   type === "line" ||
-  type === "freedraw" ||
-  type === "highlighter" ||
   type === "autoshape" ||
   // tool-only type; makes the `G` background shortcut work for bucket fill
   type === "bucketfill";

--- a/packages/element/src/comparisons.ts
+++ b/packages/element/src/comparisons.ts
@@ -8,6 +8,7 @@ export const hasBackground = (type: ElementOrToolType) =>
   type === "diamond" ||
   type === "line" ||
   type === "freedraw" ||
+  type === "highlighter" ||
   type === "autoshape" ||
   // tool-only type; makes the `G` background shortcut work for bucket fill
   type === "bucketfill";
@@ -17,6 +18,7 @@ export const hasStrokeColor = (type: ElementOrToolType) =>
   type === "ellipse" ||
   type === "diamond" ||
   type === "freedraw" ||
+  type === "highlighter" ||
   type === "arrow" ||
   type === "line" ||
   type === "text" ||
@@ -30,6 +32,7 @@ export const hasStrokeWidth = (type: ElementOrToolType) =>
   type === "ellipse" ||
   type === "diamond" ||
   type === "freedraw" ||
+  type === "highlighter" ||
   type === "arrow" ||
   type === "line" ||
   type === "autoshape";
@@ -44,7 +47,8 @@ export const hasStrokeStyle = (type: ElementOrToolType) =>
   type === "line" ||
   type === "autoshape";
 
-export const hasFreedrawMode = (type: ElementOrToolType) => type === "freedraw";
+export const hasFreedrawMode = (type: ElementOrToolType) =>
+  type === "freedraw" || type === "highlighter";
 
 export const canChangeRoundness = (type: ElementOrToolType) =>
   type === "rectangle" ||

--- a/packages/excalidraw/actions/actionFinalize.tsx
+++ b/packages/excalidraw/actions/actionFinalize.tsx
@@ -360,7 +360,10 @@ export const actionFinalize = register<FormData>({
     // converted separately), so it stays active regardless of `element`
     const keepActiveTool =
       appState.activeTool.type === "autoshape" ||
-      ((isToolLocked || appState.activeTool.type === "freedraw") && !!element);
+      ((isToolLocked ||
+        appState.activeTool.type === "freedraw" ||
+        appState.activeTool.type === "highlighter") &&
+        !!element);
 
     if (!keepActiveTool) {
       // the active tool reverts (see the returned `appState.activeTool`) —
@@ -403,7 +406,10 @@ export const actionFinalize = register<FormData>({
         frameToHighlight: null,
         selectedElementIds: isDrawShapeTool
           ? {}
-          : element && !isToolLocked && appState.activeTool.type !== "freedraw"
+          : element &&
+            !isToolLocked &&
+            appState.activeTool.type !== "freedraw" &&
+            appState.activeTool.type !== "highlighter"
           ? {
               ...appState.selectedElementIds,
               [element.id]: true,

--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -8719,10 +8719,13 @@ class App extends React.Component<AppProps, AppState> {
         this.state.activeTool.type,
         pointerDownState,
       );
-    } else if (this.state.activeTool.type === "freedraw") {
+    } else if (
+      this.state.activeTool.type === "freedraw" ||
+      this.state.activeTool.type === "highlighter"
+    ) {
       this.handleFreeDrawElementOnPointerDown(
         event,
-        this.state.activeTool.type,
+        "freedraw",
         pointerDownState,
       );
     } else if (this.state.activeTool.type === "custom") {
@@ -9789,17 +9792,26 @@ class App extends React.Component<AppProps, AppState> {
 
     const strokeVariability = this.state.currentItemStrokeVariability;
 
+    const isHighlighter = this.state.activeTool.type === "highlighter";
+    const strokeColor =
+      isHighlighter &&
+      (this.state.currentItemStrokeColor === "#1e1e1e" ||
+        this.state.currentItemStrokeColor === "#000000" ||
+        !this.state.currentItemStrokeColor)
+        ? "#ffd500"
+        : this.state.currentItemStrokeColor;
+
     const element = newFreeDrawElement({
       type: elementType,
       x: gridX,
       y: gridY,
-      strokeColor: this.state.currentItemStrokeColor,
+      strokeColor,
       backgroundColor: this.state.currentItemBackgroundColor,
       fillStyle: this.state.currentItemFillStyle,
-      strokeWidth: this.getCurrentItemStrokeWidth("freedraw"),
+      strokeWidth: isHighlighter ? 20 : this.getCurrentItemStrokeWidth("freedraw"),
       strokeStyle: this.state.currentItemStrokeStyle,
       roughness: this.state.currentItemRoughness,
-      opacity: this.state.currentItemOpacity,
+      opacity: isHighlighter ? 40 : this.state.currentItemOpacity,
       roundness: null,
       simulatePressure,
       strokeOptions: {
@@ -12338,6 +12350,7 @@ class App extends React.Component<AppProps, AppState> {
       if (
         !this.isToolLocked() &&
         activeTool.type !== "freedraw" &&
+        activeTool.type !== "highlighter" &&
         newElement
       ) {
         this.setState((prevState) => ({
@@ -12399,6 +12412,7 @@ class App extends React.Component<AppProps, AppState> {
       if (
         !this.isToolLocked() &&
         activeTool.type !== "freedraw" &&
+        activeTool.type !== "highlighter" &&
         // bucket fill stays active for back-to-back fills regardless of the
         // tool lock (paint-bucket UX)
         activeTool.type !== TOOL_TYPE.bucketfill &&

--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -6039,6 +6039,15 @@ class App extends React.Component<AppProps, AppState> {
         this.store.scheduleCapture();
       }
 
+      if (nextActiveTool.type === "highlighter") {
+        this.store.scheduleCapture();
+        if (this.state.activeTool.type !== "highlighter") {
+          this.setState({ currentItemOpacity: 40 });
+        }
+      } else if (this.state.activeTool.type === "highlighter") {
+        this.setState({ currentItemOpacity: 100 });
+      }
+
       if (nextActiveTool.type === "lasso") {
         return {
           ...prevState,
@@ -9801,6 +9810,15 @@ class App extends React.Component<AppProps, AppState> {
         ? "#ffd500"
         : this.state.currentItemStrokeColor;
 
+    const baseStrokeWidth = this.getCurrentItemStrokeWidth("freedraw");
+    const strokeWidth = isHighlighter
+      ? baseStrokeWidth <= 0.5
+        ? 2
+        : baseStrokeWidth <= 1.0
+        ? 4
+        : 6.6
+      : baseStrokeWidth;
+
     const element = newFreeDrawElement({
       type: elementType,
       x: gridX,
@@ -9808,10 +9826,10 @@ class App extends React.Component<AppProps, AppState> {
       strokeColor,
       backgroundColor: this.state.currentItemBackgroundColor,
       fillStyle: this.state.currentItemFillStyle,
-      strokeWidth: isHighlighter ? 20 : this.getCurrentItemStrokeWidth("freedraw"),
+      strokeWidth,
       strokeStyle: this.state.currentItemStrokeStyle,
       roughness: this.state.currentItemRoughness,
-      opacity: isHighlighter ? 40 : this.state.currentItemOpacity,
+      opacity: this.state.currentItemOpacity,
       roundness: null,
       simulatePressure,
       strokeOptions: {

--- a/packages/excalidraw/components/Toolbar.tsx
+++ b/packages/excalidraw/components/Toolbar.tsx
@@ -31,6 +31,7 @@ import {
   EraserToolButton,
   FreedrawToolPopover,
   FreedrawToolButton,
+  HighlighterToolButton,
   getToolShortcut,
   HandToolButton,
   ImageToolButton,
@@ -284,7 +285,10 @@ export const Toolbar = ({
         {isCompactStylesPanel ? (
           <FreedrawToolPopover {...toolProps} />
         ) : (
-          <FreedrawToolButton {...toolProps} />
+          <>
+            <FreedrawToolButton {...toolProps} />
+            <HighlighterToolButton {...toolProps} />
+          </>
         )}
         <TextToolButton {...toolProps} />
         {UIOptions.tools?.image !== false && <ImageToolButton {...toolProps} />}

--- a/packages/excalidraw/components/Tools.tsx
+++ b/packages/excalidraw/components/Tools.tsx
@@ -19,6 +19,7 @@ import {
   ArrowIcon,
   LineIcon,
   FreedrawIcon,
+  HighlighterIcon,
   drawShapeToolIcon,
   TextIcon,
   ImageIcon,
@@ -111,6 +112,10 @@ export const TOOLS = defineTools({
     icon: FreedrawIcon,
     letterKey: [KEYS.P, KEYS.X],
     numericKey: KEYS["7"],
+  },
+  highlighter: {
+    icon: HighlighterIcon,
+    letterKey: KEYS.H,
   },
   text: {
     icon: TextIcon,
@@ -322,6 +327,7 @@ export const EllipseToolButton = createToolButton("ellipse");
 export const ArrowToolButton = createToolButton("arrow");
 export const LineToolButton = createToolButton("line");
 export const FreedrawToolButton = createToolButton("freedraw");
+export const HighlighterToolButton = createToolButton("highlighter");
 export const TextToolButton = createToolButton("text");
 export const ImageToolButton = createToolButton("image");
 export const EraserToolButton = createToolButton("eraser");

--- a/packages/excalidraw/components/icons.tsx
+++ b/packages/excalidraw/components/icons.tsx
@@ -398,6 +398,20 @@ export const FreedrawIcon = createIcon(
   modifiedTablerIconProps,
 );
 
+// tabler-icons: highlight marker
+export const HighlighterIcon = createIcon(
+  <g strokeWidth="1.25">
+    <path
+      clipRule="evenodd"
+      d="M15.25 3.75 19.25 7.75 8.75 18.25H4.75V14.25L15.25 3.75Z"
+    />
+    <path d="M12.5 6.5L16.5 10.5" />
+    <path d="M3 21h18" strokeWidth="1.5" />
+  </g>,
+
+  modifiedTablerIconProps,
+);
+
 // tabler-icons: typography
 export const TextIcon = createIcon(
   <g strokeWidth="1.5">

--- a/packages/excalidraw/components/shapeActionPredicates.ts
+++ b/packages/excalidraw/components/shapeActionPredicates.ts
@@ -147,6 +147,7 @@ export const getShapeActionPredicates = (
     // active without an actual selection
     layers:
       (activeToolType !== "freedraw" &&
+        activeToolType !== "highlighter" &&
         activeToolType !== "autoshape" &&
         !targetElements.some((element) => element.type === "freedraw")) ||
       getSelectedElements(elementsMap, appState).some(

--- a/packages/excalidraw/data/restore.ts
+++ b/packages/excalidraw/data/restore.ts
@@ -217,6 +217,7 @@ export const AllowedExcalidrawActiveTools: Record<
   image: true,
   arrow: true,
   freedraw: true,
+  highlighter: true,
   eraser: false,
   custom: true,
   frame: true,

--- a/packages/excalidraw/locales/en.json
+++ b/packages/excalidraw/locales/en.json
@@ -322,6 +322,7 @@
     "arrow": "Arrow",
     "line": "Line",
     "freedraw": "Draw",
+    "highlighter": "Highlighter",
     "text": "Text",
     "library": "Library",
     "lock": "Keep selected tool active after drawing",

--- a/packages/excalidraw/types.ts
+++ b/packages/excalidraw/types.ts
@@ -153,6 +153,7 @@ export type ToolType =
   | "arrow"
   | "line"
   | "freedraw"
+  | "highlighter"
   | "text"
   | "image"
   | "eraser"


### PR DESCRIPTION
### Summary
Enhances the **Highlight Pen (Highlighter)** tool with real-time fluid opacity controls, responsive stroke width presets (8px / 16px / 28px), automatic 100% opacity reset when switching tools, and cleaned-up sidebar controls.

### Key Improvements
- **Dynamic Opacity Slider**: Sliding the Opacity slider (0–100%) updates stroke translucency in real-time.
- **Auto-Reset Opacity**: Switching to Highlighter sets opacity to 40%; switching back to standard Pen automatically resets opacity to 100%.
- **Responsive Stroke Width Presets**: Thin (`8px`), Medium (`16px`), and Thick (`28px`) produce distinct stroke diameters.
- **Cleaned Sidebar Controls**: Removed `highlighter` from `hasBackground` and hidden inactive `Layers` controls while drawing, keeping only relevant controls (Stroke Color, Stroke Width, Pressure Mode, Opacity).