### PR TITLE
docs: correct Next.js example README

### DIFF
--- a/examples/with-nextjs/README.md
+++ b/examples/with-nextjs/README.md
@@ -14,9 +14,9 @@ pnpm dev
 bun dev
 ```
 
-Open [http://localhost:3000](http://localhost:3005) with your browser to see the result.
+Open [http://localhost:3005](http://localhost:3005) with your browser to see the result.
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+You can start editing the page by modifying `src/app/page.tsx`. The page auto-updates as you edit the file.
 
 This project uses [`next/font`](https://nextjs.org/docs/basic-features/font-optimization) to automatically optimize and load Inter, a custom Google Font.
 


### PR DESCRIPTION
## Summary

Corrects outdated instructions in the Next.js example README.

## Changes

- Corrected the development server URL from `localhost:3000` to `localhost:3005`.
- Corrected the page path from `app/page.tsx` to `src/app/page.tsx`.

Fixes #11770.