### PR TITLE
fix: stabilize canvas search results order during drag (fixes #9503)

### DIFF
--- a/packages/excalidraw/components/SearchMenu.tsx
+++ b/packages/excalidraw/components/SearchMenu.tsx
@@ -798,8 +798,14 @@ const handleSearch = debounce(
       isFrameLikeElement(el),
     ) as ExcalidrawFrameLikeElement[];
 
-    texts.sort((a, b) => a.y - b.y);
-    frames.sort((a, b) => a.y - b.y);
+    // Snapshot y-positions at search time so dragging elements
+    // doesn't reorder the results list (fix #9503).
+    const yPositions = new Map<string, number>();
+    for (const el of [...texts, ...frames]) {
+      yPositions.set(el.id, el.y);
+    }
+    texts.sort((a, b) => (yPositions.get(a.id) ?? a.y) - (yPositions.get(b.id) ?? b.y));
+    frames.sort((a, b) => (yPositions.get(a.id) ?? a.y) - (yPositions.get(b.id) ?? b.y));
 
     const textMatches: SearchMatchItem[] = [];
 


### PR DESCRIPTION
## Summary

Snapshot y-positions at search time so that dragging elements doesn't reorder the search results list.

Fixes #9503

## Problem

The search results were sorted by the live `a.y - b.y` on element objects. When you dragged an element, its y-coordinate changed, causing the sort to produce a different order on the next render and the results list to shuffle unexpectedly.

## Fix

Capture each element's y-position into a `Map` before sorting, then sort by the captured positions. This makes the sort order stable regardless of subsequent element movements.

## Repro

1. Add `test 1` and `test 2` text elements at different y-positions
2. Search for `test`
3. Start dragging one of the matched elements on the canvas
4. Observe the results list no longer reorders during drag