### PR TITLE
fix(app): detect localStorage quota errors in non-Chromium browsers

### DIFF
--- a/excalidraw-app/data/LocalData.ts
+++ b/excalidraw-app/data/LocalData.ts
@@ -109,7 +109,16 @@ const saveDataStateToLocalStorage = (
 };
 
 const isQuotaExceededError = (error: any) => {
-  return error instanceof DOMException && error.name === "QuotaExceededError";
+  return (
+    error instanceof DOMException &&
+    // chromium uses "QuotaExceededError", firefox
+    // "NS_ERROR_DOM_QUOTA_REACHED", older webkit "QUOTA_EXCEEDED_ERR"
+    (error.name === "QuotaExceededError" ||
+      error.name === "NS_ERROR_DOM_QUOTA_REACHED" ||
+      error.name === "QUOTA_EXCEEDED_ERR" ||
+      error.code === 22 ||
+      error.code === 1014)
+  );
 };
 
 type SavingLockTypes = "collaboration";


### PR DESCRIPTION
Fixes #11962

The quota-exceeded banner only ever triggered on Chromium: the check matched `DOMException.name === "QuotaExceededError"`, which is the Chromium spelling.

- Firefox throws `name === "NS_ERROR_DOM_QUOTA_REACHED"` (`code === 1014`)
- Older WebKit throws `name === "QUOTA_EXCEEDED_ERR"` (`code === 22`)

On those browsers the atom stayed `false`, no banner rendered, and the scene silently stopped persisting while the user kept drawing — they'd only find out on reload.

The fix accepts all three names plus the legacy codes, matching the cross-browser handling used elsewhere in the wild for this error.

Typecheck + lint pass locally.