### PR TITLE
feat(editor): adjustable corner radius for rectangles

### DIFF
--- a/packages/element/src/utils.ts
+++ b/packages/element/src/utils.ts
@@ -499,7 +499,15 @@ export const getCornerRadius = (x: number, element: ExcalidrawElement) => {
   }
 
   if (element.roundness?.type === ROUNDNESS.ADAPTIVE_RADIUS) {
-    const fixedRadiusSize = element.roundness?.value ?? DEFAULT_ADAPTIVE_RADIUS;
+    // an explicitly chosen radius (corner radius slider) is honored as-is, so
+    // that a full pill shape stays reachable. Only clamp it to a half-circle,
+    // beyond which the corners would overlap. Elements without an explicit
+    // value keep the adaptive behavior below.
+    if (element.roundness.value != null) {
+      return Math.min(element.roundness.value, x / 2);
+    }
+
+    const fixedRadiusSize = DEFAULT_ADAPTIVE_RADIUS;
 
     const CUTOFF_SIZE = fixedRadiusSize / DEFAULT_PROPORTIONAL_RADIUS;
 

--- a/packages/excalidraw/actions/actionProperties.tsx
+++ b/packages/excalidraw/actions/actionProperties.tsx
@@ -14,6 +14,7 @@ import {
   DEFAULT_FONT_SIZE,
   FONT_FAMILY,
   ROUNDNESS,
+  DEFAULT_ADAPTIVE_RADIUS,
   STROKE_WIDTH_KEYS,
   VERTICAL_ALIGN,
   KEYS,
@@ -40,6 +41,8 @@ import {
   calculateFixedPointForElbowArrowBinding,
   updateBoundElements,
 } from "@excalidraw/element";
+
+import { getCornerRadius } from "@excalidraw/element/utils";
 
 import { LinearElementEditor } from "@excalidraw/element";
 
@@ -94,6 +97,7 @@ import type { ElementUpdate, Scene } from "@excalidraw/element";
 import type { CaptureUpdateActionType } from "@excalidraw/element";
 
 import { trackEvent } from "../analytics";
+import { CheckboxItem } from "../components/CheckboxItem";
 import { RadioSelection } from "../components/RadioSelection";
 import { IconButton } from "../components/IconButton";
 import { ColorPicker } from "../components/ColorPicker/ColorPicker";
@@ -1710,6 +1714,20 @@ export const actionChangeRoundness = register<"sharp" | "round">({
       (el) => el.roundness?.type === ROUNDNESS.LEGACY,
     );
 
+    const roundnessValue = getFormValue(
+      elements,
+      app,
+      (element) =>
+        hasLegacyRoundness ? null : element.roundness ? "round" : "sharp",
+      (element) =>
+        !isArrowElement(element) && element.hasOwnProperty("roundness"),
+      (hasSelection) => (hasSelection ? null : appState.currentItemRoundness),
+    );
+
+    const showRadiusSlider =
+      roundnessValue === "round" &&
+      targetElements.some((el) => isUsingAdaptiveRadius(el.type));
+
     return (
       <fieldset>
         <legend>{t("labels.edges")}</legend>
@@ -1728,25 +1746,99 @@ export const actionChangeRoundness = register<"sharp" | "round">({
                 icon: EdgeRoundIcon,
               },
             ]}
-            value={getFormValue(
-              elements,
-              app,
-              (element) =>
-                hasLegacyRoundness
-                  ? null
-                  : element.roundness
-                  ? "round"
-                  : "sharp",
-              (element) =>
-                !isArrowElement(element) && element.hasOwnProperty("roundness"),
-              (hasSelection) =>
-                hasSelection ? null : appState.currentItemRoundness,
-            )}
+            value={roundnessValue}
             onChange={(value) => updateData(value)}
           />
           {renderAction("togglePolygon")}
         </div>
+        {showRadiusSlider && renderAction("changeCornerRadius")}
       </fieldset>
+    );
+  },
+});
+
+export const actionChangeCornerRadius = register<number | null>({
+  name: "changeCornerRadius",
+  label: "Change corner radius",
+  trackEvent: false,
+  // `null` clears the explicit radius, returning the element to the adaptive
+  // sizing that scales the radius with the shape.
+  perform: (elements, appState, value) => {
+    return {
+      elements: changeProperty(elements, appState, (el) => {
+        if (!el.roundness || !isUsingAdaptiveRadius(el.type)) {
+          return el;
+        }
+
+        return newElementWith(el, {
+          roundness:
+            value === null
+              ? { type: ROUNDNESS.ADAPTIVE_RADIUS }
+              : { type: ROUNDNESS.ADAPTIVE_RADIUS, value },
+        });
+      }),
+      appState,
+      captureUpdate: CaptureUpdateAction.IMMEDIATELY,
+    };
+  },
+  PanelComponent: ({ elements, app, updateData }) => {
+    const selectedElements = app.scene.getSelectedElements(app.state);
+
+    const adaptiveElements = selectedElements.filter(
+      (el) => el.roundness?.type === ROUNDNESS.ADAPTIVE_RADIUS,
+    );
+
+    // "adaptive" is derived rather than stored: an element is adaptive exactly
+    // when it carries no explicit radius. Dragging the slider therefore
+    // unchecks the box on its own, with no extra bookkeeping.
+    const isAdaptive =
+      adaptiveElements.length > 0 &&
+      adaptiveElements.every((el) => el.roundness?.value == null);
+
+    // Show what the canvas is currently rendering, so unchecking "adaptive"
+    // hands the slider the number the user already sees.
+    const currentRadius = Math.round(
+      adaptiveElements.reduce((acc, element) => {
+        const radius = getCornerRadius(
+          Math.min(element.width, element.height),
+          element,
+        );
+        return acc === null ? radius : Math.min(acc, radius);
+      }, null as number | null) ?? DEFAULT_ADAPTIVE_RADIUS,
+    );
+
+    // Calculate max radius (pill shape is when radius = height/2)
+    const maxRadius = Math.min(
+      200,
+      ...selectedElements.map((el) => Math.min(el.width, el.height) / 2),
+    );
+
+    // One value for both the slider bound and the label under it, rounded
+    // because the step is 1 — deriving them separately is how the number a
+    // user reads drifts from the one the track actually stops at.
+    const sliderMax = Math.round(Math.max(maxRadius, currentRadius));
+
+    return (
+      <div className="corner-radius-control">
+        <label className="control-label">{t("labels.cornerRadius")}</label>
+        <CheckboxItem
+          className="corner-radius-adaptive-toggle"
+          checked={isAdaptive}
+          onChange={(checked) => updateData(checked ? null : currentRadius)}
+        >
+          {t("labels.adaptiveCornerRadius")}
+        </CheckboxItem>
+        <Range
+          label=""
+          value={currentRadius}
+          onChange={(value) => updateData(value)}
+          min={0}
+          max={sliderMax}
+          maxLabel={sliderMax}
+          step={1}
+          testId="cornerRadius"
+        />
+      </div>
     );
   },
 });

