### PR TITLE
fix(excalidraw): don't reject a whole scene over one malformed element entry

### DIFF
--- a/packages/excalidraw/data/restore.ts
+++ b/packages/excalidraw/data/restore.ts
@@ -862,15 +862,22 @@ export const restoreElements = <T extends ExcalidrawElement>(
       }
     | undefined,
 ): CombineBrandsIfNeeded<T, OrderedExcalidrawElement> => {
+  // imported data is untrusted, and a malformed entry would otherwise throw
+  // before it ever reaches the per-element try/catch below, rejecting the
+  // whole scene over one bad element
+  const sourceElements = (targetElements || []).filter(
+    (element): element is T => !!element && typeof element === "object",
+  );
+
   // used to detect duplicate top-level element ids
   const existingIds = new Set<string>();
-  const targetElementsMap = arrayToMap(targetElements || []);
+  const targetElementsMap = arrayToMap(sourceElements);
   const existingElementsMap = existingElements
     ? arrayToMap(existingElements)
     : null;
 
   const restoredElements = syncInvalidIndices(
-    (targetElements || []).reduce((elements, element) => {
+    sourceElements.reduce((elements, element) => {
       // filtering out selection, which is legacy, no longer kept in elements,
       // and causing issues if retained
       if (element.type === "selection") {

--- a/packages/excalidraw/tests/restoreMalformedEntries.test.ts
+++ b/packages/excalidraw/tests/restoreMalformedEntries.test.ts
@@ -1,0 +1,36 @@
+import { restoreElements } from "../data/restore";
+
+import { API } from "./helpers/api";
+
+const rect = (id: string) => API.createElement({ type: "rectangle", id });
+
+const idsOf = (elements: unknown[]) =>
+  (restoreElements(elements as any, null) as any[]).map(
+    (element) => element.id,
+  );
+
+describe("restoreElements with malformed entries", () => {
+  it("restores a well formed scene unchanged", () => {
+    expect(idsOf([rect("a"), rect("b")])).toEqual(["a", "b"]);
+  });
+
+  it("skips a null entry and keeps the rest of the scene", () => {
+    expect(idsOf([null, rect("a"), rect("b")])).toEqual(["a", "b"]);
+  });
+
+  it("skips undefined entries", () => {
+    expect(idsOf([undefined, rect("a"), undefined])).toEqual(["a"]);
+  });
+
+  it("skips primitives", () => {
+    expect(idsOf([0, "", "nope", true, rect("a")])).toEqual(["a"]);
+  });
+
+  it("survives a scene made entirely of malformed entries", () => {
+    expect(idsOf([null, undefined, 1])).toEqual([]);
+  });
+
+  it("still drops legacy selection elements", () => {
+    expect(idsOf([{ type: "selection", id: "sel" }, rect("a")])).toEqual(["a"]);
+  });
+});


### PR DESCRIPTION
## The problem

`restoreElements` wraps each element in a try/catch so one bad element cannot take the scene down:

```ts
try {
  migratedElement = restoreElement(element, …);
} catch (error) {
  console.error("Error restoring element:", error);
  migratedElement = null;
}
```

A `null` or `undefined` entry never reaches that. It throws earlier, from the line that builds the id map:

```ts
const targetElementsMap = arrayToMap(targetElements || []);
```

```
restoreElements([null, validRect], null)
→ TypeError: Cannot read properties of null (reading 'id')
   at arrayToMap (packages/common/src/utils.ts:534)
   at restoreElements (packages/excalidraw/data/restore.ts:867)
```

The `element.type === "selection"` check a few lines below is outside the guard too and would throw on the same input.

Both sites are before the try/catch, so a single `null` in the array rejects the entire import. Every other element in the file is lost with it, and via `loadSceneOrLibraryFromBlob` the user just sees `Error: invalid file`.

`[null, …]` is valid JSON, so a `.excalidraw` file written by a buggy third-party generator or a truncated sync can land here.

## The fix

Filter entries that are not objects once, up front, so the guarded path is the only one that ever sees them:

```ts
const sourceElements = (targetElements || []).filter(
  (element): element is T => !!element && typeof element === "object",
);
```

and use that for both the id map and the reduce. A scene made entirely of malformed entries now restores to `[]` rather than throwing.

## Tests

New `packages/excalidraw/tests/restoreMalformedEntries.test.ts`, 6 cases. Against the current code 3 fail:

```
skips a null entry and keeps the rest of the scene
  → Cannot read properties of null (reading 'id')
skips undefined entries
  → Cannot read properties of undefined (reading 'id')
survives a scene made entirely of malformed entries
  → Cannot read properties of null (reading 'id')
```

The three that pass on both sides are the regression guards: a well formed scene is unchanged, primitives were already skipped, and legacy `selection` elements are still dropped.

## Notes

- Only `targetElements` is filtered. `existingElements` comes from local scene state rather than an imported file, so it is not part of this trust boundary.
- Related to #11925 and its PR #11926, but a different throw site: that one is `isInvisiblySmallElement` further down the same function, this one is `arrayToMap` above the loop. The hunks do not overlap and the two fixes are independent.
- `yarn test:typecheck` and `yarn fix` clean. Full `yarn test:app` green at 123 files / 1866 tests.
