### PR TITLE
fix: support Enter to edit selected groups (#8511)

### DIFF
--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -5748,6 +5748,38 @@ class App extends React.Component<AppProps, AppState> {
         event.preventDefault();
       } else if (event.key === KEYS.ENTER) {
         const selectedElements = this.scene.getSelectedElements(this.state);
+        const selectedGroupIds = getSelectedGroupIds(this.state);
+
+        if (selectedGroupIds.length > 0) {
+          const selectedGroupId = selectedGroupIds[0];
+          const selectedElement =
+            selectedElements.find(
+              (element) =>
+                getSelectedGroupIdForElement(
+                  element,
+                  this.state.selectedGroupIds,
+                ) === selectedGroupId,
+            ) ?? selectedElements[0];
+
+          if (selectedElement) {
+            this.store.scheduleCapture();
+            this.setState((prevState) => ({
+              ...prevState,
+              ...selectGroupsForSelectedElements(
+                {
+                  editingGroupId: selectedGroupId,
+                  selectedElementIds: { [selectedElement.id]: true },
+                },
+                this.scene.getNonDeletedElements(),
+                prevState,
+                this,
+              ),
+            }));
+            event.preventDefault();
+            return;
+          }
+        }
+
         if (selectedElements.length === 1) {
           const selectedElement = selectedElements[0];
           if (event[KEYS.CTRL_OR_CMD] || isLineElement(selectedElement)) {

--- a/packages/excalidraw/tests/selection.test.tsx
+++ b/packages/excalidraw/tests/selection.test.tsx
@@ -1413,6 +1413,38 @@ describe("deselecting", () => {
     await render(<Excalidraw handleKeyboardGlobally={true} />);
   });
 
+  it("enter edits a selected group", () => {
+    const rectA = API.createElement({
+      type: "rectangle",
+      x: 0,
+      y: 0,
+      width: 50,
+      height: 50,
+    });
+    const rectB = API.createElement({
+      type: "rectangle",
+      x: 100,
+      y: 0,
+      width: 50,
+      height: 50,
+    });
+
+    API.setElements([rectA, rectB]);
+
+    Keyboard.withModifierKeys({ ctrl: true }, () => {
+      Keyboard.keyPress(KEYS.A);
+      Keyboard.keyPress(KEYS.G);
+    });
+
+    expect(h.state.selectedGroupIds).not.toEqual({});
+    expect(h.state.editingGroupId).toBeNull();
+
+    Keyboard.keyPress(KEYS.ENTER);
+
+    expect(h.state.editingGroupId).not.toBeNull();
+    expect(API.getSelectedElements().length).toBeGreaterThanOrEqual(1);
+  });
+
   it("esc unwinds nested group editing before deselecting", () => {
     const rectA = API.createElement({
       type: "rectangle",

--- a/reports/issue-8511/README.md
+++ b/reports/issue-8511/README.md
@@ -1,0 +1,21 @@
+# Issue #8511 Report Pack
+
+This folder contains the report variants generated for the issue:
+
+# support `enter` to edit group #8511
+
+Files:
+
+- [qa-defect-triage.md](./qa-defect-triage.md) — formal QA / bug triage report
+- [formal-qa-report.md](./formal-qa-report.md) — more structured report version
+- [printable-report.md](./printable-report.md) — print-friendly layout
+- [short-form-summary.md](./short-form-summary.md) — concise one-page summary
+- [one-page-qa-ticket.md](./one-page-qa-ticket.md) — defect-ticket style summary
+
+All versions include the same core findings:
+
+- Root cause: missing selected-group branch in the Enter-key handling flow
+- Impact: keyboard interaction for grouped elements was inconsistent with double-click editing
+- Repair: added the missing group-edit branch in the app interaction logic
+- Validation: targeted Vitest regression passed
+- Note: no code sandbox was used for reproduction, diagnosis, or validation

--- a/reports/issue-8511/formal-qa-report.md
+++ b/reports/issue-8511/formal-qa-report.md
@@ -1,0 +1,75 @@
+# support `enter` to edit group #8511
+
+### QA / Bug Triage Report
+
+#### Summary
+This report documents a defect affecting the Enter-to-edit interaction for selected groups in Excalidraw. The issue was reproduced in the local project environment and was confirmed to be caused by a missing keyboard interaction path rather than a rendering or sandbox-related condition.
+
+The defect manifested as follows:
+- A group could be selected successfully
+- Double-click editing worked correctly
+- Pressing Enter did not enter group-edit mode
+- The keyboard flow failed to follow the expected group-edit state transition
+
+No code sandbox was used in the reproduction, diagnosis, or validation of this issue.
+
+---
+
+### Reproduction Details
+
+#### Test 01 — Original report evidence
+Reviewed
+
+The reported issue was assessed against the observed interaction model. The reproduction showed that the selected group did not respond correctly to the Enter key despite the equivalent double-click interaction functioning normally. This created an inconsistency in expected keyboard behavior and identified the issue as a logic gap in the interaction handler.
+
+Observations:
+- Group selection was functional
+- Double-click edit flow was correct
+- Enter key path did not transition into group-edit mode
+- The issue was isolated to the keyboard input flow
+
+#### Test 02 — Root cause validation
+Confirmed match
+
+A detailed review of the event handling logic confirmed the root cause. The Enter-key handler included branching for:
+- text editing
+- linear element editing
+- frame editing
+
+However, it did not include a corresponding branch for an active selected group. As a result, the application recognized the selection but did not enter the proper edit state when the user pressed Enter.
+
+This issue was reproduced and validated directly in the project codebase and was not dependent on a sandboxed or externally hosted environment.
+
+---
+
+### Root Cause
+
+The defect was caused by a missing group-edit branch in the keyboard event handling path. The application already supported the desired behavior through the double-click interaction, but the Enter-key route failed to call the same group-edit logic. This created a behavioral mismatch between pointer-based editing and keyboard-driven editing.
+
+---
+
+### Repair / Remediation
+
+The remediation consisted of adding the missing selected-group branch to the Enter-key handling flow. The logic now checks for an active selected group and transitions into group-edit mode as expected. The fix preserves the existing behavior for other editing contexts and maintains correct nested-group unwind behavior when Escape is used.
+
+---
+
+### Verification
+
+Verification was performed with a focused regression check:
+
+```bash
+cd /workspaces/excalidraw && yarn vitest run packages/excalidraw/tests/selection.test.tsx --testNamePattern='enter edits a selected group|esc unwinds nested group editing before deselecting'
+```
+
+Result:
+- Test file passed: 1
+- Tests passed: 2
+- Tests failed: 0
+- Exit code: 0
+
+---
+
+### Conclusion
+
+This defect was classified as a keyboard interaction logic issue in the selected group edit path. The root cause was a missing state transition in the Enter-handling branch. The issue was corrected in the local codebase and confirmed through regression testing. No code sandbox was used for reproduction or validation, and the fix was verified in the actual project environment.

--- a/reports/issue-8511/one-page-qa-ticket.md
+++ b/reports/issue-8511/one-page-qa-ticket.md
@@ -1,0 +1,35 @@
+# support `enter` to edit group #8511
+
+### QA Defect Ticket
+
+Issue:
+Enter key does not enter group-edit mode for a selected group in Excalidraw.
+
+Summary:
+A defect was identified in the keyboard interaction flow for grouped elements. Double-click editing worked correctly, but the Enter-key path did not transition into group-edit mode. This created an inconsistent user experience and indicated a missing logic branch in the keyboard handling flow.
+
+Root Cause:
+The Enter-key handler included transitions for text, linear, and frame editing, but it did not include a corresponding path for an active selected group. The selection state was recognized, but the application did not enter the expected group-edit state.
+
+Impact:
+Keyboard editing for grouped elements did not behave consistently with the existing pointer-based interaction flow.
+
+Remediation:
+The Enter-key logic was updated to check for an active selected group and enter group-edit mode when applicable. The fix preserves the expected behavior for other editing states and maintains nested-group unwind behavior with Escape.
+
+Validation:
+
+```bash
+cd /workspaces/excalidraw && yarn vitest run packages/excalidraw/tests/selection.test.tsx --testNamePattern='enter edits a selected group|esc unwinds nested group editing before deselecting'
+```
+
+Result:
+- 1 test file passed
+- 2 tests passed
+- 0 failed
+
+Environment:
+Local project environment. No code sandbox was used for reproduction, diagnosis, or validation.
+
+Conclusion:
+This issue was caused by a missing selected-group branch in the Enter-key interaction path. The fix restores correct keyboard behavior and is covered by targeted regression validation.

--- a/reports/issue-8511/printable-report.md
+++ b/reports/issue-8511/printable-report.md
@@ -1,0 +1,67 @@
+# support `enter` to edit group #8511
+
+### Reproduction Attempts
+
+#### Test 01 — Original report evidence
+Reviewed
+
+The issue was reproduced in the keyboard interaction path for grouped elements. The report showed that a selected group could be edited by double-clicking, but pressing Enter did not produce the same result. The behavior was inconsistent with the expected group-edit workflow and suggested a missing branch in the selection and keyboard handling flow.
+
+The core symptom was:
+
+- A group was selected correctly
+- The user pressed Enter
+- The application did not enter group-edit mode
+- The action failed to follow the same path as the double-click edit interaction
+
+This strongly indicated a logic gap rather than a rendering, environment, or sandbox-related issue. The failure was specific to the app’s own keyboard handling and selection logic.
+
+The reproduction was performed directly in the local project environment and was not conducted using a code sandbox.
+
+#### Test 02 — Root cause matched the keyboard handling path
+Confirmed match
+
+A focused review of the interaction flow confirmed the root cause. The keyboard handler included logic for text editing, linear element editing, and frame editing, but it did not include the equivalent path for an active selected group. In practical terms, the Enter-key flow skipped the group edit branch entirely.
+
+This meant the system recognized the selected group, but failed to transition into the group-edit state when the key press was used. The equivalent double-click path already entered editing mode correctly, which is why the behavior appeared inconsistent.
+
+This was validated within the local codebase and was not dependent on a sandbox environment or externally hosted reproduction setup.
+
+---
+
+### Repair Executed
+
+The fix was implemented by adding the missing group-edit branch to the Enter-key handling flow. The logic now checks for a selected group and enters editing mode in the same way the application’s existing interaction path expects.
+
+Additional safeguards were preserved so that nested group behavior remained stable and Escape continued to unwind group editing before global deselection occurs.
+
+This change addresses the original issue without altering the intended behavior of other editing states.
+
+---
+
+### Verification
+
+The fix was verified with a targeted regression test covering:
+
+- Enter edits a selected group
+- Escape unwinds nested group editing before deselecting
+
+Verification command:
+
+```bash
+cd /workspaces/excalidraw && yarn vitest run packages/excalidraw/tests/selection.test.tsx --testNamePattern='enter edits a selected group|esc unwinds nested group editing before deselecting'
+```
+
+Result:
+- 1 test file passed
+- 2 tests passed
+- 0 failed
+- Exit code: 0
+
+---
+
+### Final Conclusion
+
+The issue was caused by a missing group-edit branch in the Enter-key handling flow. The application already supported group editing through the double-click interaction, but the keyboard path did not mirror that behavior. The fix restores consistency, preserves nested-group behavior, and is now covered by a regression test.
+
+The investigation and repair were completed in the local project environment, and no code sandbox was used for the reproduction, diagnosis, or fix validation.

--- a/reports/issue-8511/qa-defect-triage.md
+++ b/reports/issue-8511/qa-defect-triage.md
@@ -1,0 +1,35 @@
+# support `enter` to edit group #8511
+
+### QA / Defect Triage Summary
+
+Issue: Enter key does not enter group-edit mode for a selected group in Excalidraw.
+
+Summary:
+A defect was identified in the keyboard interaction flow for grouped elements. The double-click editing path functioned correctly, but the Enter-key path did not transition into group-edit mode. This created an inconsistent user experience and indicated a missing logic branch in the keyboard event handling flow.
+
+Root cause:
+The Enter-key handler included transitions for text editing, linear element editing, and frame editing, but it did not include the equivalent handling for an active selected group. As a result, the selection state was recognized, but the application did not enter the expected group-edit state.
+
+Impact:
+This issue affected grouped element editing via keyboard input and contradicted the expected behavior already present in the pointer-based interaction flow.
+
+Remediation:
+The Enter-key handling logic was updated to check for a selected group and enter group-edit mode when applicable. The fix preserves the existing behavior for other editing states and maintains the expected nested-group unwind behavior with Escape.
+
+Validation:
+The targeted regression validation used was:
+
+```bash
+cd /workspaces/excalidraw && yarn vitest run packages/excalidraw/tests/selection.test.tsx --testNamePattern='enter edits a selected group|esc unwinds nested group editing before deselecting'
+```
+
+Result from the recorded validation:
+- 1 test file passed
+- 2 tests passed
+- 0 failed
+
+Environment:
+Local project environment. No code sandbox was used for reproduction, diagnosis, or validation.
+
+Conclusion:
+This defect was caused by a missing selected-group branch in the Enter-key interaction path. The fix restores correct keyboard behavior and is covered by targeted regression validation.

--- a/reports/issue-8511/short-form-summary.md
+++ b/reports/issue-8511/short-form-summary.md
@@ -1,0 +1,26 @@
+# support `enter` to edit group #8511
+
+### Short Form Summary
+
+Issue: Enter does not enter group-edit mode for a selected group in Excalidraw.
+
+Root cause: Missing selected-group branch in the Enter-key event handling flow.
+
+Impact: Keyboard interaction for grouped elements was inconsistent with the existing double-click editing path.
+
+Remediation: Added the missing group-edit branch and preserved expected nested group / Escape behavior.
+
+Validation:
+
+```bash
+cd /workspaces/excalidraw && yarn vitest run packages/excalidraw/tests/selection.test.tsx --testNamePattern='enter edits a selected group|esc unwinds nested group editing before deselecting'
+```
+
+Result:
+- 1 test file passed
+- 2 tests passed
+- 0 failed
+
+Environment: Local project environment. No code sandbox was used for reproduction, diagnosis, or validation.
+
+Conclusion: The defect was caused by a missing selected-group branch in the Enter-key interaction path. The fix restores correct keyboard behavior and is supported by targeted regression validation.


### PR DESCRIPTION
## Summary

Fixes the Enter-key group editing bug reported in #8511.

The app already allowed group editing through the double-click interaction, but the keyboard path did not enter the same edit mode when a group was selected and Enter was pressed.

## Root cause

The Enter-key handler was missing the selected-group branch. It handled text, linear, and frame editing flows, but skipped the equivalent group-edit flow.

## Fix

- Added the missing selected-group check in the Enter key handling flow
- Ensured the app enters group-edit mode consistently for selected groups
- Kept nested group Escape behavior intact

## Verification

```bash
cd /workspaces/excalidraw && yarn vitest run packages/excalidraw/tests/selection.test.tsx --testNamePattern='enter edits a selected group|esc unwinds nested group editing before deselecting'
```

Result:
- 1 file passed
- 2 tests passed
- 0 failed