--- a/packages/excalidraw/actions/types.ts
+++ b/packages/excalidraw/actions/types.ts
@@ -105,6 +105,7 @@ export type ActionName =
   | "goToCollaborator"
   | "addToLibrary"
   | "changeRoundness"
+  | "changeCornerRadius"
   | "alignTop"
   | "alignBottom"
   | "alignLeft"

--- a/packages/excalidraw/components/Range.scss
+++ b/packages/excalidraw/components/Range.scss
@@ -53,4 +53,12 @@
     font-size: 12px;
     color: var(--text-primary-color);
   }
+
+  .max-label {
+    position: absolute;
+    bottom: 0;
+    right: 4px;
+    font-size: 12px;
+    color: var(--text-primary-color);
+  }
 }

--- a/packages/excalidraw/components/Range.tsx
+++ b/packages/excalidraw/components/Range.tsx
@@ -10,6 +10,12 @@ export type RangeProps = {
   max?: number;
   step?: number;
   minLabel?: React.ReactNode;
+  /**
+   * Renders a fixed label at the right end of the track. Omitted by default:
+   * a slider whose range is self-evident (opacity is always 0–100) does not
+   * need one, but one whose max varies with what is selected does.
+   */
+  maxLabel?: React.ReactNode;
   hasCommonValue?: boolean;
   testId?: string;
 };
@@ -22,6 +28,7 @@ export const Range = ({
   max = 100,
   step = 10,
   minLabel = min,
+  maxLabel,
   hasCommonValue = true,
   testId,
 }: RangeProps) => {
@@ -47,6 +54,13 @@ export const Range = ({
     }
   }, [max, min, value]);
 
