### PR TITLE
fix: wait for clipboard writes before showing share link success

### DIFF
--- a/excalidraw-app/share/ShareDialog.tsx
+++ b/excalidraw-app/share/ShareDialog.tsx
@@ -16,7 +16,7 @@ import { useUIAppState } from "@excalidraw/excalidraw/context/ui-appState";
 import { useCopyStatus } from "@excalidraw/excalidraw/hooks/useCopiedIndicator";
 import { useI18n } from "@excalidraw/excalidraw/i18n";
 import { KEYS, getFrame } from "@excalidraw/common";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef } from "react";
 
 import { atom, useAtom, useAtomValue } from "../app-jotai";
 import { activeRoomLinkAtom } from "../collab/Collab";
@@ -64,8 +64,6 @@ const ActiveRoomDialog = ({
   handleClose: () => void;
 }) => {
   const { t } = useI18n();
-  const [, setJustCopied] = useState(false);
-  const timerRef = useRef<number>(0);
   const ref = useRef<HTMLInputElement>(null);
   const isShareSupported = "share" in navigator;
   const { onCopy, copyStatus } = useCopyStatus();
@@ -73,19 +71,10 @@ const ActiveRoomDialog = ({
   const copyRoomLink = async () => {
     try {
       await copyTextToSystemClipboard(activeRoomLink);
+      onCopy();
     } catch (e) {
       collabAPI.setCollabError(t("errors.copyToSystemClipboardFailed"));
     }
-
-    setJustCopied(true);
-
-    if (timerRef.current) {
-      window.clearTimeout(timerRef.current);
-    }
-
-    timerRef.current = window.setTimeout(() => {
-      setJustCopied(false);
-    }, 3000);
 
     ref.current?.select();
   };
@@ -137,10 +126,7 @@ const ActiveRoomDialog = ({
           label={t("buttons.copyLink")}
           icon={copyIcon}
           status={copyStatus}
-          onClick={() => {
-            copyRoomLink();
-            onCopy();
-          }}
+          onClick={copyRoomLink}
         />
       </div>
       <QRCode value={activeRoomLink} />

--- a/excalidraw-app/tests/ShareDialog.test.tsx
+++ b/excalidraw-app/tests/ShareDialog.test.tsx
@@ -1,0 +1,174 @@
+import React from "react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
+import { vi } from "vitest";
+
+import { resolvablePromise } from "@excalidraw/common";
+import * as clipboard from "@excalidraw/excalidraw/clipboard";
+import { ShareableLinkDialog } from "@excalidraw/excalidraw/components/ShareableLinkDialog";
+import { EditorJotaiProvider } from "@excalidraw/excalidraw/editor-jotai";
+import { t } from "@excalidraw/excalidraw/i18n";
+
+import { Provider, appJotaiStore } from "../app-jotai";
+import { activeRoomLinkAtom } from "../collab/Collab";
+import { ShareDialog, shareDialogStateAtom } from "../share/ShareDialog";
+
+import type { CollabAPI } from "../collab/Collab";
+
+vi.mock("@excalidraw/excalidraw/components/Dialog", () => ({
+  Dialog: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock(
+  "@excalidraw/excalidraw/context/ui-appState",
+  async (importOriginal) => ({
+    ...(await importOriginal<
+      typeof import("@excalidraw/excalidraw/context/ui-appState")
+    >()),
+    useUIAppState: () => ({ openDialog: null }),
+  }),
+);
+
+vi.mock("../share/QRCode", () => ({ QRCode: () => null }));
+
+vi.mock("../collab/Collab", async () => {
+  const { atom } = await import("../app-jotai");
+  return { activeRoomLinkAtom: atom<string | null>(null) };
+});
+
+describe.each(["shareable", "collaboration"] as const)(
+  "%s link clipboard feedback",
+  (kind) => {
+    const link =
+      kind === "shareable"
+        ? "https://excalidraw.com/#json=scene,key"
+        : "https://excalidraw.com/#room=room,key";
+
+    const renderDialog = (onError: (message: string) => void) => {
+      if (kind === "shareable") {
+        render(
+          <ShareableLinkDialog
+            link={link}
+            onCloseRequest={vi.fn()}
+            setErrorMessage={onError}
+          />,
+          { wrapper: EditorJotaiProvider },
+        );
+      } else {
+        appJotaiStore.set(activeRoomLinkAtom, link);
+        appJotaiStore.set(shareDialogStateAtom, {
+          isOpen: true,
+          type: "share",
+        });
+
+        const collabAPI = {
+          getUsername: () => "Test user",
+          setUsername: vi.fn(),
+          setCollabError: onError,
+          stopCollaboration: vi.fn(),
+          isCollaborating: () => true,
+        } as unknown as CollabAPI;
+
+        render(
+          <Provider store={appJotaiStore}>
+            <ShareDialog collabAPI={collabAPI} onExportToBackend={vi.fn()} />
+          </Provider>,
+          { wrapper: EditorJotaiProvider },
+        );
+      }
+
+      return screen.getByRole("button", { name: t("buttons.copyLink") });
+    };
+
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      cleanup();
+      appJotaiStore.set(activeRoomLinkAtom, null);
+      appJotaiStore.set(shareDialogStateAtom, { isOpen: false });
+      vi.clearAllTimers();
+      vi.useRealTimers();
+      vi.restoreAllMocks();
+    });
+
+    it("shows success only after the clipboard write completes", async () => {
+      const write = resolvablePromise<void>();
+      const copy = vi
+        .spyOn(clipboard, "copyTextToSystemClipboard")
+        .mockReturnValue(write);
+      const onError = vi.fn();
+      const button = renderDialog(onError);
+
+      fireEvent.click(button);
+
+      expect(copy).toHaveBeenCalledWith(link);
+      expect(button).not.toHaveClass("ExcButton--status-success");
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(60);
+      });
+
+      expect(button).toHaveClass("ExcButton--status-loading");
+      expect(button).toBeDisabled();
+
+      await act(async () => {
+        write.resolve();
+        await write;
+      });
+
+      expect(button).toHaveClass("ExcButton--status-success");
+      expect(button).not.toHaveClass("ExcButton--status-loading");
+      expect(onError).not.toHaveBeenCalled();
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(2000);
+      });
+
+      expect(button).not.toHaveClass("ExcButton--status-success");
+      expect(button).toBeEnabled();
+    });
+
+    it("reports a failed write without success feedback and allows retry", async () => {
+      const write = resolvablePromise<void>();
+      const copy = vi
+        .spyOn(clipboard, "copyTextToSystemClipboard")
+        .mockReturnValueOnce(write);
+      const onError = vi.fn();
+      const button = renderDialog(onError);
+
+      fireEvent.click(button);
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(60);
+        write.reject(new Error("Clipboard access denied"));
+      });
+
+      expect(onError).toHaveBeenCalledWith(
+        t("errors.copyToSystemClipboardFailed"),
+      );
+      expect(button).not.toHaveClass("ExcButton--status-success");
+      expect(button).not.toHaveClass("ExcButton--status-loading");
+      expect(button).toBeEnabled();
+
+      const input = screen.getByDisplayValue(link) as HTMLInputElement;
+      expect(input.selectionStart).toBe(0);
+      expect(input.selectionEnd).toBe(link.length);
+
+      copy.mockResolvedValueOnce(undefined);
+      await act(async () => {
+        fireEvent.click(button);
+      });
+
+      expect(copy).toHaveBeenCalledTimes(2);
+      expect(button).toHaveClass("ExcButton--status-success");
+      expect(onError).toHaveBeenCalledTimes(1);
+    });
+  },
+);

