### PR TITLE
fix(editor): use selectionColor instead of hardcoded black for group selection border

### DIFF
--- a/packages/excalidraw/renderer/interactiveScene.ts
+++ b/packages/excalidraw/renderer/interactiveScene.ts
@@ -1906,7 +1906,7 @@ const _renderInteractiveScene = ({
           y2,
           selectionColors: groupElements.some((el) => el.locked)
             ? ["#ced4da"]
-            : ["#000"],
+            : [selectionColor],
           dashed: true,
           cx: x1 + (x2 - x1) / 2,
           cy: y1 + (y2 - y1) / 2,


### PR DESCRIPTION
## Summary
The dashed border drawn around a selected *group* of elements was
hardcoded to `#000` (black), so it became invisible when selecting
on top of a dark background while using light theme (#7177).
Selecting a single element already respects the app's theme via
`selectionColor`, computed a few lines above in the same function —
the group-selection code path just never picked it up.

## Fix
One-line change in `packages/excalidraw/renderer/interactiveScene.ts`:
use `selectionColor` instead of the hardcoded `"#000"`, matching the
pattern already used a few lines above for individual elements
(`element.locked ? ["#ced4da"] : selectionColors`).

Fixes #7177

## Test plan
- [x] `yarn test:typecheck`
- [x] `yarn test:code`
- [x] `yarn test:other`
- [x] `yarn test:app` (786 passed)
- [ ] Manual check: select a group over a dark element/background in
      light theme, confirm the border now follows the theme
