### PR TITLE
fix(editor): drop stale line editor point highlight after moves

### DIFF
--- a/packages/element/src/linearElementEditor.ts
+++ b/packages/element/src/linearElementEditor.ts
@@ -823,6 +823,20 @@ export class LinearElementEditor {
     return midpoints;
   };
 
+  static getCurrentSegmentMidpointNearPoint(
+    midPoints: readonly (GlobalPoint | null)[],
+    point: GlobalPoint,
+    zoomValue: number,
+  ): GlobalPoint | null {
+    const threshold = (LinearElementEditor.POINT_HANDLE_SIZE + 1) / zoomValue;
+    for (const midPoint of midPoints) {
+      if (midPoint && pointDistance(midPoint, point) <= threshold) {
+        return midPoint;
+      }
+    }
+    return null;
+  }
+
   static getSegmentMidpointHitCoords = (
     linearElementEditor: LinearElementEditor,
     scenePointer: { x: number; y: number },
@@ -865,14 +879,12 @@ export class LinearElementEditor {
       appState,
     );
 
-    const findHitMidpoint = (from: GlobalPoint) => {
-      for (const midPoint of midPoints) {
-        if (midPoint && pointDistance(midPoint, from) <= threshold) {
-          return midPoint;
-        }
-      }
-      return null;
-    };
+    const findHitMidpoint = (from: GlobalPoint) =>
+      LinearElementEditor.getCurrentSegmentMidpointNearPoint(
+        midPoints,
+        from,
+        appState.zoom.value,
+      );
 
     const existingSegmentMidpointHitCoords =
       linearElementEditor.segmentMidPointHoveredCoords;

--- a/packages/element/src/linearElementEditor.ts
+++ b/packages/element/src/linearElementEditor.ts
@@ -624,16 +624,6 @@ export class LinearElementEditor {
       ? newSelectedPointsIndices[0]
       : lastClickedPoint;
 
-    const newSelectedMidPointHoveredCoords =
-      !startIsSelected && !endIsSelected
-        ? LinearElementEditor.getPointGlobalCoordinates(
-            element,
-            draggingPoint,
-            elementsMap,
-          )
-        : null;
-
-    const newHoverPointIndex = newLastClickedPoint;
     const startBindingElement =
       isBindingElement(element) &&
       element.startBinding &&
@@ -680,8 +670,6 @@ export class LinearElementEditor {
               )
             : linearElementEditor.initialState.altFocusPoint,
       },
-      segmentMidPointHoveredCoords: newSelectedMidPointHoveredCoords,
-      hoverPointIndex: newHoverPointIndex,
       isDragging: true,
       customLineAngle,
     };
