### PR TITLE
feat(help): searchable shortcuts in Help dialog (Ctrl/Cmd+F focuses search)

### DIFF
--- a/packages/excalidraw/components/HelpDialog.scss
+++ b/packages/excalidraw/components/HelpDialog.scss
@@ -12,6 +12,55 @@
       font-size: 1.125rem;
     }
 
+    &__search-input {
+      box-sizing: border-box;
+      width: 100%;
+      margin-top: 1rem;
+      padding: 0.625rem 1rem;
+      border: 1px solid var(--dialog-border-color);
+      border-radius: var(--border-radius-lg);
+      background-color: var(--color-surface-mid);
+      color: var(--text-primary-color);
+      font-size: 0.875rem;
+
+      &:focus {
+        outline: none;
+        border-color: var(--color-primary);
+      }
+
+      &::placeholder {
+        color: var(--text-primary-color);
+        opacity: 0.5;
+      }
+    }
+
+    &__no-results {
+      margin: 1.5rem 0;
+      font-size: 0.875rem;
+      opacity: 0.75;
+    }
+
+    // the `hidden` attribute must be enforced explicitly because several
+    // of these nodes set their own `display` value
+    &__section[hidden],
+    &__island[hidden],
+    &__shortcut[hidden],
+    &__no-results[hidden] {
+      display: none;
+    }
+
+    // while searching, islands flow naturally instead of occupying their
+    // fixed grid areas (which would leave gaps when some are hidden)
+    @media screen and (min-width: 1024px) {
+      .HelpDialog__content--searching {
+        .HelpDialog__island--tools,
+        .HelpDialog__island--view,
+        .HelpDialog__island--editor {
+          grid-area: auto;
+        }
+      }
+    }
+
     &__header {
       display: flex;
       flex-wrap: wrap;

--- a/packages/excalidraw/components/HelpDialog.tsx
+++ b/packages/excalidraw/components/HelpDialog.tsx
@@ -1,6 +1,12 @@
 import React from "react";
 
-import { isDarwin, isFirefox, isWindows } from "@excalidraw/common";
+import {
+  addEventListener,
+  EVENT,
+  isDarwin,
+  isFirefox,
+  isWindows,
+} from "@excalidraw/common";
 
 import { KEYS } from "@excalidraw/common";
 
@@ -127,11 +133,85 @@ const ShortcutKey = (props: { children: React.ReactNode }) => (
 
 export const HelpDialog = ({ onClose }: { onClose?: () => void }) => {
   const actionManager = useExcalidrawActionManager();
+  const [query, setQuery] = React.useState("");
+  const contentRef = React.useRef<HTMLDivElement | null>(null);
+  const searchInputRef = React.useRef<HTMLInputElement | null>(null);
+
   const handleClose = React.useCallback(() => {
     if (onClose) {
       onClose();
     }
   }, [onClose]);
+
+  // While the help dialog is open, Ctrl/Cmd+F should search the shortcuts
+  // listed here rather than toggling the canvas search menu or opening the
+  // browser's find bar (#9276)
+  React.useEffect(() => {
+    return addEventListener(
+      document,
+      EVENT.KEYDOWN,
+      ((event: KeyboardEvent) => {
+        if (event[KEYS.CTRL_OR_CMD] && event.key === KEYS.F) {
+          event.preventDefault();
+          event.stopPropagation();
+          setQuery("");
+          searchInputRef.current?.focus();
+          searchInputRef.current?.select();
+        }
+      }) as EventListener,
+      { capture: true },
+    );
+  }, []);
+
+  // Filter the rendered shortcut list by the search query. We hide nodes
+  // imperatively (instead of unmounting) so that the dialog content stays
+  // stable while typing.
+  React.useEffect(() => {
+    const root = contentRef.current;
+    if (!root) {
+      return;
+    }
+
+    const normalizedQuery = query.trim().toLowerCase();
+    root.classList.toggle("HelpDialog__content--searching", !!normalizedQuery);
+
+    let visibleShortcuts = 0;
+
+    root
+      .querySelectorAll<HTMLElement>(".HelpDialog__shortcut")
+      .forEach((shortcut) => {
+        const label = shortcut.firstElementChild?.textContent ?? "";
+        const matches =
+          !normalizedQuery || label.toLowerCase().includes(normalizedQuery);
+        shortcut.hidden = !matches;
+        if (matches) {
+          visibleShortcuts++;
+        }
+      });
+
+    root
+      .querySelectorAll<HTMLElement>(".HelpDialog__island")
+      .forEach((island) => {
+        island.hidden = !island.querySelector(
+          ".HelpDialog__shortcut:not([hidden])",
+        );
+      });
+
+    root
+      .querySelectorAll<HTMLElement>(".HelpDialog__section")
+      .forEach((section) => {
+        section.hidden = !section.querySelector(
+          ".HelpDialog__island:not([hidden])",
+        );
+      });
+
+    const noResults = root.querySelector<HTMLElement>(
+      ".HelpDialog__no-results",
+    );
+    if (noResults) {
+      noResults.hidden = !normalizedQuery || visibleShortcuts !== 0;
+    }
+  }, [query]);
 
   return (
     <>
@@ -140,8 +220,16 @@ export const HelpDialog = ({ onClose }: { onClose?: () => void }) => {
         title={t("helpDialog.title")}
         className={"HelpDialog"}
       >
-        <div className="HelpDialog__content">
+        <div ref={contentRef} className="HelpDialog__content">
           <Header />
+          <input
+            ref={searchInputRef}
+            className="HelpDialog__search-input"
+            type="text"
+            value={query}
+            placeholder={t("helpDialog.searchShortcuts")}
+            onChange={(event) => setQuery(event.target.value)}
+          />
           <Section title={t("helpDialog.shortcuts")}>
             <ShortcutIsland
               className="HelpDialog__island--tools"
@@ -236,7 +324,10 @@ export const HelpDialog = ({ onClose }: { onClose?: () => void }) => {
               />
               <Shortcut
                 label={t("helpDialog.cropStart")}
-                shortcuts={[t("helpDialog.doubleClick"), getShortcutKey("Enter")]}
+                shortcuts={[
+                  t("helpDialog.doubleClick"),
+                  getShortcutKey("Enter"),
+                ]}
                 isOr={true}
               />
               <Shortcut
@@ -389,14 +480,18 @@ export const HelpDialog = ({ onClose }: { onClose?: () => void }) => {
               />
               <Shortcut
                 label={t("helpDialog.deepSelect")}
-                shortcuts={[getShortcutKey(`CtrlOrCmd+${t("helpDialog.click")}`)]}
+                shortcuts={[
+                  getShortcutKey(`CtrlOrCmd+${t("helpDialog.click")}`),
+                ]}
               />
               <Shortcut
                 label={t("helpDialog.deepBoxSelect")}
-                shortcuts={[getShortcutKey(`CtrlOrCmd+${t("helpDialog.drag")}`)]}
+                shortcuts={[
+                  getShortcutKey(`CtrlOrCmd+${t("helpDialog.drag")}`),
+                ]}
               />
               {/* firefox supports clipboard API under a flag, so we'll
-                  show users what they can do in the error message */}
+                show users what they can do in the error message */}
               {(probablySupportsClipboardBlob || isFirefox) && (
                 <Shortcut
                   label={t("labels.copyAsPng")}
@@ -515,6 +610,9 @@ export const HelpDialog = ({ onClose }: { onClose?: () => void }) => {
               />
             </ShortcutIsland>
           </Section>
+          <div className="HelpDialog__no-results" hidden>
+            {t("helpDialog.noShortcutResults")}
+          </div>
         </div>
       </Dialog>
     </>

--- a/packages/excalidraw/components/HelpDialog.tsx
+++ b/packages/excalidraw/components/HelpDialog.tsx
@@ -60,10 +60,10 @@ const Header = () => (
 );
 
 const Section = (props: { title: string; children: React.ReactNode }) => (
-  <>
+  <div className="HelpDialog__section">
     <h3>{props.title}</h3>
     <div className="HelpDialog__islands-container">{props.children}</div>
-  </>
+  </div>
 );
 
 const ShortcutIsland = (props: {
@@ -140,380 +140,382 @@ export const HelpDialog = ({ onClose }: { onClose?: () => void }) => {
         title={t("helpDialog.title")}
         className={"HelpDialog"}
       >
-        <Header />
-        <Section title={t("helpDialog.shortcuts")}>
-          <ShortcutIsland
-            className="HelpDialog__island--tools"
-            caption={t("helpDialog.tools")}
-          >
-            <Shortcut label={t("toolBar.hand")} shortcuts={[KEYS.H]} />
-            <Shortcut
-              label={t("toolBar.selection")}
-              shortcuts={[KEYS.V, KEYS["1"]]}
-            />
-            <Shortcut
-              label={t("toolBar.rectangle")}
-              shortcuts={[KEYS.R, KEYS["2"]]}
-            />
-            <Shortcut
-              label={t("toolBar.diamond")}
-              shortcuts={[KEYS.D, KEYS["3"]]}
-            />
-            <Shortcut
-              label={t("toolBar.ellipse")}
-              shortcuts={[KEYS.O, KEYS["4"]]}
-            />
-            <Shortcut
-              label={t("toolBar.arrow")}
-              shortcuts={[KEYS.A, KEYS["5"]]}
-            />
-            <Shortcut
-              label={t("toolBar.line")}
-              shortcuts={[KEYS.L, KEYS["6"]]}
-            />
-            <Shortcut
-              label={t("toolBar.freedraw")}
-              shortcuts={[KEYS.P, KEYS["7"]]}
-            />
-            <Shortcut
-              label={t("toolBar.text")}
-              shortcuts={[KEYS.T, KEYS["8"]]}
-            />
-            <Shortcut label={t("toolBar.image")} shortcuts={[KEYS["9"]]} />
-            <Shortcut
-              label={t("toolBar.eraser")}
-              shortcuts={[KEYS.E, KEYS["0"]]}
-            />
-            <Shortcut label={t("toolBar.frame")} shortcuts={[KEYS.F]} />
-            <Shortcut label={t("toolBar.laser")} shortcuts={[KEYS.K]} />
-            <Shortcut label={t("toolBar.bucketfill")} shortcuts={[KEYS.B]} />
-            <Shortcut
-              label={t("labels.eyeDropper")}
-              shortcuts={[KEYS.I, "Shift+S", "Shift+G"]}
-            />
-            <Shortcut
-              label={t("helpDialog.editLineArrowPoints")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+Enter")]}
-            />
-            <Shortcut
-              label={t("helpDialog.editText")}
-              shortcuts={[getShortcutKey("Enter")]}
-            />
-            <Shortcut
-              label={t("helpDialog.textNewLine")}
-              shortcuts={[
-                getShortcutKey("Enter"),
-                getShortcutKey("Shift+Enter"),
-              ]}
-            />
-            <Shortcut
-              label={t("helpDialog.textFinish")}
-              shortcuts={[
-                getShortcutKey("Esc"),
-                getShortcutKey("CtrlOrCmd+Enter"),
-              ]}
-            />
-            <Shortcut
-              label={t("helpDialog.curvedArrow")}
-              shortcuts={[
-                "A",
-                t("helpDialog.click"),
-                t("helpDialog.click"),
-                t("helpDialog.click"),
-              ]}
-              isOr={false}
-            />
-            <Shortcut
-              label={t("helpDialog.curvedLine")}
-              shortcuts={[
-                "L",
-                t("helpDialog.click"),
-                t("helpDialog.click"),
-                t("helpDialog.click"),
-              ]}
-              isOr={false}
-            />
-            <Shortcut
-              label={t("helpDialog.cropStart")}
-              shortcuts={[t("helpDialog.doubleClick"), getShortcutKey("Enter")]}
-              isOr={true}
-            />
-            <Shortcut
-              label={t("helpDialog.cropFinish")}
-              shortcuts={[getShortcutKey("Enter"), getShortcutKey("Escape")]}
-              isOr={true}
-            />
-            <Shortcut label={t("toolBar.lock")} shortcuts={[KEYS.Q]} />
-            <Shortcut
-              label={t("helpDialog.preventBinding")}
-              shortcuts={[getShortcutKey("CtrlOrCmd")]}
-            />
-            <Shortcut
-              label={t("toolBar.link")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+K")]}
-            />
-            <Shortcut
-              label={t("toolBar.convertElementType")}
-              shortcuts={["Tab", "Shift+Tab"]}
-              isOr={true}
-            />
-          </ShortcutIsland>
-          <ShortcutIsland
-            className="HelpDialog__island--view"
-            caption={t("helpDialog.view")}
-          >
-            <Shortcut
-              label={t("buttons.zoomIn")}
-              shortcuts={[getShortcutKey("CtrlOrCmd++")]}
-            />
-            <Shortcut
-              label={t("buttons.zoomOut")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+-")]}
-            />
-            <Shortcut
-              label={t("buttons.resetZoom")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+0")]}
-            />
-            <Shortcut
-              label={t("helpDialog.zoomToFit")}
-              shortcuts={["Shift+1"]}
-            />
-            <Shortcut
-              label={t("helpDialog.zoomToSelection")}
-              shortcuts={["Shift+2"]}
-            />
-            <Shortcut
-              label={t("helpDialog.movePageUpDown")}
-              shortcuts={["PgUp/PgDn"]}
-            />
-            <Shortcut
-              label={t("helpDialog.movePageLeftRight")}
-              shortcuts={["Shift+PgUp/PgDn"]}
-            />
-            <Shortcut
-              label={t("buttons.zenMode")}
-              shortcuts={[getShortcutKey("Alt+Z")]}
-            />
-            <Shortcut
-              label={t("buttons.objectsSnapMode")}
-              shortcuts={[getShortcutKey("Alt+S")]}
-            />
-            <Shortcut
-              label={t("labels.toggleGrid")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+'")]}
-            />
-            <Shortcut
-              label={t("labels.viewMode")}
-              shortcuts={[getShortcutKey("Alt+R")]}
-            />
-            {actionManager.isActionEnabled(actionToggleTheme) && (
+        <div className="HelpDialog__content">
+          <Header />
+          <Section title={t("helpDialog.shortcuts")}>
+            <ShortcutIsland
+              className="HelpDialog__island--tools"
+              caption={t("helpDialog.tools")}
+            >
+              <Shortcut label={t("toolBar.hand")} shortcuts={[KEYS.H]} />
               <Shortcut
-                label={t("labels.toggleTheme")}
-                shortcuts={[getShortcutKey("Alt+Shift+D")]}
+                label={t("toolBar.selection")}
+                shortcuts={[KEYS.V, KEYS["1"]]}
               />
-            )}
-            <Shortcut
-              label={t("stats.fullTitle")}
-              shortcuts={[getShortcutKey("Alt+/")]}
-            />
-            <Shortcut
-              label={t("search.title")}
-              shortcuts={[getShortcutFromShortcutName("searchMenu")]}
-            />
-            <Shortcut
-              label={t("commandPalette.title")}
-              shortcuts={
-                isFirefox
-                  ? [getShortcutFromShortcutName("commandPalette")]
-                  : [
-                      getShortcutFromShortcutName("commandPalette"),
-                      getShortcutFromShortcutName("commandPalette", 1),
-                    ]
-              }
-            />
-          </ShortcutIsland>
-          <ShortcutIsland
-            className="HelpDialog__island--editor"
-            caption={t("helpDialog.editor")}
-          >
-            <Shortcut
-              label={t("helpDialog.createFlowchart")}
-              shortcuts={[getShortcutKey(`CtrlOrCmd+Arrow Key`)]}
-              isOr={true}
-            />
-            <Shortcut
-              label={t("helpDialog.navigateFlowchart")}
-              shortcuts={[getShortcutKey(`Alt+Arrow Key`)]}
-              isOr={true}
-            />
-            <Shortcut
-              label={t("labels.moveCanvas")}
-              shortcuts={[
-                getShortcutKey(`Space+${t("helpDialog.drag")}`),
-                getShortcutKey(`Wheel+${t("helpDialog.drag")}`),
-              ]}
-              isOr={true}
-            />
-            <Shortcut
-              label={t("buttons.clearReset")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+Delete")]}
-            />
-            <Shortcut
-              label={t("labels.delete")}
-              shortcuts={[getShortcutKey("Delete")]}
-            />
-            <Shortcut
-              label={t("labels.cut")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+X")]}
-            />
-            <Shortcut
-              label={t("labels.copy")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+C")]}
-            />
-            <Shortcut
-              label={t("labels.paste")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+V")]}
-            />
-            <Shortcut
-              label={t("labels.pasteAsPlaintext")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+Shift+V")]}
-            />
-            <Shortcut
-              label={t("labels.selectAll")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+A")]}
-            />
-            <Shortcut
-              label={t("labels.multiSelect")}
-              shortcuts={[getShortcutKey(`Shift+${t("helpDialog.click")}`)]}
-            />
-            <Shortcut
-              label={t("helpDialog.deepSelect")}
-              shortcuts={[getShortcutKey(`CtrlOrCmd+${t("helpDialog.click")}`)]}
-            />
-            <Shortcut
-              label={t("helpDialog.deepBoxSelect")}
-              shortcuts={[getShortcutKey(`CtrlOrCmd+${t("helpDialog.drag")}`)]}
-            />
-            {/* firefox supports clipboard API under a flag, so we'll
-                show users what they can do in the error message */}
-            {(probablySupportsClipboardBlob || isFirefox) && (
               <Shortcut
-                label={t("labels.copyAsPng")}
-                shortcuts={[getShortcutKey("Shift+Alt+C")]}
+                label={t("toolBar.rectangle")}
+                shortcuts={[KEYS.R, KEYS["2"]]}
               />
-            )}
-            <Shortcut
-              label={t("labels.copyStyles")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+Alt+C")]}
-            />
-            <Shortcut
-              label={t("labels.pasteStyles")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+Alt+V")]}
-            />
-            <Shortcut
-              label={t("labels.sendToBack")}
-              shortcuts={[
-                isDarwin
-                  ? getShortcutKey("CtrlOrCmd+Alt+[")
-                  : getShortcutKey("CtrlOrCmd+Shift+["),
-              ]}
-            />
-            <Shortcut
-              label={t("labels.bringToFront")}
-              shortcuts={[
-                isDarwin
-                  ? getShortcutKey("CtrlOrCmd+Alt+]")
-                  : getShortcutKey("CtrlOrCmd+Shift+]"),
-              ]}
-            />
-            <Shortcut
-              label={t("labels.sendBackward")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+[")]}
-            />
-            <Shortcut
-              label={t("labels.bringForward")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+]")]}
-            />
-            <Shortcut
-              label={t("labels.alignTop")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+Shift+Up")]}
-            />
-            <Shortcut
-              label={t("labels.alignBottom")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+Shift+Down")]}
-            />
-            <Shortcut
-              label={t("labels.alignLeft")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+Shift+Left")]}
-            />
-            <Shortcut
-              label={t("labels.alignRight")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+Shift+Right")]}
-            />
-            <Shortcut
-              label={t("labels.duplicateSelection")}
-              shortcuts={[
-                getShortcutKey("CtrlOrCmd+D"),
-                getShortcutKey(`Alt+${t("helpDialog.drag")}`),
-              ]}
-            />
-            <Shortcut
-              label={t("helpDialog.toggleElementLock")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+Shift+L")]}
-            />
-            <Shortcut
-              label={t("buttons.undo")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+Z")]}
-            />
-            <Shortcut
-              label={t("buttons.redo")}
-              shortcuts={
-                isWindows
-                  ? [
-                      getShortcutKey("CtrlOrCmd+Y"),
-                      getShortcutKey("CtrlOrCmd+Shift+Z"),
-                    ]
-                  : [getShortcutKey("CtrlOrCmd+Shift+Z")]
-              }
-            />
-            <Shortcut
-              label={t("labels.group")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+G")]}
-            />
-            <Shortcut
-              label={t("labels.ungroup")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+Shift+G")]}
-            />
-            <Shortcut
-              label={t("labels.flipHorizontal")}
-              shortcuts={[getShortcutKey("Shift+H")]}
-            />
-            <Shortcut
-              label={t("labels.flipVertical")}
-              shortcuts={[getShortcutKey("Shift+V")]}
-            />
-            <Shortcut
-              label={t("labels.showStroke")}
-              shortcuts={[getShortcutKey("S")]}
-            />
-            <Shortcut
-              label={t("labels.showBackground")}
-              shortcuts={[getShortcutKey("G")]}
-            />
-            <Shortcut
-              label={t("labels.showFonts")}
-              shortcuts={[getShortcutKey("Shift+F")]}
-            />
-            <Shortcut
-              label={t("labels.decreaseFontSize")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+Shift+<")]}
-            />
-            <Shortcut
-              label={t("labels.increaseFontSize")}
-              shortcuts={[getShortcutKey("CtrlOrCmd+Shift+>")]}
-            />
-          </ShortcutIsland>
-        </Section>
+              <Shortcut
+                label={t("toolBar.diamond")}
+                shortcuts={[KEYS.D, KEYS["3"]]}
+              />
+              <Shortcut
+                label={t("toolBar.ellipse")}
+                shortcuts={[KEYS.O, KEYS["4"]]}
+              />
+              <Shortcut
+                label={t("toolBar.arrow")}
+                shortcuts={[KEYS.A, KEYS["5"]]}
+              />
+              <Shortcut
+                label={t("toolBar.line")}
+                shortcuts={[KEYS.L, KEYS["6"]]}
+              />
+              <Shortcut
+                label={t("toolBar.freedraw")}
+                shortcuts={[KEYS.P, KEYS["7"]]}
+              />
+              <Shortcut
+                label={t("toolBar.text")}
+                shortcuts={[KEYS.T, KEYS["8"]]}
+              />
+              <Shortcut label={t("toolBar.image")} shortcuts={[KEYS["9"]]} />
+              <Shortcut
+                label={t("toolBar.eraser")}
+                shortcuts={[KEYS.E, KEYS["0"]]}
+              />
+              <Shortcut label={t("toolBar.frame")} shortcuts={[KEYS.F]} />
+              <Shortcut label={t("toolBar.laser")} shortcuts={[KEYS.K]} />
+              <Shortcut label={t("toolBar.bucketfill")} shortcuts={[KEYS.B]} />
+              <Shortcut
+                label={t("labels.eyeDropper")}
+                shortcuts={[KEYS.I, "Shift+S", "Shift+G"]}
+              />
+              <Shortcut
+                label={t("helpDialog.editLineArrowPoints")}
+                shortcuts={[getShortcutKey("CtrlOrCmd+Enter")]}
+              />
+              <Shortcut
+                label={t("helpDialog.editText")}
+                shortcuts={[getShortcutKey("Enter")]}
+              />
+              <Shortcut
+                label={t("helpDialog.textNewLine")}
+                shortcuts={[
+                  getShortcutKey("Enter"),
+                  getShortcutKey("Shift+Enter"),
+                ]}
+              />
+              <Shortcut
+                label={t("helpDialog.textFinish")}
+                shortcuts={[
+                  getShortcutKey("Esc"),
+                  getShortcutKey("CtrlOrCmd+Enter"),
+                ]}
+              />
+              <Shortcut
+                label={t("helpDialog.curvedArrow")}
+                shortcuts={[
+                  "A",
+                  t("helpDialog.click"),
+                  t("helpDialog.click"),
+                  t("helpDialog.click"),
+                ]}
+                isOr={false}
+              />
+              <Shortcut
+                label={t("helpDialog.curvedLine")}
+                shortcuts={[
+                  "L",
+                  t("helpDialog.click"),
+                  t("helpDialog.click"),
+                  t("helpDialog.click"),
+                ]}
+                isOr={false}
+              />
+              <Shortcut
+                label={t("helpDialog.cropStart")}
+                shortcuts={[t("helpDialog.doubleClick"), getShortcutKey("Enter")]}
+                isOr={true}
+              />
+              <Shortcut
+                label={t("helpDialog.cropFinish")}
+                shortcuts={[getShortcutKey("Enter"), getShortcutKey("Escape")]}
+                isOr={true}
+              />
+              <Shortcut label={t("toolBar.lock")} shortcuts={[KEYS.Q]} />
+              <Shortcut
+                label={t("helpDialog.preventBinding")}
+                shortcuts={[getShortcutKey("CtrlOrCmd")]}
+              />
+              <Shortcut
+                label={t("toolBar.link")}
+                shortcuts={[getShortcutKey("CtrlOrCmd+K")]}
+              />
+              <Shortcut
+                label={t("toolBar.convertElementType")}
+                shortcuts={["Tab", "Shift+Tab"]}
+                isOr={true}
+              />
+            </ShortcutIsland>
+            <ShortcutIsland
+              className="HelpDialog__island--view"
+              caption={t("helpDialog.view")}
+            >
+              <Shortcut
+                label={t("buttons.zoomIn")}
+                shortcuts={[getShortcutKey("CtrlOrCmd++")]}
+              />
+              <Shortcut
+                label={t("buttons.zoomOut")}
+                shortcuts={[getShortcutKey("CtrlOrCmd+-")]}
+              />
+              <Shortcut
+                label={t("buttons.resetZoom")}
+                shortcuts={[getShortcutKey("CtrlOrCmd+0")]}
+              />
+              <Shortcut
+                label={t("helpDialog.zoomToFit")}
+                shortcuts={["Shift+1"]}
+              />
+              <Shortcut
+                label={t("helpDialog.zoomToSelection")}
+                shortcuts={["Shift+2"]}
+              />
+              <Shortcut
+                label={t("helpDialog.movePageUpDown")}
+                shortcuts={["PgUp/PgDn"]}
+              />
+              <Shortcut
+                label={t("helpDialog.movePageLeftRight")}
+                shortcuts={["Shift+PgUp/PgDn"]}
+              />
+              <Shortcut
+                label={t("buttons.zenMode")}
+                shortcuts={[getShortcutKey("Alt+Z")]}
+              />
+              <Shortcut
+                label={t("buttons.objectsSnapMode")}
+                shortcuts={[getShortcutKey("Alt+S")]}
+              />
+              <Shortcut
+                label={t("labels.toggleGrid")}
+                shortcuts={[getShortcutKey("CtrlOrCmd+'")]}
+              />
+              <Shortcut
+                label={t("labels.viewMode")}
+                shortcuts={[getShortcutKey("Alt+R")]}
+              />
+              {actionManager.isActionEnabled(actionToggleTheme) && (
+                <Shortcut
+                  label={t("labels.toggleTheme")}
+                  shortcuts={[getShortcutKey("Alt+Shift+D")]}
+                />
+              )}
+              <Shortcut
+                label={t("stats.fullTitle")}
+                shortcuts={[getShortcutKey("Alt+/")]}
+              />
+              <Shortcut
+                label={t("search.title")}
+                shortcuts={[getShortcutFromShortcutName("searchMenu")]}
+              />
+              <Shortcut
+                label={t("commandPalette.title")}
+                shortcuts={
+                  isFirefox
+                    ? [getShortcutFromShortcutName("commandPalette")]
+                    : [
+                        getShortcutFromShortcutName("commandPalette"),
+                        getShortcutFromShortcutName("commandPalette", 1),
+                      ]
+                }
+              />
+            </ShortcutIsland>
+            <ShortcutIsland
+              className="HelpDialog__island--editor"
+              caption={t("helpDialog.editor")}
+            >
+              <Shortcut
+                label={t("helpDialog.createFlowchart")}
+                shortcuts={[getShortcutKey(`CtrlOrCmd+Arrow Key`)]}
+                isOr={true}
+              />
+              <Shortcut
+                label={t("helpDialog.navigateFlowchart")}
+                shortcuts={[getShortcutKey(`Alt+Arrow Key`)]}
+                isOr={true}
+              />
+              <Shortcut
+                label={t("labels.moveCanvas")}
+                shortcuts={[
+                  getShortcutKey(`Space+${t("helpDialog.drag")}`),
+                  getShortcutKey(`Wheel+${t("helpDialog.drag")}`),
+                ]}
+                isOr={true}
+              />
+              <Shortcut
+                label={t("buttons.clearReset")}
+                shortcuts={[getShortcutKey("CtrlOrCmd+Delete")]}
+              />
+              <Shortcut
+                label={t("labels.delete")}
+                shortcuts={[getShortcutKey("Delete")]}
+              />
+              <Shortcut
+                label={t("labels.cut")}
+                shortcuts={[getShortcutKey("CtrlOrCmd+X")]}
+              />
+              <Shortcut
+                label={t("labels.copy")}
+                shortcuts={[getShortcutKey("CtrlOrCmd+C")]}
+              />
+              <Shortcut
+                label={t("labels.paste")}
+                shortcuts={[getShortcutKey("CtrlOrCmd+V")]}
+              />
+              <Shortcut
+                label={t("labels.pasteAsPlaintext")}
+                shortcuts={[getShortcutKey("CtrlOrCmd+Shift+V")]}
+              />
+              <Shortcut
+                label={t("labels.selectAll")}
+                shortcuts={[getShortcutKey("CtrlOrCmd+A")]}
+              />
+              <Shortcut
+                label={t("labels.multiSelect")}
+                shortcuts={[getShortcutKey(`Shift+${t("helpDialog.click")}`)]}
+              />
+              <Shortcut
+                label={t("helpDialog.deepSelect")}
+                shortcuts={[getShortcutKey(`CtrlOrCmd+${t("helpDialog.click")}`)]}
+              />
+              <Shortcut
+                label={t("helpDialog.deepBoxSelect")}
+                shortcuts={[getShortcutKey(`CtrlOrCmd+${t("helpDialog.drag")}`)]}
+              />
+              {/* firefox supports clipboard API under a flag, so we'll
+                  show users what they can do in the error message */}
+              {(probablySupportsClipboardBlob || isFirefox) && (
+                <Shortcut
+                  label={t("labels.copyAsPng")}
+                  shortcuts={[getShortcutKey("Shift+Alt+C")]}
+                />
+              )}
+              <Shortcut
+                label={t("labels.copyStyles")}
+                shortcuts={[getShortcutKey("CtrlOrCmd+Alt+C")]}
+              />
+              <Shortcut
+                label={t("labels.pasteStyles")}
+                shortcuts={[getShortcutKey("CtrlOrCmd+Alt+V")]}
+              />
+              <Shortcut
+                label={t("labels.sendToBack")}
+                shortcuts={[
+                  isDarwin
+                    ? getShortcutKey("CtrlOrCmd+Alt+[")
+                    : getShortcutKey("CtrlOrCmd+Shift+["),
+                ]}
+              />
+              <Shortcut
+                label={t("labels.bringToFront")}
+                shortcuts={[
+                  isDarwin
+                    ? getShortcutKey("CtrlOrCmd+Alt+]")
+                    : getShortcutKey("CtrlOrCmd+Shift+]"),
+                ]}
+              />
+              <Shortcut
+                label={t("labels.sendBackward")}
+                shortcuts={[getShortcutKey("CtrlOrCmd+[")]}
+              />
+              <Shortcut
+                label={t("labels.bringForward")}
+                shortcuts={[getShortcutKey("CtrlOrCmd+]")]}
+              />
+              <Shortcut
+                label={t("labels.alignTop")}
+                shortcuts={[getShortcutKey("CtrlOrCmd+Shift+Up")]}
+              />
+              <Shortcut
+                label={t("labels.alignBottom")}
+                shortcuts={[getShortcutKey("CtrlOrCmd+Shift+Down")]}
+              />
+              <Shortcut
+                label={t("labels.alignLeft")}
+                shortcuts={[getShortcutKey("CtrlOrCmd+Shift+Left")]}
+              />
+              <Shortcut
+                label={t("labels.alignRight")}
+                shortcuts={[getShortcutKey("CtrlOrCmd+Shift+Right")]}
+              />
+              <Shortcut
+                label={t("labels.duplicateSelection")}
+                shortcuts={[
+                  getShortcutKey("CtrlOrCmd+D"),
+                  getShortcutKey(`Alt+${t("helpDialog.drag")}`),
+                ]}
+              />
+              <Shortcut
+                label={t("helpDialog.toggleElementLock")}
+                shortcuts={[getShortcutKey("CtrlOrCmd+Shift+L")]}
+              />
+              <Shortcut
+                label={t("buttons.undo")}
+                shortcuts={[getShortcutKey("CtrlOrCmd+Z")]}
+              />
+              <Shortcut
+                label={t("buttons.redo")}
+                shortcuts={
+                  isWindows
+                    ? [
+                        getShortcutKey("CtrlOrCmd+Y"),
+                        getShortcutKey("CtrlOrCmd+Shift+Z"),
+                      ]
+                    : [getShortcutKey("CtrlOrCmd+Shift+Z")]
+                }
+              />
+              <Shortcut
+                label={t("labels.group")}
+                shortcuts={[getShortcutKey("CtrlOrCmd+G")]}
+              />
+              <Shortcut
+                label={t("labels.ungroup")}
+                shortcuts={[getShortcutKey("CtrlOrCmd+Shift+G")]}
+              />
+              <Shortcut
+                label={t("labels.flipHorizontal")}
+                shortcuts={[getShortcutKey("Shift+H")]}
+              />
+              <Shortcut
+                label={t("labels.flipVertical")}
+                shortcuts={[getShortcutKey("Shift+V")]}
+              />
+              <Shortcut
+                label={t("labels.showStroke")}
+                shortcuts={[getShortcutKey("S")]}
+              />
+              <Shortcut
+                label={t("labels.showBackground")}
+                shortcuts={[getShortcutKey("G")]}
+              />
+              <Shortcut
+                label={t("labels.showFonts")}
+                shortcuts={[getShortcutKey("Shift+F")]}
+              />
+              <Shortcut
+                label={t("labels.decreaseFontSize")}
+                shortcuts={[getShortcutKey("CtrlOrCmd+Shift+<")]}
+              />
+              <Shortcut
+                label={t("labels.increaseFontSize")}
+                shortcuts={[getShortcutKey("CtrlOrCmd+Shift+>")]}
+              />
+            </ShortcutIsland>
+          </Section>
+        </div>
       </Dialog>
     </>
   );

--- a/packages/excalidraw/locales/en.json
+++ b/packages/excalidraw/locales/en.json
@@ -473,7 +473,9 @@
     "movePageUpDown": "Move page up/down",
     "movePageLeftRight": "Move page left/right",
     "cropStart": "Crop image",
-    "cropFinish": "Finish image cropping"
+    "cropFinish": "Finish image cropping",
+    "searchShortcuts": "Search shortcuts...",
+    "noShortcutResults": "No matching shortcuts found"
   },
   "clearCanvasDialog": {
     "title": "Clear canvas"

--- a/packages/excalidraw/tests/helpDialog.test.tsx
+++ b/packages/excalidraw/tests/helpDialog.test.tsx
@@ -1,0 +1,97 @@
+import React from "react";
+
+import { KEYS } from "@excalidraw/common";
+
+import { Excalidraw } from "../index";
+
+import { API } from "./helpers/api";
+import { Keyboard } from "./helpers/ui";
+import { act, fireEvent, render, waitFor } from "./test-utils";
+
+const queryHelpContent = () =>
+  document.querySelector<HTMLDivElement>(".HelpDialog__content")!;
+
+const querySearchInput = () =>
+  queryHelpContent().querySelector<HTMLInputElement>(
+    ".HelpDialog__search-input",
+  )!;
+
+describe("help dialog", () => {
+  beforeEach(async () => {
+    await render(<Excalidraw handleKeyboardGlobally />);
+    API.setAppState({ openDialog: { name: "help" } });
+  });
+
+  it("should focus the shortcut search on ctrl/cmd+f", async () => {
+    await waitFor(() => {
+      expect(querySearchInput()).not.toBeNull();
+    });
+
+    const input = querySearchInput();
+    expect(input.matches(":focus")).toBe(false);
+
+    Keyboard.withModifierKeys({ ctrl: true }, () => {
+      Keyboard.keyPress(KEYS.F);
+    });
+
+    await waitFor(() => {
+      expect(querySearchInput().matches(":focus")).toBe(true);
+    });
+  });
+
+  it("should filter shortcuts and hide empty islands while searching", async () => {
+    const content = await waitFor(() => {
+      const content = queryHelpContent();
+      expect(content.querySelector(".HelpDialog__search-input")).not.toBeNull();
+      return content;
+    });
+
+    const allShortcuts = () =>
+      Array.from(
+        content.querySelectorAll<HTMLElement>(".HelpDialog__shortcut"),
+      );
+
+    const total = allShortcuts().length;
+    expect(total).toBeGreaterThan(0);
+    expect(allShortcuts().filter((el) => !el.hidden)).toHaveLength(total);
+
+    const input = querySearchInput();
+
+    act(() => {
+      fireEvent.change(input, { target: { value: "zoom" } });
+    });
+
+    await waitFor(() => {
+      const visible = allShortcuts().filter((el) => !el.hidden);
+      expect(visible.length).toBeGreaterThan(0);
+      expect(visible.length).toBeLessThan(total);
+      for (const el of visible) {
+        expect(el.firstElementChild?.textContent?.toLowerCase()).toContain(
+          "zoom",
+        );
+      }
+      for (const island of Array.from(
+        content.querySelectorAll<HTMLElement>(".HelpDialog__island"),
+      )) {
+        if (!island.hidden) {
+          expect(
+            island.querySelector(".HelpDialog__shortcut:not([hidden])"),
+          ).not.toBeNull();
+        }
+      }
+    });
+
+    act(() => {
+      fireEvent.change(input, { target: { value: "zzz-no-match-zzz" } });
+    });
+
+    await waitFor(() => {
+      expect(allShortcuts().filter((el) => !el.hidden)).toHaveLength(0);
+      const noResults = content.querySelector<HTMLElement>(
+        ".HelpDialog__no-results",
+      );
+      expect(noResults).not.toBeNull();
+      expect(noResults!.hidden).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #9276

- Adds a search input to the Help dialog that live-filters the keyboard-shortcut list by label
- Shortcut rows, shortcut islands and whole sections hide automatically when nothing matches them; a \No matching shortcuts found\ message appears when nothing matches at all
- While the dialog is open, **Ctrl/Cmd+F** now focuses/selects the help search box instead of toggling the canvas search menu or opening the browser find bar (the exact complaint in #9276)
- On wide screens the islands' fixed grid areas are released while searching so hidden islands don't leave gaps
- New i18n keys (\helpDialog.searchShortcuts\, \helpDialog.noShortcutResults\) added to \en.json\; other locales fall back

## Implementation notes

Filtering hides nodes via the \hidden\ attribute instead of unmounting so DOM stays stable while typing; explicit \display:none\ overrides were needed because shortcut rows set their own display value.

## Testing

- New \packages/excalidraw/tests/helpDialog.test.tsx\:
  - Ctrl+F focuses the search input while the dialog is open
  - typing filters shortcuts to matching labels, hides empty islands, shows the no-results state for garbage queries
- \yarn test:typecheck\, eslint (\--max-warnings=0\) and prettier all pass
- Existing suites (search, history, move, selection, dragCreate) pass