### PR TITLE
fix(common): correct the focusable element query used by focus traps

### DIFF
--- a/packages/common/src/utils.ts
+++ b/packages/common/src/utils.ts
@@ -681,15 +681,38 @@ export const isPromiseLike = (
   );
 };
 
+const FOCUSABLE_SELECTOR = [
+  "button",
+  "a[href]",
+  "input",
+  "select",
+  "textarea",
+  "summary",
+  // any element made focusable via tabindex, not just div/label
+  "[tabindex]",
+].join(", ");
+
+const isHiddenFromFocus = (element: HTMLElement) => {
+  if (element.closest("[hidden]") || element.closest('[aria-hidden="true"]')) {
+    return true;
+  }
+
+  const { display, visibility } = getComputedStyle(element);
+
+  return display === "none" || visibility === "hidden";
+};
+
 export const queryFocusableElements = (container: HTMLElement | null) => {
-  const focusableElements = container?.querySelectorAll<HTMLElement>(
-    "button, a, input, select, textarea, div[tabindex], label[tabindex]",
-  );
+  const focusableElements =
+    container?.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR);
 
   return focusableElements
     ? Array.from(focusableElements).filter(
         (element) =>
-          element.tabIndex > -1 && !(element as HTMLInputElement).disabled,
+          element.tabIndex > -1 &&
+          !(element as HTMLInputElement).disabled &&
+          element.getAttribute("aria-disabled") !== "true" &&
+          !isHiddenFromFocus(element),
       )
     : [];
 };

--- a/packages/common/tests/queryFocusableElements.test.ts
+++ b/packages/common/tests/queryFocusableElements.test.ts
@@ -1,0 +1,89 @@
+import { queryFocusableElements } from "../src/utils";
+
+const render = (html: string) => {
+  const container = document.createElement("div");
+  container.innerHTML = html;
+  document.body.appendChild(container);
+  return container;
+};
+
+const idsOf = (html: string) =>
+  queryFocusableElements(render(html)).map((element) => element.id);
+
+describe("queryFocusableElements", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("returns natively focusable controls in document order", () => {
+    expect(
+      idsOf(`
+        <button id="button">b</button>
+        <input id="input" />
+        <select id="select"></select>
+        <textarea id="textarea"></textarea>
+        <a id="link" href="#x">a</a>
+      `),
+    ).toEqual(["button", "input", "select", "textarea", "link"]);
+  });
+
+  it("includes any element made focusable via tabindex, not just div and label", () => {
+    expect(
+      idsOf(`
+        <div id="div" tabindex="0"></div>
+        <label id="label" tabindex="0"></label>
+        <span id="span" tabindex="0"></span>
+        <li id="li" tabindex="0"></li>
+      `),
+    ).toEqual(["div", "label", "span", "li"]);
+  });
+
+  it("includes a details summary", () => {
+    expect(
+      idsOf(`<details><summary id="summary">s</summary></details>`),
+    ).toEqual(["summary"]);
+  });
+
+  it("skips an anchor without href, which is not focusable", () => {
+    expect(idsOf(`<a id="no-href">a</a><a id="href" href="#x">a</a>`)).toEqual([
+      "href",
+    ]);
+  });
+
+  it("skips negative tabindex, disabled and aria-disabled", () => {
+    expect(
+      idsOf(`
+        <button id="ok">b</button>
+        <button id="negative" tabindex="-1">b</button>
+        <button id="disabled" disabled>b</button>
+        <button id="aria-disabled" aria-disabled="true">b</button>
+      `),
+    ).toEqual(["ok"]);
+  });
+
+  it("skips hidden elements", () => {
+    expect(
+      idsOf(`
+        <button id="ok">b</button>
+        <button id="display-none" style="display: none">b</button>
+        <button id="visibility-hidden" style="visibility: hidden">b</button>
+        <button id="hidden-attr" hidden>b</button>
+        <button id="aria-hidden" aria-hidden="true">b</button>
+      `),
+    ).toEqual(["ok"]);
+  });
+
+  it("skips elements inside a hidden ancestor", () => {
+    expect(
+      idsOf(`
+        <button id="ok">b</button>
+        <div hidden><button id="in-hidden">b</button></div>
+        <div aria-hidden="true"><button id="in-aria-hidden">b</button></div>
+      `),
+    ).toEqual(["ok"]);
+  });
+
+  it("returns an empty array for a null container", () => {
+    expect(queryFocusableElements(null)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## The problem

`queryFocusableElements()` in `packages/common/src/utils.ts` is what `Dialog` and `Popover` use to run their focus traps. `Dialog` calls it twice: once on open to pick the element to autofocus, and again on every Tab to work out where focus should wrap.

The selector was wrong in both directions.

```ts
"button, a, input, select, textarea, div[tabindex], label[tabindex]"
```

**Focusable, but missed:**

- anything made focusable with `tabindex` that is not a `div` or a `label`, so `span[tabindex]`, `li[tabindex]`, and so on
- `summary`

**Not focusable, but returned:**

- `a` with no `href`
- elements hidden with `display: none`, `visibility: hidden`, the `hidden` attribute, or `aria-hidden`, whether on the element itself or on an ancestor
- elements marked `aria-disabled`

What that means in practice is that a dialog can autofocus a control the user cannot see, and Tab can leave the trap early because the element the code thinks is last is not actually the last focusable one.

## The fix

Query `[tabindex]` rather than the two hardcoded tags, require `href` on anchors, add `summary`, and filter out hidden and `aria-disabled` elements.

Hidden detection uses `getComputedStyle` plus a `closest()` check for `[hidden]` and `[aria-hidden="true"]` ancestors. I deliberately did not use `offsetParent === null`, which is the usual shorthand: jsdom always reports `null` for it, even for visible elements, so it would have filtered out everything under test and quietly broken every existing dialog test.

## Tests

New `packages/common/tests/queryFocusableElements.test.ts`, 8 cases covering each bullet above plus document ordering and the null-container path.

Against the current code 6 of the 8 fail, for example:

```
includes any element made focusable via tabindex, not just div and label
  → expected [ 'div', 'label' ] to deeply equal [ 'div', 'label', 'span', 'li' ]

skips hidden elements
  → expected [ 'ok', 'display-none', …(3) ] to deeply equal [ 'ok' ]
```

All 8 pass with the fix.

## Notes

- I left `[contenteditable]` out of the selector on purpose. Nothing in the codebase uses it, and jsdom does not model its focusability (it reports `tabIndex === -1`), so the branch would have been untestable. Easy to add later if a contenteditable surface shows up.
- Scoped to the query itself. No changes to `Dialog` or `Popover`.
- `yarn test:typecheck` and `yarn fix` clean. Full `yarn test:app` green at 123 files / 1868 tests. Heads up that this suite is flaky under parallel runs independent of this change: I saw a `MermaidToExcalidraw` failure on one run that passed in isolation and did not reproduce on a rerun, and a clean-master control run failed three unrelated tests on a separate occasion.
