### PR TITLE
fix(packages/excalidraw): localize hardcoded item name placeholder

### DIFF
--- a/packages/excalidraw/components/PublishLibrary.tsx
+++ b/packages/excalidraw/components/PublishLibrary.tsx
@@ -186,7 +186,7 @@ const SingleLibraryItem = ({
             ref={inputRef}
             style={{ width: "80%", padding: "0.2rem" }}
             defaultValue={libItem.name}
-            placeholder="Item name"
+            placeholder={t("publishDialog.itemName")}
             onChange={(event) => {
               onChange(event.target.value, index);
             }}


### PR DESCRIPTION
## Problem

In the publish-library dialog, the item-name input hardcodes its placeholder:

```tsx
// packages/excalidraw/components/PublishLibrary.tsx:189
placeholder="Item name"
```

The `<span>` label directly above that same input already uses the key:

```tsx
{t("publishDialog.itemName")}   // line 178
```

`publishDialog.itemName` is `"Item name"` in `en.json` and is already translated in **47 locales**, so the placeholder is the only part of the field that stays English.

## Change

Use the existing `publishDialog.itemName` key for the placeholder. No new keys, no `en.json` changes.

The replacement is byte-identical in English, so the English UI is unchanged.

## Testing

- `yarn test:typecheck` passes (`t()` key paths are validated at compile time via `NestedKeyOf`).
- `yarn test:update` passes, including `packages/excalidraw/tests/library.test.tsx` (7 tests).
- `yarn fix` clean.
