### PR TITLE
fix: don't re-version remote elements when healing fractional indices (updateScene)

### DIFF
--- a/packages/element/src/Scene.ts
+++ b/packages/element/src/Scene.ts
@@ -272,6 +272,10 @@ export class Scene {
     nextElements: ElementsMapOrArray,
     options?: {
       skipValidation?: true;
+      /** pass when elements come from outside the editor (remote updates) —
+       * index healing then preserves `version`/`versionNonce`, so the local
+       * copy cannot outrace its source in version-based reconciliation */
+      preserveVersions?: boolean;
     },
   ) {
     // we do trust the insertion order on the map, though maybe we shouldn't and should prefer order defined by fractional indices
@@ -282,7 +286,9 @@ export class Scene {
       validateIndicesThrottled(_nextElements);
     }
 
-    this.elements = syncInvalidIndices(_nextElements);
+    this.elements = syncInvalidIndices(_nextElements, {
+      preserveVersions: options?.preserveVersions,
+    });
     this.elementsMap.clear();
     this.elements.forEach((element) => {
       if (isFrameLikeElement(element)) {

--- a/packages/element/src/fractionalIndex.ts
+++ b/packages/element/src/fractionalIndex.ts
@@ -218,17 +218,36 @@ export const syncMovedIndices = (
 /**
  * Synchronizes all invalid fractional indices within the array order by mutating elements in the passed array.
  *
+ * Pass `preserveVersions: true` when the elements come from outside the editor
+ * (e.g. applying remote elements through `updateScene`): healing an invalid
+ * index there is a repair of internal ordering state, not a user edit —
+ * bumping `version` / re-rolling `versionNonce` would make the local copy
+ * appear "newer" than its source of truth, poisoning version-based
+ * reconciliation (`reconcileElements`) so that genuine remote edits get
+ * discarded after the local copy was healed.
+ *
  * WARN: in edge cases it could modify the elements which were not moved, as it's impossible to guess the actually moved elements from the elements array itself.
  */
 export const syncInvalidIndices = <T extends ExcalidrawElement>(
   elements: readonly T[],
+  options?: { preserveVersions?: boolean },
 ): Ordered<T>[] => {
   const elementsMap = arrayToMap(elements);
   const indicesGroups = getInvalidIndicesGroups(elements);
   const elementsUpdates = generateIndices(elements, indicesGroups);
 
   for (const [element, { index }] of elementsUpdates) {
-    mutateElement(element, elementsMap, { index });
+    mutateElement(
+      element,
+      elementsMap,
+      options?.preserveVersions
+        ? {
+            index,
+            version: element.version,
+            versionNonce: element.versionNonce,
+          }
+        : { index },
+    );
   }
 
   return elements as Ordered<T>[];
@@ -237,17 +256,32 @@ export const syncInvalidIndices = <T extends ExcalidrawElement>(
 /**
  * Synchronizes all invalid fractional indices within the array order by creating new instances of elements with corrected indices.
  *
+ * See `syncInvalidIndices` for the `preserveVersions` semantics.
+ *
  * WARN: in edge cases it could modify the elements which were not moved, as it's impossible to guess the actually moved elements from the elements array itself.
  */
 export const syncInvalidIndicesImmutable = (
   elements: readonly ExcalidrawElement[],
+  options?: { preserveVersions?: boolean },
 ): SceneElementsMap | undefined => {
   const syncedElements = arrayToMap(elements);
   const indicesGroups = getInvalidIndicesGroups(elements);
   const elementsUpdates = generateIndices(elements, indicesGroups);
 
   for (const [element, { index }] of elementsUpdates) {
-    syncedElements.set(element.id, newElementWith(element, { index }));
+    syncedElements.set(
+      element.id,
+      newElementWith(
+        element,
+        options?.preserveVersions
+          ? {
+              index,
+              version: element.version,
+              versionNonce: element.versionNonce,
+            }
+          : { index },
+      ),
+    );
   }
 
   return syncedElements as SceneElementsMap;

--- a/packages/element/src/store.ts
+++ b/packages/element/src/store.ts
@@ -155,7 +155,12 @@ export class Store {
         // also have the synced elements immutable, so that we don't mutate elements,
         // that are already in the scene, otherwise we wouldn't see any change
         params.elements
-          ? syncInvalidIndicesImmutable(params.elements)
+          ? syncInvalidIndicesImmutable(params.elements, {
+              // remote updates (NEVER) preserve versions during healing —
+              // must match the healing performed by `Scene.replaceAllElements`
+              // for the same update, otherwise the two copies diverge
+              preserveVersions: action === CaptureUpdateAction.NEVER,
+            })
           : undefined,
         params.appState,
       );

--- a/packages/element/tests/fractionalIndex.test.ts
+++ b/packages/element/tests/fractionalIndex.test.ts
@@ -875,3 +875,35 @@ function test(
     });
   });
 }
+
+describe("syncInvalidIndices with preserveVersions", () => {
+  it("should not bump version or re-roll versionNonce when healing", () => {
+    const elements = [
+      API.createElement({ type: "rectangle" }),
+      API.createElement({ type: "rectangle" }),
+    ].map((element, index) =>
+      // invalid (duplicated) indices, versions as if coming from a remote peer
+      ({ ...element, index: "a1", version: 10, versionNonce: 777 + index }),
+    ) as ExcalidrawElement[];
+
+    const synced = syncInvalidIndices(
+      elements.map((x) => deepCopyElement(x)),
+      { preserveVersions: true },
+    );
+
+    // indices got healed
+    expect(() =>
+      validateFractionalIndices(synced, {
+        shouldThrow: true,
+        includeBoundTextValidation: true,
+        ignoreLogs: true,
+      }),
+    ).not.toThrowError(InvalidFractionalIndexError);
+
+    // but versions were preserved — healing is a repair, not an edit
+    synced.forEach((syncedElement, index) => {
+      expect(syncedElement.version).toBe(elements[index].version);
+      expect(syncedElement.versionNonce).toBe(elements[index].versionNonce);
+    });
+  });
+});

--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -5222,7 +5222,14 @@ class App extends React.Component<AppProps, AppState> {
       }
 
       if (elements) {
-        this.scene.replaceAllElements(elements);
+        // `CaptureUpdateAction.NEVER` marks remote updates (see docs above) —
+        // elements coming from outside the editor are authoritative, so
+        // healing their indices must not re-version them, otherwise the local
+        // copies outrace the source of truth and version-based reconciliation
+        // starts discarding genuine remote edits
+        this.scene.replaceAllElements(elements, {
+          preserveVersions: captureUpdate === CaptureUpdateAction.NEVER,
+        });
       }
 
       if (collaborators) {

--- a/packages/excalidraw/data/reconcile.ts
+++ b/packages/excalidraw/data/reconcile.ts
@@ -111,8 +111,9 @@ export const reconcileElements = (
 
   validateIndicesThrottled(orderedElements, localElements, remoteElements);
 
-  // de-duplicate indices
-  syncInvalidIndices(orderedElements);
+  // de-duplicate indices — reconciled elements are not user edits, so healing
+  // must not re-version them (would poison the next reconciliation round)
+  syncInvalidIndices(orderedElements, { preserveVersions: true });
 
   return orderedElements as ReconciledExcalidrawElement[];
 };


### PR DESCRIPTION
# fix: don't re-version remote elements when healing indices on `updateScene`

## The problem

`updateScene` → `Scene.replaceAllElements` → `syncInvalidIndices` heals invalid fractional indices via `mutateElement`, which unconditionally bumps `version` and re-rolls `versionNonce`.

For **elements coming from outside the editor** this is incorrect: applying a remote update is not a user edit, yet after healing the local copy *looks newer than its source of truth*. In any store-and-broadcast topology where the relay does not persist the internal `index` field (the norm for external CRDT/relay integrations — `index` is an Excalidraw-internal ordering key), every apply re-heals and re-bumps:

- versions inflate monotonically with **zero user edits**,
- the local copy permanently outraces the true editor,
- `reconcileElements` (exported precisely for such integrations) then discards the editor's genuine edits.

We hit this in production (Yjs relay): shapes moved by a peer were silently ignored on other clients.

## Deterministic repro (single client, no network, 0.18.1 & current master)

```
step1  apply remote element v10 (no index) via updateScene
       → local version = 11, versionNonce re-rolled (no user edit happened)
step2  re-apply after ordinary relay echoes (index stripped) ×2
       → local version = 12, 13 (inflating, still zero user edits)
step3  the true editor moves the element → broadcasts v11 (x: 400)
step4  reconcileElements: local v13 vs remote v11 → keeps x=100 → edit DISCARDED
```

Minimal runnable sandbox: https://gist.github.com/softwareDefine/ddf986e4fe723dc26c6175475f8d26bd

Closes-context: #11933

## The fix — scoped to the remote boundary

Bumping on index changes is load-bearing *inside* the editor (Store change detection, `ElementsDelta` invariants, undo/redo, restore-import semantics per #3795), so this PR deliberately does **not** change any default behavior:

- `syncInvalidIndices` / `syncInvalidIndicesImmutable`: opt-in `preserveVersions` (default unchanged)
- `Scene.replaceAllElements`: forwards the option
- `App.updateScene`: passes `preserveVersions: captureUpdate === CaptureUpdateAction.NEVER` — per the documented semantics, `NEVER` marks *remote updates / scene initialization*
- `Store.scheduleMicroAction`: heals the scheduled snapshot with the same `preserveVersions` for `NEVER`, so the store copy can't diverge from the scene copy
- `StoreSnapshot.detectChangedElements`: additionally treats an index change (same version) as a change, so remote index healing still updates the snapshot
- `reconcileElements`: post-reconcile index de-duplication preserves versions

## Test status (draft — honest disclosure)

- new test: healing with `preserveVersions` keeps `version`/`versionNonce` intact ✅
- `fractionalIndex` (55), `zindex`, `reconcile`, `restore`, `transform` suites: green, no expectation changes (default paths behave exactly as on master) ✅
- **`history.test.tsx`: 22 of the `multiplayer undo/redo` tests fail** — they simulate remote updates via `CaptureUpdateAction.NEVER` and their expectations are calibrated to the legacy behavior where remote healing bumps versions. I deliberately did **not** blanket-recalibrate them: several encode intended undo-vs-remote conflict UX, and whether those outcomes should change under repair-preserving healing is a semantics call I'd rather make with maintainers than guess at.

## Open question for maintainers

Is "healing re-versions remote elements" load-bearing *by design* in the undo-rebase model, or an accident these tests calcified around? Depending on the answer I'm happy to either:
1. recalibrate the multiplayer history expectations under the new semantics, or
2. move the preservation elsewhere (e.g. only into `reconcileElements` consumers via a documented util), or
3. any alternative you prefer — the invariant this PR is after: **applying remote elements must never make them newer than their source.**
