### PR TITLE
fix(editor): no-op zoom-to-selection on empty scene

### DIFF
--- a/packages/excalidraw/CHANGELOG.md
+++ b/packages/excalidraw/CHANGELOG.md
@@ -13,6 +13,10 @@ Please add the latest change on the top under the correct section.
 
 ## Unreleased
 
+### Fixes
+
+- Zoom to selection (`Shift+3`) and `zoomToFitBounds({ fit: "contain" })` no longer jump to maximum zoom when the scene or target bounds are empty.
+
 ## Excalidraw API
 
 ### Host-controlled active tool (2026-07-14) [#11665](https://github.com/excalidraw/excalidraw/pull/11665)

--- a/packages/excalidraw/tests/zoomToFitBounds.test.tsx
+++ b/packages/excalidraw/tests/zoomToFitBounds.test.tsx
@@ -1,0 +1,78 @@
+import React from "react";
+
+import { MAX_ZOOM } from "@excalidraw/common";
+import { getCommonBounds } from "@excalidraw/element";
+
+import { actionZoomToFitSelection } from "../actions/actionCanvas";
+import { getDefaultAppState } from "../appState";
+import { Excalidraw } from "../index";
+import { getNormalizedZoom } from "../scene";
+import { zoomToFitBounds } from "../viewport";
+
+import { API } from "./helpers/api";
+import { render } from "./test-utils";
+
+import type { AppState, NormalizedZoomValue } from "../types";
+
+const { h } = window;
+
+const createAppState = (overrides: Partial<AppState> = {}): AppState => ({
+  ...getDefaultAppState(),
+  width: 800,
+  height: 600,
+  offsetLeft: 0,
+  offsetTop: 0,
+  ...overrides,
+});
+
+describe("zoomToFitBounds", () => {
+  it("does not change zoom or scroll for empty common bounds with contain fit", () => {
+    const appState = createAppState({
+      zoom: { value: 1 as NormalizedZoomValue },
+      scrollX: 40,
+      scrollY: 20,
+    });
+
+    // empty scene: actionZoomToFitSelection falls back to getCommonBounds([])
+    const bounds = getCommonBounds([]);
+    expect(bounds).toEqual([0, 0, 0, 0]);
+
+    const result = zoomToFitBounds({
+      bounds,
+      appState,
+      fit: "contain",
+    });
+
+    expect(result.appState.zoom.value).toBe(appState.zoom.value);
+    expect(result.appState.zoom.value).not.toBe(MAX_ZOOM);
+    expect(result.appState.scrollX).toBe(appState.scrollX);
+    expect(result.appState.scrollY).toBe(appState.scrollY);
+  });
+});
+
+describe("actionZoomToFitSelection", () => {
+  it("is a no-op on an empty scene", async () => {
+    await render(<Excalidraw />);
+
+    h.state.width = 800;
+    h.state.height = 600;
+
+    API.setAppState({
+      zoom: { value: getNormalizedZoom(0.5) },
+      scrollX: 120,
+      scrollY: 80,
+    });
+
+    expect(h.elements).toHaveLength(0);
+    expect(API.getSelectedElements()).toHaveLength(0);
+
+    const { zoom, scrollX, scrollY } = h.state;
+
+    API.executeAction(actionZoomToFitSelection);
+
+    expect(h.state.zoom.value).toBe(zoom.value);
+    expect(h.state.zoom.value).not.toBe(MAX_ZOOM);
+    expect(h.state.scrollX).toBe(scrollX);
+    expect(h.state.scrollY).toBe(scrollY);
+  });
+});

--- a/packages/excalidraw/tests/zoomToFitBounds.test.tsx
+++ b/packages/excalidraw/tests/zoomToFitBounds.test.tsx
@@ -75,4 +75,53 @@ describe("actionZoomToFitSelection", () => {
     expect(h.state.scrollX).toBe(scrollX);
     expect(h.state.scrollY).toBe(scrollY);
   });
+
+  it("empty scene scrolled away from origin keeps zoom and scroll", async () => {
+    await render(<Excalidraw />);
+
+    h.state.width = 800;
+    h.state.height = 600;
+
+    API.setAppState({
+      zoom: { value: getNormalizedZoom(1) },
+      scrollX: -400,
+      scrollY: -250,
+    });
+
+    expect(h.elements).toHaveLength(0);
+    expect(API.getSelectedElements()).toHaveLength(0);
+    expect(h.state.zoom.value).toBe(1);
+    expect(h.state.scrollX).toBe(-400);
+    expect(h.state.scrollY).toBe(-250);
+
+    API.executeAction(actionZoomToFitSelection);
+
+    expect(h.state.zoom.value).toBe(1);
+    expect(h.state.zoom.value).not.toBe(MAX_ZOOM);
+    expect(h.state.scrollX).toBe(-400);
+    expect(h.state.scrollY).toBe(-250);
+  });
+
+  it("still fits a real selection", async () => {
+    await render(<Excalidraw />);
+
+    h.state.width = 100;
+    h.state.height = 100;
+
+    const rectElement = API.createElement({
+      width: 500,
+      height: 500,
+      x: 0,
+      y: 0,
+    });
+    API.setElements([rectElement]);
+    API.setSelectedElements([rectElement]);
+
+    API.executeAction(actionZoomToFitSelection);
+
+    // 500px of content into a 100px viewport — zoomed out, not slammed to max
+    expect(h.state.zoom.value).toBeLessThan(1);
+    expect(h.state.zoom.value).toBeGreaterThan(0);
+    expect(h.state.zoom.value).not.toBe(MAX_ZOOM);
+  });
 });

--- a/packages/excalidraw/viewport.ts
+++ b/packages/excalidraw/viewport.ts
@@ -296,6 +296,21 @@ export const zoomToFitBounds = ({
   steppedZoom?: boolean;
 }) => {
   const [x1, y1, x2, y2] = bounds;
+  const commonBoundsWidth = x2 - x1;
+  const commonBoundsHeight = y2 - y1;
+
+  // empty selection/scene: getCommonBounds([]) returns [0, 0, 0, 0]
+  if (
+    !Number.isFinite(commonBoundsWidth) ||
+    !Number.isFinite(commonBoundsHeight) ||
+    (commonBoundsWidth === 0 && commonBoundsHeight === 0)
+  ) {
+    return {
+      appState,
+      captureUpdate: CaptureUpdateAction.EVENTUALLY,
+    };
+  }
+
   const centerX = (x1 + x2) / 2;
   const centerY = (y1 + y2) / 2;
 
@@ -315,9 +330,6 @@ export const zoomToFitBounds = ({
     // pan-only: keep the current zoom, just center the target
     adjustedZoomValue = appState.zoom.value;
   } else if (fit === "contain") {
-    const commonBoundsWidth = x2 - x1;
-    const commonBoundsHeight = y2 - y1;
-
     adjustedZoomValue = Math.min(
       effectiveCanvasWidth / commonBoundsWidth,
       effectiveCanvasHeight / commonBoundsHeight,


### PR DESCRIPTION
With nothing on the canvas, Shift+3 (zoom to selection) fell back to `getCommonBounds([])` which is `[0, 0, 0, 0]`. `zoomToFitBounds` then divided by those bounds with `fit: \"contain\"` and jumped to `MAX_ZOOM`.

No-op when bounds are empty or non-finite, so zoom and scroll stay put.

Fixes #11913