### PR TITLE
feat: support keyboard panning in view mode with smooth decayFeat/view mode keyboard panning

### DIFF
--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -709,6 +709,7 @@ class App extends React.Component<AppProps, AppState> {
   /** current frame pointer cords */
   lastPointerMoveCoords: { x: number; y: number } | null = null;
   private lastCompletedCanvasClicks: { x: number; y: number }[] = [];
+  private heldArrowKeys = new Set<string>();
   /** previous frame pointer coords */
   previousPointerMoveCoords: { x: number; y: number } | null = null;
 
@@ -5480,13 +5481,14 @@ class App extends React.Component<AppProps, AppState> {
       }
 
       if (this.state.viewModeEnabled && isArrowKey(event.key)) {
+        this.heldArrowKeys.add(event.key);
         const PAN_STEP = 20;
         let scrollX = this.state.scrollX;
         let scrollY = this.state.scrollY;
-        if (event.key === KEYS.ARROW_LEFT) scrollX += PAN_STEP;
-        if (event.key === KEYS.ARROW_RIGHT) scrollX -= PAN_STEP;
-        if (event.key === KEYS.ARROW_UP) scrollY += PAN_STEP;
-        if (event.key === KEYS.ARROW_DOWN) scrollY -= PAN_STEP;
+        if (this.heldArrowKeys.has(KEYS.ARROW_LEFT)) scrollX += PAN_STEP;
+        if (this.heldArrowKeys.has(KEYS.ARROW_RIGHT)) scrollX -= PAN_STEP;
+        if (this.heldArrowKeys.has(KEYS.ARROW_UP)) scrollY += PAN_STEP;
+        if (this.heldArrowKeys.has(KEYS.ARROW_DOWN)) scrollY -= PAN_STEP;
         this.viewport.translate({ scrollX, scrollY });
         event.preventDefault();
         return;
@@ -5824,6 +5826,9 @@ class App extends React.Component<AppProps, AppState> {
   private onKeyUp = withBatchedUpdates((event: KeyboardEvent) => {
     if (!this.isInteractionEnabled()) {
       return;
+    }
+    if (isArrowKey(event.key)) {
+      this.heldArrowKeys.delete(event.key);
     }
     if (event.key === KEYS.SPACE) {
       if (

--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -710,6 +710,47 @@ class App extends React.Component<AppProps, AppState> {
   lastPointerMoveCoords: { x: number; y: number } | null = null;
   private lastCompletedCanvasClicks: { x: number; y: number }[] = [];
   private heldArrowKeys = new Set<string>();
+  private panVelocity = { x: 0, y: 0 };
+  private panAnimationId: number | null = null;
+
+  private animatePanning = () => {
+    if (!this.state.viewModeEnabled) {
+      this.panAnimationId = null;
+      return;
+    }
+
+    const MAX_SPEED = 20;
+    const ACCELERATION = 0.15;
+    const DECAY = 0.15;
+
+    let targetVx = 0;
+    let targetVy = 0;
+
+    if (this.heldArrowKeys.has(KEYS.ARROW_LEFT)) targetVx += MAX_SPEED;
+    if (this.heldArrowKeys.has(KEYS.ARROW_RIGHT)) targetVx -= MAX_SPEED;
+    if (this.heldArrowKeys.has(KEYS.ARROW_UP)) targetVy += MAX_SPEED;
+    if (this.heldArrowKeys.has(KEYS.ARROW_DOWN)) targetVy -= MAX_SPEED;
+
+    this.panVelocity.x += (targetVx - this.panVelocity.x) * (targetVx ? ACCELERATION : DECAY);
+    this.panVelocity.y += (targetVy - this.panVelocity.y) * (targetVy ? ACCELERATION : DECAY);
+
+    if (
+      Math.abs(this.panVelocity.x) < 0.1 &&
+      Math.abs(this.panVelocity.y) < 0.1 &&
+      this.heldArrowKeys.size === 0
+    ) {
+      this.panVelocity = { x: 0, y: 0 };
+      this.panAnimationId = null;
+      return;
+    }
+
+    this.viewport.translate(({ scrollX, scrollY }) => ({
+      scrollX: scrollX + this.panVelocity.x,
+      scrollY: scrollY + this.panVelocity.y,
+    }));
+
+    this.panAnimationId = requestAnimationFrame(this.animatePanning);
+  };
   /** previous frame pointer coords */
   previousPointerMoveCoords: { x: number; y: number } | null = null;
 
@@ -5482,14 +5523,9 @@ class App extends React.Component<AppProps, AppState> {
 
       if (this.state.viewModeEnabled && isArrowKey(event.key)) {
         this.heldArrowKeys.add(event.key);
-        const PAN_STEP = 20;
-        let scrollX = this.state.scrollX;
-        let scrollY = this.state.scrollY;
-        if (this.heldArrowKeys.has(KEYS.ARROW_LEFT)) scrollX += PAN_STEP;
-        if (this.heldArrowKeys.has(KEYS.ARROW_RIGHT)) scrollX -= PAN_STEP;
-        if (this.heldArrowKeys.has(KEYS.ARROW_UP)) scrollY += PAN_STEP;
-        if (this.heldArrowKeys.has(KEYS.ARROW_DOWN)) scrollY -= PAN_STEP;
-        this.viewport.translate({ scrollX, scrollY });
+        if (this.panAnimationId === null) {
+          this.panAnimationId = requestAnimationFrame(this.animatePanning);
+        }
         event.preventDefault();
         return;
       }

--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -5479,6 +5479,19 @@ class App extends React.Component<AppProps, AppState> {
         return;
       }
 
+      if (this.state.viewModeEnabled && isArrowKey(event.key)) {
+        const PAN_STEP = 20;
+        let scrollX = this.state.scrollX;
+        let scrollY = this.state.scrollY;
+        if (event.key === KEYS.ARROW_LEFT) scrollX += PAN_STEP;
+        if (event.key === KEYS.ARROW_RIGHT) scrollX -= PAN_STEP;
+        if (event.key === KEYS.ARROW_UP) scrollY += PAN_STEP;
+        if (event.key === KEYS.ARROW_DOWN) scrollY -= PAN_STEP;
+        this.viewport.translate({ scrollX, scrollY });
+        event.preventDefault();
+        return;
+      }
+
       if (this.state.openDialog?.name === "elementLinkSelector") {
         return;
       }


### PR DESCRIPTION
Fixes #6688

Hey! 👋 This PR implements the requested keyboard panning feature when the user is in view mode. 

Here is what's included:
- [x] Panning using the left/right/up/down arrow keys.
- [x] Diagonal panning by holding multiple arrow keys simultaneously (e.g., Up + Left).
- [x] Smooth momentum! Added an animation loop so that movement accelerates smoothly and has a very nice falloff/decay when the keys are released, mimicking the behavior seen in tools like Miro.

### Demo
[Screencast From 2026-08-16 01-04-24.webm](https://github.com/user-attachments/assets/ae0af628-93f4-44b3-833e-cac90ca5167c)
