### PR TITLE
fix(search): keep results order stable when elements move on canvas

### DIFF
--- a/packages/excalidraw/components/SearchMenu.tsx
+++ b/packages/excalidraw/components/SearchMenu.tsx
@@ -100,6 +100,40 @@ export const SearchMenu = () => {
   const [focusIndex, setFocusIndex] = useAtom(searchItemInFocusAtom);
   const elementsMap = app.scene.getNonDeletedElementsMap();
 
+  // Remembers the order in which results were first listed for the current
+  // query so that canvas changes (e.g. dragging an element around) don't
+  // reorder the list under the user's hands
+  const stableOrderRef = useRef<Map<string, number>>(new Map());
+  const stableOrderQueryRef = useRef<SearchQuery | null>(null);
+
+  const applyStableOrder = (
+    matchItems: SearchMatchItem[],
+    query: SearchQuery,
+  ) => {
+    if (
+      stableOrderQueryRef.current === query &&
+      stableOrderRef.current.size > 0
+    ) {
+      const orderMap = stableOrderRef.current;
+      const positionOf = (item: SearchMatchItem) => {
+        const position = orderMap.get(getStableKey(item));
+        return position === undefined ? Number.MAX_SAFE_INTEGER : position;
+      };
+
+      matchItems = [...matchItems].sort(
+        (a, b) => positionOf(a) - positionOf(b),
+      );
+    } else {
+      stableOrderQueryRef.current = query;
+    }
+
+    stableOrderRef.current = new Map(
+      matchItems.map((item, itemIndex) => [getStableKey(item), itemIndex]),
+    );
+
+    return matchItems;
+  };
+
   useEffect(() => {
     if (isSearching) {
       return;
@@ -110,6 +144,8 @@ export const SearchMenu = () => {
     ) {
       searchedQueryRef.current = null;
       handleSearch(searchQuery, app, (matchItems, index) => {
+        matchItems = applyStableOrder(matchItems, searchQuery);
+
         setSearchMatches({
           nonce: randomInteger(),
           items: matchItems,
@@ -355,6 +391,7 @@ export const SearchMenu = () => {
             setIsSearching(true);
             const searchQuery = value.trim() as SearchQuery;
             handleSearch(searchQuery, app, (matchItems, index) => {
+              matchItems = applyStableOrder(matchItems, searchQuery);
               setSearchMatches({
                 nonce: randomInteger(),
                 items: matchItems,
@@ -776,6 +813,12 @@ const getMatchInFrame = (
 
 const escapeSpecialCharacters = (string: string) => {
   return string.replace(/[.*+?^${}()|[\]\\-]/g, "\\$&");
+};
+
+// Identifies a single match within an element. The character offset (and
+// therefore the key) doesn't change while the element is moved around
+const getStableKey = (item: SearchMatchItem) => {
+  return `${item.element.id}:${item.index}`;
 };
 
 const handleSearch = debounce(

--- a/packages/excalidraw/components/SearchMenu.tsx
+++ b/packages/excalidraw/components/SearchMenu.tsx
@@ -110,6 +110,10 @@ export const SearchMenu = () => {
     matchItems: SearchMatchItem[],
     query: SearchQuery,
   ) => {
+    // `SearchQuery` is a branded string (`string & { _brand: "SearchQuery" }`),
+    // so identity equality here is really string equality. This only carries
+    // intent while that stays true — if it ever became an object, it would
+    // silently stop matching and the order snapshot would reset on every pass.
     if (
       stableOrderQueryRef.current === query &&
       stableOrderRef.current.size > 0
@@ -117,6 +121,11 @@ export const SearchMenu = () => {
       const orderMap = stableOrderRef.current;
       const positionOf = (item: SearchMatchItem) => {
         const position = orderMap.get(getStableKey(item));
+        // Matches that weren't part of the captured order yet (new elements
+        // added mid-search) all fall back to this sentinel key, so they sort
+        // to the end. Their relative order is then whatever `Array.prototype
+        // .sort`'s stability gives us — i.e. natural incoming order — rather
+        // than a derived key. That's the intended behaviour.
         return position === undefined ? Number.MAX_SAFE_INTEGER : position;
       };
 
@@ -127,6 +136,11 @@ export const SearchMenu = () => {
       stableOrderQueryRef.current = query;
     }
 
+    // Renumbering the snapshot on every pass (including the reuse branch) is
+    // deliberate: newly-appeared matches get real positions here instead of
+    // staying pinned at MAX_SAFE_INTEGER forever. Because the key is scoped to
+    // the element id + match offset — stable while elements move — already
+    // captured matches keep their original slots.
     stableOrderRef.current = new Map(
       matchItems.map((item, itemIndex) => [getStableKey(item), itemIndex]),
     );

--- a/packages/excalidraw/tests/search.test.tsx
+++ b/packages/excalidraw/tests/search.test.tsx
@@ -113,6 +113,64 @@ describe("search", () => {
     expect(h.app.state.searchMatches?.matches[1].focus).toBe(false);
   });
 
+  it("should keep search results order stable while elements move", async () => {
+    const draggedElement = API.createElement({
+      type: "text",
+      text: "test 1",
+      x: 50,
+      y: 50,
+    });
+    const otherElement = API.createElement({
+      type: "text",
+      text: "test 2",
+      x: 50,
+      y: 200,
+    });
+
+    API.setElements([draggedElement, otherElement]);
+
+    Keyboard.withModifierKeys({ ctrl: true }, () => {
+      Keyboard.keyPress(KEYS.F);
+    });
+
+    const searchInput = await querySearchInput();
+
+    updateTextEditor(searchInput, "test");
+
+    await waitFor(() => {
+      expect(h.app.state.searchMatches?.matches.length).toBe(2);
+    });
+
+    const orderBefore = h.app.state
+      .searchMatches!.matches.map((match) => match.id)
+      .join(",");
+
+    expect(orderBefore).toBe(`${draggedElement.id},${otherElement.id}`);
+
+    // move the top element below the second one and emit a scene update,
+    // mimicking a canvas drag which re-searches and used to reorder the
+    // results list under the user's hands (#9503)
+    const liveElement = h.app.scene
+      .getNonDeletedElements()
+      .find((element) => element.id === draggedElement.id)!;
+
+    act(() => {
+      h.app.scene.mutateElement(liveElement, { y: 350 });
+    });
+    act(() => {
+      h.app.scene.replaceAllElements(h.app.scene.getNonDeletedElements());
+    });
+
+    // wait out the search debounce (350ms) so a re-search definitely ran
+    await new Promise((resolve) => setTimeout(resolve, 500));
+
+    const orderAfter = h.app.state
+      .searchMatches!.matches.map((match) => match.id)
+      .join(",");
+
+    expect(orderAfter).toEqual(orderBefore);
+  });
+
   it("should match text split across multiple lines", async () => {
     const scrollIntoViewMock = jest.fn();
     window.HTMLElement.prototype.scrollIntoView = scrollIntoViewMock;


### PR DESCRIPTION
fix #9503

## Problem

The search results list reorders itself while you drag elements around (or anyone else changes the canvas). `handleSearch` sorts matches by `element.y`, and the search effect re-runs whenever the scene nonce changes — which happens on every drag — so the list reshuffles under your hands.

Per @dwelle in the issue: results should keep a constant ordering so the list doesn't change while you're working through it.

## Approach

The initial ordering for a query stays as-is (top-to-bottom by `y`), but the order is now **captured** when a query is (re)searched and replayed on subsequent scene-driven re-searches:

- matches are keyed by `elementId:matchOffset` (stable while elements move),
- on scene-triggered re-search the fresh match set is re-sorted into the captured order,
- new matches (elements added mid-search) are appended at the end in their natural `y` order,
- changing the query resets the order snapshot.

So dragging never reshuffles the list, but you still get sensible top-to-bottom ordering when you start a search, and newly matching elements still show up.

## Testing

- added regression test `should keep search results order stable while elements move` in `tests/search.test.tsx` (mutates an element's `y`, waits out the debounce, asserts the match order is unchanged)
- `vitest packages/excalidraw/tests/search.test.tsx` — 6/6 pass
- eslint + prettier clean
