### PR TITLE
Fix accessible-name/visible-content mismatches (WCAG 2.5.3)

### DIFF
--- a/packages/excalidraw/actions/actionCanvas.tsx
+++ b/packages/excalidraw/actions/actionCanvas.tsx
@@ -252,18 +252,24 @@ export const actionResetZoom = register({
   },
   PanelComponent: ({ updateData }) => {
     const zoomValue = useAppStateValue((appState) => appState.zoom.value);
+    // The button's own visible text is the current zoom percentage, not just its
+    // action — axe-core's label-content-name-mismatch rule (WCAG 2.5.3) correctly
+    // flagged that "Reset zoom" alone doesn't contain it. Folding the value into the
+    // name means a screen-reader user hears the same current-zoom information a
+    // sighted user already sees on the button, not just what clicking it does.
+    const zoomPercent = `${(zoomValue * 100).toFixed(0)}%`;
     return (
       <Tooltip label={t("buttons.resetZoom")} style={{ height: "100%" }}>
         <IconButton
           type="button"
           className="reset-zoom-button zoom-button"
           title={t("buttons.resetZoom")}
-          aria-label={t("buttons.resetZoom")}
+          aria-label={`${t("buttons.resetZoom")} — ${zoomPercent}`}
           onClick={() => {
             updateData(null);
           }}
         >
-          {(zoomValue * 100).toFixed(0)}%
+          {zoomPercent}
         </IconButton>
       </Tooltip>
     );

--- a/packages/excalidraw/components/Tools.tsx
+++ b/packages/excalidraw/components/Tools.tsx
@@ -274,6 +274,10 @@ const createToolButton = (
   }: ToolButtonComponentProps) => {
     const label = capitalizeString(t(`toolBar.${type}`));
     const shortcut = hideShortcut ? null : getToolShortcut(shortcutType);
+    const keyBindingLabel =
+      hideKeyBinding || hideShortcut
+        ? undefined
+        : TOOLS[shortcutType].numericKey || getToolLetter(shortcutType);
 
     return (
       <IconButton
@@ -283,12 +287,15 @@ const createToolButton = (
         checked={activeTool.type === type}
         disabled={isToolButtonDisabled(app, type)}
         title={shortcut ? `${label} — ${shortcut}` : label}
-        keyBindingLabel={
-          hideKeyBinding || hideShortcut
-            ? undefined
-            : TOOLS[shortcutType].numericKey || getToolLetter(shortcutType)
-        }
-        aria-label={label}
+        keyBindingLabel={keyBindingLabel}
+        // The keybinding badge (e.g. "2") is real visible text on the button, and
+        // axe-core's label-content-name-mismatch rule (WCAG 2.5.3) correctly flags
+        // that "Rectangle" alone doesn't contain it — a speech-input user who says
+        // what they see on the button has no reason to expect that to fail. Appending
+        // it keeps the announcement short (aria-keyshortcuts already carries the full
+        // "R or 2" form for AT that surfaces it) while satisfying the actual rule,
+        // which checks what's visually rendered, not what's exposed to a screen reader.
+        aria-label={keyBindingLabel ? `${label} ${keyBindingLabel}` : label}
         aria-keyshortcuts={shortcut ?? undefined}
         data-testid={`toolbar-${type}`}
         onSelect={({ pointerType }) => {

--- a/packages/excalidraw/components/main-menu/MainMenu.tsx
+++ b/packages/excalidraw/components/main-menu/MainMenu.tsx
@@ -50,6 +50,7 @@ const MainMenu = Object.assign(
               }}
               data-testid="main-menu-trigger"
               className="main-menu-trigger"
+              aria-label={t("buttons.menu")}
             >
               {HamburgerMenuIcon}
             </DropdownMenu.Trigger>


### PR DESCRIPTION
## What

Three controls whose visible text isn't fully contained in their accessible name — flagged by axe-core's `label-content-name-mismatch` rule (WCAG 2.5.3, Label in Name):

- **Main menu trigger** (`MainMenu.tsx`) — the hamburger icon button had no `aria-label` at all.
- **Toolbar tool buttons** (`Tools.tsx`) — the visible keybinding badge (e.g. "2" on the rectangle tool) wasn't reflected in `aria-label`, so a speech-input user saying what's on the button wouldn't match it.
- **Reset-zoom button** (`actionCanvas.tsx`) — the visible text is the live zoom percentage, not captured by the static "Reset zoom" label.

## Why this matters

WCAG 2.5.3 exists for speech-input users (Dragon, Voice Control, etc.), who activate controls by speaking the text they see. If the accessible name doesn't contain all of the visible text, "click rectangle" or "click 2" can fail even though both are printed right on the button.

## How I found these and verified the fixes

Scanned a real local dev build with a browser-driven axe-core scanner, then re-scanned after each change to confirm the finding actually cleared — rather than assuming a change would work. One early attempt (adding `aria-hidden` to the keybinding badge span) did *not* resolve the finding on re-scan, because this axe rule compares against what's visually rendered, not what's exposed to assistive tech; that attempt was reverted in favor of folding the visible text into `aria-label` instead, which did resolve it.

## Testing

- `yarn test:typecheck` passes
- Manually verified all three controls still read sensibly with a screen reader (label now includes the keybinding/percentage, doesn't duplicate awkwardly)
- Re-scanned with axe-core after each fix to confirm the mismatch is gone

Happy to adjust naming/wording if there's a preferred convention for combining a label with a shortcut hint.