### PR TITLE
fix(export): pass ownerDocument to loadFonts default in exportToCanvas (#12027)

### DIFF
--- a/packages/excalidraw/scene/export.ts
+++ b/packages/excalidraw/scene/export.ts
@@ -186,11 +186,16 @@ export const exportToCanvas = async (
     exportPadding = DEFAULT_EXPORT_PADDING,
     viewBackgroundColor,
     exportingFrame,
+    ownerDocument = document,
   }: {
     exportBackground: boolean;
     exportPadding?: number;
     viewBackgroundColor: string;
     exportingFrame?: NonDeleted<ExcalidrawFrameLikeElement> | null;
+    // Document the elements' fonts should be resolved against — matters when
+    // exporting from a scene mounted in a different document (e.g. an
+    // iframe) than the one this module was loaded into. See #11974.
+    ownerDocument?: Document;
   },
   createCanvas: (
     width: number,
@@ -202,7 +207,7 @@ export const exportToCanvas = async (
     return { canvas, scale: appState.exportScale };
   },
   loadFonts: () => Promise<void> = async () => {
-    await Fonts.loadElementsFonts(elements);
+    await Fonts.loadElementsFonts(elements, ownerDocument);
   },
 ) => {
   // load font faces before continuing, by default leverages browsers' [FontFace API](https://developer.mozilla.org/en-US/docs/Web/API/FontFace)

--- a/packages/utils/src/export.ts
+++ b/packages/utils/src/export.ts
@@ -36,6 +36,10 @@ type ExportOpts = {
     width: number,
     height: number,
   ) => { width: number; height: number; scale?: number };
+  // Document the elements' fonts should be resolved against — matters when
+  // exporting a scene mounted in a different document (e.g. an iframe) than
+  // the one this module was loaded into. See #11974.
+  ownerDocument?: Document;
 };
 
 export const exportToCanvas = ({
@@ -46,6 +50,7 @@ export const exportToCanvas = ({
   getDimensions,
   exportPadding,
   exportingFrame,
+  ownerDocument,
 }: ExportOpts & {
   exportPadding?: number;
 }) => {
@@ -61,7 +66,13 @@ export const exportToCanvas = ({
     restoredElements,
     { ...restoredAppState, offsetTop: 0, offsetLeft: 0, width: 0, height: 0 },
     files || {},
-    { exportBackground, exportPadding, viewBackgroundColor, exportingFrame },
+    {
+      exportBackground,
+      exportPadding,
+      viewBackgroundColor,
+      exportingFrame,
+      ownerDocument,
+    },
     (width: number, height: number) => {
       const canvas = document.createElement("canvas");
 

--- a/packages/utils/tests/export.test.ts
+++ b/packages/utils/tests/export.test.ts
@@ -1,4 +1,5 @@
 import { MIME_TYPES } from "@excalidraw/common";
+import { Fonts } from "@excalidraw/excalidraw/fonts";
 import * as mockedSceneExportUtils from "@excalidraw/excalidraw/scene/export";
 import { diagramFactory } from "@excalidraw/excalidraw/tests/fixtures/diagramFixture";
 import { vi } from "vitest";
@@ -27,6 +28,42 @@ describe("exportToCanvas", async () => {
 
     expect(canvas.width).toBe(200);
     expect(canvas.height).toBe(200);
+  });
+
+  it("resolves fonts against the given ownerDocument (#12027)", async () => {
+    const loadElementsFontsSpy = vi
+      .spyOn(Fonts, "loadElementsFonts")
+      .mockResolvedValue([]);
+    const iframeDocument = document.implementation.createHTMLDocument();
+
+    await utils.exportToCanvas({
+      ...diagramFactory({ elementOverrides: { width: 100, height: 100 } }),
+      ownerDocument: iframeDocument,
+    });
+
+    expect(loadElementsFontsSpy).toHaveBeenCalledWith(
+      expect.anything(),
+      iframeDocument,
+    );
+
+    loadElementsFontsSpy.mockRestore();
+  });
+
+  it("defaults to the global document when no ownerDocument is given (#12027)", async () => {
+    const loadElementsFontsSpy = vi
+      .spyOn(Fonts, "loadElementsFonts")
+      .mockResolvedValue([]);
+
+    await utils.exportToCanvas({
+      ...diagramFactory({ elementOverrides: { width: 100, height: 100 } }),
+    });
+
+    expect(loadElementsFontsSpy).toHaveBeenCalledWith(
+      expect.anything(),
+      document,
+    );
+
+    loadElementsFontsSpy.mockRestore();
   });
 });
 


### PR DESCRIPTION

<img width="779" height="540" alt="excalidraw-12027-typecheck-passing" src="https://github.com/user-attachments/assets/30c5efc1-660b-4346-b6ed-f806e4afe2bf" />
<img width="2600" height="1462" alt="excalidraw-12027-tests-passing" src="https://github.com/user-attachments/assets/50d30f2c-c651-4d9b-83fa-5e00d3cf5c7d" />
Closes #12027.

`exportToCanvas`'s default `loadFonts` in `packages/excalidraw/scene/export.ts` always resolved fonts against the global `document`, even though every other `Fonts.loadElementsFonts()` call site added by #11974 was updated to pass an `ownerDocument`. This meant exporting from a scene mounted in a different document (e.g. an iframe with its own fonts loaded into that document) would check `document.fonts` on the wrong document, producing wrong font metrics in the export.

Same gap existed one layer up in the public `exportToCanvas`/`exportToBlob` API in `packages/utils/src/export.ts`, which never had a way to pass an `ownerDocument` through at all.

## Changes

- `packages/excalidraw/scene/export.ts`: `exportToCanvas` now accepts an optional `ownerDocument` in its options object (defaults to `document`, same as before) and passes it to `Fonts.loadElementsFonts(elements, ownerDocument)` in the default `loadFonts` implementation — same pattern #11974 used for the `App.tsx` call site.
- `packages/utils/src/export.ts`: added `ownerDocument?: Document` to the shared `ExportOpts` type and threaded it through to the underlying `_exportToCanvas` call, so `exportToCanvas`/`exportToBlob` callers in the public API can pass it too.

Both changes are additive and optional — default behavior (global `document`) is unchanged for existing callers.

## Testing

- `yarn test:typecheck` passes with no errors.
- All existing export tests still pass: `packages/utils/tests/export.test.ts` (9), `packages/excalidraw/tests/export.test.tsx` (8), `packages/excalidraw/tests/scene/export.test.ts` (18) — 35/35, no regressions.
- Added 2 new tests in `packages/utils/tests/export.test.ts` that spy on `Fonts.loadElementsFonts` to assert the `ownerDocument` option is actually forwarded to it (and that it still defaults to the global `document` when omitted) — 37/37 passing with the fix in.
- Confirmed the new tests are meaningful and not tautological: temporarily reverted the one-line fix in `scene/export.ts` and reran just the new tests — both failed as expected (`expected "spy" to be called with arguments: [ Anything, HTMLDocument{} ]`), then restored the fix and reran the full suite to confirm 37/37 passing again.