### PR TITLE
fix(excalidraw): resolve relative EXCALIDRAW_ASSET_PATH instead of throwing Invalid URL

### DIFF
--- a/packages/excalidraw/fonts/ExcalidrawFontFace.test.ts
+++ b/packages/excalidraw/fonts/ExcalidrawFontFace.test.ts
@@ -1,0 +1,115 @@
+import { ExcalidrawFontFace } from "./ExcalidrawFontFace";
+
+const ASSET_PATH = "EXCALIDRAW_ASSET_PATH";
+const DEFAULT_ASSET_PATH = window.EXCALIDRAW_ASSET_PATH;
+
+/** the woff2 uri as registered by the bundled font definitions */
+const FONT_URI = "/Excalifont/Excalifont-Regular.woff2";
+
+const setAssetPath = (value: string | string[] | undefined) => {
+  Object.defineProperty(window, ASSET_PATH, {
+    value,
+    writable: true,
+    configurable: true,
+  });
+};
+
+const urlsFor = (assetPath: string | string[] | undefined) => {
+  setAssetPath(assetPath);
+  return new ExcalidrawFontFace("Excalifont", FONT_URI).urls.map(String);
+};
+
+describe("ExcalidrawFontFace", () => {
+  afterEach(() => {
+    setAssetPath(DEFAULT_ASSET_PATH);
+  });
+
+  describe("resolves EXCALIDRAW_ASSET_PATH without throwing", () => {
+    // regression test for #8870, where a non-absolute asset path made the
+    // constructor throw `TypeError: Failed to construct 'URL': Invalid URL`,
+    // which took down the whole editor on mount
+    const cases: Array<[name: string, assetPath: string, expected: string]> = [
+      ["bare relative path", "assets", "http://localhost:3000/assets/"],
+      [
+        "nested bare relative path",
+        "assets/fonts",
+        "http://localhost:3000/assets/fonts/",
+      ],
+      ["empty string", "", "http://localhost:3000/"],
+      ["root-relative path", "/assets", "http://localhost:3000/assets/"],
+      ["dot-relative path", "./assets", "http://localhost:3000/assets/"],
+      [
+        "surrounding whitespace",
+        "  /assets  ",
+        "http://localhost:3000/assets/",
+      ],
+      [
+        "absolute url",
+        "https://cdn.example.com/fonts",
+        "https://cdn.example.com/fonts/",
+      ],
+      [
+        "absolute url with trailing slash",
+        "https://cdn.example.com/fonts/",
+        "https://cdn.example.com/fonts/",
+      ],
+    ];
+
+    for (const [name, assetPath, expected] of cases) {
+      it(`${name}: ${JSON.stringify(assetPath)}`, () => {
+        let urls: string[] = [];
+
+        expect(() => {
+          urls = urlsFor(assetPath);
+        }).not.toThrow();
+
+        expect(urls[0]).toBe(`${expected}Excalifont/Excalifont-Regular.woff2`);
+      });
+    }
+  });
+
+  it("resolves every entry of an array asset path", () => {
+    const urls = urlsFor(["https://cdn.example.com/fonts", "assets"]);
+
+    expect(urls.slice(0, 2)).toEqual([
+      "https://cdn.example.com/fonts/Excalifont/Excalifont-Regular.woff2",
+      "http://localhost:3000/assets/Excalifont/Excalifont-Regular.woff2",
+    ]);
+  });
+
+  it("always appends the bundled-font fallback url last", () => {
+    const withAssetPath = urlsFor("https://cdn.example.com/fonts");
+    const withoutAssetPath = urlsFor(undefined);
+
+    expect(withAssetPath).toHaveLength(2);
+    expect(withoutAssetPath).toHaveLength(1);
+    // the fallback is the same regardless of what the asset path resolved to
+    expect(withAssetPath.at(-1)).toBe(withoutAssetPath.at(-1));
+    expect(withAssetPath.at(-1)).toContain(
+      "Excalifont/Excalifont-Regular.woff2",
+    );
+  });
+
+  it("keeps the bundled-font fallback when an entry cannot be resolved", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    // a protocol-prefixed but structurally invalid url can't be resolved, and
+    // must not prevent the fallback from being registered
+    const urls = urlsFor("http://");
+
+    expect(urls).toHaveLength(1);
+    expect(urls[0]).toContain("Excalifont/Excalifont-Regular.woff2");
+    expect(warn).toHaveBeenCalled();
+
+    warn.mockRestore();
+  });
+
+  it("does not build a url for data and local sources", () => {
+    expect(
+      new ExcalidrawFontFace("Excalifont", "data:font/woff2;base64,AAA").urls,
+    ).toEqual(["data:font/woff2;base64,AAA"]);
+    expect(
+      new ExcalidrawFontFace("Helvetica", "local://Helvetica").urls,
+    ).toEqual([]);
+  });
+});

