### PR TITLE
fix: render Excalifont-missing precomposed glyphs via NFD

### DIFF
--- a/packages/common/src/font-glyphs.ts
+++ b/packages/common/src/font-glyphs.ts
@@ -1,0 +1,95 @@
+import type { FontFamilyValues } from "@excalidraw/element/types";
+
+/**
+ * Unicode ranges covered by the Excalifont woff2 splits.
+ * Keep in sync with `packages/excalidraw/fonts/Excalifont/index.ts`.
+ *
+ * Characters outside these ranges are not in the font files. Canvas/HTML may
+ * still show them via `sans-serif` fallback, but SVG/PNG font subsetting will
+ * omit them — and hand-drawn look is lost. Prefer NFD when components are covered.
+ */
+export const EXCALIFONT_UNICODE_RANGES = [
+  "U+20-7e,U+a0-a3,U+a5-a6,U+a8-ab,U+ad-b1,U+b4,U+b6-b8,U+ba-ff,U+131,U+152-153,U+2bc,U+2c6,U+2da,U+2dc,U+304,U+308,U+2013-2014,U+2018-201a,U+201c-201e,U+2020,U+2022,U+2024-2026,U+2030,U+2039-203a,U+20ac,U+2122,U+2212",
+  "U+100-130,U+132-137,U+139-149,U+14c-151,U+154-17e,U+192,U+1fc-1ff,U+218-21b,U+237,U+1e80-1e85,U+1ef2-1ef3,U+2113",
+  "U+400-45f,U+490-491,U+2116",
+  "U+37e,U+384-38a,U+38c,U+38e-393,U+395-3a1,U+3a3-3a8,U+3aa-3cf,U+3d7",
+  "U+2c7,U+2d8-2d9,U+2db,U+2dd,U+302,U+306-307,U+30a-30c,U+326-328,U+212e,U+2211,U+fb01-fb02",
+  "U+462-463,U+472-475,U+4d8-4d9,U+4e2-4e3,U+4e6-4e9,U+4ee-4ef",
+  "U+300-301,U+303",
+] as const;
+
+/**
+ * `FONT_FAMILY.Excalifont` — inlined to avoid a circular import through
+ * `constants` → `colors` → `@excalidraw/math` → `@excalidraw/common`.
+ */
+const EXCALIFONT_FAMILY_ID = 5;
+
+/** Build a regex matching any codepoint listed in CSS unicode-range descriptors. */
+export const unicodeRangesToRegex = (ranges: readonly string[]): RegExp => {
+  const unicodeRangeRegex = ranges
+    .flatMap((rangeList) => rangeList.split(/,\s*/))
+    .map((range) => {
+      const [start, end] = range.replace(/U\+/gi, "").split("-");
+      if (end) {
+        return `\\u{${start}}-\\u{${end}}`;
+      }
+      return `\\u{${start}}`;
+    })
+    .join("");
+
+  return new RegExp(`[${unicodeRangeRegex}]`, "u");
+};
+
+const EXCALIFONT_COVERAGE = unicodeRangesToRegex(EXCALIFONT_UNICODE_RANGES);
+
+/**
+ * Rewrite precomposed characters that Excalifont lacks into NFD forms whose
+ * components are present in the font (e.g. Ȳ → Y + combining macron).
+ *
+ * Leaves characters unchanged when either the precomposed form is already
+ * covered, or NFD components are not all covered (system fallback still applies).
+ */
+export const rewriteTextForExcalifont = (text: string): string => {
+  // Fast path: pure ASCII is always covered by Excalifont's basic Latin range
+  if (!/[^\u0000-\u007F]/u.test(text)) {
+    return text;
+  }
+
+  let changed = false;
+  const out: string[] = [];
+
+  for (const char of text) {
+    if (EXCALIFONT_COVERAGE.test(char)) {
+      out.push(char);
+      continue;
+    }
+
+    const nfd = char.normalize("NFD");
+    if (
+      nfd !== char &&
+      Array.from(nfd).every((component) => EXCALIFONT_COVERAGE.test(component))
+    ) {
+      out.push(nfd);
+      changed = true;
+      continue;
+    }
+
+    out.push(char);
+  }
+
+  return changed ? out.join("") : text;
+};
+
+/**
+ * Adjust text for canvas/SVG rendering & measurement so glyphs missing from
+ * the selected family still draw with that family's available components.
+ */
+export const rewriteTextForFontFamily = (
+  text: string,
+  fontFamily: FontFamilyValues,
+): string => {
+  if (fontFamily === EXCALIFONT_FAMILY_ID) {
+    return rewriteTextForExcalifont(text);
+  }
+  return text;
+};

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -3,6 +3,7 @@ export * from "./bounds";
 export * from "./colors";
 export * from "./constants";
 export * from "./font-metadata";
