### PR TITLE
fix: ensure deleted elements are synced in collaboration when ESC is pressed

### DIFF
--- a/packages/excalidraw/actions/actionFinalize.tsx
+++ b/packages/excalidraw/actions/actionFinalize.tsx
@@ -56,6 +56,7 @@ export const actionFinalize = register<FormData>({
   trackEvent: false,
   perform: (elements, appState, data, app) => {
     let shouldCommit = true;
+    let elementWasDeleted = false;
     let newElements = elements;
     const { focusContainer, scene } = app;
     const elementsMap = scene.getNonDeletedElementsMap();
@@ -298,6 +299,7 @@ export const actionFinalize = register<FormData>({
       }
 
       if (element && isInvisiblySmallElement(element)) {
+        elementWasDeleted = true;
         // TODO: #7348 in theory this gets recorded by the store, so the invisible elements could be restored by the undo/redo, which might be not what we would want
         newElements = newElements.map((el) => {
           if (el.id === element?.id) {
@@ -415,7 +417,7 @@ export const actionFinalize = register<FormData>({
         selectedLinearElement: isDrawShapeTool ? null : selectedLinearElement,
       },
       // TODO: #7348 we should not capture everything, but if we don't, it leads to incosistencies -> revisit
-      captureUpdate: shouldCommit
+      captureUpdate: shouldCommit || elementWasDeleted
         ? CaptureUpdateAction.IMMEDIATELY
         : CaptureUpdateAction.NEVER,
     };


### PR DESCRIPTION
## Description

When pressing ESC to cancel a multi-point arrow during collaboration, the element was being marked as deleted and the version was bumped, but the `captureUpdate` was set to `NEVER` because `shouldCommit` was `false`. This could affect the sync to remote clients.

## Fix

The fix tracks whether an element was deleted using a new `elementWasDeleted` flag and ensures that `captureUpdate` is set to `IMMEDIATELY` when an element is deleted, regardless of the `shouldCommit` flag.

### Changes:
1. Added `elementWasDeleted = false` variable
2. Set `elementWasDeleted = true` before marking element as deleted
3. Changed `captureUpdate` logic to: `shouldCommit || elementWasDeleted ? IMMEDIATELY : NEVER`

## Related Issue

Fixes #9467
