### PR TITLE
perf: reuse cached shape for remote elements that only moved

### DIFF
--- a/packages/element/src/__tests__/shape.test.ts
+++ b/packages/element/src/__tests__/shape.test.ts
@@ -1,0 +1,56 @@
+import { newElement } from "../newElement";
+import { ShapeCache } from "../shape";
+
+import type { ExcalidrawRectangleElement } from "../types";
+
+describe("ShapeCache.copy", () => {
+  afterEach(() => {
+    ShapeCache.destroy();
+  });
+
+  it("carries a cached shape over to a different element instance", () => {
+    const from = newElement({
+      type: "rectangle",
+      x: 0,
+      y: 0,
+      width: 100,
+      height: 50,
+    }) as ExcalidrawRectangleElement;
+    const to = newElement({
+      type: "rectangle",
+      x: 10,
+      y: 10,
+      width: 100,
+      height: 50,
+    });
+
+    const shape = ShapeCache.generateElementShape(from, null);
+
+    expect(ShapeCache.get(to, null)).toBeUndefined();
+
+    ShapeCache.copy(from, to);
+
+    expect(ShapeCache.get(to, null)).toBe(shape);
+  });
+
+  it("is a no-op when the source has no cached shape", () => {
+    const from = newElement({
+      type: "rectangle",
+      x: 0,
+      y: 0,
+      width: 100,
+      height: 50,
+    });
+    const to = newElement({
+      type: "rectangle",
+      x: 10,
+      y: 10,
+      width: 100,
+      height: 50,
+    });
+
+    ShapeCache.copy(from, to);
+
+    expect(ShapeCache.get(to, null)).toBeUndefined();
+  });
+});

--- a/packages/element/src/shape.ts
+++ b/packages/element/src/shape.ts
@@ -108,6 +108,21 @@ export class ShapeCache {
     elementWithCanvasCache.delete(element);
   };
 
+  /**
+   * Copies a cached shape from one element instance to another, without
+   * regenerating it. Since the cache is a WeakMap keyed by object identity,
+   * every element instance normally needs its own entry — this lets a
+   * caller that knows two instances are shape-equivalent (e.g. the same
+   * element re-received from a remote peer with only its position changed)
+   * carry the cache forward instead of paying for a full regeneration.
+   */
+  public static copy = (from: ExcalidrawElement, to: ExcalidrawElement) => {
+    const cached = ShapeCache.cache.get(from);
+    if (cached) {
+      ShapeCache.cache.set(to, cached);
+    }
+  };
+
   public static destroy = () => {
     ShapeCache.cache = new WeakMap();
   };

--- a/packages/excalidraw/data/reconcile.ts
+++ b/packages/excalidraw/data/reconcile.ts
@@ -6,6 +6,7 @@ import {
   orderByFractionalIndex,
   syncInvalidIndices,
   validateFractionalIndices,
+  ShapeCache,
 } from "@excalidraw/element";
 
 import type { OrderedExcalidrawElement } from "@excalidraw/element/types";
@@ -41,6 +42,64 @@ export const shouldDiscardRemoteElement = (
     return true;
   }
   return false;
