### PR TITLE
fix: convert mermaid `<br/>` labels to line breaks

### DIFF
--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -417,7 +417,10 @@ import { withBatchedUpdates, withBatchedUpdatesThrottled } from "../reactUtils";
 import { isPointHittingTextAutoResizeHandle } from "../textAutoResizeHandle";
 import { textWysiwyg } from "../wysiwyg/textWysiwyg";
 import { isOverScrollBars } from "../scene/scrollbars";
-import { isMaybeMermaidDefinition } from "../mermaid";
+import {
+  isMaybeMermaidDefinition,
+  normalizeMermaidLineBreaks,
+} from "../mermaid";
 import { LassoTrail } from "../lasso";
 import { EraserTrail } from "../eraser";
 import { getShortcutKey } from "../shortcut";
@@ -4578,9 +4581,12 @@ class App extends React.Component<AppProps, AppState> {
         const { elements: skeletonElements, files = {} } =
           await api.parseMermaidToExcalidraw(data.text);
 
-        const elements = convertToExcalidrawElements(skeletonElements, {
-          regenerateIds: true,
-        });
+        const elements = convertToExcalidrawElements(
+          normalizeMermaidLineBreaks(skeletonElements),
+          {
+            regenerateIds: true,
+          },
+        );
 
         this.addElementsFromPasteOrLibrary({
           elements,

--- a/packages/excalidraw/components/TTDDialog/common.ts
+++ b/packages/excalidraw/components/TTDDialog/common.ts
@@ -14,6 +14,7 @@ import type {
 } from "@excalidraw/element/types";
 
 import { EditorLocalStorage } from "../../data/EditorLocalStorage";
+import { normalizeMermaidLineBreaks } from "../../mermaid";
 
 import type { MermaidToExcalidrawLibProps } from "./types";
 
@@ -98,9 +99,12 @@ export const convertMermaidToExcalidraw = async ({
     setError(null);
 
     data.current = {
-      elements: convertToExcalidrawElements(elements, {
-        regenerateIds: true,
-      }),
+      elements: convertToExcalidrawElements(
+        normalizeMermaidLineBreaks(elements),
+        {
+          regenerateIds: true,
+        },
+      ),
       files,
     };
 

--- a/packages/excalidraw/mermaid.test.ts
+++ b/packages/excalidraw/mermaid.test.ts
@@ -1,4 +1,9 @@
-import { isMaybeMermaidDefinition } from "./mermaid";
+import type { ExcalidrawElementSkeleton } from "@excalidraw/element";
+
+import {
+  isMaybeMermaidDefinition,
+  normalizeMermaidLineBreaks,
+} from "./mermaid";
 
 describe("isMaybeMermaidDefinition", () => {
   it("should return true for a valid mermaid definition", () => {
@@ -11,5 +16,53 @@ describe("isMaybeMermaidDefinition", () => {
     expect(isMaybeMermaidDefinition("graphs")).toBe(false);
     expect(isMaybeMermaidDefinition("this flowchart")).toBe(false);
     expect(isMaybeMermaidDefinition("this\nflowchart")).toBe(false);
+  });
+});
+
+describe("normalizeMermaidLineBreaks", () => {
+  it("should convert html line breaks in container labels", () => {
+    const elements = [
+      {
+        type: "rectangle",
+        x: 0,
+        y: 0,
+        label: { text: "A<br/>B<br>C<BR />D", fontSize: 20 },
+      },
+    ] as ExcalidrawElementSkeleton[];
+
+    expect(normalizeMermaidLineBreaks(elements)).toEqual([
+      {
+        type: "rectangle",
+        x: 0,
+        y: 0,
+        label: { text: "A\nB\nC\nD", fontSize: 20 },
+      },
+    ]);
+  });
+
+  it("should convert html line breaks in text elements and arrow labels", () => {
+    const elements = [
+      { type: "text", x: 0, y: 0, text: "A<br/>B" },
+      { type: "arrow", x: 0, y: 0, label: { text: "yes<br />no" } },
+    ] as ExcalidrawElementSkeleton[];
+
+    expect(normalizeMermaidLineBreaks(elements)).toEqual([
+      { type: "text", x: 0, y: 0, text: "A\nB" },
+      { type: "arrow", x: 0, y: 0, label: { text: "yes\nno" } },
+    ]);
+  });
+
+  it("should leave elements without html line breaks untouched", () => {
+    const elements = [
+      { type: "text", x: 0, y: 0, text: "A" },
+      { type: "rectangle", x: 0, y: 0, label: { text: "B" } },
+      { type: "ellipse", x: 0, y: 0 },
+    ] as ExcalidrawElementSkeleton[];
+
+    const normalized = normalizeMermaidLineBreaks(elements);
+
+    expect(normalized[0]).toBe(elements[0]);
+    expect(normalized[1]).toBe(elements[1]);
+    expect(normalized[2]).toBe(elements[2]);
   });
 });

--- a/packages/excalidraw/mermaid.ts
+++ b/packages/excalidraw/mermaid.ts
@@ -1,3 +1,5 @@
+import type { ExcalidrawElementSkeleton } from "@excalidraw/element";
+
 /** heuristically checks whether the text may be a mermaid diagram definition */
 export const isMaybeMermaidDefinition = (text: string) => {
   const chartTypes = [
@@ -30,4 +32,38 @@ export const isMaybeMermaidDefinition = (text: string) => {
   );
 
   return re.test(text.trim());
+};
+
+/**
+ * mermaid renders `<br>` (and its `<br/>` / `<br />` variants) inside labels as
+ * a line break, but `@excalidraw/mermaid-to-excalidraw` passes the label text
+ * through verbatim, so the tag would end up drawn as literal text on canvas.
+ */
+export const normalizeMermaidLineBreaks = (
+  elements: readonly ExcalidrawElementSkeleton[],
+): ExcalidrawElementSkeleton[] => {
+  const replaceBreaks = (text: string) => text.replace(/<br\s*\/?>/gi, "\n");
+
+  return elements.map((element) => {
+    const { text, label } = element as {
+      text?: string;
+      label?: { text?: string };
+    };
+
+    const nextText = text != null ? replaceBreaks(text) : text;
+    const nextLabelText =
+      label?.text != null ? replaceBreaks(label.text) : label?.text;
+
+    if (nextText === text && nextLabelText === label?.text) {
+      return element;
+    }
+
+    return {
+      ...element,
+      ...(nextText !== text && { text: nextText }),
+      ...(nextLabelText !== label?.text && {
+        label: { ...label, text: nextLabelText },
+      }),
+    } as ExcalidrawElementSkeleton;
+  });
 };

--- a/packages/excalidraw/tests/clipboard.test.tsx
+++ b/packages/excalidraw/tests/clipboard.test.tsx
@@ -586,7 +586,7 @@ describe("clipboard - pasting mermaid definition", () => {
                   strokeWidth: 2,
                   label: {
                     groupIds: [],
-                    text: "A",
+                    text: lines[lines.length - 1],
                     fontSize: 20,
                   },
                   link: null,
@@ -626,6 +626,21 @@ describe("clipboard - pasting mermaid definition", () => {
         expect.arrayContaining([
           expect.objectContaining({ type: "rectangle" }),
           expect.objectContaining({ type: "text", text: "A" }),
+        ]),
+      );
+    });
+  });
+
+  it("should convert html line breaks in labels to newlines", async () => {
+    const text = "flowchart TD\nA<br/>B";
+
+    pasteWithCtrlCmdV(text);
+    await waitFor(() => {
+      expect(h.elements.length).toEqual(2);
+      expect(h.elements).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ type: "rectangle" }),
+          expect.objectContaining({ type: "text", text: "A\nB" }),
         ]),
       );
     });


### PR DESCRIPTION
## Problem

Pasting a mermaid definition whose labels contain `<br/>` renders the tag as literal text on canvas instead of breaking the line:

```
flowchart TD
  A[Hello<br/>World] --> B[Line1<br />Line2]
```

The node reads `Hello<br/>World` on canvas, while mermaid itself renders two lines.

## Cause

`@excalidraw/mermaid-to-excalidraw` takes labels straight from mermaid's db and only decodes character references — `entityCodesToText` in `parser/flowchart.js`, and `converter/helpers.js#getText` which strips markdown and font-awesome icons. Neither touches `<br>`, so the tag reaches `convertToExcalidrawElements` verbatim.

Note this isn't something entity decoding could fix upstream. `<br>` is markup, not a character reference — and `entityCodesToText` uses a `<textarea>`, which is an RCDATA element, so tags inside it are never parsed as markup by design. Even parsing it into a real DOM `<br>` node would lose the break: `textContent` of `A<br/>B` is `"AB"`, and an Excalidraw text element holds a flat string with no DOM to render.

## Fix

Normalize `<br>` / `<br/>` / `<br />` (case-insensitive) to `\n` right before `convertToExcalidrawElements`, on both paths that create elements from a mermaid definition:

- pasting a definition onto the canvas (`App.tsx`)
- the Mermaid/TTD dialog preview + insert (`TTDDialog/common.ts`)

The two remaining `parseMermaidToExcalidraw` call sites (`useTextGeneration.ts`, the auto-fix probe in `MermaidToExcalidraw.tsx`) only validate and don't create elements, so they're left alone.

Containers don't overflow: `bindTextToContainer` calls `redrawTextBoundingBox`, which grows the container to fit the extra lines.

The transform is idempotent, so it stays correct if `mermaid-to-excalidraw` handles this itself later.

## Tests

- 3 unit tests in `mermaid.test.ts` — container label, text element + arrow label, and that untouched elements keep their identity.
- 1 integration test in `clipboard.test.tsx` — pasting `flowchart TD\nA<br/>B` yields a text element with `"A\nB"`. The mock there now returns the label from the definition's last line instead of a hardcoded `"A"`.

`yarn test:update` (123 files, 1866 passed, no snapshot changes), `yarn test:typecheck`, `yarn test:code` and `yarn test:other` all pass.

## Verification

Verified manually on a local dev build against the real mermaid library, on both affected paths: pasting a definition onto the canvas, and the Mermaid to Excalidraw dialog (preview + insert). Labels containing `<br/>` now break onto separate lines instead of showing the tag.