@@ -870,42 +858,44 @@ export class LinearElementEditor {
 
     const threshold =
       (LinearElementEditor.POINT_HANDLE_SIZE + 1) / appState.zoom.value;
-
-    const existingSegmentMidpointHitCoords =
-      linearElementEditor.segmentMidPointHoveredCoords;
-    if (existingSegmentMidpointHitCoords) {
-      const distance = pointDistance(
-        pointFrom(
-          existingSegmentMidpointHitCoords[0],
-          existingSegmentMidpointHitCoords[1],
-        ),
-        pointFrom(scenePointer.x, scenePointer.y),
-      );
-      if (distance <= threshold) {
-        return existingSegmentMidpointHitCoords;
-      }
-    }
-    let index = 0;
+    const pointer = pointFrom<GlobalPoint>(scenePointer.x, scenePointer.y);
     const midPoints = LinearElementEditor.getEditorMidPoints(
       element,
       elementsMap,
       appState,
     );
 
-    while (index < midPoints.length) {
-      if (midPoints[index] !== null) {
-        const distance = pointDistance(
-          midPoints[index]!,
-          pointFrom(scenePointer.x, scenePointer.y),
-        );
-        if (distance <= threshold) {
-          return midPoints[index];
+    const findHitMidpoint = (from: GlobalPoint) => {
+      for (const midPoint of midPoints) {
+        if (midPoint && pointDistance(midPoint, from) <= threshold) {
+          return midPoint;
         }
       }
+      return null;
+    };
 
-      index++;
+    const existingSegmentMidpointHitCoords =
+      linearElementEditor.segmentMidPointHoveredCoords;
+    if (
+      existingSegmentMidpointHitCoords &&
+      pointDistance(existingSegmentMidpointHitCoords, pointer) <= threshold
+    ) {
+      // Keep hover sticky while the pointer stays near the last hit, but always
+      // return a *current* midpoint. Cached global coords go stale after a
+      // point or the whole line is moved (#9500, #9510).
+      const currentNearPointer = findHitMidpoint(pointer);
+      if (currentNearPointer) {
+        return currentNearPointer;
+      }
+      const currentNearCache = findHitMidpoint(
+        existingSegmentMidpointHitCoords,
+      );
+      if (currentNearCache) {
+        return currentNearCache;
+      }
     }
-    return null;
+
+    return findHitMidpoint(pointer);
   };
 
   static isSegmentTooShort<P extends GlobalPoint | LocalPoint>(
@@ -1105,6 +1095,8 @@ export class LinearElementEditor {
         },
         selectedPointsIndices: [element.points.length - 1],
         lastUncommittedPoint: null,
+        hoverPointIndex: element.points.length - 1,
+        segmentMidPointHoveredCoords: null,
       };
 
       ret.didAddPoint = true;
@@ -1175,6 +1167,8 @@ export class LinearElementEditor {
             y: scenePointer.y - targetPoint[1],
           }
         : { x: 0, y: 0 },
+      hoverPointIndex: clickedPointIndex,
+      segmentMidPointHoveredCoords: segmentMidpoint,
     };
 
     return ret;

--- a/packages/element/tests/linearElementEditor.test.tsx
+++ b/packages/element/tests/linearElementEditor.test.tsx
@@ -474,6 +474,85 @@ describe("Test Linear Elements", () => {
   });
 
   describe("Inside editor", () => {
+    it("should not keep a stale point highlight after dragging a point then the line (#9510)", () => {
+      createThreePointerLinearElement("line");
+      const line = h.elements[0] as ExcalidrawLinearElement;
+      enterLineEditingMode(line);
+
+      const points = LinearElementEditor.getPointsGlobalCoordinates(
+        line,
+        h.app.scene.getNonDeletedElementsMap(),
+      );
+      const middlePoint = points[1];
+
+      drag(
+        middlePoint,
+        pointFrom(middlePoint[0] + delta, middlePoint[1] + delta),
+      );
+
+      expect(h.state.selectedLinearElement?.isEditing).toBe(true);
+      expect(h.state.selectedLinearElement?.hoverPointIndex).toBe(-1);
+      expect(
+        h.state.selectedLinearElement?.segmentMidPointHoveredCoords,
+      ).toBeNull();
+
+      // macOS often fires a pointermove at the release point after pointerup
+      const movedPoints = LinearElementEditor.getPointsGlobalCoordinates(
+        line,
+        h.app.scene.getNonDeletedElementsMap(),
+      );
+      fireEvent.pointerMove(interactiveCanvas, {
+        clientX: movedPoints[1][0],
+        clientY: movedPoints[1][1],
+      });
+
+      const lineBody = pointFrom<GlobalPoint>(
+        movedPoints[0][0] + (movedPoints[1][0] - movedPoints[0][0]) * 0.25,
+        movedPoints[0][1] + (movedPoints[1][1] - movedPoints[0][1]) * 0.25,
+      );
+      drag(
+        pointFrom(lineBody[0], lineBody[1]),
+        pointFrom(lineBody[0] + 40, lineBody[1] + 30),
+      );
+
+      expect(h.state.selectedLinearElement?.hoverPointIndex).toBe(-1);
+      expect(
+        h.state.selectedLinearElement?.segmentMidPointHoveredCoords,
+      ).toBeNull();
+    });
+
+    it("should not return stale midpoint hover coords after the line moves (#9510)", () => {
+      createThreePointerLinearElement("line");
+      const line = h.elements[0] as ExcalidrawLinearElement;
+      enterLineEditingMode(line);
+
+      const elementsMap = h.app.scene.getNonDeletedElementsMap();
+      const midPoints = LinearElementEditor.getEditorMidPoints(
+        line,
+        elementsMap,
+        h.state,
+      );
+      expect(midPoints[0]).not.toBeNull();
+
+      const editorWithStaleCache = {
+        ...h.state.selectedLinearElement!,
+        segmentMidPointHoveredCoords: midPoints[0],
+      };
+
+      act(() => {
+        h.app.scene.mutateElement(line, { x: line.x + 100, y: line.y + 80 });
+      });
+
+      const hit = LinearElementEditor.getSegmentMidpointHitCoords(
+        editorWithStaleCache,
+        { x: midPoints[0]![0], y: midPoints[0]![1] },
+        { ...h.state, selectedLinearElement: editorWithStaleCache },
+        h.app.scene.getNonDeletedElementsMap(),
+      );
+
+      expect(hit).toBeNull();
+    });
+
     it("should not drag line and add midpoint when dragged irrespective of threshold", () => {
       createTwoPointerLinearElement("line");
       const line = h.elements[0] as ExcalidrawLinearElement;

--- a/packages/element/tests/linearElementEditor.test.tsx
+++ b/packages/element/tests/linearElementEditor.test.tsx
@@ -1,4 +1,4 @@
-import { pointCenter, pointFrom } from "@excalidraw/math";
+import { pointCenter, pointDistance, pointFrom } from "@excalidraw/math";
 import { act, queryByTestId, queryByText } from "@testing-library/react";
 import { vi } from "vitest";
 
@@ -551,6 +551,51 @@ describe("Test Linear Elements", () => {
       );
 
       expect(hit).toBeNull();
+    });
+
+    it("should snap a slightly moved hovered midpoint to the current handle (#9510)", () => {
+      createThreePointerLinearElement("line");
+      const line = h.elements[0] as ExcalidrawLinearElement;
+      enterLineEditingMode(line);
+
+      const elementsMap = h.app.scene.getNonDeletedElementsMap();
+      const midPoints = LinearElementEditor.getEditorMidPoints(
+        line,
+        elementsMap,
+        h.state,
+      );
+      expect(midPoints[0]).not.toBeNull();
+
+      const threshold =
+        (LinearElementEditor.POINT_HANDLE_SIZE + 1) / h.state.zoom.value;
+      const subThresholdOffset = threshold / 2;
+
+      act(() => {
+        h.app.scene.mutateElement(line, {
+          x: line.x + subThresholdOffset,
+          y: line.y,
+        });
+      });
+
+      const currentMidPoints = LinearElementEditor.getEditorMidPoints(
+        line,
+        h.app.scene.getNonDeletedElementsMap(),
+        h.state,
+      );
+      expect(currentMidPoints[0]).not.toBeNull();
+      expect(pointDistance(midPoints[0]!, currentMidPoints[0]!)).toBeLessThan(
+        threshold,
+      );
+      expect(currentMidPoints[0]).not.toEqual(midPoints[0]);
+
+      const resolved = LinearElementEditor.getCurrentSegmentMidpointNearPoint(
+        currentMidPoints,
+        midPoints[0]!,
+        h.state.zoom.value,
+      );
+
+      expect(resolved).toEqual(currentMidPoints[0]);
+      expect(resolved).not.toEqual(midPoints[0]);
     });
 
     it("should not drag line and add midpoint when dragged irrespective of threshold", () => {

--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -8236,31 +8236,6 @@ class App extends React.Component<AppProps, AppState> {
         }
       }
 
-      if (
-        this.state.selectedLinearElement.hoverPointIndex !== hoverPointIndex
-      ) {
-        this.setState({
-          selectedLinearElement: {
-            ...this.state.selectedLinearElement,
-            hoverPointIndex,
-          },
-        });
-      }
-
-      if (
-        !LinearElementEditor.arePointsEqual(
-          this.state.selectedLinearElement.segmentMidPointHoveredCoords,
-          segmentMidPointHoveredCoords,
-        )
-      ) {
-        this.setState({
-          selectedLinearElement: {
-            ...this.state.selectedLinearElement,
-            segmentMidPointHoveredCoords,
-          },
-        });
-      }
-
       // Check for focus point hover
       let hoveredFocusPointBinding: "start" | "end" | null = null;
       const arrow = element as any;
@@ -8274,15 +8249,30 @@ class App extends React.Component<AppProps, AppState> {
         );
       }
 
-      if (
+      const hoverPointIndexChanged =
+        this.state.selectedLinearElement.hoverPointIndex !== hoverPointIndex;
+      const segmentMidPointChanged = !LinearElementEditor.arePointsEqual(
+        this.state.selectedLinearElement.segmentMidPointHoveredCoords,
+        segmentMidPointHoveredCoords,
+      );
+      const focusPointChanged =
         this.state.selectedLinearElement.hoveredFocusPointBinding !==
-        hoveredFocusPointBinding
+        hoveredFocusPointBinding;
+
+      // Single setState so hover index / midpoint coords cannot clobber each
+      // other (separate updates used `this.state` and the last write won).
+      if (
+        hoverPointIndexChanged ||
+        segmentMidPointChanged ||
+        focusPointChanged
       ) {
         this.setState({
           selectedLinearElement: {
             ...this.state.selectedLinearElement,
-            isDragging: false,
+            hoverPointIndex,
+            segmentMidPointHoveredCoords,
             hoveredFocusPointBinding,
+            ...(focusPointChanged ? { isDragging: false } : {}),
           },
         });
       }
@@ -11610,6 +11600,8 @@ class App extends React.Component<AppProps, AppState> {
             selectedLinearElement: {
               ...this.state.selectedLinearElement,
               isDragging: false,
+              hoverPointIndex: -1,
+              segmentMidPointHoveredCoords: null,
             },
           });
           this.actionManager.executeAction(actionFinalize, "ui", {

--- a/packages/excalidraw/renderer/interactiveScene.ts
+++ b/packages/excalidraw/renderer/interactiveScene.ts
@@ -16,7 +16,6 @@ import {
   DEFAULT_TRANSFORM_HANDLE_SPACING,
   FRAME_STYLE,
   getFeatureFlag,
-  invariant,
   shouldRotateWithDiscreteAngle,
   THEME,
 } from "@excalidraw/common";
@@ -114,14 +113,9 @@ import type {
 const renderElbowArrowMidPointHighlight = (
   context: CanvasRenderingContext2D,
   appState: InteractiveCanvasAppState,
+  midPointCoords: GlobalPoint,
 ) => {
-  invariant(appState.selectedLinearElement, "selectedLinearElement is null");
-
-  const { segmentMidPointHoveredCoords } = appState.selectedLinearElement;
-
-  invariant(segmentMidPointHoveredCoords, "midPointCoords is null");
-
-  highlightPoint(segmentMidPointHoveredCoords, context, appState);
+  highlightPoint(midPointCoords, context, appState);
 };
 
 const renderLinearElementPointHighlight = (
@@ -1770,15 +1764,14 @@ const _renderInteractiveScene = ({
           allElementsMap,
           appState,
         );
-        const threshold =
-          (LinearElementEditor.POINT_HANDLE_SIZE + 1) / appState.zoom.value;
-        const cached = linearState.segmentMidPointHoveredCoords;
-        const cacheIsCurrent = midPoints.some(
-          (midPoint) =>
-            midPoint != null && pointDistance(midPoint, cached) <= threshold,
-        );
-        if (cacheIsCurrent) {
-          renderElbowArrowMidPointHighlight(context, appState);
+        const currentMidPoint =
+          LinearElementEditor.getCurrentSegmentMidpointNearPoint(
+            midPoints,
+            linearState.segmentMidPointHoveredCoords,
+            appState.zoom.value,
+          );
+        if (currentMidPoint) {
+          renderElbowArrowMidPointHighlight(context, appState, currentMidPoint);
         }
       } else if (
         isElbowArrow(selectedLinearElement)

--- a/packages/excalidraw/renderer/interactiveScene.ts
+++ b/packages/excalidraw/renderer/interactiveScene.ts
@@ -1765,7 +1765,21 @@ const _renderInteractiveScene = ({
   if (selectedLinearElement) {
     if (!appState.selectedLinearElement.isDragging) {
       if (linearState.segmentMidPointHoveredCoords) {
-        renderElbowArrowMidPointHighlight(context, appState);
+        const midPoints = LinearElementEditor.getEditorMidPoints(
+          selectedLinearElement,
+          allElementsMap,
+          appState,
+        );
+        const threshold =
+          (LinearElementEditor.POINT_HANDLE_SIZE + 1) / appState.zoom.value;
+        const cached = linearState.segmentMidPointHoveredCoords;
+        const cacheIsCurrent = midPoints.some(
+          (midPoint) =>
+            midPoint != null && pointDistance(midPoint, cached) <= threshold,
+        );
+        if (cacheIsCurrent) {
+          renderElbowArrowMidPointHighlight(context, appState);
+        }
       } else if (
         isElbowArrow(selectedLinearElement)
           ? linearState.hoverPointIndex === 0 ||


### PR DESCRIPTION
## Summary

- Stop writing hover highlight state while dragging a line point, and refresh `hoverPointIndex` / `segmentMidPointHoveredCoords` from the actual hit on pointer-down so a later click cannot keep a leftover handle.
- Midpoint hit-testing and interactive rendering now ignore cached scene coordinates that no longer match a current midpoint, so the highlight cannot stay behind after a point or the whole line moves.

Fixes #9510
Related: #9500

## Test plan

- [x] Draw a line, enter the line editor, drag a vertex, then pointer-down on the line body (macOS mouse and trackpad): no ghost highlight at the old point.
- [x] Same setup, then drag the whole line: the moved vertex has no leftover highlight.
- [x] Hover a segment midpoint, move away, hover again: midpoint highlight still appears and tracks the handle.
- [x] Elbow arrows: endpoint and midpoint hover highlights still work.