### PR TITLE
fix: handle freedraw outlines with fewer than two points

### DIFF
--- a/packages/excalidraw/eraser/index.ts
+++ b/packages/excalidraw/eraser/index.ts
@@ -236,11 +236,15 @@ const eraserTest = (
   // which offers a good visual precision at various zoom levels
   if (isFreeDrawElement(element)) {
     const outlinePoints = getFreedrawOutlinePoints(element);
+    if (outlinePoints.length < 2) {
+  return false;
+}
     const strokeSegments = getFreedrawOutlineAsSegments(
       element,
       outlinePoints,
       elementsMap,
     );
+ 
     const tolerance = Math.max(2.25, 5 / zoom); // NOTE: Visually fine-tuned approximation
 
     for (const seg of strokeSegments) {


### PR DESCRIPTION
Fixes #11945

This prevents the eraser from throwing an error when a freedraw element generates fewer than two outline points.

Before this change, getFreedrawOutlineAsSegments() could throw:

"Freepath outline must have at least 2 points"

The eraser now skips those invalid outline cases instead of crashing, allowing the remaining freedraw elements to be erased normally.

Tested locally with the reproduction drawing from the issue.