### PR TITLE
fix(editor): re-apply theme-dependent tool cursors on theme change

### DIFF
--- a/packages/excalidraw/components/App.bucketFill.ts
+++ b/packages/excalidraw/components/App.bucketFill.ts
@@ -295,7 +295,10 @@ export class AppBucketFill {
     /** supply only for display purposes such as when applying to the cursor */
     theme?: Theme,
   ) =>
-    isTransparent(backgroundColor)
-      ? COLOR_PALETTE.green[DEFAULT_ELEMENT_BACKGROUND_COLOR_INDEX]
-      : applyDarkModeFilter(backgroundColor, theme === THEME.DARK);
+    applyDarkModeFilter(
+      isTransparent(backgroundColor)
+        ? COLOR_PALETTE.green[DEFAULT_ELEMENT_BACKGROUND_COLOR_INDEX]
+        : backgroundColor,
+      theme === THEME.DARK,
+    );
 }

--- a/packages/excalidraw/components/App.cursor.ts
+++ b/packages/excalidraw/components/App.cursor.ts
@@ -36,6 +36,15 @@ const createBucketFillCursorDataURL = (color: string) => {
 };
 
 /**
+ * Tools whose cursor is rendered from the current theme. Their cursor must be
+ * re-applied when the theme changes, or it keeps advertising the old theme's
+ * colors — keep in sync with the `theme` lookup in `applyForTool()`.
+ */
+export const isThemeDependentToolCursor = (
+  type: AppState["activeTool"]["type"],
+) => type === "eraser" || type === "laser" || type === "bucketfill";
+
+/**
  * Captures all cursor management for the interactive canvas.
  *
  * The canvas cursor is set exclusively imperatively, through this class —
@@ -100,12 +109,9 @@ export class AppCursor {
       return;
     }
 
-    const theme =
-      activeTool.type === "eraser" ||
-      activeTool.type === "laser" ||
-      activeTool.type === "bucketfill"
-        ? this.app.state.theme
-        : undefined;
+    const theme = isThemeDependentToolCursor(activeTool.type)
+      ? this.app.state.theme
+      : undefined;
 
     const bucketFillColor =
       activeTool.type === "bucketfill"

--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -433,7 +433,7 @@ import ConvertElementTypePopup, {
 import { activeConfirmDialogAtom } from "./ActiveConfirmDialog";
 import { AppArrowText } from "./App.arrowText";
 import { AppBucketFill } from "./App.bucketFill";
-import { AppCursor } from "./App.cursor";
+import { AppCursor, isThemeDependentToolCursor } from "./App.cursor";
 import { AppDrawShape } from "./App.drawshape";
 import { AppFlowchart } from "./App.flowchart";
 import { AppViewport, RIGHT_SIDEBAR_WIDTH } from "./App.viewport";
@@ -4140,7 +4140,7 @@ class App extends React.Component<AppProps, AppState> {
       });
     }
     if (
-      this.state.activeTool.type === "eraser" &&
+      isThemeDependentToolCursor(this.state.activeTool.type) &&
       prevState.theme !== this.state.theme
     ) {
       this.cursor.applyForTool();

--- a/packages/excalidraw/tests/bucketFill.test.tsx
+++ b/packages/excalidraw/tests/bucketFill.test.tsx
@@ -1,7 +1,10 @@
 import {
+  applyDarkModeFilter,
   BUCKET_FILL_BACKGROUND_PICKS,
   COLOR_PALETTE,
+  DEFAULT_ELEMENT_BACKGROUND_COLOR_INDEX,
   KEYS,
+  THEME,
 } from "@excalidraw/common";
 import { CaptureUpdateAction } from "@excalidraw/element";
 import { pointFrom } from "@excalidraw/math";
@@ -106,6 +109,64 @@ describe("bucket fill tool", () => {
     const updatedCursor = GlobalTestState.interactiveCanvas.style.cursor;
     expect(updatedCursor).not.toBe(fallbackCursor);
     expect(decodeURIComponent(updatedCursor)).toContain(`fill="${nextColor}"`);
+  });
+
+  it("re-applies the cursor when the theme changes", () => {
+    act(() => {
+      API.setAppState({
+        theme: THEME.LIGHT,
+        currentItemBackgroundColor: COLOR_PALETTE.transparent,
+      });
+    });
+    selectBucketFill();
+
+    const fallback = COLOR_PALETTE.green[DEFAULT_ELEMENT_BACKGROUND_COLOR_INDEX];
+    const lightCursor = GlobalTestState.interactiveCanvas.style.cursor;
+    expect(decodeURIComponent(lightCursor)).toContain(`fill="${fallback}"`);
+
+    act(() => {
+      API.setAppState({ theme: THEME.DARK });
+    });
+
+    // the refresh used to be gated on the eraser tool only, so the bucket-fill
+    // (and laser) cursor kept the previous theme's colors
+    const darkCursor = GlobalTestState.interactiveCanvas.style.cursor;
+    expect(darkCursor).not.toBe(lightCursor);
+    expect(decodeURIComponent(darkCursor)).toContain(
+      `fill="${applyDarkModeFilter(fallback, true)}"`,
+    );
+  });
+
+  it("dark-mode filters the transparent fallback color, same as an explicit one", () => {
+    const { bucketFill } = h.app;
+    const fallback = COLOR_PALETTE.green[DEFAULT_ELEMENT_BACKGROUND_COLOR_INDEX];
+    const explicit = "#e03131";
+
+    // an explicit color has always been filtered for display
+    expect(
+      bucketFill.getBucketFillBackgroundColor(explicit, THEME.DARK),
+    ).toBe(applyDarkModeFilter(explicit, true));
+
+    // the transparent fallback must be too, or the cursor swatch advertises a
+    // color the canvas won't paint once the dark filter is applied on render
+    expect(
+      bucketFill.getBucketFillBackgroundColor(
+        COLOR_PALETTE.transparent,
+        THEME.DARK,
+      ),
+    ).toBe(applyDarkModeFilter(fallback, true));
+
+    expect(
+      bucketFill.getBucketFillBackgroundColor(
+        COLOR_PALETTE.transparent,
+        THEME.LIGHT,
+      ),
+    ).toBe(fallback);
+
+    // no theme = the color actually written to the element; stays unfiltered
+    expect(
+      bucketFill.getBucketFillBackgroundColor(COLOR_PALETTE.transparent),
+    ).toBe(fallback);
   });
 
   it("does not rebuild or reapply an unchanged bucket fill cursor", () => {


### PR DESCRIPTION

Follow-up to #11849

## Summary

The theme-change cursor refresh in `componentDidUpdate` was gated on `activeTool.type === "eraser"`, but `AppCursor.applyForTool()` builds a theme-dependent cursor for **eraser, laser and bucketfill**. Switching theme while the laser or bucket-fill tool was active left the previous theme's cursor installed.

Separately, `getBucketFillBackgroundColor()` dark-filtered an explicit background colour but returned the transparent fallback raw — and transparent is the default, so the bucket cursor advertised `#b2f2bb` while the dark canvas painted something else.

Fixing only one of these is invisible: without the refresh the corrected colour never re-renders, and without the filter the refresh recomputes the same value.

Extracted `isThemeDependentToolCursor()` so `App` and `AppCursor` share one definition instead of two lists that can drift, and wrapped `applyDarkModeFilter` around both branches of the getter.

**The painted colour is unchanged.** The fill path calls the getter with no `theme` argument, and `applyDarkModeFilter(colour, false)` is identity — verified on the running app: still `#b2f2bb`.

## Before / After

Bucket-fill tool, transparent background, dark mode — the cursor SVG the editor actually installs:

| | light | dark |
|---|---|---|
| before | `#b2f2bb` | `#b2f2bb` ← unchanged by the theme |
| after | `#b2f2bb` | `#043b0c` |

![Bucket-fill cursor following the theme toggle](https://raw.githubusercontent.com/MITRAKER/excalidraw/pursuit-l3-audit/screenshots/02-fixes-local/00-CURSOR-PROOF.gif)

Toggling the theme with the bucket-fill tool active: the cursor swatch now follows the theme instead of keeping the light-mode colour.

## Tests

Two added to `packages/excalidraw/tests/bucketFill.test.tsx`:

- `re-applies the cursor when the theme changes` — pins the refresh. Reverting the `componentDidUpdate` change makes it fail (the dark cursor comes back byte-identical to light).
- `dark-mode filters the transparent fallback color, same as an explicit one` — pins the getter, including that the no-theme paint path stays unfiltered.

```
yarn vitest run packages/excalidraw/tests/bucketFill.test.tsx
```

33/33 pass. `yarn test:typecheck` clean.