### PR TITLE
fix(laser-pointer): count each path segment once

### DIFF
--- a/packages/laser-pointer/src/math.ts
+++ b/packages/laser-pointer/src/math.ts
@@ -73,8 +73,6 @@ export function runLength(ps: Point[]): number {
     len += dist(ps[i - 1], ps[i]);
   }
 
-  len += dist(ps[ps.length - 2], ps[ps.length - 1]);
-
   return len;
 }
 

--- a/packages/laser-pointer/tests/runLength.test.ts
+++ b/packages/laser-pointer/tests/runLength.test.ts
@@ -1,0 +1,38 @@
+import { runLength } from "../src/math";
+
+describe("runLength", () => {
+  it("returns zero for an empty path or a single point", () => {
+    expect(runLength([])).toBe(0);
+    expect(runLength([[5, 5, 1]])).toBe(0);
+  });
+
+  it("counts a two-point segment once and ignores the radius", () => {
+    expect(
+      runLength([
+        [0, 0, 1],
+        [3, 4, 10],
+      ]),
+    ).toBe(5);
+  });
+
+  it("sums every segment of a multi-point path once", () => {
+    expect(
+      runLength([
+        [0, 0, 1],
+        [10, 0, 1],
+        [10, 10, 1],
+        [0, 10, 1],
+      ]),
+    ).toBe(30);
+  });
+
+  it("does not add distance for repeated points", () => {
+    expect(
+      runLength([
+        [0, 0, 1],
+        [0, 0, 1],
+        [3, 4, 1],
+      ]),
+    ).toBe(5);
+  });
+});


### PR DESCRIPTION
Fixes #12034.

`runLength` already visits every segment in its loop, then adds the final segment again. Remove that duplicate addition so a two-point 3–4–5 path measures 5 instead of 10, and the laser tail uses the actual path length when checking `maxTailLength`.

Add focused regression coverage for empty/single-point paths, two-point and multi-point paths, repeated points, and radius-independent distance. This complements #12035, which intentionally leaves `runLength` uncovered. The tail threshold remains 50.

Validation:
- `vitest run packages/laser-pointer/tests/runLength.test.ts`: 3 failed / 1 passed before the fix; 4 passed afterward.
- `eslint --max-warnings=0 packages/laser-pointer/src/math.ts packages/laser-pointer/tests/runLength.test.ts`: passed.
- `tsc --noEmit`: passed.

Checked the deployed PR preview in the browser: selected Laser pointer, dragged across the canvas, and confirmed a red pointer trail renders. No browser console errors were recorded. Prepared with AI assistance.