+};
+
+const SHAPE_IRRELEVANT_ELEMENT_KEYS = new Set<string>([
+  "x",
+  "y",
+  "version",
+  "versionNonce",
+  "updated",
+]);
+
+/**
+ * Whether `a` and `b` are equal in every property that can affect the
+ * rough.js/perfect-freehand shape ShapeCache generates for an element —
+ * i.e. everything except position and version bookkeeping. Used to decide
+ * whether a cached shape can be carried over to a new element instance
+ * instead of being regenerated from scratch (see reconcileElements below).
+ */
+const hasEquivalentShape = (
+  a: OrderedExcalidrawElement,
+  b: OrderedExcalidrawElement,
+): boolean => {
+  if (a.type !== b.type) {
+    return false;
+  }
+
+  const aKeys = Object.keys(a);
+
+  if (aKeys.length !== Object.keys(b).length) {
+    return false;
+  }
+
+  for (const key of aKeys) {
+    if (SHAPE_IRRELEVANT_ELEMENT_KEYS.has(key)) {
+      continue;
+    }
+
+    const aValue = (a as Record<string, unknown>)[key];
+    const bValue = (b as Record<string, unknown>)[key];
+
+    if (aValue === bValue) {
+      continue;
+    }
+
+    if (
+      typeof aValue !== "object" ||
+      aValue === null ||
+      typeof bValue !== "object" ||
+      bValue === null
+    ) {
+      return false;
+    }
+
+    if (JSON.stringify(aValue) !== JSON.stringify(bValue)) {
+      return false;
+    }
+  }
+
+  return true;
 };
 
 const validateIndicesThrottled = throttle(
@@ -93,6 +152,15 @@ export const reconcileElements = (
         reconciledElements.push(localElement);
         added.add(localElement.id);
       } else {
+        if (localElement && hasEquivalentShape(localElement, remoteElement)) {
+          // Avoid an unnecessary shape regeneration (expensive for
+          // rough.js/perfect-freehand elements) when the remote update only
+          // moved the element — e.g. a live collaborative drag broadcasts a
+          // fresh element instance per frame, and ShapeCache is keyed by
+          // instance identity, so every such instance is otherwise a cache
+          // miss even though the geometry hasn't changed.
+          ShapeCache.copy(localElement, remoteElement);
+        }
         reconciledElements.push(remoteElement);
         added.add(remoteElement.id);
       }

--- a/packages/excalidraw/tests/data/reconcile.test.ts
+++ b/packages/excalidraw/tests/data/reconcile.test.ts
@@ -1,9 +1,14 @@
-import { syncInvalidIndices } from "@excalidraw/element";
+import {
+  syncInvalidIndices,
+  ShapeCache,
+  newElement,
+} from "@excalidraw/element";
 
 import { randomInteger, cloneJSON } from "@excalidraw/common";
 
 import type {
   ExcalidrawElement,
+  ExcalidrawRectangleElement,
   OrderedExcalidrawElement,
 } from "@excalidraw/element/types";
 
@@ -382,5 +387,81 @@ describe("elements reconciliation", () => {
       index: "a0",
     };
     testIdentical([el1, el2], [el2, el1], ["A", "B"]);
+  });
+});
+
+describe("elements reconciliation: shape cache reuse", () => {
+  afterEach(() => {
+    ShapeCache.destroy();
+  });
+
+  const asLocal = (element: OrderedExcalidrawElement) =>
+    cloneJSON([element]) as unknown as OrderedExcalidrawElement[];
+
+  it("carries the cached shape over when a remote update only moves the element", () => {
+    const source = newElement({
+      type: "rectangle",
+      x: 0,
+      y: 0,
+      width: 100,
+      height: 50,
+      index: "a0" as OrderedExcalidrawElement["index"],
+    }) as OrderedExcalidrawElement;
+
+    // Cache the shape on the exact instance that will be passed as the
+    // local element below — ShapeCache is keyed by object identity, so a
+    // separately-cloned copy would never hit.
+    const localElements = asLocal(source);
+    const localElement = localElements[0] as ExcalidrawRectangleElement;
+    const cachedShape = ShapeCache.generateElementShape(localElement, null);
+
+    // Simulates a remote peer re-broadcasting the same element (a fresh
+    // instance, per the collab wire format) with only its position and
+    // version bookkeeping changed — e.g. one frame of a live drag.
+    const remote = {
+      ...cloneJSON(localElement),
+      x: 42,
+      y: 17,
+      version: localElement.version + 1,
+      versionNonce: localElement.versionNonce + 1,
+    } as unknown as RemoteExcalidrawElement;
+
+    const [reconciled] = reconcileElements(
+      localElements,
+      [remote],
+      {} as AppState,
+    );
+
+    expect(ShapeCache.get(reconciled, null)).toBe(cachedShape);
+  });
+
+  it("does not reuse the cached shape when a shape-relevant property changed", () => {
+    const source = newElement({
+      type: "rectangle",
+      x: 0,
+      y: 0,
+      width: 100,
+      height: 50,
+      index: "a0" as OrderedExcalidrawElement["index"],
+    }) as OrderedExcalidrawElement;
+
+    const localElements = asLocal(source);
+    const localElement = localElements[0] as ExcalidrawRectangleElement;
+    ShapeCache.generateElementShape(localElement, null);
+
+    const remote = {
+      ...cloneJSON(localElement),
+      width: 200, // shape-relevant change
+      version: localElement.version + 1,
+      versionNonce: localElement.versionNonce + 1,
+    } as unknown as RemoteExcalidrawElement;
+
+    const [reconciled] = reconcileElements(
+      localElements,
+      [remote],
+      {} as AppState,
+    );
+
+    expect(ShapeCache.get(reconciled, null)).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

Fixes #9038 — remote element updates during a live collaborative drag render in slow motion because every update forces a full shape regeneration.

`ShapeCache` (`packages/element/src/shape.ts`) is a `WeakMap` keyed by element **instance identity**. A remote collaboration update always arrives as a freshly deserialized element object, even when only `x`/`y` changed (e.g. one frame of another user's drag) — so every accepted remote update was a guaranteed cache miss, forcing a full rough.js/perfect-freehand shape regeneration on every single frame, regardless of whether the element's actual geometry changed. This is most visible on freedraw elements, where shape regeneration is the most expensive, but it applies to every element type.

Shape generation never reads `element.x`/`element.y` for any element type — position is applied via a canvas transform at draw time, not baked into the generated shape. That means a remote element that differs from the local element it's replacing only in position and version bookkeeping (`x`, `y`, `version`, `versionNonce`) can safely reuse the local element's cached shape instead of paying for a full regeneration.

## Change

- `ShapeCache.copy(from, to)` — new method to transfer a cached shape entry between two element instances.
- `reconcileElements()` (`packages/excalidraw/data/reconcile.ts`) — when a remote element is accepted over its local counterpart, and the two are equal in every property except `x`, `y`, `version`, and `versionNonce`, copies the cached shape forward instead of leaving it to regenerate on next render.

## Testing

- `packages/element/src/__tests__/shape.test.ts` — unit tests for `ShapeCache.copy()`.
- `packages/excalidraw/tests/data/reconcile.test.ts` — two new tests: reuse happens when a remote update only moves the element, and reuse correctly does **not** happen when a shape-relevant property (e.g. `width`) changed.
- Verified both new reconcile tests actually catch the regression by temporarily reverting the fix locally and confirming they fail against the old code.
- `tsc` — clean
- `eslint --max-warnings=0` — clean