### PR TITLE
ci(repo): fix broken heredoc in semantic-pr-title.yml

### DIFF
--- a/.github/scripts/pr-scope-labels.mjs
+++ b/.github/scripts/pr-scope-labels.mjs
@@ -1,4 +1,4 @@
-const title = process.env.PR_TITLE;
+const title = process.env.PR_TITLE ?? "";
 const match = title.match(/^[a-z]+(?:\(([^)]+)\))?!?:/i);
 const scopes = match?.[1]?.split(",").map((scope) => scope.trim()) ?? [];
 const labels = new Set();

--- a/.github/scripts/pr-scope-labels.mjs
+++ b/.github/scripts/pr-scope-labels.mjs
@@ -1,0 +1,16 @@
+const title = process.env.PR_TITLE;
+const match = title.match(/^[a-z]+(?:\(([^)]+)\))?!?:/i);
+const scopes = match?.[1]?.split(",").map((scope) => scope.trim()) ?? [];
+const labels = new Set();
+
+for (const scope of scopes) {
+  if (scope === "app") {
+    labels.add("s-app");
+  } else if (scope === "editor") {
+    labels.add("s-editor");
+  } else if (scope.startsWith("packages/")) {
+    labels.add("s-package");
+  }
+}
+
+process.stdout.write([...labels].join("\n"));

--- a/.github/workflows/semantic-pr-title.yml
+++ b/.github/workflows/semantic-pr-title.yml
@@ -61,26 +61,7 @@ jobs:
 
           scope_labels=(s-app s-editor s-package)
 
-          readarray -t desired_labels < <(
-            node <<'NODE'
-          const title = process.env.PR_TITLE;
-          const match = title.match(/^[a-z]+(?:\(([^)]+)\))?!?:/i);
-          const scopes = match?.[1]?.split(",").map((scope) => scope.trim()) ?? [];
-          const labels = new Set();
-
-          for (const scope of scopes) {
-            if (scope === "app") {
-              labels.add("s-app");
-            } else if (scope === "editor") {
-              labels.add("s-editor");
-            } else if (scope.startsWith("packages/")) {
-              labels.add("s-package");
-            }
-          }
-
-          process.stdout.write([...labels].join("\n"));
-          NODE
-          )
+          readarray -t desired_labels < <(node "$GITHUB_WORKSPACE/.github/scripts/pr-scope-labels.mjs")
 
           should_apply_label() {
             local label="$1"

--- a/.github/workflows/semantic-pr-title.yml
+++ b/.github/workflows/semantic-pr-title.yml
@@ -61,7 +61,9 @@ jobs:
 
           scope_labels=(s-app s-editor s-package)
 
-          readarray -t desired_labels < <(node "$GITHUB_WORKSPACE/.github/scripts/pr-scope-labels.mjs")
+          # pr-scope-labels.mjs reads PR_TITLE from the environment above — keep it exported
+          # into whichever step calls this script.
+          readarray -t desired_labels < <(node "${{ github.workspace }}/.github/scripts/pr-scope-labels.mjs")
 
           should_apply_label() {
             local label="$1"


### PR DESCRIPTION
## What
Fixes a broken heredoc in the `label-scope` job of `semantic-pr-title.yml`
that causes the job to fail on every PR, and extracts the inline Node
script to its own file to avoid the underlying structural issue.

## The bug
The step embedded a Node.js script via a heredoc inside a YAML `run: |`
block:

```bash
node <<'NODE'
...
          NODE
```

This has two constraints in direct conflict:
- YAML's block scalar requires every line to stay at or above the block's
  base indentation (10 spaces here) or the block scalar ends early.
- Bash's heredoc requires a quoted terminator (`<<'NODE'`) to have **zero**
  leading whitespace.

As written, the terminator satisfied YAML but not bash, so bash never
found the terminator, read to EOF, and fed the rest of the script into
Node's stdin — throwing a SyntaxError and failing the job.

## Fix
Moved the script to `.github/scripts/pr-scope-labels.mjs` and call it
directly with `node`, removing the heredoc (and the conflict) entirely.

## Testing
Ran the extracted script locally against both a scoped and unscoped title:

```bash
PR_TITLE="fix(app,editor): some title" node .github/scripts/pr-scope-labels.mjs
# -> s-app
#    s-editor

PR_TITLE="chore: bump deps" node .github/scripts/pr-scope-labels.mjs
# -> (no output, no scopes matched)
```

Will also confirm the `label-scope` job passes on this PR itself, since
`semantic-pr-title.yml` runs on every pull request.