### PR TITLE
docs: fix Prettier check command

### DIFF
--- a/dev-docs/docs/introduction/development.mdx
+++ b/dev-docs/docs/introduction/development.mdx
@@ -75,7 +75,7 @@ yarn test:update
 ### Test for formatting with Prettier
 
 ```bash
-yarn test:code
+yarn test:other
 ```
 
 ### Docker Compose


### PR DESCRIPTION
## Summary

Updates the development guide to use `yarn test:other` for the Prettier check. `yarn test:code` runs ESLint.

## Testing

- `git diff --check`