### PR TITLE
fix(editor): keep canvas background picker full-size in the main menu

### DIFF
--- a/packages/excalidraw/components/ColorPicker/ColorPicker.tsx
+++ b/packages/excalidraw/components/ColorPicker/ColorPicker.tsx
@@ -13,7 +13,11 @@ import {
   THEME,
 } from "@excalidraw/common";
 
-import type { ColorTuple, ColorPaletteCustom } from "@excalidraw/common";
+import type {
+  ColorTuple,
+  ColorPaletteCustom,
+  StylesPanelMode,
+} from "@excalidraw/common";
 
 import type { ExcalidrawElement, Theme } from "@excalidraw/element/types";
 
@@ -69,6 +73,13 @@ interface ColorPickerProps {
   customizableTopPicks?: keyof AppState["colorTopPicks"];
 }
 
+// canvasBackground only renders in the fixed-width main menu, so it must not
+// inherit the styles panel's viewport-derived compact mode.
+const getPickerLayoutMode = (
+  type: ColorPickerType,
+  mode: StylesPanelMode,
+): StylesPanelMode => (type === "canvasBackground" ? "full" : mode);
+
 const ColorPickerPopupContent = ({
   type,
   color,
@@ -96,7 +107,7 @@ const ColorPickerPopupContent = ({
 }) => {
   const { container } = useExcalidrawContainer();
   const app = useApp();
-  const stylesPanelMode = useStylesPanelMode();
+  const stylesPanelMode = getPickerLayoutMode(type, useStylesPanelMode());
   const isCompactMode = stylesPanelMode !== "full";
   const isMobileMode = stylesPanelMode === "mobile";
   const [, setActiveColorPickerSection] = useAtom(activeColorPickerSectionAtom);
@@ -278,7 +289,7 @@ const ColorPickerTrigger = ({
   editingTextElement?: boolean;
 }) => {
   const app = useApp();
-  const stylesPanelMode = useStylesPanelMode();
+  const stylesPanelMode = getPickerLayoutMode(type, useStylesPanelMode());
   const isCompactMode = stylesPanelMode !== "full";
   const isMobileMode = stylesPanelMode === "mobile";
   const dnd = useColorPickerDnD();
@@ -360,7 +371,7 @@ const ColorPickerComponent = ({
   useEffect(() => {
     openRef.current = appState.openPopup;
   }, [appState.openPopup]);
-  const stylesPanelMode = useStylesPanelMode();
+  const stylesPanelMode = getPickerLayoutMode(type, useStylesPanelMode());
   const isCompactMode = stylesPanelMode !== "full";
 
   const isTopPicksCustomizable = !!customizableTopPicks && !isCompactMode;

--- a/packages/excalidraw/tests/excalidraw.test.tsx
+++ b/packages/excalidraw/tests/excalidraw.test.tsx
@@ -235,6 +235,28 @@ describe("<Excalidraw/>", () => {
         expect(queryByTestId(container, "canvas-background-picker")).toBeNull();
       });
 
+      it("should keep the canvas background picker full-size in the menu on tablet", async () => {
+        const { container } = await render(
+          <Excalidraw UIOptions={{ getFormFactor: () => "tablet" }} />,
+        );
+        fireEvent.resize(window);
+        await waitFor(() =>
+          expect(h.app.editorInterface.formFactor).toBe("tablet"),
+        );
+        //open menu
+        toggleMenu(container);
+        const picker = container.querySelector(
+          ".dropdown-menu .color-picker-container",
+        );
+        expect(picker).not.toBeNull();
+        expect(picker).not.toHaveClass("color-picker-container--no-top-picks");
+        expect(
+          container.querySelector(
+            ".dropdown-menu .color-picker__button.compact-sizing",
+          ),
+        ).toBeNull();
+      });
+
       it("should hide the theme toggle when theme is false", async () => {
         const { container } = await render(
           <Excalidraw UIOptions={{ canvasActions: { toggleTheme: false } }} />,


### PR DESCRIPTION
Fixes #12084

### Problem
The canvas background color picker in the main menu collapsed to a single enlarged button on tablet-sized viewports. It derived its compact layout from the editor's global styles-panel mode, which is viewport-based, even though the main menu is fixed-width.

### Fix
Render the canvas background picker at full size, since it only appears in the fixed-width main menu.

### Test
Added a regression test asserting the picker keeps its swatch strip and normal-size trigger in the menu at a tablet-sized viewport.

### Screenshots
_**At 1180px Screen Width**_

<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td>
      <img width="234" height="670" alt="Before" src="https://github.com/user-attachments/assets/62bb2888-0ef5-4a25-8104-01822315dddc" />
    </td>
    <td>
      <img width="236" height="657" alt="After" src="https://github.com/user-attachments/assets/02065f29-2441-4691-ba04-5b876889de41" />
    </td>
  </tr>
</table>


