### PR TITLE
test(laser-pointer): add unit tests for math and simplify

### DIFF
--- a/packages/laser-pointer/tests/math.test.ts
+++ b/packages/laser-pointer/tests/math.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  add,
+  angle,
+  clamp,
+  dist,
+  distancePointToSegment,
+  lerp,
+  mag,
+  norm,
+  normAngle,
+  plerp,
+  rot,
+  smul,
+  sub,
+  type Point,
+} from "../src/math";
+
+/** Points carry a radius as the third component: [x, y, r]. */
+const p = (x: number, y: number, r = 0): Point => [x, y, r];
+
+describe("vector arithmetic", () => {
+  it("adds and subtracts componentwise, radius included", () => {
+    expect(add(p(1, 2, 3), p(10, 20, 30))).toEqual([11, 22, 33]);
+    expect(sub(p(10, 20, 30), p(1, 2, 3))).toEqual([9, 18, 27]);
+  });
+
+  it("is its own inverse: a + b - b === a", () => {
+    const a = p(3, -4, 5);
+    expect(sub(add(a, p(7, 8, 9)), p(7, 8, 9))).toEqual(a);
+  });
+
+  it("scales every component, including negative and zero factors", () => {
+    expect(smul(p(1, 2, 3), 2)).toEqual([2, 4, 6]);
+    expect(smul(p(1, 2, 3), -1)).toEqual([-1, -2, -3]);
+    expect(smul(p(1, 2, 3), 0)).toEqual([0, 0, 0]);
+  });
+});
+
+describe("norm", () => {
+  it("returns a unit vector and leaves the radius untouched", () => {
+    const [x, y, r] = norm(p(3, 4, 99));
+    expect(x).toBeCloseTo(0.6);
+    expect(y).toBeCloseTo(0.8);
+    expect(r).toBe(99);
+    expect(mag([x, y, r])).toBeCloseTo(1);
+  });
+
+  it("is already-normalised-safe", () => {
+    const [x, y] = norm(p(1, 0));
+    expect(x).toBeCloseTo(1);
+    expect(y).toBeCloseTo(0);
+  });
+
+  // Documents current behaviour rather than endorsing it: the zero vector has no
+  // direction, so normalising it divides by zero.
+  it("produces NaN for the zero vector", () => {
+    const [x, y] = norm(p(0, 0));
+    expect(Number.isNaN(x)).toBe(true);
+    expect(Number.isNaN(y)).toBe(true);
+  });
+});
+
+describe("rot", () => {
+  it("rotates a quarter turn counter-clockwise", () => {
+    const [x, y] = rot(p(1, 0), Math.PI / 2);
+    expect(x).toBeCloseTo(0);
+    expect(y).toBeCloseTo(1);
+  });
+
+  it("preserves magnitude and radius", () => {
+    const rotated = rot(p(3, 4, 7), 1.234);
+    expect(mag(rotated)).toBeCloseTo(5);
+    expect(rotated[2]).toBe(7);
+  });
+
+  it("a full turn is the identity", () => {
+    const [x, y] = rot(p(2, -5), Math.PI * 2);
+    expect(x).toBeCloseTo(2);
+    expect(y).toBeCloseTo(-5);
+  });
+});
+
+describe("interpolation", () => {
+  it("lerp hits both endpoints and the midpoint", () => {
+    expect(lerp(0, 10, 0)).toBe(0);
+    expect(lerp(0, 10, 1)).toBe(10);
+    expect(lerp(0, 10, 0.5)).toBe(5);
+  });
+
+  it("lerp extrapolates outside [0,1]", () => {
+    expect(lerp(0, 10, 2)).toBe(20);
+    expect(lerp(0, 10, -1)).toBe(-10);
+  });
+
+  it("plerp interpolates every component", () => {
+    expect(plerp(p(0, 0, 0), p(10, 20, 30), 0.5)).toEqual([5, 10, 15]);
+    expect(plerp(p(0, 0, 0), p(10, 20, 30), 0)).toEqual([0, 0, 0]);
+    expect(plerp(p(0, 0, 0), p(10, 20, 30), 1)).toEqual([10, 20, 30]);
+  });
+});
+
+describe("angle", () => {
+  it("measures the signed angle between two rays from a shared origin", () => {
+    // p1 points east, p2 points north -> +90deg
+    expect(angle(p(0, 0), p(1, 0), p(0, 1))).toBeCloseTo(Math.PI / 2);
+  });
+
+  it("is zero for identical directions", () => {
+    expect(angle(p(0, 0), p(5, 0), p(9, 0))).toBeCloseTo(0);
+  });
+
+  it("normAngle wraps a wound-up angle back into [-pi, pi], keeping its sign", () => {
+    expect(normAngle(Math.PI * 3)).toBeCloseTo(Math.PI);
+    expect(normAngle(-Math.PI * 3)).toBeCloseTo(-Math.PI);
+    expect(normAngle(Math.PI / 4)).toBeCloseTo(Math.PI / 4);
+    expect(normAngle(0)).toBeCloseTo(0);
+  });
+});
+
+describe("mag and dist", () => {
+  it("mag ignores the radius component", () => {
+    expect(mag(p(3, 4, 1000))).toBe(5);
+    expect(mag(p(0, 0))).toBe(0);
+  });
+
+  it("dist is symmetric and zero for identical points", () => {
+    expect(dist(p(0, 0), p(3, 4))).toBe(5);
+    expect(dist(p(3, 4), p(0, 0))).toBe(5);
+    expect(dist(p(7, 7), p(7, 7))).toBe(0);
+  });
+});
+
+describe("clamp", () => {
+  it("bounds the value on both sides and passes the middle through", () => {
+    expect(clamp(5, 0, 10)).toBe(5);
+    expect(clamp(-5, 0, 10)).toBe(0);
+    expect(clamp(50, 0, 10)).toBe(10);
+  });
+
+  it("returns the boundaries exactly", () => {
+    expect(clamp(0, 0, 10)).toBe(0);
+    expect(clamp(10, 0, 10)).toBe(10);
+  });
+});
+
+describe("distancePointToSegment", () => {
+  it("measures perpendicular distance when the foot is inside the segment", () => {
+    expect(distancePointToSegment(p(5, 3), p(0, 0), p(10, 0))).toBeCloseTo(3);
+  });
+
+  it("clamps to the nearest endpoint when the projection falls outside", () => {
+    // beyond the far end
+    expect(distancePointToSegment(p(20, 0), p(0, 0), p(10, 0))).toBeCloseTo(10);
+    // behind the near end
+    expect(distancePointToSegment(p(-10, 0), p(0, 0), p(10, 0))).toBeCloseTo(
+      10,
+    );
+  });
+
+  it("returns zero for a point lying on the segment", () => {
+    expect(distancePointToSegment(p(5, 0), p(0, 0), p(10, 0))).toBeCloseTo(0);
+  });
+
+  it("degenerates to point-to-point distance for a zero-length segment", () => {
+    expect(distancePointToSegment(p(3, 4), p(0, 0), p(0, 0))).toBeCloseTo(5);
+  });
+});

