### PR TITLE
fix(excalidraw): sanitize non-finite element geometry on restore

### DIFF
--- a/packages/excalidraw/data/restore.ts
+++ b/packages/excalidraw/data/restore.ts
@@ -412,6 +412,10 @@ const repairBinding = <T extends ExcalidrawArrowElement>(
   return null;
 };
 
+/** geometry from imported data, falling back when it is not a usable number */
+const coerceFiniteNumber = (value: unknown, fallback = 0) =>
+  isFiniteNumber(value) ? value : fallback;
+
 const restoreElementWithProperties = <
   T extends Required<Omit<ExcalidrawElement, "customData">> & {
     customData?: ExcalidrawElement["customData"];
@@ -447,13 +451,15 @@ const restoreElementWithProperties = <
     opacity:
       element.opacity == null ? DEFAULT_ELEMENT_PROPS.opacity : element.opacity,
     angle: element.angle || (0 as Radians),
-    x: extra.x ?? element.x ?? 0,
-    y: extra.y ?? element.y ?? 0,
+    // geometry comes from untrusted data, and `??` lets NaN/Infinity through
+    x: coerceFiniteNumber(extra.x ?? element.x),
+    y: coerceFiniteNumber(extra.y ?? element.y),
     strokeColor: element.strokeColor || DEFAULT_ELEMENT_PROPS.strokeColor,
     backgroundColor:
       element.backgroundColor || DEFAULT_ELEMENT_PROPS.backgroundColor,
-    width: element.width || 0,
-    height: element.height || 0,
+    // `||` happens to catch NaN but not Infinity
+    width: coerceFiniteNumber(element.width),
+    height: coerceFiniteNumber(element.height),
     seed: element.seed ?? 1,
     groupIds: element.groupIds ?? [],
     frameId: element.frameId ?? null,

--- a/packages/excalidraw/tests/restoreElementGeometry.test.ts
+++ b/packages/excalidraw/tests/restoreElementGeometry.test.ts
@@ -1,0 +1,77 @@
+import { restoreElements } from "../data/restore";
+
+import { API } from "./helpers/api";
+
+/** restore a single rectangle with the given raw overrides, keeping geometry */
+const restoreGeometry = (overrides: Record<string, unknown>) => {
+  const base = API.createElement({
+    type: "rectangle",
+    x: 1,
+    y: 2,
+    width: 10,
+    height: 20,
+  });
+
+  const [restored] = restoreElements(
+    [{ ...base, ...overrides }] as any,
+    null,
+  ) as any[];
+
+  return {
+    x: restored.x,
+    y: restored.y,
+    width: restored.width,
+    height: restored.height,
+  };
+};
+
+describe("restoreElements geometry sanitization", () => {
+  it("keeps finite geometry as it is", () => {
+    expect(restoreGeometry({ x: 1, y: 2, width: 10, height: 20 })).toEqual({
+      x: 1,
+      y: 2,
+      width: 10,
+      height: 20,
+    });
+  });
+
+  it("keeps negative coordinates", () => {
+    expect(restoreGeometry({ x: -100, y: -50 })).toMatchObject({
+      x: -100,
+      y: -50,
+    });
+  });
+
+  it("replaces NaN coordinates with 0", () => {
+    expect(restoreGeometry({ x: NaN, y: NaN })).toMatchObject({ x: 0, y: 0 });
+  });
+
+  it("replaces non-finite coordinates with 0", () => {
+    expect(restoreGeometry({ x: Infinity, y: -Infinity })).toMatchObject({
+      x: 0,
+      y: 0,
+    });
+  });
+
+  it("replaces non-finite dimensions with 0", () => {
+    expect(restoreGeometry({ width: Infinity, height: NaN })).toMatchObject({
+      width: 0,
+      height: 0,
+    });
+  });
+
+  it("replaces non-numeric geometry with 0", () => {
+    expect(
+      restoreGeometry({ x: "5", y: null, width: undefined, height: {} }),
+    ).toEqual({ x: 0, y: 0, width: 0, height: 0 });
+  });
+
+  it("sanitizes each axis independently", () => {
+    expect(restoreGeometry({ x: NaN, y: 42, width: 7, height: NaN })).toEqual({
+      x: 0,
+      y: 42,
+      width: 7,
+      height: 0,
+    });
+  });
+});


### PR DESCRIPTION
## The problem

`restoreElementWithProperties` resolves element geometry with operators that do not reject non-finite numbers:

```ts
x: extra.x ?? element.x ?? 0,       // ?? only catches null and undefined
y: extra.y ?? element.y ?? 0,
width: element.width || 0,          // || catches NaN, but not Infinity
height: element.height || 0,
```

So importing an element with bad geometry keeps it, verified against master:

| input | restored |
| --- | --- |
| `{ x: NaN }` | `x: NaN` |
| `{ x: Infinity }` | `x: Infinity` |
| `{ width: Infinity }` | `width: Infinity` |
| `{ x: "5" }` | `x: "5"`, a string on a field typed `number` |
| `{ width: NaN }` | `width: 0` |

Only that last one is handled, and by accident rather than design: `NaN` is falsy, so `||` happens to catch it. `Infinity` is truthy and goes straight through.

The consequence is not limited to the bad element. `getCommonBounds` reduces with `Math.min`/`Math.max`, so a single `NaN` coordinate propagates to the bounds of the whole selection. The element itself cannot be selected or scrolled to, and it can take the rest of the canvas with it.

The same file already guards this correctly a few lines up, in `restoreLinearPoints`:

```ts
pointFrom<LocalPoint>(
  isFiniteNumber(width) ? width : 0,
  isFiniteNumber(height) ? height : 0,
)
```

so the intent is established, it just was not applied to the element's own `x`, `y`, `width` and `height`.

## The fix

Route the four through a small helper that falls back to `0` when the value is not a finite number, reusing the `isFiniteNumber` already imported in the file.

Non-numeric values now fall back too, which is why `{ x: "5" }` becomes `0` rather than staying a string. I chose the fallback over coercing numeric strings deliberately: `restore` is the trust boundary for imported data, and quietly accepting a wrong-typed field is what let this through in the first place.

## Tests

New `packages/excalidraw/tests/restoreElementGeometry.test.ts`, 7 cases. Against the current code 5 fail:

```
replaces NaN coordinates with 0
  → expected { x: NaN, y: NaN, width: 10, …(1) } to match object { x: +0, y: +0 }
replaces non-finite dimensions with 0
  → expected { x: 1, y: 2, width: Infinity, …(1) } to match object { width: +0, height: +0 }
sanitizes each axis independently
  → expected { x: NaN, y: 42, width: 7, height: +0 } to deeply equal { x: +0, y: 42, width: 7, height: +0 }
```

The two that pass on both sides pin the behaviour that already worked, finite and negative values, so the change is not silently altering those.

## Notes

- Each axis is sanitized independently, so one bad coordinate does not discard a good one next to it.
- This is the element-level counterpart to the same problem in app state, which I have sent separately as #11990. They are independent files and independent fixes.
- Does not overlap #11926, which touches this file further down at the `isInvisiblySmallElement` call.
- `yarn test:typecheck` and `yarn fix` clean. Full `yarn test:app` green at 123 files / 1867 tests.
