### PR TITLE
fix(editor): save the scene on Ctrl/Cmd+S while an input is focused

### DIFF
--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -319,6 +319,7 @@ import {
   actionFlipVertical,
   actionGroup,
   actionPasteStyles,
+  actionSaveToActiveFile,
   actionSelectAll,
   actionSendBackward,
   actionSendToBack,
@@ -5567,6 +5568,16 @@ class App extends React.Component<AppProps, AppState> {
       if (event[KEYS.CTRL_OR_CMD] && isWritableElement(event.target)) {
         if (event.code === CODES.MINUS || event.code === CODES.EQUAL) {
           event.preventDefault();
+          return;
+        }
+        // Ctrl/Cmd+S while focus is in an input (e.g. the canvas search
+        // field or a dialog) would otherwise open the browser's "save page
+        // as" dialog. Route it through the save shortcut instead. Text
+        // editing runs its own save on submit, hence the defaultPrevented
+        // guard to avoid saving twice.
+        if (!event.defaultPrevented && actionSaveToActiveFile.keyTest(event)) {
+          event.preventDefault();
+          this.actionManager.handleKeyDown(event);
           return;
         }
       }

--- a/packages/excalidraw/tests/shortcuts.test.tsx
+++ b/packages/excalidraw/tests/shortcuts.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { KEYS } from "@excalidraw/common";
+import { CLASSES, KEYS } from "@excalidraw/common";
 
 import { Excalidraw } from "../index";
 
@@ -30,5 +30,40 @@ describe("shortcuts", () => {
     await waitFor(() => {
       expect(window.h.elements[0].isDeleted).toBe(true);
     });
+  });
+
+  // regression test for #9281: Ctrl/Cmd+S while focus is inside an input
+  // (here the canvas search field) used to fall through to the browser's
+  // "save page as" dialog instead of saving the scene
+  it("Ctrl/Cmd+S should save the scene while an input is focused", async () => {
+    await render(<Excalidraw handleKeyboardGlobally />);
+
+    // open the canvas search sidebar, which focuses a text input
+    Keyboard.withModifierKeys({ ctrl: true }, () => {
+      Keyboard.keyPress(KEYS.F);
+    });
+
+    const searchInput =
+      window.h.app.excalidrawContainerValue.container?.querySelector<HTMLInputElement>(
+        `.${CLASSES.SEARCH_MENU_INPUT_WRAPPER} input`,
+      )!;
+    await waitFor(() => expect(searchInput).not.toBeNull());
+    expect(searchInput.matches(":focus")).toBe(true);
+
+    const handleKeyDown = jest
+      .spyOn(window.h.app.actionManager, "handleKeyDown")
+      .mockReturnValue(true);
+
+    // dispatching returns false when a handler called preventDefault, i.e.
+    // the browser's native save-page dialog was suppressed
+    const notCancelled = fireEvent.keyDown(searchInput, {
+      key: KEYS.S,
+      ctrlKey: true,
+    });
+
+    expect(notCancelled).toBe(false);
+    expect(handleKeyDown).toHaveBeenCalled();
+
+    handleKeyDown.mockRestore();
   });
 });


### PR DESCRIPTION
Fixes #9281.

Pressing Ctrl/Cmd+S while focus is inside a text input (the canvas search field, a dialog input, and so on) used to trigger the browser's "save page as" dialog instead of saving the scene.

## Root cause
The global keydown handler in `App.tsx` bails out early for writable elements (inputs and textareas) before the save shortcut runs, so nothing calls `preventDefault` and the browser hijacks Ctrl/Cmd+S. Canvas text editing got its own save handler in #9295, but every other input still had the problem.

## Fix
When a writable element is focused and the save shortcut is pressed, route it through the action manager (the same path the canvas uses) instead of bailing. That saves the scene and stops the browser dialog. A `defaultPrevented` guard skips the canvas text-editor case, which handles its own save on submit, so we never save twice.

## Testing
Added a regression test in `shortcuts.test.tsx`: open the canvas search field, press Ctrl/Cmd+S, then assert the browser default was prevented and the save shortcut ran. The test fails without the fix and passes with it. Full suite is green (2078 passing), typecheck and lint clean.