--- a/packages/laser-pointer/tests/simplify.test.ts
+++ b/packages/laser-pointer/tests/simplify.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+
+import { type Point } from "../src/math";
+import { douglasPeucker } from "../src/simplify";
+
+const p = (x: number, y: number, r = 0): Point => [x, y, r];
+
+describe("douglasPeucker", () => {
+  it("returns the input untouched when epsilon is 0", () => {
+    const points = [p(0, 0), p(5, 5), p(10, 0)];
+    expect(douglasPeucker(points, 0)).toBe(points);
+  });
+
+  it("passes through paths of two points or fewer", () => {
+    expect(douglasPeucker([], 1)).toEqual([]);
+    const one = [p(1, 1)];
+    expect(douglasPeucker(one, 1)).toBe(one);
+    const two = [p(0, 0), p(10, 0)];
+    expect(douglasPeucker(two, 1)).toBe(two);
+  });
+
+  it("drops collinear midpoints, keeping only the endpoints", () => {
+    const straight = [p(0, 0), p(2, 0), p(5, 0), p(8, 0), p(10, 0)];
+    expect(douglasPeucker(straight, 1)).toEqual([p(0, 0), p(10, 0)]);
+  });
+
+  it("keeps a vertex whose deviation reaches epsilon", () => {
+    // apex sits 5 units off the baseline; epsilon 1 must retain it
+    const result = douglasPeucker([p(0, 0), p(5, 5), p(10, 0)], 1);
+    expect(result).toEqual([p(0, 0), p(5, 5), p(10, 0)]);
+  });
+
+  it("drops a vertex whose deviation is below epsilon", () => {
+    // apex deviates by only 0.5, well under epsilon 2
+    const result = douglasPeucker([p(0, 0), p(5, 0.5), p(10, 0)], 2);
+    expect(result).toEqual([p(0, 0), p(10, 0)]);
+  });
+
+  it("treats epsilon as inclusive at the boundary", () => {
+    // deviation is exactly 5, epsilon is exactly 5 -> retained (maxDistance >= epsilon)
+    const result = douglasPeucker([p(0, 0), p(5, 5), p(10, 0)], 5);
+    expect(result).toContainEqual(p(5, 5));
+  });
+
+  it("always preserves the first and last point", () => {
+    const points = [p(0, 0), p(1, 0.1), p(2, -0.1), p(3, 0.05), p(4, 0)];
+    const result = douglasPeucker(points, 10);
+    expect(result[0]).toEqual(p(0, 0));
+    expect(result[result.length - 1]).toEqual(p(4, 0));
+  });
+
+  it("never returns more points than it was given, and keeps them in order", () => {
+    const points = [
+      p(0, 0),
+      p(1, 4),
+      p(2, 1),
+      p(3, 6),
+      p(4, 2),
+      p(5, 5),
+      p(6, 0),
+    ];
+    const result = douglasPeucker(points, 1.5);
+
+    expect(result.length).toBeLessThanOrEqual(points.length);
+
+    const indices = result.map((point) =>
+      points.findIndex(([x, y]) => x === point[0] && y === point[1]),
+    );
+    expect(indices).toEqual([...indices].sort((a, b) => a - b));
+  });
+
+  it("simplifies more aggressively as epsilon grows", () => {
+    const points = [p(0, 0), p(1, 3), p(2, 1), p(3, 4), p(4, 1), p(5, 0)];
+    const fine = douglasPeucker(points, 0.5);
+    const coarse = douglasPeucker(points, 3);
+    expect(coarse.length).toBeLessThanOrEqual(fine.length);
+  });
+});


