### PR TITLE
fix(i18n): localize sign up and sign in menu labels

### DIFF
--- a/excalidraw-app/components/AppMainMenu.tsx
+++ b/excalidraw-app/components/AppMainMenu.tsx
@@ -3,9 +3,8 @@ import {
   ExcalLogo,
   eyeIcon,
 } from "@excalidraw/excalidraw/components/icons";
-import { MainMenu } from "@excalidraw/excalidraw/index";
+import { MainMenu, useI18n } from "@excalidraw/excalidraw/index";
 import React from "react";
-
 import { isDevEnv } from "@excalidraw/common";
 
 import type { Theme } from "@excalidraw/element/types";
@@ -22,6 +21,7 @@ export const AppMainMenu: React.FC<{
   theme: Theme | "system";
   refresh: () => void;
 }> = React.memo((props) => {
+  const { t } = useI18n();
   return (
     <MainMenu>
       <MainMenu.DefaultItems.LoadScene />
@@ -56,7 +56,7 @@ export const AppMainMenu: React.FC<{
         }?utm_source=signin&utm_medium=app&utm_content=hamburger`}
         className="highlighted"
       >
-        {isExcalidrawPlusSignedUser ? "Sign in" : "Sign up"}
+        {isExcalidrawPlusSignedUser ? t("labels.signIn") : t("labels.signUp")}
       </MainMenu.ItemLink>
       {isDevEnv() && (
         <MainMenu.Item

--- a/excalidraw-app/components/AppWelcomeScreen.tsx
+++ b/excalidraw-app/components/AppWelcomeScreen.tsx
@@ -72,7 +72,7 @@ export const AppWelcomeScreen: React.FC<{
               shortcut={null}
               icon={loginIcon}
             >
-              Sign up
+              {t("labels.signUp")}
             </WelcomeScreen.Center.MenuItemLink>
           )}
         </WelcomeScreen.Center.Menu>

--- a/packages/excalidraw/locales/en.json
+++ b/packages/excalidraw/locales/en.json
@@ -141,6 +141,8 @@
     "increaseFontSize": "Increase font size",
     "unbindText": "Unbind text",
     "bindText": "Bind text to the container",
+    "signIn": "Sign in",
+    "signUp": "Sign up",
     "createContainerFromText": "Wrap text in a container",
     "link": {
       "edit": "Edit link",


### PR DESCRIPTION
### Description
Replaces hardcoded English "Sign up" and "Sign in" strings in `AppMainMenu.tsx` and `AppWelcomeScreen.tsx` with registered keys in `packages/excalidraw/locales/en.json` to enable full internationalization support via Crowdin.

Fixes #11876

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Internationalization / localization

### Test plan
- Verified that strings correctly resolve from `en.json`.
- Tested in development mode across language toggles in the main menu and welcome screen.
- All linter, Prettier, and TypeScript checks pass without errors.