### PR TITLE
feat(editor): add duplicate button next to bottom left undo/redo section

### DIFF
--- a/packages/excalidraw/components/Actions.scss
+++ b/packages/excalidraw/components/Actions.scss
@@ -78,6 +78,15 @@
   }
 
   .redo-button-container button {
+    border-radius: 0 !important;
+    border-right: 0 !important;
+
+    .ToolIcon__icon {
+      border-radius: 0 !important;
+    }
+  }
+
+  .duplicate-button-container button {
     border-top-right-radius: var(--border-radius-lg) !important;
     border-bottom-right-radius: var(--border-radius-lg) !important;
 

--- a/packages/excalidraw/components/Actions.tsx
+++ b/packages/excalidraw/components/Actions.tsx
@@ -907,6 +907,9 @@ export const UndoRedoActions = ({
     <div className="redo-button-container">
       <Tooltip label={t("buttons.redo")}> {renderAction("redo")}</Tooltip>
     </div>
+    <div className="duplicate-button-container">
+      {renderAction("duplicateSelection")}
+    </div>
   </div>
 );
 


### PR DESCRIPTION
- Reuses the existing duplicateSelection action (same icon, shortcut, and disabled-when-nothing-selected behavior) so it's always reachable without opening the side panel.

<img width="960" height="738" alt="excalidraw-duplicate-button-annotated" src="https://github.com/user-attachments/assets/ce27d7de-a49a-46f2-a5b6-7cb72be4af79" />
