### PR TITLE
docs: fix two 404 contributing and serializeAsJSON links

### DIFF
--- a/packages/excalidraw/README.md
+++ b/packages/excalidraw/README.md
@@ -139,4 +139,4 @@ Read the [API docs](https://docs.excalidraw.com/docs/@excalidraw/excalidraw/api)
 
 ## Contributing
 
-Read the [contributing docs](https://docs.excalidraw.com/docs/@excalidraw/excalidraw/contributing).
+Read the [contributing docs](https://docs.excalidraw.com/docs/introduction/contributing).

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -16,7 +16,7 @@ yarn add @excalidraw/utils
 
 ### `serializeAsJSON`
 
-See [`serializeAsJSON`](https://github.com/excalidraw/excalidraw/blob/master/src/packages/excalidraw/README.md#serializeAsJSON) for API and description.
+See [`serializeAsJSON`](https://docs.excalidraw.com/docs/@excalidraw/excalidraw/api/utils/export#serializeasjson) for API and description.
 
 ### `exportToBlob` (async)
 


### PR DESCRIPTION
## Problem
Two documentation links in this repo 404:

1. `packages/excalidraw/README.md` pointed at `https://docs.excalidraw.com/docs/@excalidraw/excalidraw/contributing` (GET 404). The live contributing guide is `https://docs.excalidraw.com/docs/introduction/contributing` (GET 200), which is also what the top-level `CONTRIBUTING.md` already uses.
2. `packages/utils/README.md` pointed `serializeAsJSON` at the pre-monorepo path `src/packages/excalidraw/README.md` (GET 404 after the package moved). The current API docs page is live at `https://docs.excalidraw.com/docs/@excalidraw/excalidraw/api/utils/export#serializeasjson` (GET 200).

## Solution
Update both links to the current documented URLs. No code changes.

## Verification
- Old contributing URL: GET 404
- New contributing URL: GET 200
- Old serializeAsJSON blob: GET 404
- New serializeAsJSON docs: GET 200
