### PR TITLE
fix: preserve endArrowhead when converting arrow to elbow type

### DIFF
--- a/packages/excalidraw/components/ConvertElementTypePopup.tsx
+++ b/packages/excalidraw/components/ConvertElementTypePopup.tsx
@@ -579,10 +579,11 @@ export const convertElementTypes = (
                 fixedSegments,
               },
             );
-            mutateElement(element, app.scene.getNonDeletedElementsMap(), {
-              ...updates,
-              endArrowhead: "arrow",
-            });
+            mutateElement(
+              element,
+              app.scene.getNonDeletedElementsMap(),
+              updates,
+            );
           } else {
             // if we're converting to non-elbow linear element, check if
             // we've already cached one of these linear elements so we can

--- a/packages/excalidraw/tests/convertElementType.test.tsx
+++ b/packages/excalidraw/tests/convertElementType.test.tsx
@@ -1,5 +1,9 @@
 import { ROUNDNESS } from "@excalidraw/common";
 
+import { pointFrom, type LocalPoint } from "@excalidraw/math";
+
+import type { ExcalidrawArrowElement } from "@excalidraw/element/types";
+
 import { convertElementTypes } from "../components/ConvertElementTypePopup";
 import { Excalidraw } from "../index";
 
@@ -42,5 +46,32 @@ describe("convert element type", () => {
 
     expect(h.elements[0].type).toBe("rectangle");
     expect(h.elements[0].roundness?.type).toBe(ROUNDNESS.ADAPTIVE_RADIUS);
+  });
+
+  // #11967
+  it("preserves endArrowhead when converting an arrow to elbow", () => {
+    const arrow = API.createElement({
+      type: "arrow",
+      x: 0,
+      y: 0,
+      width: 100,
+      height: 100,
+      points: [pointFrom<LocalPoint>(0, 0), pointFrom<LocalPoint>(100, 100)],
+      endArrowhead: "triangle",
+    });
+
+    API.setElements([arrow]);
+    API.setSelectedElements([arrow]);
+
+    act(() => {
+      convertElementTypes(h.app, {
+        conversionType: "linear",
+        nextType: "elbowArrow",
+      });
+    });
+
+    expect((h.elements[0] as ExcalidrawArrowElement).endArrowhead).toBe(
+      "triangle",
+    );
   });
 });


### PR DESCRIPTION
Converting an arrow to an elbow arrow unconditionally forced endArrowhead to "arrow", discarding whatever the user had set (e.g. "none"). The override was added incidentally in #9556 while fixing an unrelated fixed-segment geometry bug, not as a deliberate choice.

Removes the override so the arrowhead the element already had passes through untouched, matching how the non-elbow conversion path already behaves.

Fixes #11967