--- a/packages/excalidraw/fonts/ExcalidrawFontFace.ts
+++ b/packages/excalidraw/fonts/ExcalidrawFontFace.ts
@@ -150,17 +150,20 @@ export class ExcalidrawFontFace {
     const assetUrl: string = uri.replace(/^\/+/, "");
     const urls: URL[] = [];
 
-    if (typeof window.EXCALIDRAW_ASSET_PATH === "string") {
-      const normalizedBaseUrl = this.normalizeBaseUrl(
-        window.EXCALIDRAW_ASSET_PATH,
-      );
+    const assetPath = window.EXCALIDRAW_ASSET_PATH;
+    const basePaths =
+      typeof assetPath === "string"
+        ? [assetPath]
+        : Array.isArray(assetPath)
+        ? assetPath
+        : [];
 
-      urls.push(new URL(assetUrl, normalizedBaseUrl));
-    } else if (Array.isArray(window.EXCALIDRAW_ASSET_PATH)) {
-      window.EXCALIDRAW_ASSET_PATH.forEach((path) => {
-        const normalizedBaseUrl = this.normalizeBaseUrl(path);
-        urls.push(new URL(assetUrl, normalizedBaseUrl));
-      });
+    for (const basePath of basePaths) {
+      const url = ExcalidrawFontFace.createUrl(assetUrl, basePath);
+
+      if (url) {
+        urls.push(url);
+      }
     }
 
     // fallback url for bundled fonts
@@ -188,13 +191,34 @@ export class ExcalidrawFontFace {
     }
   }
 
-  private static normalizeBaseUrl(baseUrl: string) {
-    let result = baseUrl;
+  /**
+   * Resolves a single `EXCALIDRAW_ASSET_PATH` entry into an absolute font url.
+   *
+   * Never throws, so that a malformed custom asset path degrades to the bundled
+   * font fallback instead of taking down the whole editor on mount.
+   */
+  private static createUrl(assetUrl: string, basePath: string): URL | null {
+    try {
+      return new URL(assetUrl, ExcalidrawFontFace.normalizeBaseUrl(basePath));
+    } catch (error) {
+      console.warn(
+        `Skipping invalid EXCALIDRAW_ASSET_PATH entry "${basePath}", falling back to the bundled fonts.`,
+        error,
+      );
 
-    // in case user passed a root-relative url (~absolute path),
-    // like "/" or "/some/path", or relative (starts with "./"),
-    // prepend it with `location.origin`
-    if (/^\.?\//.test(result)) {
+      return null;
+    }
+  }
+
+  private static normalizeBaseUrl(baseUrl: string) {
+    let result = baseUrl.trim();
+
+    // `new URL(asset, base)` requires `base` to be an absolute url, so anything
+    // without a protocol gets resolved against `location.origin` first. that
+    // covers root-relative paths ("/" or "/some/path"), dot-relative ones
+    // ("./some/path"), and bare relative ones ("some/path"), the last of which
+    // used to throw `TypeError: Failed to construct 'URL': Invalid URL`.
+    if (!/^[a-zA-Z][a-zA-Z\d+\-.]*:/.test(result)) {
       result = new URL(
         result.replace(/^\.?\/+/, ""),
         window?.location?.origin,

--- a/setupTests.ts
+++ b/setupTests.ts
@@ -96,6 +96,9 @@ Object.defineProperty(document, "fonts", {
 
 Object.defineProperty(window, "EXCALIDRAW_ASSET_PATH", {
   value: `file://${__dirname}/`,
+  // so that tests can temporarily override the asset path
+  writable: true,
+  configurable: true,
 });
 
 // mock the font fetch only, so that everything else, as font subsetting, can run inside of the (snapshot) tests


### PR DESCRIPTION
Fixes #8870

## The problem

`ExcalidrawFontFace.normalizeBaseUrl()` only prepended `location.origin` when the configured asset path started with `/` or `./`:

```ts
if (/^\.?\//.test(result)) {
  result = new URL(result.replace(/^\.?\/+/, ""), window?.location?.origin).toString();
}
```

Anything else was handed straight to `new URL(assetUrl, base)` as the `base` argument, which requires an absolute url. So these all threw `TypeError: Failed to construct 'URL': Invalid URL`:

| `EXCALIDRAW_ASSET_PATH` | normalized base | result |
| --- | --- | --- |
| `"assets"` | `"assets/"` | throws |
| `"assets/fonts"` | `"assets/fonts/"` | throws |
| `""` | `"/"` | throws |
| `"  /assets  "` | `" /assets/"` | throws |
| `"/assets"` | `"http://host/assets/"` | ok |
| `"./assets"` | `"http://host/assets/"` | ok |
| `"https://cdn.example.com"` | `"https://cdn.example.com/"` | ok |

The empty string case is the easy one to hit by accident, since `window.EXCALIDRAW_ASSET_PATH = process.env.ASSET_PATH ?? ""` looks harmless.

What makes it more than a bad font url is where it throws. `createUrls()` is called from the `ExcalidrawFontFace` constructor, which runs during font registration in `Fonts.ts`, so the exception escapes the editor's mount and takes down the whole component. The user gets a blank area and a runtime error instead of an editor with fallback fonts.

## The fix

Two parts.

**Resolve any protocol-less base against `location.origin`.** The check becomes "does this have a scheme" rather than "does this start with a slash", so bare relative paths and empty strings now resolve the same way root-relative ones already did. Values that already have a protocol (`https:`, `file:`, and so on) are untouched, so existing setups including the `file://` path used in the test setup behave exactly as before.

**Never let a bad entry escape the constructor.** Each entry now resolves through a small `createUrl()` helper that catches, warns, and returns `null`. The bundled-font fallback url is appended unconditionally either way, so a value that still cannot be resolved degrades to bundled fonts rather than breaking mount. This also means one bad entry in an array asset path no longer discards the good ones.

The string and array branches were collapsed into one loop since they were doing the same thing.

## Tests

New `packages/excalidraw/fonts/ExcalidrawFontFace.test.ts`, 12 cases covering the table above plus array asset paths, the unconditional fallback url, the unresolvable-entry path, and the existing data-url and `local://` short circuits.

Against the unfixed source 6 of the 12 fail with `TypeError: Invalid URL`; all 12 pass with the fix.

`setupTests.ts` needed `writable`/`configurable` on the `EXCALIDRAW_ASSET_PATH` property so tests can override it and restore it. The value is unchanged.

## Notes

- No behavior change for any asset path that worked before. The only paths whose output changes are the ones that used to throw.
- Protocol-relative bases (`//cdn.example.com`) keep their current behavior, which resolves them against the origin as a path rather than as a host. That looks like a separate bug but I left it alone to keep this diff to the crash.
- `yarn test:typecheck` and `yarn fix` are clean. Font and export suites pass. Worth flagging that the full `yarn test:app` run is flaky on this machine independent of this change: a clean master run failed 3 unrelated tests (`align.test.tsx`, `linearElementEditor.test.tsx`, `history.test.tsx`) and a different pair failed on another run, all of which pass in isolation. Nothing in that set is font related.
