### PR TITLE
fix: handle Ctrl+Shift+S during text editing

### DIFF
--- a/packages/excalidraw/wysiwyg/textWysiwyg.tsx
+++ b/packages/excalidraw/wysiwyg/textWysiwyg.tsx
@@ -54,7 +54,7 @@ import type {
   ExcalidrawTextContainer,
 } from "@excalidraw/element/types";
 
-import { actionSaveToActiveFile } from "../actions";
+import { actionSaveFileToDisk, actionSaveToActiveFile } from "../actions";
 
 import {
   parseClipboard,
@@ -661,6 +661,10 @@ export const textWysiwyg = ({
       event.preventDefault();
       handleSubmit();
       app.actionManager.executeAction(actionSaveToActiveFile);
+    } else if (actionSaveFileToDisk.keyTest(event)) {
+      event.preventDefault();
+      handleSubmit();
+      app.actionManager.executeAction(actionSaveFileToDisk);
     } else if (event.key === KEYS.ENTER && event[KEYS.CTRL_OR_CMD]) {
       event.preventDefault();
       if (event.isComposing || event.keyCode === 229) {


### PR DESCRIPTION
Fixes #11914

## What
The text wysiwyg keydown handler only handled `actionSaveToActiveFile` (Ctrl+S) but not `actionSaveFileToDisk` (Ctrl+Shift+S). This meant that pressing Cmd/Ctrl+Shift+S while editing a text element did nothing — the text editor stayed open and no save occurred.

## Fix
Added `actionSaveFileToDisk` to the text wysiwyg keydown handler, alongside the existing `actionSaveToActiveFile` handler. When Ctrl+Shift+S is pressed during text editing, the text is committed and the save-to-disk action is executed, matching the behavior of plain Ctrl+S.

## Testing
- TypeScript compiles clean
- Existing keyboard shortcut tests unaffected