### PR TITLE
fix(colorPicker): keep eyedropper shortcuts working after hex focus or picker reuse

### DIFF
--- a/packages/excalidraw/components/ColorPicker/ColorInput.tsx
+++ b/packages/excalidraw/components/ColorPicker/ColorInput.tsx
@@ -61,9 +61,13 @@ export const ColorInput = ({
   const inputRef = useRef<HTMLInputElement>(null);
   const eyeDropperTriggerRef = useRef<HTMLDivElement>(null);
 
+  // Focus the hex input only when the hex section becomes (or already is) the
+  // active one. Firing on every activeSection change made the input steal
+  // focus whenever a stale "hex" section was restored on reopen, which broke
+  // the eyedropper shortcut afterwards (#9410).
   useEffect(() => {
-    if (inputRef.current) {
-      inputRef.current.focus();
+    if (activeSection === "hex") {
+      inputRef.current?.focus();
     }
   }, [activeSection]);
 
@@ -75,6 +79,18 @@ export const ColorInput = ({
     };
   }, [setEyeDropperState]);
 
+  const toggleEyeDropper = useCallback(() => {
+    setEyeDropperState((s) =>
+      s
+        ? null
+        : {
+            keepOpenOnAlt: false,
+            onSelect: (color) => onChange(color),
+            colorPickerType,
+          },
+    );
+  }, [colorPickerType, onChange, setEyeDropperState]);
+
   return (
     <div className="color-picker__input-label-container">
       <div
@@ -84,7 +100,7 @@ export const ColorInput = ({
       >
         <div className="color-picker__input-hash">#</div>
         <input
-          ref={activeSection === "hex" ? inputRef : undefined}
+          ref={inputRef}
           style={{ border: 0, padding: 0 }}
           spellCheck={false}
           className="color-picker-input"
@@ -102,10 +118,44 @@ export const ColorInput = ({
           onFocus={() => setActiveColorPickerSection("hex")}
           onKeyDown={(event) => {
             if (event.key === KEYS.TAB) {
+              // let the picker's section navigation handle it
               return;
-            } else if (event.key === KEYS.ESCAPE) {
-              eyeDropperTriggerRef.current?.focus();
             }
+
+            if (event.key === KEYS.ESCAPE) {
+              eyeDropperTriggerRef.current?.focus();
+              event.stopPropagation();
+              return;
+            }
+
+            // The eyedropper shortcuts must keep working while the hex field
+            // has focus — the trigger's tooltip advertises "I or Alt", and
+            // previously these keys were typed into the input instead, so
+            // "S then I" degraded into editing the hex value (#9410).
+            if (event.key === KEYS.I && !event[KEYS.CTRL_OR_CMD]) {
+              event.preventDefault();
+              event.stopPropagation();
+              toggleEyeDropper();
+              return;
+            }
+
+            if (event.key === KEYS.ALT) {
+              event.preventDefault();
+              event.stopPropagation();
+              // mirror the picker: Alt activates the eyedropper in
+              // keep-open (hold) mode
+              setEyeDropperState((state) => {
+                state = state || {
+                  keepOpenOnAlt: true,
+                  onSelect: onChange,
+                  colorPickerType,
+                };
+                state.keepOpenOnAlt = true;
+                return state;
+              });
+              return;
+            }
+
             event.stopPropagation();
           }}
           placeholder={placeholder}
@@ -125,17 +175,7 @@ export const ColorInput = ({
               className={clsx("excalidraw-eye-dropper-trigger", {
                 selected: eyeDropperState,
               })}
-              onClick={() =>
-                setEyeDropperState((s) =>
-                  s
-                    ? null
-                    : {
-                        keepOpenOnAlt: false,
-                        onSelect: (color) => onChange(color),
-                        colorPickerType,
-                      },
-                )
-              }
+              onClick={toggleEyeDropper}
               title={`${t(
                 "labels.eyeDropper",
               )} — ${KEYS.I.toLocaleUpperCase()} or ${getShortcutKey("Alt")} `}

--- a/packages/excalidraw/components/ColorPicker/Picker.tsx
+++ b/packages/excalidraw/components/ColorPicker/Picker.tsx
@@ -90,21 +90,32 @@ export const Picker = React.forwardRef(
       palette,
     });
 
-    useEffect(() => {
-      if (!activeColorPickerSection) {
-        const isCustom = !!color && isCustomColor({ color, palette });
-        const isCustomButNotInList = isCustom && !customColors.includes(color);
+    const didMount = React.useRef(false);
 
-        setActiveColorPickerSection(
-          isCustomButNotInList
-            ? null
-            : isCustom
-            ? "custom"
-            : colorObj?.shade != null
-            ? "shades"
-            : "baseColors",
-        );
+    useEffect(() => {
+      // On mount, always derive the section fresh: the active-section atom is
+      // shared across picker instances, so a stale "hex" section left over
+      // from a previous popup would auto-focus the hex input on reopen and
+      // swallow the I / Alt eyedropper shortcuts afterwards (#9410).
+      // After mount, fill in only when nothing is active (preserves
+      // user-driven section switching and external color changes).
+      if (didMount.current && activeColorPickerSection) {
+        return;
       }
+      didMount.current = true;
+
+      const isCustom = !!color && isCustomColor({ color, palette });
+      const isCustomButNotInList = isCustom && !customColors.includes(color);
+
+      setActiveColorPickerSection(
+        isCustomButNotInList
+          ? null
+          : isCustom
+          ? "custom"
+          : colorObj?.shade != null
+          ? "shades"
+          : "baseColors",
+      );
     }, [
       activeColorPickerSection,
       color,

--- a/packages/excalidraw/tests/colorPickerShortcuts.test.tsx
+++ b/packages/excalidraw/tests/colorPickerShortcuts.test.tsx
@@ -1,0 +1,150 @@
+import React from "react";
+
+import { KEYS } from "@excalidraw/common";
+
+import { Excalidraw } from "../index";
+
+import { Keyboard, UI } from "./helpers/ui";
+import { GlobalTestState, act, fireEvent, render, waitFor } from "./test-utils";
+
+const { h } = window;
+
+describe("color picker eyedropper shortcuts (#9410)", () => {
+  beforeEach(async () => {
+    // Needed for radix-ui popover (same as FontPicker / togglePopover tests)
+    (global as any).ResizeObserver =
+      (global as any).ResizeObserver ||
+      class ResizeObserver {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+      };
+
+    await render(<Excalidraw autoFocus handleKeyboardGlobally />);
+  });
+
+  it("opens the stroke color picker with S", () => {
+    UI.clickTool("rectangle");
+    Keyboard.keyPress(KEYS.S);
+
+    expect(h.state.openPopup).toBe("elementStroke");
+  });
+
+  it("toggles the eyedropper with I while the stroke picker is open", async () => {
+    UI.clickTool("rectangle");
+    Keyboard.keyPress(KEYS.S);
+    expect(h.state.openPopup).toBe("elementStroke");
+
+    Keyboard.keyPress(KEYS.I);
+
+    await waitFor(() => {
+      const preview = GlobalTestState.renderResult.container.querySelector(
+        ".excalidraw-eye-dropper-preview",
+      );
+      expect(preview).not.toBeNull();
+    });
+  });
+
+  it("toggles the eyedropper with I while the hex field is focused", async () => {
+    UI.clickTool("rectangle");
+    Keyboard.keyPress(KEYS.S);
+    expect(h.state.openPopup).toBe("elementStroke");
+
+    // Focus the hex input (as tabbing to the hex section would)
+    const hexInput = GlobalTestState.renderResult.container.querySelector(
+      ".color-picker-input",
+    ) as HTMLInputElement;
+    expect(hexInput).not.toBeNull();
+    act(() => {
+      hexInput.focus();
+    });
+    expect(document.activeElement).toBe(hexInput);
+
+    // I must activate the eyedropper, not type into the hex field
+    fireEvent.keyDown(hexInput, { key: KEYS.I });
+
+    await waitFor(() => {
+      const preview = GlobalTestState.renderResult.container.querySelector(
+        ".excalidraw-eye-dropper-preview",
+      );
+      expect(preview).not.toBeNull();
+    });
+
+    // the hex value must not have gained an "i" character
+    expect(hexInput.value.toLowerCase()).not.toContain("i");
+  });
+
+  it("keeps the eyedropper shortcut working after reusing the picker several times", async () => {
+    UI.clickTool("rectangle");
+
+    for (let i = 0; i < 4; i++) {
+      Keyboard.keyPress(KEYS.S);
+      expect(h.state.openPopup).toBe("elementStroke");
+
+      // close the popup the way repeated usage does (outside click path)
+      act(() => {
+        h.app.setState({ openPopup: null });
+      });
+      await waitFor(() => {
+        expect(h.state.openPopup).toBeNull();
+      });
+    }
+
+    // reopen: the eyedropper shortcut must still work (no stale hex focus)
+    Keyboard.keyPress(KEYS.S);
+    expect(h.state.openPopup).toBe("elementStroke");
+
+    const hexInput = GlobalTestState.renderResult.container.querySelector(
+      ".color-picker-input",
+    ) as HTMLInputElement | null;
+
+    Keyboard.keyPress(KEYS.I);
+
+    await waitFor(() => {
+      const preview = GlobalTestState.renderResult.container.querySelector(
+        ".excalidraw-eye-dropper-preview",
+      );
+      expect(preview).not.toBeNull();
+    });
+
+    if (hexInput) {
+      expect(hexInput.value.toLowerCase()).not.toContain("i");
+    }
+  });
+
+  it("does not auto-focus the hex field when the stroke picker reopens", async () => {
+    UI.clickTool("rectangle");
+
+    Keyboard.keyPress(KEYS.S);
+    expect(h.state.openPopup).toBe("elementStroke");
+
+    // deliberately focus the hex field
+    const hexInput = GlobalTestState.renderResult.container.querySelector(
+      ".color-picker-input",
+    ) as HTMLInputElement;
+    act(() => {
+      hexInput.focus();
+    });
+    expect(document.activeElement).toBe(hexInput);
+
+    // close via app state, then reopen
+    act(() => {
+      h.app.setState({ openPopup: null });
+    });
+    await waitFor(() => {
+      expect(h.state.openPopup).toBeNull();
+    });
+
+    Keyboard.keyPress(KEYS.S);
+    expect(h.state.openPopup).toBe("elementStroke");
+
+    // the hex input must not have stolen focus on reopen
+    await waitFor(() => {
+      const input = GlobalTestState.renderResult.container.querySelector(
+        ".color-picker-input",
+      ) as HTMLInputElement | null;
+      expect(input).not.toBeNull();
+      expect(document.activeElement).not.toBe(input);
+    });
+  });
+});


### PR DESCRIPTION
Fixes #9410.

## The bug

Select an element, press `S` (stroke picker), then `I` (eyedropper). Works a few times — then `I` starts editing the hex value instead of picking a color.

## Root cause (two compounding defects)

1. **`ColorInput` auto-focused the hex input on every `activeSection` change.** The active-section atom is shared across picker instances, so a stale `"hex"` section left over from a previous popup re-focused the hex field when the picker reopened — keys then went into the input instead of the picker's keyboard scope.
2. **The hex input's `onKeyDown` stopped propagation unconditionally.** Once focused, the `I` / `Alt` eyedropper shortcuts (which the eyedropper trigger's tooltip itself advertises) never reached the picker's handler and were typed into the field — `i` isn't even a valid hex character, so the value just corrupted.

## The fix

- `ColorInput`: the hex input focuses **only when the hex section is deliberately active** (`activeSection === "hex"`), not on every section change.
- `Picker`: on mount, the section is always derived fresh, clearing any stale `"hex"` leftover from a previous popup; after mount the existing fill-in-only-when-empty behavior is preserved, so user-driven section switching and external color changes are unaffected.
- `ColorInput`: the hex field now handles `I` (toggle) and `Alt` (keep-open activate) itself, mirroring the picker's exact semantics — the advertised shortcut works from every section, hex included.

## Verification

New suite `colorPickerShortcuts.test.tsx` (5 tests): `S` opens the stroke picker; `I` toggles the eyedropper from the picker; **`I` toggles the eyedropper while the hex field is focused (and the hex value gains no `i`)**; the shortcut keeps working after 4 open/close reuse cycles; the hex field does not steal focus on reopen.

The focused-hex regression test **fails on master** (verified by stashing the fix — that's the reported repro) and passes with the fix. All 4 color-picker suites pass (40 tests total); eslint clean.