+  // The bubble travels with the thumb, so at either end of the track it lands
+  // on top of the fixed edge label. Hiding it at `min` is why the zero label
+  // reads cleanly; do the same at `max`, but only when a max label is actually
+  // rendered — sliders without one (opacity) must keep showing their value
+  // when they reach the top of the range.
+  const showValueBubble = value !== min && !(maxLabel != null && value === max);
+
   return (
     <label className="control-label">
       {label}
@@ -70,9 +84,10 @@ export const Range = ({
           data-testid={testId}
         />
         <div className="value-bubble" ref={valueRef}>
-          {value !== min ? value : null}
+          {showValueBubble ? value : null}
         </div>
         <div className="zero-label">{minLabel}</div>
+        {maxLabel != null && <div className="max-label">{maxLabel}</div>}
       </div>
     </label>
   );

--- a/packages/excalidraw/css/styles.scss
+++ b/packages/excalidraw/css/styles.scss
@@ -188,6 +188,55 @@ body.excalidraw-cursor-resize * {
       position: relative;
     }
 
+    .corner-radius-control {
+      // CheckboxItem is sized for the export dialog and hardcodes its blues as
+      // SCSS literals, so it neither fits this narrow panel nor follows the
+      // theme. Both are corrected here rather than in CheckboxItem.scss: that
+      // component is stock upstream and shared with the dialogs, so restyling
+      // it globally would be a far larger diff to carry across rebases.
+      .corner-radius-adaptive-toggle {
+        margin: 0 0 0.5rem;
+
+        .Checkbox-box {
+          width: 16px;
+          height: 16px;
+          margin: 0 0.5em 0 0;
+          // --color-primary* are theme-aware and are what the panel's active
+          // radio buttons (Edges, Sloppiness) already use, so the checkbox
+          // reads as part of the same control set in both themes.
+          box-shadow: 0 0 0 2px var(--color-primary);
+          color: var(--color-primary);
+
+          &:focus {
+            box-shadow: 0 0 0 3px var(--color-primary);
+          }
+
+          svg {
+            width: 12px;
+            height: 12px;
+          }
+        }
+
+        &:hover .Checkbox-box {
+          background-color: var(--color-primary-light);
+        }
+
+        &.is-checked {
+          .Checkbox-box {
+            background-color: var(--color-primary-light);
+          }
+
+          &:hover .Checkbox-box {
+            background-color: var(--color-primary-light-darker);
+          }
+        }
+
+        .Checkbox-label {
+          font-size: 0.75rem;
+        }
+      }
+    }
+
     .buttonList {
       flex-wrap: wrap;
       display: flex;

--- a/packages/excalidraw/locales/en.json
+++ b/packages/excalidraw/locales/en.json
@@ -45,6 +45,8 @@
     "edges": "Edges",
     "sharp": "Sharp",
     "round": "Round",
+    "cornerRadius": "Corner radius",
+    "adaptiveCornerRadius": "Adaptive",
     "arrowheads": "Arrowheads",
     "arrowhead_none": "None",
     "arrowhead_arrow": "Arrow",


### PR DESCRIPTION
I've wanted pill-shaped rectangles for flowchart terminators and less rounded rectangles... 

This builds on #10811 by @bmilne1981, which implements #3600. I started from that branch and ran into a few things while using it.
<p align="center">
  <img src="https://github.com/user-attachments/assets/4c6f5e39-ba21-4687-b041-f05b2dd86350" width="30%" alt="The same rectangle at 0%, at the adaptive default, and at 100%">
</p>

The middle one is today's behaviour, unchanged. That's what you get without touching the slider.

### What's here beyond #10811

**The slider can now reach a pill.** Explicit values were still going through the adaptive cutoff, so they saturated at `min(w, h) / 4`. Ask for 60 on a 120px-tall shape and you got 30. Explicit radii are now used as-is, clamped only to a half circle. Elements without a value keep the old path.

**An "Adaptive" checkbox** to get back to size-scaling once you've moved the slider. It's derived from `roundness.value == null`, so there's no new field and no format change. Moving the slider unchecks it by itself.

**The control uses the shared `Range` component**, so it matches Opacity instead of a bare `<input type="range">`.

<p align="center">
  <img src="https://github.com/user-attachments/assets/335eef04-76d6-4a8a-b8bb-e9a30db85152" width="70%" alt="The control in light and dark themes">
</p>

`Range` also gains an optional `maxLabel`. Opacity is always 0 to 100 so it needs no such thing, but this slider's ceiling moves with the selection, which seemed worth showing. Sliders that don't pass it are unchanged.

### Known quirk...

I kept the max from #10811, which is `min(200, shorter side / 2)`. That 200 means anything taller than 400px can't actually reach a pill, so the feature quietly stops working on larger shapes. I guess it would make more sense for the max to keep scaling with the shape and drop the cap altogether.

### Test plan

- [x] `yarn test:typecheck` clean
- [x] `yarn test:code` (eslint) and `yarn test:other` (prettier) clean on the changed files
- [x] `selection`, `convertElementType` and `bucketFill` suites pass, being the ones that touch roundness
- [x] Light and dark themes
- [x] The max follows the selection: 60 on a 120px-tall shape, 150 on 300px, then held at 200
- [x] Adaptive round-trips cleanly. Unchecking seeds `value` with the radius already on screen (32), so nothing moves, and rechecking clears it back to exactly `{ type: 3 }`

### How this was written

_Most of this was written with agentic AI assistance (Claude Code)._ 
I've read, run and manually tested all of it, but I'd rather say so up front than have you infer it from the commit style.

One side effect is that there are probably more inline comments than you'd normally keep, since a lot of them are the AI explaining its own reasoning. I don't know what the policy is here, so I left them in.

Happy to change any of it. If you'd rather I split the fix from the UI work, drop the styling changes, or hand it to @bmilne1981 to fold into #10811.