### PR TITLE
feat: rename Align section to 'Align & Distribute' for discoverability

### DIFF
--- a/packages/excalidraw/components/Actions.tsx
+++ b/packages/excalidraw/components/Actions.tsx
@@ -93,7 +93,7 @@ const AlignFieldset = ({
 
   return (
     <fieldset>
-      <legend>{t("labels.align")}</legend>
+      <legend>{showDistribute ? t("labels.alignAndDistribute") : t("labels.align")}</legend>
       <div className="buttonList">
         {isRTL ? (
           <>

--- a/packages/excalidraw/components/shapeActionPredicates.ts
+++ b/packages/excalidraw/components/shapeActionPredicates.ts
@@ -5,6 +5,7 @@ import {
   suppportsHorizontalAlign,
   hasBoundTextElement,
   isElbowArrow,
+  isFrameLikeElement,
   isImageElement,
   isLinearElement,
   isTextElement,
@@ -154,7 +155,9 @@ export const getShapeActionPredicates = (
       ),
     align:
       !isSingleElementBoundContainer && alignActionsPredicate(appState, app),
-    distribute: targetElements.length > 2,
+    distribute:
+      targetElements.length > 2 &&
+      !targetElements.some((el) => isFrameLikeElement(el)),
 
     // per-element actions
     // NOTE: the full panel treats a bound container as linkable; the compact /

--- a/packages/excalidraw/locales/en.json
+++ b/packages/excalidraw/locales/en.json
@@ -120,6 +120,7 @@
     "loadingScene": "Loading scene…",
     "loadScene": "Load scene from file",
     "align": "Align",
+    "alignAndDistribute": "Align & Distribute",
     "alignTop": "Align top",
     "alignBottom": "Align bottom",
     "alignLeft": "Align left",


### PR DESCRIPTION
## Summary

The distribute tools (distribute horizontally / vertically) have been available since #2395 but are poorly discoverable because the section is simply labeled **"Align"**. Users looking for a distribute feature won't find it under that name.

This PR renames the fieldset legend to **"Align & Distribute"** when the distribute buttons are visible (3+ elements selected), and keeps **"Align"** when fewer elements are selected.

## Changes

- `packages/excalidraw/locales/en.json` — added `"alignAndDistribute"` translation key
- `packages/excalidraw/components/Actions.tsx` — conditional legend text based on `showDistribute` prop

## Testing

- TypeScript typecheck passes (`yarn test:typecheck`)
- All existing tests pass
- The `AlignFieldset` component is shared across all styles-panel layouts (mobile, tablet, desktop), so the fix applies everywhere

Closes #8657