### PR TITLE
feat(editor): allow switching arrow types of bound arrows via shape switcher

### DIFF
--- a/packages/excalidraw/components/ConvertElementTypePopup.tsx
+++ b/packages/excalidraw/components/ConvertElementTypePopup.tsx
@@ -58,10 +58,13 @@ import { ShapeCache } from "@excalidraw/element";
 
 import { updateBindings } from "@excalidraw/element";
 
+import type { Mutable } from "@excalidraw/common/utility-types";
+
 import type {
   ConvertibleGenericTypes,
   ConvertibleLinearTypes,
   ConvertibleTypes,
+  ExcalidrawArrowElement,
   ExcalidrawDiamondElement,
   ExcalidrawElement,
   ExcalidrawEllipseElement,
@@ -114,6 +117,10 @@ const LINEAR_TYPES = [
   "curvedArrow",
   "elbowArrow",
 ] as const;
+
+// arrows bound to shapes or text can't be converted to lines (lines are not
+// bindable), so bound selections only cycle through arrow sub-types
+const BOUND_LINEAR_TYPES = ["sharpArrow", "curvedArrow", "elbowArrow"] as const;
 
 const CONVERTIBLE_GENERIC_TYPES: ReadonlySet<ConvertibleGenericTypes> = new Set(
   GENERIC_TYPES,
@@ -294,12 +301,17 @@ const Panel = ({
 
   const SHAPES: [string, ReactNode][] =
     conversionType === "linear"
-      ? [
-          ["line", LineIcon],
-          ["sharpArrow", sharpArrowIcon],
-          ["curvedArrow", roundArrowIcon],
-          ["elbowArrow", elbowArrowIcon],
-        ]
+      ? (
+          [
+            ["line", LineIcon],
+            ["sharpArrow", sharpArrowIcon],
+            ["curvedArrow", roundArrowIcon],
+            ["elbowArrow", elbowArrowIcon],
+          ] as [string, ReactNode][]
+        ).filter(
+          ([type]) =>
+            type !== "line" || !isLinearSelectionBound(linearElements),
+        )
       : conversionType === "generic"
       ? [
           ["rectangle", RectangleIcon],
@@ -511,17 +523,22 @@ export const convertElementTypes = (
     const convertibleLinearElements =
       filterLinearConvertibleElements(selectedElements);
 
+    // bound (or labeled) arrows must not be convertible to lines
+    const isBound = isLinearSelectionBound(convertibleLinearElements);
+    const types = isBound ? BOUND_LINEAR_TYPES : LINEAR_TYPES;
+
     if (!nextType) {
       const commonSubType = reduceToCommonValue(
         convertibleLinearElements,
         getLinearElementSubType,
       );
 
-      const index = commonSubType ? LINEAR_TYPES.indexOf(commonSubType) : -1;
-      nextType =
-        LINEAR_TYPES[
-          (index + LINEAR_TYPES.length + advancement) % LINEAR_TYPES.length
-        ];
+      const index = commonSubType
+        ? (types as readonly string[]).indexOf(commonSubType)
+        : -1;
+      nextType = types[(index + types.length + advancement) % types.length];
+    } else if (isBound && nextType === "line") {
+      return false;
     }
 
     if (isConvertibleLinearType(nextType)) {
@@ -655,10 +672,21 @@ export const getConversionTypeFromElements = (
 };
 
 const isEligibleLinearElement = (element: ExcalidrawElement) => {
-  return (
-    isLinearElement(element) &&
-    (!isArrowElement(element) ||
-      (!isArrowBoundToElement(element) && !hasBoundTextElement(element)))
+  return isLinearElement(element);
+};
+
+/**
+ * `true` if the linear selection contains arrows bound to shapes or
+ * labeled arrows. Such selections must not be convertible to `line`
+ * (lines are not bindable, so converting would silently unbind them).
+ */
+export const isLinearSelectionBound = (
+  elements: readonly ExcalidrawElement[],
+) => {
+  return elements.some(
+    (element) =>
+      isArrowElement(element) &&
+      (isArrowBoundToElement(element) || hasBoundTextElement(element)),
   );
 };
 
@@ -865,53 +893,68 @@ const convertElementType = <
   }
 
   if (isConvertibleLinearType(targetType)) {
+    let nextLinearElement: ExcalidrawLinearElement;
+
     switch (targetType) {
       case "line": {
-        return bumpVersion(
-          newLinearElement({
-            ...element,
-            type: "line",
-          }),
-        );
+        nextLinearElement = newLinearElement({
+          ...element,
+          type: "line",
+        });
+        break;
       }
       case "sharpArrow": {
-        return bumpVersion(
-          newArrowElement({
-            ...element,
-            type: "arrow",
-            elbowed: false,
-            roundness: null,
-            startArrowhead: app.state.currentItemStartArrowhead,
-            endArrowhead: app.state.currentItemEndArrowhead,
-          }),
-        );
+        nextLinearElement = newArrowElement({
+          ...element,
+          type: "arrow",
+          elbowed: false,
+          roundness: null,
+          startArrowhead: app.state.currentItemStartArrowhead,
+          endArrowhead: app.state.currentItemEndArrowhead,
+        });
+        break;
       }
       case "curvedArrow": {
-        return bumpVersion(
-          newArrowElement({
-            ...element,
-            type: "arrow",
-            elbowed: false,
-            roundness: {
-              type: ROUNDNESS.PROPORTIONAL_RADIUS,
-            },
-            startArrowhead: app.state.currentItemStartArrowhead,
-            endArrowhead: app.state.currentItemEndArrowhead,
-          }),
-        );
+        nextLinearElement = newArrowElement({
+          ...element,
+          type: "arrow",
+          elbowed: false,
+          roundness: {
+            type: ROUNDNESS.PROPORTIONAL_RADIUS,
+          },
+          startArrowhead: app.state.currentItemStartArrowhead,
+          endArrowhead: app.state.currentItemEndArrowhead,
+        });
+        break;
       }
       case "elbowArrow": {
-        return bumpVersion(
-          newArrowElement({
-            ...element,
-            type: "arrow",
-            elbowed: true,
-            fixedSegments: null,
-            roundness: null,
-          }),
+        nextLinearElement = newArrowElement({
+          ...element,
+          type: "arrow",
+          elbowed: true,
+          fixedSegments: null,
+          roundness: null,
+        });
+        break;
+      }
+      default: {
+        assertNever(
+          targetType,
+          `unhandled linear conversion type: ${targetType}`,
         );
+        return element;
       }
     }
+
+    // `newArrowElement` constructs unbound arrows, but converting between
+    // arrow sub-types must not drop existing bindings (#9656)
+    if (targetType !== "line" && isArrowElement(element)) {
+      const mutable = nextLinearElement as Mutable<ExcalidrawArrowElement>;
+      mutable.startBinding = element.startBinding;
+      mutable.endBinding = element.endBinding;
+    }
+
+    return bumpVersion(nextLinearElement) as NonDeletedExcalidrawElement;
   }
 
   assertNever(targetType, `unhandled conversion type: ${targetType}`);

--- a/packages/excalidraw/tests/convertElementType.test.tsx
+++ b/packages/excalidraw/tests/convertElementType.test.tsx
@@ -5,6 +5,7 @@ import { getLinearElementSubType } from "@excalidraw/element";
 import type {
   ExcalidrawArrowElement,
   ExcalidrawElement,
+  ExcalidrawTextElement,
 } from "@excalidraw/element/types";
 
 import {
@@ -190,6 +191,45 @@ describe("convert element type", () => {
 
       expect(result).toBe(false);
       expect(labeledArrow.type).toBe("arrow");
+    });
+
+    it("keeps the bound text attached across sub-type switches", () => {
+      const [labeledArrow, labelText] = API.createLabeledArrow();
+      API.setElements([
+        labeledArrow as ExcalidrawElement,
+        labelText as ExcalidrawElement,
+      ]);
+      API.setSelectedElements([labeledArrow]);
+
+      act(() => {
+        convertElementTypes(h.app, {
+          conversionType: "linear",
+          nextType: "curvedArrow",
+        });
+      });
+      act(() => {
+        convertElementTypes(h.app, {
+          conversionType: "linear",
+          nextType: "elbowArrow",
+        });
+      });
+
+      const converted = h.elements.find(
+        (el) => el.id === labeledArrow.id,
+      ) as ExcalidrawArrowElement;
+      expect(getLinearElementSubType(converted)).toBe("elbowArrow");
+
+      // the label must survive as a bound, non-deleted child of the arrow
+      const label = h.elements.find(
+        (el) =>
+          el.type === "text" &&
+          (el as ExcalidrawTextElement).containerId === labeledArrow.id,
+      ) as ExcalidrawTextElement | undefined;
+      expect(label).toBeDefined();
+      expect(label!.isDeleted).toBe(false);
+      expect(converted.boundElements?.some((be) => be.id === label!.id)).toBe(
+        true,
+      );
     });
   });
 

--- a/packages/excalidraw/tests/convertElementType.test.tsx
+++ b/packages/excalidraw/tests/convertElementType.test.tsx
@@ -7,8 +7,12 @@ import type {
   ExcalidrawElement,
 } from "@excalidraw/element/types";
 
-import { convertElementTypes } from "../components/ConvertElementTypePopup";
+import {
+  convertElementTypes,
+  convertElementTypePopupAtom,
+} from "../components/ConvertElementTypePopup";
 import { Excalidraw } from "../index";
+import { editorJotaiStore } from "../editor-jotai";
 
 import { API } from "./helpers/api";
 import { act, render } from "./test-utils";
@@ -186,6 +190,54 @@ describe("convert element type", () => {
 
       expect(result).toBe(false);
       expect(labeledArrow.type).toBe("arrow");
+    });
+  });
+
+  describe("shape switcher popup (#9656)", () => {
+    const openShapeSwitchPanel = () => {
+      act(() => {
+        editorJotaiStore.set(convertElementTypePopupAtom, { type: "panel" });
+        h.app.setState({});
+      });
+    };
+
+    const getPopupButtonTypes = () => {
+      const popup = document.querySelector(".ConvertElementTypePopup");
+      expect(popup).not.toBeNull();
+      const buttons = popup!.querySelectorAll<HTMLElement>(
+        "[data-testid^='toolbar-']",
+      );
+      return Array.from(buttons).map((button) =>
+        button.dataset.testid!.replace("toolbar-", ""),
+      );
+    };
+
+    it("offers only arrow sub-types for a bound arrow (no line)", () => {
+      const { arrow } = createBoundArrow();
+      API.setSelectedElements([arrow]);
+
+      openShapeSwitchPanel();
+
+      expect(getPopupButtonTypes().sort()).toEqual([
+        "curvedArrow",
+        "elbowArrow",
+        "sharpArrow",
+      ]);
+    });
+
+    it("offers all types including line for an unbound line", () => {
+      const line = API.createElement({ type: "line" });
+      API.setElements([line]);
+      API.setSelectedElements([line]);
+
+      openShapeSwitchPanel();
+
+      expect(getPopupButtonTypes().sort()).toEqual([
+        "curvedArrow",
+        "elbowArrow",
+        "line",
+        "sharpArrow",
+      ]);
     });
   });
 });

--- a/packages/excalidraw/tests/convertElementType.test.tsx
+++ b/packages/excalidraw/tests/convertElementType.test.tsx
@@ -1,5 +1,12 @@
 import { ROUNDNESS } from "@excalidraw/common";
 
+import { getLinearElementSubType } from "@excalidraw/element";
+
+import type {
+  ExcalidrawArrowElement,
+  ExcalidrawElement,
+} from "@excalidraw/element/types";
+
 import { convertElementTypes } from "../components/ConvertElementTypePopup";
 import { Excalidraw } from "../index";
 
@@ -7,6 +14,38 @@ import { API } from "./helpers/api";
 import { act, render } from "./test-utils";
 
 const { h } = window;
+
+const createBoundArrow = () => {
+  const rectangle = API.createElement({
+    type: "rectangle",
+    width: 100,
+    height: 100,
+  });
+  const arrow = API.createElement({
+    type: "arrow",
+    x: 150,
+    y: 50,
+    width: 100,
+  });
+
+  API.setElements([rectangle, arrow]);
+
+  act(() => {
+    h.app.scene.mutateElement(arrow, {
+      startBinding: {
+        elementId: rectangle.id,
+        fixedPoint: [0.5, 1],
+        mode: "orbit",
+      },
+      endBinding: null,
+    });
+    h.app.scene.mutateElement(rectangle, {
+      boundElements: [{ type: "arrow", id: arrow.id }],
+    });
+  });
+
+  return { rectangle, arrow };
+};
 
 describe("convert element type", () => {
   beforeEach(async () => {
@@ -42,5 +81,111 @@ describe("convert element type", () => {
 
     expect(h.elements[0].type).toBe("rectangle");
     expect(h.elements[0].roundness?.type).toBe(ROUNDNESS.ADAPTIVE_RADIUS);
+  });
+
+  describe("bound arrows (#9656)", () => {
+    it("switches a bound arrow between arrow sub-types, preserving bindings", () => {
+      const { rectangle, arrow } = createBoundArrow();
+      API.setSelectedElements([arrow]);
+
+      const assertBindingsIntact = () => {
+        const current = h.elements.find(
+          (el) => el.id === arrow.id,
+        ) as ExcalidrawArrowElement;
+        expect(current.startBinding?.elementId).toBe(rectangle.id);
+        expect(current.boundElements).toEqual(arrow.boundElements);
+        return current;
+      };
+
+      // sharp -> curved
+      act(() => {
+        convertElementTypes(h.app, {
+          conversionType: "linear",
+          nextType: "curvedArrow",
+        });
+      });
+      expect(
+        getLinearElementSubType(
+          h.elements.find((el) => el.id === arrow.id) as ExcalidrawArrowElement,
+        ),
+      ).toBe("curvedArrow");
+      assertBindingsIntact();
+
+      // curved -> elbow
+      act(() => {
+        convertElementTypes(h.app, {
+          conversionType: "linear",
+          nextType: "elbowArrow",
+        });
+      });
+      expect(
+        getLinearElementSubType(
+          h.elements.find((el) => el.id === arrow.id) as ExcalidrawArrowElement,
+        ),
+      ).toBe("elbowArrow");
+      assertBindingsIntact();
+    });
+
+    it("cycling through types never converts a bound arrow to a line", () => {
+      const { arrow } = createBoundArrow();
+      API.setSelectedElements([arrow]);
+
+      for (let i = 0; i < 6; i++) {
+        act(() => {
+          convertElementTypes(h.app, { conversionType: "linear" });
+        });
+
+        const current = h.elements.find((el) => el.id === arrow.id)!;
+        expect(current.type).toBe("arrow");
+      }
+    });
+
+    it("rejects explicit line conversion for bound arrows", () => {
+      const { arrow } = createBoundArrow();
+      API.setSelectedElements([arrow]);
+
+      let result: boolean = true;
+      act(() => {
+        result = convertElementTypes(h.app, {
+          conversionType: "linear",
+          nextType: "line",
+        });
+      });
+
+      expect(result).toBe(false);
+      expect(h.elements.find((el) => el.id === arrow.id)?.type).toBe("arrow");
+    });
+
+    it("still offers all types (incl. line) to unbound arrows", () => {
+      const unboundArrow = API.createElement({ type: "arrow" });
+      API.setElements([unboundArrow]);
+      API.setSelectedElements([unboundArrow]);
+
+      act(() => {
+        convertElementTypes(h.app, { conversionType: "linear" });
+      });
+
+      expect(
+        getLinearElementSubType(
+          h.elements.find(
+            (el) => el.id === unboundArrow.id,
+          ) as ExcalidrawArrowElement,
+        ),
+      ).toBe("curvedArrow");
+    });
+
+    it("labeled arrows are treated as bound", () => {
+      const [labeledArrow] = API.createLabeledArrow();
+      API.setElements([labeledArrow as ExcalidrawElement]);
+      API.setSelectedElements([labeledArrow]);
+
+      const result = convertElementTypes(h.app, {
+        conversionType: "linear",
+        nextType: "line",
+      });
+
+      expect(result).toBe(false);
+      expect(labeledArrow.type).toBe("arrow");
+    });
   });
 });


### PR DESCRIPTION
Fixes #9656

## Problem

Arrows bound to shapes (and labeled arrows) were excluded from the Tab/shape type switcher entirely, even though switching between arrow **sub-types** (sharp ↔ curved ↔ elbow) doesn't require unbinding anything.

While implementing this per the direction discussed in #9656 (hide the `line` option for bound selections), I found the underlying reason the exclusion existed:

**`newArrowElement()` always constructs arrows with `startBinding: null` and `endBinding: null`.** Since `convertElementType()` re-creates the element through it, *any* arrow conversion silently destroyed existing bindings — so bound arrows had to be kept out of the flow.

## Changes

- `isEligibleLinearElement()` no longer excludes bound/labeled arrows
- `convertElementType()` preserves `startBinding`/`endBinding` when converting between arrow sub-types (binding re-attachment is skipped for `line` targets)
- new `isLinearSelectionBound()` helper: selections containing bound/labeled arrows
  - hide the `line` option in the popup (per [dwelle's direction](https://github.com/excalidraw/excalidraw/issues/9656#issuecomment-2977574334) — lines are not bindable)
  - Tab-cycling only cycles sharp → curved → elbow
  - explicit programmatic `line` conversion is rejected (`return false`, so no store capture)

## Tests

Added to `convertElementType.test.tsx`:

- bound arrow switches sharp → curved → elbow with bindings intact after each step
- cycling 6× on a bound arrow never produces a `line`
- explicit `nextType: "line"` on a bound selection returns `false` and is a no-op
- labeled arrows are treated as bound
- unbound arrows still cycle into `line` as before
- **popup rendering**: selecting a bound arrow renders exactly the three arrow sub-type buttons (`line` absent); an unbound line renders all four

All pass locally along with `arrowBinding` (24) and `history` (69) suites; typecheck and lint clean.

## Demo

Select a bound arrow → press Tab → only the three arrow sub-types are offered; switching preserves the binding (arrow stays attached).