### PR TITLE
docs: remove obsolete CodeSandbox contribution workflow

### DIFF
--- a/dev-docs/docs/introduction/contributing.mdx
+++ b/dev-docs/docs/introduction/contributing.mdx
@@ -23,15 +23,6 @@ In case you want to pick up something from the roadmap, comment on that issue an
 > git branch --set-upstream-to=upstream/master master
 > ```
 
-### Option 2 - CodeSandbox
-
-1. Go to https://codesandbox.io/p/github/excalidraw/excalidraw
-1. Connect your GitHub account
-1. Go to Git tab on left side
-1. Tap on `Fork Sandbox`
-1. Write your code
-1. Commit and PR automatically
-
 ## Pull Request Guidelines
 
 Don't worry if you get any of the below wrong, or if you don't know how. We'll gladly help out.

--- a/dev-docs/docs/introduction/development.mdx
+++ b/dev-docs/docs/introduction/development.mdx
@@ -1,11 +1,5 @@
 # Development
 
-## Code Sandbox
-
-- Go to https://codesandbox.io/p/github/excalidraw/excalidraw
-  - You may need to sign in with GitHub and reload the page
-- You can start coding instantly, and even send PRs from there!
-
 ## Local Installation
 
 These instructions will get you a copy of the project up and running on your local machine for development and testing purposes.


### PR DESCRIPTION
## Summary

Removes the obsolete CodeSandbox contribution workflow from the documentation.

## Changes

* Removed the CodeSandbox option from the contributing guide.
* Removed the CodeSandbox section from the development guide.

Fixes #11761.
