### PR TITLE
fix: clip patterned fills to closed shape bounds

### DIFF
--- a/packages/element/src/renderElement.ts
+++ b/packages/element/src/renderElement.ts
@@ -477,48 +477,6 @@ const applyRoughOutlineClip = (
   return didDrawPath;
 };
 
-const getFillExpansionPadding = (
-  shape: Drawable,
-  element: NonDeletedExcalidrawElement,
-) => {
-  const hachureGap =
-    typeof shape.options.hachureGap === "number" && shape.options.hachureGap > 0
-      ? shape.options.hachureGap
-      : 0;
-
-  const strokeWidth =
-    typeof element.strokeWidth === "number" ? element.strokeWidth : 1;
-
-  return Math.max(hachureGap, strokeWidth * 4, 8);
-};
-
-const expandFillSet = (
-  set: OpSet,
-  element: NonDeletedExcalidrawElement,
-  padding: number,
-) => {
-  if (!element.width || !element.height) {
-    return set;
-  }
-
-  const centerX = element.width / 2;
-  const centerY = element.height / 2;
-  const scaleX = (element.width + padding * 2) / element.width;
-  const scaleY = (element.height + padding * 2) / element.height;
-
-  return {
-    ...set,
-    ops: set.ops.map((op) => ({
-      ...op,
-      data: op.data.map((value, index) =>
-        index % 2 === 0
-          ? centerX + (value - centerX) * scaleX
-          : centerY + (value - centerY) * scaleY,
-      ),
-    })),
-  };
-};
-
 export const drawRoughShapeWithClippedFill = (
   shape: Drawable,
   element: NonDeletedExcalidrawElement,
@@ -538,10 +496,6 @@ export const drawRoughShapeWithClippedFill = (
     (set) => set.type !== "fillSketch" && set.type !== "fillPath",
   );
 
-  const expandedFillSets = fillSets.map((set) =>
-    expandFillSet(set, element, getFillExpansionPadding(shape, element)),
-  );
-
   context.save();
   if (element.type === "ellipse") {
     if (!applyRoughOutlineClip(nonFillSets, context)) {
@@ -550,7 +504,7 @@ export const drawRoughShapeWithClippedFill = (
   } else {
     applyShapeFillClip(element, context);
   }
-  rc.draw({ ...shape, sets: expandedFillSets });
+  rc.draw({ ...shape, sets: fillSets });
   context.restore();
 
   if (nonFillSets.length) {

--- a/packages/element/src/renderElement.ts
+++ b/packages/element/src/renderElement.ts
@@ -42,7 +42,11 @@ import type {
   InteractiveCanvasRenderConfig,
 } from "@excalidraw/excalidraw/scene/types";
 
-import { getElementAbsoluteCoords, getElementBounds } from "./bounds";
+import {
+  getDiamondPoints,
+  getElementAbsoluteCoords,
+  getElementBounds,
+} from "./bounds";
 import { getUncroppedImageElement } from "./cropElement";
 import { LinearElementEditor } from "./linearElementEditor";
 import {
@@ -82,6 +86,7 @@ import type {
 } from "./types";
 
 import type { RoughCanvas } from "roughjs/bin/canvas";
+import type { Drawable, OpSet } from "roughjs/bin/core";
 
 const isPendingImageElement = (
   element: ExcalidrawElement,
@@ -315,6 +320,244 @@ const drawImagePlaceholder = (
   );
 };
 
+const applyShapeFillClip = (
+  element: NonDeletedExcalidrawElement,
+  context: CanvasRenderingContext2D,
+) => {
+  context.beginPath();
+
+  switch (element.type) {
+    case "rectangle":
+    case "iframe":
+    case "embeddable": {
+      const radius = getCornerRadius(
+        Math.min(element.width, element.height),
+        element,
+      );
+      if (radius && context.roundRect) {
+        context.roundRect(0, 0, element.width, element.height, radius);
+      } else {
+        context.rect(0, 0, element.width, element.height);
+      }
+      break;
+    }
+    case "diamond": {
+      const [topX, topY, rightX, rightY, bottomX, bottomY, leftX, leftY] =
+        getDiamondPoints(element);
+
+      if (element.roundness) {
+        const verticalRadius = getCornerRadius(Math.abs(topX - leftX), element);
+        const horizontalRadius = getCornerRadius(
+          Math.abs(rightY - topY),
+          element,
+        );
+
+        context.moveTo(topX + verticalRadius, topY + horizontalRadius);
+        context.lineTo(rightX - verticalRadius, rightY - horizontalRadius);
+        context.bezierCurveTo(
+          rightX,
+          rightY,
+          rightX,
+          rightY,
+          rightX - verticalRadius,
+          rightY + horizontalRadius,
+        );
+        context.lineTo(bottomX + verticalRadius, bottomY - horizontalRadius);
+        context.bezierCurveTo(
+          bottomX,
+          bottomY,
+          bottomX,
+          bottomY,
+          bottomX - verticalRadius,
+          bottomY - horizontalRadius,
+        );
+        context.lineTo(leftX + verticalRadius, leftY + horizontalRadius);
+        context.bezierCurveTo(
+          leftX,
+          leftY,
+          leftX,
+          leftY,
+          leftX + verticalRadius,
+          leftY - horizontalRadius,
+        );
+        context.lineTo(topX - verticalRadius, topY + horizontalRadius);
+        context.bezierCurveTo(
+          topX,
+          topY,
+          topX,
+          topY,
+          topX + verticalRadius,
+          topY + horizontalRadius,
+        );
+        context.closePath();
+        break;
+      }
+
+      context.moveTo(topX, topY);
+      context.lineTo(rightX, rightY);
+      context.lineTo(bottomX, bottomY);
+      context.lineTo(leftX, leftY);
+      context.closePath();
+      break;
+    }
+    case "ellipse": {
+      context.ellipse(
+        element.width / 2,
+        element.height / 2,
+        Math.abs(element.width / 2),
+        Math.abs(element.height / 2),
+        0,
+        0,
+        Math.PI * 2,
+      );
+      break;
+    }
+    default:
+      return;
+  }
+
+  context.clip();
+};
+
+const applyRoughOutlineClip = (
+  sets: OpSet[],
+  context: CanvasRenderingContext2D,
+) => {
+  let didDrawPath = false;
+
+  context.beginPath();
+
+  for (const set of sets) {
+    if (set.type !== "path") {
+      continue;
+    }
+
+    let pathStarted = false;
+
+    for (const item of set.ops) {
+      const data = item.data;
+
+      switch (item.op) {
+        case "move": {
+          if (pathStarted) {
+            context.closePath();
+          }
+          context.moveTo(data[0], data[1]);
+          pathStarted = true;
+          didDrawPath = true;
+          break;
+        }
+        case "lineTo": {
+          context.lineTo(data[0], data[1]);
+          break;
+        }
+        case "bcurveTo": {
+          context.bezierCurveTo(
+            data[0],
+            data[1],
+            data[2],
+            data[3],
+            data[4],
+            data[5],
+          );
+          break;
+        }
+      }
+    }
+
+    if (pathStarted) {
+      context.closePath();
+    }
+  }
+
+  if (didDrawPath) {
+    context.clip();
+  }
+
+  return didDrawPath;
+};
+
+const getFillExpansionPadding = (
+  shape: Drawable,
+  element: NonDeletedExcalidrawElement,
+) => {
+  const hachureGap =
+    typeof shape.options.hachureGap === "number" && shape.options.hachureGap > 0
+      ? shape.options.hachureGap
+      : 0;
+
+  const strokeWidth =
+    typeof element.strokeWidth === "number" ? element.strokeWidth : 1;
+
+  return Math.max(hachureGap, strokeWidth * 4, 8);
+};
+
+const expandFillSet = (
+  set: OpSet,
+  element: NonDeletedExcalidrawElement,
+  padding: number,
+) => {
+  if (!element.width || !element.height) {
+    return set;
+  }
+
+  const centerX = element.width / 2;
+  const centerY = element.height / 2;
+  const scaleX = (element.width + padding * 2) / element.width;
+  const scaleY = (element.height + padding * 2) / element.height;
+
+  return {
+    ...set,
+    ops: set.ops.map((op) => ({
+      ...op,
+      data: op.data.map((value, index) =>
+        index % 2 === 0
+          ? centerX + (value - centerX) * scaleX
+          : centerY + (value - centerY) * scaleY,
+      ),
+    })),
+  };
+};
+
+export const drawRoughShapeWithClippedFill = (
+  shape: Drawable,
+  element: NonDeletedExcalidrawElement,
+  rc: RoughCanvas,
+  context: CanvasRenderingContext2D,
+) => {
+  const fillSets = shape.sets.filter(
+    (set) => set.type === "fillSketch" || set.type === "fillPath",
+  );
+
+  if (!fillSets.length) {
+    rc.draw(shape);
+    return;
+  }
+
+  const nonFillSets = shape.sets.filter(
+    (set) => set.type !== "fillSketch" && set.type !== "fillPath",
+  );
+
+  const expandedFillSets = fillSets.map((set) =>
+    expandFillSet(set, element, getFillExpansionPadding(shape, element)),
+  );
+
+  context.save();
+  if (element.type === "ellipse") {
+    if (!applyRoughOutlineClip(nonFillSets, context)) {
+      applyShapeFillClip(element, context);
+    }
+  } else {
+    applyShapeFillClip(element, context);
+  }
+  rc.draw({ ...shape, sets: expandedFillSets });
+  context.restore();
+
+  if (nonFillSets.length) {
+    rc.draw({ ...shape, sets: nonFillSets });
+  }
+};
+
 const drawElementOnCanvas = (
   element: NonDeletedExcalidrawElement,
   rc: RoughCanvas,
@@ -330,7 +573,12 @@ const drawElementOnCanvas = (
       context.lineJoin = "round";
       context.lineCap = "round";
 
-      rc.draw(ShapeCache.generateElementShape(element, renderConfig));
+      drawRoughShapeWithClippedFill(
+        ShapeCache.generateElementShape(element, renderConfig),
+        element,
+        rc,
+        context,
+      );
       break;
     }
     case "arrow":

--- a/packages/element/src/renderElement.ts
+++ b/packages/element/src/renderElement.ts
@@ -46,7 +46,11 @@ import type {
   InteractiveCanvasRenderConfig,
 } from "@excalidraw/excalidraw/scene/types";
 
-import { getElementAbsoluteCoords, getElementBounds } from "./bounds";
+import {
+  getDiamondPoints,
+  getElementAbsoluteCoords,
+  getElementBounds,
+} from "./bounds";
 import { getUncroppedImageElement } from "./cropElement";
 import { LinearElementEditor } from "./linearElementEditor";
 import {
@@ -91,6 +95,7 @@ import type {
 } from "./types";
 
 import type { RoughCanvas } from "roughjs/bin/canvas";
+import type { Drawable, OpSet } from "roughjs/bin/core";
 
 const isPendingImageElement = (
   element: ExcalidrawElement,
@@ -368,6 +373,244 @@ const strokeStickyNoteEdge = (
   context.restore();
 };
 
+const applyShapeFillClip = (
+  element: NonDeletedExcalidrawElement,
+  context: CanvasRenderingContext2D,
+) => {
+  context.beginPath();
+
+  switch (element.type) {
+    case "rectangle":
+    case "iframe":
+    case "embeddable": {
+      const radius = getCornerRadius(
+        Math.min(element.width, element.height),
+        element,
+      );
+      if (radius && context.roundRect) {
+        context.roundRect(0, 0, element.width, element.height, radius);
+      } else {
+        context.rect(0, 0, element.width, element.height);
+      }
+      break;
+    }
+    case "diamond": {
+      const [topX, topY, rightX, rightY, bottomX, bottomY, leftX, leftY] =
+        getDiamondPoints(element);
+
+      if (element.roundness) {
+        const verticalRadius = getCornerRadius(Math.abs(topX - leftX), element);
+        const horizontalRadius = getCornerRadius(
+          Math.abs(rightY - topY),
+          element,
+        );
+
+        context.moveTo(topX + verticalRadius, topY + horizontalRadius);
+        context.lineTo(rightX - verticalRadius, rightY - horizontalRadius);
+        context.bezierCurveTo(
+          rightX,
+          rightY,
+          rightX,
+          rightY,
+          rightX - verticalRadius,
+          rightY + horizontalRadius,
+        );
+        context.lineTo(bottomX + verticalRadius, bottomY - horizontalRadius);
+        context.bezierCurveTo(
+          bottomX,
+          bottomY,
+          bottomX,
+          bottomY,
+          bottomX - verticalRadius,
+          bottomY - horizontalRadius,
+        );
+        context.lineTo(leftX + verticalRadius, leftY + horizontalRadius);
+        context.bezierCurveTo(
+          leftX,
+          leftY,
+          leftX,
+          leftY,
+          leftX + verticalRadius,
+          leftY - horizontalRadius,
+        );
+        context.lineTo(topX - verticalRadius, topY + horizontalRadius);
+        context.bezierCurveTo(
+          topX,
+          topY,
+          topX,
+          topY,
+          topX + verticalRadius,
+          topY + horizontalRadius,
+        );
+        context.closePath();
+        break;
+      }
+
+      context.moveTo(topX, topY);
+      context.lineTo(rightX, rightY);
+      context.lineTo(bottomX, bottomY);
+      context.lineTo(leftX, leftY);
+      context.closePath();
+      break;
+    }
+    case "ellipse": {
+      context.ellipse(
+        element.width / 2,
+        element.height / 2,
+        Math.abs(element.width / 2),
+        Math.abs(element.height / 2),
+        0,
+        0,
+        Math.PI * 2,
+      );
+      break;
+    }
+    default:
+      return;
+  }
+
+  context.clip();
+};
+
+const applyRoughOutlineClip = (
+  sets: OpSet[],
+  context: CanvasRenderingContext2D,
+) => {
+  let didDrawPath = false;
+
+  context.beginPath();
+
+  for (const set of sets) {
+    if (set.type !== "path") {
+      continue;
+    }
+
+    let pathStarted = false;
+
+    for (const item of set.ops) {
+      const data = item.data;
+
+      switch (item.op) {
+        case "move": {
+          if (pathStarted) {
+            context.closePath();
+          }
+          context.moveTo(data[0], data[1]);
+          pathStarted = true;
+          didDrawPath = true;
+          break;
+        }
+        case "lineTo": {
+          context.lineTo(data[0], data[1]);
+          break;
+        }
+        case "bcurveTo": {
+          context.bezierCurveTo(
+            data[0],
+            data[1],
+            data[2],
+            data[3],
+            data[4],
+            data[5],
+          );
+          break;
+        }
+      }
+    }
+
+    if (pathStarted) {
+      context.closePath();
+    }
+  }
+
+  if (didDrawPath) {
+    context.clip();
+  }
+
+  return didDrawPath;
+};
+
+const getFillExpansionPadding = (
+  shape: Drawable,
+  element: NonDeletedExcalidrawElement,
+) => {
+  const hachureGap =
+    typeof shape.options.hachureGap === "number" && shape.options.hachureGap > 0
+      ? shape.options.hachureGap
+      : 0;
+
+  const strokeWidth =
+    typeof element.strokeWidth === "number" ? element.strokeWidth : 1;
+
+  return Math.max(hachureGap, strokeWidth * 4, 8);
+};
+
+const expandFillSet = (
+  set: OpSet,
+  element: NonDeletedExcalidrawElement,
+  padding: number,
+) => {
+  if (!element.width || !element.height) {
+    return set;
+  }
+
+  const centerX = element.width / 2;
+  const centerY = element.height / 2;
+  const scaleX = (element.width + padding * 2) / element.width;
+  const scaleY = (element.height + padding * 2) / element.height;
+
+  return {
+    ...set,
+    ops: set.ops.map((op) => ({
+      ...op,
+      data: op.data.map((value, index) =>
+        index % 2 === 0
+          ? centerX + (value - centerX) * scaleX
+          : centerY + (value - centerY) * scaleY,
+      ),
+    })),
+  };
+};
+
+export const drawRoughShapeWithClippedFill = (
+  shape: Drawable,
+  element: NonDeletedExcalidrawElement,
+  rc: RoughCanvas,
+  context: CanvasRenderingContext2D,
+) => {
+  const fillSets = shape.sets.filter(
+    (set) => set.type === "fillSketch" || set.type === "fillPath",
+  );
+
+  if (!fillSets.length) {
+    rc.draw(shape);
+    return;
+  }
+
+  const nonFillSets = shape.sets.filter(
+    (set) => set.type !== "fillSketch" && set.type !== "fillPath",
+  );
+
+  const expandedFillSets = fillSets.map((set) =>
+    expandFillSet(set, element, getFillExpansionPadding(shape, element)),
+  );
+
+  context.save();
+  if (element.type === "ellipse") {
+    if (!applyRoughOutlineClip(nonFillSets, context)) {
+      applyShapeFillClip(element, context);
+    }
+  } else {
+    applyShapeFillClip(element, context);
+  }
+  rc.draw({ ...shape, sets: expandedFillSets });
+  context.restore();
+
+  if (nonFillSets.length) {
+    rc.draw({ ...shape, sets: nonFillSets });
+  }
+};
+
 const drawElementOnCanvas = (
   element: NonDeletedExcalidrawElement,
   rc: RoughCanvas,
@@ -418,7 +661,12 @@ const drawElementOnCanvas = (
       context.lineJoin = "round";
       context.lineCap = "round";
 
-      rc.draw(ShapeCache.generateElementShape(element, renderConfig));
+      drawRoughShapeWithClippedFill(
+        ShapeCache.generateElementShape(element, renderConfig),
+        element,
+        rc,
+        context,
+      );
       break;
     }
     case "arrow":

--- a/packages/element/src/renderElement.ts
+++ b/packages/element/src/renderElement.ts
@@ -530,48 +530,6 @@ const applyRoughOutlineClip = (
   return didDrawPath;
 };
 
-const getFillExpansionPadding = (
-  shape: Drawable,
-  element: NonDeletedExcalidrawElement,
-) => {
-  const hachureGap =
-    typeof shape.options.hachureGap === "number" && shape.options.hachureGap > 0
-      ? shape.options.hachureGap
-      : 0;
-
-  const strokeWidth =
-    typeof element.strokeWidth === "number" ? element.strokeWidth : 1;
-
-  return Math.max(hachureGap, strokeWidth * 4, 8);
-};
-
-const expandFillSet = (
-  set: OpSet,
-  element: NonDeletedExcalidrawElement,
-  padding: number,
-) => {
-  if (!element.width || !element.height) {
-    return set;
-  }
-
-  const centerX = element.width / 2;
-  const centerY = element.height / 2;
-  const scaleX = (element.width + padding * 2) / element.width;
-  const scaleY = (element.height + padding * 2) / element.height;
-
-  return {
-    ...set,
-    ops: set.ops.map((op) => ({
-      ...op,
-      data: op.data.map((value, index) =>
-        index % 2 === 0
-          ? centerX + (value - centerX) * scaleX
-          : centerY + (value - centerY) * scaleY,
-      ),
-    })),
-  };
-};
-
 export const drawRoughShapeWithClippedFill = (
   shape: Drawable,
   element: NonDeletedExcalidrawElement,
@@ -591,10 +549,6 @@ export const drawRoughShapeWithClippedFill = (
     (set) => set.type !== "fillSketch" && set.type !== "fillPath",
   );
 
-  const expandedFillSets = fillSets.map((set) =>
-    expandFillSet(set, element, getFillExpansionPadding(shape, element)),
-  );
-
   context.save();
   if (element.type === "ellipse") {
     if (!applyRoughOutlineClip(nonFillSets, context)) {
@@ -603,7 +557,7 @@ export const drawRoughShapeWithClippedFill = (
   } else {
     applyShapeFillClip(element, context);
   }
-  rc.draw({ ...shape, sets: expandedFillSets });
+  rc.draw({ ...shape, sets: fillSets });
   context.restore();
 
   if (nonFillSets.length) {

--- a/packages/element/tests/renderElement.test.ts
+++ b/packages/element/tests/renderElement.test.ts
@@ -107,12 +107,9 @@ describe("drawRoughShapeWithClippedFill", () => {
     ]);
     expect(rc.draw).toHaveBeenCalledTimes(2);
     expect(vi.mocked(rc.draw).mock.calls[0][0].sets[0].type).toBe("fillSketch");
-    expect(
-      vi.mocked(rc.draw).mock.calls[0][0].sets[0].ops[0].data[0],
-    ).toBeCloseTo(13.6);
-    expect(
-      vi.mocked(rc.draw).mock.calls[0][0].sets[0].ops[0].data[1],
-    ).toBeCloseTo(15.2);
+    // fill geometry must reach the canvas untouched - the clip constrains what
+    // is visible, it must not move the strokes
+    expect(vi.mocked(rc.draw).mock.calls[0][0].sets[0]).toEqual(fillSketchSet);
     expect(vi.mocked(rc.draw).mock.calls[1][0].sets).toEqual([outlineSet]);
   });
 
@@ -136,12 +133,9 @@ describe("drawRoughShapeWithClippedFill", () => {
     ]);
     expect(rc.draw).toHaveBeenCalledTimes(2);
     expect(vi.mocked(rc.draw).mock.calls[0][0].sets[0].type).toBe("fillPath");
-    expect(
-      vi.mocked(rc.draw).mock.calls[0][0].sets[0].ops[0].data[0],
-    ).toBeCloseTo(13.6);
-    expect(
-      vi.mocked(rc.draw).mock.calls[0][0].sets[0].ops[0].data[1],
-    ).toBeCloseTo(15.2);
+    // fill geometry must reach the canvas untouched - the clip constrains what
+    // is visible, it must not move the strokes
+    expect(vi.mocked(rc.draw).mock.calls[0][0].sets[0]).toEqual(fillPathSet);
     expect(vi.mocked(rc.draw).mock.calls[1][0].sets).toEqual([outlineSet]);
   });
 

--- a/packages/element/tests/renderElement.test.ts
+++ b/packages/element/tests/renderElement.test.ts
@@ -1,0 +1,184 @@
+import { vi } from "vitest";
+
+import { drawRoughShapeWithClippedFill } from "../src/renderElement";
+
+import type { NonDeletedExcalidrawElement } from "../src/types";
+import type { RoughCanvas } from "roughjs/bin/canvas";
+import type { Drawable, OpSet } from "roughjs/bin/core";
+
+const createRectangleElement = () =>
+  ({
+    type: "rectangle",
+    width: 200,
+    height: 100,
+    roundness: null,
+    strokeWidth: 1,
+  } as NonDeletedExcalidrawElement);
+
+const createEllipseElement = () =>
+  ({
+    type: "ellipse",
+    width: 200,
+    height: 100,
+    roundness: null,
+    strokeWidth: 1,
+  } as NonDeletedExcalidrawElement);
+
+const createContext = () => {
+  const calls: string[] = [];
+
+  const context = {
+    save: vi.fn(() => calls.push("save")),
+    beginPath: vi.fn(() => calls.push("beginPath")),
+    moveTo: vi.fn(() => calls.push("moveTo")),
+    lineTo: vi.fn(() => calls.push("lineTo")),
+    bezierCurveTo: vi.fn(() => calls.push("bezierCurveTo")),
+    closePath: vi.fn(() => calls.push("closePath")),
+    rect: vi.fn(() => calls.push("rect")),
+    clip: vi.fn(() => calls.push("clip")),
+    restore: vi.fn(() => calls.push("restore")),
+  } as unknown as CanvasRenderingContext2D;
+
+  return { context, calls };
+};
+
+const createRoughCanvas = (calls: string[]) => {
+  const draw = vi.fn((drawable: Drawable) => {
+    calls.push(`draw:${drawable.sets.map((set) => set.type).join(",")}`);
+  });
+
+  return { draw } as unknown as RoughCanvas;
+};
+
+const createShape = (sets: OpSet[]): Drawable =>
+  ({
+    shape: "rectangle",
+    sets,
+    options: { hachureGap: 8 },
+  } as Drawable);
+
+const createFillSketchSet = () =>
+  ({
+    type: "fillSketch",
+    ops: [
+      { op: "move", data: [20, 20] },
+      { op: "lineTo", data: [180, 80] },
+    ],
+  } as OpSet);
+
+const createFillPathSet = () =>
+  ({
+    type: "fillPath",
+    ops: [
+      { op: "move", data: [20, 20] },
+      { op: "lineTo", data: [180, 80] },
+    ],
+  } as OpSet);
+
+const createOutlineSet = () =>
+  ({
+    type: "path",
+    ops: [
+      { op: "move", data: [-2, 0] },
+      { op: "lineTo", data: [202, 0] },
+      { op: "bcurveTo", data: [204, 20, 204, 80, 202, 100] },
+      { op: "lineTo", data: [-2, 100] },
+    ],
+  } as OpSet);
+
+describe("drawRoughShapeWithClippedFill", () => {
+  it("clips patterned fillSketch sets before drawing the outline", () => {
+    const fillSketchSet = createFillSketchSet();
+    const outlineSet = createOutlineSet();
+    const shape = createShape([fillSketchSet, outlineSet]);
+    const { context, calls } = createContext();
+    const rc = createRoughCanvas(calls);
+
+    drawRoughShapeWithClippedFill(shape, createRectangleElement(), rc, context);
+
+    expect(calls).toEqual([
+      "save",
+      "beginPath",
+      "rect",
+      "clip",
+      "draw:fillSketch",
+      "restore",
+      "draw:path",
+    ]);
+    expect(rc.draw).toHaveBeenCalledTimes(2);
+    expect(vi.mocked(rc.draw).mock.calls[0][0].sets[0].type).toBe("fillSketch");
+    expect(
+      vi.mocked(rc.draw).mock.calls[0][0].sets[0].ops[0].data[0],
+    ).toBeCloseTo(13.6);
+    expect(
+      vi.mocked(rc.draw).mock.calls[0][0].sets[0].ops[0].data[1],
+    ).toBeCloseTo(15.2);
+    expect(vi.mocked(rc.draw).mock.calls[1][0].sets).toEqual([outlineSet]);
+  });
+
+  it("clips solid fillPath sets before drawing the outline", () => {
+    const fillPathSet = createFillPathSet();
+    const outlineSet = createOutlineSet();
+    const shape = createShape([fillPathSet, outlineSet]);
+    const { context, calls } = createContext();
+    const rc = createRoughCanvas(calls);
+
+    drawRoughShapeWithClippedFill(shape, createRectangleElement(), rc, context);
+
+    expect(calls).toEqual([
+      "save",
+      "beginPath",
+      "rect",
+      "clip",
+      "draw:fillPath",
+      "restore",
+      "draw:path",
+    ]);
+    expect(rc.draw).toHaveBeenCalledTimes(2);
+    expect(vi.mocked(rc.draw).mock.calls[0][0].sets[0].type).toBe("fillPath");
+    expect(
+      vi.mocked(rc.draw).mock.calls[0][0].sets[0].ops[0].data[0],
+    ).toBeCloseTo(13.6);
+    expect(
+      vi.mocked(rc.draw).mock.calls[0][0].sets[0].ops[0].data[1],
+    ).toBeCloseTo(15.2);
+    expect(vi.mocked(rc.draw).mock.calls[1][0].sets).toEqual([outlineSet]);
+  });
+
+  it("uses the rough outline for ellipse fill clipping", () => {
+    const fillSketchSet = createFillSketchSet();
+    const outlineSet = createOutlineSet();
+    const shape = createShape([fillSketchSet, outlineSet]);
+    const { context, calls } = createContext();
+    const rc = createRoughCanvas(calls);
+
+    drawRoughShapeWithClippedFill(shape, createEllipseElement(), rc, context);
+
+    expect(calls).toEqual([
+      "save",
+      "beginPath",
+      "moveTo",
+      "lineTo",
+      "bezierCurveTo",
+      "lineTo",
+      "closePath",
+      "clip",
+      "draw:fillSketch",
+      "restore",
+      "draw:path",
+    ]);
+  });
+
+  it("draws shapes without fill sets in one pass", () => {
+    const outlineSet = { type: "path", ops: [] } as OpSet;
+    const shape = createShape([outlineSet]);
+    const { context, calls } = createContext();
+    const rc = createRoughCanvas(calls);
+
+    drawRoughShapeWithClippedFill(shape, createRectangleElement(), rc, context);
+
+    expect(calls).toEqual(["draw:path"]);
+    expect(rc.draw).toHaveBeenCalledWith(shape);
+    expect(context.clip).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Fixes #5990

At Artist and Cartoonist sloppiness, hachure and cross-hatch fill strokes can render outside the shape they are filling. This is reproducible on rectangles, diamonds, and ellipses, and it also affects PNG export because export renders through the same canvas path.

<img width="1460" height="2058" alt="figure-1-containment" src="https://github.com/user-attachments/assets/397656e7-e392-4b73-91a2-ddc999b4e538" />


Red dashed line is the shape's true boundary. Both columns use identical RoughJS drawable geometry and seed; only the fill layer's clipping differs. The 4x detail at the bottom shows the issue most clearly.

## Cause

RoughJS emits the protruding geometry itself: the perturbation it applies to fill stroke endpoints and Bezier control points is not constrained to the shape being filled. Excalidraw then draws that drawable as-is, so the overflow reaches the canvas.

Measured on raw RoughJS `fillSketch` / `fillPath` output before Excalidraw paints anything, using a 200x120 element, fixed seed, and the options produced by `generateRoughOptions` (`fillWeight: strokeWidth / 2`, `hachureGap: strokeWidth * 4`):

| shape | fill | roughness 0 | roughness 1 | roughness 2 |
|---|---:|---:|---:|---:|
| rectangle | hachure | 0.63 px | 2.33 px | 4.08 px |
| rectangle | cross-hatch | 0.86 px | 2.33 px | 4.08 px |
| diamond | hachure | 0.95 px | 3.41 px | 6.01 px |
| diamond | cross-hatch | 0.95 px | 3.41 px | 6.01 px |
| ellipse | hachure | 0.98 px | 2.00 px | 4.25 px |
| ellipse | cross-hatch | 0.98 px | 2.30 px | 4.70 px |
| ellipse | solid | 0.03 px | 1.97 px | 4.74 px |
| diamond | solid | 0.00 px | 0.84 px | 1.68 px |

Solid fill is affected too on diamonds and ellipses, which is why `fillPath` is handled alongside `fillSketch`.

## Approach

This constrains the fill layer at the Excalidraw drawing layer rather than changing how RoughJS generates the sketch. In `drawElementOnCanvas`, the drawable is split into fill sets (`fillSketch`, `fillPath`) and outline sets. The canvas is clipped to the shape boundary, only the fill is drawn inside that clip, then the canvas state is restored and the rough outline is drawn unclipped.

- Rectangle / iframe / embeddable: `rect`, or `roundRect` when the element is rounded
- Diamond: path clip mirroring the `getDiamondPoints` and cubic-corner geometry in `shape.ts`
- Ellipse: clipped to the rough outline path, so the fill stays inside the stroke that is actually drawn

Shapes with no fill sets take the original single-`rc.draw` path unchanged.

Fill geometry itself is passed through untouched. The clip is the only thing constraining it, so fill density is identical to current master. This keeps RoughJS generation untouched too: same seed, same outline, same hand-drawn character. Only the visibility of the fill layer changes.

## Alternatives considered

- **Patching RoughJS**: closest to the source, but changes behavior for every consumer and needs an upstream release before Excalidraw can ship anything.
- **Reducing fill roughness**: a one-line change, but it weakens the Artist/Cartoonist look and still does not guarantee containment.
- **Forcing `preserveVertices`**: pins vertices but leaves Bezier control points free, so bowing can still escape.
- **Clamping coordinates**: fragile on curves and produces visible distortion.

## Testing

- `yarn test:typecheck` - pass
- `yarn test:code` - pass
- `yarn test:other` - pass
- `yarn test:app --watch=false` - 1864 tests across 123 files, no failures
- New unit tests in `packages/element/tests/renderElement.test.ts` covering the fill/outline split, the clip, the no-fill passthrough, and that fill geometry reaches the canvas unmodified
- Painted-pixel fill coverage sampled on canvas across element sizes from 24x24 up to 200x120 matches master exactly, confirming the clip removes the overflow without thinning the fill

<details>
<summary>Deterministic repro scene</summary>

Paste in the devtools console on a dev build:

```js
const els = ["rectangle", "diamond", "ellipse"].flatMap((type, r) =>
  ["hachure", "cross-hatch", "solid"].map((fillStyle, c) => ({
    id: "el-" + type + "-" + fillStyle,
    type,
    x: 80 + c * 260,
    y: 60 + r * 175,
    width: 200,
    height: 120,
    angle: 0,
    strokeColor: "#1e1e1e",
    backgroundColor: "#4dabf7",
    fillStyle,
    strokeWidth: 1,
    strokeStyle: "solid",
    roughness: 2,
    opacity: 100,
    groupIds: [],
    frameId: null,
    roundness: null,
    seed: 12345 + (r * 3 + c) * 7,
    version: 1,
    versionNonce: 1000 + r * 3 + c,
    isDeleted: false,
    boundElements: null,
    updated: 1,
    link: null,
    locked: false,
    index: "a" + (r * 3 + c),
  })),
);
h.app.updateScene({ elements: els, captureUpdate: "IMMEDIATELY" });
```

</details>

## Why there are two commits

The first commit scaled fill geometry outward slightly before clipping it, on the theory that clipped strokes would otherwise stop short of the edge. Reviewing it against fixed-seed renders showed that was wrong on both counts: the clip alone already contains the fill, and the expansion measurably thinned it.

<img width="1998" height="1888" alt="figure-2-fill-expansion" src="https://github.com/user-attachments/assets/06bd0e55-b004-4264-9c74-3d35f6230bf9" />


Left: current master. Middle: after the first commit. Right: after the second. Percentages are measured painted-pixel coverage of the inner 70% of each rectangle.

`getFillExpansionPadding()` returned `max(hachureGap, strokeWidth * 4, 8)`, but `generateRoughOptions` already sets `hachureGap = strokeWidth * 4`, so at the default `strokeWidth: 1` the padding was the `8` floor, twice the hachure gap. Because the scale factor is `(w + 2 * padding) / w`, the distortion grew as shapes shrank: 1.08x on a 200px shape but 1.67x on a 24px one. `scaleX` and `scaleY` also differ on non-square shapes, which sheared the hachure angle.

| element | master | first commit | second commit |
|---|---:|---:|---:|
| 24x24 | 28.4% | 18.1% | 28.4% |
| 40x30 | 34.4% | 24.8% | 34.4% |
| 60x45 | 38.5% | 31.6% | 38.5% |
| 100x70 | 38.0% | 34.4% | 38.0% |

The second commit removes the expansion, restoring master's fill density while the fill still stops at the boundary. The net effect of this PR is the right-hand column: the expansion does not survive into the final diff against master. The two commits are kept separate so the reasoning stays visible; they can be squashed on merge if maintainers prefer.

`adjustRoughness()` reduces roughness on small shapes, so 24x24 and 40x30 render at roughness 1, not 2. The thinning was caused by the expansion, not by roughness.

## Notes for reviewers

Two deliberate choices are worth flagging, and both can be adjusted if maintainers prefer a different tradeoff.

**Ellipse clips to the rough outline, rectangle and diamond clip to the logical shape.** For rectangles and diamonds the logical geometry is exact, so clipping to it is unambiguous. A rough ellipse can wander noticeably from its ideal path, and clipping the fill to the ideal ellipse left a visible gap between the fill and the stroke where the stroke bows outward. Clipping to the drawn outline avoids that, at the cost of two different rules. It means ellipse fill can still sit slightly outside the ideal ellipse, up to wherever the stroke wanders.

**Rounded rectangles use `context.roundRect()` for the clip.** This produces circular arc corners, while `shape.ts` builds the rounded rectangle path with quadratic `Q` curves. The two are close but not identical, so a very thin sliver of fill can fall outside the clip right at a rounded corner. The diamond clip mirrors `shape.ts` exactly; the rectangle case could be aligned the same way if preferred.

## Scope

Deliberately narrow: closed shapes and their fill layer only.

- Canvas rendering and PNG export are covered. PNG export goes through `exportToCanvas` -> `renderStaticScene` -> `drawElementOnCanvas`.
- SVG export is not covered. `staticSvgScene.ts` draws the drawable through `roughSVGDrawWithPrecision` with no `clipPath`, so `exportToSvg` still shows the overflow. I can follow up with the SVG `clipPath` equivalent in a separate PR, or fold it into this one if maintainers would rather have canvas and SVG land together.
- Lines, arrows, and freedraw are untouched.

Happy to adjust the approach if maintainers would prefer this solved somewhere else in the pipeline.
