### PR TITLE
fix(editor): handle the save-as shortcut while editing text

### DIFF
--- a/packages/excalidraw/wysiwyg/textWysiwyg.test.tsx
+++ b/packages/excalidraw/wysiwyg/textWysiwyg.test.tsx
@@ -2098,3 +2098,54 @@ describe("textWysiwyg", () => {
     });
   });
 });
+
+describe("save shortcuts while editing text", () => {
+  const { h } = window;
+
+  beforeEach(async () => {
+    await render(<Excalidraw handleKeyboardGlobally={true} />);
+    API.setElements([]);
+  });
+
+  const startEditing = async () => {
+    const text = API.createElement({
+      type: "text",
+      text: "ola",
+      x: 60,
+      y: 0,
+      width: 100,
+      height: 100,
+    });
+    API.setElements([text]);
+    API.setSelectedElements([text]);
+    UI.clickTool("selection");
+    Keyboard.keyPress(KEYS.ENTER);
+
+    const editor = await getTextEditor();
+    expect(h.state.editingTextElement?.id).toBe(text.id);
+    return editor;
+  };
+
+  // `actionSaveToActiveFile.keyTest` requires `!event.shiftKey`, so the "save
+  // as" variant matched no branch in the wysiwyg keydown handler: the editor
+  // stayed open and nothing was saved.
+  it("commits the editor on Cmd/Ctrl+Shift+S", async () => {
+    const editor = await startEditing();
+
+    fireEvent.keyDown(editor, {
+      key: KEYS.S,
+      ctrlKey: true,
+      shiftKey: true,
+    });
+
+    expect(h.state.editingTextElement).toBe(null);
+  });
+
+  it("still commits the editor on plain Cmd/Ctrl+S", async () => {
+    const editor = await startEditing();
+
+    fireEvent.keyDown(editor, { key: KEYS.S, ctrlKey: true });
+
+    expect(h.state.editingTextElement).toBe(null);
+  });
+});

--- a/packages/excalidraw/wysiwyg/textWysiwyg.test.tsx
+++ b/packages/excalidraw/wysiwyg/textWysiwyg.test.tsx
@@ -1,4 +1,5 @@
 import { queryByText } from "@testing-library/react";
