### PR TITLE
docs: remove obsolete CodeSandbox contribution workflow

### DIFF
--- a/dev-docs/docs/introduction/contributing.mdx
+++ b/dev-docs/docs/introduction/contributing.mdx
@@ -9,8 +9,6 @@ In case you want to pick up something from the roadmap, comment on that issue an
 
 ## Setup
 
-### Option 1 - Manual
-
 1. Fork and clone the repo
 1. Run `yarn` to install dependencies
 1. Create a branch for your PR with `git checkout -b your-branch-name`
@@ -22,15 +20,6 @@ In case you want to pick up something from the roadmap, comment on that issue an
 > git fetch upstream
 > git branch --set-upstream-to=upstream/master master
 > ```
-
-### Option 2 - CodeSandbox
-
-1. Go to https://codesandbox.io/p/github/excalidraw/excalidraw
-1. Connect your GitHub account
-1. Go to Git tab on left side
-1. Tap on `Fork Sandbox`
-1. Write your code
-1. Commit and PR automatically
 
 ## Pull Request Guidelines
 

--- a/dev-docs/docs/introduction/development.mdx
+++ b/dev-docs/docs/introduction/development.mdx
@@ -1,11 +1,5 @@
 # Development
 
-## Code Sandbox
-
-- Go to https://codesandbox.io/p/github/excalidraw/excalidraw
-  - You may need to sign in with GitHub and reload the page
-- You can start coding instantly, and even send PRs from there!
-
 ## Local Installation
 
 These instructions will get you a copy of the project up and running on your local machine for development and testing purposes.


### PR DESCRIPTION
Fixes #11761.

`https://codesandbox.io/p/github/excalidraw/excalidraw` (forking the whole repo as an editable CodeSandbox to submit PRs from) no longer works — it was documented as "Option 2" in the Contributing guide and again in the Development guide as an alternative to the manual clone/fork/install setup.

This PR removes both mentions, leaving the manual setup (which still works) as the only documented path.

I deliberately left the other CodeSandbox links elsewhere in the docs (root/package READMEs, the installation/integration/development guides for the `@excalidraw/excalidraw` package) untouched — those point at the separate `examples/with-script-in-browser` usage-example sandbox, which is a different, still-functional link unrelated to this contribution workflow.