### PR TITLE
fix: preserve caret position when outdenting partial tabs

### DIFF
--- a/packages/excalidraw/wysiwyg/textWysiwyg.test.tsx
+++ b/packages/excalidraw/wysiwyg/textWysiwyg.test.tsx
@@ -653,19 +653,34 @@ describe("textWysiwyg", () => {
     });
 
     it("should keep cursor position when removing a partial tab", () => {
-  textarea.value = `Line#1\n   Line#2`;
-  textarea.selectionStart = 16;
-  textarea.selectionEnd = 16;
+      // cursor: "Line#1\n   Line#2|"
+      textarea.value = `Line#1\n   Line#2`;
+      textarea.selectionStart = 16;
+      textarea.selectionEnd = 16;
 
-  fireEvent.keyDown(textarea, {
-    key: KEYS.TAB,
-    shiftKey: true,
-  });
-  expect(textarea.value).toEqual(`Line#1\nLine#2`);
-  expect(textarea.selectionStart).toEqual(13);
-  expect(textarea.selectionEnd).toEqual(13);
-});
+      fireEvent.keyDown(textarea, {
+        key: KEYS.TAB,
+        shiftKey: true,
+      });
+      expect(textarea.value).toEqual(`Line#1\nLine#2`);
+      expect(textarea.selectionStart).toEqual(13);
+      expect(textarea.selectionEnd).toEqual(13);
+    });
 
+    it("should keep cursor position inside partial tab whitespace", () => {
+      // cursor: "Line#1\n  | Line#2"
+      textarea.value = `Line#1\n   Line#2`;
+      textarea.selectionStart = 9;
+      textarea.selectionEnd = 9;
+      
+      fireEvent.keyDown(textarea, {
+        key: KEYS.TAB,
+        shiftKey: true,
+      });
+      expect(textarea.value).toEqual(`Line#1\nLine#2`);
+      expect(textarea.selectionStart).toEqual(7);
+      expect(textarea.selectionEnd).toEqual(7);
+    });
     it("should remove nothing", () => {
       // cursor: "Line#1\n  Li|ne#2"
       textarea.value = `Line#1\nLine#2`;

--- a/packages/excalidraw/wysiwyg/textWysiwyg.test.tsx
+++ b/packages/excalidraw/wysiwyg/textWysiwyg.test.tsx
@@ -672,7 +672,7 @@ describe("textWysiwyg", () => {
       textarea.value = `Line#1\n   Line#2`;
       textarea.selectionStart = 9;
       textarea.selectionEnd = 9;
-      
+
       fireEvent.keyDown(textarea, {
         key: KEYS.TAB,
         shiftKey: true,

--- a/packages/excalidraw/wysiwyg/textWysiwyg.test.tsx
+++ b/packages/excalidraw/wysiwyg/textWysiwyg.test.tsx
@@ -652,6 +652,20 @@ describe("textWysiwyg", () => {
       expect(textarea.value).toEqual(`Line#1\nLine#2`);
     });
 
+    it("should keep cursor position when removing a partial tab", () => {
+  textarea.value = `Line#1\n   Line#2`;
+  textarea.selectionStart = 16;
+  textarea.selectionEnd = 16;
+
+  fireEvent.keyDown(textarea, {
+    key: KEYS.TAB,
+    shiftKey: true,
+  });
+  expect(textarea.value).toEqual(`Line#1\nLine#2`);
+  expect(textarea.selectionStart).toEqual(13);
+  expect(textarea.selectionEnd).toEqual(13);
+});
+
     it("should remove nothing", () => {
       // cursor: "Line#1\n  Li|ne#2"
       textarea.value = `Line#1\nLine#2`;

--- a/packages/excalidraw/wysiwyg/textWysiwyg.tsx
+++ b/packages/excalidraw/wysiwyg/textWysiwyg.tsx
@@ -702,7 +702,7 @@ export const textWysiwyg = ({
   const outdent = () => {
     const { selectionStart, selectionEnd } = editable;
     const linesStartIndices = getSelectedLinesStartIndices();
-    const removedTabs: number[] = [];
+    const removedTabs: { startIndex: number; length: number }[] = [];
 
     let value = editable.value;
     linesStartIndices.forEach((startIndex) => {
@@ -716,17 +716,18 @@ export const textWysiwyg = ({
 
         // Delete a tab from the line
         value = `${startValue}${endValue}`;
-        removedTabs.push(startIndex);
+        removedTabs.push({ startIndex, length: tabMatch[0].length });
       }
     });
 
     editable.value = value;
 
     if (removedTabs.length) {
-      if (selectionStart > removedTabs[removedTabs.length - 1]) {
+      const lastRemovedTab = removedTabs[removedTabs.length - 1];
+      if (selectionStart > lastRemovedTab.startIndex) {
         editable.selectionStart = Math.max(
-          selectionStart - TAB_SIZE,
-          removedTabs[removedTabs.length - 1],
+          selectionStart - lastRemovedTab.length,
+          lastRemovedTab.startIndex,
         );
       } else {
         // If the cursor is before the first tab removed, ex:
@@ -738,7 +739,8 @@ export const textWysiwyg = ({
       }
       editable.selectionEnd = Math.max(
         editable.selectionStart,
-        selectionEnd - TAB_SIZE * removedTabs.length,
+        selectionEnd -
+  removedTabs.reduce((total, tab) => total + tab.length, 0),
       );
     }
   };


### PR DESCRIPTION
## What changed

Fixes the caret position when using Shift+Tab to outdent text that starts with fewer than four spaces.

Previously, the outdent logic correctly removed the leading spaces, but adjusted the caret position as though a full four-space tab had been removed. This could move the caret backward into the text.

## Example

Before Shift+Tab:

`   Second line|`

Previous result:

`Second li|ne`

Expected result:

`Second line|`

## Fix

Track the actual number of spaces removed when outdenting and use that amount when updating the selection and caret position.

## Testing

- Manually tested outdenting with 2 and 3 leading spaces.
- Confirmed the caret remains in the correct position.
- Added a regression test for partial-tab outdenting and caret position.
- Ran `yarn test:app packages/excalidraw/wysiwyg/textWysiwyg.test.tsx --watch=false`.
- Result: 79 passed, 1 skipped.