### PR TITLE
fix(editor): correct x position for arrow's end-bound text label

### DIFF
--- a/packages/element/src/__tests__/__snapshots__/transform.test.ts.snap
+++ b/packages/element/src/__tests__/__snapshots__/transform.test.ts.snap
@@ -324,7 +324,7 @@ exports[`Test Transform > Test arrow bindings > should bind arrows to existing t
   "versionNonce": Any<Number>,
   "verticalAlign": "top",
   "width": 100,
-  "x": 560,
+  "x": 355,
   "y": 226.5,
 }
 `;
@@ -345,7 +345,7 @@ exports[`Test Transform > Test arrow bindings > should bind arrows to existing t
   "endBinding": {
     "elementId": "text-2",
     "fixedPoint": [
-      -2.05,
+      0,
       0.5001,
     ],
     "mode": "orbit",
@@ -1316,7 +1316,7 @@ exports[`Test Transform > should transform the elements correctly when linear el
   "backgroundColor": "transparent",
   "boundElements": [
     {
-      "id": "id56",
+      "id": "id58",
       "type": "text",
     },
     {
@@ -1359,7 +1359,7 @@ exports[`Test Transform > should transform the elements correctly when linear el
   "backgroundColor": "transparent",
   "boundElements": [
     {
-      "id": "id57",
+      "id": "id59",
       "type": "text",
     },
   ],
@@ -1398,7 +1398,7 @@ exports[`Test Transform > should transform the elements correctly when linear el
   "backgroundColor": "transparent",
   "boundElements": [
     {
-      "id": "id58",
+      "id": "id60",
       "type": "text",
     },
     {
@@ -1441,7 +1441,7 @@ exports[`Test Transform > should transform the elements correctly when linear el
   "backgroundColor": "transparent",
   "boundElements": [
     {
-      "id": "id59",
+      "id": "id61",
       "type": "text",
     },
     {
@@ -1488,7 +1488,7 @@ exports[`Test Transform > should transform the elements correctly when linear el
   "backgroundColor": "transparent",
   "boundElements": [
     {
-      "id": "id60",
+      "id": "id62",
       "type": "text",
     },
   ],
@@ -1556,7 +1556,7 @@ exports[`Test Transform > should transform the elements correctly when linear el
   "backgroundColor": "transparent",
   "boundElements": [
     {
-      "id": "id61",
+      "id": "id63",
       "type": "text",
     },
   ],

--- a/packages/element/src/__tests__/transform.test.ts
+++ b/packages/element/src/__tests__/transform.test.ts
@@ -678,6 +678,59 @@ describe("Test Transform", () => {
       });
     });
 
+    it("should position start/end bound text correctly when the referenced elements have no explicit x/y (#7003)", () => {
+      const elements = [
+        {
+          type: "text",
+          id: "start-text",
+          text: "input",
+        },
+        {
+          type: "text",
+          id: "end-text",
+          text: "result",
+        },
+        {
+          type: "arrow",
+          x: 200,
+          y: 200,
+          label: {
+            text: "=deno",
+          },
+          start: {
+            id: "start-text",
+          },
+          end: {
+            id: "end-text",
+          },
+        },
+      ];
+
+      const excalidrawElements = convertToExcalidrawElements(
+        elements as ExcalidrawElementSkeleton[],
+        opts,
+      );
+
+      const arrow = excalidrawElements.find(
+        (el) => el.type === "arrow",
+      ) as ExcalidrawArrowElement;
+      const startText = excalidrawElements.find(
+        (el) => el.id === "start-text",
+      )!;
+      const endText = excalidrawElements.find((el) => el.id === "end-text")!;
+
+      expect(typeof startText.x).toBe("number");
+      expect(Number.isNaN(startText.x)).toBe(false);
+      expect(typeof endText.x).toBe("number");
+      expect(Number.isNaN(endText.x)).toBe(false);
+
+      // the start-bound text sits before the arrow's start, the
+      // end-bound text sits at (within a sub-pixel binding-overlap
+      // adjustment) or after the arrow's end
+      expect(startText.x).toBeLessThan(arrow.x);
+      expect(endText.x).toBeGreaterThan(arrow.x + arrow.width - 1);
+    });
+
     it("should bind arrows to existing elements if ids are correct", () => {
       const consoleErrorSpy = vi
         .spyOn(console, "error")

--- a/packages/element/src/transform.ts
+++ b/packages/element/src/transform.ts
@@ -380,6 +380,7 @@ const bindLinearElementToElement = (
         });
         // to position the text correctly when coordinates not provided
         Object.assign(endBoundElement, {
+          x: end.x || linearElement.x + linearElement.width,
           y: end.y || linearElement.y - endBoundElement.height / 2,
         });
       } else {


### PR DESCRIPTION
bindLinearElementToElement's end-binding fixup only re-asserted `y` after construction, unlike the equivalent start-binding block, which also re-asserts `x`. When `end` references a pre-existing skeleton element with no x/y of its own, that missing line let an invalid value through as the final x.

Fixes #7003