### PR TITLE
fix(editor): resolve Dialog aria-labelledby to the namespaced title id

### DIFF
--- a/packages/excalidraw/components/Dialog.tsx
+++ b/packages/excalidraw/components/Dialog.tsx
@@ -108,7 +108,7 @@ export const Dialog = (props: DialogProps) => {
       className={clsx("Dialog", props.className, {
         "Dialog--fullscreen": isFullscreen,
       })}
-      labelledBy="dialog-title"
+      labelledBy={`${id}-dialog-title`}
       maxWidth={getDialogSize(props.size)}
       onCloseRequest={onClose}
       closeOnClickOutside={props.closeOnClickOutside}


### PR DESCRIPTION
Fixes #11961

`Dialog` hardcoded `labelledBy="dialog-title"` into `Modal`, but the heading it refers to renders as `id="${containerId}-dialog-title"`. The resulting `aria-labelledby="dialog-title"` never resolves, so every `Dialog`-based dialog was exposed to screen readers without an accessible name.

One-line fix: pass the same namespaced id that the `h2` receives:

```tsx
labelledBy={`${id}-dialog-title`}
```

(`id` already comes from `useExcalidrawContainer()` in this component.)

Typecheck + lint pass locally.