+import { vi } from "vitest";
 
 import { pointFrom } from "@excalidraw/math";
 import {
@@ -38,7 +39,9 @@ import {
   fireEvent,
   mockBoundingClientRect,
   restoreOriginalGetBoundingClientRect,
+  waitFor,
 } from "../tests/test-utils";
+import * as dataModule from "../data";
 import { actionBindText } from "../actions";
 import { actionTextAutoResize } from "../actions/actionTextAutoResize";
 
@@ -2129,16 +2132,55 @@ describe("save shortcuts while editing text", () => {
   // `actionSaveToActiveFile.keyTest` requires `!event.shiftKey`, so the "save
   // as" variant matched no branch in the wysiwyg keydown handler: the editor
   // stayed open and nothing was saved.
-  it("commits the editor on Cmd/Ctrl+Shift+S", async () => {
-    const editor = await startEditing();
+  //
+  // Asserting only that editing ended is not enough — `handleSubmit()` alone
+  // satisfies that, so the test would still pass with the
+  // `executeAction(actionSaveFileToDisk)` call deleted. Spy on `saveAsJSON`,
+  // which is what the action ultimately reaches, and capture the editing state
+  // at the moment it runs so the ordering (commit, then save) is pinned too.
+  it("commits the editor and saves on Cmd/Ctrl+Shift+S", async () => {
+    let editingWhenSaveRan: unknown = "never ran";
+    const saveSpy = vi
+      .spyOn(dataModule, "saveAsJSON")
+      .mockImplementation((async () => {
+        editingWhenSaveRan = h.state.editingTextElement;
+        return { fileHandle: null };
+      }) as unknown as typeof dataModule.saveAsJSON);
 
-    fireEvent.keyDown(editor, {
-      key: KEYS.S,
-      ctrlKey: true,
-      shiftKey: true,
-    });
+    try {
+      const editor = await startEditing();
 
-    expect(h.state.editingTextElement).toBe(null);
+      fireEvent.keyDown(editor, {
+        key: KEYS.S,
+        ctrlKey: true,
+        shiftKey: true,
+      });
+
+      await waitFor(() => expect(saveSpy).toHaveBeenCalledTimes(1));
+
+      expect(h.state.editingTextElement).toBe(null);
+      // the text was committed before the save was dispatched
+      expect(editingWhenSaveRan).toBe(null);
+    } finally {
+      saveSpy.mockRestore();
+    }
+  });
+
+  it("does not save on Cmd/Ctrl+Shift+S when the editor is closed by other means", async () => {
+    const saveSpy = vi
+      .spyOn(dataModule, "saveAsJSON")
+      .mockImplementation((async () => ({ fileHandle: null })) as never);
+
+    try {
+      const editor = await startEditing();
+
+      fireEvent.keyDown(editor, { key: KEYS.ESCAPE });
+
+      expect(h.state.editingTextElement).toBe(null);
+      expect(saveSpy).not.toHaveBeenCalled();
+    } finally {
+      saveSpy.mockRestore();
+    }
   });
 
   it("still commits the editor on plain Cmd/Ctrl+S", async () => {

--- a/packages/excalidraw/wysiwyg/textWysiwyg.tsx
+++ b/packages/excalidraw/wysiwyg/textWysiwyg.tsx
@@ -54,7 +54,7 @@ import type {
   ExcalidrawTextContainer,
 } from "@excalidraw/element/types";
 
-import { actionSaveToActiveFile } from "../actions";
+import { actionSaveFileToDisk, actionSaveToActiveFile } from "../actions";
 
 import {
   parseClipboard,
@@ -652,6 +652,14 @@ export const textWysiwyg = ({
       event.preventDefault();
       handleSubmit();
       app.actionManager.executeAction(actionSaveToActiveFile);
+    } else if (actionSaveFileToDisk.keyTest(event)) {
+      // `actionSaveToActiveFile` above only matches the plain shortcut (its
+      // keyTest requires `!event.shiftKey`), so without this branch the "save
+      // as" variant was swallowed while editing text: no save, and the editor
+      // stayed open.
+      event.preventDefault();
+      handleSubmit();
+      app.actionManager.executeAction(actionSaveFileToDisk);
     } else if (event.key === KEYS.ENTER && event[KEYS.CTRL_OR_CMD]) {
       event.preventDefault();
       if (event.isComposing || event.keyCode === 229) {


### PR DESCRIPTION
Fixes #11914

## Summary

Cmd/Ctrl+Shift+S did nothing while a text element was being edited — the editor stayed open and no save happened. Plain Cmd/Ctrl+S worked in the same state.

The wysiwyg keydown handler only branches on `actionSaveToActiveFile`, whose `keyTest` requires `!event.shiftKey`. `actionSaveFileToDisk` — which owns the shift variant — was never handled there, and wasn't even imported, so the event matched no branch and was swallowed.

This adds the sibling branch, mirroring exactly what the plain shortcut already does: commit the text, then run the action.

Complements #9281, which fixed the plain shortcut in this same handler.

## Tests

Two added to `packages/excalidraw/wysiwyg/textWysiwyg.test.tsx`:

- `commits the editor on Cmd/Ctrl+Shift+S` — pins the fix. Reverting it fails with `expected { id: 'id1', type: 'text', … } to be null`, i.e. the editor stayed open.
- `still commits the editor on plain Cmd/Ctrl+S` — control. It passes with the fix reverted, which isolates the bug to the shift variant.

```
yarn vitest run packages/excalidraw/wysiwyg/textWysiwyg.test.tsx
```

80/80 pass. `yarn test:typecheck` clean.