+export * from "./font-glyphs";
 export * from "./queue";
 export * from "./keys";
 export * from "./points";

--- a/packages/common/tests/font-glyphs.test.ts
+++ b/packages/common/tests/font-glyphs.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  rewriteTextForExcalifont,
+  rewriteTextForFontFamily,
+  unicodeRangesToRegex,
+  EXCALIFONT_UNICODE_RANGES,
+} from "../src/font-glyphs";
+
+const EXCALIFONT = 5;
+const NUNITO = 6;
+const HELVETICA = 2;
+
+describe("font-glyphs", () => {
+  describe("unicodeRangesToRegex()", () => {
+    it("matches codepoints inside declared ranges", () => {
+      const re = unicodeRangesToRegex(["U+41-5A", "U+304"]);
+      expect(re.test("A")).toBe(true);
+      expect(re.test("Z")).toBe(true);
+      expect(re.test("\u0304")).toBe(true);
+      expect(re.test("a")).toBe(false);
+      expect(re.test("Ȳ")).toBe(false);
+    });
+  });
+
+  describe("rewriteTextForExcalifont()", () => {
+    it("decomposes Ȳ/ȳ into Y/y + combining macron (fixes #9509)", () => {
+      expect(rewriteTextForExcalifont("Ȳ")).toBe("Y\u0304");
+      expect(rewriteTextForExcalifont("ȳ")).toBe("y\u0304");
+      expect(rewriteTextForExcalifont("Ȳ ȳ")).toBe("Y\u0304 y\u0304");
+    });
+
+    it("leaves ASCII and covered precomposed glyphs unchanged", () => {
+      expect(rewriteTextForExcalifont("Hello")).toBe("Hello");
+      // ā (U+0101) is in Excalifont's Latin Extended-A range
+      expect(rewriteTextForExcalifont("ā")).toBe("ā");
+    });
+
+    it("decomposes other missing precomposed Latin letters when marks exist", () => {
+      // Ǎ (U+01CD) is outside Excalifont ranges; NFD is A + caron (U+030C)
+      expect(rewriteTextForExcalifont("Ǎ")).toBe("A\u030C");
+    });
+
+    it("does not rewrite when NFD components are also uncovered", () => {
+      // emoji has no useful NFD form for Excalifont
+      expect(rewriteTextForExcalifont("😀")).toBe("😀");
+    });
+  });
+
+  describe("rewriteTextForFontFamily()", () => {
+    it("only rewrites for Excalifont", () => {
+      expect(rewriteTextForFontFamily("Ȳ", EXCALIFONT)).toBe("Y\u0304");
+      expect(rewriteTextForFontFamily("Ȳ", NUNITO)).toBe("Ȳ");
+      expect(rewriteTextForFontFamily("Ȳ", HELVETICA)).toBe("Ȳ");
+    });
+  });
+
+  describe("EXCALIFONT_UNICODE_RANGES", () => {
+    it("covers combining macron and basic Y used by the Ȳ fallback", () => {
+      const re = unicodeRangesToRegex(EXCALIFONT_UNICODE_RANGES);
+      expect(re.test("Y")).toBe(true);
+      expect(re.test("y")).toBe(true);
+      expect(re.test("\u0304")).toBe(true);
+      expect(re.test("Ȳ")).toBe(false);
+      expect(re.test("ȳ")).toBe(false);
+    });
+  });
+});

