### PR TITLE
fix: detect localStorage quota errors in Firefox and Safari

### DIFF
--- a/excalidraw-app/data/LocalData.ts
+++ b/excalidraw-app/data/LocalData.ts
@@ -109,7 +109,24 @@ const saveDataStateToLocalStorage = (
 };
 
 const isQuotaExceededError = (error: any) => {
-  return error instanceof DOMException && error.name === "QuotaExceededError";
+  if (!(error instanceof DOMException)) {
+    return false;
+  }
+  // Chromium
+  if (error.name === "QuotaExceededError") {
+    return true;
+  }
+  // Firefox
+  if (error.name === "NS_ERROR_DOM_QUOTA_REACHED") {
+    return true;
+  }
+  // Older WebKit / Safari
+  if (error.name === "QUOTA_EXCEEDED_ERR") {
+    return true;
+  }
+  // Fallback: check DOMException.code for quota errors
+  // code 22 = QUOTA_EXCEEDED_ERR, code 1014 = NS_ERROR_DOM_QUOTA_REACHED
+  return error.code === 22 || error.code === 1014;
 };
 
 type SavingLockTypes = "collaboration";


### PR DESCRIPTION
Fixes #11962

## What
The localStorage quota exceeded error detection only recognized Chromium's `QuotaExceededError` DOMException name. Firefox throws `NS_ERROR_DOM_QUOTA_REACHED` and older WebKit uses `QUOTA_EXCEEDED_ERR`. This meant the quota warning banner never appeared in Firefox, silently dropping scene saves.

## Fix
Added detection for all three browser-specific error names plus a `DOMException.code` fallback (codes 22 and 1014), matching the exact fix suggested in the issue.

## Testing
- TypeScript compiles clean (excalidraw-app has no new errors)
- The detection now covers Chromium, Firefox, and older WebKit/Safari

🤖 Generated with Codebuff
Co-Authored-By: Codebuff <noreply@codebuff.com>