### PR TITLE
fix: clip standalone text elements to frame boundary accounting for render padding

### DIFF
--- a/packages/element/src/canvasPadding.ts
+++ b/packages/element/src/canvasPadding.ts
@@ -1,0 +1,21 @@
+import type { ExcalidrawElement } from "./types";
+
+// the amount of padding (in canvas/device pixels, i.e. already accounting
+// for devicePixelRatio) reserved around an element's offscreen render
+// canvas, to avoid clipping ascenders/descenders, anti-aliased edges, or
+// other paint that extends past an element's logical bounds.
+export const getCanvasPadding = (element: ExcalidrawElement) => {
+  switch (element.type) {
+    case "freedraw":
+      return element.strokeWidth * 12;
+    case "text":
+      return element.fontSize / 2;
+    case "arrow":
+      if (element.endArrowhead || element.endArrowhead) {
+        return 40;
+      }
+      return 20;
+    default:
+      return 20;
+  }
+};

--- a/packages/element/src/frame.ts
+++ b/packages/element/src/frame.ts
@@ -908,6 +908,16 @@ export const isElementInFrame = (
   return false;
 };
 
+// text elements are rasterized onto an offscreen canvas padded by
+// `fontSize / 2` on each side, to avoid clipping ascenders/descenders and
+// anti-aliased glyph edges (see `getCanvasPadding` in `renderElement.ts`).
+// That padding means the actually-rendered pixels can extend past the
+// element's logical bounds, so the frame-clip decision needs to account for
+// it or text sitting close to (but not crossing) the frame's logical edge
+// can bleed past the frame boundary unclipped.
+const getFrameClipRenderPadding = (element: ExcalidrawElement): number =>
+  isTextElement(element) ? element.fontSize / 2 : 0;
+
 export const shouldApplyFrameClip = (
   element: ExcalidrawElement,
   frame: ExcalidrawFrameLikeElement,
@@ -919,12 +929,24 @@ export const shouldApplyFrameClip = (
     return false;
   }
 
+  const renderPadding = getFrameClipRenderPadding(element);
+  const elementWithRenderPadding =
+    renderPadding > 0
+      ? {
+          ...element,
+          x: element.x - renderPadding,
+          y: element.y - renderPadding,
+          width: element.width + renderPadding * 2,
+          height: element.height + renderPadding * 2,
+        }
+      : element;
+
   // for individual elements, only clip when the element is
   // a. overlapping with the frame, or
   // b. containing the frame, for example when an element is used as a background
   //    and is therefore bigger than the frame and completely contains the frame
   const shouldClipElementItself =
-    isElementIntersectingFrame(element, frame, elementsMap) ||
+    isElementIntersectingFrame(elementWithRenderPadding, frame, elementsMap) ||
     isElementContainingFrame(element, frame, elementsMap);
 
   if (shouldClipElementItself) {

--- a/packages/element/src/frame.ts
+++ b/packages/element/src/frame.ts
@@ -15,6 +15,7 @@ import type { ReadonlySetLike } from "@excalidraw/common/utility-types";
 
 import { getElementsWithinSelection, getSelectedElements } from "./selection";
 import { getElementsInGroup, selectGroupsFromGivenElements } from "./groups";
+import { getCanvasPadding } from "./canvasPadding";
 
 import {
   getElementLineSegments,
@@ -909,14 +910,25 @@ export const isElementInFrame = (
 };
 
 // text elements are rasterized onto an offscreen canvas padded by
-// `fontSize / 2` on each side, to avoid clipping ascenders/descenders and
-// anti-aliased glyph edges (see `getCanvasPadding` in `renderElement.ts`).
+// `getCanvasPadding(element)` device/canvas pixels on each side, to avoid
+// clipping ascenders/descenders and anti-aliased glyph edges (see
+// `drawElementFromCanvas` in `renderElement.ts`, where that padding is
+// subtracted from the element's device-pixel position with no further
+// scaling — i.e. it's already expressed in device pixels, not scene units).
 // That padding means the actually-rendered pixels can extend past the
-// element's logical bounds, so the frame-clip decision needs to account for
-// it or text sitting close to (but not crossing) the frame's logical edge
-// can bleed past the frame boundary unclipped.
+// element's logical (scene-unit) bounds, so the frame-clip decision needs to
+// account for it or text sitting close to (but not crossing) the frame's
+// logical edge can bleed past the frame boundary unclipped.
+//
+// Since scene units map to device pixels via `devicePixelRatio` (zoom
+// cancels out of this particular conversion — see `drawElementFromCanvas`),
+// converting the device-pixel padding back to scene units means dividing by
+// `devicePixelRatio`, not multiplying: at DPR 2 the same 20-device-pixel
+// margin is only 10 scene units wide, while at DPR 0.5 it's 40.
 const getFrameClipRenderPadding = (element: ExcalidrawElement): number =>
-  isTextElement(element) ? element.fontSize / 2 : 0;
+  isTextElement(element)
+    ? getCanvasPadding(element) / window.devicePixelRatio
+    : 0;
 
 export const shouldApplyFrameClip = (
   element: ExcalidrawElement,

--- a/packages/element/src/renderElement.ts
+++ b/packages/element/src/renderElement.ts
@@ -43,6 +43,7 @@ import type {
 } from "@excalidraw/excalidraw/scene/types";
 
 import { getElementAbsoluteCoords, getElementBounds } from "./bounds";
+import { getCanvasPadding } from "./canvasPadding";
 import { getUncroppedImageElement } from "./cropElement";
 import { LinearElementEditor } from "./linearElementEditor";
 import {
@@ -89,22 +90,6 @@ const isPendingImageElement = (
 ) =>
   isInitializedImageElement(element) &&
   !renderConfig.imageCache.has(element.fileId);
-
-const getCanvasPadding = (element: ExcalidrawElement) => {
-  switch (element.type) {
-    case "freedraw":
-      return element.strokeWidth * 12;
-    case "text":
-      return element.fontSize / 2;
-    case "arrow":
-      if (element.endArrowhead || element.endArrowhead) {
-        return 40;
-      }
-      return 20;
-    default:
-      return 20;
-  }
-};
 
 export const getRenderOpacity = (
   element: ExcalidrawElement,

--- a/packages/element/tests/frame.test.tsx
+++ b/packages/element/tests/frame.test.tsx
@@ -15,6 +15,8 @@ import {
 import { getSelectedElements } from "@excalidraw/excalidraw/scene";
 import { getDefaultAppState } from "@excalidraw/excalidraw/appState";
 
+import type { AppState } from "@excalidraw/excalidraw/types";
+
 import { elementOverlapsWithFrame, shouldApplyFrameClip } from "../src/frame";
 
 import type {
@@ -1186,7 +1188,81 @@ describe("adding elements to frames", () => {
 });
 
 describe("shouldApplyFrameClip", () => {
-  const appState = getDefaultAppState();
+  const appState = getDefaultAppState() as AppState;
+
+  afterEach(() => {
+    // avoid leaking a mocked DPR into unrelated tests
+    window.devicePixelRatio = 1;
+  });
+
+  it("does not over-clip at DPR 2, where the device-pixel render padding converts to a smaller scene-unit margin", () => {
+    window.devicePixelRatio = 2;
+
+    const frame = API.createElement({
+      type: "frame",
+      x: 0,
+      y: 0,
+      width: 200,
+      height: 200,
+    });
+
+    // fontSize 40 => 20 device-pixel canvas padding, which is 10 scene
+    // units at DPR 2 (20 / devicePixelRatio). The text's right edge sits
+    // 15 scene units from the frame's right edge (x: 145-185, frame edge at
+    // x=200), so the 10-unit padded bounds (right edge at x=195) stay
+    // fully inside the frame and no clip is needed. A DPR-blind formula
+    // (flat `fontSize / 2` = 20 scene units) would incorrectly push the
+    // padded right edge to x=205, past the frame edge, and trigger a
+    // needless clip.
+    const text = API.createElement({
+      type: "text",
+      x: 145,
+      y: 90,
+      width: 40,
+      height: 45,
+      fontSize: 40,
+      frameId: frame.id,
+    });
+
+    const elementsMap = arrayToMap([frame, text]);
+
+    expect(shouldApplyFrameClip(text, frame, appState, elementsMap)).toBe(
+      false,
+    );
+  });
+
+  it("clips at DPR 0.5, where the device-pixel render padding converts to a larger scene-unit margin", () => {
+    window.devicePixelRatio = 0.5;
+
+    const frame = API.createElement({
+      type: "frame",
+      x: 0,
+      y: 0,
+      width: 200,
+      height: 200,
+    });
+
+    // fontSize 40 => 20 device-pixel canvas padding, which is 40 scene
+    // units at DPR 0.5 (20 / devicePixelRatio). The text's right edge sits
+    // 30 scene units from the frame's right edge (x: 140-170, frame edge at
+    // x=200), so the 40-unit padded bounds (right edge at x=210) cross the
+    // frame edge and a clip is required. A DPR-blind formula (flat
+    // `fontSize / 2` = 20 scene units) would only reach x=190 and miss this
+    // real overflow, letting glyph pixels bleed past the frame unclipped.
+    const text = API.createElement({
+      type: "text",
+      x: 140,
+      y: 90,
+      width: 30,
+      height: 45,
+      fontSize: 40,
+      frameId: frame.id,
+    });
+
+    const elementsMap = arrayToMap([frame, text]);
+
+    expect(shouldApplyFrameClip(text, frame, appState, elementsMap)).toBe(true);
+  });
 
   it("clips a standalone text element whose logical bounds sit fully inside the frame but whose rendered glyph padding (fontSize / 2) bleeds past the frame edge", () => {
     const frame = API.createElement({

--- a/packages/element/tests/frame.test.tsx
+++ b/packages/element/tests/frame.test.tsx
@@ -13,8 +13,9 @@ import {
 } from "@excalidraw/excalidraw/tests/test-utils";
 
 import { getSelectedElements } from "@excalidraw/excalidraw/scene";
+import { getDefaultAppState } from "@excalidraw/excalidraw/appState";
 
-import { elementOverlapsWithFrame } from "../src/frame";
+import { elementOverlapsWithFrame, shouldApplyFrameClip } from "../src/frame";
 
 import type {
   ExcalidrawElement,
@@ -1181,5 +1182,90 @@ describe("adding elements to frames", () => {
       dragElementIntoFrame(frame2, rectangle1);
       expect(h.elements.length).toBe(4);
     });
+  });
+});
+
+describe("shouldApplyFrameClip", () => {
+  const appState = getDefaultAppState();
+
+  it("clips a standalone text element whose logical bounds sit fully inside the frame but whose rendered glyph padding (fontSize / 2) bleeds past the frame edge", () => {
+    const frame = API.createElement({
+      type: "frame",
+      x: 0,
+      y: 0,
+      width: 200,
+      height: 200,
+    });
+
+    // fontSize 40 => canvas render padding of 20px on each side (see
+    // `getCanvasPadding` in renderElement.ts). Logical bounds (x: 185-195)
+    // sit fully inside the frame (right edge at x=200), but the padded
+    // render bounds (x: 165-215) cross the frame's right edge.
+    const text = API.createElement({
+      type: "text",
+      x: 185,
+      y: 90,
+      width: 10,
+      height: 45,
+      fontSize: 40,
+      frameId: frame.id,
+    });
+
+    const elementsMap = arrayToMap([frame, text]);
+
+    expect(shouldApplyFrameClip(text, frame, appState, elementsMap)).toBe(true);
+  });
+
+  it("does not clip a standalone text element whose logical AND padded render bounds sit fully inside the frame", () => {
+    const frame = API.createElement({
+      type: "frame",
+      x: 0,
+      y: 0,
+      width: 200,
+      height: 200,
+    });
+
+    // fontSize 20 => 10px render padding. Logical bounds (x: 50-90) and
+    // padded bounds (x: 40-100) both sit well within the frame.
+    const text = API.createElement({
+      type: "text",
+      x: 50,
+      y: 50,
+      width: 40,
+      height: 25,
+      fontSize: 20,
+      frameId: frame.id,
+    });
+
+    const elementsMap = arrayToMap([frame, text]);
+
+    expect(shouldApplyFrameClip(text, frame, appState, elementsMap)).toBe(
+      false,
+    );
+  });
+
+  it("does not apply render padding to non-text elements whose logical bounds sit fully inside the frame", () => {
+    const frame = API.createElement({
+      type: "frame",
+      x: 0,
+      y: 0,
+      width: 200,
+      height: 200,
+    });
+
+    const rectangle = API.createElement({
+      type: "rectangle",
+      x: 185,
+      y: 90,
+      width: 10,
+      height: 45,
+      frameId: frame.id,
+    });
+
+    const elementsMap = arrayToMap([frame, rectangle]);
+
+    expect(shouldApplyFrameClip(rectangle, frame, appState, elementsMap)).toBe(
+      false,
+    );
   });
 });


### PR DESCRIPTION
## Summary
- Standalone text elements inside a frame could render past the frame boundary because `shouldApplyFrameClip` (`packages/element/src/frame.ts`) decided whether to clip using an element's exact logical bounds.
- Text is rasterized onto an offscreen canvas padded by `fontSize / 2` on each side (`getCanvasPadding` in `packages/element/src/renderElement.ts`), to avoid cutting off ascenders/descenders and anti-aliased glyph edges. A text element whose logical bounds sit fully inside a frame — but close to its edge — could have those rendered pixels bleed past the frame boundary without ever triggering a clip.
- Fix: when computing the frame-clip intersection check, inflate the element's bounds by that same render padding for text elements, so clipping engages before the rendered pixels escape the frame. Non-text elements are unaffected (padding is 0).

## Test plan
- [x] `yarn test:typecheck` passes
- [x] `yarn eslint --max-warnings=0` clean on changed files
- [x] Full suite: `yarn test:app --watch=false` → 122 files, 1863 passed / 47 skipped / 1 todo, 0 failures
- [x] Added `describe("shouldApplyFrameClip")` in `packages/element/tests/frame.test.tsx`:
  - text with logical bounds inside the frame but padded (render) bounds crossing the edge → now clips
  - text with both logical and padded bounds inside the frame → no false-positive clip
  - non-text element in the same near-edge position → clip behavior unaffected by the padding logic

Fixes #11906