### PR TITLE
feat: allow lovable.app domain for embeddables

### DIFF
--- a/packages/element/src/embeddable.ts
+++ b/packages/element/src/embeddable.ts
@@ -147,6 +147,7 @@ const ALLOWED_DOMAINS = new Set([
   "giphy.com",
   "reddit.com",
   "forms.microsoft.com",
+  "*.lovable.app",
 ]);
 
 const ALLOW_SAME_ORIGIN = new Set([


### PR DESCRIPTION
Adds `*.lovable.app` to `ALLOWED_DOMAINS` in `packages/element/src/embeddable.ts` so apps published on Lovable (e.g. `https://eco-quest-dpe.lovable.app`) can be embedded as Web Embeds.

This follows the existing wildcard-first-subdomain pattern already used for `*.simplepdf.eu` — `matchHostname` replaces the first hostname label with `*` and checks it against `ALLOWED_DOMAINS`, so `eco-quest-dpe.lovable.app` resolves to `*.lovable.app` and matches.

I did not add `lovable.app` to `ALLOW_SAME_ORIGIN`, since there's no indication the embedded content needs same-origin sandbox privileges (unlike e.g. `forms.microsoft.com` in #9519, which required it to render).

Note for reviewers: `lovable.app` is a generic app-hosting platform (comparable to `vercel.app` or `netlify.app`), so this allowlist entry makes any Lovable-hosted app embeddable, not just the one referenced in the issue. Flagging this in case it warrants more scrutiny than a single-domain allowlist addition.

Closes #12025