### PR TITLE
feat: add <title> element to exported SVGs for searchability

### DIFF
--- a/packages/excalidraw/data/index.ts
+++ b/packages/excalidraw/data/index.ts
@@ -130,6 +130,7 @@ export const exportCanvas = async (
         exportPadding,
         exportScale: appState.exportScale,
         exportEmbedScene: appState.exportEmbedScene && type === "svg",
+        name,
       },
       files,
       { exportingFrame },

--- a/packages/excalidraw/scene/export.ts
+++ b/packages/excalidraw/scene/export.ts
@@ -300,6 +300,7 @@ export const exportToSvg = async (
     exportWithDarkMode?: boolean;
     exportEmbedScene?: boolean;
     frameRendering?: AppState["frameRendering"];
+    name?: string | null;
   },
   files: BinaryFiles | null,
   opts?: {
@@ -367,6 +368,16 @@ export const exportToSvg = async (
 
   svgRoot.appendChild(createHTMLComment("svg-source:excalidraw"));
   svgRoot.appendChild(metadataElement);
+
+  if (appState.name) {
+    const titleElement = svgRoot.ownerDocument.createElementNS(
+      SVG_NS,
+      "title",
+    );
+    titleElement.textContent = appState.name;
+    svgRoot.appendChild(titleElement);
+  }
+
   svgRoot.appendChild(defsElement);
 
   // ---------------------------------------------------------------------------

--- a/packages/excalidraw/tests/scene/export.test.ts
+++ b/packages/excalidraw/tests/scene/export.test.ts
@@ -190,6 +190,46 @@ describe("exportToSvg", () => {
     expect(svgElement.innerHTML).toMatchSnapshot();
   });
 
+  it("with title from name", async () => {
+    const svgElement = await exportUtils.exportToSvg(
+      ELEMENTS,
+      {
+        ...DEFAULT_OPTIONS,
+        name: "My Drawing",
+      },
+      null,
+    );
+
+    const titleEl = svgElement.querySelector("title");
+    expect(titleEl).not.toBeNull();
+    expect(titleEl!.textContent).toBe("My Drawing");
+  });
+
+  it("without title when name is not provided", async () => {
+    const svgElement = await exportUtils.exportToSvg(
+      ELEMENTS,
+      DEFAULT_OPTIONS,
+      null,
+    );
+
+    const titleEl = svgElement.querySelector("title");
+    expect(titleEl).toBeNull();
+  });
+
+  it("without title when name is empty string", async () => {
+    const svgElement = await exportUtils.exportToSvg(
+      ELEMENTS,
+      {
+        ...DEFAULT_OPTIONS,
+        name: "",
+      },
+      null,
+    );
+
+    const titleEl = svgElement.querySelector("title");
+    expect(titleEl).toBeNull();
+  });
+
   it("with elements that have a link", async () => {
     const svgElement = await exportUtils.exportToSvg(
       [rectangleWithLinkFixture] as NonDeletedExcalidrawElement[],


### PR DESCRIPTION
## Summary

When exporting to SVG, there is no way to set a title on the exported file. This makes SVGs harder to find on GitHub and other platforms that index `<title>` content.

This PR threads the existing project name (`AppState.name`) through the SVG export pipeline to produce a `<title>` element, making exported SVGs searchable on GitHub and other tools.

## Approach

Instead of adding a new UI input, this reuses the already-available `name` field:

- Added `name?: string | null` to `exportToSvg`'s `appState` parameter
- When `appState.name` is set, a `<title>` element is appended to the SVG root
- `exportCanvas` now passes `name` through to `exportToSvg`
- Falls back gracefully: no title when name is empty/undefined

## Tests

Added 3 new tests:
1. **with title from name** — verifies `<title>` text matches `appState.name`
2. **without title when name is not provided** — verifies no `<title>` element
3. **without title when name is empty string** — verifies no `<title>` for empty string

All 20 tests pass. TypeScript typecheck passes.

Closes #8301