### PR DESCRIPTION
`packages/laser-pointer` ships with no tests. This adds 32 covering the two pure modules,
`math.ts` and `simplify.ts`. No production code is touched.

### What is covered

`math.ts` — `add`, `sub`, `smul`, `norm`, `rot`, `lerp`, `plerp`, `angle`, `normAngle`,
`mag`, `dist`, `clamp`, `distancePointToSegment`.

`simplify.ts` — `douglasPeucker`, including the `epsilon === 0` and `length <= 2`
short-circuits, the inclusive epsilon boundary, first/last preservation, and the
monotonicity of simplification as epsilon grows.

Tests assert properties rather than snapshots where a property exists — `a + b - b === a`,
rotation preserves magnitude, a full turn is the identity, simplification never returns
more points than it was given and never reorders them. Those hold for inputs nobody
thought to write down, which is most of the value in a suite like this.

### Why you can trust these tests

A tests-only PR cannot use the usual gate — there is no fix, so "fails without the change"
does not apply. The equivalent check is mutation: break each function and confirm a test
notices. A test that stays green through a broken implementation is not offering anything.

I ran 21 single-edit mutations across both modules — sign flips, dropped components,
swapped operands, removed guards, an off-by-one on the epsilon comparison. **All 21 were
killed.** No mutation survived.

<details>
<summary>The 21 mutations</summary>

| mutation | result |
|---|---|
| `add`: `+` becomes `-` | killed |
| `sub`: `-` becomes `+` | killed |
| `smul`: drops the y scale | killed |
| `smul`: drops the radius scale | killed |
| `norm`: normalises y only | killed |
| `norm`: scales the radius too | killed |
| `rot`: sign flip | killed |
| `lerp`: ignores `t` | killed |
| `lerp`: endpoints swapped | killed |
| `angle`: operands swapped | killed |
| `normAngle`: no wrapping | killed |
| `mag`: ignores y | killed |
| `dist`: ignores the y axis | killed |
| `clamp`: min/max swapped | killed |
| `clamp`: upper bound dropped | killed |
| `distancePointToSegment`: no clamp to segment | killed |
| `distancePointToSegment`: degenerate case wrong | killed |
| `douglasPeucker`: epsilon exclusive rather than inclusive | killed |
| `douglasPeucker`: `epsilon === 0` short-circuit removed | killed |
| `douglasPeucker`: drops the last point | killed |
| `douglasPeucker`: two-point guard off by one | killed |

</details>

### Two exports deliberately left uncovered

`runLength` — it has a bug: the final segment is added twice, so a two-point path measures
double. Filed as #12034. A test written against it today would have to assert the wrong
answer and would then have to be rewritten when it is fixed, so I have left it alone rather
than enshrine the double-count.

`getCircleAndPerpendicularLineIntersectionsAtPoint` — its contract depends on rendering
conventions I did not want to guess at from the outside. Happy to add coverage if you can
say what it should guarantee.

### Checks

- 32/32 passing
- `yarn test:typecheck` clean
- `eslint --max-warnings=0` clean on both new files
- `prettier --check` clean
