### PR TITLE
fix: make opacity slider RTL-compatible

### DIFF
--- a/packages/excalidraw/components/Range.scss
+++ b/packages/excalidraw/components/Range.scss
@@ -46,10 +46,14 @@
     color: var(--text-primary-color);
   }
 
+  [dir="rtl"] & .value-bubble {
+    transform: translateX(50%);
+  }
+
   .zero-label {
     position: absolute;
     bottom: 0;
-    left: 4px;
+    inset-inline-start: 4px;
     font-size: 12px;
     color: var(--text-primary-color);
   }

--- a/packages/excalidraw/components/Range.tsx
+++ b/packages/excalidraw/components/Range.tsx
@@ -42,8 +42,18 @@ export const Range = ({
       const progress = ((value - min) / (max - min || 1)) * 100;
       const position =
         (progress / 100) * (inputWidth - thumbWidth) + thumbWidth / 2;
-      valueElement.style.left = `${position}px`;
-      rangeElement.style.background = `linear-gradient(to right, var(--color-slider-track) 0%, var(--color-slider-track) ${progress}%, var(--button-bg) ${progress}%, var(--button-bg) 100%)`;
+      const isRTL =
+        rangeElement.ownerDocument.dir === "rtl" ||
+        rangeElement.closest("[dir='rtl']") !== null;
+      if (isRTL) {
+        valueElement.style.left = "auto";
+        valueElement.style.right = `${position}px`;
+        rangeElement.style.background = `linear-gradient(to left, var(--color-slider-track) 0%, var(--color-slider-track) ${progress}%, var(--button-bg) ${progress}%, var(--button-bg) 100%)`;
+      } else {
+        valueElement.style.left = `${position}px`;
+        valueElement.style.right = "auto";
+        rangeElement.style.background = `linear-gradient(to right, var(--color-slider-track) 0%, var(--color-slider-track) ${progress}%, var(--button-bg) ${progress}%, var(--button-bg) 100%)`;
+      }
     }
   }, [max, min, value]);
 


### PR DESCRIPTION
## Summary

Fixes the opacity slider (and other Range components) to work correctly in RTL layouts.

## Problem

Issue #9710: The element transparency option bar is not compatible with RTL. The value bubble and gradient were hardcoded for LTR, causing incorrect positioning in RTL mode.

## Fix

- **Range.tsx**: Detect RTL direction and position the value bubble on the correct side (right for RTL, left for LTR). Reverse gradient direction for RTL.
- **Range.scss**: Use logical CSS property `inset-inline-start` instead of `left` for the zero-label. Add RTL-specific transform for value bubble.

## Testing

1. Set `dir="rtl"` on the document or a parent element
2. Select an element and adjust opacity
3. Verify the value bubble appears on the correct side
4. Verify the gradient fills from the correct direction
5. Test in LTR mode to ensure no regression

Fixes #9710
