### PR TITLE
docs(readme): add pnpm and bun install commands to quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,12 +84,16 @@ We'll be adding these features as drop-in plugins for the npm package in the fut
 
 **Note:** following instructions are for installing the Excalidraw [npm package](https://www.npmjs.com/package/@excalidraw/excalidraw) when integrating Excalidraw into your own app. To run the repository locally for development, please refer to our [Development Guide](https://docs.excalidraw.com/docs/introduction/development).
 
-Use `npm` or `yarn` to install the package.
+Use `npm`, `yarn`, `pnpm`, or `bun` to install the package.
 
 ```bash
 npm install react react-dom @excalidraw/excalidraw
 # or
 yarn add react react-dom @excalidraw/excalidraw
+# or
+pnpm add react react-dom @excalidraw/excalidraw
+# or
+bun add react react-dom @excalidraw/excalidraw
 ```
 
 Check out our [documentation](https://docs.excalidraw.com/docs/@excalidraw/excalidraw/installation) for more details!


### PR DESCRIPTION
## Summary

Adds `pnpm` and `bun` installation command examples to the Quick start section in `README.md` alongside `npm` and `yarn`.