### PR TITLE
fix(excalidraw): handle malformed input in restoreLibraryItems

### DIFF
--- a/packages/excalidraw/data/restore.ts
+++ b/packages/excalidraw/data/restore.ts
@@ -1245,8 +1245,18 @@ export const restoreLibraryItems = (
   libraryItems: ImportedDataState["libraryItems"] = [],
   defaultStatus: LibraryItem["status"],
 ) => {
+  // `.excalidrawlib` files are untrusted input, and the default parameter only
+  // covers `undefined`, so anything else non-iterable would throw here
+  if (!Array.isArray(libraryItems)) {
+    return [];
+  }
+
   const restoredItems: LibraryItem[] = [];
   for (const item of libraryItems) {
+    if (!item || typeof item !== "object") {
+      continue;
+    }
+
     // migrate older libraries
     if (Array.isArray(item)) {
       const restoredItem = restoreLibraryItem({

--- a/packages/excalidraw/tests/restoreLibraryItems.test.ts
+++ b/packages/excalidraw/tests/restoreLibraryItems.test.ts
@@ -1,0 +1,43 @@
+import { restoreLibraryItems } from "../data/restore";
+
+import { API } from "./helpers/api";
+
+const rect = () => API.createElement({ type: "rectangle" });
+
+const restore = (input: unknown) =>
+  restoreLibraryItems(input as any, "published");
+
+describe("restoreLibraryItems with malformed input", () => {
+  it("restores a well formed library", () => {
+    expect(
+      restore([
+        { id: "a", status: "published", created: 1, elements: [rect()] },
+      ]),
+    ).toHaveLength(1);
+  });
+
+  it("still migrates the legacy array-of-arrays shape", () => {
+    expect(restore([[rect()]])).toHaveLength(1);
+  });
+
+  it("returns an empty library when the input is not an array", () => {
+    for (const bad of [null, undefined, {}, 0, "", "nope", true]) {
+      expect(restore(bad)).toEqual([]);
+    }
+  });
+
+  it("skips malformed items and keeps the rest", () => {
+    const good = {
+      id: "a",
+      status: "published",
+      created: 1,
+      elements: [rect()],
+    };
+
+    expect(restore([null, good, undefined, 1, "x"])).toHaveLength(1);
+  });
+
+  it("skips an item whose elements are missing", () => {
+    expect(restore([{ id: "a", status: "published", created: 1 }])).toEqual([]);
+  });
+});


### PR DESCRIPTION
## The problem

`restoreLibraryItems` is exported from `index.tsx`, so it is public API, and it is what a `.excalidrawlib` import runs through (`data/blob.ts`, `data/library.ts`). It assumes its input is well formed.

The default parameter only covers `undefined`:

```ts
export const restoreLibraryItems = (
  libraryItems: ImportedDataState["libraryItems"] = [],
  defaultStatus: LibraryItem["status"],
) => {
  const restoredItems: LibraryItem[] = [];
  for (const item of libraryItems) {
```

so anything else non-iterable reaches the `for..of` and throws:

```
restoreLibraryItems(null, "published")  → TypeError: libraryItems is not iterable
restoreLibraryItems({}, "published")    → TypeError: libraryItems is not iterable
```

And a `null` entry inside an otherwise valid array throws on property access before `restoreLibraryItem` gets the chance to reject it:

```
restoreLibraryItems([null, validItem], "published")
  → TypeError: Cannot read properties of null (reading 'id')
```

Either way the whole library fails to import instead of the one bad entry being dropped, even though `restoreLibraryItem` already returns `null` for items it cannot use and the loop already knows how to skip those.

Call sites are inconsistent about compensating for this. `data/library.ts:557` passes `data?.libraryItems || []`, but the calls at `:319` and `:862` pass their value through directly, and a package consumer calling the exported function gets no guard at all.

## The fix

Return an empty library when the input is not an array, and skip entries that are not objects, so the existing per-item handling is the only thing that sees them.

## Tests

New `packages/excalidraw/tests/restoreLibraryItems.test.ts`, 5 cases. Against the current code 2 fail:

```
returns an empty library when the input is not an array
  → libraryItems is not iterable
skips malformed items and keeps the rest
  → Cannot read properties of null (reading 'id')
```

The other three pin behaviour that already worked, a well formed library, the legacy array-of-arrays migration, and items with no usable elements, so the guard is not changing any of those.

## Notes

- The legacy array-of-arrays shape still migrates. The new `typeof item !== "object"` skip runs before the `Array.isArray(item)` branch, and arrays are objects, so that path is untouched.
- Same trust-boundary theme as #11991 and #11992, which I sent separately, but a different function and a different file section. None of the three overlap.
- `yarn test:typecheck` and `yarn fix` clean. Full `yarn test:app` green at 123 files / 1865 tests.
