### PR TITLE
fix: Ctrl+S saves file even when text element is being edited

### DIFF
--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -5521,7 +5521,9 @@ class App extends React.Component<AppProps, AppState> {
         // inside an input
         (isWritableElement(event.target) &&
           // unless pressing escape (finalize action)
-          event.key !== KEYS.ESCAPE) ||
+          event.key !== KEYS.ESCAPE &&
+          // unless pressing Ctrl+S/Cmd+S (save to file)
+          !(event[KEYS.CTRL_OR_CMD] && event.key.toLowerCase() === KEYS.S)) ||
         // or unless using arrows (to move between buttons)
         (isArrowKey(event.key) && isInputLike(event.target))
       ) {


### PR DESCRIPTION
## Summary

Fixes #9281

### The problem

When a text element was being edited (textarea focused), pressing Ctrl+S / Cmd+S would fall through to the browsers save-as dialog instead of Excalidraws save-to-file action.

### The fix

The keyboard handler in `App.tsx` bails early for writable elements (textareas) unless the key is Escape. Added an exception for Ctrl+S / Cmd+S so the save action fires regardless of text focus.

```diff
 (isWritableElement(event.target) &&
   event.key !== KEYS.ESCAPE &&
+  !(event[KEYS.CTRL_OR_CMD] && event.key.toLowerCase() === KEYS.S)) ||
```

### Verification

- ✅ TypeScript compiles clean
- ✅ Only 3 lines changed (1 file)