### PR TITLE
feat(editor): add lasso tool shortcut and update HelpDialog

### DIFF
--- a/packages/excalidraw/components/HelpDialog.tsx
+++ b/packages/excalidraw/components/HelpDialog.tsx
@@ -151,6 +151,7 @@ export const HelpDialog = ({ onClose }: { onClose?: () => void }) => {
               label={t("toolBar.selection")}
               shortcuts={[KEYS.V, KEYS["1"]]}
             />
+            <Shortcut label={t("toolBar.lasso")} shortcuts={[KEYS.C]} />
             <Shortcut
               label={t("toolBar.rectangle")}
               shortcuts={[KEYS.R, KEYS["2"]]}

--- a/packages/excalidraw/components/Toolbar.tsx
+++ b/packages/excalidraw/components/Toolbar.tsx
@@ -187,6 +187,7 @@ const ExtraToolsDropdown = ({
             icon={LassoIcon}
             data-testid="toolbar-lasso"
             selected={lassoToolSelected}
+            shortcut={getToolShortcut("lasso")}
             disabled={isToolButtonDisabled(app, "lasso")}
           >
             {t("toolBar.lasso")}

--- a/packages/excalidraw/components/Tools.tsx
+++ b/packages/excalidraw/components/Tools.tsx
@@ -155,6 +155,7 @@ export const TOOLS = defineTools({
   },
   lasso: {
     icon: LassoIcon,
+    letterKey: KEYS.C,
     fillable: false,
   },
 });
@@ -360,11 +361,9 @@ export const SelectionToolButton = createToolButton("selection", {
 
 /**
  * Rendered in place of the selection button when lasso is the preferred
- * selection tool; the selection shortcut activates it then.
+ * selection tool.
  */
-export const LassoToolButton = createToolButton("lasso", {
-  shortcutType: "selection",
-});
+export const LassoToolButton = createToolButton("lasso");
 
 /**
  * The selection ⇄ lasso popover used in compact (tablet) and mobile

--- a/packages/excalidraw/tests/tool.test.tsx
+++ b/packages/excalidraw/tests/tool.test.tsx
@@ -100,6 +100,12 @@ describe("findShapeByKey()", () => {
     expect(findShapeByKey("1", app)).toBe("lasso");
   });
 
+  it("lasso has a direct shortcut", () => {
+    const app = appWithPreferredTool("selection");
+
+    expect(findShapeByKey("c", app)).toBe("lasso");
+  });
+
   it("letter shortcuts are CapsLock-insensitive", () => {
     const app = appWithPreferredTool("selection");
 


### PR DESCRIPTION
Fixes #12073 

Adds a dedicated keyboard shortcut (C) for the Lasso selection tool in Excalidraw.

Changes
Added C as the direct shortcut for Lasso selection.
Updated the toolbar/help UI to display the shortcut.
Added/updated tests to verify the Lasso shortcut.