### PR TITLE
fix: keyboard shortcut and search bugs (#9276, #9281, #9503)

### DIFF
--- a/packages/excalidraw/actions/actionToggleSearchMenu.ts
+++ b/packages/excalidraw/actions/actionToggleSearchMenu.ts
@@ -54,5 +54,11 @@ export const actionToggleSearchMenu = register({
   predicate: (element, appState, props) => {
     return props.gridModeEnabled === undefined;
   },
-  keyTest: (event) => event[KEYS.CTRL_OR_CMD] && event.key === KEYS.F,
+  keyTest: (event, appState) =>
+    event[KEYS.CTRL_OR_CMD] &&
+    event.key === KEYS.F &&
+    // don't swallow Ctrl/Cmd+F while a dialog (e.g. help) is open: `perform`
+    // bails out in that case, so intercepting the event here would block the
+    // browser's native find-in-page without opening canvas search instead
+    !appState.openDialog,
 });

--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -5521,7 +5521,10 @@ class App extends React.Component<AppProps, AppState> {
         // inside an input
         (isWritableElement(event.target) &&
           // unless pressing escape (finalize action)
-          event.key !== KEYS.ESCAPE) ||
+          event.key !== KEYS.ESCAPE &&
+          // unless saving (Ctrl/Cmd+S), otherwise the browser's native
+          // "save page" dialog opens instead of saving the .excalidraw file
+          !(event[KEYS.CTRL_OR_CMD] && event.key.toLowerCase() === KEYS.S)) ||
         // or unless using arrows (to move between buttons)
         (isArrowKey(event.key) && isInputLike(event.target))
       ) {

--- a/packages/excalidraw/components/SearchMenu.tsx
+++ b/packages/excalidraw/components/SearchMenu.tsx
@@ -104,6 +104,13 @@ export const SearchMenu = () => {
     if (isSearching) {
       return;
     }
+    // skip re-searching while an element is actively being dragged: matches
+    // are sorted by canvas position, so re-running here would reorder the
+    // results list on every pointer-move frame of the drag. The scene nonce
+    // stays dirty and is picked up on the next effect run once the drag ends.
+    if (app.state.selectedElementsAreBeingDragged) {
+      return;
+    }
     if (
       searchQuery !== searchedQueryRef.current ||
       app.scene.getSceneNonce() !== lastSceneNonceRef.current
@@ -135,6 +142,7 @@ export const SearchMenu = () => {
     searchQuery,
     elementsMap,
     app,
+    app.state.selectedElementsAreBeingDragged,
     setAppState,
     setFocusIndex,
     lastSceneNonceRef,

--- a/packages/excalidraw/tests/search.test.tsx
+++ b/packages/excalidraw/tests/search.test.tsx
@@ -17,7 +17,7 @@ import { Excalidraw } from "../index";
 import { API } from "./helpers/api";
 import { Keyboard } from "./helpers/ui";
 import { updateTextEditor } from "./queries/dom";
-import { act, render, waitFor } from "./test-utils";
+import { act, fireEvent, render, waitFor } from "./test-utils";
 
 const { h } = window;
 
@@ -192,6 +192,72 @@ describe("search", () => {
 
     await waitFor(() => {
       expect(h.app.state.searchMatches?.matches.length).toBe(3);
+    });
+  });
+
+  it("should not steal cmd+f while a dialog is open", async () => {
+    API.setAppState({ openDialog: { name: "help" } });
+    expect(h.app.state.openSidebar).toBeNull();
+
+    Keyboard.withModifierKeys({ ctrl: true }, () => {
+      Keyboard.keyPress(KEYS.F);
+    });
+
+    // the search action should not have intercepted the shortcut, leaving
+    // the browser's native find-in-page behavior (and the help dialog) intact
+    expect(h.app.state.openSidebar).toBeNull();
+    expect(h.app.state.openDialog?.name).toBe("help");
+  });
+
+  it("should not block cmd+s while a text input is focused", async () => {
+    Keyboard.withModifierKeys({ ctrl: true }, () => {
+      Keyboard.keyPress(KEYS.F);
+    });
+    const searchInput = await querySearchInput();
+
+    const notCancelled = fireEvent.keyDown(searchInput, {
+      key: "s",
+      ctrlKey: true,
+    });
+
+    // returns false when a handler called preventDefault(), which is what we
+    // want here so the app's save action runs instead of the browser's
+    // native "save page" dialog
+    expect(notCancelled).toBe(false);
+  });
+
+  it("should not reorder search matches while dragging", async () => {
+    const scrollIntoViewMock = jest.fn();
+    window.HTMLElement.prototype.scrollIntoView = scrollIntoViewMock;
+
+    API.setElements([
+      API.createElement({ type: "text", text: "test one", y: 0 }),
+      API.createElement({ type: "text", text: "test two", y: 100 }),
+    ]);
+
+    Keyboard.withModifierKeys({ ctrl: true }, () => {
+      Keyboard.keyPress(KEYS.F);
+    });
+    const searchInput = await querySearchInput();
+    updateTextEditor(searchInput, "test");
+
+    await waitFor(() => {
+      expect(h.app.state.searchMatches?.matches.length).toBe(2);
+    });
+    const firstMatchId = h.app.state.searchMatches!.matches[0].id;
+    expect(firstMatchId).toBe(h.elements[0].id);
+
+    API.setAppState({ selectedElementsAreBeingDragged: true });
+    // move the second element above the first, as if it were being dragged
+    API.updateElement(h.elements[1] as ExcalidrawTextElement, { y: -100 });
+
+    // give the debounced search a chance to run if it were going to
+    await act(() => new Promise((resolve) => setTimeout(resolve, 500)));
+    expect(h.app.state.searchMatches?.matches[0].id).toBe(firstMatchId);
+
+    API.setAppState({ selectedElementsAreBeingDragged: false });
+    await waitFor(() => {
+      expect(h.app.state.searchMatches?.matches[0].id).toBe(h.elements[1].id);
     });
   });
 });


### PR DESCRIPTION
Fixes #9276, fixes #9281, fixes #9503

## What
Three small, related bugs in keyboard-shortcut / search handling:

- **#9276** — Ctrl/Cmd+F did nothing while a dialog (e.g. the help dialog) was open. The search action's `keyTest` matched the shortcut regardless of `openDialog`, so `handleKeyDown` called `preventDefault()`/`stopPropagation()` even though `perform()` immediately bails out when a dialog is open — swallowing the event without opening search, and blocking the browser's native find-in-page as a side effect. `keyTest` now skips the match while any dialog is open, letting the event fall through.
- **#9281** — Ctrl/Cmd+S while a text input was focused (e.g. renaming, or the search box) opened the browser's native "save page" dialog instead of saving the `.excalidraw` file, because the global keydown handler bails out early for any writable-element target except Escape. Save is now exempted from that bail, same as Escape already is.
- **#9503** — the canvas search results list visibly reordered while dragging an element around the canvas. Root cause: matches are sorted by `y` position, and the search effect re-runs (and re-sorts) on every scene-nonce change, including every pointer-move frame of a drag. The effect now skips re-searching while `selectedElementsAreBeingDragged` is true, and picks up the final position once the drag ends.

## Testing
- `yarn test:typecheck` passes
- Added three regression tests in `packages/excalidraw/tests/search.test.tsx`, one per bug, all passing alongside the existing search/shortcut suites (`yarn vitest run packages/excalidraw/tests/search.test.tsx packages/excalidraw/tests/shortcuts.test.tsx` — 9/9 passing)
- `yarn fix` run to match repo lint/format conventions