### PR TITLE
test: preserve element geometry when resizing frames

### DIFF
--- a/packages/element/tests/frame.test.tsx
+++ b/packages/element/tests/frame.test.tsx
@@ -551,6 +551,20 @@ describe("adding elements to frames", () => {
   describe("resizing frame over elements", async () => {
     await commonTestCases(resizeFrameOverElement);
 
+    it("should preserve element geometry when resizing a frame over it", async () => {
+      API.setElements([frame, rect2]);
+
+      const { x, y, width, height } = rect2;
+
+      resizeFrameOverElement(frame, rect2);
+
+      expect(rect2.x).toBe(x);
+      expect(rect2.y).toBe(y);
+      expect(rect2.width).toBe(width);
+      expect(rect2.height).toBe(height);
+      expect(rect2.frameId).toBe(frame.id);
+    });
+
     it.skip("resizing over text containers and labelled arrows", async () => {
       await resizingTest(
         "rectangle",


### PR DESCRIPTION
## Summary
Adds a regression test ensuring that resizing a frame over an existing element does not resize or move the contained element.

## Why
The independent bug audit identified that existing frame-resize tests verified frame membership and ordering but did not explicitly assert that the contained element's own geometry remained unchanged.

## Test
- Focused test passed:
  `yarn vitest run packages/element/tests/frame.test.tsx -t "should preserve element geometry when resizing a frame over it"`
- Full file passed:
  `yarn vitest run packages/element/tests/frame.test.tsx`
  24 passed, 30 skipped
- The skipped tests are pre-existing skips.

## Scope
- Test-only change.
- No production code changed.
- One file changed.
- 14 lines added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)