### PR TITLE
fix(editor): skip empty frames in bucket fill

### DIFF
--- a/packages/element/src/bucketFill.ts
+++ b/packages/element/src/bucketFill.ts
@@ -570,15 +570,15 @@ export const rendersOpaqueFill = (element: ExcalidrawElement): boolean => {
 
 /**
  * Element types whose outlines can participate in a fill — as the owner
- * (when closed) and as boundaries. Text, image, embeddable, iframe and
- * arrows are excluded in v1.
+ * (when closed) and as boundaries. Frames are containers rather than
+ * fillable shapes: their outline must not turn otherwise empty frame space
+ * into a bucket-fill region. Text, image, embeddable, iframe and arrows are
+ * also excluded in v1.
  */
 const FILL_BOUNDARY_TYPES = new Set<ExcalidrawElement["type"]>([
   "rectangle",
   "diamond",
   "ellipse",
-  "frame",
-  "magicframe",
   "line",
   "freedraw",
 ]);

--- a/packages/element/tests/bucketFill.test.ts
+++ b/packages/element/tests/bucketFill.test.ts
@@ -59,6 +59,28 @@ const isClosed = (pts: GlobalPoint[]): boolean =>
   pts[0][1] === pts[pts.length - 1][1];
 
 describe("computeBucketFillPolygon", () => {
+  it.each(["frame", "magicframe"] as const)(
+    "does not fill blank space inside an empty %s",
+    (type) => {
+      const frame = API.createElement({
+        type,
+        x: 0,
+        y: 0,
+        width: 100,
+        height: 100,
+      });
+      const { elements, elementsMap } = setup([frame]);
+
+      expect(
+        computeBucketFillPolygon({
+          point: pointFrom<GlobalPoint>(50, 50),
+          elements,
+          elementsMap,
+        }),
+      ).toEqual({ ok: false, reason: "no_owner" });
+    },
+  );
+
   it("fills a simple rectangle and returns a closed polygon", () => {
     const rect = API.createElement({
       type: "rectangle",


### PR DESCRIPTION
Summary: Prevent bucket fill from treating empty frames and magic frames as enclosed fill regions. Adds regression coverage for both frame types. Testing: node node_modules/vitest/vitest.mjs run packages/element/tests/bucketFill.test.ts (59 passed); Prettier check passed.