### PR TITLE
fix(editor): make element body clickable for links on mobile in view mode

### DIFF
--- a/packages/excalidraw/components/hyperlink/helpers.test.ts
+++ b/packages/excalidraw/components/hyperlink/helpers.test.ts
@@ -1,0 +1,139 @@
+import { pointFrom } from "@excalidraw/math";
+
+import { newElement } from "@excalidraw/element";
+
+import type { ElementsMap } from "@excalidraw/element/types";
+
+import { getDefaultAppState } from "../../appState";
+
+import { isPointHittingLink } from "./helpers";
+
+import type { AppState } from "../../types";
+
+// getDefaultAppState() omits the viewport-derived fields (they are only
+// known once the editor has mounted); fill in fixed values for the test.
+const createAppState = (overrides: Partial<AppState> = {}): AppState => ({
+  ...getDefaultAppState(),
+  width: 1000,
+  height: 800,
+  offsetTop: 0,
+  offsetLeft: 0,
+  ...overrides,
+});
+
+// Uses real elements and the real hit-test logic (getElementAbsoluteCoords /
+// hitElementBoundingBox) instead of mocking @excalidraw/element, matching
+// how the other tests in this directory (e.g.
+// positionElementBesideCursor.test.ts) exercise real implementations rather
+// than mocks. See STYLE.md for the reasoning.
+const createLinkedRectangle = () =>
+  newElement({
+    type: "rectangle",
+    x: 0,
+    y: 0,
+    width: 100,
+    height: 100,
+    link: "https://example.com",
+  });
+
+const createElementsMap = (
+  ...elements: ReturnType<typeof createLinkedRectangle>[]
+): ElementsMap => new Map(elements.map((element) => [element.id, element]));
+
+describe("isPointHittingLink", () => {
+  it("returns false when the element has no link", () => {
+    const element = { ...createLinkedRectangle(), link: null };
+    const elementsMap = createElementsMap(element);
+    const appState = createAppState({ viewModeEnabled: true });
+
+    expect(
+      isPointHittingLink(
+        element,
+        elementsMap,
+        appState,
+        pointFrom(50, 50),
+        true,
+      ),
+    ).toBe(false);
+  });
+
+  it("returns false when the element is currently selected", () => {
+    const element = createLinkedRectangle();
+    const elementsMap = createElementsMap(element);
+    const appState = createAppState({
+      viewModeEnabled: true,
+      selectedElementIds: { [element.id]: true },
+    });
+
+    expect(
+      isPointHittingLink(
+        element,
+        elementsMap,
+        appState,
+        pointFrom(50, 50),
+        true,
+      ),
+    ).toBe(false);
+  });
+
+  it("regression #9637: hitting anywhere on the element body opens the link on mobile in view mode", () => {
+    // Previously `!isMobile && appState.viewModeEnabled && ...` excluded
+    // mobile from the "whole bounding box is clickable" path, so on mobile
+    // only the small link icon (not the element body) was clickable.
+    const element = createLinkedRectangle();
+    const elementsMap = createElementsMap(element);
+    const appState = createAppState({ viewModeEnabled: true });
+
+    expect(
+      isPointHittingLink(
+        element,
+        elementsMap,
+        appState,
+        pointFrom(50, 50),
+        true,
+      ),
+    ).toBe(true);
+  });
+
+  it("still hits anywhere on the element body on desktop in view mode (unchanged behavior)", () => {
+    const element = createLinkedRectangle();
+    const elementsMap = createElementsMap(element);
+    const appState = createAppState({ viewModeEnabled: true });
+
+    expect(
+      isPointHittingLink(
+        element,
+        elementsMap,
+        appState,
+        pointFrom(50, 50),
+        false,
+      ),
+    ).toBe(true);
+  });
+
+  it("outside view mode, only the link icon is hit, on both mobile and desktop", () => {
+    const element = createLinkedRectangle();
+    const elementsMap = createElementsMap(element);
+    const appState = createAppState({ viewModeEnabled: false });
+
+    // center of the element body: not the link icon location
+    expect(
+      isPointHittingLink(
+        element,
+        elementsMap,
+        appState,
+        pointFrom(50, 50),
+        true,
+      ),
+    ).toBe(false);
+    expect(
+      isPointHittingLink(
+        element,
+        elementsMap,
+        appState,
+        pointFrom(50, 50),
+        false,
+      ),
+    ).toBe(false);
+  });
+});

--- a/packages/excalidraw/components/hyperlink/helpers.ts
+++ b/packages/excalidraw/components/hyperlink/helpers.ts
@@ -90,7 +90,6 @@ export const isPointHittingLink = (
     return false;
   }
   if (
-    !isMobile &&
     appState.viewModeEnabled &&
     hitElementBoundingBox(pointFrom(x, y), element, elementsMap)
   ) {


### PR DESCRIPTION
## Summary
On desktop, when `viewModeEnabled` is true (e.g. a shared/read-only view or presentation mode), clicking anywhere on an element's bounding box opens its link. On mobile, `isPointHittingLink` explicitly excluded this path via a `!isMobile` guard, so only the small (~12px) link icon was clickable — inconsistent with desktop and easy to miss on a touch screen. This closes #9637.

## Fix
Remove the `!isMobile &&` guard in `packages/excalidraw/components/hyperlink/helpers.ts` (`isPointHittingLink`), so the "whole bounding box is clickable in view mode" path applies equally on mobile and desktop. Outside view mode, behavior is unchanged on both platforms (only the link icon is hit-testable).

This is safe because the existing drag/scroll protection in `App.tsx#handleElementLinkClick` (the `draggedDistance > DRAGGING_THRESHOLD` check, plus requiring both pointerdown and pointerup to hit) is already platform-independent and applies identically regardless of `isMobile`.

## Test plan
- Added `packages/excalidraw/components/hyperlink/helpers.test.ts` (5 tests) covering: no link → false; selected element → false; mobile view-mode body tap → true (regression for #9637); desktop view-mode body click → true (unchanged); outside view mode, only the icon is hit on both platforms.
- `yarn test:typecheck`, `yarn test:code`, `yarn test:other` all pass with zero errors/warnings.
- Full `packages/excalidraw/tests` suite (49 files / 796 tests): 786 passed, 10 skipped, 0 failed.
- [ ] Manual verification on a real mobile/touch device is recommended before merge (not performed here — jsdom only).
