### PR TITLE
fix(element): don't treat frames as bucket-fill boundaries

### DIFF
--- a/packages/element/src/bucketFill.ts
+++ b/packages/element/src/bucketFill.ts
@@ -577,8 +577,6 @@ const FILL_BOUNDARY_TYPES = new Set<ExcalidrawElement["type"]>([
   "rectangle",
   "diamond",
   "ellipse",
-  "frame",
-  "magicframe",
   "line",
   "freedraw",
 ]);

--- a/packages/element/tests/bucketFill.test.ts
+++ b/packages/element/tests/bucketFill.test.ts
@@ -59,6 +59,61 @@ const isClosed = (pts: GlobalPoint[]): boolean =>
   pts[0][1] === pts[pts.length - 1][1];
 
 describe("computeBucketFillPolygon", () => {
+  // Frames are containers, not drawn shapes. Before this was fixed, "frame"
+  // and "magicframe" sat in FILL_BOUNDARY_TYPES, so an empty frame qualified
+  // as a closed owner and a click on blank canvas inside it produced a fill
+  // covering the frame's full bounds.
+  it("does not fill an empty frame from a click on blank canvas", () => {
+    const frame = API.createElement({
+      type: "frame",
+      x: 0,
+      y: 0,
+      width: 520,
+      height: 400,
+    });
+    const { elements, elementsMap } = setup([frame]);
+
+    const result = computeBucketFillPolygon({
+      point: pointFrom<GlobalPoint>(260, 200),
+      elements,
+      elementsMap,
+    });
+
+    expect(result.ok).toBe(false);
+  });
+
+  it("still fills a real shape that sits inside a frame", () => {
+    const frame = API.createElement({
+      type: "frame",
+      x: 0,
+      y: 0,
+      width: 520,
+      height: 400,
+    });
+    const rect = API.createElement({
+      type: "rectangle",
+      x: 100,
+      y: 100,
+      width: 100,
+      height: 100,
+      roundness: null,
+    });
+    const { elements, elementsMap } = setup([frame, rect]);
+
+    const result = computeBucketFillPolygon({
+      point: pointFrom<GlobalPoint>(150, 150),
+      elements,
+      elementsMap,
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      return;
+    }
+    expect(result.ownerId).toBe(rect.id);
+    expect(polygonArea(result.scenePoints)).toBeCloseTo(10000, -1);
+  });
+
   it("fills a simple rectangle and returns a closed polygon", () => {
     const rect = API.createElement({
       type: "rectangle",

--- a/packages/element/tests/bucketFill.test.ts
+++ b/packages/element/tests/bucketFill.test.ts
@@ -63,24 +63,30 @@ describe("computeBucketFillPolygon", () => {
   // and "magicframe" sat in FILL_BOUNDARY_TYPES, so an empty frame qualified
   // as a closed owner and a click on blank canvas inside it produced a fill
   // covering the frame's full bounds.
-  it("does not fill an empty frame from a click on blank canvas", () => {
-    const frame = API.createElement({
-      type: "frame",
-      x: 0,
-      y: 0,
-      width: 520,
-      height: 400,
-    });
-    const { elements, elementsMap } = setup([frame]);
+  // both frame types must be covered: they were removed from
+  // FILL_BOUNDARY_TYPES together, and testing only one leaves the other free to
+  // regress unnoticed
+  it.each(["frame", "magicframe"] as const)(
+    "does not fill an empty %s from a click on blank canvas",
+    (type) => {
+      const frame = API.createElement({
+        type,
+        x: 0,
+        y: 0,
+        width: 520,
+        height: 400,
+      });
+      const { elements, elementsMap } = setup([frame]);
 
-    const result = computeBucketFillPolygon({
-      point: pointFrom<GlobalPoint>(260, 200),
-      elements,
-      elementsMap,
-    });
+      const result = computeBucketFillPolygon({
+        point: pointFrom<GlobalPoint>(260, 200),
+        elements,
+        elementsMap,
+      });
 
-    expect(result.ok).toBe(false);
-  });
+      expect(result.ok).toBe(false);
+    },
+  );
 
   it("still fills a real shape that sits inside a frame", () => {
     const frame = API.createElement({


### PR DESCRIPTION
Fixes #11924

## Summary

Clicking blank canvas inside an empty frame with the bucket-fill tool produced a fill covering the frame's entire bounds, owned by the frame itself — there was nothing drawn to fill.

`"frame"` and `"magicframe"` were members of `FILL_BOUNDARY_TYPES`, which gave a frame two roles at once: it passed `isEligibleBoundary`, so its edge enclosed the region, and in `isClosedOwnerCandidate` it cleared the `FILL_BOUNDARY_TYPES` gate and fell through to `return true`, so it also qualified as a closed owner.

Removing both frame types from the set addresses both roles. Worth noting for review: **excluding frames only from owner candidacy is not sufficient** — I tried that first and got the same full-size fill with a `null` owner, because the frame edge was still bounding the region.

A frame is a container rather than drawn ink, so a click on open canvas inside one should produce nothing. Please see the open question in #11924 — if you'd prefer a frame's edge to keep bounding fills from real shapes near it, this needs to be narrower and I'm happy to redo it that way.

## Before / After

Unit-level, 520×400 frame, clicking its centre:

| | `result.ok` | `ownerId` | polygon area |
|---|---|---|---|
| before | `true` | the frame | `207991` (= 520 × 400) |
| after | `false` | — | — |

## Tests

Two added to `packages/element/tests/bucketFill.test.ts`, which previously had **zero** `frame` coverage:

- `does not fill an empty frame from a click on blank canvas` — pins the fix. Reverting it fails with `expected true to be false`.
- `still fills a real shape that sits inside a frame` — control, so the fix can't silently disable bucket fill inside frames. Passes either way.

```
yarn vitest run packages/element/tests/bucketFill.test.ts
```

59/59 pass. The app-level suite (`packages/excalidraw/tests/bucketFill.test.tsx`) is 31/31. `yarn test:typecheck` clean.