### PR TITLE
docs: remove obsolete CodeSandbox contribution workflow

### DIFF
--- a/dev-docs/docs/introduction/contributing.mdx
+++ b/dev-docs/docs/introduction/contributing.mdx
@@ -9,7 +9,7 @@ In case you want to pick up something from the roadmap, comment on that issue an
 
 ## Setup
 
-### Option 1 - Manual
+### Manual
 
 1. Fork and clone the repo
 1. Run `yarn` to install dependencies
@@ -22,15 +22,6 @@ In case you want to pick up something from the roadmap, comment on that issue an
 > git fetch upstream
 > git branch --set-upstream-to=upstream/master master
 > ```
-
-### Option 2 - CodeSandbox
-
-1. Go to https://codesandbox.io/p/github/excalidraw/excalidraw
-1. Connect your GitHub account
-1. Go to Git tab on left side
-1. Tap on `Fork Sandbox`
-1. Write your code
-1. Commit and PR automatically
 
 ## Pull Request Guidelines
 

--- a/dev-docs/docs/introduction/development.mdx
+++ b/dev-docs/docs/introduction/development.mdx
@@ -1,11 +1,5 @@
 # Development
 
-## Code Sandbox
-
-- Go to https://codesandbox.io/p/github/excalidraw/excalidraw
-  - You may need to sign in with GitHub and reload the page
-- You can start coding instantly, and even send PRs from there!
-
 ## Local Installation
 
 These instructions will get you a copy of the project up and running on your local machine for development and testing purposes.


### PR DESCRIPTION
Fixes #11761

Removes the CodeSandbox-based contribution workflow from the dev docs
(`### Option 2 - CodeSandbox` in contributing.mdx and `## Code Sandbox`
in development.mdx). CodeSandbox Repositories — which powered the
`/p/github/...` GitHub-import-and-PR flow these sections documented —
stopped accepting new imports on April 1, 2026, with full support
ending July 1, 2026, so the instructions are now dead.

Also renamed `### Option 1 - Manual` to `### Manual` in contributing.mdx
as a direct consequence of removing the second option.

Note: four other CodeSandbox references in dev-docs (live demo embeds
in installation.mdx, integration.mdx, development.mdx under
`@excalidraw/excalidraw/`, and excalidraw-api.mdx) were deliberately
left untouched — those link to hosted example sandboxes, not a
contribution/dev workflow, and are out of scope for this issue.