### PR TITLE
fix: malformed element no longer rejects entire file import (fixes #11925)

### DIFF
--- a/packages/excalidraw/data/restore.ts
+++ b/packages/excalidraw/data/restore.ts
@@ -894,7 +894,8 @@ export const restoreElements = <T extends ExcalidrawElement>(
         const localElement = existingElementsMap?.get(element.id);
 
         const shouldMarkAsDeleted =
-          opts?.deleteInvisibleElements && isInvisiblySmallElement(element);
+          opts?.deleteInvisibleElements &&
+          isInvisiblySmallElement(migratedElement);
 
         if (shouldMarkAsDeleted) {
           migratedElement = bumpVersion(migratedElement, localElement?.version);


### PR DESCRIPTION
## Summary

Check the restored `migratedElement` instead of the raw input element in `isInvisiblySmallElement`, preventing a secondary crash that kills the entire file import.

Fixes #11925

## Problem

When `restoreElement` throws for a malformed element (e.g. a freedraw with `points: null`), the catch block sets `migratedElement = null` and the element is skipped. However, when the raw input element is later passed to `isInvisiblySmallElement` it tries to read `element.points.length` on the broken element, throwing a second uncaught `TypeError` that kills the entire import — including valid elements.

## Fix

Replace `isInvisiblySmallElement(element)` with `isInvisiblySmallElement(migratedElement)` on line 897. This is safe because:

1. The check is inside `if (migratedElement)`, so it only runs when restoration succeeded and the element has valid geometry
2. If `restoreElement` threw, `migratedElement` is null and the block is skipped entirely