### PR TITLE
fix(editor): evaluate invisibility on the restored element, not the r…

### DIFF
--- a/packages/excalidraw/data/blob.ts
+++ b/packages/excalidraw/data/blob.ts
@@ -158,20 +158,28 @@ export const loadSceneOrLibraryFromBlob = async (
       throw error;
     }
     if (isValidExcalidrawData(data)) {
+      const restoredElements = restoreElements(data.elements, localElements, {
+        repairBindings: true,
+        deleteInvisibleElements: true,
+      });
+
       return {
         type: MIME_TYPES.excalidraw,
         data: {
-          elements: restoreElements(data.elements, localElements, {
-            repairBindings: true,
-            deleteInvisibleElements: true,
-          }),
+          elements: restoredElements,
           appState: restoreAppState(
             {
               theme: localAppState?.theme,
               fileHandle: fileHandle || blob.handle || null,
               ...cleanAppStateForExport(data.appState || {}),
+              // must be the restored elements, not the raw ones:
+              // `getScrollToContentState` filters through
+              // `isInvisiblySmallElement`, which dereferences geometry and
+              // throws on malformed input — rejecting the whole import from
+              // inside the same try/catch. App.tsx already passes restored
+              // elements here.
               ...(localAppState
-                ? getScrollToContentState(data.elements || [], localAppState)
+                ? getScrollToContentState(restoredElements, localAppState)
                 : {}),
             },
             localAppState,

--- a/packages/excalidraw/data/blob.ts
+++ b/packages/excalidraw/data/blob.ts
@@ -190,7 +190,12 @@ export const loadSceneOrLibraryFromBlob = async (
     if (error instanceof ImageSceneDataError) {
       throw error;
     }
-    throw new Error("Error: invalid file");
+    // Preserve what actually went wrong. Every failure in here — a JSON parse
+    // error, a throw from `restoreElements`, anything — was collapsed into this
+    // one message with the original discarded and nothing logged, so an import
+    // failure was indistinguishable from any other and left no trace in the
+    // console either. `cause` is already the idiom used elsewhere in this file.
+    throw new Error("Error: invalid file", { cause: error });
   }
 };
 

--- a/packages/excalidraw/data/restore.ts
+++ b/packages/excalidraw/data/restore.ts
@@ -893,8 +893,15 @@ export const restoreElements = <T extends ExcalidrawElement>(
       if (migratedElement) {
         const localElement = existingElementsMap?.get(element.id);
 
+        // Must be evaluated on `migratedElement`, not the raw input. The raw
+        // element can carry malformed geometry (e.g. a freedraw with null
+        // `points`), and `isInvisiblySmallElement` dereferences it — throwing
+        // out here, outside the try/catch above, which rejects the *entire*
+        // import rather than the one bad element. `migratedElement` has been
+        // through `restoreElement` and is always normalized.
         const shouldMarkAsDeleted =
-          opts?.deleteInvisibleElements && isInvisiblySmallElement(element);
+          opts?.deleteInvisibleElements &&
+          isInvisiblySmallElement(migratedElement);
 
         if (shouldMarkAsDeleted) {
           migratedElement = bumpVersion(migratedElement, localElement?.version);

--- a/packages/excalidraw/tests/data/blob.test.ts
+++ b/packages/excalidraw/tests/data/blob.test.ts
@@ -1,7 +1,11 @@
 import { vi } from "vitest";
 
+import { getDefaultAppState } from "../../appState";
+
 import { loadSceneOrLibraryFromBlob } from "../../data/blob";
 import * as restoreModule from "../../data/restore";
+
+import type { AppState } from "../../types";
 
 const sceneBlob = (elements: unknown[] = []) =>
   new Blob(
@@ -43,6 +47,59 @@ describe("loadSceneOrLibraryFromBlob", () => {
     } finally {
       spy.mockRestore();
     }
+  });
+
+  // The end-to-end path, which the restore.test.ts unit tests never traverse:
+  // they call `restoreElements` directly. Fixing the raw-element call inside
+  // `restoreElements` is not sufficient on its own, because
+  // `getScrollToContentState` was handed the *raw* array three lines later and
+  // filters it through `isInvisiblySmallElement`, throwing inside the same
+  // try/catch. `localAppState` is non-null on the real open/drop path
+  // (App.tsx passes `this.state`), so that branch does run in production.
+  it("imports a scene containing a malformed element, with localAppState set", async () => {
+    const localAppState = {
+      ...getDefaultAppState(),
+      width: 800,
+      height: 600,
+      offsetLeft: 0,
+      offsetTop: 0,
+    } as AppState;
+
+    const result: any = await loadSceneOrLibraryFromBlob(
+      sceneBlob([
+        {
+          type: "freedraw",
+          id: "broken",
+          x: 0,
+          y: 0,
+          width: 10,
+          height: 10,
+          points: null,
+          version: 1,
+          versionNonce: 1,
+          seed: 1,
+          isDeleted: false,
+        },
+        {
+          type: "rectangle",
+          id: "keep-me",
+          x: 0,
+          y: 0,
+          width: 100,
+          height: 100,
+          version: 1,
+          versionNonce: 1,
+          seed: 1,
+          isDeleted: false,
+        },
+      ]),
+      localAppState,
+      null,
+    );
+
+    expect(result.data.elements.map((element: any) => element.id)).toContain(
+      "keep-me",
+    );
   });
 
   it("still rejects with the same message for genuinely unrecognized data", async () => {

--- a/packages/excalidraw/tests/data/blob.test.ts
+++ b/packages/excalidraw/tests/data/blob.test.ts
@@ -1,0 +1,57 @@
+import { vi } from "vitest";
+
+import { loadSceneOrLibraryFromBlob } from "../../data/blob";
+import * as restoreModule from "../../data/restore";
+
+const sceneBlob = (elements: unknown[] = []) =>
+  new Blob(
+    [
+      JSON.stringify({
+        type: "excalidraw",
+        version: 2,
+        source: "test",
+        elements,
+        appState: {},
+      }),
+    ],
+    { type: "application/json" },
+  ) as Blob & { handle?: unknown };
+
+describe("loadSceneOrLibraryFromBlob", () => {
+  // Every failure in here was collapsed into "Error: invalid file" with the
+  // original discarded and nothing logged, which is why import failures are
+  // undiagnosable from a bug report — see #8444.
+  it("preserves the underlying error as `cause` when restore throws", async () => {
+    const underlying = new TypeError("points is null");
+    const spy = vi
+      .spyOn(restoreModule, "restoreElements")
+      .mockImplementation(() => {
+        throw underlying;
+      });
+
+    try {
+      await expect(
+        loadSceneOrLibraryFromBlob(
+          sceneBlob([{ type: "rectangle" }]),
+          null,
+          null,
+        ),
+      ).rejects.toMatchObject({
+        message: "Error: invalid file",
+        cause: underlying,
+      });
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("still rejects with the same message for genuinely unrecognized data", async () => {
+    const notAScene = new Blob([JSON.stringify({ hello: "world" })], {
+      type: "application/json",
+    }) as Blob;
+
+    await expect(
+      loadSceneOrLibraryFromBlob(notAScene as any, null, null),
+    ).rejects.toThrow("Error: invalid file");
+  });
+});

--- a/packages/excalidraw/tests/data/restore.test.ts
+++ b/packages/excalidraw/tests/data/restore.test.ts
@@ -81,6 +81,44 @@ describe("restoreElements", () => {
     ).toEqual([expect.objectContaining({ isDeleted: true })]);
   });
 
+  // `isInvisiblySmallElement` used to be called on the RAW element, outside the
+  // try/catch that wraps `restoreElement`. Malformed geometry therefore threw
+  // out of the reduce and rejected the whole import — defeating the #11321
+  // fallback, which every real entry point made unreachable by passing
+  // `deleteInvisibleElements: true`.
+  it("keeps the rest of the scene when one element has malformed geometry", () => {
+    const rect = API.createElement({
+      type: "rectangle",
+      id: "keep-me",
+      width: 100,
+      height: 100,
+    });
+    const broken = {
+      ...API.createElement({ type: "freedraw", id: "broken" }),
+      points: null,
+    } as any;
+
+    const restored = restore.restoreElements([broken, rect], null, {
+      deleteInvisibleElements: true,
+    });
+
+    expect(restored.map((element) => element.id)).toContain("keep-me");
+  });
+
+  it("still marks a genuinely invisible element as deleted", () => {
+    const tiny = API.createElement({
+      type: "freedraw",
+      id: "tiny",
+      points: [pointFrom<LocalPoint>(0, 0)],
+    });
+
+    const restored = restore.restoreElements([tiny], null, {
+      deleteInvisibleElements: true,
+    });
+
+    expect(restored).toEqual([expect.objectContaining({ isDeleted: true })]);
+  });
+
   it("should restore text element correctly passing value for each attribute", () => {
     const textElement = API.createElement({
       type: "text",


### PR DESCRIPTION
Fixes #11925

Three fixes on one import path. They are together because each one only becomes visible once the previous is removed — happy to split if you would rather review them separately.

## 1. One malformed element rejected the entire import

`restoreElements` guards `restoreElement` with a try/catch, but then called `isInvisiblySmallElement` on the **raw** input element, outside that guard:

```ts
try {
  migratedElement = restoreElement(element, …);   // guarded
} catch (error) { … }
if (migratedElement) {
  const shouldMarkAsDeleted =
    opts?.deleteInvisibleElements && isInvisiblySmallElement(element);  // ← RAW, unguarded
```

`isInvisiblySmallElement` dereferences the geometry (`element.points.length`), so a freedraw with null `points` throws out of the `reduce` and takes the whole scene with it — including every valid element.

This also made **#11321 unreachable in practice**. That PR added the try/catch so a malformed freedraw is restored with usable points rather than killing the load, but every real entry point passes `deleteInvisibleElements: true`, and the unguarded call runs after the try/catch — so the throw fires before the fallback can matter.

The normalized element was already in hand one line above: `migratedElement` has been through `restoreElement` and always has valid geometry.

## 2. …and so did its sibling, three lines later

Fixing (1) alone is **not sufficient**. The same object literal handed `getScrollToContentState` the *raw* `data.elements`:

```ts
...(localAppState
  ? getScrollToContentState(data.elements || [], localAppState)
  : {}),
```

That filters through `getVisibleElements` → `isInvisiblySmallElement`, which throws on the same input, inside the same try/catch, producing the same flattened message. Properties evaluate in source order, so the restore fix ran and the sibling crashed immediately after it.

`localAppState` is non-null on the real open/drop path (`App.tsx` passes `this.state`), so this branch does run in production. Measured end to end through `loadSceneOrLibraryFromBlob`:

| `localAppState` | with fix 1 only |
|---|---|
| non-null (real path) | still throws `Error: invalid file`, restores `[]` |
| null | restores `["broken", "keep-me"]` |

`App.tsx` already passes restored elements to `getScrollToContentState`; this makes `blob.ts` consistent with it.

## 3. The failure was undiagnosable either way

`loadSceneOrLibraryFromBlob` collapsed **every** failure into `Error: invalid file`, discarding the original and logging nothing:

```ts
} catch (error: any) {
  if (error instanceof ImageSceneDataError) {
    throw error;
  }
  throw new Error("Error: invalid file");   // original discarded
}
```

A JSON parse error, a throw from `restoreElements`, and a genuinely unrecognized file are indistinguishable — to the user and in the console. That is why a report like #8444 (open since 2024, no replies) cannot be diagnosed from anything the reporter is able to see. This attaches the original as `cause`; the user-facing message is unchanged, and `cause` is already the idiom used elsewhere in this same file.

## Tests

`packages/excalidraw/tests/data/restore.test.ts`:

- `keeps the rest of the scene when one element has malformed geometry` — pins fix 1.
- `still marks a genuinely invisible element as deleted` — control, so the fix cannot silently weaken `deleteInvisibleElements`.

`packages/excalidraw/tests/data/blob.test.ts` — the first tests for this module:

- `imports a scene containing a malformed element, with localAppState set` — the end-to-end path. Pins fix 2; reverting only that hunk fails with `Error: invalid file`.
- `preserves the underlying error as cause when restore throws` — pins fix 3.
- `still rejects with the same message for genuinely unrecognized data` — control, so the message contract is unchanged.

Each regression test was verified by reverting only its own hunk, so none is passing for the wrong reason.

Two coverage gaps worth noting, since they explain why this survived:

- The existing freedraw-points tests pass `null` opts, leaving `deleteInvisibleElements` undefined, so the faulty line in (1) never ran.
- The `restore.test.ts` tests call `restoreElements` directly and never traverse `blob.ts`, so (2) was invisible to them entirely.

```
yarn vitest run packages/excalidraw/tests/data/
```

58/58 pass. `regressionTests` + `excalidraw` suites 82/82. `yarn test:typecheck` clean.