### PR TITLE
fix(app): localize hardcoded "Sign up"/"Sign in" menu labels

### DIFF
--- a/excalidraw-app/components/AppMainMenu.tsx
+++ b/excalidraw-app/components/AppMainMenu.tsx
@@ -3,6 +3,7 @@ import {
   ExcalLogo,
   eyeIcon,
 } from "@excalidraw/excalidraw/components/icons";
+import { useI18n } from "@excalidraw/excalidraw/i18n";
 import { MainMenu } from "@excalidraw/excalidraw/index";
 import React from "react";
 
@@ -22,6 +23,7 @@ export const AppMainMenu: React.FC<{
   theme: Theme | "system";
   refresh: () => void;
 }> = React.memo((props) => {
+  const { t } = useI18n();
   return (
     <MainMenu>
       <MainMenu.DefaultItems.LoadScene />
@@ -56,7 +58,7 @@ export const AppMainMenu: React.FC<{
         }?utm_source=signin&utm_medium=app&utm_content=hamburger`}
         className="highlighted"
       >
-        {isExcalidrawPlusSignedUser ? "Sign in" : "Sign up"}
+        {isExcalidrawPlusSignedUser ? t("labels.signIn") : t("labels.signUp")}
       </MainMenu.ItemLink>
       {isDevEnv() && (
         <MainMenu.Item

--- a/excalidraw-app/components/AppWelcomeScreen.tsx
+++ b/excalidraw-app/components/AppWelcomeScreen.tsx
@@ -72,7 +72,7 @@ export const AppWelcomeScreen: React.FC<{
               shortcut={null}
               icon={loginIcon}
             >
-              Sign up
+              {t("labels.signUp")}
             </WelcomeScreen.Center.MenuItemLink>
           )}
         </WelcomeScreen.Center.Menu>

--- a/packages/excalidraw/locales/en.json
+++ b/packages/excalidraw/locales/en.json
@@ -1,5 +1,7 @@
 {
   "labels": {
+    "signUp": "Sign up",
+    "signIn": "Sign in",
     "paste": "Paste",
     "pasteAsPlaintext": "Paste as plaintext",
     "pasteCharts": "Paste charts",


### PR DESCRIPTION
## Summary
"Sign up" / "Sign in" in the hamburger menu (AppMainMenu) and "Sign up" on the welcome screen menu (AppWelcomeScreen) were hardcoded English strings, never registered in the i18n system, so translators had no way to localize them.

- Added `labels.signUp` / `labels.signIn` to `packages/excalidraw/locales/en.json`
- Replaced the hardcoded strings in `AppMainMenu.tsx` and `AppWelcomeScreen.tsx` with `t("labels.signUp")` / `t("labels.signIn")`

Fixes #11876

## Test plan
- [x] `yarn test:typecheck`
- [x] `yarn test:update`
- [x] Manually switch locale to ja-JP/fr-FR and confirm "Sign up"/"Sign in" render in English until Crowdin translations land (expected — same as other keys), and both instances now flow through the same `t()` key
