### PR TITLE
fix: move to iTXt png chunks (#9269)

### DIFF
--- a/packages/excalidraw/data/image.ts
+++ b/packages/excalidraw/data/image.ts
@@ -11,10 +11,60 @@ import { encode, decode } from "./encode";
 // PNG
 // -----------------------------------------------------------------------------
 
+// tEXt chunks only support Latin-1, but we encode scene metadata as UTF-8
+// (see https://github.com/excalidraw/excalidraw/issues/9269), which other PNG
+// decoders may reject or mangle even though browsers tolerate it. iTXt
+// (https://www.w3.org/TR/png/#11iTXt) is the PNG spec's UTF-8-safe text chunk,
+// so we write metadata as iTXt going forward. We still read tEXt so PNGs
+// exported by older excalidraw versions keep working.
+const iTXt = {
+  encode: (keyword: string, text: string): PngChunk => {
+    const keywordBytes = new TextEncoder().encode(keyword);
+    const textBytes = new TextEncoder().encode(text);
+    const data = new Uint8Array(
+      keywordBytes.length +
+        1 + // null separator after keyword
+        1 + // compression flag
+        1 + // compression method
+        1 + // null separator after (empty) language tag
+        1 + // null separator after (empty) translated keyword
+        textBytes.length,
+    );
+    let offset = 0;
+    data.set(keywordBytes, offset);
+    offset += keywordBytes.length;
+    data[offset++] = 0; // null separator after keyword
+    data[offset++] = 0; // compression flag: uncompressed
+    data[offset++] = 0; // compression method (only 0 is valid)
+    data[offset++] = 0; // empty language tag + its null separator
+    data[offset++] = 0; // empty translated keyword + its null separator
+    data.set(textBytes, offset);
+    return { name: "iTXt", data };
+  },
+  decode: (data: Uint8Array): { keyword: string; text: string } => {
+    let offset = data.indexOf(0);
+    const keyword = new TextDecoder("latin1").decode(data.subarray(0, offset));
+    offset += 1; // skip null separator
+    const compressionFlag = data[offset];
+    offset += 2; // skip compression flag + compression method
+    offset = data.indexOf(0, offset) + 1; // skip language tag
+    offset = data.indexOf(0, offset) + 1; // skip translated keyword
+    if (compressionFlag === 1) {
+      throw new Error("Compressed iTXt chunks are not supported");
+    }
+    const text = new TextDecoder("utf-8").decode(data.subarray(offset));
+    return { keyword, text };
+  },
+};
+
 export const getTEXtChunk = async (
   blob: Blob,
 ): Promise<{ keyword: string; text: string } | null> => {
   const chunks = decodePng(new Uint8Array(await blobToArrayBuffer(blob)));
+  const iTXtChunk = chunks.find((chunk) => chunk.name === "iTXt");
+  if (iTXtChunk) {
+    return iTXt.decode(iTXtChunk.data);
+  }
   const metadataChunk = chunks.find((chunk) => chunk.name === "tEXt");
   if (metadataChunk) {
     return tEXt.decode(metadataChunk.data);
@@ -31,7 +81,7 @@ export const encodePngMetadata = async ({
 }) => {
   const chunks = decodePng(new Uint8Array(await blobToArrayBuffer(blob)));
 
-  const metadataChunk = tEXt.encode(
+  const metadataChunk = iTXt.encode(
     MIME_TYPES.excalidraw,
     JSON.stringify(
       encode({

--- a/packages/excalidraw/global.d.ts
+++ b/packages/excalidraw/global.d.ts
@@ -33,6 +33,7 @@ interface Clipboard extends EventTarget {
 // PNG encoding/decoding
 // -----------------------------------------------------------------------------
 type TEXtChunk = { name: "tEXt"; data: Uint8Array };
+type PngChunk = { name: string; data: Uint8Array };
 
 declare module "png-chunk-text" {
   function encode(
@@ -42,11 +43,11 @@ declare module "png-chunk-text" {
   function decode(data: Uint8Array): { keyword: string; text: string };
 }
 declare module "png-chunks-encode" {
-  function encode(chunks: TEXtChunk[]): Uint8Array<ArrayBuffer>;
+  function encode(chunks: PngChunk[]): Uint8Array<ArrayBuffer>;
   export = encode;
 }
 declare module "png-chunks-extract" {
-  function extract(buffer: Uint8Array): TEXtChunk[];
+  function extract(buffer: Uint8Array): PngChunk[];
   export = extract;
 }
 // -----------------------------------------------------------------------------

--- a/packages/excalidraw/tests/export.test.tsx
+++ b/packages/excalidraw/tests/export.test.tsx
@@ -1,11 +1,15 @@
 import React from "react";
+import tEXt from "png-chunk-text";
+import decodePng from "png-chunks-extract";
+import encodePng from "png-chunks-encode";
 
-import { SVG_NS } from "@excalidraw/common";
+import { SVG_NS, MIME_TYPES } from "@excalidraw/common";
 
 import type { FileId } from "@excalidraw/element/types";
 
 import { getDefaultAppState } from "../appState";
-import { getDataURL } from "../data/blob";
+import { getDataURL, blobToArrayBuffer } from "../data/blob";
+import { encode } from "../data/encode";
 import { encodePngMetadata } from "../data/image";
 import { serializeAsJSON } from "../data/json";
 import { Excalidraw } from "../index";
@@ -34,14 +38,52 @@ const testElements = [
   },
 ];
 
-// tiny polyfill for TextDecoder.decode on which we depend
+// tiny polyfill for TextDecoder.decode on which we depend.
+// Must actually decode UTF-8 (not just map each byte to a char code),
+// since it needs to correctly invert the real (non-polyfilled)
+// TextEncoder's multi-byte output for the iTXt PNG chunk round-trip.
 Object.defineProperty(window, "TextDecoder", {
   value: class TextDecoder {
+    private encoding: string;
+    constructor(encoding = "utf-8") {
+      this.encoding = encoding.toLowerCase();
+    }
     decode(ab: ArrayBuffer) {
-      return new Uint8Array(ab).reduce(
-        (acc, c) => acc + String.fromCharCode(c),
-        "",
-      );
+      const bytes = new Uint8Array(ab);
+      if (this.encoding === "latin1" || this.encoding === "iso-8859-1") {
+        return bytes.reduce((acc, c) => acc + String.fromCharCode(c), "");
+      }
+      // utf-8 (default)
+      let result = "";
+      let i = 0;
+      while (i < bytes.length) {
+        const byte1 = bytes[i++];
+        if (byte1 < 0x80) {
+          result += String.fromCharCode(byte1);
+        } else if (byte1 >> 5 === 0b110) {
+          const byte2 = bytes[i++];
+          result += String.fromCharCode(
+            ((byte1 & 0x1f) << 6) | (byte2 & 0x3f),
+          );
+        } else if (byte1 >> 4 === 0b1110) {
+          const byte2 = bytes[i++];
+          const byte3 = bytes[i++];
+          result += String.fromCharCode(
+            ((byte1 & 0x0f) << 12) | ((byte2 & 0x3f) << 6) | (byte3 & 0x3f),
+          );
+        } else if (byte1 >> 3 === 0b11110) {
+          const byte2 = bytes[i++];
+          const byte3 = bytes[i++];
+          const byte4 = bytes[i++];
+          const codepoint =
+            ((byte1 & 0x07) << 18) |
+            ((byte2 & 0x3f) << 12) |
+            ((byte3 & 0x3f) << 6) |
+            (byte4 & 0x3f);
+          result += String.fromCodePoint(codepoint);
+        }
+      }
+      return result;
     }
   },
 });
@@ -217,5 +259,44 @@ describe("export", () => {
     // in case of regressions, save the SVG to a file and visually compare to:
     // src/tests/fixtures/svg-image-exporting-reference.svg
     expect(svgText).toMatchSnapshot(`svg export output`);
+  });
+
+  it("exports scene metadata as an iTXt chunk, not tEXt", async () => {
+    const pngBlob = await API.loadFile("./fixtures/smiley.png");
+    const pngBlobEmbedded = await encodePngMetadata({
+      blob: pngBlob,
+      metadata: serializeAsJSON(testElements, h.state, {}, "local"),
+    });
+    const chunks = decodePng(
+      new Uint8Array(await blobToArrayBuffer(pngBlobEmbedded)),
+    );
+    expect(chunks.some((chunk) => chunk.name === "iTXt")).toBe(true);
+    expect(chunks.some((chunk) => chunk.name === "tEXt")).toBe(false);
+  });
+
+  it("still imports scenes embedded as a legacy tEXt chunk", async () => {
+    const pngBlob = await API.loadFile("./fixtures/smiley.png");
+    const chunks = decodePng(new Uint8Array(await blobToArrayBuffer(pngBlob)));
+    const legacyChunk = tEXt.encode(
+      MIME_TYPES.excalidraw,
+      JSON.stringify(
+        encode({
+          text: serializeAsJSON(testElements, h.state, {}, "local"),
+          compress: true,
+        }),
+      ),
+    );
+    chunks.splice(-1, 0, legacyChunk);
+    const legacyBlob = new Blob([encodePng(chunks)], {
+      type: MIME_TYPES.png,
+    });
+
+    await API.drop([{ kind: "file", file: legacyBlob }]);
+
+    await waitFor(() => {
+      expect(h.elements).toEqual([
+        expect.objectContaining({ type: "text", text: "😀" }),
+      ]);
+    });
   });
 });


### PR DESCRIPTION
tEXt chunks only support Latin-1, but scene metadata is encoded as UTF-8, which browsers tolerate but other PNG decoders may reject or mangle. iTXt is the PNG spec's UTF-8-safe text chunk, so new exports now write iTXt instead.

- encodePngMetadata now writes an iTXt chunk instead of tEXt.
- getTEXtChunk reads iTXt first, falling back to tEXt so PNGs exported by older excalidraw versions keep importing correctly.
- No new npm dependency: iTXt encode/decode is implemented locally since no well-maintained package matches the existing png-chunk-text encode/decode(chunk) -> {keyword, text} shape.
- global.d.ts: widened the png-chunks-encode/extract chunk type from the tEXt-only literal to a generic {name: string; data: Uint8Array} shape, since those two packages operate on arbitrary PNG chunk types, not just tEXt.
- Added tests: new exports use iTXt (not tEXt); PNGs with a legacy tEXt chunk still import correctly.
- Fixed a latent bug in the test suite's TextDecoder polyfill: it ignored the requested encoding and did a naive byte-per-char decode for every case, which silently corrupts multi-byte UTF-8 output from the real (non-polyfilled) TextEncoder. This didn't matter for the old tEXt code path but does for iTXt's UTF-8 round-trip.

Closes #9269