### PR TITLE
fix: allow precise rotation in grid mode

### DIFF
--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -13446,10 +13446,12 @@ class App extends React.Component<AppProps, AppState> {
       activeEmbeddable: null,
     });
     const pointerCoords = pointerDownState.lastCoords;
+    const shouldSnapToGrid =
+      transformHandleType !== "rotation" && !event[KEYS.CTRL_OR_CMD];
     let [resizeX, resizeY] = getGridPoint(
       pointerCoords.x - pointerDownState.resize.offset.x,
       pointerCoords.y - pointerDownState.resize.offset.y,
-      event[KEYS.CTRL_OR_CMD] ? null : this.getEffectiveGridSize(),
+      shouldSnapToGrid ? this.getEffectiveGridSize() : null,
     );
 
     const frameElementsOffsetsMap = new Map<
@@ -13480,7 +13482,7 @@ class App extends React.Component<AppProps, AppState> {
       const [gridX, gridY] = getGridPoint(
         pointerCoords.x,
         pointerCoords.y,
-        event[KEYS.CTRL_OR_CMD] ? null : this.getEffectiveGridSize(),
+        shouldSnapToGrid ? this.getEffectiveGridSize() : null,
       );
 
       const dragOffset = {

--- a/packages/excalidraw/tests/rotate.test.tsx
+++ b/packages/excalidraw/tests/rotate.test.tsx
@@ -1,14 +1,18 @@
 import React from "react";
 import { expect } from "vitest";
 
-import { reseed } from "@excalidraw/common";
+import { arrayToMap, reseed } from "@excalidraw/common";
+import { getTransformHandles } from "@excalidraw/element";
 
 import { Excalidraw } from "../index";
 
+import { API } from "./helpers/api";
 import { UI } from "./helpers/ui";
 import { render, unmountComponent } from "./test-utils";
 
 unmountComponent();
+
+const { h } = window;
 
 beforeEach(() => {
   localStorage.clear();
@@ -82,4 +86,38 @@ test("unselected bound arrows update when rotating their target elements", async
   expect(textArrow.points[0]).toEqual([0, 0]);
   expect(textArrow.points[1][0]).toBeCloseTo(-95.4635969899922, 0);
   expect(textArrow.points[1][1]).toBeCloseTo(-126.8785027399889, 0);
+});
+
+test("rotates exactly to 90 degrees in grid mode", async () => {
+  await render(<Excalidraw />);
+  API.setAppState({ gridModeEnabled: true });
+
+  const rectangle = API.createElement({
+    type: "rectangle",
+    x: 100,
+    y: 103,
+    width: 80,
+    height: 40,
+  });
+  API.setElements([rectangle]);
+
+  const rotationHandle = getTransformHandles(
+    rectangle,
+    h.state.zoom,
+    arrayToMap(h.elements),
+    "mouse",
+    {},
+  ).rotation!;
+
+  const handleCenterX = rotationHandle[0] + rotationHandle[2] / 2;
+  const handleCenterY = rotationHandle[1] + rotationHandle[3] / 2;
+  const elementCenterX = rectangle.x + rectangle.width / 2;
+  const elementCenterY = rectangle.y + rectangle.height / 2;
+
+  UI.rotate(rectangle, [
+    elementCenterX + 100 - handleCenterX,
+    elementCenterY - handleCenterY,
+  ]);
+
+  expect(API.getElement(rectangle).angle).toBeCloseTo(Math.PI / 2);
 });


### PR DESCRIPTION
Fixes #4057

## Summary
- Avoid grid-snapping pointer coordinates while rotating elements
- Add a regression test for exact 90-degree rotation in grid mode

## Tests
- corepack yarn test:app packages/excalidraw/tests/rotate.test.tsx --watch=false
- corepack yarn eslint --max-warnings=0 packages/excalidraw/components/App.tsx packages/excalidraw/tests/rotate.test.tsx