### PR TITLE
feat: add renderIframe prop

### DIFF
--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -2020,7 +2020,7 @@ class App extends React.Component<AppProps, AppState> {
                   >
                     {(isEmbeddableElement(el)
                       ? this.props.renderEmbeddable?.(el, this.state)
-                      : null) ?? (
+                      : this.props.renderIframe?.(el, this.state)) ?? (
                       <iframe
                         ref={(ref) => this.cacheEmbeddableRef(el, ref)}
                         className="excalidraw__embeddable"

--- a/packages/excalidraw/index.tsx
+++ b/packages/excalidraw/index.tsx
@@ -110,6 +110,7 @@ const ExcalidrawBase = (props: ExcalidrawProps) => {
     children,
     validateEmbeddable,
     renderEmbeddable,
+    renderIframe,
     aiEnabled,
     showDeprecatedFonts,
     renderScrollbars,
@@ -252,6 +253,7 @@ const ExcalidrawBase = (props: ExcalidrawProps) => {
           onDuplicate={onDuplicate}
           validateEmbeddable={validateEmbeddable}
           renderEmbeddable={renderEmbeddable}
+          renderIframe={renderIframe}
           aiEnabled={aiEnabled !== false}
           showDeprecatedFonts={showDeprecatedFonts}
           renderScrollbars={renderScrollbars}

--- a/packages/excalidraw/tests/App.test.tsx
+++ b/packages/excalidraw/tests/App.test.tsx
@@ -7,6 +7,8 @@ import { Excalidraw } from "../index";
 import * as StaticScene from "../renderer/staticScene";
 import { render, queryByTestId, unmountComponent } from "../tests/test-utils";
 
+import { API } from "./helpers/api";
+
 const renderStaticScene = vi.spyOn(StaticScene, "renderStaticScene");
 
 describe("Test <App/>", () => {
@@ -42,5 +44,26 @@ describe("Test <App/>", () => {
         "brave-measure-text-error",
       ),
     ).toMatchSnapshot();
+  });
+
+  it("should render iframe elements with renderIframe", async () => {
+    const iframe = API.createElement({
+      type: "iframe",
+      id: "iframe",
+      width: 320,
+      height: 180,
+    });
+
+    const { getByTestId, queryByTitle } = await render(
+      <Excalidraw
+        initialData={{ elements: [iframe] }}
+        renderIframe={(element) => (
+          <div data-testid="custom-iframe">{element.id}</div>
+        )}
+      />,
+    );
+
+    expect(getByTestId("custom-iframe")).toHaveTextContent("iframe");
+    expect(queryByTitle("Excalidraw Embedded Content")).toBeNull();
   });
 });

--- a/packages/excalidraw/types.ts
+++ b/packages/excalidraw/types.ts
@@ -27,6 +27,7 @@ import type {
   Theme,
   StrokeRoundness,
   ExcalidrawEmbeddableElement,
+  ExcalidrawIframeElement,
   ExcalidrawMagicFrameElement,
   ExcalidrawFrameLikeElement,
   ExcalidrawElementType,
@@ -966,6 +967,10 @@ export interface ExcalidrawProps {
     | ((link: string) => boolean | undefined);
   renderEmbeddable?: (
     element: NonDeleted<ExcalidrawEmbeddableElement>,
+    appState: AppState,
+  ) => JSX.Element | null;
+  renderIframe?: (
+    element: NonDeleted<ExcalidrawIframeElement>,
     appState: AppState,
   ) => JSX.Element | null;
   aiEnabled?: boolean;


### PR DESCRIPTION
## Summary

- add a typed `renderIframe(element, appState)` host hook for native iframe elements
- preserve Excalidraw's existing iframe renderer when the hook is absent or returns `null`
- add a regression test covering custom rendering and fallback replacement

## Motivation

`renderEmbeddable` lets host applications own the rendering and security policy for embeddable elements, but native iframe elements do not expose the equivalent extension point. Host applications that store custom iframe content in `customData` therefore have to patch Excalidraw or reimplement the element outside the canvas.

The new hook keeps iframe geometry and interaction native to Excalidraw while allowing the host to supply its own sandboxed content and CSP.

## Validation

- `yarn test:typecheck`
- `yarn vitest run packages/excalidraw/tests/App.test.tsx`
- ESLint with zero warnings on the changed files