### PR TITLE
fix: link icon background chip not matching canvas in dark theme

### DIFF
--- a/packages/excalidraw/renderer/staticScene.test.ts
+++ b/packages/excalidraw/renderer/staticScene.test.ts
@@ -1,0 +1,25 @@
+import { applyDarkModeFilter, THEME } from "@excalidraw/common";
+
+import { getLinkIconBackgroundColor } from "./staticScene";
+
+describe("getLinkIconBackgroundColor", () => {
+  it("returns the background color unchanged in light theme", () => {
+    expect(getLinkIconBackgroundColor("#ffffff", THEME.LIGHT)).toBe("#ffffff");
+  });
+
+  it("applies the dark mode filter in dark theme", () => {
+    const result = getLinkIconBackgroundColor("#ffffff", THEME.DARK);
+    expect(result).toBe(applyDarkModeFilter("#ffffff"));
+    expect(result).not.toBe("#ffffff");
+  });
+
+  it("returns null for a transparent background", () => {
+    expect(getLinkIconBackgroundColor("transparent", THEME.LIGHT)).toBeNull();
+    expect(getLinkIconBackgroundColor("transparent", THEME.DARK)).toBeNull();
+  });
+
+  it("returns null when no background color is set", () => {
+    expect(getLinkIconBackgroundColor(null, THEME.LIGHT)).toBeNull();
+    expect(getLinkIconBackgroundColor(null, THEME.DARK)).toBeNull();
+  });
+});

--- a/packages/excalidraw/renderer/staticScene.ts
+++ b/packages/excalidraw/renderer/staticScene.ts
@@ -156,7 +156,11 @@ export const frameClip = (
   );
 };
 
-type LinkIconCanvas = HTMLCanvasElement & { zoom: number };
+type LinkIconCanvas = HTMLCanvasElement & {
+  zoom: Zoom["value"];
+  theme: StaticCanvasAppState["theme"];
+  viewBackgroundColor: StaticCanvasAppState["viewBackgroundColor"];
+};
 
 const linkIconCanvasCache: {
   regularLink: LinkIconCanvas | null;
@@ -164,6 +168,16 @@ const linkIconCanvasCache: {
 } = {
   regularLink: null,
   elementLink: null,
+};
+
+export const getLinkIconBackgroundColor = (
+  viewBackgroundColor: StaticCanvasAppState["viewBackgroundColor"],
+  theme: StaticCanvasAppState["theme"],
+): string | null => {
+  if (!viewBackgroundColor || viewBackgroundColor === "transparent") {
+    return null;
+  }
+  return applyDarkModeFilter(viewBackgroundColor, theme === THEME.DARK);
 };
 
 const renderLinkIcon = (
@@ -189,11 +203,20 @@ const renderLinkIcon = (
       ? "elementLink"
       : "regularLink";
 
+    const viewBackgroundColor = appState.viewBackgroundColor || COLOR_WHITE;
+
     let linkCanvas = linkIconCanvasCache[canvasKey];
 
-    if (!linkCanvas || linkCanvas.zoom !== appState.zoom.value) {
+    if (
+      !linkCanvas ||
+      linkCanvas.zoom !== appState.zoom.value ||
+      linkCanvas.theme !== appState.theme ||
+      linkCanvas.viewBackgroundColor !== viewBackgroundColor
+    ) {
       linkCanvas = Object.assign(document.createElement("canvas"), {
         zoom: appState.zoom.value,
+        theme: appState.theme,
+        viewBackgroundColor,
       });
       linkCanvas.width = width * window.devicePixelRatio * appState.zoom.value;
       linkCanvas.height =
@@ -209,10 +232,14 @@ const renderLinkIcon = (
       // Seed a sane default so a corrupted color (silently rejected by the
       // canvas) falls back to white instead of a stale fillStyle.
       linkCanvasCacheContext.fillStyle = COLOR_WHITE;
-      linkCanvasCacheContext.fillStyle =
-        appState.viewBackgroundColor || COLOR_WHITE;
-
-      linkCanvasCacheContext.fillRect(0, 0, width, height);
+      const backgroundColor = getLinkIconBackgroundColor(
+        viewBackgroundColor,
+        appState.theme,
+      );
+      if (backgroundColor) {
+        linkCanvasCacheContext.fillStyle = backgroundColor;
+        linkCanvasCacheContext.fillRect(0, 0, width, height);
+      }
 
       if (canvasKey === "elementLink") {
         linkCanvasCacheContext.drawImage(ELEMENT_LINK_IMG, 0, 0, width, height);


### PR DESCRIPTION
## Summary

Fixes #11844 — the link handle icon renders on a white background chip in dark theme (and stays stale when switching theme or background color).

## Root cause

In `renderLinkIcon` (`packages/excalidraw/renderer/staticScene.ts`), the icon chip was filled with the raw `viewBackgroundColor`, while the canvas background is painted through `applyDarkModeFilter()` in dark theme (`renderer/helpers.ts#bootstrapCanvas`). So in dark theme the canvas shows the filtered (dark) color, but the chip keeps the unfiltered white.

Additionally, the module-level `linkIconCanvasCache` was only invalidated on zoom changes, so switching theme or background color at the same zoom reused the stale chip.

## Changes

- Fill the chip with `applyDarkModeFilter(viewBackgroundColor, theme === THEME.DARK)` — the same transform the canvas background uses.
- Skip the chip fill entirely when there is no background (`null` / `"transparent"`), matching `bootstrapCanvas` behavior.
- Include `theme` and `viewBackgroundColor` in the icon cache key so the chip re-renders when either changes.
- Extracted the color resolution into `getLinkIconBackgroundColor` and added unit tests.

## Test plan

- Added `packages/excalidraw/renderer/staticScene.test.ts` covering light/dark/transparent/null background cases.
- `yarn vitest run packages/excalidraw/renderer/` — 12/12 pass
- `yarn vitest run packages/excalidraw/tests/export.test.tsx` — 8/8 pass
- `yarn test:typecheck` and eslint pass

Note: I used Claude Code to help locate the root cause and draft the fix. I reviewed the change, ran the tests locally, and take responsibility for it.