### PR TITLE
fix(eraser): prevent throw and support erasing freedraw strokes with short/empty outlines

### DIFF
--- a/packages/element/src/renderElement.ts
+++ b/packages/element/src/renderElement.ts
@@ -21,7 +21,6 @@ import {
   getFontString,
   isRTL,
   getVerticalOffset,
-  invariant,
   applyDarkModeFilter,
   isSafari,
 } from "@excalidraw/common";
@@ -998,6 +997,10 @@ export function getFreedrawOutlineAsSegments(
   points: [number, number][],
   elementsMap: ElementsMap,
 ) {
+  if (points.length < 2) {
+    return [];
+  }
+
   const bounds = getElementBounds(
     {
       ...element,
@@ -1009,8 +1012,6 @@ export function getFreedrawOutlineAsSegments(
     (bounds[0] + bounds[2]) / 2,
     (bounds[1] + bounds[3]) / 2,
   );
-
-  invariant(points.length >= 2, "Freepath outline must have at least 2 points");
 
   return points.slice(2).reduce(
     (acc, curr) => {

--- a/packages/element/tests/collision.test.tsx
+++ b/packages/element/tests/collision.test.tsx
@@ -8,6 +8,7 @@ import { render } from "@excalidraw/excalidraw/tests/test-utils";
 
 import * as distance from "../src/distance";
 import { hitElementItself } from "../src/collision";
+import { getFreedrawOutlineAsSegments } from "../src/renderElement";
 
 describe("check rotated elements can be hit:", () => {
   beforeEach(async () => {
@@ -216,5 +217,38 @@ describe("hitElementItself cache", () => {
         overrideShouldTestInside: true,
       }),
     ).toBe(true);
+  });
+});
+
+describe("getFreedrawOutlineAsSegments", () => {
+  it("safely handles outline points with fewer than 2 points without throwing (#11945)", () => {
+    const element = API.createElement({
+      type: "freedraw",
+      x: 0,
+      y: 0,
+      width: 10,
+      height: 10,
+      points: [[0, 0]],
+    });
+    const elementsMap = arrayToMap([element]);
+
+    expect(
+      getFreedrawOutlineAsSegments(element as any, [], elementsMap),
+    ).toEqual([]);
+
+    expect(
+      getFreedrawOutlineAsSegments(element as any, [[0, 0]], elementsMap),
+    ).toEqual([]);
+
+    const segments = getFreedrawOutlineAsSegments(
+      element as any,
+      [
+        [0, 0],
+        [10, 10],
+        [20, 20],
+      ],
+      elementsMap,
+    );
+    expect(segments.length).toBe(2);
   });
 });

--- a/packages/excalidraw/eraser/index.ts
+++ b/packages/excalidraw/eraser/index.ts
@@ -15,9 +15,11 @@ import {
   isPointInElement,
 } from "@excalidraw/element";
 import {
+  distanceToLineSegment,
   lineSegment,
   lineSegmentsDistance,
   pointFrom,
+  pointRotateRads,
   polygon,
   polygonIncludesPointNonZero,
 } from "@excalidraw/math";
@@ -30,7 +32,7 @@ import { getBoundTextElementId } from "@excalidraw/element";
 
 import type { Bounds } from "@excalidraw/common";
 
-import type { GlobalPoint, LineSegment } from "@excalidraw/math/types";
+import type { GlobalPoint, LineSegment, Radians } from "@excalidraw/math/types";
 import type { ElementsMap, ExcalidrawElement } from "@excalidraw/element/types";
 
 import { AnimatedTrail } from "../animatedTrail";
@@ -249,17 +251,44 @@ const eraserTest = (
       }
     }
 
-    const poly = polygon(
-      ...(outlinePoints.map(([x, y]) =>
-        pointFrom<GlobalPoint>(element.x + x, element.y + y),
-      ) as GlobalPoint[]),
-    );
+    if (outlinePoints.length >= 3) {
+      const poly = polygon(
+        ...(outlinePoints.map(([x, y]) =>
+          pointFrom<GlobalPoint>(element.x + x, element.y + y),
+        ) as GlobalPoint[]),
+      );
 
-    // PERF: Check only one point of the eraser segment. If the eraser segment
-    // start is inside the closed freedraw shape, the other point is either also
-    // inside or the eraser segment will intersect the shape outline anyway
-    if (polygonIncludesPointNonZero(pathSegment[0], poly)) {
-      return true;
+      // PERF: Check only one point of the eraser segment. If the eraser segment
+      // start is inside the closed freedraw shape, the other point is either also
+      // inside or the eraser segment will intersect the shape outline anyway
+      if (polygonIncludesPointNonZero(pathSegment[0], poly)) {
+        return true;
+      }
+    }
+
+    if (strokeSegments.length === 0) {
+      const bounds = getElementBounds(
+        {
+          ...element,
+          angle: 0 as Radians,
+        },
+        elementsMap,
+      );
+      const center = pointFrom<GlobalPoint>(
+        (bounds[0] + bounds[2]) / 2,
+        (bounds[1] + bounds[3]) / 2,
+      );
+
+      for (const pt of element.points) {
+        const globalPt = pointRotateRads(
+          pointFrom<GlobalPoint>(pt[0] + element.x, pt[1] + element.y),
+          center,
+          element.angle,
+        );
+        if (distanceToLineSegment(globalPt, pathSegment) <= tolerance) {
+          return true;
+        }
+      }
     }
 
     return false;


### PR DESCRIPTION
### Summary
Fixes #11945

**Problem:** Erasing certain freedraw elements (dots, sub-pixel strokes, empty pressures) crashed with `Freepath outline must have at least 2 points`, blocking the eraser interaction.

**Solution:**
- `getFreedrawOutlineAsSegments`: return `[]` safely when `points.length < 2` instead of throwing.
- `eraserTest`: gate polygon check to `outlinePoints.length >= 3`; fall back to distance check for dots/sub-pixel strokes.
- Added unit tests for empty/short points.