### PR TITLE
test(editor): re-enable flip tests for curves outside min/max points

### DIFF
--- a/packages/excalidraw/tests/flip.test.tsx
+++ b/packages/excalidraw/tests/flip.test.tsx
@@ -476,8 +476,7 @@ describe("arrow", () => {
     );
   });
 
-  //TODO: elements with curve outside minMax points have a wrong bounding box!!!
-  it.skip("flips an unrotated arrow horizontally with line outside min/max points bounds", async () => {
+  it("flips an unrotated arrow horizontally with line outside min/max points bounds", async () => {
     const arrow = createLinearElementsWithCurveOutsideMinMaxPoints("arrow");
     API.setElements([arrow]);
     API.setAppState({ selectedElementIds: { [arrow.id]: true } });
@@ -487,8 +486,7 @@ describe("arrow", () => {
     );
   });
 
-  //TODO: elements with curve outside minMax points have a wrong bounding box!!!
-  it.skip("flips a rotated arrow horizontally with line outside min/max points bounds", async () => {
+  it("flips a rotated arrow horizontally with line outside min/max points bounds", async () => {
     const originalAngle = (Math.PI / 4) as Radians;
     const expectedAngle = ((7 * Math.PI) / 4) as Radians;
     const line = createLinearElementsWithCurveOutsideMinMaxPoints("arrow");
@@ -502,8 +500,7 @@ describe("arrow", () => {
     );
   });
 
-  //TODO: elements with curve outside minMax points have a wrong bounding box!!!
-  it.skip("flips an unrotated arrow vertically with line outside min/max points bounds", async () => {
+  it("flips an unrotated arrow vertically with line outside min/max points bounds", async () => {
     const arrow = createLinearElementsWithCurveOutsideMinMaxPoints("arrow");
     API.setElements([arrow]);
     API.setAppState({ selectedElementIds: { [arrow.id]: true } });
@@ -511,8 +508,7 @@ describe("arrow", () => {
     await checkVerticalFlip(MULTIPOINT_LINEAR_ELEMENT_FLIP_TOLERANCE_IN_PIXELS);
   });
 
-  //TODO: elements with curve outside minMax points have a wrong bounding box!!!
-  it.skip("flips a rotated arrow vertically with line outside min/max points bounds", async () => {
+  it("flips a rotated arrow vertically with line outside min/max points bounds", async () => {
     const originalAngle = (Math.PI / 4) as Radians;
     const expectedAngle = ((7 * Math.PI) / 4) as Radians;
     const line = createLinearElementsWithCurveOutsideMinMaxPoints("arrow");
@@ -575,8 +571,7 @@ describe("line", () => {
       TWO_POINTS_LINEAR_ELEMENT_FLIP_TOLERANCE_IN_PIXELS,
     );
   });
-  //TODO: elements with curve outside minMax points have a wrong bounding box
-  it.skip("flips an unrotated line horizontally with line outside min/max points bounds", async () => {
+  it("flips an unrotated line horizontally with line outside min/max points bounds", async () => {
     const line = createLinearElementsWithCurveOutsideMinMaxPoints("line");
     API.setElements([line]);
     API.setAppState({ selectedElementIds: { [line.id]: true } });
@@ -586,8 +581,7 @@ describe("line", () => {
     );
   });
 
-  //TODO: elements with curve outside minMax points have a wrong bounding box
-  it.skip("flips an unrotated line vertically with line outside min/max points bounds", async () => {
+  it("flips an unrotated line vertically with line outside min/max points bounds", async () => {
     const line = createLinearElementsWithCurveOutsideMinMaxPoints("line");
     API.setElements([line]);
     API.setAppState({ selectedElementIds: { [line.id]: true } });
@@ -595,8 +589,7 @@ describe("line", () => {
     await checkVerticalFlip(MULTIPOINT_LINEAR_ELEMENT_FLIP_TOLERANCE_IN_PIXELS);
   });
 
-  //TODO: elements with curve outside minMax points have a wrong bounding box
-  it.skip("flips a rotated line horizontally with line outside min/max points bounds", async () => {
+  it("flips a rotated line horizontally with line outside min/max points bounds", async () => {
     const originalAngle = (Math.PI / 4) as Radians;
     const expectedAngle = ((7 * Math.PI) / 4) as Radians;
     const line = createLinearElementsWithCurveOutsideMinMaxPoints("line");
@@ -610,8 +603,7 @@ describe("line", () => {
     );
   });
 
-  //TODO: elements with curve outside minMax points have a wrong bounding box
-  it.skip("flips a rotated line vertically with line outside min/max points bounds", async () => {
+  it("flips a rotated line vertically with line outside min/max points bounds", async () => {
     const originalAngle = (Math.PI / 4) as Radians;
     const expectedAngle = ((7 * Math.PI) / 4) as Radians;
     const line = createLinearElementsWithCurveOutsideMinMaxPoints("line");


### PR DESCRIPTION
Closes #11709.

Eight tests in `flip.test.tsx` were skipped behind `//TODO: elements with curve outside minMax points have a wrong bounding box!!!` — they cover flipping arrows and lines whose curve extends beyond their min/max points, rotated and unrotated, horizontally and vertically.

That TODO no longer holds. The bounds of such an element now account for the curve rather than the declared width/height, so the flip keeps the bounding box dimensions and the tests pass.

## Verification

- Re-enabled the eight tests: `flip.test.tsx` passes 46/46, and the result is stable across repeated runs.
- Full suite is unaffected: 122 files, 1868 tests passing.
- Checked the underlying claim directly rather than trusting the passing tests alone: for an arrow whose curve reaches well past its declared height, `getElementAbsoluteCoords` and `getElementBounds` both return bounds that include the curve.

This matches what @ezemskov reported on the issue after reproducing the fixture by hand.

Only the skips and the stale TODO comments are removed; no product code is touched.

### Reproduced on current master (e1bb9ff8)

Applying the same eight un-skips to a clean checkout of master and running the file:

```
 RUN  v3.0.6

 ✓ packages/excalidraw/tests/flip.test.tsx (46 tests) 6938ms

 Test Files  1 passed (1)
      Tests  46 passed (46)
   Duration  14.39s
```

### The re-enabled tests are not vacuous

Measuring the `createLinearElementsWithCurveOutsideMinMaxPoints` fixture directly, comparing point-only bounds against the curve-aware bounds returned by `getElementAbsoluteCoords`:

| | width | height |
| --- | --- | --- |
| declared on the element | 591.28 | 69.33 |
| bounds from points only | 591.28 | 69.33 |
| bounds including the curve | 652.67 | 72.67 |
| curve overshoot | +61.39 | +3.34 |

The curve overshoots the declared box by 61px horizontally, and the point-only bounds come out identical to the declared width/height. So the fixture does overshoot as its name claims, and `checkElementsBoundingBox` is comparing curve-aware bounds on both sides of the flip. The assertions still have something real to measure.

### On the commit that fixed it

I could not pin it to a single commit, and I would rather say so than guess. The skips and the TODO comments were introduced in 06b45e0c (#5799). Between that and master, `bounds.ts` changed 40 times and `actionFlip.ts` 25 times. Settling it properly means a bisect using this file as the oracle, which I am happy to run if it matters for the merge.
