### PR TITLE
feat(editor): add shortcut search to help dialog

### DIFF
--- a/packages/excalidraw/components/HelpDialog.scss
+++ b/packages/excalidraw/components/HelpDialog.scss
@@ -58,6 +58,17 @@
       }
     }
 
+    &__search {
+      margin-top: 1.5rem;
+    }
+
+    &__no-results {
+      margin: 1.5rem 0;
+      color: var(--text-primary-color);
+      opacity: 0.6;
+      font-size: 0.875rem;
+    }
+
     &__islands-container {
       display: grid;
       grid-column-gap: 1.5rem;

--- a/packages/excalidraw/components/HelpDialog.tsx
+++ b/packages/excalidraw/components/HelpDialog.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 import { isDarwin, isFirefox, isWindows } from "@excalidraw/common";
 
-import { KEYS } from "@excalidraw/common";
+import { KEYS, EVENT, addEventListener } from "@excalidraw/common";
 
 import { actionToggleTheme } from "../actions";
 import { getShortcutFromShortcutName } from "../actions/shortcuts";
@@ -12,7 +12,8 @@ import { getShortcutKey } from "../shortcut";
 
 import { useExcalidrawActionManager } from "./App";
 import { Dialog } from "./Dialog";
-import { ExternalLinkIcon, GithubIcon, youtubeIcon } from "./icons";
+import { TextField } from "./TextField";
+import { ExternalLinkIcon, GithubIcon, searchIcon, youtubeIcon } from "./icons";
 
 import "./HelpDialog.scss";
 
@@ -59,23 +60,63 @@ const Header = () => (
   </div>
 );
 
-const Section = (props: { title: string; children: React.ReactNode }) => (
-  <>
-    <h3>{props.title}</h3>
-    <div className="HelpDialog__islands-container">{props.children}</div>
-  </>
-);
+const SearchQueryContext = React.createContext("");
+
+// shortcuts are authored as JSX rather than data, so matching reads the
+// `label` prop off each child instead of filtering a list
+const getMatchingShortcuts = (children: React.ReactNode, query: string) =>
+  React.Children.toArray(children).filter(
+    (child) =>
+      React.isValidElement<{ label?: string }>(child) &&
+      (!query || !!child.props.label?.toLowerCase().includes(query)),
+  );
+
+const Section = (props: {
+  title: string;
+  query: string;
+  children: React.ReactNode;
+}) => {
+  const islands = React.Children.toArray(props.children).filter(
+    (island) =>
+      React.isValidElement<{ children?: React.ReactNode }>(island) &&
+      getMatchingShortcuts(island.props.children, props.query).length > 0,
+  );
+
+  if (!islands.length) {
+    return (
+      <div className="HelpDialog__no-results">
+        {t("helpDialog.searchNoResults")}
+      </div>
+    );
+  }
+
+  return (
+    <SearchQueryContext.Provider value={props.query}>
+      <h3>{props.title}</h3>
+      <div className="HelpDialog__islands-container">{islands}</div>
+    </SearchQueryContext.Provider>
+  );
+};
 
 const ShortcutIsland = (props: {
   caption: string;
   children: React.ReactNode;
   className?: string;
-}) => (
-  <div className={`HelpDialog__island ${props.className}`}>
-    <h4 className="HelpDialog__island-title">{props.caption}</h4>
-    <div className="HelpDialog__island-content">{props.children}</div>
-  </div>
-);
+}) => {
+  const query = React.useContext(SearchQueryContext);
+  const shortcuts = getMatchingShortcuts(props.children, query);
+
+  if (!shortcuts.length) {
+    return null;
+  }
+
+  return (
+    <div className={`HelpDialog__island ${props.className}`}>
+      <h4 className="HelpDialog__island-title">{props.caption}</h4>
+      <div className="HelpDialog__island-content">{shortcuts}</div>
+    </div>
+  );
+};
 
 function* intersperse(as: JSX.Element[][], delim: string | null) {
   let first = true;
@@ -127,11 +168,33 @@ const ShortcutKey = (props: { children: React.ReactNode }) => (
 
 export const HelpDialog = ({ onClose }: { onClose?: () => void }) => {
   const actionManager = useExcalidrawActionManager();
+  const searchInputRef = React.useRef<HTMLInputElement>(null);
+  const [searchQuery, setSearchQuery] = React.useState("");
+
   const handleClose = React.useCallback(() => {
     if (onClose) {
       onClose();
     }
   }, [onClose]);
+
+  React.useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event[KEYS.CTRL_OR_CMD] && event.key === KEYS.F) {
+        event.preventDefault();
+        event.stopPropagation();
+
+        searchInputRef.current?.focus();
+        searchInputRef.current?.select();
+      }
+    };
+
+    // `capture` needed to claim the shortcut before the editor's global
+    // keydown handler consumes it
+    return addEventListener(window, EVENT.KEYDOWN, handleKeyDown, {
+      capture: true,
+      passive: false,
+    });
+  }, []);
 
   return (
     <>
@@ -141,7 +204,19 @@ export const HelpDialog = ({ onClose }: { onClose?: () => void }) => {
         className={"HelpDialog"}
       >
         <Header />
-        <Section title={t("helpDialog.shortcuts")}>
+        <TextField
+          ref={searchInputRef}
+          className="HelpDialog__search"
+          value={searchQuery}
+          onChange={setSearchQuery}
+          placeholder={t("helpDialog.searchPlaceholder")}
+          icon={searchIcon}
+          fullWidth
+        />
+        <Section
+          title={t("helpDialog.shortcuts")}
+          query={searchQuery.trim().toLowerCase()}
+        >
           <ShortcutIsland
             className="HelpDialog__island--tools"
             caption={t("helpDialog.tools")}

--- a/packages/excalidraw/locales/en.json
+++ b/packages/excalidraw/locales/en.json
@@ -461,6 +461,8 @@
     "howto": "Follow our guides",
     "or": "or",
     "preventBinding": "Prevent arrow binding",
+    "searchPlaceholder": "Search shortcuts",
+    "searchNoResults": "No matching shortcuts",
     "tools": "Tools",
     "shortcuts": "Keyboard shortcuts",
     "textFinish": "Finish editing (text editor)",

--- a/packages/excalidraw/tests/helpDialog.test.tsx
+++ b/packages/excalidraw/tests/helpDialog.test.tsx
@@ -1,0 +1,102 @@
+import React from "react";
+
+import { KEYS } from "@excalidraw/common";
+
+import { Excalidraw } from "../index";
+
+import { API } from "./helpers/api";
+import { Keyboard } from "./helpers/ui";
+import { act, fireEvent, render, waitFor } from "./test-utils";
+
+const { h } = window;
+
+const getShortcutLabels = () =>
+  Array.from(
+    document.querySelectorAll(
+      ".HelpDialog .HelpDialog__shortcut > div:first-child",
+    ),
+  ).map((element) => element.textContent ?? "");
+
+const openHelpDialog = async () => {
+  API.setAppState({ openSidebar: null, openDialog: { name: "help" } });
+
+  const input = await waitFor(() => {
+    const input = document.querySelector<HTMLInputElement>(
+      ".HelpDialog .HelpDialog__search input",
+    );
+    expect(input).not.toBeNull();
+    return input!;
+  });
+
+  // let the dialog's own autofocus settle so it can't race the assertions
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+
+  return input;
+};
+
+describe("help dialog", () => {
+  beforeEach(async () => {
+    await render(<Excalidraw handleKeyboardGlobally />);
+  });
+
+  it("should focus the shortcut search on cmd+f instead of leaving the key dead", async () => {
+    const input = await openHelpDialog();
+    expect(input.matches(":focus")).toBe(false);
+
+    Keyboard.withModifierKeys({ ctrl: true }, () => {
+      Keyboard.keyPress(KEYS.F);
+    });
+
+    expect(input.matches(":focus")).toBe(true);
+  });
+
+  it("should keep the dialog open and not open canvas search on cmd+f", async () => {
+    await openHelpDialog();
+
+    Keyboard.withModifierKeys({ ctrl: true }, () => {
+      Keyboard.keyPress(KEYS.F);
+    });
+
+    expect(h.app.state.openDialog?.name).toBe("help");
+    expect(h.app.state.openSidebar).toBeNull();
+  });
+
+  it("should filter shortcuts by label", async () => {
+    const input = await openHelpDialog();
+    expect(getShortcutLabels().length).toBeGreaterThan(1);
+
+    fireEvent.change(input, { target: { value: "zoom" } });
+
+    await waitFor(() => {
+      const labels = getShortcutLabels();
+      expect(labels.length).toBeGreaterThan(0);
+      expect(labels.every((label) => /zoom/i.test(label))).toBe(true);
+    });
+  });
+
+  it("should show an empty state when no shortcut matches", async () => {
+    const input = await openHelpDialog();
+
+    fireEvent.change(input, { target: { value: "no-such-shortcut" } });
+
+    await waitFor(() => {
+      expect(getShortcutLabels()).toHaveLength(0);
+      expect(document.querySelector(".HelpDialog__no-results")).not.toBeNull();
+    });
+  });
+
+  it("should restore all shortcuts when the query is cleared", async () => {
+    const input = await openHelpDialog();
+    const initialCount = getShortcutLabels().length;
+
+    fireEvent.change(input, { target: { value: "zoom" } });
+    await waitFor(() =>
+      expect(getShortcutLabels().length).toBeLessThan(initialCount),
+    );
+
+    fireEvent.change(input, { target: { value: "" } });
+    await waitFor(() => expect(getShortcutLabels()).toHaveLength(initialCount));
+  });
+});


### PR DESCRIPTION
Closes #9276

## Background

#9276 is still open, despite #9279 being merged as a fix for it. The report reads:

> If you press Ctrl + F in the help menu it closes the menu and brings up the global find panel. Some way to search the help panel would be nice

The request was for a way to search the help panel's contents. #9279 read it as "Ctrl+F should not open search while a dialog is open" and added an `openDialog` guard to `actionToggleSearchMenu.perform`.

That guard runs *after* `ActionManager.handleKeyDown` has already called `event.preventDefault()` and `event.stopPropagation()`, so today the key is inert: the browser's find bar is suppressed and the canvas search never opens. Nothing happens at all.

## What this does

Gives the help dialog its own filter over the shortcut list and points Cmd/Ctrl+F at it.

- Adds a `TextField` search box to `HelpDialog`, filtering shortcuts by their `label`.
- `ShortcutIsland` hides itself when none of its rows match; `Section` shows an empty state when no island survives.
- `HelpDialog` registers a capture-phase `keydown` listener on `window` so it claims Cmd/Ctrl+F before the editor's global handler consumes it.

The shortcut rows are authored as JSX rather than data, so matching reads the `label` prop off each child. Restructuring them into a data array would make the filter tidier but would rewrite ~390 lines of unrelated markup, so I kept the change contained to the three wrapper components.

`actionToggleSearchMenu.ts` is intentionally untouched. Since the dialog now consumes the event first, the existing guard never comes into play, and leaving it alone avoids reintroducing the behavior the issue originally complained about.

## Not covered

Cmd/Ctrl+F is still inert in other dialogs (image export, etc.) for the same `preventDefault`-before-bail reason. That's outside this issue's scope and probably deserves its own fix, either by moving the guard into the action's `keyTest` so the event is never claimed, or by giving other dialogs similar handling.

## Test plan

- `packages/excalidraw/tests/helpDialog.test.tsx` (new) covers: Cmd+F focuses the filter, the dialog stays open and canvas search does not open, filtering by label, the empty state, and restoring the full list when the query is cleared.
- `yarn test:typecheck` passes.
- Full suite passes: 123 files, 1865 tests, no snapshot changes.
- New strings added to `en.json` only; other locales come from Crowdin.

Made with [Cursor](https://cursor.com)