### PR TITLE
  fix(app): detect Firefox/WebKit localStorage quota exceeded errors

### DIFF
--- a/excalidraw-app/data/LocalData.ts
+++ b/excalidraw-app/data/LocalData.ts
@@ -108,8 +108,17 @@ const saveDataStateToLocalStorage = (
   }
 };
 
-const isQuotaExceededError = (error: any) => {
-  return error instanceof DOMException && error.name === "QuotaExceededError";
+export const isQuotaExceededError = (error: any) => {
+  return (
+    error instanceof DOMException &&
+    (error.name === "QuotaExceededError" ||
+      // Firefox
+      error.name === "NS_ERROR_DOM_QUOTA_REACHED" ||
+      // older WebKit
+      error.name === "QUOTA_EXCEEDED_ERR" ||
+      error.code === 22 ||
+      error.code === 1014)
+  );
 };
 
 type SavingLockTypes = "collaboration";

--- a/excalidraw-app/tests/LocalData.test.ts
+++ b/excalidraw-app/tests/LocalData.test.ts
@@ -1,0 +1,44 @@
+import { isQuotaExceededError } from "../data/LocalData";
+
+describe("isQuotaExceededError", () => {
+  it("detects the Chromium QuotaExceededError", () => {
+    const error = new DOMException("quota exceeded", "QuotaExceededError");
+    expect(isQuotaExceededError(error)).toBe(true);
+  });
+
+  it("detects the Firefox NS_ERROR_DOM_QUOTA_REACHED name", () => {
+    const error = new DOMException(
+      "quota exceeded",
+      "NS_ERROR_DOM_QUOTA_REACHED",
+    );
+    expect(isQuotaExceededError(error)).toBe(true);
+  });
+
+  it("detects the legacy WebKit QUOTA_EXCEEDED_ERR name", () => {
+    const error = new DOMException("quota exceeded", "QUOTA_EXCEEDED_ERR");
+    expect(isQuotaExceededError(error)).toBe(true);
+  });
+
+  it("detects legacy WebKit error code 22", () => {
+    const error = new DOMException("quota exceeded", "SomeOtherName");
+    Object.defineProperty(error, "code", { value: 22 });
+    expect(isQuotaExceededError(error)).toBe(true);
+  });
+
+  it("detects Firefox error code 1014", () => {
+    const error = new DOMException("quota exceeded", "SomeOtherName");
+    Object.defineProperty(error, "code", { value: 1014 });
+    expect(isQuotaExceededError(error)).toBe(true);
+  });
+
+  it("returns false for unrelated DOMExceptions", () => {
+    const error = new DOMException("not related", "NotFoundError");
+    expect(isQuotaExceededError(error)).toBe(false);
+  });
+
+  it("returns false for non-DOMException errors", () => {
+    expect(isQuotaExceededError(new Error("boom"))).toBe(false);
+    expect(isQuotaExceededError(null)).toBe(false);
+    expect(isQuotaExceededError(undefined)).toBe(false);
+  });
+});


### PR DESCRIPTION
  (#11962)

  isQuotaExceededError only matched the Chromium DOMException name
  ("QuotaExceededError"), so on Firefox and older WebKit browsers
  the quota-exceeded banner never appeared and the scene silently
  stopped persisting. Widen the check to also match Firefox's
  NS_ERROR_DOM_QUOTA_REACHED, legacy WebKit's QUOTA_EXCEEDED_ERR,
  and their respective error codes (1014, 22).

  Fixes #11962