### PR TITLE
docs: add macOS Yarn install note to avoid EACCES error

### DIFF
--- a/dev-docs/docs/introduction/development.mdx
+++ b/dev-docs/docs/introduction/development.mdx
@@ -16,6 +16,30 @@ These instructions will get you a copy of the project up and running on your loc
 - [Yarn](https://yarnpkg.com/getting-started/install) (v1 or v2.4.2+)
 - [Git](https://git-scm.com/downloads)
 
+### Installing Yarn on macOS
+
+On macOS, installing Yarn globally with `npm install -g yarn` can fail with a permissions error (`EACCES`). To avoid this, you can enable Yarn through Corepack (which comes with Node.js), installing it into a folder you own:
+
+```bash
+export COREPACK_HOME="$HOME/.corepack"
+mkdir -p "$HOME/.local/bin"
+corepack enable --install-directory "$HOME/.local/bin"
+export PATH="$HOME/.local/bin:$PATH"
+```
+
+To confirm Yarn is installed, run:
+
+```bash
+yarn --version
+```
+
+The `export PATH` line above only applies to your current terminal session. To make Yarn available in every new terminal, add it to your shell profile:
+
+```bash
+echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.zshrc
+```
+
+
 ### Clone the repo
 
 ```bash


### PR DESCRIPTION
### Summary of Changes

Added clear setup instructions and troubleshooting steps for installing Yarn on macOS to the development setup guide.

### Why this is needed

When setting up the project locally on macOS, I ran into a permissions error (EACCES) when installing Yarn globally with npm. Documenting the Corepack-based installation steps directly in the guide eliminates this friction for new macOS contributors and makes onboarding smoother.

### Verification

- I personally hit this EACCES error when installing Yarn on macOS during setup, and resolved it using the Corepack steps documented here.
- After running these steps, `yarn --version` returned a working Yarn install, and I was able to run the project locally.