### PR TITLE
fix(editor): keep zoom unchanged when there is nothing to fit

### DIFF
--- a/packages/excalidraw/tests/fitToContent.test.tsx
+++ b/packages/excalidraw/tests/fitToContent.test.tsx
@@ -4,6 +4,7 @@ import { Excalidraw } from "../index";
 import { SCROLL_TO_CONTENT_ANIMATION_KEY } from "../components/App.viewport";
 import { AnimationController } from "../renderer/animation";
 import { getNormalizedZoom } from "../scene";
+import { actionZoomToFitSelection } from "../actions/actionCanvas";
 
 import { API } from "./helpers/api";
 import { act, render } from "./test-utils";
@@ -365,5 +366,48 @@ describe("scale-down animated", () => {
     await waitForAnimationProgress();
     expect(h.state.scrollX).toBe(settledScrollX);
     expect(h.state.scrollY).toBe(settledScrollY);
+  });
+});
+
+describe("contain", () => {
+  // `fit: "contain"` divides the viewport by the bounds. `getCommonBounds([])`
+  // returns [0, 0, 0, 0], so with nothing to fit both ratios are Infinity and
+  // the zoom clamped to MAX_ZOOM (3000%) instead of staying put.
+  it("keeps the current zoom when there is nothing to fit", async () => {
+    await render(<Excalidraw />);
+
+    API.setElements([]);
+    expect(h.state.zoom.value).toBe(1);
+
+    act(() => {
+      h.app.actionManager.executeAction(actionZoomToFitSelection);
+    });
+
+    expect(h.state.zoom.value).toBe(1);
+    expect(h.state.zoom.value).not.toBe(getNormalizedZoom(Infinity));
+  });
+
+  it("still fits a real selection", async () => {
+    await render(<Excalidraw />);
+
+    h.state.width = 100;
+    h.state.height = 100;
+
+    const rectElement = API.createElement({
+      width: 500,
+      height: 500,
+      x: 0,
+      y: 0,
+    });
+    API.setElements([rectElement]);
+    API.setSelectedElements([rectElement]);
+
+    act(() => {
+      h.app.actionManager.executeAction(actionZoomToFitSelection);
+    });
+
+    // 500px of content into a 100px viewport — zoomed out, not slammed to max
+    expect(h.state.zoom.value).toBeLessThan(1);
+    expect(h.state.zoom.value).toBeGreaterThan(0);
   });
 });

--- a/packages/excalidraw/viewport.ts
+++ b/packages/excalidraw/viewport.ts
@@ -322,6 +322,15 @@ export const zoomToFitBounds = ({
       effectiveCanvasWidth / commonBoundsWidth,
       effectiveCanvasHeight / commonBoundsHeight,
     );
+
+    // Degenerate bounds divide by zero. `getCommonBounds([])` returns
+    // [0, 0, 0, 0], so fitting an empty scene makes both ratios Infinity,
+    // which then clamps to MAX_ZOOM (3000%). Keep the current zoom instead —
+    // there is nothing to fit. The "scale-down" path is already immune because
+    // it ends in `Math.min(smallestZoomValue, 1)`.
+    if (!Number.isFinite(adjustedZoomValue)) {
+      adjustedZoomValue = appState.zoom.value;
+    }
   } else {
     adjustedZoomValue = zoomValueToFitBoundsOnViewport(bounds, {
       width: effectiveCanvasWidth,


### PR DESCRIPTION
Fixes #11913

## Summary

Zoom to selection (<kbd>Shift</kbd>+<kbd>3</kbd>) on an empty scene jumped straight to 3000%.

With no selection the action falls back to `getCommonBounds(getNonDeletedElements(elements))`, and `getCommonBounds([])` returns `[0, 0, 0, 0]`. Those bounds reach `zoomToFitBounds` with `fit: "contain"`, which divides the viewport by them — both ratios come out non-finite, and `getNormalizedZoom` clamps the result to the extreme.

The `scale-down` path never had this problem because `zoomValueToFitBoundsOnViewport` ends in `Math.min(smallestZoomValue, 1)`. This adds the equivalent guard to the `contain` branch: when the ratio isn't finite there is nothing to fit, so the current zoom is kept.

Guarding inside `zoomToFitBounds` rather than in the action also covers `setViewport({ fit: "contain" })` from the package API, which hits the same division whenever the target resolves to degenerate bounds.

## Tests

Two added to `packages/excalidraw/tests/fitToContent.test.tsx`:

- `keeps the current zoom when there is nothing to fit` — pins the fix. Reverting it fails with `expected 0.1 to be 1`.
- `still fits a real selection` — guards against the fix turning `contain` into a no-op.

```
yarn vitest run packages/excalidraw/tests/fitToContent.test.tsx
```

10/10 pass. `yarn test:typecheck` clean.

Note on the failing value: in jsdom the test canvas has zero dimensions, so the division is `0/0 = NaN` and clamps to `MIN_ZOOM`; in a real browser it is `N/0 = Infinity` and clamps to `MAX_ZOOM` (the 3000% in the issue). Same root cause, and the finiteness check covers both.

Zoom to selection (shift+3) on an empty scene jumped straight to 3000%.

`getCommonBounds([])` returns [0, 0, 0, 0], and the `fit: "contain"` branch of `zoomToFitBounds` divides the viewport by those bounds. With nothing to fit both ratios are non-finite, and `getNormalizedZoom` then clamps to the extreme.

The `scale-down` path never had this problem because it ends in `Math.min(smallestZoomValue, 1)`. This adds the equivalent guard to `contain`, so it also covers `setViewport({ fit: "contain" })` from the public API rather than only the keyboard shortcut.