### PR TITLE
fix: exclude frames from bucket fill boundary types

### DIFF
--- a/packages/element/src/bucketFill.ts
+++ b/packages/element/src/bucketFill.ts
@@ -570,15 +570,13 @@ export const rendersOpaqueFill = (element: ExcalidrawElement): boolean => {
 
 /**
  * Element types whose outlines can participate in a fill — as the owner
- * (when closed) and as boundaries. Text, image, embeddable, iframe and
- * arrows are excluded in v1.
+ * (when closed) and as boundaries. Frames, text, image, embeddable,
+ * iframe and arrows are excluded.
  */
 const FILL_BOUNDARY_TYPES = new Set<ExcalidrawElement["type"]>([
   "rectangle",
   "diamond",
   "ellipse",
-  "frame",
-  "magicframe",
   "line",
   "freedraw",
 ]);


### PR DESCRIPTION
Fixes #11924

Frames and magic frames were included in FILL_BOUNDARY_TYPES, which gave them dual roles: both as boundary (enclosing the fill region) and as owner (the element the fill is assigned to). This meant clicking blank canvas inside an empty frame created a fill polygon at exactly the frame's bounds, even though there was nothing to fill.

The fix removes frame and magicframe from FILL_BOUNDARY_TYPES so they no longer participate as fill boundaries or owners.

Changes:
- Removed 'frame' and 'magicframe' from FILL_BOUNDARY_TYPES in bucketFill.ts
- Updated the doc comment to reflect the exclusion