### PR TITLE
fix(excalidraw): sanitize non-finite scroll and zoom on restore

### DIFF
--- a/packages/excalidraw/data/restore.ts
+++ b/packages/excalidraw/data/restore.ts
@@ -1211,12 +1211,24 @@ export const restoreAppState = (
       lastActiveTool: null,
       locked: nextAppState.activeTool.locked ?? false,
     },
+    // the viewport is untrusted input, and a non-finite value here leaves the
+    // canvas unrenderable with no way for the user to recover
+    scrollX: isFiniteNumber(nextAppState.scrollX)
+      ? nextAppState.scrollX
+      : defaultAppState.scrollX,
+    scrollY: isFiniteNumber(nextAppState.scrollY)
+      ? nextAppState.scrollY
+      : defaultAppState.scrollY,
     // Migrates from previous version where appState.zoom was a number
     zoom: {
+      // `getNormalizedZoom` clamps with Math.min/Math.max, which pass NaN
+      // straight through, so the value has to be checked before it gets there
       value: getNormalizedZoom(
         isFiniteNumber(appState.zoom)
           ? appState.zoom
-          : appState.zoom?.value ?? defaultAppState.zoom.value,
+          : isFiniteNumber(appState.zoom?.value)
+          ? appState.zoom.value
+          : defaultAppState.zoom.value,
       ),
     },
     openSidebar:

--- a/packages/excalidraw/tests/restoreViewport.test.ts
+++ b/packages/excalidraw/tests/restoreViewport.test.ts
@@ -1,0 +1,59 @@
+import { getDefaultAppState } from "../appState";
+import { restoreAppState } from "../data/restore";
+
+const defaults = getDefaultAppState();
+
+const restoreViewport = (appState: any) => {
+  const restored = restoreAppState(appState, null);
+  return {
+    scrollX: restored.scrollX,
+    scrollY: restored.scrollY,
+    zoom: restored.zoom.value,
+  };
+};
+
+describe("restoreAppState viewport sanitization", () => {
+  it("keeps finite values as they are", () => {
+    expect(
+      restoreViewport({ scrollX: 100, scrollY: -50, zoom: { value: 2 } }),
+    ).toEqual({ scrollX: 100, scrollY: -50, zoom: 2 });
+  });
+
+  it("falls back when scroll is not finite", () => {
+    for (const bad of [NaN, Infinity, -Infinity]) {
+      expect(restoreViewport({ scrollX: bad, scrollY: bad })).toEqual({
+        scrollX: defaults.scrollX,
+        scrollY: defaults.scrollY,
+        zoom: defaults.zoom.value,
+      });
+    }
+  });
+
+  it("falls back per axis, not all or nothing", () => {
+    expect(restoreViewport({ scrollX: NaN, scrollY: 42 })).toMatchObject({
+      scrollX: defaults.scrollX,
+      scrollY: 42,
+    });
+  });
+
+  it("falls back when zoom value is not finite", () => {
+    for (const bad of [NaN, Infinity, -Infinity]) {
+      expect(restoreViewport({ zoom: { value: bad } }).zoom).toBe(
+        defaults.zoom.value,
+      );
+    }
+  });
+
+  it("falls back when the legacy numeric zoom is not finite", () => {
+    expect(restoreViewport({ zoom: NaN }).zoom).toBe(defaults.zoom.value);
+  });
+
+  it("still clamps finite but out of range zoom", () => {
+    expect(restoreViewport({ zoom: { value: 0 } }).zoom).toBe(0.1);
+    expect(restoreViewport({ zoom: { value: 9999 } }).zoom).toBe(30);
+  });
+
+  it("still accepts the legacy numeric zoom", () => {
+    expect(restoreViewport({ zoom: 2 }).zoom).toBe(2);
+  });
+});


### PR DESCRIPTION
## The problem

`restoreAppState()` treats imported scene data as untrusted for some fields but not for the viewport. `gridSize` and `gridStep` are both guarded:

```ts
gridSize: getNormalizedGridSize(
  isFiniteNumber(appState.gridSize) ? appState.gridSize : DEFAULT_GRID_SIZE,
),
```

`scrollX`, `scrollY` and `zoom` are not, so a non-finite value survives the restore:

```
restoreAppState({ scrollX: NaN, scrollY: Infinity, zoom: { value: NaN } }, null)
→ { scrollX: NaN, scrollY: Infinity, zoom: { value: NaN } }
```

Once that lands in app state nothing renders, and because the value is persisted the user cannot get back to a usable canvas by reloading. Scrolling and zooming from a `NaN` origin stay `NaN`.

Two separate gaps behind it:

**Scroll** is never checked. `scrollX` and `scrollY` come through the generic `defaultAppState` key loop, which only asks whether the value is `undefined`, and `NaN !== undefined`.

**Zoom** looks guarded but is not:

```ts
value: getNormalizedZoom(
  isFiniteNumber(appState.zoom)
    ? appState.zoom
    : appState.zoom?.value ?? defaultAppState.zoom.value,
),
```

The `isFiniteNumber` branch only covers the legacy numeric form. The modern object form resolves through `??`, which only catches `null` and `undefined`, so `{ value: NaN }` passes straight through. `getNormalizedZoom` does not catch it either:

```ts
clamp(round(zoom, 6), MIN_ZOOM, MAX_ZOOM)  // Math.min(Math.max(NaN, …), …) === NaN
```

## The fix

Fall back to the default for each of the three when the incoming value is not finite, matching the shape already used for `gridSize` and `gridStep`. Finite values are untouched, including out of range zoom, which still gets clamped as before.

## Tests

New `packages/excalidraw/tests/restoreViewport.test.ts`, 7 cases. Against the current code 3 fail:

```
falls back when scroll is not finite
  → expected { scrollX: NaN, scrollY: NaN, zoom: 1 } to deeply equal { scrollX: +0, scrollY: +0, zoom: 1 }
falls back per axis, not all or nothing
  → expected { scrollX: NaN, scrollY: 42, zoom: 1 } to match object { scrollX: +0, scrollY: 42 }
falls back when zoom value is not finite
  → expected NaN to be 1
```

The remaining 4 pin behaviour that already worked (legacy numeric zoom, clamping of finite out of range zoom, finite values passing through) so the change does not quietly alter any of it.

## Notes

- I deliberately did not add the guard inside `getNormalizedZoom` itself, even though that would also catch this. That function is the subject of #11913 and has open PRs against it (#11921, #11923), and putting a finiteness check there would collide with them. This change stays inside `restoreAppState`.
- Scroll falls back per axis rather than resetting both, so one bad axis does not throw away a good one.
- `yarn test:typecheck` and `yarn fix` clean. Full `yarn test:app` green at 123 files / 1867 tests.
