### PR TITLE
feat(editor): add table insert tool

### DIFF
--- a/packages/excalidraw/components/CommandPalette/CommandPalette.tsx
+++ b/packages/excalidraw/components/CommandPalette/CommandPalette.tsx
@@ -48,6 +48,7 @@ import {
   bucketFillIcon,
   ExportImageIcon,
   mermaidLogoIcon,
+  tableIcon,
   brainIconThin,
   LibraryIcon,
   historyCommandIcon,
@@ -551,6 +552,19 @@ function CommandPaletteInner({
           viewMode: false,
           perform: () => {
             app.toggleLock();
+          },
+        },
+        {
+          label: `${t("toolBar.table")}...`,
+          category: DEFAULT_CATEGORIES.tools,
+          icon: tableIcon,
+          keywords: ["toolbar", "grid"],
+          viewMode: false,
+          perform: () => {
+            setAppState((state) => ({
+              ...state,
+              openDialog: { name: "createTable" },
+            }));
           },
         },
         {

--- a/packages/excalidraw/components/CreateTableDialog.scss
+++ b/packages/excalidraw/components/CreateTableDialog.scss
@@ -1,0 +1,19 @@
+.excalidraw {
+  .CreateTableDialog {
+    .CreateTableDialog__fields {
+      display: flex;
+      gap: 0.75rem;
+      margin-bottom: 1.25rem;
+    }
+
+    .CreateTableDialog__fields > * {
+      flex: 1;
+      min-width: 0;
+    }
+
+    .CreateTableDialog__actions {
+      display: flex;
+      justify-content: flex-end;
+    }
+  }
+}

--- a/packages/excalidraw/components/CreateTableDialog.tsx
+++ b/packages/excalidraw/components/CreateTableDialog.tsx
@@ -1,0 +1,108 @@
+import { useState } from "react";
+
+import { getStrokeWidthByKey, KEYS } from "@excalidraw/common";
+
+import { trackEvent } from "../analytics";
+import { useUIAppState } from "../context/ui-appState";
+import { t } from "../i18n";
+import {
+  createTableElements,
+  DEFAULT_TABLE_COLS,
+  DEFAULT_TABLE_ROWS,
+  parseTableDimension,
+} from "../tables/createTable";
+
+import { useApp } from "./App";
+import { Dialog } from "./Dialog";
+import { FilledButton } from "./FilledButton";
+import { TextField } from "./TextField";
+
+import "./CreateTableDialog.scss";
+
+import type { KeyboardEvent } from "react";
+
+let lastTableSize = {
+  rows: DEFAULT_TABLE_ROWS,
+  cols: DEFAULT_TABLE_COLS,
+};
+
+export const CreateTableDialog = ({ onClose }: { onClose: () => void }) => {
+  const app = useApp();
+  const appState = useUIAppState();
+  const [rowsInput, setRowsInput] = useState(String(lastTableSize.rows));
+  const [colsInput, setColsInput] = useState(String(lastTableSize.cols));
+
+  const insertTable = () => {
+    const rows = parseTableDimension(rowsInput, lastTableSize.rows);
+    const cols = parseTableDimension(colsInput, lastTableSize.cols);
+
+    lastTableSize = { rows, cols };
+
+    const elements = createTableElements({
+      rows,
+      cols,
+      styles: {
+        strokeColor: appState.currentItemStrokeColor,
+        backgroundColor: appState.currentItemBackgroundColor,
+        fillStyle: appState.currentItemFillStyle,
+        strokeWidth: getStrokeWidthByKey(
+          "rectangle",
+          appState.currentItemStrokeWidthKey,
+        ),
+        strokeStyle: appState.currentItemStrokeStyle,
+        roughness: appState.currentItemRoughness,
+        opacity: appState.currentItemOpacity,
+      },
+    });
+
+    app.onInsertElements(elements);
+    trackEvent("toolbar", "table", "insert");
+    onClose();
+    app.focusContainer();
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === KEYS.ENTER) {
+      event.preventDefault();
+      insertTable();
+    }
+  };
+
+  return (
+    <Dialog
+      size={360}
+      onCloseRequest={onClose}
+      title={t("labels.createTable")}
+      className="CreateTableDialog"
+    >
+      <div className="CreateTableDialog__fields">
+        <div data-testid="create-table-cols">
+          <TextField
+            label={t("labels.tableColumns")}
+            value={colsInput}
+            onChange={setColsInput}
+            onKeyDown={handleKeyDown}
+            selectOnRender
+          />
+        </div>
+        <div data-testid="create-table-rows">
+          <TextField
+            label={t("labels.tableRows")}
+            value={rowsInput}
+            onChange={setRowsInput}
+            onKeyDown={handleKeyDown}
+          />
+        </div>
+      </div>
+      <div className="CreateTableDialog__actions">
+        <FilledButton
+          color="primary"
+          label={t("buttons.insertTable")}
+          onClick={insertTable}
+        >
+          {t("buttons.insertTable")}
+        </FilledButton>
+      </div>
+    </Dialog>
+  );
+};

--- a/packages/excalidraw/components/LayerUI.tsx
+++ b/packages/excalidraw/components/LayerUI.tsx
@@ -30,6 +30,7 @@ import { getScrollToContentState } from "../scene";
 import { SelectedShapeActions, CompactShapeActions } from "./Actions";
 import { LoadingMessage } from "./LoadingMessage";
 import { MobileMenu } from "./MobileMenu";
+import { CreateTableDialog } from "./CreateTableDialog";
 import { PasteChartDialog } from "./PasteChartDialog";
 import { Section } from "./Section";
 import Stack from "./Stack";
@@ -585,6 +586,15 @@ const LayerUI = ({
         <PasteChartDialog
           data={appState.openDialog.data}
           rawText={appState.openDialog.rawText}
+          onClose={() =>
+            setAppState({
+              openDialog: null,
+            })
+          }
+        />
+      )}
+      {defaultUIEnabled && appState.openDialog?.name === "createTable" && (
+        <CreateTableDialog
           onClose={() =>
             setAppState({
               openDialog: null,

--- a/packages/excalidraw/components/MobileToolbar.tsx
+++ b/packages/excalidraw/components/MobileToolbar.tsx
@@ -33,6 +33,7 @@ import {
   bucketFillIcon,
   mermaidLogoIcon,
   MagicIcon,
+  tableIcon,
 } from "./icons";
 
 import "./ToolIcon.scss";
@@ -298,6 +299,14 @@ export const MobileToolbar = ({ app, setAppState }: MobileToolbarProps) => {
             disabled={isToolButtonDisabled(app, "embeddable")}
           >
             {t("toolBar.embeddable")}
+          </DropdownMenu.Item>
+          <DropdownMenu.Item
+            onSelect={() => app.setOpenDialog({ name: "createTable" })}
+            icon={tableIcon}
+            data-testid="toolbar-table"
+            selected={app.state.openDialog?.name === "createTable"}
+          >
+            {t("toolBar.table")}
           </DropdownMenu.Item>
           <DropdownMenu.Item
             onSelect={() => app.setActiveTool({ type: "autoshape" })}

--- a/packages/excalidraw/components/Toolbar.tsx
+++ b/packages/excalidraw/components/Toolbar.tsx
@@ -23,6 +23,7 @@ import {
   MagicIcon,
   mermaidLogoIcon,
   DotsIcon,
+  tableIcon,
 } from "./icons";
 import {
   ArrowToolButton,
@@ -40,6 +41,7 @@ import {
   RectangleToolButton,
   SelectionToolButton,
   SelectionToolPopover,
+  TableToolButton,
   TextToolButton,
 } from "./Tools";
 
@@ -131,6 +133,14 @@ const ExtraToolsDropdown = ({
           disabled={isToolButtonDisabled(app, "embeddable")}
         >
           {t("toolBar.embeddable")}
+        </DropdownMenu.Item>
+        <DropdownMenu.Item
+          onSelect={() => app.setOpenDialog({ name: "createTable" })}
+          icon={tableIcon}
+          data-testid="toolbar-table-extra"
+          selected={app.state.openDialog?.name === "createTable"}
+        >
+          {t("toolBar.table")}
         </DropdownMenu.Item>
         <DropdownMenu.Item
           onSelect={() => app.setActiveTool({ type: "autoshape" })}
@@ -289,6 +299,7 @@ export const Toolbar = ({
         <TextToolButton {...toolProps} />
         {UIOptions.tools?.image !== false && <ImageToolButton {...toolProps} />}
         <EraserToolButton {...toolProps} />
+        <TableToolButton app={app} appState={appState} />
 
         <div
           className="App-toolbar__divider"

--- a/packages/excalidraw/components/Tools.tsx
+++ b/packages/excalidraw/components/Tools.tsx
@@ -29,6 +29,7 @@ import {
   handIcon,
   frameToolIcon,
   EmbedIcon,
+  tableIcon,
 } from "./icons";
 
 import type {
@@ -316,6 +317,37 @@ const createToolButton = (
 };
 
 export const HandToolButton = createToolButton("hand");
+
+/**
+ * Inserts a table of rectangles and lines. Opens a size dialog instead of
+ * becoming an active drawing tool.
+ */
+export const TableToolButton = ({
+  app,
+  appState,
+}: {
+  app: AppClassProperties;
+  appState: UIAppState;
+}) => {
+  const label = t("toolBar.table");
+  const isOpen = appState.openDialog?.name === "createTable";
+
+  return (
+    <IconButton
+      type="toggle"
+      icon={tableIcon}
+      checked={isOpen}
+      title={label}
+      aria-label={label}
+      data-testid="toolbar-table"
+      onSelect={() => {
+        trackEvent("toolbar", "table", "ui");
+        app.setOpenDialog(isOpen ? null : { name: "createTable" });
+      }}
+    />
+  );
+};
+
 export const RectangleToolButton = createToolButton("rectangle");
 export const DiamondToolButton = createToolButton("diamond");
 export const EllipseToolButton = createToolButton("ellipse");

--- a/packages/excalidraw/components/icons.tsx
+++ b/packages/excalidraw/components/icons.tsx
@@ -2363,6 +2363,17 @@ export const youtubeIcon = createIcon(
   tablerIconProps,
 );
 
+// tabler-icons: table
+export const tableIcon = createIcon(
+  <g strokeWidth={1.5}>
+    <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+    <path d="M3 5a2 2 0 0 1 2 -2h14a2 2 0 0 1 2 2v14a2 2 0 0 1 -2 2h-14a2 2 0 0 1 -2 -2v-14z" />
+    <path d="M3 10h18" />
+    <path d="M10 3v18" />
+  </g>,
+  tablerIconProps,
+);
+
 export const gridIcon = createIcon(
   <g strokeWidth={1.5}>
     <path stroke="none" d="M0 0h24v24H0z" fill="none" />

--- a/packages/excalidraw/locales/en.json
+++ b/packages/excalidraw/locales/en.json
@@ -5,6 +5,9 @@
     "paste": "Paste",
     "pasteAsPlaintext": "Paste as plaintext",
     "pasteCharts": "Paste charts",
+    "createTable": "Create table",
+    "tableRows": "Rows",
+    "tableColumns": "Columns",
     "chartType_bar": "Bar chart",
     "chartType_line": "Line chart",
     "chartType_radar": "Radar chart",
@@ -261,6 +264,7 @@
     "publishLibrary": "Rename or publish",
     "submit": "Submit",
     "confirm": "Confirm",
+    "insertTable": "Insert table",
     "embeddableInteractionButton": "Click to interact"
   },
   "alerts": {
@@ -338,6 +342,7 @@
     "bucketfill": "Bucket fill",
     "hand": "Hand (panning tool)",
     "extraTools": "More tools",
+    "table": "Table",
     "mermaidToExcalidraw": "Mermaid to Excalidraw",
     "convertElementType": "Toggle shape type"
   },

--- a/packages/excalidraw/tables/createTable.test.ts
+++ b/packages/excalidraw/tables/createTable.test.ts
@@ -1,0 +1,80 @@
+import { expect, describe, it } from "vitest";
+
+import { isLineElement } from "@excalidraw/element";
+
+import {
+  clampTableDimension,
+  createTableElements,
+  MAX_TABLE_SIZE,
+  MIN_TABLE_SIZE,
+  parseTableDimension,
+  TABLE_CELL_HEIGHT,
+  TABLE_CELL_WIDTH,
+} from "./createTable";
+
+describe("createTable", () => {
+  describe("clampTableDimension", () => {
+    it("clamps to the allowed range", () => {
+      expect(clampTableDimension(0)).toBe(MIN_TABLE_SIZE);
+      expect(clampTableDimension(-3)).toBe(MIN_TABLE_SIZE);
+      expect(clampTableDimension(MAX_TABLE_SIZE + 10)).toBe(MAX_TABLE_SIZE);
+      expect(clampTableDimension(4.9)).toBe(4);
+    });
+  });
+
+  describe("parseTableDimension", () => {
+    it("parses integers and falls back when invalid", () => {
+      expect(parseTableDimension("5", 3)).toBe(5);
+      expect(parseTableDimension("abc", 3)).toBe(3);
+      expect(parseTableDimension("", 2)).toBe(2);
+    });
+  });
+
+  describe("createTableElements", () => {
+    it("builds a grouped rectangle with internal grid lines", () => {
+      const elements = createTableElements({ rows: 3, cols: 4 });
+
+      // 1 rectangle + (cols-1) vertical lines + (rows-1) horizontal lines
+      expect(elements).toHaveLength(1 + 3 + 2);
+
+      const rectangle = elements.find(
+        (element) => element.type === "rectangle",
+      );
+      const lines = elements.filter(isLineElement);
+
+      expect(rectangle).toBeDefined();
+      expect(rectangle!.width).toBe(4 * TABLE_CELL_WIDTH);
+      expect(rectangle!.height).toBe(3 * TABLE_CELL_HEIGHT);
+      expect(lines).toHaveLength(5);
+
+      const groupId = rectangle!.groupIds[0];
+      expect(groupId).toBeTruthy();
+      expect(elements.every((element) => element.groupIds[0] === groupId)).toBe(
+        true,
+      );
+
+      const verticalLines = lines.filter((line) => line.width === 0);
+      const horizontalLines = lines.filter((line) => line.height === 0);
+
+      expect(verticalLines).toHaveLength(3);
+      expect(horizontalLines).toHaveLength(2);
+
+      expect(verticalLines.map((line) => line.x)).toEqual([
+        TABLE_CELL_WIDTH,
+        TABLE_CELL_WIDTH * 2,
+        TABLE_CELL_WIDTH * 3,
+      ]);
+      expect(horizontalLines.map((line) => line.y)).toEqual([
+        TABLE_CELL_HEIGHT,
+        TABLE_CELL_HEIGHT * 2,
+      ]);
+    });
+
+    it("creates only the outer rectangle for a 1x1 table", () => {
+      const elements = createTableElements({ rows: 1, cols: 1 });
+
+      expect(elements).toHaveLength(1);
+      expect(elements[0].type).toBe("rectangle");
+    });
+  });
+});

--- a/packages/excalidraw/tables/createTable.ts
+++ b/packages/excalidraw/tables/createTable.ts
@@ -1,0 +1,118 @@
+import { randomId } from "@excalidraw/common";
+import { newElement, newLinearElement } from "@excalidraw/element";
+import { pointFrom } from "@excalidraw/math";
+
+import type { ElementConstructorOpts } from "@excalidraw/element";
+import type {
+  ExcalidrawElement,
+  NonDeletedExcalidrawElement,
+} from "@excalidraw/element/types";
+
+export const MIN_TABLE_SIZE = 1;
+export const MAX_TABLE_SIZE = 50;
+export const DEFAULT_TABLE_ROWS = 3;
+export const DEFAULT_TABLE_COLS = 3;
+export const TABLE_CELL_WIDTH = 120;
+export const TABLE_CELL_HEIGHT = 48;
+
+export type TableElementStyles = Pick<
+  ElementConstructorOpts,
+  | "strokeColor"
+  | "backgroundColor"
+  | "fillStyle"
+  | "strokeWidth"
+  | "strokeStyle"
+  | "roughness"
+  | "opacity"
+>;
+
+export type CreateTableOptions = {
+  rows: number;
+  cols: number;
+  x?: number;
+  y?: number;
+  cellWidth?: number;
+  cellHeight?: number;
+  styles?: TableElementStyles;
+};
+
+export const clampTableDimension = (value: number): number =>
+  Math.min(MAX_TABLE_SIZE, Math.max(MIN_TABLE_SIZE, Math.floor(value)));
+
+export const parseTableDimension = (raw: string, fallback: number): number => {
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed)) {
+    return fallback;
+  }
+  return clampTableDimension(parsed);
+};
+
+/**
+ * Builds a table from a single outer rectangle and internal grid lines,
+ * grouped so it can be moved as one object.
+ */
+export const createTableElements = ({
+  rows,
+  cols,
+  x = 0,
+  y = 0,
+  cellWidth = TABLE_CELL_WIDTH,
+  cellHeight = TABLE_CELL_HEIGHT,
+  styles = {},
+}: CreateTableOptions): NonDeletedExcalidrawElement[] => {
+  const safeRows = clampTableDimension(rows);
+  const safeCols = clampTableDimension(cols);
+  const width = safeCols * cellWidth;
+  const height = safeRows * cellHeight;
+  const groupId = randomId();
+  const groupIds: ExcalidrawElement["groupIds"] = [groupId];
+
+  const sharedProps = {
+    ...styles,
+    groupIds,
+    roundness: null,
+  };
+
+  const elements: NonDeletedExcalidrawElement[] = [
+    newElement({
+      ...sharedProps,
+      type: "rectangle",
+      x,
+      y,
+      width,
+      height,
+    }),
+  ];
+
+  for (let col = 1; col < safeCols; col++) {
+    const lineX = x + col * cellWidth;
+    elements.push(
+      newLinearElement({
+        ...sharedProps,
+        type: "line",
+        x: lineX,
+        y,
+        width: 0,
+        height,
+        points: [pointFrom(0, 0), pointFrom(0, height)],
+      }),
+    );
+  }
+
+  for (let row = 1; row < safeRows; row++) {
+    const lineY = y + row * cellHeight;
+    elements.push(
+      newLinearElement({
+        ...sharedProps,
+        type: "line",
+        x,
+        y: lineY,
+        width,
+        height: 0,
+        points: [pointFrom(0, 0), pointFrom(width, 0)],
+      }),
+    );
+  }
+
+  return elements;
+};

--- a/packages/excalidraw/tests/createTable.test.tsx
+++ b/packages/excalidraw/tests/createTable.test.tsx
@@ -1,0 +1,50 @@
+import { fireEvent, screen } from "@testing-library/react";
+import { expect, describe, it } from "vitest";
+
+import { isLineElement } from "@excalidraw/element";
+
+import { Excalidraw } from "../index";
+import { TABLE_CELL_HEIGHT, TABLE_CELL_WIDTH } from "../tables/createTable";
+
+import { API } from "./helpers/api";
+import { render } from "./test-utils";
+
+const { h } = window;
+
+describe("create table from toolbar", () => {
+  it("inserts a grouped table of a rectangle and lines", async () => {
+    await render(<Excalidraw />);
+
+    fireEvent.click(screen.getByTestId("toolbar-table"));
+    expect(h.state.openDialog).toEqual({ name: "createTable" });
+
+    const colsInput = screen
+      .getByTestId("create-table-cols")
+      .querySelector("input")!;
+    const rowsInput = screen
+      .getByTestId("create-table-rows")
+      .querySelector("input")!;
+
+    fireEvent.change(colsInput, { target: { value: "3" } });
+    fireEvent.change(rowsInput, { target: { value: "2" } });
+    fireEvent.click(screen.getByRole("button", { name: "Insert table" }));
+
+    expect(h.state.openDialog).toBeNull();
+
+    const elements = API.getSelectedElements();
+    expect(elements).toHaveLength(4);
+
+    const rectangle = elements.find((element) => element.type === "rectangle");
+    const lines = elements.filter(isLineElement);
+
+    expect(rectangle).toBeDefined();
+    expect(rectangle!.width).toBe(3 * TABLE_CELL_WIDTH);
+    expect(rectangle!.height).toBe(2 * TABLE_CELL_HEIGHT);
+    expect(lines).toHaveLength(3);
+
+    const groupId = rectangle!.groupIds[0];
+    expect(
+      elements.every((element) => element.groupIds.includes(groupId)),
+    ).toBe(true);
+  });
+});

--- a/packages/excalidraw/types.ts
+++ b/packages/excalidraw/types.ts
@@ -460,7 +460,8 @@ export interface AppState {
     | { name: "commandPalette" }
     | { name: "settings" }
     | { name: "elementLinkSelector"; sourceElementId: ExcalidrawElement["id"] }
-    | { name: "charts"; data: Spreadsheet; rawText: string };
+    | { name: "charts"; data: Spreadsheet; rawText: string }
+    | { name: "createTable" };
   /**
    * Reflects user preference for whether the default sidebar should be docked.
    *


### PR DESCRIPTION
## Summary
- Add a Table button to the editor toolbar (also in extra tools, mobile toolbar, and the command palette)
- Insert a grouped table built from a rectangle and internal grid lines
- Allow configuring columns and rows in a small dialog before placing the table at the viewport center

## Test plan
- [ ] Click the Table toolbar button and confirm the create-table dialog opens
- [ ] Insert a 3×2 table and confirm it is a grouped rectangle plus grid lines
- [ ] Move the group as a single object
- [ ] Check the extra-tools menu, mobile extra tools, and command palette entry
- [ ] Insert with current stroke/fill styles and confirm they apply to the table