### PR TITLE
fix(app): localize hardcoded strings in the share dialog

### DIFF
--- a/excalidraw-app/share/ShareDialog.tsx
+++ b/excalidraw-app/share/ShareDialog.tsx
@@ -109,15 +109,15 @@ const ActiveRoomDialog = ({
       </h3>
       <TextField
         defaultValue={collabAPI.getUsername()}
-        placeholder="Your name"
-        label="Your name"
+        placeholder={t("labels.yourName")}
+        label={t("labels.yourName")}
         onChange={collabAPI.setUsername}
         onKeyDown={(event) => event.key === KEYS.ENTER && handleClose()}
       />
       <div className="ShareDialog__active__linkRow">
         <TextField
           ref={ref}
-          label="Link"
+          label={t("labels.link.label")}
           readonly
           fullWidth
           value={activeRoomLink}
@@ -126,7 +126,7 @@ const ActiveRoomDialog = ({
           <FilledButton
             size="large"
             variant="icon"
-            label="Share"
+            label={t("labels.share")}
             icon={getShareIcon()}
             className="ShareDialog__active__share"
             onClick={shareRoomLink}


### PR DESCRIPTION
## Problem

Three user-facing strings in the live-collaboration share dialog are hardcoded in English, so they are never localized:

```tsx
// excalidraw-app/share/ShareDialog.tsx
placeholder="Your name"
label="Your name"
label="Link"
label="Share"
```

All three already have translation keys, and those keys are already translated:

| Hardcoded string | Existing key | Locales already translated |
| --- | --- | --- |
| `"Your name"` | `labels.yourName` | **54 / 56** |
| `"Link"` | `labels.link.label` | already used by `actionLink.tsx` |
| `"Share"` | `labels.share` | 52 / 56 |

`labels.yourName` is the clearest case: it exists in `en.json`, translators have translated it into 54 of 56 locales via Crowdin, but **no code referenced it at all** — so that work never reached a single user. Non-English users see an English "Your name" in the share dialog despite a translation shipping in the bundle.

This is inconsistent within the same component: `ActiveRoomDialog` already does

```tsx
label={t("buttons.copyLink")}   // line 137
```

on the same `<TextField>`/`<FilledButton>` props, 24 lines below the hardcoded ones.

## Change

Route the four props through `t()` using the keys that already exist. No new keys, no `en.json` changes, no Crowdin work needed.

**Every replacement resolves to a byte-identical English string**, so the English UI is unchanged — only non-English locales are affected.

## Testing

- `yarn test:typecheck` passes. This is a meaningful guard here: `t()` is typed as `NestedKeyOf<typeof fallbackLangData>`, so compilation verifies every key path resolves.
- `yarn test:update` passes, including `excalidraw-app/tests/LanguageList.test.tsx` ("rerenders UI on language change").
- `yarn fix` clean.

No new test added: this is a pure string→existing-key swap with no branching, and the key paths are already validated at compile time. Happy to add one if you'd prefer.
