### PR TITLE
fix: convert HTML br tags to newlines in Mermaid diagrams

### DIFF
--- a/packages/excalidraw/components/TTDDialog/common.ts
+++ b/packages/excalidraw/components/TTDDialog/common.ts
@@ -75,7 +75,7 @@ export const convertMermaidToExcalidraw = async ({
     const api = await mermaidToExcalidrawLib.api;
 
     try {
-      ret = await api.parseMermaidToExcalidraw(mermaidDefinition);
+      ret = await api.parseMermaidToExcalidraw(mermaidDefinition.replace(/<br\s*\/?>/gi, "\\n"));
     } catch (err: unknown) {
       const originalParseError = err as Error;
 
@@ -85,7 +85,7 @@ export const convertMermaidToExcalidraw = async ({
 
       try {
         ret = await api.parseMermaidToExcalidraw(
-          mermaidDefinition.replace(/"/g, "'"),
+          mermaidDefinition.replace(/"/g, "'").replace(/<br\s*\/?>/gi, "\\n"),
         );
       } catch {
         // Keep the original error so line/column references stay aligned with


### PR DESCRIPTION
## Summary

Fixes #9708 — Mermaid diagrams with `<br>` tags render the raw tag text instead of line breaks.

## Bug

When pasting Mermaid diagrams that contain HTML `<br>` tags (common in AI-generated diagrams), Excalidraw shows the raw tag text instead of converting it to actual line breaks.

## Fix

Replace HTML `<br>` tags with `\n` before passing to the Mermaid parser:

```typescript
ret = await api.parseMermaidToExcalidraw(
  mermaidDefinition.replace(/<br\s*\/?>/gi, "\\n"),
);
```

The same replacement is applied in the fallback quote-replacement path.

## Acceptance criteria

- [x] `<br>` tags in Mermaid diagrams render as line breaks
- [x] `<BR>`, `<br/>`, `<br />` variants all handled (case-insensitive)
- [x] `\n` is preserved as-is (only HTML tags are replaced)
- [x] Works in both direct paste and TTD dialog flows
- [x] No regression for diagrams without `<br>` tags

## Testing

Tested with the example from the issue:

```
graph TD
    A["User Registration<br>Process"] --> B["Validate Input<br>Data"]
```

/claim #9708