### PR TITLE
feat: cmd/ctrl+click continues freedraw stroke with straight segment

### DIFF
--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -711,6 +711,8 @@ class App extends React.Component<AppProps, AppState> {
   private lastCompletedCanvasClicks: { x: number; y: number }[] = [];
   /** previous frame pointer coords */
   previousPointerMoveCoords: { x: number; y: number } | null = null;
+  /** id of the most recently finalized freedraw stroke, so a modifier-click can continue it */
+  private lastFreedrawElementId: string | null = null;
 
   drawShape = new AppDrawShape(this);
   laserTrails = new LaserTrails(this);
@@ -8720,11 +8722,15 @@ class App extends React.Component<AppProps, AppState> {
         pointerDownState,
       );
     } else if (this.state.activeTool.type === "freedraw") {
-      this.handleFreeDrawElementOnPointerDown(
-        event,
-        this.state.activeTool.type,
-        pointerDownState,
-      );
+      if (event[KEYS.CTRL_OR_CMD] && this.lastFreedrawElementId) {
+        this.handleFreeDrawContinuationOnPointerDown(event, pointerDownState);
+      } else {
+        this.handleFreeDrawElementOnPointerDown(
+          event,
+          this.state.activeTool.type,
+          pointerDownState,
+        );
+      }
     } else if (this.state.activeTool.type === "custom") {
       this.cursor.applyForTool();
     } else if (
@@ -9830,6 +9836,72 @@ class App extends React.Component<AppProps, AppState> {
           prevState,
         ),
       };
+    });
+
+    this.setState({
+      newElement: element,
+      suggestedBinding: null,
+    });
+  };
+
+  // Cmd/Ctrl+click with the pencil tool continues the last finished stroke
+  // with a straight segment, mirroring Illustrator's modifier-click behavior.
+  private handleFreeDrawContinuationOnPointerDown = (
+    event: React.PointerEvent<HTMLElement>,
+    pointerDownState: PointerDownState,
+  ) => {
+    const previousElement = this.lastFreedrawElementId
+      ? this.scene.getElement<ExcalidrawFreeDrawElement>(
+          this.lastFreedrawElementId,
+        )
+      : null;
+
+    if (!previousElement || previousElement.isDeleted) {
+      this.handleFreeDrawElementOnPointerDown(
+        event,
+        "freedraw",
+        pointerDownState,
+      );
+      return;
+    }
+
+    const element = previousElement as NonDeleted<ExcalidrawFreeDrawElement>;
+
+    const [gridX, gridY] = getGridPoint(
+      pointerDownState.origin.x,
+      pointerDownState.origin.y,
+      null,
+    );
+
+    // perfect-freehand's streamline smoothing assumes closely-spaced points
+    // like a real hand-drawn stroke, so a single distant point undershoots
+    // the target. Interpolate the straight segment densely to match.
+    const lastPoint = element.points[element.points.length - 1];
+    const target = pointFrom<LocalPoint>(gridX - element.x, gridY - element.y);
+    const STEP_SIZE = 4;
+    const steps = Math.max(
+      1,
+      Math.round(pointDistance(lastPoint, target) / STEP_SIZE),
+    );
+    const interpolatedPoints: LocalPoint[] = [];
+    for (let i = 1; i <= steps; i++) {
+      const t = i / steps;
+      interpolatedPoints.push(
+        pointFrom<LocalPoint>(
+          lastPoint[0] + (target[0] - lastPoint[0]) * t,
+          lastPoint[1] + (target[1] - lastPoint[1]) * t,
+        ),
+      );
+    }
+
+    this.scene.mutateElement(element, {
+      points: [...element.points, ...interpolatedPoints],
+      pressures: element.simulatePressure
+        ? element.pressures
+        : [
+            ...element.pressures,
+            ...interpolatedPoints.map(() => event.pressure),
+          ],
     });
 
     this.setState({
@@ -11686,6 +11758,8 @@ class App extends React.Component<AppProps, AppState> {
           points: [...points, pointFrom<LocalPoint>(dx, dy)],
           pressures,
         });
+
+        this.lastFreedrawElementId = newElement.id;
 
         this.actionManager.executeAction(actionFinalize);
 

--- a/packages/excalidraw/tests/freedrawMode.test.tsx
+++ b/packages/excalidraw/tests/freedrawMode.test.tsx
@@ -6,10 +6,11 @@ import type {
 import { Excalidraw } from "../index";
 
 import { API } from "./helpers/api";
-import { UI } from "./helpers/ui";
+import { Keyboard, Pointer, UI } from "./helpers/ui";
 import { act, fireEvent, render, screen } from "./test-utils";
 
 const { h } = window;
+const mouse = new Pointer("mouse");
 
 describe("freedraw mode action", () => {
   beforeEach(async () => {
@@ -56,5 +57,45 @@ describe("freedraw mode action", () => {
       (h.elements[0] as ExcalidrawFreeDrawElement).strokeOptions?.streamline,
     ).toBe(0.5);
     expect(h.state.currentItemStrokeVariability).toBe("constant");
+  });
+
+  it("ctrl/cmd+click continues the last stroke with a straight segment", () => {
+    UI.createElement("freedraw", { x: 0, y: 0, width: 10, height: 10 });
+
+    expect(h.elements.length).toBe(1);
+    const firstElement = h.elements[0] as ExcalidrawFreeDrawElement;
+    const pointCountBeforeContinuation = firstElement.points.length;
+
+    Keyboard.withModifierKeys({ ctrl: true }, () => {
+      mouse.reset();
+      mouse.clickAt(200, 200);
+    });
+
+    // continues the same element rather than starting a new one
+    expect(h.elements.length).toBe(1);
+
+    const continuedElement = h.elements[0] as ExcalidrawFreeDrawElement;
+    expect(continuedElement.id).toBe(firstElement.id);
+
+    // the straight segment is densely interpolated (not a single distant
+    // point), otherwise perfect-freehand's smoothing undershoots the target
+    expect(continuedElement.points.length).toBeGreaterThan(
+      pointCountBeforeContinuation + 5,
+    );
+
+    const lastPoint =
+      continuedElement.points[continuedElement.points.length - 1];
+    expect(lastPoint[0] + continuedElement.x).toBeCloseTo(200, 0);
+    expect(lastPoint[1] + continuedElement.y).toBeCloseTo(200, 0);
+  });
+
+  it("click without ctrl/cmd starts a new stroke instead of continuing", () => {
+    UI.createElement("freedraw", { x: 0, y: 0, width: 10, height: 10 });
+    expect(h.elements.length).toBe(1);
+
+    mouse.reset();
+    mouse.clickAt(200, 200);
+
+    expect(h.elements.length).toBe(2);
   });
 });


### PR DESCRIPTION
Draft — implements #11915. Cmd/Ctrl+click while the pencil tool is active continues the last finished stroke with a straight segment (mirrors Illustrator's Alt+click pencil behavior), instead of starting a new shape. Includes tests. Early version, feedback on the approach welcome.