--- a/packages/excalidraw/components/ShareableLinkDialog.tsx
+++ b/packages/excalidraw/components/ShareableLinkDialog.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from "react";
+import { useRef } from "react";
 
 import { copyTextToSystemClipboard } from "../clipboard";
 import { useCopyStatus } from "../hooks/useCopiedIndicator";
@@ -24,29 +24,18 @@ export const ShareableLinkDialog = ({
   setErrorMessage,
 }: ShareableLinkDialogProps) => {
   const { t } = useI18n();
-  const [, setJustCopied] = useState(false);
-  const timerRef = useRef<number>(0);
   const ref = useRef<HTMLInputElement>(null);
+  const { onCopy, copyStatus } = useCopyStatus();
 
   const copyRoomLink = async () => {
     try {
       await copyTextToSystemClipboard(link);
+      onCopy();
     } catch (e) {
       setErrorMessage(t("errors.copyToSystemClipboardFailed"));
     }
-    setJustCopied(true);
-
-    if (timerRef.current) {
-      window.clearTimeout(timerRef.current);
-    }
-
-    timerRef.current = window.setTimeout(() => {
-      setJustCopied(false);
-    }, 3000);
-
     ref.current?.select();
   };
-  const { onCopy, copyStatus } = useCopyStatus();
   return (
     <Dialog onCloseRequest={onCloseRequest} title={false} size="small">
       <div className="ShareableLinkDialog">
@@ -65,10 +54,7 @@ export const ShareableLinkDialog = ({
             label={t("buttons.copyLink")}
             icon={copyIcon}
             status={copyStatus}
-            onClick={() => {
-              onCopy();
-              copyRoomLink();
-            }}
+            onClick={copyRoomLink}
           />
         </div>
         <div className="ShareableLinkDialog__description">


### PR DESCRIPTION
Both the shareable-link dialog and the active collaboration dialog showed copy success immediately, even when the clipboard write was still pending or later rejected.

Trigger success only after `copyTextToSystemClipboard` resolves and pass the asynchronous handler directly to `FilledButton`, enabling its existing loading feedback. Preserve error reporting and link selection for manual copying, and remove the unused copy-state timers.

Validation:
- Four component regression tests cover pending/successful writes and rejected writes followed by retry for both dialogs. All four pass with the fix and fail against the original implementation because of premature success feedback.
- `tsc --noEmit` passed.
- ESLint and Prettier passed for all three changed files; `git diff --check` passed.

Vitest ran with the repository configuration loaded programmatically through Node to avoid an esbuild configuration-loader restriction in the Windows sandbox. Clipboard failures and retries are covered by the component tests. A Vercel preview smoke test also confirmed successful shareable-link export, the success indicator, and the exact generated link in the clipboard.