### PR TITLE
fix(store): clear scheduled micro actions on Store.clear()

### DIFF
--- a/packages/element/src/store.ts
+++ b/packages/element/src/store.ts
@@ -206,6 +206,10 @@ export class Store {
   public clear(): void {
     this.snapshot = StoreSnapshot.empty();
     this.scheduledMacroActions = new Set();
+    // scheduled micro actions capture a change relative to the pre-clear
+    // snapshot; flushing them after a clear would apply a stale change
+    // on top of the now-empty snapshot and corrupt it.
+    this.scheduledMicroActions = [];
   }
 
   /**

--- a/packages/excalidraw/tests/__snapshots__/history.test.tsx.snap
+++ b/packages/excalidraw/tests/__snapshots__/history.test.tsx.snap
@@ -12430,6 +12430,301 @@ exports[`history > singleplayer undo/redo > remounting undo/redo buttons should 
 
 exports[`history > singleplayer undo/redo > remounting undo/redo buttons should initialize undo/redo state correctly > [end of test] undo stack 1`] = `[]`;
 
+exports[`history > singleplayer undo/redo > should allow undoing the first element drawn after resetScene() > [end of test] appState 1`] = `
+{
+  "activeEmbeddable": null,
+  "activeLockedId": null,
+  "activeTool": {
+    "customType": null,
+    "fromSelection": false,
+    "lastActiveTool": null,
+    "locked": false,
+    "type": "selection",
+  },
+  "bindMode": "orbit",
+  "bindingPreference": "enabled",
+  "boxSelectionMode": "contain",
+  "collaborators": Map {},
+  "colorTopPicks": {
+    "bucketFill": null,
+    "elementBackground": null,
+    "elementStroke": null,
+  },
+  "contextMenu": null,
+  "croppingElementId": null,
+  "currentHoveredFontFamily": null,
+  "currentItemArrowType": "round",
+  "currentItemBackgroundColor": "transparent",
+  "currentItemEndArrowhead": "arrow",
+  "currentItemFillStyle": "solid",
+  "currentItemFontFamily": 5,
+  "currentItemFontSize": 20,
+  "currentItemOpacity": 100,
+  "currentItemRoughness": 1,
+  "currentItemRoundness": "sharp",
+  "currentItemStartArrowhead": null,
+  "currentItemStrokeColor": "#1e1e1e",
+  "currentItemStrokeStyle": "solid",
+  "currentItemStrokeVariability": "constant",
+  "currentItemStrokeWidthKey": "medium",
+  "currentItemTextAlign": "left",
+  "cursorButton": "up",
+  "defaultSidebarDockedPreference": false,
+  "editingFrame": null,
+  "editingGroupId": null,
+  "editingTextElement": null,
+  "elementsToHighlight": null,
+  "errorMessage": null,
+  "exportBackground": true,
+  "exportEmbedScene": false,
+  "exportScale": 1,
+  "exportWithDarkMode": false,
+  "fileHandle": null,
+  "frameRendering": {
+    "clip": true,
+    "enabled": true,
+    "name": true,
+    "outline": true,
+  },
+  "frameToHighlight": null,
+  "gridModeEnabled": false,
+  "gridSize": 20,
+  "gridStep": 5,
+  "height": 0,
+  "hoveredArrowTextAnchor": null,
+  "hoveredElementIds": {},
+  "isBindingEnabled": true,
+  "isCropping": false,
+  "isLoading": false,
+  "isMidpointSnappingEnabled": true,
+  "isResizing": false,
+  "isRotating": false,
+  "lastPointerDownWith": "mouse",
+  "lockedMultiSelections": {},
+  "multiElement": null,
+  "newElement": null,
+  "objectsSnapModeEnabled": false,
+  "offsetLeft": 0,
+  "offsetTop": 0,
+  "openDialog": null,
+  "openMenu": null,
+  "openPopup": null,
+  "openSidebar": null,
+  "originSnapOffset": null,
+  "penDetected": false,
+  "penMode": false,
+  "preferredSelectionTool": {
+    "initialized": false,
+    "type": "selection",
+  },
+  "previousSelectedElementIds": {},
+  "resizingElement": null,
+  "scrollConstraints": null,
+  "scrollX": 0,
+  "scrollY": 0,
+  "searchMatches": null,
+  "selectedElementIds": {},
+  "selectedElementsAreBeingDragged": false,
+  "selectedGroupIds": {},
+  "selectionElement": null,
+  "shouldCacheIgnoreZoom": false,
+  "showHyperlinkPopup": false,
+  "showWelcomeScreen": true,
+  "snapLines": [],
+  "stats": {
+    "open": false,
+    "panels": 3,
+  },
+  "suggestedBinding": null,
+  "theme": "light",
+  "toast": null,
+  "viewBackgroundColor": "#ffffff",
+  "viewModeEnabled": false,
+  "width": 0,
+  "zenModeEnabled": false,
+  "zoom": {
+    "value": 1,
+  },
+}
+`;
+
+exports[`history > singleplayer undo/redo > should allow undoing the first element drawn after resetScene() > [end of test] element 0 1`] = `
+{
+  "angle": 0,
+  "backgroundColor": "transparent",
+  "boundElements": null,
+  "customData": undefined,
+  "fillStyle": "solid",
+  "frameId": null,
+  "groupIds": [],
+  "height": 10,
+  "id": "id1",
+  "index": "a0",
+  "isDeleted": true,
+  "link": null,
+  "locked": false,
+  "opacity": 100,
+  "roughness": 1,
+  "roundness": null,
+  "strokeColor": "#1e1e1e",
+  "strokeStyle": "solid",
+  "strokeWidth": 2,
+  "type": "rectangle",
+  "updated": 1,
+  "version": 4,
+  "width": 10,
+  "x": 0,
+  "y": 0,
+}
+`;
+
+exports[`history > singleplayer undo/redo > should allow undoing the first element drawn after resetScene() > [end of test] element 1 1`] = `
+{
+  "angle": 0,
+  "backgroundColor": "transparent",
+  "boundElements": null,
+  "customData": undefined,
+  "fillStyle": "solid",
+  "frameId": null,
+  "groupIds": [],
+  "height": 10,
+  "id": "id4",
+  "index": "a1",
+  "isDeleted": true,
+  "link": null,
+  "locked": false,
+  "opacity": 100,
+  "roughness": 1,
+  "roundness": null,
+  "strokeColor": "#1e1e1e",
+  "strokeStyle": "solid",
+  "strokeWidth": 2,
+  "type": "rectangle",
+  "updated": 1,
+  "version": 4,
+  "width": 10,
+  "x": 0,
+  "y": 0,
+}
+`;
+
+exports[`history > singleplayer undo/redo > should allow undoing the first element drawn after resetScene() > [end of test] number of elements 1`] = `2`;
+
+exports[`history > singleplayer undo/redo > should allow undoing the first element drawn after resetScene() > [end of test] number of renders 1`] = `11`;
+
+exports[`history > singleplayer undo/redo > should allow undoing the first element drawn after resetScene() > [end of test] redo stack 1`] = `
+[
+  {
+    "appState": AppStateDelta {
+      "delta": Delta {
+        "deleted": {
+          "selectedElementIds": {
+            "id1": true,
+          },
+        },
+        "inserted": {
+          "selectedElementIds": {
+            "id4": true,
+          },
+        },
+      },
+    },
+    "elements": {
+      "added": {
+        "id4": {
+          "deleted": {
+            "isDeleted": true,
+            "version": 4,
+          },
+          "inserted": {
+            "angle": 0,
+            "backgroundColor": "transparent",
+            "boundElements": null,
+            "customData": undefined,
+            "fillStyle": "solid",
+            "frameId": null,
+            "groupIds": [],
+            "height": 10,
+            "index": "a1",
+            "isDeleted": false,
+            "link": null,
+            "locked": false,
+            "opacity": 100,
+            "roughness": 1,
+            "roundness": null,
+            "strokeColor": "#1e1e1e",
+            "strokeStyle": "solid",
+            "strokeWidth": 2,
+            "type": "rectangle",
+            "version": 3,
+            "width": 10,
+            "x": 0,
+            "y": 0,
+          },
+        },
+      },
+      "removed": {},
+      "updated": {},
+    },
+    "id": "id7",
+  },
+  {
+    "appState": AppStateDelta {
+      "delta": Delta {
+        "deleted": {
+          "selectedElementIds": {},
+        },
+        "inserted": {
+          "selectedElementIds": {
+            "id1": true,
+          },
+        },
+      },
+    },
+    "elements": {
+      "added": {
+        "id1": {
+          "deleted": {
+            "isDeleted": true,
+            "version": 4,
+          },
+          "inserted": {
+            "angle": 0,
+            "backgroundColor": "transparent",
+            "boundElements": null,
+            "customData": undefined,
+            "fillStyle": "solid",
+            "frameId": null,
+            "groupIds": [],
+            "height": 10,
+            "index": "a0",
+            "isDeleted": false,
+            "link": null,
+            "locked": false,
+            "opacity": 100,
+            "roughness": 1,
+            "roundness": null,
+            "strokeColor": "#1e1e1e",
+            "strokeStyle": "solid",
+            "strokeWidth": 2,
+            "type": "rectangle",
+            "version": 3,
+            "width": 10,
+            "x": 0,
+            "y": 0,
+          },
+        },
+      },
+      "removed": {},
+      "updated": {},
+    },
+    "id": "id8",
+  },
+]
+`;
+
+exports[`history > singleplayer undo/redo > should allow undoing the first element drawn after resetScene() > [end of test] undo stack 1`] = `[]`;
+
 exports[`history > singleplayer undo/redo > should clear the redo stack on elements change > [end of test] appState 1`] = `
 {
   "activeEmbeddable": null,

--- a/packages/excalidraw/tests/helpers/api.ts
+++ b/packages/excalidraw/tests/helpers/api.ts
@@ -71,6 +71,11 @@ export class API {
       h.app.updateScene(...args);
     });
   };
+  static resetScene = (opts?: { resetLoadingState: boolean }) => {
+    act(() => {
+      (h.app as any).resetScene(opts);
+    });
+  };
   static setAppState: React.Component<any, AppState>["setState"] = (
     state,
     cb,

--- a/packages/excalidraw/tests/history.test.tsx
+++ b/packages/excalidraw/tests/history.test.tsx
@@ -251,6 +251,48 @@ describe("history", () => {
       ]);
     });
 
+    it("should allow undoing the first element drawn after resetScene()", async () => {
+      await render(<Excalidraw handleKeyboardGlobally={true} />);
+
+      const stale = API.createElement({ type: "rectangle" });
+
+      // `updateScene` schedules a micro action (a captured elements snapshot)
+      // that is only flushed on the *next* store commit, not synchronously.
+      // Calling `resetScene` before that commit happens must not let the
+      // stale, pre-reset micro action leak into the post-reset store/history.
+      act(() => {
+        h.app.updateScene({
+          elements: [stale],
+          captureUpdate: CaptureUpdateAction.IMMEDIATELY,
+        });
+        (h.app as any).resetScene();
+      });
+
+      expect(h.elements.filter((el) => !el.isDeleted)).toHaveLength(0);
+      expect(API.getUndoStack().length).toBe(0);
+
+      const rect1 = UI.createElement("rectangle");
+      const rect2 = UI.createElement("rectangle");
+
+      expect(h.elements).toEqual([
+        expect.objectContaining({ id: rect1.id, isDeleted: false }),
+        expect.objectContaining({ id: rect2.id, isDeleted: false }),
+      ]);
+
+      const undoAction = createUndoAction(h.history);
+      API.executeAction(undoAction);
+      expect(h.elements).toEqual([
+        expect.objectContaining({ id: rect1.id, isDeleted: false }),
+        expect.objectContaining({ id: rect2.id, isDeleted: true }),
+      ]);
+
+      API.executeAction(undoAction);
+      expect(h.elements).toEqual([
+        expect.objectContaining({ id: rect1.id, isDeleted: true }),
+        expect.objectContaining({ id: rect2.id, isDeleted: true }),
+      ]);
+    });
+
     it("should not modify anything on unrelated appstate change", async () => {
       const rect = API.createElement({ type: "rectangle" });
       await render(


### PR DESCRIPTION
## What

Fixes #9238 — undo doesn't work for the first element added after `resetScene()`.

## Root cause

`Store.clear()` resets `scheduledMacroActions` but never touches `scheduledMicroActions`:

```ts
public clear(): void {
  this.snapshot = StoreSnapshot.empty();
  this.scheduledMacroActions = new Set();
}
```

A micro action (scheduled via `scheduleMicroAction`, e.g. from `updateScene({ ..., captureUpdate })`) captures its `change`/`delta` relative to the snapshot **at schedule time**, but doesn't actually run until the *next* `Store.commit()`, via `flushMicroActions()`.

If `resetScene()` runs in between — it calls `store.clear()` synchronously right after any pending `updateScene(..., captureUpdate)` call in the same React batch/act — the stale micro action survives the clear. On the next commit it still fires, applying its pre-reset change on top of the just-cleared (empty) snapshot. That corrupts the snapshot and pushes a phantom entry onto the undo stack before the user has drawn anything.

Any further capture (e.g. drawing the first new element after reset) then computes its delta against that corrupted snapshot instead of a clean empty one, so the resulting undo entry for that first element is wrong — undo appears to do nothing for it, while every subsequent element undoes fine (their deltas are computed against an already-consistent snapshot).

## Fix

One-line fix in the single method whose job is to fully clear the store — also drop any not-yet-flushed micro actions:

```ts
public clear(): void {
  this.snapshot = StoreSnapshot.empty();
  this.scheduledMacroActions = new Set();
  this.scheduledMicroActions = [];
}
```

## Testing

Added a regression test in `history.test.tsx` (`should allow undoing the first element drawn after resetScene()`) that reproduces the exact race deterministically: schedules a micro action via `updateScene({ elements, captureUpdate: IMMEDIATELY })` and calls `resetScene()` in the same `act()`, before that micro action would normally flush. Verified as a negative control that it fails on unfixed `main` (`API.getUndoStack().length` was `1` instead of `0` immediately after reset, before drawing anything) and passes with the fix.

Also added a small `API.resetScene` test helper (mirroring the existing `API.updateScene`) since none existed.

- `vitest packages/excalidraw/tests/history.test.tsx` — 70 passed, 1 pre-existing unrelated skip
- `tsc` (test:typecheck) — clean
- `eslint --max-warnings=0` on changed files — clean
