### PR TITLE
fix(editor): warn instead of error when worker subsetting falls back

### DIFF
--- a/packages/excalidraw/subset/subset-main.test.ts
+++ b/packages/excalidraw/subset/subset-main.test.ts
@@ -11,6 +11,11 @@ import { describe, expect, it, vi, afterEach, beforeEach } from "vitest";
  */
 describe("subsetWoff2GlyphsByCodepoints", () => {
   beforeEach(() => {
+    // load-bearing: subset-main caches whether workers are usable in module
+    // scope, so the module has to be re-evaluated after the Worker stub is in
+    // place. This is also why the import below is dynamic — hoisting it to a
+    // static import at the top of the file would evaluate the module before
+    // the stub exists, and the test would pass whatever the code did.
     vi.resetModules();
   });
 
@@ -49,7 +54,7 @@ describe("subsetWoff2GlyphsByCodepoints", () => {
     expect(error).not.toHaveBeenCalled();
     expect(warn).toHaveBeenCalledWith(
       "Failed to use workers for subsetting, falling back to the main thread.",
-      expect.anything(),
+      expect.any(DOMException),
     );
   });
 });

--- a/packages/excalidraw/subset/subset-main.test.ts
+++ b/packages/excalidraw/subset/subset-main.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi, afterEach, beforeEach } from "vitest";
+
+/**
+ * When worker-based font subsetting fails, `subsetWoff2GlyphsByCodepoints`
+ * falls back to the main thread and still returns a correct result. The
+ * fallback is expected and recoverable, so it must be reported as a warning
+ * rather than an error — hosts that bundle the package (e.g. via webpack) hit
+ * this on every load and surface console errors to their users.
+ *
+ * See https://github.com/excalidraw/excalidraw/issues/9317
+ */
+describe("subsetWoff2GlyphsByCodepoints", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("logs a warning, not an error, when falling back to the main thread", async () => {
+    // force the worker path, then make worker construction fail the way a
+    // bundled host does (the URL resolves outside the serving origin)
+    vi.stubGlobal(
+      "Worker",
+      class {
+        constructor() {
+          throw new DOMException(
+            "Failed to construct 'Worker'",
+            "SecurityError",
+          );
+        }
+      },
+    );
+
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const { subsetWoff2GlyphsByCodepoints } = await import("./subset-main");
+
+    // a non-woff2 buffer is enough: we only care about the fallback logging,
+    // and the main-thread path resolves rather than throwing
+    const result = await subsetWoff2GlyphsByCodepoints(new ArrayBuffer(8), [
+      65,
+    ]);
+
+    expect(typeof result).toBe("string");
+    expect(error).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledWith(
+      "Failed to use workers for subsetting, falling back to the main thread.",
+      expect.anything(),
+    );
+  });
+});

--- a/packages/excalidraw/subset/subset-main.ts
+++ b/packages/excalidraw/subset/subset-main.ts
@@ -58,8 +58,9 @@ export const subsetWoff2GlyphsByCodepoints = async (
             e instanceof WorkerInTheMainChunkError)
         )
       ) {
+        // the fallback below recovers from this, so it's a warning, not an error
         // eslint-disable-next-line no-console
-        console.error(
+        console.warn(
           "Failed to use workers for subsetting, falling back to the main thread.",
           e,
         );


### PR DESCRIPTION
Addresses #9317

## Summary

When worker-based font subsetting can't start a worker, `subsetWoff2GlyphsByCodepoints` already recovers — it disables workers and finishes the job on the main thread. The fallback is expected and handled, but it's reported with `console.error`, so apps that bundle the package surface a red error to their own users on every load for something that isn't broken.

This switches that one call to `console.warn`, per @dwelle's note on the issue:

> If nothing else, it shouldn't be an error, but a warning

The `isServerEnv()` guard directly above it already treats this class of worker failure as non-exceptional, so this brings the browser path in line with it. Grepped the message — it's the only call site.

## Scope

Deliberately narrow, so it's worth saying what this **doesn't** do:

- It doesn't add a way to disable workers entirely, which is what the issue title asks for. Happy to follow up with that if you want it.
- It doesn't address @Mrazator's point that the underlying cause may be the host's bundler not emitting the worker chunk. This only changes how the (already handled) failure is reported.
- It leaves `"Skipped glyph subsetting"` in `subset-shared.chunk.ts` as an error — there the glyph really is dropped, so the output is degraded.

## Tests

Adds `packages/excalidraw/subset/subset-main.test.ts`: stubs `Worker` to throw the `SecurityError` a bundled host hits, then asserts the fallback still resolves to a font **and** that the message goes to `console.warn` rather than `console.error`.

Verified the test fails against `master` before the change and passes after — checked by running the new test alone against the base commit.

```
yarn vitest run packages/excalidraw/subset/subset-main.test.ts
```

No behaviour change beyond log severity; no snapshot updates required.
