### PR TITLE
fix(build): bump PWA precache size limit to 4MB and add build check to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,8 @@ jobs:
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20.x
-      - name: Install and test
+      - name: Install, test, and build check
         run: |
           yarn install
           yarn test:app
+          yarn build:app:docker

--- a/excalidraw-app/vite.config.mts
+++ b/excalidraw-app/vite.config.mts
@@ -223,7 +223,7 @@ export default defineConfig(({ mode }) => {
               },
             },
           ],
-          maximumFileSizeToCacheInBytes: 2.3 * 1024 ** 2, // 2.3MB
+          maximumFileSizeToCacheInBytes: 4 * 1024 ** 2, // 4MB
         },
         manifest: {
           short_name: "Excalidraw",


### PR DESCRIPTION
## Description

### Context & Problem
As features and dependencies grew over recent commits, the core main bundle exceeded the 2.3MB limit (`maximumFileSizeToCacheInBytes`) configured for `vite-plugin-pwa` (Workbox). This resulted in production Docker build failures (`yarn build:app:docker`), while CI tests continued to pass because CI only ran unit tests (`yarn test:app`) and never verified the actual Vite production build.

### Changes Made
1. **Workbox Precache Limit**: Increased `maximumFileSizeToCacheInBytes` from `2.3 * 1024 ** 2` (2.3MB) to `4 * 1024 ** 2` (4MB) in `excalidraw-app/vite.config.mts` to accommodate current app bundle size.
2. **CI Pipeline Integration**: Added `yarn build:app:docker` to `.github/workflows/test.yml` to ensure Vite production builds and PWA limits are validated on pushes to `master`.

## How to Test
1. Run `yarn build:app:docker` locally and verify the build completes with exit code 0.
2. Verify that `sw.js` and precache manifest are generated without `maximumFileSizeToCacheInBytes` errors.
