### PR TITLE
fix(element): clip frame children that can paint outside the frame

### DIFF
--- a/packages/element/src/frame.ts
+++ b/packages/element/src/frame.ts
@@ -923,9 +923,18 @@ export const shouldApplyFrameClip = (
   // a. overlapping with the frame, or
   // b. containing the frame, for example when an element is used as a background
   //    and is therefore bigger than the frame and completely contains the frame
+  // c. owned by the frame but not fully within its bounds. (a) only catches
+  //    elements whose *border* crosses the frame's border, so an element that
+  //    sits entirely outside its own frame would otherwise never be clipped.
+  // d. text owned by the frame. Text paints beyond its recorded bounds (glyph
+  //    overhang, font-metric mismatch, fixed-width text whose content overflows),
+  //    so a bounds test can't prove it stays inside the frame.
   const shouldClipElementItself =
     isElementIntersectingFrame(element, frame, elementsMap) ||
-    isElementContainingFrame(element, frame, elementsMap);
+    isElementContainingFrame(element, frame, elementsMap) ||
+    (element.frameId === frame.id &&
+      (isTextElement(element) ||
+        !elementsAreInFrameBounds([element], frame, elementsMap)));
 
   if (shouldClipElementItself) {
     for (const groupId of element.groupIds) {

--- a/packages/element/tests/frameClip.test.ts
+++ b/packages/element/tests/frameClip.test.ts
@@ -1,0 +1,114 @@
+import { arrayToMap } from "@excalidraw/common";
+
+import { API } from "@excalidraw/excalidraw/tests/helpers/api";
+
+import { shouldApplyFrameClip } from "../src/frame";
+
+import type { ExcalidrawFrameLikeElement } from "../src/types";
+
+const appState = {
+  frameRendering: { enabled: true, clip: true, name: true, outline: true },
+  selectedElementsAreBeingDragged: false,
+} as any;
+
+const createFrame = () =>
+  API.createElement({
+    type: "frame",
+    x: 0,
+    y: 0,
+    width: 500,
+    height: 500,
+  }) as ExcalidrawFrameLikeElement;
+
+describe("shouldApplyFrameClip", () => {
+  it("clips a standalone text element that sits fully inside its frame", () => {
+    // regression test for #11906 — text paints beyond its recorded bounds
+    // (glyph overhang, font-metric mismatch, fixed-width overflow), so being
+    // within the frame's bounds does not prove it renders within them.
+    const frame = createFrame();
+    const text = API.createElement({
+      type: "text",
+      x: 50,
+      y: 50,
+      width: 100,
+      height: 25,
+      frameId: frame.id,
+    });
+
+    expect(
+      shouldApplyFrameClip(
+        text,
+        frame,
+        appState,
+        arrayToMap([frame, text]) as any,
+      ),
+    ).toBe(true);
+  });
+
+  it("clips an element whose border crosses the frame border", () => {
+    const frame = createFrame();
+    const text = API.createElement({
+      type: "text",
+      x: 450,
+      y: 50,
+      width: 200,
+      height: 25,
+      frameId: frame.id,
+    });
+
+    expect(
+      shouldApplyFrameClip(
+        text,
+        frame,
+        appState,
+        arrayToMap([frame, text]) as any,
+      ),
+    ).toBe(true);
+  });
+
+  it("clips an element owned by a frame but lying entirely outside it", () => {
+    // the border-intersection test alone never fires here, so such an element
+    // used to render unclipped well outside its own frame.
+    const frame = createFrame();
+    const rect = API.createElement({
+      type: "rectangle",
+      x: 700,
+      y: 700,
+      width: 100,
+      height: 25,
+      frameId: frame.id,
+    });
+
+    expect(
+      shouldApplyFrameClip(
+        rect,
+        frame,
+        appState,
+        arrayToMap([frame, rect]) as any,
+      ),
+    ).toBe(true);
+  });
+
+  it("does not clip a non-text element fully within the frame", () => {
+    // keeps the existing fast path: a shape inside the frame cannot paint
+    // outside it, so no clip region is needed.
+    const frame = createFrame();
+    const rect = API.createElement({
+      type: "rectangle",
+      x: 50,
+      y: 50,
+      width: 100,
+      height: 100,
+      frameId: frame.id,
+    });
+
+    expect(
+      shouldApplyFrameClip(
+        rect,
+        frame,
+        appState,
+        arrayToMap([frame, rect]) as any,
+      ),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
Fixes #11906

### Problem

`shouldApplyFrameClip` only allocated a clip region when an element's border geometrically intersected the frame's border (`isElementIntersectingFrame`), or when the element contained the frame. Anything that never touches the frame border is never clipped.

That misses two cases:

1. **Standalone text inside the frame (#11906).** A text element whose bounds sit fully inside the frame passes the bounds test, so no clip is applied — but text paints past its recorded `width`/`height` (glyph overhang, font-metric/fallback mismatch, fixed-width text whose content overflows), so it renders over the frame edge. This is why the reported behaviour looks inconsistent: text near the edge crosses the border and clips correctly, while text further inside never clips at all.

2. **An element owned by a frame but lying entirely outside it.** It never intersects the frame border either, so it rendered unclipped well outside its own frame. Not part of the original report, but the same root cause.

### Fix

Also clip when the element belongs to the frame and is either text, or not fully within the frame's bounds.

Non-text elements fully inside the frame keep the existing fast path and allocate no clip region, so the optimisation this check exists for is preserved.

### Tests

Adds `packages/element/tests/frameClip.test.ts` with 4 cases. Two are regression tests that **fail without the source change** (verified by stashing it) and pass with it; the other two are controls that pass in both states — a border-crossing element still clips, and a non-text element fully inside still does not.

Full suite: 1863 passed, 0 failed. `tsc --noEmit` and `eslint` clean.