### PR TITLE
fix(common): don't treat a leading emoji as left-to-right in isRTL

### DIFF
--- a/packages/common/src/utils.ts
+++ b/packages/common/src/utils.ts
@@ -331,11 +331,26 @@ export const sceneCoordsToViewportCoords = (
 export const getGlobalCSSVariable = (name: string) =>
   getComputedStyle(document.documentElement).getPropertyValue(`--${name}`);
 
-const RS_LTR_CHARS =
-  "A-Za-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02B8\u0300-\u0590\u0800-\u1FFF" +
-  "\u2C00-\uFB1C\uFDFE-\uFE6F\uFEFD-\uFFFF";
-const RS_RTL_CHARS = "\u0591-\u07FF\uFB1D-\uFDFD\uFE70-\uFEFC";
-const RE_RTL_CHECK = new RegExp(`^[^${RS_LTR_CHARS}]*[${RS_RTL_CHARS}]`);
+/** scripts written right-to-left */
+const RS_RTL_SCRIPTS = [
+  "Hebrew",
+  "Arabic",
+  "Syriac",
+  "Thaana",
+  "Nko",
+  "Samaritan",
+  "Mandaic",
+  "Adlam",
+]
+  .map((script) => `\\p{Script=${script}}`)
+  .join("");
+
+// skip over everything that carries no direction of its own (digits,
+// punctuation, symbols, emoji), then look at the first actual letter.
+// the `u` flag matters: without it astral characters are matched as separate
+// surrogate halves, and the high surrogate range overlaps the letter ranges.
+const RE_RTL_CHECK = new RegExp(`^\\P{L}*[${RS_RTL_SCRIPTS}]`, "u");
+
 /**
  * Checks whether first directional character is RTL. Meaning whether it starts
  *  with RTL characters, or indeterminate (numbers etc.) characters followed by

--- a/packages/common/tests/isRTL.test.ts
+++ b/packages/common/tests/isRTL.test.ts
@@ -1,0 +1,42 @@
+import { isRTL } from "../src/utils";
+
+describe("isRTL", () => {
+  it("detects text starting with an RTL letter", () => {
+    expect(isRTL("שלום")).toBe(true);
+    expect(isRTL("مرحبا")).toBe(true);
+    expect(isRTL("ܐܒ")).toBe(true);
+  });
+
+  it("detects LTR text", () => {
+    expect(isRTL("hello")).toBe(false);
+    expect(isRTL("Ünïcode")).toBe(false);
+    expect(isRTL("日本語")).toBe(false);
+    expect(isRTL("")).toBe(false);
+  });
+
+  it("skips leading characters that carry no direction", () => {
+    expect(isRTL("123 שלום")).toBe(true);
+    expect(isRTL("(שלום)")).toBe(true);
+    expect(isRTL("★ שלום")).toBe(true);
+    expect(isRTL("123 hello")).toBe(false);
+  });
+
+  it("treats a leading emoji as directionless", () => {
+    // emoji are astral, and their high surrogate used to land inside the
+    // LTR letter ranges, forcing the whole string to LTR
+    expect(isRTL("😀 שלום")).toBe(true);
+    expect(isRTL("🎉مرحبا")).toBe(true);
+    expect(isRTL("😀 hello")).toBe(false);
+    expect(isRTL("😀")).toBe(false);
+  });
+
+  it("still respects an astral letter that is left-to-right", () => {
+    // U+1D400 MATHEMATICAL BOLD CAPITAL A is a letter, not a symbol
+    expect(isRTL("\u{1D400} שלום")).toBe(false);
+  });
+
+  it("uses the first letter, not a later one", () => {
+    expect(isRTL("中 שלום")).toBe(false);
+    expect(isRTL("hello שלום")).toBe(false);
+  });
+});


### PR DESCRIPTION
## The problem

`isRTL()` decides the text direction used when rendering a text element (`renderElement.ts`) and when opening the wysiwyg editor (`textWysiwyg.tsx`). It reports LTR for any string that starts with an emoji, regardless of what comes after.

```
isRTL("שלום")      // true
isRTL("😀 שלום")   // false  <- should be true
isRTL("🎉مرحبا")   // false  <- should be true
```

So typing an emoji in front of Hebrew or Arabic silently flips the whole element to left-to-right.

The cause is the missing `u` flag:

```ts
const RS_LTR_CHARS =
  "A-Za-zÀ-Ö…Ⰰ-﬜…";
const RE_RTL_CHECK = new RegExp(`^[^${RS_LTR_CHARS}]*[${RS_RTL_CHARS}]`);
```

Without `u`, an astral character is matched as its two surrogate halves rather than one code point. `😀` is U+1F600, whose high surrogate is U+D83D, and `0xD83D` falls inside the `Ⰰ-﬜` run of the LTR set. So the leading-neutrals part of the pattern stops immediately on what it thinks is a strong LTR character, and the RTL branch is never reached.

Every emoji hits this, since the whole high surrogate block U+D800 to U+DBFF sits inside that range.

## The fix

Match on Unicode properties with the `u` flag instead of hand-rolled code unit ranges: skip everything that is not a letter, then check whether the first letter belongs to an RTL script.

```ts
const RE_RTL_CHECK = new RegExp(`^\\P{L}*[${RS_RTL_SCRIPTS}]`, "u");
```

This keeps emoji, digits, punctuation and symbols directionless, which is the behaviour the existing `"(שלום)"` and `"★ שלום"` cases already depended on. It also avoids the obvious cheap fix of just carving the surrogate block out of the LTR range, which would have made *all* astral characters directionless, including astral letters that really are strong LTR.

| input | before | after |
| --- | --- | --- |
| `שלום` | true | true |
| `😀 שלום` | false | **true** |
| `🎉مرحبا` | false | **true** |
| `😀 hello` | false | false |
| `𝐀 שלום` | false | false |
| `中 שלום` | false | false |
| `123 שלום` | true | true |
| `★ שלום` | true | true |

## Tests

New `packages/common/tests/isRTL.test.ts`, 6 cases. Against the current code exactly one fails, the emoji one:

```
treats a leading emoji as directionless
  → expected false to be true
```

The other five pass both before and after, which is the point: they pin the existing behaviour so the rewrite is not changing anything it should not.

## Notes

- Scripts covered: Hebrew, Arabic, Syriac, Thaana, Nko, Samaritan, Mandaic, Adlam. That is a superset of what the old `֑-߿`, `יִ-﷽` and `ﹰ-ﻼ` ranges reached, and it now also picks up the RTL scripts that live outside the BMP.
- `\p{Script=…}` with the `u` flag is ES2018 and matches the support level already relied on elsewhere in the repo (`ExcalidrawFontFace.getUnicodeRangeRegex` builds a `u` flag regex).
- The regex is still built once at module load, so there is no per-call cost change on the render path.
- `yarn test:typecheck` and `yarn fix` clean. Full `yarn test:app` green at 123 files / 1866 tests.
