### PR TITLE
perf(editor): stop inverting the interactive canvas via CSS filter in dark mode

### DIFF
--- a/packages/common/src/colors.ts
+++ b/packages/common/src/colors.ts
@@ -345,6 +345,19 @@ export const rgbToHex = (r: number, g: number, b: number, a?: number) => {
 };
 
 /**
+ * @returns the color with its alpha replaced by `alpha` (as #RRGGBBAA), or the
+ *  input unchanged if it's not a valid color
+ */
+export const setColorAlpha = (color: string, alpha: number): string => {
+  const tc = tinycolor(color);
+  if (!tc.isValid()) {
+    return color;
+  }
+  const { r, g, b } = tc.toRgb();
+  return rgbToHex(r, g, b, alpha);
+};
+
+/**
  * @returns #RRGGBB or #RRGGBBAA based on color containing non-opaque alpha,
  *  null if not valid color
  */

--- a/packages/element/src/renderElement.ts
+++ b/packages/element/src/renderElement.ts
@@ -696,7 +696,10 @@ export const renderSelectionElement = (
 ) => {
   context.save();
   context.translate(element.x + appState.scrollX, element.y + appState.scrollY);
-  context.fillStyle = "rgba(0, 0, 200, 0.04)";
+  context.fillStyle = applyDarkModeFilter(
+    "rgba(0, 0, 200, 0.04)",
+    appState.theme === THEME.DARK,
+  );
 
   // render from 0.5px offset  to get 1px wide line
   // https://stackoverflow.com/questions/7530593/html5-canvas-and-line-width/7531540#7531540

--- a/packages/excalidraw/clients.ts
+++ b/packages/excalidraw/clients.ts
@@ -2,7 +2,6 @@ import {
   COLOR_CHARCOAL_BLACK,
   COLOR_VOICE_CALL,
   COLOR_WHITE,
-  THEME,
   UserIdleState,
 } from "@excalidraw/common";
 
@@ -122,9 +121,7 @@ export const renderRemoteCursors = ({
       context.closePath();
     }
 
-    // TODO remove the dark theme color after we stop inverting canvas colors
-    const IS_SPEAKING_COLOR =
-      appState.theme === THEME.DARK ? "#2f6330" : COLOR_VOICE_CALL;
+    const IS_SPEAKING_COLOR = COLOR_VOICE_CALL;
 
     const isSpeaking = collaborator?.isSpeaking;
 

--- a/packages/excalidraw/components/canvases/InteractiveCanvas.tsx
+++ b/packages/excalidraw/components/canvases/InteractiveCanvas.tsx
@@ -20,6 +20,7 @@ import type {
 } from "@excalidraw/element/types";
 
 import { t } from "../../i18n";
+import { getSelectionColor } from "../../renderer/helpers";
 import { renderInteractiveScene } from "../../renderer/interactiveScene";
 
 import { AnimationController } from "../../renderer/animation";
@@ -136,12 +137,7 @@ const InteractiveCanvas = (props: InteractiveCanvasProps) => {
       remotePointerButton.set(socketId, user.button);
     });
 
-    const selectionColor =
-      (props.containerRef?.current &&
-        getComputedStyle(props.containerRef.current).getPropertyValue(
-          "--color-selection",
-        )) ||
-      "#6965db";
+    const selectionColor = getSelectionColor(props.containerRef?.current);
 
     rendererParams.current = {
       app: props.app,

--- a/packages/excalidraw/css/styles.scss
+++ b/packages/excalidraw/css/styles.scss
@@ -115,9 +115,6 @@ body.excalidraw-cursor-resize * {
 
     &.interactive {
       z-index: var(--zIndex-interactiveCanvas);
-      // Apply theme filter only to interactive canvas for UI elements
-      // (resize handles, selection boxes, etc.)
-      filter: var(--theme-filter);
     }
 
     // Remove the main canvas from document flow to avoid resizeObserver

--- a/packages/excalidraw/css/theme.scss
+++ b/packages/excalidraw/css/theme.scss
@@ -226,7 +226,7 @@
     --color-slider-track: hsl(244, 23%, 39%);
 
     // will be inverted to a lighter color.
-    --color-selection: #3530c4;
+    --color-selection: #b4b0ff;
 
     --color-icon-white: var(--color-gray-90);
 

--- a/packages/excalidraw/lasso/index.ts
+++ b/packages/excalidraw/lasso/index.ts
@@ -11,7 +11,12 @@ import { isFrameLikeElement, isLinearElement } from "@excalidraw/element";
 import { getFrameChildren } from "@excalidraw/element";
 import { selectGroupsForSelectedElements } from "@excalidraw/element";
 
-import { arrayToMap, easeOut, isShallowEqual } from "@excalidraw/common";
+import {
+  arrayToMap,
+  easeOut,
+  isShallowEqual,
+  setColorAlpha,
+} from "@excalidraw/common";
 
 import type {
   ExcalidrawElement,
@@ -20,6 +25,7 @@ import type {
 } from "@excalidraw/element/types";
 
 import { AnimatedTrail } from "../animatedTrail";
+import { getSelectionColor } from "../renderer/helpers";
 
 import { getLassoSelectedElementIds } from "./utils";
 
@@ -57,8 +63,9 @@ export class LassoTrail extends AnimatedTrail {
 
         return Math.min(easeOut(l), easeOut(t));
       },
-      fill: () => "rgba(105,101,219,0.05)",
-      stroke: () => "rgba(105,101,219)",
+      // same color as the marquee selection (theme-aware, host-overridable)
+      fill: () => setColorAlpha(getSelectionColor(app.interactiveCanvas), 0.05),
+      stroke: () => getSelectionColor(app.interactiveCanvas),
     });
   }
 

--- a/packages/excalidraw/renderer/helpers.ts
+++ b/packages/excalidraw/renderer/helpers.ts
@@ -3,6 +3,18 @@ import { COLOR_WHITE, THEME, applyDarkModeFilter } from "@excalidraw/common";
 import type { StaticCanvasRenderConfig } from "../scene/types";
 import type { AppState, StaticCanvasAppState } from "../types";
 
+export const DEFAULT_SELECTION_COLOR = "#6965db";
+
+/**
+ * Returns the theme's selection color (`--color-selection`), read from the
+ * computed style of any element inside the editor container so that host
+ * overrides are respected. Falls back to the default when unavailable.
+ */
+export const getSelectionColor = (element: Element | null | undefined) =>
+  (element &&
+    getComputedStyle(element).getPropertyValue("--color-selection").trim()) ||
+  DEFAULT_SELECTION_COLOR;
+
 export const fillCircle = (
   context: CanvasRenderingContext2D,
   cx: number,

--- a/packages/excalidraw/renderer/interactiveScene.ts
+++ b/packages/excalidraw/renderer/interactiveScene.ts
@@ -19,6 +19,7 @@ import {
   invariant,
   shouldRotateWithDiscreteAngle,
   THEME,
+  applyDarkModeFilter,
 } from "@excalidraw/common";
 
 import {
@@ -111,6 +112,40 @@ import type {
   RenderableElementsMap,
 } from "../scene/types";
 
+// The interactive canvas used to be inverted in dark mode via a CSS filter
+// (`invert(93%) hue-rotate(180deg)`), which is prohibitively slow in browsers
+// that composite in software (e.g. Firefox on software WebRender). We now map
+// the colors in JS instead (see `applyDarkModeFilter`), so the dark-mode
+// values below are the post-filter equivalents of the previous ones.
+// ---------------------------------------------------------------------------
+
+const BINDING_HIGHLIGHT_RGB = {
+  [THEME.LIGHT]: "106, 189, 252",
+  [THEME.DARK]: "104, 182, 240",
+} as const;
+
+const BINDING_MIDPOINT_COLOR = {
+  [THEME.LIGHT]: "rgba(65, 65, 65, 0.5)",
+  [THEME.DARK]: "rgba(237, 237, 237, 0.8)",
+} as const;
+
+const SEARCH_MATCH_COLOR = {
+  [THEME.LIGHT]: {
+    focus: "rgba(255, 124, 0, 0.4)",
+    match: "rgba(255, 226, 0, 0.4)",
+  },
+  [THEME.DARK]: {
+    focus: "rgba(250, 123, 53, 0.4)",
+    match: "rgba(221, 181, 136, 0.4)",
+  },
+} as const;
+
+/** maps a light-mode UI color to its dark-mode counterpart when in dark mode */
+const getThemedColor = (
+  color: string,
+  theme: InteractiveCanvasAppState["theme"],
+) => applyDarkModeFilter(color, theme === THEME.DARK);
+
 const renderElbowArrowMidPointHighlight = (
   context: CanvasRenderingContext2D,
   appState: InteractiveCanvasAppState,
@@ -163,7 +198,10 @@ const highlightPoint = <Point extends LocalPoint | GlobalPoint>(
   context.save();
   context.translate(appState.scrollX, appState.scrollY);
 
-  context.fillStyle = "rgba(105, 101, 219, 0.4)";
+  context.fillStyle = getThemedColor(
+    "rgba(105, 101, 219, 0.4)",
+    appState.theme,
+  );
 
   fillCircle(
     context,
@@ -220,13 +258,22 @@ const renderSingleLinearPoint = <Point extends GlobalPoint | LocalPoint>(
   isPhantomPoint: boolean,
   isOverlappingPoint: boolean,
 ) => {
-  context.strokeStyle = "#5e5ad8";
+  context.strokeStyle = getThemedColor("#5e5ad8", appState.theme);
   context.setLineDash([]);
-  context.fillStyle = "rgba(255, 255, 255, 0.9)";
+  context.fillStyle = getThemedColor(
+    "rgba(255, 255, 255, 0.9)",
+    appState.theme,
+  );
   if (isSelected) {
-    context.fillStyle = "rgba(134, 131, 226, 0.9)";
+    context.fillStyle = getThemedColor(
+      "rgba(134, 131, 226, 0.9)",
+      appState.theme,
+    );
   } else if (isPhantomPoint) {
-    context.fillStyle = "rgba(177, 151, 252, 0.7)";
+    context.fillStyle = getThemedColor(
+      "rgba(177, 151, 252, 0.7)",
+      appState.theme,
+    );
   }
 
   fillCircle(
@@ -282,10 +329,7 @@ const renderBindingHighlightForBindableElement_simple = (
       context.translate(suggestedBinding.element.x, suggestedBinding.element.y);
 
       context.lineWidth = FRAME_STYLE.strokeWidth / appState.zoom.value;
-      context.strokeStyle =
-        appState.theme === THEME.DARK
-          ? `rgba(3, 93, 161, 1)`
-          : `rgba(106, 189, 252, 1)`;
+      context.strokeStyle = `rgba(${BINDING_HIGHLIGHT_RGB[appState.theme]}, 1)`;
 
       if (FRAME_STYLE.radius && context.roundRect) {
         context.beginPath();
@@ -323,10 +367,7 @@ const renderBindingHighlightForBindableElement_simple = (
       context.lineWidth =
         clamp(1.75, suggestedBinding.element.strokeWidth, 4) /
         Math.max(0.25, appState.zoom.value);
-      context.strokeStyle =
-        appState.theme === THEME.DARK
-          ? `rgba(3, 93, 161, 1)`
-          : `rgba(106, 189, 252, 1)`;
+      context.strokeStyle = `rgba(${BINDING_HIGHLIGHT_RGB[appState.theme]}, 1)`;
 
       switch (suggestedBinding.element.type) {
         case "ellipse":
@@ -552,19 +593,15 @@ const renderBindingHighlightForBindableElement_simple = (
               hoveredMidpoint.distance <= highlightThreshold * 2));
 
         if (isHighlighted) {
-          context.fillStyle =
-            appState.theme === THEME.DARK
-              ? `rgba(3, 93, 161, 1)`
-              : `rgba(106, 189, 252, 1)`;
+          context.fillStyle = `rgba(${
+            BINDING_HIGHLIGHT_RGB[appState.theme]
+          }, 1)`;
 
           context.beginPath();
           context.arc(midpoint[0], midpoint[1], midpointRadius, 0, 2 * Math.PI);
           context.fill();
         } else if (isShown) {
-          context.fillStyle =
-            appState.theme === THEME.DARK
-              ? `rgba(0, 0, 0, 0.8)`
-              : `rgba(65, 65, 65, 0.5)`;
+          context.fillStyle = BINDING_MIDPOINT_COLOR[appState.theme];
           context.beginPath();
           context.arc(midpoint[0], midpoint[1], midpointRadius, 0, 2 * Math.PI);
           context.fill();
@@ -625,10 +662,9 @@ const renderBindingHighlightForBindableElement_complex = (
       context.translate(element.x, element.y);
 
       context.lineWidth = FRAME_STYLE.strokeWidth / appState.zoom.value;
-      context.strokeStyle =
-        appState.theme === THEME.DARK
-          ? `rgba(3, 93, 161, ${opacity})`
-          : `rgba(106, 189, 252, ${opacity})`;
+      context.strokeStyle = `rgba(${
+        BINDING_HIGHLIGHT_RGB[appState.theme]
+      }, ${opacity})`;
 
       if (FRAME_STYLE.radius && context.roundRect) {
         context.beginPath();
@@ -666,10 +702,9 @@ const renderBindingHighlightForBindableElement_complex = (
       context.lineWidth =
         clamp(2.5, element.strokeWidth * 1.75, 4) /
         Math.max(0.25, appState.zoom.value);
-      context.strokeStyle =
-        appState.theme === THEME.DARK
-          ? `rgba(3, 93, 161, ${opacity / 2})`
-          : `rgba(106, 189, 252, ${opacity / 2})`;
+      context.strokeStyle = `rgba(${BINDING_HIGHLIGHT_RGB[appState.theme]}, ${
+        opacity / 2
+      })`;
 
       switch (element.type) {
         case "ellipse":
@@ -794,7 +829,7 @@ const renderBindingHighlightForBindableElement_complex = (
 
     const PROGRESS_RATIO = (1 / BIND_MODE_TIMEOUT) * remainingTime;
 
-    context.strokeStyle = "rgba(0, 0, 0, 0.2)";
+    context.strokeStyle = getThemedColor("rgba(0, 0, 0, 0.2)", appState.theme);
     context.lineWidth = 1 / appState.zoom.value;
     context.setLineDash([4 / appState.zoom.value, 4 / appState.zoom.value]);
     context.lineDashOffset = (-PROGRESS_RATIO * 10) / appState.zoom.value;
@@ -812,7 +847,7 @@ const renderBindingHighlightForBindableElement_complex = (
     context.stroke();
 
     // context.strokeStyle = "transparent";
-    context.fillStyle = "rgba(0, 0, 0, 0.04)";
+    context.fillStyle = getThemedColor("rgba(0, 0, 0, 0.04)", appState.theme);
     context.beginPath();
     context.ellipse(
       element.width / 2,
@@ -893,10 +928,9 @@ const renderBindingHighlightForBindableElement_complex = (
         );
       });
 
-      context.fillStyle =
-        appState.theme === THEME.DARK
-          ? `rgba(3, 93, 161, ${opacity})`
-          : `rgba(106, 189, 252, ${opacity})`;
+      context.fillStyle = `rgba(${
+        BINDING_HIGHLIGHT_RGB[appState.theme]
+      }, ${opacity})`;
 
       midpoints.forEach((midpoint) => {
         context.beginPath();
@@ -1039,7 +1073,7 @@ const renderFrameHighlight = (
   const width = x2 - x1;
   const height = y2 - y1;
 
-  context.strokeStyle = "rgb(0,118,255)";
+  context.strokeStyle = getThemedColor("rgb(0,118,255)", appState.theme);
   context.lineWidth = FRAME_STYLE.strokeWidth / appState.zoom.value;
 
   context.save();
@@ -1065,7 +1099,10 @@ const renderElementsBoxHighlight = (
   elements: readonly NonDeletedExcalidrawElement[],
   config?: { colors?: string[]; dashed?: boolean },
 ) => {
-  const { colors = ["rgb(0,118,255)"], dashed = false } = config || {};
+  const {
+    colors = [getThemedColor("rgb(0,118,255)", appState.theme)],
+    dashed = false,
+  } = config || {};
   const individualElements = elements.filter(
     (element) => element.groupIds.length === 0,
   );
@@ -1241,7 +1278,10 @@ const renderFocusPointConnectionLine = (
   context.save();
   context.translate(appState.scrollX, appState.scrollY);
 
-  context.strokeStyle = "rgba(134, 131, 226, 0.6)";
+  context.strokeStyle = getThemedColor(
+    "rgba(134, 131, 226, 0.6)",
+    appState.theme,
+  );
   context.lineWidth = 1 / appState.zoom.value;
   context.setLineDash([4 / appState.zoom.value, 4 / appState.zoom.value]);
 
@@ -1262,12 +1302,16 @@ const renderFocusPointCicle = (
 ) => {
   context.save();
   context.translate(appState.scrollX, appState.scrollY);
-  context.strokeStyle = "rgba(134, 131, 226, 0.6)";
+  context.strokeStyle = getThemedColor(
+    "rgba(134, 131, 226, 0.6)",
+    appState.theme,
+  );
   context.lineWidth = 1 / appState.zoom.value;
   context.setLineDash([]);
-  context.fillStyle = isHovered
-    ? "rgba(134, 131, 226, 0.9)"
-    : "rgba(255, 255, 255, 0.9)";
+  context.fillStyle = getThemedColor(
+    isHovered ? "rgba(134, 131, 226, 0.9)" : "rgba(255, 255, 255, 0.9)",
+    appState.theme,
+  );
 
   fillCircle(
     context,
@@ -1730,7 +1774,7 @@ const _renderInteractiveScene = ({
       appState,
       elements as NonDeletedExcalidrawElement[], // We don't typecheck runtime because of performance
       {
-        colors: ["#ced4da"],
+        colors: [getThemedColor("#ced4da", appState.theme)],
         dashed: true,
       },
     );
@@ -1823,7 +1867,10 @@ const _renderInteractiveScene = ({
         elementsMap,
       );
     }
-    const selectionColor = renderConfig.selectionColor || "#000";
+    const selectionColor =
+      renderConfig.selectionColor || getThemedColor("#000", appState.theme);
+    const lockedSelectionColor = getThemedColor("#ced4da", appState.theme);
+    const groupSelectionColor = getThemedColor("#000", appState.theme);
 
     if (showBoundingBox) {
       // Optimisation for finding quickly relevant element ids
@@ -1879,7 +1926,9 @@ const _renderInteractiveScene = ({
             y1,
             x2,
             y2,
-            selectionColors: element.locked ? ["#ced4da"] : selectionColors,
+            selectionColors: element.locked
+              ? [lockedSelectionColor]
+              : selectionColors,
             dashed: !!remoteClients || element.locked,
             cx,
             cy,
@@ -1905,8 +1954,8 @@ const _renderInteractiveScene = ({
           y1,
           y2,
           selectionColors: groupElements.some((el) => el.locked)
-            ? ["#ced4da"]
-            : ["#000"],
+            ? [lockedSelectionColor]
+            : [groupSelectionColor],
           dashed: true,
           cx: x1 + (x2 - x1) / 2,
           cy: y1 + (y2 - y1) / 2,
@@ -1932,7 +1981,7 @@ const _renderInteractiveScene = ({
     context.translate(appState.scrollX, appState.scrollY);
 
     if (selectedElements.length === 1) {
-      context.fillStyle = "#fff";
+      context.fillStyle = getThemedColor("#fff", appState.theme);
       const transformHandles = getTransformHandles(
         selectedElements[0],
         appState.zoom,
@@ -1977,7 +2026,7 @@ const _renderInteractiveScene = ({
     ) {
       const dashedLinePadding =
         (DEFAULT_TRANSFORM_HANDLE_SPACING * 2) / appState.zoom.value;
-      context.fillStyle = "#fff";
+      context.fillStyle = getThemedColor("#fff", appState.theme);
       const [x1, y1, x2, y2] = getCommonBounds(selectedElements, elementsMap);
       const initialLineDash = context.getLineDash();
       context.setLineDash([2 / appState.zoom.value]);
@@ -2032,17 +2081,8 @@ const _renderInteractiveScene = ({
       );
 
       context.save();
-      if (appState.theme === THEME.LIGHT) {
-        if (focus) {
-          context.fillStyle = "rgba(255, 124, 0, 0.4)";
-        } else {
-          context.fillStyle = "rgba(255, 226, 0, 0.4)";
-        }
-      } else if (focus) {
-        context.fillStyle = "rgba(229, 82, 0, 0.4)";
-      } else {
-        context.fillStyle = "rgba(99, 52, 0, 0.4)";
-      }
+      context.fillStyle =
+        SEARCH_MATCH_COLOR[appState.theme][focus ? "focus" : "match"];
 
       const zoomFactor = isFrameLikeElement(element) ? appState.zoom.value : 1;
 
@@ -2087,8 +2127,11 @@ const _renderInteractiveScene = ({
     );
 
     context.save();
-    context.fillStyle = SCROLLBAR_COLOR;
-    context.strokeStyle = "rgba(255,255,255,0.8)";
+    context.fillStyle = getThemedColor(SCROLLBAR_COLOR, appState.theme);
+    context.strokeStyle = getThemedColor(
+      "rgba(255,255,255,0.8)",
+      appState.theme,
+    );
     [scrollBars.horizontal, scrollBars.vertical].forEach((scrollBar) => {
       if (scrollBar) {
         roundRect(

--- a/packages/excalidraw/renderer/renderSnaps.ts
+++ b/packages/excalidraw/renderer/renderSnaps.ts
@@ -6,7 +6,10 @@ import type { PointSnapLine, PointerSnapLine } from "../snapping";
 import type { InteractiveCanvasAppState } from "../types";
 
 const SNAP_COLOR_LIGHT = "#ff6b6b";
-const SNAP_COLOR_DARK = "#ff0000";
+// dark-mode colors are the equivalents of what the former CSS inversion filter
+// produced (see `applyDarkModeFilter`)
+const SNAP_COLOR_DARK = "#ff9090";
+const SNAP_COLOR_DARK_ZEN = "#da5b5b";
 const SNAP_WIDTH = 1;
 const SNAP_CROSS_SIZE = 2;
 
@@ -18,12 +21,13 @@ export const renderSnaps = (
     return;
   }
 
-  // in dark mode, we need to adjust the color to account for color inversion.
-  // Don't change if zen mode, because we draw only crosses, we want the
-  // colors to be more visible
+  // in zen mode we draw only crosses, so use a different color to keep them
+  // visible
   const snapColor =
-    appState.theme === THEME.LIGHT || appState.zenModeEnabled
+    appState.theme === THEME.LIGHT
       ? SNAP_COLOR_LIGHT
+      : appState.zenModeEnabled
+      ? SNAP_COLOR_DARK_ZEN
       : SNAP_COLOR_DARK;
   // in zen mode make the cross more visible since we don't draw the lines
   const snapWidth =


### PR DESCRIPTION
## Problem

Users on Firefox/Zen reported the editor being laggy in dark mode only (light mode and Chrome fine). #10578 removed the CSS inversion filter from the static canvas, but the **interactive canvas** (selection outlines, transform handles, binding highlights, collaborator cursors, snap lines, scrollbars) was still composited through `filter: invert(93%) hue-rotate(180deg)` in dark mode. That canvas covers the whole viewport and repaints on nearly every pointer move, so browsers that composite in software pay for a full-viewport color-matrix pass per frame.

Reproduced in Firefox 154 with throwaway profiles (1920×1080 @ DPR 2, rAF frame timing during 150-step marquee/drag):

| profile | light | dark | dark, interactive filter removed |
|---|---|---|---|
| default (GPU WebRender) | 120 fps | 120 fps | 120 fps |
| `gfx.webrender.software=true` | 120 fps | 38 / 65 fps | 116–120 fps |
| `layers.acceleration.disabled=true` (HW accel off) | 120 fps | 42 / 64 fps | 120 fps |
| `gfx.canvas.accelerated=false` | 120 fps | 120 fps | 120 fps |

p95 frame time in the slow rows is a flat 33 ms (every other vsync dropped). Removing only the interactive-canvas filter restores full frame rate.

## Fix

Drop the CSS filter from `canvas.interactive` and map colors in JS via `applyDarkModeFilter`, the same approach as the static canvas:

- `interactiveScene.ts`: `getThemedColor` helper + tables for binding highlight / midpoint / search-match colors; every literal goes through it. The seven pre-compensated `THEME.DARK` ternaries are replaced by their actual post-filter colors.
- `renderSnaps.ts`: explicit dark / dark-zen snap colors instead of the pre-inverted red.
- `renderElement.ts` (`renderSelectionElement`): marquee fill themed.
- `theme.scss`: dark `--color-selection` now holds the actual rendered color (`#b4b0ff`, the post-filter value of the old `#3530c4`). The variable is only consumed by the canvas.
- `helpers.ts`: `getSelectionColor()` (reads `--color-selection` off any element inside the editor container, host overrides respected); `InteractiveCanvas.tsx` uses it.
- `lasso/index.ts`: lasso trail uses the same selection color (stroke + 5% fill) instead of a hardcoded light-theme purple. `common/colors.ts`: small `setColorAlpha` helper.
- `clients.ts`: drop the dark-mode speaking-color hack per the existing TODO.

All hardcoded dark constants were verified to equal `applyDarkModeFilter(<old value>)`.

## Visual changes

Rendering is pixel-identical (verified by screenshot diff in Chrome with a multi-selection in dark mode; only ~150 anti-aliased handle-edge pixels differ), except two intentional changes:

- collaborator cursors and remote selection outlines now render in the collaborators' actual colors (matching their avatars) instead of inverted ones
- the lasso trail now matches the marquee selection color in dark mode (it lives in the SVG overlay, which the filter never touched, so it was previously the light-mode purple on a dark canvas)

## Host note

If you override `--color-selection` for the dark theme, supply the actual color you want rendered — it is no longer inverted.

Closes #2346, closes #6876, closes #7332

## Test plan

- [x] `yarn test:typecheck`
- [x] `yarn test:update` (123 files / 1872 tests, no snapshot changes)
- [x] Firefox software-WebRender profile: dark mode back to 120 fps with the filter removed
- [x] Chrome: before/after screenshot diff of selection UI in dark mode; lasso stroke/fill attributes `#b4b0ff` / `#b4b0ff0d` in dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)
