### PR TITLE
Fix: scope RTL to Excalidraw container instead of document (#11963)

### DIFF
--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -2345,6 +2345,16 @@ class App extends React.Component<AppProps, AppState> {
     return (
       <div
         translate="no"
+        dir={
+          this.props.applyLanguageToDocument
+            ? undefined
+            : getLanguage().rtl
+            ? "rtl"
+            : "ltr"
+        }
+        lang={
+          this.props.applyLanguageToDocument ? undefined : getLanguage().code
+        }
         className={clsx(
           "excalidraw excalidraw-container notranslate",
           this.props.className,
@@ -13975,7 +13985,7 @@ class App extends React.Component<AppProps, AppState> {
     const currentLang =
       languages.find((lang) => lang.code === this.props.langCode) ||
       defaultLang;
-    await setLanguage(currentLang);
+    await setLanguage(currentLang, this.props.applyLanguageToDocument);
     this.setAppState({});
   }
 }

--- a/packages/excalidraw/components/InitializeApp.tsx
+++ b/packages/excalidraw/components/InitializeApp.tsx
@@ -12,6 +12,7 @@ interface Props {
   langCode: Language["code"];
   children: React.ReactElement;
   theme?: Theme;
+  applyLanguageToDocument?: boolean;
 }
 
 export const InitializeApp = (props: Props) => {
@@ -19,13 +20,13 @@ export const InitializeApp = (props: Props) => {
 
   useEffect(() => {
     const updateLang = async () => {
-      await setLanguage(currentLang);
+      await setLanguage(currentLang, props.applyLanguageToDocument);
       setLoading(false);
     };
     const currentLang =
       languages.find((lang) => lang.code === props.langCode) || defaultLang;
     updateLang();
-  }, [props.langCode]);
+  }, [props.langCode, props.applyLanguageToDocument]);
 
   return loading ? <LoadingMessage theme={props.theme} /> : props.children;
 };

--- a/packages/excalidraw/hooks/useCreatePortalContainer.ts
+++ b/packages/excalidraw/hooks/useCreatePortalContainer.ts
@@ -2,6 +2,8 @@ import { useState, useLayoutEffect } from "react";
 
 import { THEME } from "@excalidraw/common";
 
+import { getLanguage } from "../i18n";
+
 import { useEditorInterface, useExcalidrawContainer } from "../components/App";
 import { useUIAppState } from "../context/ui-appState";
 
@@ -39,6 +41,11 @@ export const useCreatePortalContainer = (opts?: {
     }
 
     const div = ownerDocument.createElement("div");
+
+    const lang = getLanguage();
+    if (lang.rtl) {
+      div.dir = "rtl";
+    }
 
     container.appendChild(div);
 

--- a/packages/excalidraw/i18n.ts
+++ b/packages/excalidraw/i18n.ts
@@ -89,10 +89,15 @@ if (isDevEnv()) {
 let currentLang: Language = defaultLang;
 let currentLangData = {};
 
-export const setLanguage = async (lang: Language) => {
+export const setLanguage = async (
+  lang: Language,
+  applyLanguageToDocument = true,
+) => {
   currentLang = lang;
-  document.documentElement.dir = currentLang.rtl ? "rtl" : "ltr";
-  document.documentElement.lang = currentLang.code;
+  if (applyLanguageToDocument) {
+    document.documentElement.dir = currentLang.rtl ? "rtl" : "ltr";
+    document.documentElement.lang = currentLang.code;
+  }
 
   if (lang.code.startsWith(TEST_LANG_CODE)) {
     currentLangData = {};

--- a/packages/excalidraw/index.tsx
+++ b/packages/excalidraw/index.tsx
@@ -83,6 +83,7 @@ const ExcalidrawBase = (props: ExcalidrawProps) => {
     renderTopLeftUI,
     renderTopRightUI,
     langCode = defaultLang.code,
+    applyLanguageToDocument = true,
     viewModeEnabled,
     interaction,
     ui,
@@ -206,7 +207,11 @@ const ExcalidrawBase = (props: ExcalidrawProps) => {
 
   return (
     <EditorJotaiProvider store={editorJotaiStore}>
-      <InitializeApp langCode={langCode} theme={theme}>
+      <InitializeApp
+        langCode={langCode}
+        theme={theme}
+        applyLanguageToDocument={applyLanguageToDocument}
+      >
         <App
           onExport={onExport}
           className={className}
@@ -225,6 +230,7 @@ const ExcalidrawBase = (props: ExcalidrawProps) => {
           renderTopLeftUI={renderTopLeftUI}
           renderTopRightUI={renderTopRightUI}
           langCode={langCode}
+          applyLanguageToDocument={applyLanguageToDocument}
           viewModeEnabled={viewModeEnabled}
           interaction={interaction}
           ui={ui}

--- a/packages/excalidraw/types.ts
+++ b/packages/excalidraw/types.ts
@@ -857,6 +857,7 @@ export interface ExcalidrawProps {
     appState: UIAppState,
   ) => JSX.Element | null;
   langCode?: Language["code"];
+  applyLanguageToDocument?: boolean;
   viewModeEnabled?: boolean;
   /**
    * Whether the editor accepts user input (pointer, keyboard, wheel, touch,


### PR DESCRIPTION
Fixes #11963

Hey! I noticed that when you embed `@excalidraw/excalidraw` in another app and call `setLanguage()`, it writes `dir` and `lang` directly to `document.documentElement`, which breaks the host page layout.

This PR fixes that by adding an `applyLanguageToDocument` prop (default: `true` for backward compatibility). When set to `false`, RTL/LTR is scoped to the Excalidraw container and portal containers instead of the global document.

**What changed:**
- Added `applyLanguageToDocument` prop to `Excalidraw` component
- `setLanguage()` now accepts the prop to conditionally skip `document.documentElement` mutation
- Portal containers get `dir` attribute for proper RTL support
- `App.tsx` sets `dir` and `lang` on the main container

**How to test:**
1. Embed Excalidraw in a host app with existing `dir="ltr"` on `<html>`
2. Use `<Excalidraw langCode="ar-SA" applyLanguageToDocument={false} />`
3. Verify the host page direction doesn't change
4. Verify Excalidraw's RTL layout still works correctly (toolbar, dialogs, text alignment)