### PR TITLE
fix(types): expose actionManager on AppClassProperties

### DIFF
--- a/packages/excalidraw/types.ts
+++ b/packages/excalidraw/types.ts
@@ -1105,6 +1105,7 @@ export type AppClassProperties = {
   state: AppState;
   readonly ownerDocument: Document;
   readonly ownerWindow: Window & typeof globalThis;
+  actionManager: App["actionManager"];
   api: App["api"];
   sessionExportThemeOverride: App["sessionExportThemeOverride"];
   interactiveCanvas: HTMLCanvasElement | null;


### PR DESCRIPTION
Exposes the `actionManager' property on the `AppClassProperties` type definition in `packages/excalidraw/types.ts`.
 Closes #11983