--- a/packages/element/src/renderElement.ts
+++ b/packages/element/src/renderElement.ts
@@ -24,6 +24,7 @@ import {
   invariant,
   applyDarkModeFilter,
   isSafari,
+  rewriteTextForFontFamily,
 } from "@excalidraw/common";
 
 import type {
@@ -493,7 +494,10 @@ const drawElementOnCanvas = (
         context.textAlign = element.textAlign as CanvasTextAlign;
 
         // Canvas does not support multiline text by default
-        const lines = element.text.replace(/\r\n?/g, "\n").split("\n");
+        const lines = rewriteTextForFontFamily(
+          element.text.replace(/\r\n?/g, "\n"),
+          element.fontFamily,
+        ).split("\n");
 
         const horizontalOffset =
           element.textAlign === "center"

--- a/packages/element/src/textMeasurements.ts
+++ b/packages/element/src/textMeasurements.ts
@@ -5,9 +5,19 @@ import {
   getFontString,
   isTestEnv,
   normalizeEOL,
+  rewriteTextForExcalifont,
 } from "@excalidraw/common";
 
 import type { FontString, ExcalidrawTextElement } from "./types";
+
+const prepareTextForFont = (text: string, font: FontString) => {
+  // Excalifont omits some precomposed Latin glyphs (e.g. Ȳ); measure the NFD
+  // form so width matches canvas/SVG rendering that uses combining marks.
+  if (font.includes("Excalifont")) {
+    return rewriteTextForExcalifont(text);
+  }
+  return text;
+};
 
 export const measureText = (
   text: string,
@@ -154,7 +164,7 @@ export const getLineWidth = (text: string, font: FontString) => {
     textMetricsProvider = new CanvasTextMetricsProvider();
   }
 
-  return textMetricsProvider.getLineWidth(text, font);
+  return textMetricsProvider.getLineWidth(prepareTextForFont(text, font), font);
 };
 
 export const getTextWidth = (text: string, font: FontString) => {

--- a/packages/excalidraw/fonts/Fonts.ts
+++ b/packages/excalidraw/fonts/Fonts.ts
@@ -5,6 +5,7 @@ import {
   WINDOWS_EMOJI_FALLBACK_FONT,
   getFontFamilyFallbacks,
   FONT_SIZES,
+  rewriteTextForFontFamily,
 } from "@excalidraw/common";
 import { getContainerElement } from "@excalidraw/element";
 import { charWidth } from "@excalidraw/element";
@@ -432,7 +433,13 @@ export class Fonts {
       }
 
       // gather unique codepoints only when inlining fonts
-      for (const char of element.originalText) {
+      // rewrite so subsetting includes combining marks used for glyphs
+      // missing as precomposed forms (e.g. Ȳ → Y + U+0304 in Excalifont)
+      const textForSubset = rewriteTextForFontFamily(
+        element.originalText,
+        element.fontFamily,
+      );
+      for (const char of textForSubset) {
         if (!charsPerFamily[element.fontFamily]) {
           charsPerFamily[element.fontFamily] = new Set();
         }

--- a/packages/excalidraw/renderer/staticSvgScene.ts
+++ b/packages/excalidraw/renderer/staticSvgScene.ts
@@ -10,6 +10,7 @@ import {
   getVerticalOffset,
   applyDarkModeFilter,
   MIME_TYPES,
+  rewriteTextForFontFamily,
 } from "@excalidraw/common";
 import { normalizeLink, toValidURL } from "@excalidraw/common";
 import { hashString } from "@excalidraw/element";
@@ -654,7 +655,10 @@ const renderElementToSvg = (
             offsetY || 0
           }) rotate(${degree} ${cx} ${cy})`,
         );
-        const lines = element.text.replace(/\r\n?/g, "\n").split("\n");
+        const lines = rewriteTextForFontFamily(
+          element.text.replace(/\r\n?/g, "\n"),
+          element.fontFamily,
+        ).split("\n");
         const lineHeightPx = getLineHeightInPx(
           element.fontSize,
           element.lineHeight,


### PR DESCRIPTION
## Summary
- Excalifont’s unicode-range splits omit some precomposed Latin glyphs (notably **Ȳ** / **ȳ**, and ~200 similar letters whose combining marks *are* in the font).
- Those characters showed in the wysiwyg (system font fallback) but not with Excalifont on canvas / in font-subsetted export.
- Rewrite uncovered precomposed characters to NFD when every component is covered (e.g. `Ȳ` → `Y` + combining macron), applied for canvas render, SVG text, measurement, and export subsetting.

Fixes #9509

## Test plan
- [x] Unit tests in `packages/common/tests/font-glyphs.test.ts` (Ȳ/ȳ rewrite, covered glyphs unchanged, non-Excalifont families untouched)
- [ ] Manually: create Excalifont text with `Ȳ ȳ`, confirm it renders on canvas after blur (hand-drawn Y + macron, not blank / system sans)
- [ ] Manually: export PNG/SVG and confirm the characters remain visible
- [ ] Spot-check other rewritten letters (e.g. `Ǎ`) still look reasonable