### PR TITLE
feat: edit shared hyperlinks on selected groups

### DIFF
--- a/packages/excalidraw/actions/actionLink.tsx
+++ b/packages/excalidraw/actions/actionLink.tsx
@@ -9,6 +9,7 @@ import { CaptureUpdateAction } from "@excalidraw/element";
 
 import { IconButton } from "../components/IconButton";
 import { getContextMenuLabel } from "../components/hyperlink/Hyperlink";
+import { canEditHyperlink } from "../components/hyperlink/selection";
 import { LinkIcon } from "../components/icons";
 import { t } from "../i18n";
 import { getSelectedElements } from "../scene";
@@ -22,7 +23,10 @@ export const actionLink = register({
     getContextMenuLabel(getNonDeletedElements(elements), appState),
   icon: LinkIcon,
   perform: (elements, appState) => {
-    if (appState.showHyperlinkPopup === "editor") {
+    if (
+      appState.showHyperlinkPopup === "editor" ||
+      !canEditHyperlink(getSelectedElements(elements, appState), appState)
+    ) {
       return false;
     }
 
@@ -40,7 +44,7 @@ export const actionLink = register({
   keyTest: (event) => event[KEYS.CTRL_OR_CMD] && event.key === KEYS.K,
   predicate: (elements, appState) => {
     const selectedElements = getSelectedElements(elements, appState);
-    return selectedElements.length === 1;
+    return canEditHyperlink(selectedElements, appState);
   },
   PanelComponent: ({ elements, appState, updateData }) => {
     const selectedElements = getSelectedElements(elements, appState);
@@ -53,12 +57,12 @@ export const actionLink = register({
           getContextMenuLabel(getNonDeletedElements(elements), appState),
         )}
         title={`${
-          isEmbeddableElement(elements[0])
+          isEmbeddableElement(selectedElements[0])
             ? t("labels.link.labelEmbed")
             : t("labels.link.label")
         } - ${getShortcutKey("CtrlOrCmd+K")}`}
         onSelect={() => updateData(null)}
-        checked={selectedElements.length === 1 && !!selectedElements[0].link}
+        checked={!!selectedElements[0]?.link}
       />
     );
   },

--- a/packages/excalidraw/components/Actions.tsx
+++ b/packages/excalidraw/components/Actions.tsx
@@ -573,7 +573,7 @@ const CombinedExtraActions = ({
                 <div className="buttonList">
                   {renderAction("group")}
                   {renderAction("ungroup")}
-                  {predicates.linkSingleOnly && renderAction("hyperlink")}
+                  {predicates.linkSelection && renderAction("hyperlink")}
                   {predicates.cropEditor && renderAction("cropEditor")}
                   {showDuplicate && renderAction("duplicateSelection")}
                   {showDelete && renderAction("deleteSelectedElements")}

--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -465,6 +465,7 @@ import { isSidebarDockedAtom } from "./Sidebar/Sidebar";
 import { StaticCanvas, InteractiveCanvas } from "./canvases";
 import NewElementCanvas from "./canvases/NewElementCanvas";
 import { isPointHittingLink } from "./hyperlink/helpers";
+import { canEditHyperlink } from "./hyperlink/selection";
 import { CursorHint, CursorHints } from "./CursorHint";
 import { MagicIcon, copyIcon, fullscreenIcon } from "./icons";
 import { AppStateObserver, type OnStateChange } from "./AppStateObserver";
@@ -2500,14 +2501,18 @@ class App extends React.Component<AppProps, AppState> {
                           />
                           {this.isDefaultUIEnabled() && <CursorHint />}
                           {this.isDefaultUIEnabled() &&
-                            selectedElements.length === 1 &&
+                            canEditHyperlink(selectedElements, this.state) &&
                             this.state.openDialog?.name !==
                               "elementLinkSelector" &&
                             this.state.showHyperlinkPopup && (
                               <Hyperlink
-                                key={firstSelectedElement.id}
+                                key={selectedElements
+                                  .map(({ id }) => id)
+                                  .join(",")}
                                 element={firstSelectedElement}
+                                elements={selectedElements}
                                 scene={this.scene}
+                                scheduleCapture={this.scheduleCapture}
                                 setAppState={this.setAppState}
                                 onLinkOpen={this.props.onLinkOpen}
                                 setToast={this.setToast}

--- a/packages/excalidraw/components/hyperlink/Hyperlink.tsx
+++ b/packages/excalidraw/components/hyperlink/Hyperlink.tsx
@@ -10,7 +10,7 @@ import {
 
 import { EVENT, HYPERLINK_TOOLTIP_DELAY, KEYS } from "@excalidraw/common";
 
-import { getElementAbsoluteCoords } from "@excalidraw/element";
+import { getCommonBounds, getElementAbsoluteCoords } from "@excalidraw/element";
 
 import { hitElementBoundingBox } from "@excalidraw/element";
 
@@ -67,14 +67,18 @@ const embeddableLinkCache = new Map<
 
 export const Hyperlink = ({
   element,
+  elements,
   scene,
+  scheduleCapture,
   setAppState,
   onLinkOpen,
   setToast,
   updateEmbedValidationStatus,
 }: {
   element: NonDeletedExcalidrawElement;
+  elements: readonly NonDeletedExcalidrawElement[];
   scene: Scene;
+  scheduleCapture: () => void;
   setAppState: React.Component<any, AppState>["setState"];
   onLinkOpen: ExcalidrawProps["onLinkOpen"];
   setToast: (
@@ -94,14 +98,23 @@ export const Hyperlink = ({
 
   const [inputVal, setInputVal] = useState(linkVal);
   const inputRef = useRef<HTMLInputElement>(null);
+  const isInputDirty = useRef(false);
   const isEditing = appState.showHyperlinkPopup === "editor";
 
+  useEffect(() => {
+    if (!isInputDirty.current) {
+      setInputVal(linkVal);
+    }
+  }, [linkVal]);
+
   const handleSubmit = useCallback(() => {
-    if (!inputRef.current) {
+    if (!inputRef.current || !isInputDirty.current) {
       return;
     }
 
+    isInputDirty.current = false;
     const link = normalizeLink(inputRef.current.value) || null;
+    scheduleCapture();
 
     if (!element.link && link) {
       trackEvent("hyperlink", "create");
@@ -167,11 +180,15 @@ export const Hyperlink = ({
         }
       }
     } else {
-      scene.mutateElement(element, { link });
+      for (const member of elements) {
+        scene.mutateElement(member, { link });
+      }
     }
   }, [
     element,
+    elements,
     scene,
+    scheduleCapture,
     setToast,
     appProps.validateEmbeddable,
     appState.activeEmbeddable,
@@ -206,7 +223,7 @@ export const Hyperlink = ({
         clearTimeout(timeoutId);
       }
       const shouldHide = shouldHideLinkPopup(
-        element,
+        elements,
         elementsMap,
         appState,
         pointFrom(event.clientX, event.clientY),
@@ -224,19 +241,23 @@ export const Hyperlink = ({
         clearTimeout(timeoutId);
       }
     };
-  }, [appState, element, isEditing, setAppState, elementsMap]);
+  }, [appState, elements, isEditing, setAppState, elementsMap]);
 
   const handleRemove = useCallback(() => {
     trackEvent("hyperlink", "delete");
-    scene.mutateElement(element, { link: null });
+    isInputDirty.current = false;
+    scheduleCapture();
+    for (const member of elements) {
+      scene.mutateElement(member, { link: null });
+    }
     setAppState({ showHyperlinkPopup: false });
-  }, [setAppState, element, scene]);
+  }, [setAppState, elements, scene, scheduleCapture]);
 
   const onEdit = () => {
     trackEvent("hyperlink", "edit", "popup-ui");
     setAppState({ showHyperlinkPopup: "editor" });
   };
-  const { x, y } = getCoordsForPopover(element, appState, elementsMap);
+  const { x, y } = getCoordsForPopover(elements, appState, elementsMap);
   if (
     appState.contextMenu ||
     appState.selectedElementsAreBeingDragged ||
@@ -264,7 +285,10 @@ export const Hyperlink = ({
           placeholder={t("labels.link.hint")}
           ref={inputRef}
           value={inputVal}
-          onChange={(event) => setInputVal(event.target.value)}
+          onChange={(event) => {
+            isInputDirty.current = true;
+            setInputVal(event.target.value);
+          }}
           autoFocus
           onKeyDown={(event) => {
             event.stopPropagation();
@@ -322,21 +346,23 @@ export const Hyperlink = ({
             icon={FreedrawIcon}
           />
         )}
-        <IconButton
-          type="button"
-          title={t("labels.linkToElement")}
-          aria-label={t("labels.linkToElement")}
-          label={t("labels.linkToElement")}
-          onClick={() => {
-            setAppState({
-              openDialog: {
-                name: "elementLinkSelector",
-                sourceElementId: element.id,
-              },
-            });
-          }}
-          icon={elementLinkIcon}
-        />
+        {elements.length === 1 && (
+          <IconButton
+            type="button"
+            title={t("labels.linkToElement")}
+            aria-label={t("labels.linkToElement")}
+            label={t("labels.linkToElement")}
+            onClick={() => {
+              setAppState({
+                openDialog: {
+                  name: "elementLinkSelector",
+                  sourceElementId: element.id,
+                },
+              });
+            }}
+            icon={elementLinkIcon}
+          />
+        )}
         {linkVal && !isEmbeddableElement(element) && (
           <IconButton
             type="button"
@@ -354,13 +380,16 @@ export const Hyperlink = ({
 };
 
 const getCoordsForPopover = (
-  element: NonDeletedExcalidrawElement,
+  elements: readonly NonDeletedExcalidrawElement[],
   appState: AppState,
   elementsMap: ElementsMap,
 ) => {
-  const [x1, y1] = getElementAbsoluteCoords(element, elementsMap);
+  const [x1, y1, x2] =
+    elements.length === 1
+      ? getElementAbsoluteCoords(elements[0], elementsMap)
+      : getCommonBounds(elements);
   const { x: viewportX, y: viewportY } = sceneCoordsToViewportCoords(
-    { sceneX: x1 + element.width / 2, sceneY: y1 },
+    { sceneX: (x1 + x2) / 2, sceneY: y1 },
     appState,
   );
   const x = viewportX - appState.offsetLeft - POPUP_WIDTH / 2;
@@ -451,7 +480,7 @@ export const hideHyperlinkToolip = () => {
 };
 
 const shouldHideLinkPopup = (
-  element: NonDeletedExcalidrawElement,
+  elements: readonly NonDeletedExcalidrawElement[],
   elementsMap: ElementsMap,
   appState: AppState,
   [clientX, clientY]: GlobalPoint,
@@ -463,10 +492,26 @@ const shouldHideLinkPopup = (
 
   const threshold = 15 / appState.zoom.value;
   // hitbox to prevent hiding when hovered in element bounding box
-  if (hitElementBoundingBox(pointFrom(sceneX, sceneY), element, elementsMap)) {
+  if (
+    elements.some((element) =>
+      hitElementBoundingBox(pointFrom(sceneX, sceneY), element, elementsMap),
+    )
+  ) {
     return false;
   }
-  const [x1, y1, x2] = getElementAbsoluteCoords(element, elementsMap);
+  const [x1, y1, x2, y2] =
+    elements.length === 1
+      ? getElementAbsoluteCoords(elements[0], elementsMap)
+      : getCommonBounds(elements);
+  if (
+    elements.length > 1 &&
+    sceneX >= x1 &&
+    sceneX <= x2 &&
+    sceneY >= y1 &&
+    sceneY <= y2
+  ) {
+    return false;
+  }
   // hit box to prevent hiding when hovered in the vertical area between element and popover
   if (
     sceneX >= x1 &&
@@ -478,7 +523,7 @@ const shouldHideLinkPopup = (
   }
   // hit box to prevent hiding when hovered around popover within threshold
   const { x: popoverX, y: popoverY } = getCoordsForPopover(
-    element,
+    elements,
     appState,
     elementsMap,
   );

--- a/packages/excalidraw/components/hyperlink/selection.ts
+++ b/packages/excalidraw/components/hyperlink/selection.ts
@@ -1,0 +1,35 @@
+import { isEmbeddableElement } from "@excalidraw/element";
+
+import type { ExcalidrawElement } from "@excalidraw/element/types";
+
+import type { UIAppState } from "../../types";
+
+/** Groups share their members' existing links, without introducing a new URL
+ * that overrides individual links or changes the scene format. */
+export const canEditHyperlink = (
+  selectedElements: readonly ExcalidrawElement[],
+  appState: Pick<UIAppState, "selectedGroupIds">,
+) => {
+  if (selectedElements.length === 1) {
+    return true;
+  }
+  if (selectedElements.length < 2) {
+    return false;
+  }
+
+  const selectedGroupIds = Object.keys(appState.selectedGroupIds).filter(
+    (id) => appState.selectedGroupIds[id],
+  );
+  if (selectedGroupIds.length !== 1) {
+    return false;
+  }
+
+  const link = selectedElements[0].link || null;
+  return selectedElements.every(
+    (element) =>
+      element.groupIds.includes(selectedGroupIds[0]) &&
+      !element.locked &&
+      !isEmbeddableElement(element) &&
+      (element.link || null) === link,
+  );
+};

--- a/packages/excalidraw/components/shapeActionPredicates.ts
+++ b/packages/excalidraw/components/shapeActionPredicates.ts
@@ -22,6 +22,7 @@ import type {
 } from "@excalidraw/element/types";
 
 import { alignActionsPredicate } from "../actions/actionAlign";
+
 import {
   canChangeRoundness,
   canHaveArrowheads,
@@ -33,6 +34,8 @@ import {
   hasStrokeStyle,
   hasStrokeWidth,
 } from "../scene";
+
+import { canEditHyperlink } from "./hyperlink/selection";
 
 import type { ElementOrToolType } from "../types";
 
@@ -113,6 +116,10 @@ export const getShapeActionPredicates = (
     appState.editingTextElement || appState.newElement,
   );
   const hasSelection = targetElements.length > 0;
+  const canLinkSelection = canEditHyperlink(
+    getSelectedElements(elementsMap, appState),
+    appState,
+  );
 
   return {
     /** some element(s) selected */
@@ -172,10 +179,10 @@ export const getShapeActionPredicates = (
 
     // per-element actions
     // NOTE: the full panel treats a bound container as linkable; the compact /
-    // mobile layouts only link a truly single selection. Both are preserved via
+    // mobile layouts use the selection directly. Both are preserved via
     // the two flags below.
-    link: singleSelected || isSingleElementBoundContainer,
-    linkSingleOnly: singleSelected,
+    link: canLinkSelection || isSingleElementBoundContainer,
+    linkSelection: canLinkSelection,
     cropEditor:
       !appState.croppingElementId &&
       singleSelected &&

--- a/packages/excalidraw/tests/contextmenu.test.tsx
+++ b/packages/excalidraw/tests/contextmenu.test.tsx
@@ -279,6 +279,7 @@ describe("contextMenu element", () => {
       "deleteSelectedElements",
       "copyElementLink",
       "ungroup",
+      "hyperlink",
       "addToLibrary",
       "flipHorizontal",
       "flipVertical",

--- a/packages/excalidraw/tests/hyperlink.test.tsx
+++ b/packages/excalidraw/tests/hyperlink.test.tsx
@@ -1,0 +1,231 @@
+import React from "react";
+
+import { KEYS } from "@excalidraw/common";
+import { getNonDeletedElements } from "@excalidraw/element";
+
+import { Excalidraw } from "../index";
+import { t } from "../i18n";
+import { actionUngroup } from "../actions/actionGroup";
+import { actionDuplicateSelection } from "../actions/actionDuplicateSelection";
+import { serializeAsJSON } from "../data/json";
+import { restoreElements } from "../data/restore";
+import { exportToSvg } from "../scene/export";
+
+import { API } from "./helpers/api";
+import { Keyboard } from "./helpers/ui";
+import { fireEvent, render, screen } from "./test-utils";
+
+const { h } = window;
+
+describe("group hyperlinks", () => {
+  beforeEach(async () => {
+    await render(<Excalidraw handleKeyboardGlobally />);
+  });
+
+  it("creates a shared hyperlink from the keyboard for a selected group", () => {
+    const elements = [
+      API.createElement({ type: "ellipse", groupIds: ["icon"] }),
+      API.createElement({ type: "ellipse", x: 100, groupIds: ["icon"] }),
+    ];
+    API.setElements(elements);
+    API.setSelectedElements(elements);
+
+    Keyboard.withModifierKeys({ ctrl: true }, () => Keyboard.keyPress(KEYS.K));
+    const input = screen.getByPlaceholderText(t("labels.link.hint"));
+    fireEvent.change(input, { target: { value: "https://example.com" } });
+    fireEvent.keyDown(input, { key: KEYS.ENTER });
+
+    expect(h.elements.map((element) => element.link)).toEqual([
+      "https://example.com",
+      "https://example.com",
+    ]);
+  });
+});
+
+const openEditor = () => {
+  Keyboard.withModifierKeys({ ctrl: true }, () => Keyboard.keyPress(KEYS.K));
+  return screen.getByPlaceholderText(t("labels.link.hint"));
+};
+
+const submitLink = (value: string) => {
+  const input = openEditor();
+  fireEvent.change(input, { target: { value } });
+  fireEvent.keyDown(input, { key: KEYS.ENTER });
+};
+
+const selectGroup = (link: string | null = null) => {
+  const elements = [
+    API.createElement({ type: "ellipse", groupIds: ["icon"] }),
+    API.createElement({ type: "ellipse", x: 100, groupIds: ["icon"] }),
+  ];
+  const linkedElements = elements.map((element) => ({ ...element, link }));
+  API.setElements(linkedElements);
+  API.setSelectedElements(linkedElements);
+  return linkedElements;
+};
+
+describe("editing group hyperlinks", () => {
+  beforeEach(async () => {
+    await render(<Excalidraw handleKeyboardGlobally />);
+  });
+
+  it("edits and removes the shared URL for every member", () => {
+    selectGroup("https://example.com/old");
+    submitLink("https://example.com/new");
+    expect(
+      h.elements.every(({ link }) => link === "https://example.com/new"),
+    ).toBe(true);
+    fireEvent.click(screen.getByRole("button", { name: t("buttons.remove") }));
+    expect(h.elements.every(({ link }) => link === null)).toBe(true);
+  });
+
+  it("commits a draft when selection changes, without changing the new selection", () => {
+    const elements = selectGroup();
+    const other = API.createElement({ type: "rectangle", x: 400 });
+    API.setElements([...elements, other]);
+    const input = openEditor();
+    fireEvent.change(input, { target: { value: "https://example.com" } });
+    API.setSelectedElements([other]);
+    expect(h.elements.map(({ link }) => link)).toEqual([
+      "https://example.com",
+      "https://example.com",
+      null,
+    ]);
+  });
+
+  it("undoes and redoes a group link as one edit", () => {
+    selectGroup();
+    submitLink("https://example.com");
+    API.setSelectedElements([]);
+    Keyboard.undo();
+    expect(h.elements.map(({ link }) => link)).toEqual([null, null]);
+    Keyboard.redo();
+    expect(h.elements.map(({ link }) => link)).toEqual([
+      "https://example.com",
+      "https://example.com",
+    ]);
+  });
+
+  it("opens from the properties panel", () => {
+    selectGroup();
+    fireEvent.click(
+      screen.getByRole("button", { name: t("labels.link.create") }),
+    );
+    expect(
+      screen.getByPlaceholderText(t("labels.link.hint")),
+    ).toBeInTheDocument();
+  });
+
+  it("edits a nested group inside its parent without changing its siblings", () => {
+    const inner = [
+      API.createElement({ type: "ellipse", groupIds: ["inner", "outer"] }),
+      API.createElement({
+        type: "ellipse",
+        x: 100,
+        groupIds: ["inner", "outer"],
+      }),
+    ];
+    const sibling = API.createElement({
+      type: "rectangle",
+      x: 300,
+      groupIds: ["outer"],
+    });
+    API.setElements([...inner, sibling]);
+    API.setSelectedElements(inner, "outer");
+    submitLink("https://example.com");
+    expect(h.elements.map(({ link }) => link)).toEqual([
+      "https://example.com",
+      "https://example.com",
+      null,
+    ]);
+  });
+
+  it.each([
+    "mixed",
+    "partly linked",
+    "embeddable",
+    "locked",
+    "ungrouped",
+    "two groups",
+  ])("does not bulk-edit a %s selection", (kind) => {
+    const elements = [
+      API.createElement({
+        type: "ellipse",
+        groupIds: kind === "ungrouped" ? [] : ["icon"],
+      }),
+      API.createElement({
+        type: kind === "embeddable" ? "embeddable" : "ellipse",
+        x: 100,
+        groupIds:
+          kind === "ungrouped"
+            ? []
+            : kind === "two groups"
+            ? ["other"]
+            : ["icon"],
+        locked: kind === "locked",
+      }),
+    ];
+    const linkedElements = elements.map((element, index) => ({
+      ...element,
+      link:
+        kind === "mixed"
+          ? `https://example.com/${index}`
+          : kind === "partly linked" && index === 0
+          ? "https://example.com"
+          : null,
+    }));
+    API.setElements(linkedElements);
+    API.setSelectedElements(linkedElements);
+    const originalLinks = h.elements.map(({ link }) => link);
+    Keyboard.withModifierKeys({ ctrl: true }, () => Keyboard.keyPress(KEYS.K));
+    expect(
+      screen.queryByPlaceholderText(t("labels.link.hint")),
+    ).not.toBeInTheDocument();
+    expect(h.elements.map(({ link }) => link)).toEqual(originalLinks);
+  });
+
+  it("preserves group links through duplication and ungrouping", () => {
+    selectGroup();
+    submitLink("https://example.com");
+    API.executeAction(actionDuplicateSelection);
+    expect(h.elements).toHaveLength(4);
+    expect(h.elements.every(({ link }) => link === "https://example.com")).toBe(
+      true,
+    );
+    API.executeAction(actionUngroup);
+    expect(
+      API.getSelectedElements().every(
+        ({ groupIds, link }) =>
+          groupIds.length === 0 && link === "https://example.com",
+      ),
+    ).toBe(true);
+  });
+
+  it("preserves working links in saved scenes and SVG exports", async () => {
+    selectGroup();
+    submitLink("https://example.com");
+    const saved = JSON.parse(serializeAsJSON(h.elements, h.state, {}, "local"));
+    const restored = restoreElements(saved.elements, null);
+    expect(restored.map(({ groupIds, link }) => ({ groupIds, link }))).toEqual([
+      { groupIds: ["icon"], link: "https://example.com" },
+      { groupIds: ["icon"], link: "https://example.com" },
+    ]);
+    const svg = await exportToSvg(getNonDeletedElements(restored), h.state, {});
+    expect(svg.querySelectorAll("a")).toHaveLength(2);
+    for (const anchor of svg.querySelectorAll("a")) {
+      expect(
+        anchor.getAttribute("href") || anchor.getAttribute("xlink:href"),
+      ).toBe("https://example.com");
+    }
+  });
+
+  it("still edits a single element inside a group independently", () => {
+    const elements = selectGroup("https://example.com/shared");
+    API.setSelectedElements([elements[0]], "icon");
+    submitLink("https://example.com/individual");
+    expect(h.elements.map(({ link }) => link)).toEqual([
+      "https://example.com/individual",
+      "https://example.com/shared",
+    ]);
+  });
+});


### PR DESCRIPTION
A custom icon or handwritten word made from several grouped shapes cannot currently use Create link: the action and popup require a single selected element. This adds Create/Edit/Remove link for one selected group, with the editor positioned above the group's bounds.

Refs #6334. **Draft for design review**, following the [scope proposal](https://github.com/excalidraw/excalidraw/issues/6334#issuecomment-5645606518).

### Proposed behavior

- A group can share a URL when all selected members currently have the same link (including no link). Keyboard, context-menu and properties-panel entry points use the same eligibility check.
- Editing/removing the URL updates the members together, with an explicit undo checkpoint. Switching selection commits an edited draft to the original selection only.
- Groups with different member links, locked members or embeddables are excluded from bulk editing. A member can still be edited independently while editing its group.
- The existing per-element `link` field is retained: duplication, scene reload and SVG export preserve the URLs; ungrouping leaves the URL on each member.

This is shared-link editing, not a new group-owned URL that temporarily overrides individual links. Existing individual link handles remain, and the internal element-target picker remains single-element-only. Is this a useful first step for #6334, or would you prefer a separate group-link model before exposing this interaction?

### Demonstration

![One link editor centered over a two-shape group](https://raw.githubusercontent.com/maximilliangrand/excalidraw/5d5021e9381d10ee8e49c942fb76c0826fbc99ab/group-link-saved.png)

[Editing screenshot and reproduction steps](https://github.com/maximilliangrand/excalidraw/tree/5d5021e9381d10ee8e49c942fb76c0826fbc99ab). Demo assets are outside the PR diff.

### Validation

- Added a regression that fails on the base revision because Ctrl/Cmd+K does not open the group editor; 15 focused tests now pass.
- Full Vitest run: **2,092 passed**, 47 skipped, 1 todo across 132 files (Node 26.7.0).
- Relevant hyperlink, context-menu, history, export, laser and duplication suites on **Node 20.20.2**: **135 passed**, 1 skipped.
- `yarn test:typecheck`, `yarn test:code` and `yarn test:other` pass.
- Browser automation in Chromium and WebKit verified group-link creation, undo/redo and opening the URL through a link handle.

The [hosted Vercel preview](https://excalidraw-git-fork-maximilliangrand-codex-gr-85014b-excalidraw.vercel.app) also passed the create/undo/redo/open-URL browser checks in Chromium and WebKit.

Developed with Codex assistance.
