### PR TITLE
fix: release new element canvas backing store

### DIFF
--- a/packages/excalidraw/components/canvases/NewElementCanvas.tsx
+++ b/packages/excalidraw/components/canvases/NewElementCanvas.tsx
@@ -27,25 +27,13 @@ const NewElementCanvas = (props: NewElementCanvasProps) => {
 
   useEffect(() => {
     const canvas = canvasRef.current;
-
-    return () => {
-      // Releasing the backing store explicitly is necessary on older Safari
-      // versions, which may otherwise retain detached canvases until the
-      // browser-wide canvas memory limit is exhausted.
-      if (canvas && !canvas.isConnected) {
-        canvas.width = 0;
-        canvas.height = 0;
-      }
-    };
-  }, []);
-
-  useEffect(() => {
-    if (!canvasRef.current) {
+    if (!canvas) {
       return;
     }
+
     renderNewElementScene(
       {
-        canvas: canvasRef.current,
+        canvas,
         scale: props.scale,
         newElement: props.newElement,
         elementsMap: props.elementsMap,
@@ -56,6 +44,20 @@ const NewElementCanvas = (props: NewElementCanvasProps) => {
       },
       isRenderThrottlingEnabled(),
     );
+
+    return () => {
+      // Use the node captured by this effect because React may clear the ref
+      // before unmount cleanup. This component keeps the same canvas node
+      // throughout its mounted lifetime.
+      //
+      // Releasing the backing store explicitly is necessary on older Safari
+      // versions, which may otherwise retain detached canvases until the
+      // browser-wide canvas memory limit is exhausted.
+      if (!canvas.isConnected) {
+        canvas.width = 0;
+        canvas.height = 0;
+      }
+    };
   });
 
   return (

--- a/packages/excalidraw/components/canvases/NewElementCanvas.tsx
+++ b/packages/excalidraw/components/canvases/NewElementCanvas.tsx
@@ -24,6 +24,21 @@ interface NewElementCanvasProps {
 
 const NewElementCanvas = (props: NewElementCanvasProps) => {
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+
+    return () => {
+      // Releasing the backing store explicitly is necessary on older Safari
+      // versions, which may otherwise retain detached canvases until the
+      // browser-wide canvas memory limit is exhausted.
+      if (canvas && !canvas.isConnected) {
+        canvas.width = 0;
+        canvas.height = 0;
+      }
+    };
+  }, []);
+
   useEffect(() => {
     if (!canvasRef.current) {
       return;

--- a/packages/excalidraw/tests/freedrawMode.test.tsx
+++ b/packages/excalidraw/tests/freedrawMode.test.tsx
@@ -1,3 +1,5 @@
+import { StrictMode } from "react";
+
 import type {
   ExcalidrawFreeDrawElement,
   NonDeletedExcalidrawElement,
@@ -6,17 +8,28 @@ import type {
 import { Excalidraw } from "../index";
 
 import { API } from "./helpers/api";
-import { UI } from "./helpers/ui";
-import { act, fireEvent, render, screen } from "./test-utils";
+import { Pointer, UI } from "./helpers/ui";
+import {
+  act,
+  fireEvent,
+  mockBoundingClientRect,
+  render,
+  restoreOriginalGetBoundingClientRect,
+  screen,
+  unmountComponent,
+  waitFor,
+} from "./test-utils";
 
 const { h } = window;
 
 describe("freedraw mode action", () => {
   beforeEach(async () => {
+    mockBoundingClientRect();
     await render(<Excalidraw handleKeyboardGlobally={true} />);
   });
 
   afterEach(async () => {
+    restoreOriginalGetBoundingClientRect();
     // https://github.com/floating-ui/floating-ui/issues/1908#issuecomment-1301553793
     await act(async () => {});
   });
@@ -56,5 +69,35 @@ describe("freedraw mode action", () => {
       (h.elements[0] as ExcalidrawFreeDrawElement).strokeOptions?.streamline,
     ).toBe(0.5);
     expect(h.state.currentItemStrokeVariability).toBe("constant");
+  });
+
+  it("releases the new element canvas backing store after drawing", async () => {
+    unmountComponent();
+    await render(
+      <StrictMode>
+        <Excalidraw handleKeyboardGlobally={true} />
+      </StrictMode>,
+    );
+
+    const mouse = new Pointer("mouse");
+    UI.clickTool("freedraw");
+
+    mouse.downAt(10, 10);
+    mouse.moveTo(20, 20);
+
+    const canvas = document.querySelector<HTMLCanvasElement>(
+      "canvas.excalidraw__canvas:not(.static):not(.interactive)",
+    );
+    expect(canvas).not.toBeNull();
+    expect(canvas!.width).toBeGreaterThan(0);
+    expect(canvas!.height).toBeGreaterThan(0);
+
+    mouse.upAt(30, 30);
+
+    await waitFor(() => {
+      expect(canvas!.isConnected).toBe(false);
+      expect(canvas!.width).toBe(0);
+      expect(canvas!.height).toBe(0);
+    });
   });
 });


### PR DESCRIPTION
## Summary

- release `NewElementCanvas`'s backing store after the canvas is detached
- keep the live canvas intact during React StrictMode effect replay
- add a freedraw regression test that retains and checks the detached canvas

## Why

`NewElementCanvas`, introduced in #8340, creates a viewport-sized canvas for the element currently being drawn. On older Safari/WebKit versions, removing a canvas from the DOM does not necessarily release its backing store. Repeated strokes can therefore contribute to the browser-wide canvas memory limit described in #4036 and [WebKit bug 195325](https://bugs.webkit.org/show_bug.cgi?id=195325).

Explicitly resetting the detached canvas dimensions releases that backing store. The `isConnected` guard avoids clearing the still-live canvas when React StrictMode replays effects in development.

## Testing

- `yarn test:app packages/excalidraw/tests/freedrawMode.test.tsx --watch=false`
- `yarn test:update` (122 files, 1861 passed)
- `yarn test:typecheck`
- `yarn test:code`
- `yarn test:other`
- `yarn build:excalidraw`

